### PR TITLE
CE-33707: Fixed deprecated methods for PHPUnit v9.3.0

### DIFF
--- a/app/code/Magento/ProductAlert/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/ProductAlert/Test/Unit/Model/ObserverTest.php
@@ -78,6 +78,8 @@ class ObserverTest extends TestCase
 
     /**
      * Test process alerts with exception in loading websites
+     *
+     * @return void
      */
     public function testGetWebsitesThrowsException(): void
     {
@@ -94,6 +96,8 @@ class ObserverTest extends TestCase
 
     /**
      * Test process alerts with exception in creating price collection
+     *
+     * @return void
      */
     public function testProcessPriceThrowsException(): void
     {
@@ -120,6 +124,8 @@ class ObserverTest extends TestCase
 
     /**
      * Test process alerts with exception in creating stock collection
+     *
+     * @return void
      */
     public function testProcessStockThrowsException(): void
     {
@@ -135,8 +141,9 @@ class ObserverTest extends TestCase
         $websiteMock->method('getDefaultGroup')->willReturn($groupMock);
         $this->storeManagerMock->method('getWebsites')->willReturn([$websiteMock]);
 
-        $this->scopeConfigMock->expects($this->at(0))->method('getValue')->willReturn(false);
-        $this->scopeConfigMock->expects($this->at(1))->method('getValue')->willReturn(true);
+        $this->scopeConfigMock
+            ->method('getValue')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $this->stockColFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Quote/Test/Unit/Model/Cart/ShippingMethodConverterTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Cart/ShippingMethodConverterTest.php
@@ -67,6 +67,9 @@ class ShippingMethodConverterTest extends TestCase
      */
     protected $taxHelper;
 
+    /**
+     * @inheriDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -111,7 +114,10 @@ class ShippingMethodConverterTest extends TestCase
         );
     }
 
-    public function testModelToDataObject()
+    /**
+     * @return void
+     */
+    public function testModelToDataObject(): void
     {
         $customerTaxClassId = 100;
         $shippingPriceExclTax = 1000;
@@ -126,12 +132,10 @@ class ShippingMethodConverterTest extends TestCase
         $this->rateModelMock->expects($this->once())->method('getCarrier')->willReturn('CARRIER_CODE');
         $this->rateModelMock->expects($this->once())->method('getMethod')->willReturn('METHOD_CODE');
         $this->rateModelMock->expects($this->any())->method('getPrice')->willReturn($price);
-        $this->currencyMock->expects($this->at(0))
-            ->method('convert')->with($price, 'USD')->willReturn(100.12);
-        $this->currencyMock->expects($this->at(1))
-            ->method('convert')->with($shippingPriceExclTax, 'USD')->willReturn($shippingPriceExclTax);
-        $this->currencyMock->expects($this->at(2))
-            ->method('convert')->with($shippingPriceInclTax, 'USD')->willReturn($shippingPriceInclTax);
+        $this->currencyMock
+            ->method('convert')
+            ->withConsecutive([$price, 'USD'], [$shippingPriceExclTax, 'USD'], [$shippingPriceInclTax, 'USD'])
+            ->willReturnOnConsecutiveCalls(100.12, $shippingPriceExclTax, $shippingPriceInclTax);
 
         $this->rateModelMock->expects($this->once())
             ->method('getCarrierTitle')->willReturn('CARRIER_TITLE');
@@ -186,15 +190,13 @@ class ShippingMethodConverterTest extends TestCase
             ->with($shippingPriceInclTax)
             ->willReturn($this->shippingMethodMock);
 
-        $this->taxHelper->expects($this->at(0))
+        $this->taxHelper
             ->method('getShippingPrice')
-            ->with($price, false, $addressMock, $customerTaxClassId)
-            ->willReturn($shippingPriceExclTax);
-
-        $this->taxHelper->expects($this->at(1))
-            ->method('getShippingPrice')
-            ->with($price, true, $addressMock, $customerTaxClassId)
-            ->willReturn($shippingPriceInclTax);
+            ->withConsecutive(
+                [$price, false, $addressMock, $customerTaxClassId],
+                [$price, true, $addressMock, $customerTaxClassId]
+            )
+            ->willReturnOnConsecutiveCalls($shippingPriceExclTax, $shippingPriceInclTax);
 
         $this->assertEquals(
             $this->shippingMethodMock,

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/GrandTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/GrandTest.php
@@ -38,27 +38,31 @@ class GrandTest extends TestCase
     {
         $this->priceRounder = $this->getMockBuilder(PriceRounder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['roundPrice'])
+            ->addMethods(['roundPrice'])
             ->getMockForAbstractClass();
 
         $helper = new ObjectManager($this);
         $this->model = $helper->getObject(
             Grand::class,
             [
-                'priceRounder' => $this->priceRounder,
+                'priceRounder' => $this->priceRounder
             ]
         );
     }
 
-    public function testCollect()
+    /**
+     * @return void
+     */
+    public function testCollect(): void
     {
         $totals = [1, 2, 3.4];
         $totalsBase = [4, 5, 6.7];
         $grandTotal = 6.4; // 1 + 2 + 3.4
         $grandTotalBase = 15.7; // 4 + 5 + 6.7
 
-        $this->priceRounder->expects($this->at(0))->method('roundPrice')->willReturn($grandTotal + 2);
-        $this->priceRounder->expects($this->at(1))->method('roundPrice')->willReturn($grandTotalBase + 2);
+        $this->priceRounder
+            ->method('roundPrice')
+            ->willReturnOnConsecutiveCalls($grandTotal + 2, $grandTotalBase + 2);
 
         $totalMock = $this->getMockBuilder(Total::class)
             ->addMethods(['setGrandTotal', 'setBaseGrandTotal', 'getGrandTotal', 'getBaseGrandTotal'])

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/ShippingTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/ShippingTest.php
@@ -32,34 +32,54 @@ class ShippingTest extends TestCase
      */
     protected $shippingModel;
 
-    /** @var Quote|MockObject */
+    /**
+     * @var Quote|MockObject
+     */
     protected $quote;
 
-    /** @var Total|MockObject  */
+    /**
+     * @var Total|MockObject
+     */
     protected $total;
 
-    /** @var ShippingAssignmentInterface|MockObject  */
+    /**
+     * @var ShippingAssignmentInterface|MockObject
+     */
     protected $shippingAssignment;
 
-    /** @var Address|MockObject  */
+    /**
+     * @var Address|MockObject
+     */
     protected $address;
 
-    /** @var ShippingInterface|MockObject  */
+    /**
+     * @var ShippingInterface|MockObject
+     */
     protected $shipping;
 
-    /** @var FreeShippingInterface|MockObject */
+    /**
+     * @var FreeShippingInterface|MockObject
+     */
     protected $freeShipping;
 
-    /** @var CartItemInterface|MockObject */
+    /**
+     * @var CartItemInterface|MockObject
+     */
     protected $cartItem;
 
-    /** @var Rate|MockObject */
+    /**
+     * @var Rate|MockObject
+     */
     protected $rate;
 
-    /** @var Store|MockObject */
+    /**
+     * @var Store|MockObject
+     */
     protected $store;
 
-    /** @var PriceCurrencyInterface|MockObject */
+    /**
+     * @var PriceCurrencyInterface|MockObject
+     */
     protected $priceCurrency;
 
     /**
@@ -84,7 +104,7 @@ class ShippingTest extends TestCase
             Shipping::class,
             [
                 'freeShipping' => $this->freeShipping,
-                'priceCurrency' => $this->priceCurrency,
+                'priceCurrency' => $this->priceCurrency
             ]
         );
 
@@ -138,7 +158,7 @@ class ShippingTest extends TestCase
                 'isVirtual',
                 'getWeight',
                 'getQty',
-                'setRowWeight',
+                'setRowWeight'
             ]
         );
         $this->rate = $this->getMockBuilder(Rate::class)
@@ -270,12 +290,9 @@ class ShippingTest extends TestCase
      */
     protected function freeShippingAssertions(): void
     {
-        $this->address->expects($this->at(0))
+        $this->address
             ->method('getFreeShipping')
-            ->willReturn(false);
-        $this->address->expects($this->at(1))
-            ->method('getFreeShipping')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, true);
         $this->cartItem->expects($this->atLeastOnce())
             ->method('getFreeShipping')
             ->willReturn(true);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Address/Total/SubtotalTest.php
@@ -32,18 +32,29 @@ use PHPUnit\Framework\TestCase;
  */
 class SubtotalTest extends TestCase
 {
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
 
-    /**  @var Subtotal */
+    /**
+     * @var Subtotal
+     */
     protected $subtotalModel;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $stockItemMock;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $stockRegistry;
 
+    /**
+     * @inheriDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -65,7 +76,7 @@ class SubtotalTest extends TestCase
     /**
      * @return array
      */
-    public function collectDataProvider()
+    public function collectDataProvider(): array
     {
         return [
             [12, 10, false, 12, 10],
@@ -77,18 +88,23 @@ class SubtotalTest extends TestCase
     }
 
     /**
-     * @dataProvider collectDataProvider
-     *
      * @param int $price
      * @param int $originalPrice
      * @param bool $itemHasParent
-     * @param int $expectedPrice
-     * @param int $expectedOriginalPrice
+     * @param int|null $expectedPrice
+     * @param int|null $expectedOriginalPrice
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider collectDataProvider
      */
-    public function testCollect($price, $originalPrice, $itemHasParent, $expectedPrice, $expectedOriginalPrice)
-    {
+    public function testCollect(
+        int $price,
+        int $originalPrice,
+        bool $itemHasParent,
+        ?int $expectedPrice,
+        ?int $expectedOriginalPrice
+    ): void {
         $this->stockRegistry->expects($this->any())->method('getStockItem')->willReturn($this->stockItemMock);
 
         $priceCurrency = $this->getMockBuilder(PriceCurrencyInterface::class)->getMock();
@@ -101,7 +117,7 @@ class SubtotalTest extends TestCase
             Item::class,
             [
                 'stockRegistry' => $this->stockRegistry,
-                'priceCurrency' => $priceCurrency,
+                'priceCurrency' => $priceCurrency
             ]
         );
         /** @var Address|MockObject $address */
@@ -125,7 +141,7 @@ class SubtotalTest extends TestCase
         $product->expects($this->any())->method('getStore')->willReturn($store);
         $product->expects($this->any())->method('isVisibleInCatalog')->will($this->returnValue(true));
         $extensionAttribute = $this->getMockBuilder(ProductExtensionInterface::class)
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $extensionAttribute->expects($this->atLeastOnce())
@@ -151,7 +167,9 @@ class SubtotalTest extends TestCase
 
         $shipping = $this->createMock(ShippingInterface::class);
         $shipping->expects($this->exactly(2))->method('getAddress')->willReturn($address);
-        $address->expects($this->at(0))->method('setTotalQty')->with(0);
+        $address
+            ->method('setTotalQty')
+            ->with(0);
         $address->expects($this->any())->method('getTotalQty')->willReturn(0);
         $shippingAssignmentMock = $this->createMock(ShippingAssignmentInterface::class);
         $shippingAssignmentMock->expects($this->exactly(2))->method('getShipping')->willReturn($shipping);
@@ -172,7 +190,10 @@ class SubtotalTest extends TestCase
         $this->assertEquals($convertedPrice, $quoteItem->getConvertedPrice());
     }
 
-    public function testFetch()
+    /**
+     * @return void
+     */
+    public function testFetch(): void
     {
         $expectedResult = [
             'code' => null,
@@ -193,8 +214,10 @@ class SubtotalTest extends TestCase
 
     /**
      * Test that invalid items are not collected
+     *
+     * @return void
      */
-    public function testCollectWithInvalidItems()
+    public function testCollectWithInvalidItems(): void
     {
         $addressItemId = 38203;
         $addressQuoteItemId = 7643;
@@ -202,7 +225,7 @@ class SubtotalTest extends TestCase
         $quote = $this->createPartialMock(
             Quote::class,
             [
-                'getItemsCollection',
+                'getItemsCollection'
             ]
         );
         $quote->setData(

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
@@ -124,6 +124,9 @@ class AddressTest extends TestCase
      */
     protected $serializer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -149,7 +152,7 @@ class AddressTest extends TestCase
 
         $this->rateCollection = $this->getMockBuilder(RateCollectorInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getResult'])
+            ->addMethods(['getResult'])
             ->getMockForAbstractClass();
 
         $this->itemCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
@@ -170,7 +173,7 @@ class AddressTest extends TestCase
 
         $this->store = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getBaseCurrency', 'getCurrentCurrency', 'getCurrentCurrencyCode'])
+            ->addMethods(['getBaseCurrency', 'getCurrentCurrency', 'getCurrentCurrencyCode'])
             ->getMockForAbstractClass();
 
         $this->website = $this->getMockBuilder(WebsiteInterface::class)
@@ -201,7 +204,10 @@ class AddressTest extends TestCase
         $this->address->setQuote($this->quote);
     }
 
-    public function testValidateMinimumAmountDisabled()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmountDisabled(): void
     {
         $storeId = 1;
 
@@ -217,14 +223,17 @@ class AddressTest extends TestCase
         $this->assertTrue($this->address->validateMinimumAmount());
     }
 
-    public function testValidateMinimumAmountVirtual()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmountVirtual(): void
     {
         $storeId = 1;
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
 
         $this->quote->expects($this->once())
@@ -242,14 +251,17 @@ class AddressTest extends TestCase
         $this->assertTrue($this->address->validateMinimumAmount());
     }
 
-    public function testValidateMinimumAmount()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmount(): void
     {
         $storeId = 1;
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
 
         $this->quote->expects($this->once())
@@ -266,14 +278,17 @@ class AddressTest extends TestCase
         $this->assertTrue($this->address->validateMinimumAmount());
     }
 
-    public function testValidateMiniumumAmountWithoutDiscount()
+    /**
+     * @return void
+     */
+    public function testValidateMiniumumAmountWithoutDiscount(): void
     {
         $storeId = 1;
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, false],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
 
         $this->quote->expects($this->once())
@@ -290,14 +305,17 @@ class AddressTest extends TestCase
         $this->assertTrue($this->address->validateMinimumAmount());
     }
 
-    public function testValidateMinimumAmountNegative()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmountNegative(): void
     {
         $storeId = 1;
         $scopeConfigValues = [
             ['sales/minimum_order/active', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
 
         $this->quote->expects($this->once())
@@ -315,7 +333,10 @@ class AddressTest extends TestCase
         $this->assertTrue($this->address->validateMinimumAmount());
     }
 
-    public function testSetAndGetAppliedTaxes()
+    /**
+     * @return void
+     */
+    public function testSetAndGetAppliedTaxes(): void
     {
         $data = ['data'];
         self::assertInstanceOf(Address::class, $this->address->setAppliedTaxes($data));
@@ -324,8 +345,10 @@ class AddressTest extends TestCase
 
     /**
      * Checks a case, when applied taxes are not provided.
+     *
+     * @return void
      */
-    public function testGetAppliedTaxesWithEmptyValue()
+    public function testGetAppliedTaxesWithEmptyValue(): void
     {
         $this->address->setData('applied_taxes', null);
         self::assertEquals([], $this->address->getAppliedTaxes());
@@ -334,20 +357,23 @@ class AddressTest extends TestCase
     /**
      * Test of requesting shipping rates by address
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testRequestShippingRates()
+    public function testRequestShippingRates(): void
     {
         $storeId = 12345;
         $webSiteId = 6789;
         $baseCurrency = $this->getMockBuilder(Currency::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCurrentCurrencyCode','convert'])
+            ->onlyMethods(['convert'])
+            ->addMethods(['getCurrentCurrencyCode'])
             ->getMockForAbstractClass();
 
         $currentCurrency = $this->getMockBuilder(Currency::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCurrentCurrencyCode','convert'])
+            ->onlyMethods(['convert'])
+            ->addMethods(['getCurrentCurrencyCode'])
             ->getMockForAbstractClass();
 
         $currentCurrencyCode = 'UAH';
@@ -356,10 +382,6 @@ class AddressTest extends TestCase
             ->method('getStoreId')
             ->willReturn($storeId);
 
-        $this->storeManager->expects($this->at(0))
-            ->method('getStore')
-            ->with($storeId)
-            ->willReturn($this->store);
         $this->store->expects($this->any())
             ->method('getWebsiteId')
             ->willReturn($webSiteId);
@@ -376,7 +398,7 @@ class AddressTest extends TestCase
         /** @var RateRequest */
         $request = $this->getMockBuilder(RateRequest::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->addMethods(
                 [
                     'setStoreId',
                     'setWebsiteId',
@@ -462,6 +484,7 @@ class AddressTest extends TestCase
             ->willReturnSelf();
 
         $this->storeManager->method('getStore')
+            ->withConsecutive([$storeId], [null])
             ->willReturn($this->store);
 
         $this->store->method('getBaseCurrency')

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ToOrderItemTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/ToOrderItemTest.php
@@ -55,6 +55,9 @@ class ToOrderItemTest extends TestCase
      */
     protected $orderItemMock;
 
+    /**
+     * @inheriDoc
+     */
     protected function setUp(): void
     {
         $this->orderItemFactoryMock = $this->createPartialMock(
@@ -77,8 +80,10 @@ class ToOrderItemTest extends TestCase
 
     /**
      * test for convert method
+     *
+     * @return void
      */
-    public function testConvert()
+    public function testConvert(): void
     {
         $this->quoteItemMock->expects($this->exactly(2))
             ->method('getProduct')
@@ -90,14 +95,13 @@ class ToOrderItemTest extends TestCase
             ->method('getOrderOptions')
             ->with($this->productMock)
             ->willReturn(['option']);
-        $this->objectCopyServiceMock->expects($this->at(0))
+        $this->objectCopyServiceMock
             ->method('getDataFromFieldset')
-            ->with('quote_convert_item', 'to_order_item', $this->quoteItemMock)
-            ->willReturn([]);
-        $this->objectCopyServiceMock->expects($this->at(1))
-            ->method('getDataFromFieldset')
-            ->with('quote_convert_item', 'to_order_item_discount', $this->quoteItemMock)
-            ->willReturn([]);
+            ->withConsecutive(
+                ['quote_convert_item', 'to_order_item', $this->quoteItemMock],
+                ['quote_convert_item', 'to_order_item_discount', $this->quoteItemMock]
+            )
+            ->willReturnOnConsecutiveCalls([], []);
         $this->orderItemFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($this->orderItemMock);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/ItemTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/ItemTest.php
@@ -73,7 +73,9 @@ class ItemTest extends TestCase
      */
     protected $compareHelper;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $stockItemMock;
 
     /**
@@ -87,8 +89,11 @@ class ItemTest extends TestCase
     const PRODUCT_NAME = 'test_product';
     const PRODUCT_WEIGHT = '1lb';
     const PRODUCT_TAX_CLASS_ID = 3;
-    const PRODUCT_COST = '9.00';
+    const PRODUCT_COST = 9.00;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManager($this);
@@ -99,12 +104,12 @@ class ItemTest extends TestCase
 
         $this->modelContext = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getEventDispatcher'])
+            ->onlyMethods(['getEventDispatcher'])
             ->getMock();
 
         $this->eventDispatcher = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['dispatch'])
+            ->onlyMethods(['dispatch'])
             ->getMockForAbstractClass();
 
         $this->modelContext->expects($this->any())
@@ -113,12 +118,12 @@ class ItemTest extends TestCase
 
         $this->errorInfos = $this->getMockBuilder(ListStatus::class)
             ->disableOriginalConstructor()
-            ->setMethods(['clear', 'addItem', 'getItems', 'removeItemsByParams'])
+            ->onlyMethods(['clear', 'addItem', 'getItems', 'removeItemsByParams'])
             ->getMock();
 
         $statusListFactory = $this->getMockBuilder(ListFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $statusListFactory->expects($this->any())
@@ -127,7 +132,7 @@ class ItemTest extends TestCase
 
         $this->itemOptionFactory = $this->getMockBuilder(OptionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->compareHelper = $this->createMock(Compare::class);
@@ -138,7 +143,7 @@ class ItemTest extends TestCase
         );
 
         $this->serializer = $this->getMockBuilder(Json::class)
-            ->setMethods(['unserialize'])
+            ->onlyMethods(['unserialize'])
             ->getMockForAbstractClass();
 
         $this->model = $this->objectManagerHelper->getObject(
@@ -155,10 +160,13 @@ class ItemTest extends TestCase
         );
     }
 
-    public function testGetAddress()
+    /**
+     * @return void
+     */
+    public function testGetAddress(): void
     {
         $quote = $this->getMockBuilder(Quote::class)
-            ->setMethods(['getShippingAddress', 'getBillingAddress', 'getStoreId', '__wakeup', 'isVirtual'])
+            ->onlyMethods(['getShippingAddress', 'getBillingAddress', 'getStoreId', '__wakeup', 'isVirtual'])
             ->disableOriginalConstructor()
             ->getMock();
         $quote->expects($this->once())
@@ -179,12 +187,15 @@ class ItemTest extends TestCase
         $this->assertEquals('billing', $this->model->getAddress(), 'Wrong billing address');
     }
 
-    public function testSetAndQuote()
+    /**
+     * @return void
+     */
+    public function testSetAndQuote(): void
     {
         $idValue = "id_value";
 
         $quote = $this->getMockBuilder(Quote::class)
-            ->setMethods(['getId', 'getStoreId', '__wakeup'])
+            ->onlyMethods(['getId', 'getStoreId', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $quote->expects($this->once())
@@ -202,8 +213,10 @@ class ItemTest extends TestCase
 
     /**
      * Tests that adding a quantity to an item without a parent item or an id will add additional quantity.
+     *
+     * @return void
      */
-    public function testAddQtyNormal()
+    public function testAddQtyNormal(): void
     {
         $existingQuantity = 2;
         $quantityToAdd = 3;
@@ -211,15 +224,10 @@ class ItemTest extends TestCase
 
         $this->model->setData('qty', $existingQuantity);
 
-        $this->localeFormat->expects($this->at(0))
+        $this->localeFormat
             ->method('getNumber')
-            ->with($quantityToAdd)
-            ->willReturn($preparedQuantityToAdd);
-
-        $this->localeFormat->expects($this->at(1))
-            ->method('getNumber')
-            ->with($preparedQuantityToAdd + $existingQuantity)
-            ->willReturn($preparedQuantityToAdd + $existingQuantity);
+            ->withConsecutive([$quantityToAdd], [$preparedQuantityToAdd + $existingQuantity])
+            ->willReturnOnConsecutiveCalls($preparedQuantityToAdd, $preparedQuantityToAdd + $existingQuantity);
 
         $this->model->addQty($quantityToAdd);
         $this->assertEquals($preparedQuantityToAdd, $this->model->getQtyToAdd());
@@ -228,14 +236,16 @@ class ItemTest extends TestCase
 
     /**
      * Tests that adding a quantity to an item with a parent item and an id will not change the quantity.
+     *
+     * @return void
      */
-    public function testAddQtyExistingParentItemAndId()
+    public function testAddQtyExistingParentItemAndId(): void
     {
         $existingQuantity = 2;
         $quantityToAdd = 3;
 
         $parentItemMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['addChild', '__wakeup'])
+            ->onlyMethods(['addChild', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -248,7 +258,10 @@ class ItemTest extends TestCase
         $this->assertNull($this->model->getQtyToAdd());
     }
 
-    public function testSetQty()
+    /**
+     * @return void
+     */
+    public function testSetQty(): void
     {
         $existingQuantity = 2;
         $quantityToAdd = 3;
@@ -269,7 +282,10 @@ class ItemTest extends TestCase
         $this->assertEquals($preparedQuantityToAdd, $this->model->getQty());
     }
 
-    public function testSetQtyQuoteIgnoreOldQuantity()
+    /**
+     * @return void
+     */
+    public function testSetQtyQuoteIgnoreOldQuantity(): void
     {
         $existingQuantity = 2;
         $quantityToAdd = 3;
@@ -282,7 +298,8 @@ class ItemTest extends TestCase
 
         $quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getIgnoreOldQty', 'getStoreId', '__wakeup'])
+            ->onlyMethods(['getStoreId', '__wakeup'])
+            ->addMethods(['getIgnoreOldQty'])
             ->getMock();
         $quoteMock->expects($this->once())
             ->method('getIgnoreOldQty')
@@ -303,7 +320,10 @@ class ItemTest extends TestCase
         $this->assertEquals($preparedQuantityToAdd, $this->model->getQty());
     }
 
-    public function testSetQtyUseOldQuantity()
+    /**
+     * @return void
+     */
+    public function testSetQtyUseOldQuantity(): void
     {
         $existingQuantity = 2;
         $quantityToAdd = 3;
@@ -325,14 +345,20 @@ class ItemTest extends TestCase
         $this->assertEquals($existingQuantity, $this->model->getQty());
     }
 
-    public function testSetQtyOptions()
+    /**
+     * @return void
+     */
+    public function testSetQtyOptions(): void
     {
         $value = ['a' => 'b'];
         $this->model->setQtyOptions($value);
         $this->assertEquals($value, $this->model->getQtyOptions());
     }
 
-    public function testSetProduct()
+    /**
+     * @return void
+     */
+    public function testSetProduct(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -361,7 +387,10 @@ class ItemTest extends TestCase
         $this->assertNull($this->model->getIsQtyDecimal());
     }
 
-    public function testSetProductWithQuoteAndStockItem()
+    /**
+     * @return void
+     */
+    public function testSetProductWithQuoteAndStockItem(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -386,7 +415,7 @@ class ItemTest extends TestCase
         $customerGroupId = 11;
         $quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStoreId', 'getCustomerGroupId', '__wakeup'])
+            ->onlyMethods(['getStoreId', 'getCustomerGroupId', '__wakeup'])
             ->getMock();
         $quoteMock->expects($this->any())
             ->method('getStoreId')
@@ -426,37 +455,42 @@ class ItemTest extends TestCase
      * @param string $productWeight
      * @param int $productTaxClassId
      * @param float $productCost
+     *
      * @return MockObject
      */
     private function generateProductMock(
-        $productId,
-        $productType,
-        $productSku,
-        $productName,
-        $productWeight,
-        $productTaxClassId,
-        $productCost
-    ) {
+        int $productId,
+        string $productType,
+        string $productSku,
+        string $productName,
+        string $productWeight,
+        int $productTaxClassId,
+        float $productCost
+    ): MockObject {
         $productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getId',
                     'getTypeId',
                     'getSku',
                     'getName',
                     'getWeight',
-                    'getTaxClassId',
-                    'getCost',
                     'setStoreId',
-                    'setCustomerGroupId',
                     'getTypeInstance',
-                    'getStickWithinParent',
                     'getCustomOptions',
                     'getExtensionAttributes',
                     'toArray',
                     '__wakeup',
-                    'getStore',
+                    'getStore'
+                ]
+            )
+            ->addMethods(
+                [
+                    'getTaxClassId',
+                    'getCost',
+                    'setCustomerGroupId',
+                    'getStickWithinParent'
                 ]
             )
             ->getMock();
@@ -491,7 +525,7 @@ class ItemTest extends TestCase
             ->method('getStore')
             ->willReturn($store);
         $extensionAttribute = $this->getMockBuilder(ProductExtensionInterface::class)
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $extensionAttribute->expects($this->atLeastOnce())
@@ -501,7 +535,10 @@ class ItemTest extends TestCase
         return $productMock;
     }
 
-    public function testRepresentProductNoProduct()
+    /**
+     * @return void
+     */
+    public function testRepresentProductNoProduct(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -518,7 +555,10 @@ class ItemTest extends TestCase
         $this->assertFalse($this->model->representProduct(null));
     }
 
-    public function testRepresentProductStickWithinParentNotSameAsParentItem()
+    /**
+     * @return void
+     */
+    public function testRepresentProductStickWithinParentNotSameAsParentItem(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -531,7 +571,7 @@ class ItemTest extends TestCase
         );
 
         $parentItemMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['addChild', '__wakeup'])
+            ->onlyMethods(['addChild', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -545,7 +585,10 @@ class ItemTest extends TestCase
         $this->assertFalse($this->model->representProduct($productMock));
     }
 
-    public function testRepresentProductItemOptionsNotInProductOptions()
+    /**
+     * @return void
+     */
+    public function testRepresentProductItemOptionsNotInProductOptions(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -558,7 +601,7 @@ class ItemTest extends TestCase
         );
 
         $parentItemMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['addChild', '__wakeup'])
+            ->onlyMethods(['addChild', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -588,7 +631,10 @@ class ItemTest extends TestCase
         $this->assertFalse($this->model->representProduct($productMock));
     }
 
-    public function testRepresentProductProductOptionsNotInItemOptions()
+    /**
+     * @return void
+     */
+    public function testRepresentProductProductOptionsNotInItemOptions(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -601,7 +647,7 @@ class ItemTest extends TestCase
         );
 
         $parentItemMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['addChild', '__wakeup'])
+            ->onlyMethods(['addChild', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -631,7 +677,10 @@ class ItemTest extends TestCase
         $this->assertFalse($this->model->representProduct($productMock));
     }
 
-    public function testRepresentProductTrue()
+    /**
+     * @return void
+     */
+    public function testRepresentProductTrue(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -644,7 +693,7 @@ class ItemTest extends TestCase
         );
 
         $parentItemMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['addChild', '__wakeup'])
+            ->onlyMethods(['addChild', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -676,8 +725,10 @@ class ItemTest extends TestCase
 
     /**
      * test compare
+     *
+     * @return void
      */
-    public function testCompare()
+    public function testCompare(): void
     {
         $itemMock = $this->createMock(Item::class);
         $this->compareHelper->expects($this->once())
@@ -687,7 +738,10 @@ class ItemTest extends TestCase
         $this->assertTrue($this->model->compare($itemMock));
     }
 
-    public function testCompareOptionsEqual()
+    /**
+     * @return void
+     */
+    public function testCompareOptionsEqual(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -700,7 +754,10 @@ class ItemTest extends TestCase
         );
     }
 
-    public function testCompareOptionsDifferentValues()
+    /**
+     * @return void
+     */
+    public function testCompareOptionsDifferentValues(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -719,7 +776,10 @@ class ItemTest extends TestCase
         );
     }
 
-    public function testCompareOptionsNullValues()
+    /**
+     * @return void
+     */
+    public function testCompareOptionsNullValues(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -738,7 +798,10 @@ class ItemTest extends TestCase
         );
     }
 
-    public function testCompareOptionsMultipleEquals()
+    /**
+     * @return void
+     */
+    public function testCompareOptionsMultipleEquals(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -760,7 +823,10 @@ class ItemTest extends TestCase
         );
     }
 
-    public function testGetQtyOptions()
+    /**
+     * @return void
+     */
+    public function testGetQtyOptions(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -797,7 +863,10 @@ class ItemTest extends TestCase
         $this->assertEquals([self::PRODUCT_ID => $optionMock2], $this->model->getQtyOptions());
     }
 
-    public function testToArray()
+    /**
+     * @return void
+     */
+    public function testToArray(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -820,7 +889,10 @@ class ItemTest extends TestCase
         $this->assertEquals($toArrayValue, $data['product']);
     }
 
-    public function testGetProductTypeOption()
+    /**
+     * @return void
+     */
+    public function testGetProductTypeOption(): void
     {
         $optionProductType = 'product_type';
         $optionProductTypeValue = 'abcd';
@@ -833,7 +905,10 @@ class ItemTest extends TestCase
         $this->assertEquals($optionProductTypeValue, $this->model->getProductType());
     }
 
-    public function testGetProductTypeWithProduct()
+    /**
+     * @return void
+     */
+    public function testGetProductTypeWithProduct(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -848,7 +923,10 @@ class ItemTest extends TestCase
         $this->assertEquals(self::PRODUCT_TYPE, $this->model->getProductType());
     }
 
-    public function testSetOptions()
+    /**
+     * @return void
+     */
+    public function testSetOptions(): void
     {
         $optionCode1 = 1234;
         $optionMock1 = $this->createOptionMock($optionCode1);
@@ -862,25 +940,28 @@ class ItemTest extends TestCase
         $this->assertEquals($optionMock2, $this->model->getOptionByCode($optionCode2));
     }
 
-    public function testSetOptionsWithNull()
+    /**
+     * @return void
+     */
+    public function testSetOptionsWithNull(): void
     {
         $this->assertEquals($this->model, $this->model->setOptions(null));
     }
 
     /**
-     * @param $optionCode
+     * @param mixed $optionCode
      * @param array $optionData
+     *
      * @return MockObject
      */
-    private function createOptionMock($optionCode, $optionData = [])
+    private function createOptionMock($optionCode, array $optionData = []): MockObject
     {
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'setData',
                     'setItem',
                     'getItem',
-                    'getCode',
                     '__wakeup',
                     'isDeleted',
                     'delete',
@@ -889,6 +970,7 @@ class ItemTest extends TestCase
                     'save'
                 ]
             )
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->any())
@@ -906,13 +988,17 @@ class ItemTest extends TestCase
         return $optionMock;
     }
 
-    public function testAddOptionArray()
+    /**
+     * @return void
+     */
+    public function testAddOptionArray(): void
     {
         $optionCode = 1234;
         $optionData = ['product' => 'test', 'code' => $optionCode];
 
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setData', 'setItem', 'getCode', '__wakeup', 'isDeleted'])
+            ->onlyMethods(['setData', 'setItem', '__wakeup', 'isDeleted'])
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->once())
@@ -927,7 +1013,7 @@ class ItemTest extends TestCase
             ->method('getCode')
             ->willReturn($optionCode);
 
-        $this->itemOptionFactory->expects($this->at(0))
+        $this->itemOptionFactory
             ->method('create')
             ->willReturn($optionMock);
 
@@ -937,7 +1023,10 @@ class ItemTest extends TestCase
         $this->assertEquals($optionMock, $this->model->getOptionByCode($optionCode));
     }
 
-    public function testUpdateQtyOption()
+    /**
+     * @return void
+     */
+    public function testUpdateQtyOption(): void
     {
         $productMock = $this->generateProductMock(
             self::PRODUCT_ID,
@@ -964,7 +1053,7 @@ class ItemTest extends TestCase
 
         $optionMock = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProduct'])
+            ->addMethods(['getProduct'])
             ->getMock();
         $optionMock->expects($this->once())
             ->method('getProduct')
@@ -979,12 +1068,16 @@ class ItemTest extends TestCase
         $this->assertEquals($this->model, $this->model->updateQtyOption($optionMock, $quantityValue));
     }
 
-    public function testRemoveOption()
+    /**
+     * @return void
+     */
+    public function testRemoveOption(): void
     {
         $optionCode = 1234;
 
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setItem', 'getCode', '__wakeup', 'isDeleted'])
+            ->onlyMethods(['setItem', '__wakeup', 'isDeleted'])
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->once())
@@ -994,34 +1087,40 @@ class ItemTest extends TestCase
         $optionMock->expects($this->exactly(3))
             ->method('getCode')
             ->willReturn($optionCode);
-        $optionMock->expects($this->at(0))
-            ->method('isDeleted')
-            ->willReturn(false);
-        $optionMock->expects($this->at(1))
-            ->method('isDeleted')
-            ->willReturn(true);
+        $optionMock->method('isDeleted')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $this->model->addOption($optionMock);
 
         $this->assertEquals($this->model, $this->model->removeOption($optionCode));
     }
 
-    public function testRemoveOptionNoOptionCodeExists()
+    /**
+     * @return void
+     */
+    public function testRemoveOptionNoOptionCodeExists(): void
     {
         $this->assertEquals($this->model, $this->model->removeOption('random'));
     }
 
-    public function testGetOptionByCodeNonExistent()
+    /**
+     * @return void
+     */
+    public function testGetOptionByCodeNonExistent(): void
     {
         $this->assertNull($this->model->getOptionByCode('random'));
     }
 
-    public function testGetOptionByCodeDeletedCode()
+    /**
+     * @return void
+     */
+    public function testGetOptionByCodeDeletedCode(): void
     {
         $optionCode = 1234;
 
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setItem', 'getCode', '__wakeup', 'isDeleted'])
+            ->onlyMethods(['setItem', '__wakeup', 'isDeleted'])
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->once())
@@ -1040,12 +1139,16 @@ class ItemTest extends TestCase
         $this->assertNull($this->model->getOptionByCode($optionCode));
     }
 
-    public function testGetOptionByCodeNotDeletedCode()
+    /**
+     * @return void
+     */
+    public function testGetOptionByCodeNotDeletedCode(): void
     {
         $optionCode = 1234;
 
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setItem', 'getCode', '__wakeup', 'isDeleted'])
+            ->onlyMethods(['setItem', '__wakeup', 'isDeleted'])
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->once())
@@ -1064,10 +1167,13 @@ class ItemTest extends TestCase
         $this->assertSame($optionMock, $this->model->getOptionByCode($optionCode));
     }
 
-    public function testGetBuyRequestNoOptionByCode()
+    /**
+     * @return void
+     */
+    public function testGetBuyRequestNoOptionByCode(): void
     {
         $quantity = 12;
-        $this->localeFormat->expects($this->at(0))
+        $this->localeFormat
             ->method('getNumber')
             ->with($quantity)
             ->willReturn($quantity);
@@ -1078,12 +1184,16 @@ class ItemTest extends TestCase
         $this->assertEquals($quantity, $buyRequest->getQty());
     }
 
-    public function testGetBuyRequestOptionByCode()
+    /**
+     * @return void
+     */
+    public function testGetBuyRequestOptionByCode(): void
     {
-        $optionCode = "info_buyRequest";
+        $optionCode = 'info_buyRequest';
         $buyRequestQuantity = 23;
         $optionMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setItem', 'getCode', '__wakeup', 'getValue'])
+            ->onlyMethods(['setItem', '__wakeup', 'getValue'])
+            ->addMethods(['getCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock->expects($this->once())
@@ -1100,7 +1210,7 @@ class ItemTest extends TestCase
         $this->model->addOption($optionMock);
 
         $quantity = 12;
-        $this->localeFormat->expects($this->at(0))
+        $this->localeFormat
             ->method('getNumber')
             ->with($quantity)
             ->willReturn($quantity);
@@ -1114,7 +1224,10 @@ class ItemTest extends TestCase
         $this->assertEquals($quantity, $buyRequest->getQty());
     }
 
-    public function testSetHasErrorFalse()
+    /**
+     * @return void
+     */
+    public function testSetHasErrorFalse(): void
     {
         $this->errorInfos->expects($this->once())
             ->method('clear');
@@ -1124,7 +1237,10 @@ class ItemTest extends TestCase
         $this->assertFalse($this->model->getHasError());
     }
 
-    public function testSetHasErrorTrue()
+    /**
+     * @return void
+     */
+    public function testSetHasErrorTrue(): void
     {
         $this->errorInfos->expects($this->once())
             ->method('addItem')
@@ -1136,11 +1252,14 @@ class ItemTest extends TestCase
         $this->assertEquals('', $this->model->getMessage());
     }
 
-    public function testAddErrorInfo()
+    /**
+     * @return void
+     */
+    public function testAddErrorInfo(): void
     {
         $origin = 'origin';
         $code = 1;
-        $message = "message";
+        $message = 'message';
         $additionalData = new DataObject();
         $additionalData->setTemp(true);
 
@@ -1154,7 +1273,10 @@ class ItemTest extends TestCase
         $this->assertEquals($message, $this->model->getMessage());
     }
 
-    public function testGetErrorInfos()
+    /**
+     * @return void
+     */
+    public function testGetErrorInfos(): void
     {
         $retValue = 'return value';
 
@@ -1165,17 +1287,19 @@ class ItemTest extends TestCase
         $this->assertEquals($retValue, $this->model->getErrorInfos());
     }
 
-    public function testRemoveErrorInfosByParams()
+    /**
+     * @return void
+     */
+    public function testRemoveErrorInfosByParams(): void
     {
-        $message = "message";
-        $message2 = "message2";
+        $message = 'message';
+        $message2 = 'message2';
 
-        $this->errorInfos->expects($this->at(0))
-            ->method('addItem')
-            ->with(null, null, $message);
-        $this->errorInfos->expects($this->at(1))
-            ->method('addItem')
-            ->with(null, null, $message2);
+        $this->errorInfos->method('addItem')
+            ->withConsecutive(
+                [null, null, $message],
+                [null, null, $message2]
+            );
         $this->assertEquals($this->model, $this->model->addErrorInfo(null, null, $message));
         $this->assertEquals($this->model, $this->model->addErrorInfo(null, null, $message2));
         $this->assertEquals($message . "\n" . $message2, $this->model->getMessage());
@@ -1196,17 +1320,19 @@ class ItemTest extends TestCase
         $this->assertEquals($message2, $this->model->getMessage());
     }
 
-    public function testRemoveErrorInfosByParamsAllErrorsRemoved()
+    /**
+     * @return void
+     */
+    public function testRemoveErrorInfosByParamsAllErrorsRemoved(): void
     {
-        $message = "message";
-        $message2 = "message2";
+        $message = 'message';
+        $message2 = 'message2';
 
-        $this->errorInfos->expects($this->at(0))
-            ->method('addItem')
-            ->with(null, null, $message);
-        $this->errorInfos->expects($this->at(1))
-            ->method('addItem')
-            ->with(null, null, $message2);
+        $this->errorInfos->method('addItem')
+            ->withConsecutive(
+                [null, null, $message],
+                [null, null, $message2]
+            );
         $this->assertEquals($this->model, $this->model->addErrorInfo(null, null, $message));
         $this->assertEquals($this->model, $this->model->addErrorInfo(null, null, $message2));
         $this->assertEquals($message . "\n" . $message2, $this->model->getMessage());
@@ -1230,8 +1356,10 @@ class ItemTest extends TestCase
 
     /**
      * Test method \Magento\Quote\Model\Quote\Item::saveItemOptions
+     *
+     * @return void
      */
-    public function testSaveItemOptions()
+    public function testSaveItemOptions(): void
     {
         $optionMockDeleted = $this->createOptionMock(100);
         $optionMockDeleted->expects(self::once())->method('isDeleted')->willReturn(true);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsReaderTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsReaderTest.php
@@ -48,6 +48,9 @@ class TotalsReaderTest extends TestCase
      */
     protected $collectorMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->totalFactoryMock =
@@ -63,7 +66,10 @@ class TotalsReaderTest extends TestCase
         );
     }
 
-    public function testFetch()
+    /**
+     * @return void
+     */
+    public function testFetch(): void
     {
         $total = [];
         $storeId = 1;
@@ -78,10 +84,8 @@ class TotalsReaderTest extends TestCase
         $this->totalMock->expects($this->once())->method('setData')->with([])->willReturnSelf();
         $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($storeId);
         $this->totalFactoryMock
-            ->expects($this->at(0))
             ->method('create')
-            ->willReturn($this->totalMock);
-        $this->totalFactoryMock->expects($this->at(1))->method('create')->willReturn($testedTotalMock);
+            ->willReturnOnConsecutiveCalls($this->totalMock, $testedTotalMock);
         $this->collectionListMock
             ->expects($this->once())
             ->method('getCollectors')
@@ -96,7 +100,10 @@ class TotalsReaderTest extends TestCase
         $this->assertEquals($expected, $this->model->fetch($this->quoteMock, $total));
     }
 
-    public function testFetchWithEmptyData()
+    /**
+     * @return void
+     */
+    public function testFetchWithEmptyData(): void
     {
         $total = [];
         $storeId = 1;
@@ -118,7 +125,10 @@ class TotalsReaderTest extends TestCase
         $this->assertEquals([], $this->model->fetch($this->quoteMock, $total));
     }
 
-    public function testFetchSeveralCollectors()
+    /**
+     * @return void
+     */
+    public function testFetchSeveralCollectors(): void
     {
         $total = [];
         $storeId = 1;
@@ -139,11 +149,8 @@ class TotalsReaderTest extends TestCase
         $this->totalMock->expects($this->once())->method('setData')->with([])->willReturnSelf();
         $this->quoteMock->expects($this->once())->method('getStoreId')->willReturn($storeId);
         $this->totalFactoryMock
-            ->expects($this->at(0))
             ->method('create')
-            ->willReturn($this->totalMock);
-        $this->totalFactoryMock->expects($this->at(1))->method('create')->willReturn($firstTotalMock);
-        $this->totalFactoryMock->expects($this->at(2))->method('create')->willReturn($secondTotalMock);
+            ->willReturnOnConsecutiveCalls($this->totalMock, $firstTotalMock, $secondTotalMock);
         $this->collectionListMock
             ->expects($this->once())
             ->method('getCollectors')
@@ -160,7 +167,10 @@ class TotalsReaderTest extends TestCase
         $this->assertEquals($expected, $this->model->fetch($this->quoteMock, $total));
     }
 
-    public function testConvert()
+    /**
+     * @return void
+     */
+    public function testConvert(): void
     {
         $total = [];
         $storeId = 1;

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Validator/MinimumOrderAmount/ValidationMessageTest.php
@@ -45,6 +45,9 @@ class ValidationMessageTest extends TestCase
      */
     private $priceHelperMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
@@ -60,19 +63,21 @@ class ValidationMessageTest extends TestCase
         );
     }
 
-    public function testGetMessage()
+    /**
+     * @return void
+     */
+    public function testGetMessage(): void
     {
         $minimumAmount = 20;
         $minimumAmountCurrency = '$20';
-        $this->scopeConfigMock->expects($this->at(0))
-            ->method('getValue')
-            ->with('sales/minimum_order/description', ScopeInterface::SCOPE_STORE)
-            ->willReturn(null);
 
-        $this->scopeConfigMock->expects($this->at(1))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with('sales/minimum_order/amount', ScopeInterface::SCOPE_STORE)
-            ->willReturn($minimumAmount);
+            ->withConsecutive(
+                ['sales/minimum_order/description', ScopeInterface::SCOPE_STORE],
+                ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE]
+            )
+            ->willReturnOnConsecutiveCalls(null, $minimumAmount);
 
         $this->priceHelperMock->expects($this->once())
             ->method('currency')
@@ -81,7 +86,11 @@ class ValidationMessageTest extends TestCase
 
         $this->assertEquals(__('Minimum order amount is %1', $minimumAmountCurrency), $this->model->getMessage());
     }
-    public function testGetConfigMessage()
+
+    /**
+     * @return void
+     */
+    public function testGetConfigMessage(): void
     {
         $configMessage = 'config_message';
         $this->scopeConfigMock->expects($this->once())

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -22,6 +22,7 @@ use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\StateException;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Quote\Api\CartRepositoryInterface;
@@ -45,7 +46,6 @@ use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderInterfaceFactory;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\StoreManagerInterface;
@@ -196,6 +196,8 @@ class QuoteManagementTest extends TestCase
     private $quoteIdMaskFactoryMock;
 
     /**
+     * @inheriDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -315,7 +317,10 @@ class QuoteManagementTest extends TestCase
         $this->remoteAddressMock = $this->createMock(RemoteAddress::class);
     }
 
-    public function testCreateEmptyCartAnonymous()
+    /**
+     * @return void
+     */
+    public function testCreateEmptyCartAnonymous(): void
     {
         $storeId = 345;
         $quoteId = 2311;
@@ -345,7 +350,10 @@ class QuoteManagementTest extends TestCase
         $this->assertEquals($quoteId, $this->model->createEmptyCart());
     }
 
-    public function testCreateEmptyCartForCustomer()
+    /**
+     * @return void
+     */
+    public function testCreateEmptyCartForCustomer(): void
     {
         $storeId = 345;
         $quoteId = 2311;
@@ -359,7 +367,8 @@ class QuoteManagementTest extends TestCase
             ->with($userId)
             ->willThrowException(new NoSuchEntityException());
         $customer = $this->getMockBuilder(CustomerInterface::class)
-            ->setMethods(['getDefaultBilling'])->disableOriginalConstructor()
+            ->onlyMethods(['getDefaultBilling'])
+            ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $quoteAddress = $this->createPartialMock(
             Address::class,
@@ -383,7 +392,10 @@ class QuoteManagementTest extends TestCase
         $this->assertEquals($quoteId, $this->model->createEmptyCartForCustomer($userId));
     }
 
-    public function testCreateEmptyCartForCustomerReturnExistsQuote()
+    /**
+     * @return void
+     */
+    public function testCreateEmptyCartForCustomerReturnExistsQuote(): void
     {
         $storeId = 345;
         $userId = 567;
@@ -396,7 +408,8 @@ class QuoteManagementTest extends TestCase
             ->with($userId)->willReturn($quoteMock);
 
         $customer = $this->getMockBuilder(CustomerInterface::class)
-            ->setMethods(['getDefaultBilling'])->disableOriginalConstructor()
+            ->onlyMethods(['getDefaultBilling'])
+            ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $quoteAddress = $this->createPartialMock(
             Address::class,
@@ -416,9 +429,12 @@ class QuoteManagementTest extends TestCase
         $this->model->createEmptyCartForCustomer($userId);
     }
 
-    public function testAssignCustomerFromAnotherStore()
+    /**
+     * @return void
+     */
+    public function testAssignCustomerFromAnotherStore(): void
     {
-        $this->expectException('Magento\Framework\Exception\StateException');
+        $this->expectException(StateException::class);
         $this->expectExceptionMessage(
             'The customer can\'t be assigned to the cart. The cart belongs to a different store.'
         );
@@ -460,9 +476,12 @@ class QuoteManagementTest extends TestCase
         $this->model->assignCustomer($cartId, $customerId, $storeId);
     }
 
-    public function testAssignCustomerToNonanonymousCart()
+    /**
+     * @return void
+     */
+    public function testAssignCustomerToNonanonymousCart(): void
     {
-        $this->expectException('Magento\Framework\Exception\StateException');
+        $this->expectException(StateException::class);
         $this->expectExceptionMessage('The customer can\'t be assigned to the cart because the cart isn\'t anonymous.');
         $cartId = 220;
         $customerId = 455;
@@ -508,9 +527,12 @@ class QuoteManagementTest extends TestCase
         $this->model->assignCustomer($cartId, $customerId, $storeId);
     }
 
-    public function testAssignCustomerNoSuchCustomer()
+    /**
+     * @return void
+     */
+    public function testAssignCustomerNoSuchCustomer(): void
     {
-        $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
+        $this->expectException(NoSuchEntityException::class);
         $cartId = 220;
         $customerId = 455;
         $storeId = 5;
@@ -540,7 +562,10 @@ class QuoteManagementTest extends TestCase
         $this->model->assignCustomer($cartId, $customerId, $storeId);
     }
 
-    public function testAssignCustomerWithActiveCart()
+    /**
+     * @return void
+     */
+    public function testAssignCustomerWithActiveCart(): void
     {
         $cartId = 220;
         $customerId = 455;
@@ -616,7 +641,10 @@ class QuoteManagementTest extends TestCase
         $this->model->assignCustomer($cartId, $customerId, $storeId);
     }
 
-    public function testAssignCustomer()
+    /**
+     * @return void
+     */
+    public function testAssignCustomer(): void
     {
         $cartId = 220;
         $customerId = 455;
@@ -686,7 +714,10 @@ class QuoteManagementTest extends TestCase
         $this->model->assignCustomer($cartId, $customerId, $storeId);
     }
 
-    public function testSubmit()
+    /**
+     * @return void
+     */
+    public function testSubmit(): void
     {
         $orderData = [];
         $isGuest = true;
@@ -729,26 +760,24 @@ class QuoteManagementTest extends TestCase
             ->method('convert')
             ->with($shippingAddress, $orderData)
             ->willReturn($baseOrder);
-        $this->quoteAddressToOrderAddress->expects($this->at(0))
+        $this->quoteAddressToOrderAddress
             ->method('convert')
-            ->with(
-                $shippingAddress,
+            ->withConsecutive(
                 [
-                    'address_type' => 'shipping',
-                    'email' => 'customer@example.com'
-                ]
-            )
-            ->willReturn($convertedShipping);
-        $this->quoteAddressToOrderAddress->expects($this->at(1))
-            ->method('convert')
-            ->with(
-                $billingAddress,
+                    $shippingAddress,
+                    [
+                        'address_type' => 'shipping',
+                        'email' => 'customer@example.com'
+                    ]
+                ],
                 [
-                    'address_type' => 'billing',
-                    'email' => 'customer@example.com'
+                    $billingAddress,
+                    [
+                        'address_type' => 'billing',
+                        'email' => 'customer@example.com'
+                    ]
                 ]
-            )
-            ->willReturn($convertedBilling);
+            )->willReturnOnConsecutiveCalls($convertedShipping, $convertedBilling);
         $billingAddress->expects($this->once())->method('getId')->willReturn(4);
         $convertedBilling->expects($this->once())->method('setData')->with('quote_address_id', 4);
 
@@ -774,17 +803,26 @@ class QuoteManagementTest extends TestCase
             ->method('place')
             ->with($order)
             ->willReturn($order);
-        $this->eventManager->expects($this->at(0))
+        $this->eventManager
             ->method('dispatch')
-            ->with('sales_model_service_quote_submit_before', ['order' => $order, 'quote' => $quote]);
-        $this->eventManager->expects($this->at(1))
-            ->method('dispatch')
-            ->with('sales_model_service_quote_submit_success', ['order' => $order, 'quote' => $quote]);
+            ->withConsecutive(
+                [
+                    'sales_model_service_quote_submit_before',
+                    ['order' => $order, 'quote' => $quote]
+                ],
+                [
+                    'sales_model_service_quote_submit_success',
+                    ['order' => $order, 'quote' => $quote]
+                ]
+            );
         $this->quoteRepositoryMock->expects($this->once())->method('save')->with($quote);
         $this->assertEquals($order, $this->model->submit($quote, $orderData));
     }
 
-    public function testPlaceOrderIfCustomerIsGuest()
+    /**
+     * @return void
+     */
+    public function testPlaceOrderIfCustomerIsGuest(): void
     {
         $cartId = 100;
         $orderId = 332;
@@ -820,7 +858,7 @@ class QuoteManagementTest extends TestCase
 
         /** @var MockObject|QuoteManagement $service */
         $service = $this->getMockBuilder(QuoteManagement::class)
-            ->setMethods(['submit'])
+            ->onlyMethods(['submit'])
             ->setConstructorArgs(
                 [
                     'eventManager' => $this->eventManager,
@@ -846,7 +884,7 @@ class QuoteManagementTest extends TestCase
                     'quoteIdMaskFactory' => $this->quoteIdMaskFactoryMock,
                     'addressRepository' => $this->addressRepositoryMock,
                     'request' => $this->requestMock,
-                    'remoteAddress' => $this->remoteAddressMock,
+                    'remoteAddress' => $this->remoteAddressMock
                 ]
             )
             ->getMock();
@@ -874,9 +912,10 @@ class QuoteManagementTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPlaceOrder()
+    public function testPlaceOrder(): void
     {
         $cartId = 323;
         $orderId = 332;
@@ -887,7 +926,7 @@ class QuoteManagementTest extends TestCase
 
         /** @var MockObject|QuoteManagement $service */
         $service = $this->getMockBuilder(QuoteManagement::class)
-            ->setMethods(['submit'])
+            ->onlyMethods(['submit'])
             ->setConstructorArgs(
                 [
                     'eventManager' => $this->eventManager,
@@ -913,7 +952,7 @@ class QuoteManagementTest extends TestCase
                     'quoteIdMaskFactory' => $this->quoteIdMaskFactoryMock,
                     'addressRepository' => $this->addressRepositoryMock,
                     'request' => $this->requestMock,
-                    'remoteAddress' => $this->remoteAddressMock,
+                    'remoteAddress' => $this->remoteAddressMock
                 ]
             )
             ->getMock();
@@ -978,26 +1017,27 @@ class QuoteManagementTest extends TestCase
     }
 
     /**
-     * @param $isGuest
-     * @param $isVirtual
+     * @param bool $isGuest
+     * @param bool $isVirtual
      * @param Address $billingAddress
      * @param Payment $payment
-     * @param $customerId
-     * @param $id
+     * @param int $customerId
+     * @param int $id
      * @param array $quoteItems
      * @param Address|null $shippingAddress
+     *
      * @return MockObject
      */
     protected function getQuote(
-        $isGuest,
-        $isVirtual,
+        bool $isGuest,
+        bool $isVirtual,
         Address $billingAddress,
         Payment $payment,
-        $customerId,
-        $id,
+        int $customerId,
+        int $id,
         array $quoteItems,
         Address $shippingAddress = null
-    ) {
+    ): MockObject {
         $quote = $this->getMockBuilder(Quote::class)
             ->addMethods(['getCustomerEmail', 'getCustomerId'])
             ->onlyMethods(
@@ -1075,22 +1115,24 @@ class QuoteManagementTest extends TestCase
      * @param OrderInterface $baseOrder
      * @param OrderAddressInterface $billingAddress
      * @param array $addresses
-     * @param $payment
+     * @param OrderPaymentInterface $payment
      * @param array $items
-     * @param $quoteId
-     * @param OrderAddressInterface $shippingAddress
+     * @param int $quoteId
+     * @param OrderAddressInterface|null $shippingAddress
+     * @param int|null $customerId
+     *
      * @return MockObject
      */
     protected function prepareOrderFactory(
         OrderInterface $baseOrder,
         OrderAddressInterface $billingAddress,
         array $addresses,
-        $payment,
+        OrderPaymentInterface $payment,
         array $items,
-        $quoteId,
+        int $quoteId,
         OrderAddressInterface $shippingAddress = null,
-        $customerId = null
-    ) {
+        int $customerId = null
+    ): MockObject {
         $order = $this->getMockBuilder(Order::class)
             ->addMethods(['addAddresses', 'setAddresses'])
             ->onlyMethods(
@@ -1137,9 +1179,10 @@ class QuoteManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @return void
+     * @throws NoSuchEntityException
      */
-    public function testGetCartForCustomer()
+    public function testGetCartForCustomer(): void
     {
         $customerId = 100;
         $cartMock = $this->createMock(Quote::class);
@@ -1186,9 +1229,10 @@ class QuoteManagementTest extends TestCase
     /**
      * Test submit for customer
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSubmitForCustomer()
+    public function testSubmitForCustomer(): void
     {
         $orderData = [];
         $isGuest = false;
@@ -1230,26 +1274,25 @@ class QuoteManagementTest extends TestCase
             ->method('convert')
             ->with($shippingAddress, $orderData)
             ->willReturn($baseOrder);
-        $this->quoteAddressToOrderAddress->expects($this->at(0))
+        $this->quoteAddressToOrderAddress
             ->method('convert')
-            ->with(
-                $shippingAddress,
+            ->withConsecutive(
                 [
-                    'address_type' => 'shipping',
-                    'email' => 'customer@example.com'
+                    $shippingAddress,
+                    [
+                        'address_type' => 'shipping',
+                        'email' => 'customer@example.com'
+                    ]
+                ],
+                [
+                    $billingAddress,
+                    [
+                        'address_type' => 'billing',
+                        'email' => 'customer@example.com'
+                    ]
                 ]
             )
-            ->willReturn($convertedShipping);
-        $this->quoteAddressToOrderAddress->expects($this->at(1))
-            ->method('convert')
-            ->with(
-                $billingAddress,
-                [
-                    'address_type' => 'billing',
-                    'email' => 'customer@example.com'
-                ]
-            )
-            ->willReturn($convertedBilling);
+            ->willReturnOnConsecutiveCalls($convertedShipping, $convertedBilling);
         $this->quoteItemToOrderItem->expects($this->once())->method('convert')
             ->with($quoteItem, ['parent_item' => null])
             ->willReturn($convertedQuoteItem);
@@ -1280,12 +1323,18 @@ class QuoteManagementTest extends TestCase
             ->method('place')
             ->with($order)
             ->willReturn($order);
-        $this->eventManager->expects($this->at(0))
+        $this->eventManager
             ->method('dispatch')
-            ->with('sales_model_service_quote_submit_before', ['order' => $order, 'quote' => $quote]);
-        $this->eventManager->expects($this->at(1))
-            ->method('dispatch')
-            ->with('sales_model_service_quote_submit_success', ['order' => $order, 'quote' => $quote]);
+            ->withConsecutive(
+                [
+                    'sales_model_service_quote_submit_before',
+                    ['order' => $order, 'quote' => $quote]
+                ],
+                [
+                    'sales_model_service_quote_submit_success',
+                    ['order' => $order, 'quote' => $quote]
+                ]
+            );
         $this->quoteRepositoryMock->expects($this->once())->method('save')->with($quote);
         $this->assertEquals($order, $this->model->submit($quote, $orderData));
     }
@@ -1298,7 +1347,7 @@ class QuoteManagementTest extends TestCase
      *
      * @return MockObject
      */
-    private function createPartialMockForAbstractClass($className, $methods = [])
+    private function createPartialMockForAbstractClass(string $className, array $methods = []): MockObject
     {
         return $this->getMockForAbstractClass(
             $className,

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteTest.php
@@ -191,6 +191,8 @@ class QuoteTest extends TestCase
     private $orderIncrementIdChecker;
 
     /**
+     * @inheritDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -263,7 +265,7 @@ class QuoteTest extends TestCase
             ->getMock();
         $this->customerFactoryMock = $this->getMockBuilder(CustomerFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->groupRepositoryMock = $this->getMockBuilder(GroupRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -338,8 +340,8 @@ class QuoteTest extends TestCase
                     'itemProcessor' => $this->itemProcessor,
                     'orderIncrementIdChecker' => $this->orderIncrementIdChecker,
                     'data' => [
-                        'reserved_order_id' => 1000001,
-                    ],
+                        'reserved_order_id' => 1000001
+                    ]
                 ]
             );
     }
@@ -347,9 +349,11 @@ class QuoteTest extends TestCase
     /**
      * @param array $addresses
      * @param bool $expected
+     *
+     * @return void
      * @dataProvider isMultipleShippingAddressesDataProvider
      */
-    public function testIsMultipleShippingAddresses($addresses, $expected)
+    public function testIsMultipleShippingAddresses($addresses, $expected): void
     {
         $this->quoteAddressCollectionMock->expects(
             $this->any()
@@ -371,8 +375,10 @@ class QuoteTest extends TestCase
 
     /**
      * Customer group ID is not set to quote object and customer data is not available.
+     *
+     * @return void
      */
-    public function testGetCustomerGroupIdNotSet()
+    public function testGetCustomerGroupIdNotSet(): void
     {
         $this->assertEquals(
             GroupManagement::NOT_LOGGED_IN_ID,
@@ -383,8 +389,10 @@ class QuoteTest extends TestCase
 
     /**
      * Customer group ID is set to quote object.
+     *
+     * @return void
      */
-    public function testGetCustomerGroupId()
+    public function testGetCustomerGroupId(): void
     {
         /** Preconditions */
         $customerGroupId = 33;
@@ -397,7 +405,7 @@ class QuoteTest extends TestCase
     /**
      * @return array
      */
-    public function isMultipleShippingAddressesDataProvider()
+    public function isMultipleShippingAddressesDataProvider(): array
     {
         return [
             [
@@ -413,9 +421,10 @@ class QuoteTest extends TestCase
 
     /**
      * @param string $type One of \Magento\Customer\Model\Address\AbstractAddress::TYPE_ const
+     *
      * @return MockObject
      */
-    protected function getAddressMock($type)
+    protected function getAddressMock($type): MockObject
     {
         $shippingAddressMock = $this->getMockBuilder(Address::class)
             ->addMethods(['getAddressType'])
@@ -428,7 +437,10 @@ class QuoteTest extends TestCase
         return $shippingAddressMock;
     }
 
-    public function testGetStoreIdNoId()
+    /**
+     * @return void
+     */
+    public function testGetStoreIdNoId(): void
     {
         $storeMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
@@ -444,7 +456,10 @@ class QuoteTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testGetStoreId()
+    /**
+     * @return void
+     */
+    public function testGetStoreId(): void
     {
         $storeId = 1;
 
@@ -452,7 +467,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($storeId, $result);
     }
 
-    public function testGetStore()
+    /**
+     * @return void
+     */
+    public function testGetStore(): void
     {
         $storeId = 1;
 
@@ -469,7 +487,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Store::class, $result);
     }
 
-    public function testSetStore()
+    /**
+     * @return void
+     */
+    public function testSetStore(): void
     {
         $storeId = 1;
 
@@ -484,7 +505,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Quote::class, $result);
     }
 
-    public function testGetSharedWebsiteStoreIds()
+    /**
+     * @return void
+     */
+    public function testGetSharedWebsiteStoreIds(): void
     {
         $sharedIds = null;
         $storeIds = [1, 2, 3];
@@ -502,7 +526,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($storeIds, $result);
     }
 
-    public function testGetSharedStoreIds()
+    /**
+     * @return void
+     */
+    public function testGetSharedStoreIds(): void
     {
         $sharedIds = null;
         $storeIds = [1, 2, 3];
@@ -533,7 +560,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($storeIds, $result);
     }
 
-    public function testLoadActive()
+    /**
+     * @return void
+     */
+    public function testLoadActive(): void
     {
         $quoteId = 1;
 
@@ -548,7 +578,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Quote::class, $result);
     }
 
-    public function testloadByIdWithoutStore()
+    /**
+     * @return void
+     */
+    public function testloadByIdWithoutStore(): void
     {
         $quoteId = 1;
 
@@ -564,9 +597,10 @@ class QuoteTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function testSetCustomerAddressData()
+    public function testSetCustomerAddressData(): void
     {
         $customerId = 1;
         $addressMock = $this->getMockForAbstractClass(
@@ -625,7 +659,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($customerResultMock, $this->quote->getCustomer());
     }
 
-    public function testGetCustomerTaxClassId()
+    /**
+     * @return void
+     */
+    public function testGetCustomerTaxClassId(): void
     {
         $groupId = 1;
         $taxClassId = 1;
@@ -646,18 +683,17 @@ class QuoteTest extends TestCase
      * Test case when non-existent customer group is stored into the quote.
      * In such a case we should get a NoSuchEntityException exception and try
      * to get a valid customer group from the current customer object.
+     *
+     * @return void
      */
-    public function testGetCustomerTaxClassIdForNonExistentCustomerGroup()
+    public function testGetCustomerTaxClassIdForNonExistentCustomerGroup(): void
     {
         $customerId = 1;
         $nonExistentGroupId = 100;
         $groupId = 1;
         $taxClassId = 1;
         $groupMock = $this->getMockForAbstractClass(GroupInterface::class, [], '', false);
-        $this->groupRepositoryMock->expects($this->at(0))
-            ->method('getById')
-            ->with($nonExistentGroupId)
-            ->willThrowException(new NoSuchEntityException(new Phrase('Entity Id does not exist')));
+
         $customerMock = $this->getMockForAbstractClass(
             CustomerInterface::class,
             [],
@@ -671,10 +707,15 @@ class QuoteTest extends TestCase
             ->method('getById')
             ->with($customerId)
             ->willReturn($customerMock);
-        $this->groupRepositoryMock->expects($this->at(1))
+
+        $this->groupRepositoryMock
             ->method('getById')
-            ->with($groupId)
-            ->willReturn($groupMock);
+            ->withConsecutive([$nonExistentGroupId], [$groupId])
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new NoSuchEntityException(new Phrase('Entity Id does not exist'))),
+                $groupMock
+            );
+
         $groupMock->expects($this->once())
             ->method('getTaxClassId')
             ->willReturn($taxClassId);
@@ -684,7 +725,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($taxClassId, $result);
     }
 
-    public function testGetAllAddresses()
+    /**
+     * @return void
+     */
+    public function testGetAllAddresses(): void
     {
         $id = 1;
         $this->quoteAddressCollectionMock->expects($this->once())
@@ -706,9 +750,10 @@ class QuoteTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataProviderGetAddress
      */
-    public function testGetAddressById($addressId, $expected)
+    public function testGetAddressById($addressId, $expected): void
     {
         $id = 1;
         $this->quoteAddressCollectionMock->expects($this->once())
@@ -733,7 +778,7 @@ class QuoteTest extends TestCase
     /**
      * @return array
      */
-    public static function dataProviderGetAddress()
+    public static function dataProviderGetAddress(): array
     {
         return [
             [1, true],
@@ -746,9 +791,10 @@ class QuoteTest extends TestCase
      * @param $customerAddressId
      * @param $expected
      *
+     * @return void
      * @dataProvider dataProviderGetAddressByCustomer
      */
-    public function testGetAddressByCustomerAddressId($isDeleted, $customerAddressId, $expected)
+    public function testGetAddressByCustomerAddressId($isDeleted, $customerAddressId, $expected): void
     {
         $id = 1;
         $this->quoteAddressCollectionMock->expects($this->once())
@@ -776,7 +822,7 @@ class QuoteTest extends TestCase
     /**
      * @return array
      */
-    public static function dataProviderGetAddressByCustomer()
+    public static function dataProviderGetAddressByCustomer(): array
     {
         return [
             [false, 1, true],
@@ -790,10 +836,15 @@ class QuoteTest extends TestCase
      * @param $customerAddressId
      * @param $expected
      *
+     * @return void
      * @dataProvider dataProviderShippingAddress
      */
-    public function testGetShippingAddressByCustomerAddressId($isDeleted, $addressType, $customerAddressId, $expected)
-    {
+    public function testGetShippingAddressByCustomerAddressId(
+        $isDeleted,
+        $addressType,
+        $customerAddressId,
+        $expected
+    ): void {
         $id = 1;
 
         $this->quoteAddressCollectionMock->expects($this->once())
@@ -824,15 +875,18 @@ class QuoteTest extends TestCase
     /**
      * @return array
      */
-    public static function dataProviderShippingAddress()
+    public static function dataProviderShippingAddress(): array
     {
         return [
             [false, AbstractAddress::TYPE_SHIPPING, 1, true],
-            [false, AbstractAddress::TYPE_SHIPPING, 2, false],
+            [false, AbstractAddress::TYPE_SHIPPING, 2, false]
         ];
     }
 
-    public function testRemoveAddress()
+    /**
+     * @return void
+     */
+    public function testRemoveAddress(): void
     {
         $id = 1;
 
@@ -858,7 +912,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Quote::class, $result);
     }
 
-    public function testRemoveAllAddresses()
+    /**
+     * @return void
+     */
+    public function testRemoveAllAddresses(): void
     {
         $id = 1;
 
@@ -899,13 +956,19 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Quote::class, $result);
     }
 
-    public function testAddProductException()
+    /**
+     * @return void
+     */
+    public function testAddProductException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->quote->addProduct($this->productMock, 'test');
     }
 
-    public function testAddProductNoCandidates()
+    /**
+     * @return void
+     */
+    public function testAddProductNoCandidates(): void
     {
         $expectedResult = 'test_string';
         $requestMock = $this->createMock(
@@ -937,7 +1000,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testAddProductItemPreparation()
+    /**
+     * @return void
+     */
+    public function testAddProductItemPreparation(): void
     {
         $itemMock = $this->createMock(Item::class);
 
@@ -993,7 +1059,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testAddProductItemNew()
+    /**
+     * @return void
+     */
+    public function testAddProductItemNew(): void
     {
         $itemMock = $this->createMock(Item::class);
 
@@ -1059,7 +1128,10 @@ class QuoteTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testValidateMinimumAmount()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmount(): void
     {
         $storeId = 1;
         $this->quote->setStoreId($storeId);
@@ -1069,7 +1141,7 @@ class QuoteTest extends TestCase
             ['sales/minimum_order/multi_address', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
         $this->scopeConfig->expects($this->any())
             ->method('isSetFlag')
@@ -1086,7 +1158,10 @@ class QuoteTest extends TestCase
         $this->assertTrue($this->quote->validateMinimumAmount());
     }
 
-    public function testValidateMinimumAmountNegative()
+    /**
+     * @return void
+     */
+    public function testValidateMinimumAmountNegative(): void
     {
         $storeId = 1;
         $this->quote->setStoreId($storeId);
@@ -1096,7 +1171,7 @@ class QuoteTest extends TestCase
             ['sales/minimum_order/multi_address', ScopeInterface::SCOPE_STORE, $storeId, true],
             ['sales/minimum_order/amount', ScopeInterface::SCOPE_STORE, $storeId, 20],
             ['sales/minimum_order/include_discount_amount', ScopeInterface::SCOPE_STORE, $storeId, true],
-            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true],
+            ['sales/minimum_order/tax_including', ScopeInterface::SCOPE_STORE, $storeId, true]
         ];
         $this->scopeConfig->expects($this->any())
             ->method('isSetFlag')
@@ -1113,7 +1188,10 @@ class QuoteTest extends TestCase
         $this->assertFalse($this->quote->validateMinimumAmount());
     }
 
-    public function testGetPaymentIsNotDeleted()
+    /**
+     * @return void
+     */
+    public function testGetPaymentIsNotDeleted(): void
     {
         $this->quote->setId(1);
         $payment = $this->createPartialMock(
@@ -1142,7 +1220,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Payment::class, $this->quote->getPayment());
     }
 
-    public function testGetPaymentIsDeleted()
+    /**
+     * @return void
+     */
+    public function testGetPaymentIsDeleted(): void
     {
         $this->quote->setId(1);
         $payment = $this->createPartialMock(
@@ -1178,7 +1259,10 @@ class QuoteTest extends TestCase
         $this->assertInstanceOf(Payment::class, $this->quote->getPayment());
     }
 
-    public function testAddItem()
+    /**
+     * @return void
+     */
+    public function testAddItem(): void
     {
         $item = $this->createPartialMock(Item::class, ['setQuote', 'getId']);
         $item->expects($this->once())
@@ -1208,9 +1292,11 @@ class QuoteTest extends TestCase
     /**
      * @param array $productTypes
      * @param int $expected
+     *
+     * @return void
      * @dataProvider dataProviderForTestBeforeSaveIsVirtualQuote
      */
-    public function testBeforeSaveIsVirtualQuote(array $productTypes, $expected)
+    public function testBeforeSaveIsVirtualQuote(array $productTypes, $expected): void
     {
         $storeId = 1;
         $currencyMock = $this->getMockBuilder(Currency::class)
@@ -1276,7 +1362,7 @@ class QuoteTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestBeforeSaveIsVirtualQuote()
+    public function dataProviderForTestBeforeSaveIsVirtualQuote(): array
     {
         return [
             [[true], 1],
@@ -1287,11 +1373,14 @@ class QuoteTest extends TestCase
         ];
     }
 
-    public function testGetItemsCollection()
+    /**
+     * @return void
+     */
+    public function testGetItemsCollection(): void
     {
         $itemCollectionMock = $this->getMockBuilder(\Magento\Quote\Model\ResourceModel\Quote\Collection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setQuote'])
+            ->addMethods(['setQuote'])
             ->getMock();
         $this->quoteItemCollectionFactoryMock->expects($this->once())
             ->method('create')
@@ -1307,10 +1396,13 @@ class QuoteTest extends TestCase
         $this->quote->getItemsCollection();
     }
 
-    public function testGetAllItems()
+    /**
+     * @return void
+     */
+    public function testGetAllItems(): void
     {
         $itemOneMock = $this->getMockBuilder(\Magento\Quote\Model\ResourceModel\Quote\Item::class)
-            ->setMethods(['isDeleted'])
+            ->addMethods(['isDeleted'])
             ->disableOriginalConstructor()
             ->getMock();
         $itemOneMock->expects($this->once())
@@ -1318,7 +1410,7 @@ class QuoteTest extends TestCase
             ->willReturn(false);
 
         $itemTwoMock = $this->getMockBuilder(\Magento\Quote\Model\ResourceModel\Quote\Item::class)
-            ->setMethods(['isDeleted'])
+            ->addMethods(['isDeleted'])
             ->disableOriginalConstructor()
             ->getMock();
         $itemTwoMock->expects($this->once())
@@ -1337,6 +1429,7 @@ class QuoteTest extends TestCase
      *
      * @param bool $isReservedOrderIdExist
      * @param int $reservedOrderId
+     *
      * @return void
      * @dataProvider reservedOrderIdDataProvider
      */
@@ -1358,7 +1451,7 @@ class QuoteTest extends TestCase
     {
         return [
             'id_already_in_use' => [true, 100002],
-            'id_not_in_use' => [false, 1000001],
+            'id_not_in_use' => [false, 1000001]
         ];
     }
 }

--- a/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/AccountsTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/AccountsTest.php
@@ -16,7 +16,7 @@ use Magento\Reports\Test\Unit\Controller\Adminhtml\Report\AbstractControllerTest
 class AccountsTest extends AbstractControllerTest
 {
     /**
-     * @var \Magento\Reports\Controller\Adminhtml\Report\Customer\Accounts
+     * @var Accounts
      */
     protected $accounts;
 
@@ -36,7 +36,7 @@ class AccountsTest extends AbstractControllerTest
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $titleMock = $this->getMockBuilder(Title::class)
             ->disableOriginalConstructor()
@@ -62,17 +62,12 @@ class AccountsTest extends AbstractControllerTest
             ->method('setActive')
             ->with('Magento_Reports::report_customers_accounts');
         $this->breadcrumbsBlockMock
-            ->expects($this->at(0))
             ->method('addLink')
-            ->with(new Phrase('Reports'), new Phrase('Reports'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(1))
-            ->method('addLink')
-            ->with(new Phrase('Customers'), new Phrase('Customers'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(2))
-            ->method('addLink')
-            ->with(new Phrase('New Accounts'), new Phrase('New Accounts'));
+            ->withConsecutive(
+                [new Phrase('Reports'), new Phrase('Reports')],
+                [new Phrase('Customers'), new Phrase('Customers')],
+                [new Phrase('New Accounts'), new Phrase('New Accounts')]
+            );
         $this->accounts->execute();
     }
 }

--- a/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/OrdersTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/OrdersTest.php
@@ -16,7 +16,7 @@ use Magento\Reports\Test\Unit\Controller\Adminhtml\Report\AbstractControllerTest
 class OrdersTest extends AbstractControllerTest
 {
     /**
-     * @var \Magento\Reports\Controller\Adminhtml\Report\Customer\Orders
+     * @var Orders
      */
     protected $orders;
 
@@ -36,7 +36,7 @@ class OrdersTest extends AbstractControllerTest
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $titleMock = $this->getMockBuilder(Title::class)
             ->disableOriginalConstructor()
@@ -62,17 +62,12 @@ class OrdersTest extends AbstractControllerTest
             ->method('setActive')
             ->with('Magento_Reports::report_customers_orders');
         $this->breadcrumbsBlockMock
-            ->expects($this->at(0))
             ->method('addLink')
-            ->with(new Phrase('Reports'), new Phrase('Reports'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(1))
-            ->method('addLink')
-            ->with(new Phrase('Customers'), new Phrase('Customers'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(2))
-            ->method('addLink')
-            ->with(new Phrase('Customers by Number of Orders'), new Phrase('Customers by Number of Orders'));
+            ->withConsecutive(
+                [new Phrase('Reports'), new Phrase('Reports')],
+                [new Phrase('Customers'), new Phrase('Customers')],
+                [new Phrase('Customers by Number of Orders'), new Phrase('Customers by Number of Orders')]
+            );
         $this->orders->execute();
     }
 }

--- a/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/TotalsTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Controller/Adminhtml/Report/Customer/TotalsTest.php
@@ -36,7 +36,7 @@ class TotalsTest extends AbstractControllerTest
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $titleMock = $this->getMockBuilder(Title::class)
             ->disableOriginalConstructor()
@@ -62,17 +62,12 @@ class TotalsTest extends AbstractControllerTest
             ->method('setActive')
             ->with('Magento_Reports::report_customers_totals');
         $this->breadcrumbsBlockMock
-            ->expects($this->at(0))
             ->method('addLink')
-            ->with(new Phrase('Reports'), new Phrase('Reports'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(1))
-            ->method('addLink')
-            ->with(new Phrase('Customers'), new Phrase('Customers'));
-        $this->breadcrumbsBlockMock
-            ->expects($this->at(2))
-            ->method('addLink')
-            ->with(new Phrase('Customers by Orders Total'), new Phrase('Customers by Orders Total'));
+            ->withConsecutive(
+                [new Phrase('Reports'), new Phrase('Reports')],
+                [new Phrase('Customers'), new Phrase('Customers')],
+                [new Phrase('Customers by Orders Total'), new Phrase('Customers by Orders Total')]
+            );
         $this->totals->execute();
     }
 }

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/EventTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/EventTest.php
@@ -106,7 +106,7 @@ class EventTest extends TestCase
     /**
      * @return void
      */
-    public function testUpdateCustomerTypeWithoutType()
+    public function testUpdateCustomerTypeWithoutType(): void
     {
         $eventMock = $this->getMockBuilder(\Magento\Reports\Model\Event::class)
             ->disableOriginalConstructor()
@@ -121,7 +121,7 @@ class EventTest extends TestCase
     /**
      * @return void
      */
-    public function testUpdateCustomerTypeWithType()
+    public function testUpdateCustomerTypeWithType(): void
     {
         $eventMock = $this->getMockBuilder(\Magento\Reports\Model\Event::class)
             ->disableOriginalConstructor()
@@ -134,20 +134,20 @@ class EventTest extends TestCase
     }
 
     /**
-     * @dataProvider getApplyLogToCollectionDataProvider
-     * @param null|array $storeId
-     * @param null|array $storeIdSelect
+     * @param int|null $storeId
+     * @param array|null $storeIdSelect
      *
      * @return void
+     * @dataProvider getApplyLogToCollectionDataProvider
      */
-    public function testApplyLogToCollection($storeId, $storeIdSelect)
+    public function testApplyLogToCollection(?int $storeId, ?array $storeIdSelect): void
     {
         $derivedSelect = 'SELECT * FROM table';
         $idFieldName = 'IdFieldName';
 
         $collectionSelectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
-            ->setMethods(['joinInner', 'order'])
+            ->onlyMethods(['joinInner', 'order'])
             ->getMock();
         $collectionSelectMock
             ->expects($this->once())
@@ -164,7 +164,8 @@ class EventTest extends TestCase
             ->willReturnSelf();
 
         $collectionMock = $this->getMockBuilder(AbstractDb::class)
-            ->setMethods(['getResource', 'getIdFieldName', 'getSelect', 'getStoreId'])
+            ->onlyMethods(['getResource', 'getIdFieldName', 'getSelect'])
+            ->addMethods(['getStoreId'])
             ->disableOriginalConstructor()
             ->getMock();
         $collectionMock
@@ -186,7 +187,7 @@ class EventTest extends TestCase
 
         $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
-            ->setMethods(['from', 'where', 'group', 'joinInner', '__toString'])
+            ->onlyMethods(['where', '__toString', 'from', 'group', 'joinInner'])
             ->getMock();
         $selectMock
             ->expects($this->once())
@@ -230,17 +231,17 @@ class EventTest extends TestCase
     /**
      * @return array
      */
-    public function getApplyLogToCollectionDataProvider()
+    public function getApplyLogToCollectionDataProvider(): array
     {
         return [
             ['storeId' => 1, 'storeIdSelect' => [1]],
-            ['storeId' => null, 'storeIdSelect' => [1]],
+            ['storeId' => null, 'storeIdSelect' => [1]]
         ];
     }
     /**
      * @return void
      */
-    public function testClean()
+    public function testClean(): void
     {
         $eventMock = $this->getMockBuilder(\Magento\Reports\Model\Event::class)
             ->disableOriginalConstructor()
@@ -248,13 +249,13 @@ class EventTest extends TestCase
 
         $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
-            ->setMethods(['select', 'from', 'joinLeft', 'where', 'limit', 'fetchCol'])
+            ->onlyMethods(['where', 'limit', 'from', 'joinLeft'])
+            ->addMethods(['select', 'fetchCol'])
             ->getMock();
 
         $this->connectionMock
-            ->expects($this->at(1))
             ->method('fetchCol')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(1);
         $this->connectionMock
             ->expects($this->any())
             ->method('delete');

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
@@ -142,7 +142,7 @@ class CollectionTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->orderFactoryMock = $this->getMockBuilder(OrderFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->selectMock = $this->getMockBuilder(Select::class)
@@ -170,7 +170,7 @@ class CollectionTest extends TestCase
             ->willReturn([]);
 
         $this->connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'getIfNullSql', 'getDateFormatSql', 'prepareSqlCondition', 'getCheckSql'])
+            ->onlyMethods(['select', 'getIfNullSql', 'getDateFormatSql', 'prepareSqlCondition', 'getCheckSql'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->connectionMock
@@ -206,7 +206,7 @@ class CollectionTest extends TestCase
     /**
      * @return void
      */
-    public function testCheckIsLive()
+    public function testCheckIsLive(): void
     {
         $range = '';
         $this->scopeConfigMock
@@ -225,10 +225,11 @@ class CollectionTest extends TestCase
      * @param string $mainTable
      * @param int $isFilter
      * @param InvokedCount $getIfNullSqlResult
-     * @dataProvider useAggregatedDataDataProvider
+     *
      * @return void
+     * @dataProvider useAggregatedDataDataProvider
      */
-    public function testPrepareSummary($useAggregatedData, $mainTable, $isFilter, $getIfNullSqlResult)
+    public function testPrepareSummary($useAggregatedData, $mainTable, $isFilter, $getIfNullSqlResult): void
     {
         $range = '';
         $customStart = 1;
@@ -253,9 +254,8 @@ class CollectionTest extends TestCase
             ->willReturn($orderMock);
 
         $this->resourceMock
-            ->expects($this->at(0))
             ->method('getTable')
-            ->with($mainTable);
+            ->withConsecutive([$mainTable]);
 
         $this->connectionMock
             ->expects($getIfNullSqlResult)
@@ -269,10 +269,11 @@ class CollectionTest extends TestCase
      * @param string $customStart
      * @param string $customEnd
      * @param string $expectedInterval
-     * @dataProvider firstPartDateRangeDataProvider
+     *
      * @return void
+     * @dataProvider firstPartDateRangeDataProvider
      */
-    public function testGetDateRangeFirstPart($range, $customStart, $customEnd, $expectedInterval)
+    public function testGetDateRangeFirstPart($range, $customStart, $customEnd, $expectedInterval): void
     {
         $timeZoneToReturn = date_default_timezone_get();
         date_default_timezone_set('UTC');
@@ -291,7 +292,7 @@ class CollectionTest extends TestCase
      * @dataProvider secondPartDateRangeDataProvider
      * @return void
      */
-    public function testGetDateRangeSecondPart($range, $customStart, $customEnd, $config)
+    public function testGetDateRangeSecondPart($range, $customStart, $customEnd, $config): void
     {
         $this->scopeConfigMock
             ->expects($this->once())
@@ -309,7 +310,7 @@ class CollectionTest extends TestCase
     /**
      * @return void
      */
-    public function testGetDateRangeWithReturnObject()
+    public function testGetDateRangeWithReturnObject(): void
     {
         $this->assertCount(2, $this->collection->getDateRange('7d', '', '', true));
         $this->assertCount(3, $this->collection->getDateRange('7d', '', '', false));
@@ -318,7 +319,7 @@ class CollectionTest extends TestCase
     /**
      * @return void
      */
-    public function testAddItemCountExpr()
+    public function testAddItemCountExpr(): void
     {
         $this->selectMock
             ->expects($this->once())
@@ -332,10 +333,11 @@ class CollectionTest extends TestCase
      * @param int $useAggregatedData
      * @param string $mainTable
      * @param InvokedCount $getIfNullSqlResult
-     * @dataProvider totalsDataProvider
+     *
      * @return void
+     * @dataProvider totalsDataProvider
      */
-    public function testCalculateTotals($isFilter, $useAggregatedData, $mainTable, $getIfNullSqlResult)
+    public function testCalculateTotals($isFilter, $useAggregatedData, $mainTable, $getIfNullSqlResult): void
     {
         $this->scopeConfigMock
             ->expects($this->once())
@@ -347,7 +349,6 @@ class CollectionTest extends TestCase
             ->willReturn($useAggregatedData);
 
         $this->resourceMock
-            ->expects($this->at(0))
             ->method('getTable')
             ->with($mainTable);
 
@@ -363,10 +364,11 @@ class CollectionTest extends TestCase
      * @param int $isFilter
      * @param string $useAggregatedData
      * @param string $mainTable
-     * @dataProvider salesDataProvider
+     *
      * @return void
+     * @dataProvider salesDataProvider
      */
-    public function testCalculateSales($isFilter, $useAggregatedData, $mainTable)
+    public function testCalculateSales($isFilter, $useAggregatedData, $mainTable): void
     {
         $this->scopeConfigMock
             ->expects($this->once())
@@ -387,7 +389,6 @@ class CollectionTest extends TestCase
             ->willReturn($storeMock);
 
         $this->resourceMock
-            ->expects($this->at(0))
             ->method('getTable')
             ->with($mainTable);
 
@@ -397,15 +398,14 @@ class CollectionTest extends TestCase
     /**
      * @return void
      */
-    public function testSetDateRange()
+    public function testSetDateRange(): void
     {
         $fromDate = '1';
         $toDate = '2';
 
         $this->connectionMock
-            ->expects($this->at(0))
             ->method('prepareSqlCondition')
-            ->with('`created_at`', ['from' => $fromDate, 'to' => $toDate]);
+            ->withConsecutive(['`created_at`', ['from' => $fromDate, 'to' => $toDate]]);
 
         $this->collection->setDateRange($fromDate, $toDate);
     }
@@ -413,10 +413,11 @@ class CollectionTest extends TestCase
     /**
      * @param array $storeIds
      * @param array $parameters
-     * @dataProvider storesDataProvider
+     *
      * @return void
+     * @dataProvider storesDataProvider
      */
-    public function testSetStoreIds($storeIds, $parameters)
+    public function testSetStoreIds($storeIds, $parameters): void
     {
         $this->connectionMock
             ->expects($this->any())
@@ -435,7 +436,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function useAggregatedDataDataProvider()
+    public function useAggregatedDataDataProvider(): array
     {
         return [
             [1, 'sales_order_aggregated_created', 0, $this->never()],
@@ -447,7 +448,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function firstPartDateRangeDataProvider()
+    public function firstPartDateRangeDataProvider(): array
     {
         return [
             ['', '', '', '0 0 0 23:59:59'],
@@ -459,7 +460,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function secondPartDateRangeDataProvider()
+    public function secondPartDateRangeDataProvider(): array
     {
         return [
             ['1m', 1, 10, 'reports/dashboard/mtd_start'],
@@ -471,7 +472,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function totalsDataProvider()
+    public function totalsDataProvider(): array
     {
         return [
             [1, 1, 'sales_order_aggregated_created', $this->never()],
@@ -484,7 +485,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function salesDataProvider()
+    public function salesDataProvider(): array
     {
         return [
             [1, 1, 'sales_order_aggregated_created'],
@@ -497,7 +498,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function storesDataProvider()
+    public function storesDataProvider(): array
     {
         $firstReturn = [
             'subtotal' => 'SUM(main_table.base_subtotal * main_table.base_to_global_rate)',
@@ -520,7 +521,7 @@ class CollectionTest extends TestCase
             'total' => 'SUM(main_table.base_grand_total)',
             'invoiced' => 'SUM(main_table.base_total_paid)',
             'refunded' => 'SUM(main_table.base_total_refunded)',
-            'profit' => 'SUM(text) + SUM(text) - SUM(text) - SUM(text) - SUM(text)',
+            'profit' => 'SUM(text) + SUM(text) - SUM(text) - SUM(text) - SUM(text)'
         ];
 
         return [

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/Product/ViewedTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Report/Product/ViewedTest.php
@@ -20,7 +20,7 @@ use Magento\Reports\Model\Flag;
 use Magento\Reports\Model\FlagFactory;
 use Magento\Reports\Model\ResourceModel\Helper;
 use Magento\Reports\Model\ResourceModel\Report\Product\Viewed;
-use PHPUnit\Framework\MockObject\Matcher\InvokedCount;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -102,29 +102,28 @@ class ViewedTest extends TestCase
     protected $flagMock;
 
     /**
+     * @inheritDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
-     * @return void
      */
     protected function setUp(): void
     {
         $this->zendDbMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)->getMock();
         $this->zendDbMock->expects($this->any())->method('fetchColumn')->willReturn([]);
 
-        $this->selectMock = $this->getMockBuilder(Select::class)
-            ->disableOriginalConstructor()
-            ->setMethods(
+        $this->selectMock = $this->getMockBuilder(Select::class)->disableOriginalConstructor()
+            ->onlyMethods(
                 [
-                    'from',
                     'where',
-                    'joinInner',
-                    'joinLeft',
                     'having',
                     'useStraightJoin',
                     'insertFromSelect',
-                    '__toString'
+                    '__toString',
+                    'from',
+                    'joinInner',
+                    'joinLeft'
                 ]
-            )
-            ->getMock();
+            )->getMock();
         $this->selectMock->expects($this->any())->method('from')->willReturnSelf();
         $this->selectMock->expects($this->any())->method('where')->willReturnSelf();
         $this->selectMock->expects($this->any())->method('joinInner')->willReturnSelf();
@@ -163,12 +162,13 @@ class ViewedTest extends TestCase
 
         $this->flagMock = $this->getMockBuilder(Flag::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setReportFlagCode', 'unsetData', 'loadSelf', 'setFlagData', 'setLastUpdate', 'save'])
+            ->onlyMethods(['setReportFlagCode', 'unsetData', 'loadSelf', 'setFlagData', 'save'])
+            ->addMethods(['setLastUpdate'])
             ->getMock();
 
         $this->flagFactoryMock = $this->getMockBuilder(FlagFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->flagFactoryMock->expects($this->any())->method('create')->willReturn($this->flagMock);
 
@@ -197,7 +197,7 @@ class ViewedTest extends TestCase
                 'localeDate' => $this->timezoneMock,
                 'reportsFlagFactory' => $this->flagFactoryMock,
                 'productResource' => $this->productMock,
-                'resourceHelper' => $this->helperMock,
+                'resourceHelper' => $this->helperMock
             ]
         );
     }
@@ -207,47 +207,40 @@ class ViewedTest extends TestCase
      * @param mixed $to
      * @param InvokedCount $truncateCount
      * @param InvokedCount $deleteCount
-     * @dataProvider intervalsDataProvider
+     *
      * @return void
+     * @dataProvider intervalsDataProvider
      */
-    public function testAggregate($from, $to, $truncateCount, $deleteCount)
+    public function testAggregate($from, $to, InvokedCount $truncateCount, InvokedCount $deleteCount): void
     {
         $this->connectionMock->expects($truncateCount)->method('truncateTable');
         $this->connectionMock->expects($deleteCount)->method('delete');
 
         $this->helperMock
-            ->expects($this->at(0))
             ->method('updateReportRatingPos')
-            ->with(
-                $this->connectionMock,
-                'day',
-                'views_num',
-                'report_viewed_product_aggregated_daily',
-                'report_viewed_product_aggregated_daily'
-            )
-            ->willReturnSelf();
-        $this->helperMock
-            ->expects($this->at(1))
-            ->method('updateReportRatingPos')
-            ->with(
-                $this->connectionMock,
-                'month',
-                'views_num',
-                'report_viewed_product_aggregated_daily',
-                'report_viewed_product_aggregated_monthly'
-            )
-            ->willReturnSelf();
-        $this->helperMock
-            ->expects($this->at(2))
-            ->method('updateReportRatingPos')
-            ->with(
-                $this->connectionMock,
-                'year',
-                'views_num',
-                'report_viewed_product_aggregated_daily',
-                'report_viewed_product_aggregated_yearly'
-            )
-            ->willReturnSelf();
+            ->withConsecutive(
+                [
+                    $this->connectionMock,
+                    'day',
+                    'views_num',
+                    'report_viewed_product_aggregated_daily',
+                    'report_viewed_product_aggregated_daily'
+                ],
+                [
+                    $this->connectionMock,
+                    'month',
+                    'views_num',
+                    'report_viewed_product_aggregated_daily',
+                    'report_viewed_product_aggregated_monthly'
+                ],
+                [
+                    $this->connectionMock,
+                    'year',
+                    'views_num',
+                    'report_viewed_product_aggregated_daily',
+                    'report_viewed_product_aggregated_yearly'
+                ]
+            )->willReturnOnConsecutiveCalls($this->helperMock, $this->helperMock, $this->helperMock);
 
         $this->flagMock->expects($this->once())->method('unsetData')->willReturnSelf();
         $this->flagMock->expects($this->once())->method('loadSelf')->willReturnSelf();
@@ -265,7 +258,7 @@ class ViewedTest extends TestCase
     /**
      * @return array
      */
-    public function intervalsDataProvider()
+    public function intervalsDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Review/Customer/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Review/Customer/CollectionTest.php
@@ -33,28 +33,38 @@ class CollectionTest extends TestCase
      */
     private $collectionMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->selectMock = $this->createMock(Select::class);
         $this->collectionMock = $this->getMockBuilder(Collection::class)
-            ->setMethods(['getSelect'])
+            ->onlyMethods(['getSelect'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->collectionMock->expects($this->atLeastOnce())->method('getSelect')->willReturn($this->selectMock);
     }
 
-    public function testGetSelectCountSqlWithoutHavingClauses()
+    /**
+     * @return void
+     */
+    public function testGetSelectCountSqlWithoutHavingClauses(): void
     {
         $havingClauses = [];
         $whereClauses = [];
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($havingClauses);
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($whereClauses);
-        $this->selectMock->expects($this->at(2))->method('reset')->with(Select::ORDER);
-        $this->selectMock->expects($this->at(3))->method('reset')->with(Select::LIMIT_COUNT);
-        $this->selectMock->expects($this->at(4))->method('reset')->with(Select::LIMIT_OFFSET);
-        $this->selectMock->expects($this->at(5))->method('reset')->with(Select::WHERE);
-        $this->selectMock->expects($this->at(6))->method('reset')->with(Select::HAVING);
+        $this->selectMock
+            ->method('reset')
+            ->withConsecutive(
+                [Select::ORDER],
+                [Select::LIMIT_COUNT],
+                [Select::LIMIT_OFFSET],
+                [Select::WHERE],
+                [Select::HAVING]
+            );
         $this->selectMock->expects($this->atLeastOnce())->method('columns')
             ->with(new \Zend_Db_Expr('COUNT(DISTINCT detail.customer_id)'))->willReturnSelf();
         $this->selectMock->expects($this->atLeastOnce())->method('reset')->willReturnSelf();
@@ -63,7 +73,10 @@ class CollectionTest extends TestCase
         $this->assertEquals($this->selectMock, $this->collectionMock->getSelectCountSql());
     }
 
-    public function testGetSelectCountSqlWithHavingClauses()
+    /**
+     * @return void
+     */
+    public function testGetSelectCountSqlWithHavingClauses(): void
     {
         $havingClauses = [
             'clause-1' => '(review_cnt LIKE %4%)',
@@ -75,9 +88,9 @@ class CollectionTest extends TestCase
 
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($havingClauses);
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($whereClauses);
-        $this->selectMock->expects($this->at(2))->method('reset')->with(Select::ORDER);
-        $this->selectMock->expects($this->at(3))->method('reset')->with(Select::LIMIT_COUNT);
-        $this->selectMock->expects($this->at(4))->method('reset')->with(Select::LIMIT_OFFSET);
+        $this->selectMock
+            ->method('reset')
+            ->withConsecutive([Select::ORDER], [Select::LIMIT_COUNT], [Select::LIMIT_OFFSET]);
         $this->selectMock->expects($this->atLeastOnce())->method('reset')->willReturnSelf();
         $this->selectMock->expects($this->atLeastOnce())->method('from')->willReturnSelf();
 

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Review/Product/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Review/Product/CollectionTest.php
@@ -33,37 +33,50 @@ class CollectionTest extends TestCase
      */
     private $collectionMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->selectMock = $this->createMock(Select::class);
         $this->collectionMock = $this->getMockBuilder(Collection::class)
-            ->setMethods(['getSelect'])
+            ->onlyMethods(['getSelect'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->collectionMock->expects($this->atLeastOnce())->method('getSelect')->willReturn($this->selectMock);
     }
 
-    public function testGetSelectCountSqlWithoutHavingClauses()
+    /**
+     * @return void
+     */
+    public function testGetSelectCountSqlWithoutHavingClauses(): void
     {
         $havingClauses = [];
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($havingClauses);
-        $this->selectMock->expects($this->at(1))->method('reset')->with(Select::ORDER);
-        $this->selectMock->expects($this->at(2))->method('reset')->with(Select::LIMIT_COUNT);
-        $this->selectMock->expects($this->at(3))->method('reset')->with(Select::LIMIT_OFFSET);
         $this->selectMock->expects($this->atLeastOnce())->method('columns')
             ->with(new \Zend_Db_Expr('1'))->willReturnSelf();
         $this->selectMock->expects($this->atLeastOnce())->method('resetJoinLeft')->willReturnSelf();
 
-        $this->selectMock->expects($this->at(4))->method('reset')->with(Select::COLUMNS);
-        $this->selectMock->expects($this->at(5))->method('reset')->with(Select::HAVING);
+        $this->selectMock
+            ->method('reset')
+            ->withConsecutive(
+                [Select::ORDER],
+                [Select::LIMIT_COUNT],
+                [Select::LIMIT_OFFSET],
+                [Select::COLUMNS],
+                [Select::HAVING]
+            );
         $this->selectMock->expects($this->atLeastOnce())->method('reset')->willReturnSelf();
         $this->selectMock->expects($this->atLeastOnce())->method('from')->willReturnSelf();
 
         $this->assertEquals($this->selectMock, $this->collectionMock->getSelectCountSql());
     }
 
-    public function testGetSelectCountSqlWithHavingClauses()
+    /**
+     * @return void
+     */
+    public function testGetSelectCountSqlWithHavingClauses(): void
     {
         $havingClauses = [
             'clause-1' => '(review_cnt LIKE %4%)',
@@ -71,9 +84,9 @@ class CollectionTest extends TestCase
         ];
 
         $this->selectMock->expects($this->atLeastOnce())->method('getPart')->willReturn($havingClauses);
-        $this->selectMock->expects($this->at(1))->method('reset')->with(Select::ORDER);
-        $this->selectMock->expects($this->at(2))->method('reset')->with(Select::LIMIT_COUNT);
-        $this->selectMock->expects($this->at(3))->method('reset')->with(Select::LIMIT_OFFSET);
+        $this->selectMock
+            ->method('reset')
+            ->withConsecutive([Select::ORDER], [Select::LIMIT_COUNT], [Select::LIMIT_OFFSET]);
         $this->selectMock->expects($this->atLeastOnce())->method('reset')->willReturnSelf();
         $this->selectMock->expects($this->atLeastOnce())->method('from')->willReturnSelf();
 

--- a/app/code/Magento/Review/Test/Unit/Block/Adminhtml/MainTest.php
+++ b/app/code/Magento/Review/Test/Unit/Block/Adminhtml/MainTest.php
@@ -51,7 +51,10 @@ class MainTest extends TestCase
      */
     protected $collectionFactory;
 
-    public function testConstruct()
+    /**
+     * @return void
+     */
+    public function testConstruct(): void
     {
         $this->customerRepository = $this
             ->getMockForAbstractClass(CustomerRepositoryInterface::class);
@@ -68,14 +71,10 @@ class MainTest extends TestCase
             ->with($dummyCustomer)
             ->willReturn(new DataObject());
         $this->request = $this->getMockForAbstractClass(RequestInterface::class);
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with('customerId', false)
-            ->willReturn('customer id');
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('productId', false)
-            ->willReturn(false);
+            ->withConsecutive(['customerId', false], ['productId', false])
+            ->willReturnOnConsecutiveCalls('customer id', false);
         $productCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
+++ b/app/code/Magento/Review/Test/Unit/Controller/Product/PostTest.php
@@ -122,6 +122,8 @@ class PostTest extends TestCase
     protected $resultRedirectMock;
 
     /**
+     * @inheritDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -215,9 +217,10 @@ class PostTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $reviewData = [
             'ratings' => [1 => 1],
@@ -234,12 +237,10 @@ class PostTest extends TestCase
         $this->reviewSession->expects($this->any())->method('getFormData')
             ->with(true)
             ->willReturn($reviewData);
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with('category', false)
-            ->willReturn(false);
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with('id')
-            ->willReturn(1);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['category', false], ['id'])
+            ->willReturnOnConsecutiveCalls(false, 1);
         $product = $this->createPartialMock(
             Product::class,
             ['__wakeup', 'isVisibleInCatalog', 'isVisibleInSiteVisibility', 'getId', 'getWebsiteIds']
@@ -262,12 +263,10 @@ class PostTest extends TestCase
         $this->productRepository->expects($this->any())->method('getById')
             ->with(1)
             ->willReturn($product);
-        $this->coreRegistry->expects($this->at(0))->method('register')
-            ->with('current_product', $product)
-            ->willReturnSelf();
-        $this->coreRegistry->expects($this->at(1))->method('register')
-            ->with('product', $product)
-            ->willReturnSelf();
+        $this->coreRegistry
+            ->method('register')
+            ->withConsecutive(['current_product', $product], ['product', $product])
+            ->willReturnOnConsecutiveCalls($this->coreRegistry, $this->coreRegistry);
         $this->review->expects($this->once())->method('setData')
             ->with($reviewData)
             ->willReturnSelf();

--- a/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/CollectionTest.php
+++ b/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/CollectionTest.php
@@ -50,6 +50,9 @@ class CollectionTest extends TestCase
      */
     protected $objectManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $store = $this->createPartialMock(Store::class, ['getId']);
@@ -59,11 +62,11 @@ class CollectionTest extends TestCase
         $this->objectManager = (new ObjectManager($this));
         $this->resourceMock = $this->getMockBuilder(AbstractDb::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getConnection', 'getMainTable', 'getTable'])
+            ->onlyMethods(['getConnection', 'getMainTable', 'getTable'])
             ->getMockForAbstractClass();
         $this->readerAdapterMock = $this->getMockBuilder(Mysql::class)
             ->disableOriginalConstructor()
-            ->setMethods(['select', 'prepareSqlCondition', 'quoteInto'])
+            ->onlyMethods(['select', 'prepareSqlCondition', 'quoteInto'])
             ->getMockForAbstractClass();
         $this->selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
@@ -91,7 +94,10 @@ class CollectionTest extends TestCase
         );
     }
 
-    public function testInitSelect()
+    /**
+     * @return void
+     */
+    public function testInitSelect(): void
     {
         $this->selectMock->expects($this->once())
             ->method('join')
@@ -109,7 +115,10 @@ class CollectionTest extends TestCase
         );
     }
 
-    public function testAddStoreFilter()
+    /**
+     * @return void
+     */
+    public function testAddStoreFilter(): void
     {
         $this->readerAdapterMock->expects($this->once())
             ->method('prepareSqlCondition');
@@ -126,30 +135,30 @@ class CollectionTest extends TestCase
     /**
      * @param int|string $entity
      * @param int $pkValue
-     * @param string $quoteIntoArguments1
-     * @param string $quoteIntoArguments2
+     * @param array $quoteIntoArguments1
+     * @param array $quoteIntoArguments2
      * @param string $quoteIntoReturn1
      * @param string $quoteIntoReturn2
      * @param int $callNum
+     *
+     * @return void
      * @dataProvider addEntityFilterDataProvider
      */
     public function testAddEntityFilter(
         $entity,
-        $pkValue,
-        $quoteIntoArguments1,
-        $quoteIntoArguments2,
-        $quoteIntoReturn1,
-        $quoteIntoReturn2,
-        $callNum
-    ) {
-        $this->readerAdapterMock->expects($this->at(0))
+        int $pkValue,
+        array $quoteIntoArguments1,
+        array $quoteIntoArguments2,
+        string $quoteIntoReturn1,
+        string $quoteIntoReturn2,
+        int $callNum
+    ): void {
+        $this->readerAdapterMock
             ->method('quoteInto')
-            ->with($quoteIntoArguments1[0], $quoteIntoArguments1[1])
-            ->willReturn($quoteIntoReturn1);
-        $this->readerAdapterMock->expects($this->at(1))
-            ->method('quoteInto')
-            ->with($quoteIntoArguments2[0], $quoteIntoArguments2[1])
-            ->willReturn($quoteIntoReturn2);
+            ->withConsecutive(
+                [$quoteIntoArguments1[0], $quoteIntoArguments1[1]],
+                [$quoteIntoArguments2[0], $quoteIntoArguments2[1]]
+            )->willReturnOnConsecutiveCalls($quoteIntoReturn1, $quoteIntoReturn2);
         $this->selectMock->expects($this->exactly($callNum))
             ->method('join')
             ->with(
@@ -163,7 +172,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function addEntityFilterDataProvider()
+    public function addEntityFilterDataProvider(): array
     {
         return [
             [
@@ -187,7 +196,10 @@ class CollectionTest extends TestCase
         ];
     }
 
-    public function testAddReviewsTotalCount()
+    /**
+     * @return void
+     */
+    public function testAddReviewsTotalCount(): void
     {
         $this->selectMock->expects($this->once())
             ->method('joinLeft')

--- a/app/code/Magento/Review/Test/Unit/Observer/PredispatchReviewObserverTest.php
+++ b/app/code/Magento/Review/Test/Unit/Observer/PredispatchReviewObserverTest.php
@@ -66,7 +66,7 @@ class PredispatchReviewObserverTest extends TestCase
             ->getMockForAbstractClass();
         $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setRedirect'])
+            ->addMethods(['setRedirect'])
             ->getMockForAbstractClass();
         $this->redirectMock = $this->getMockBuilder(RedirectInterface::class)
             ->getMock();
@@ -82,12 +82,15 @@ class PredispatchReviewObserverTest extends TestCase
 
     /**
      * Test with enabled review active config.
+     *
+     * @return void
      */
     public function testReviewEnabled() : void
     {
         $observerMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getResponse', 'getData', 'setRedirect'])
+            ->onlyMethods(['getData'])
+            ->addMethods(['getResponse', 'setRedirect'])
             ->getMockForAbstractClass();
 
         $this->configMock->method('getValue')
@@ -107,25 +110,24 @@ class PredispatchReviewObserverTest extends TestCase
 
     /**
      * Test with disabled review active config.
+     *
+     * @return void
      */
     public function testReviewDisabled() : void
     {
         $observerMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getControllerAction', 'getResponse'])
+            ->addMethods(['getControllerAction', 'getResponse'])
             ->getMockForAbstractClass();
-
-        $this->configMock->expects($this->at(0))
-            ->method('getValue')
-            ->with(PredispatchReviewObserver::XML_PATH_REVIEW_ACTIVE, ScopeInterface::SCOPE_STORE)
-            ->willReturn(false);
 
         $expectedRedirectUrl = 'https://test.com/index';
 
-        $this->configMock->expects($this->at(1))
+        $this->configMock
             ->method('getValue')
-            ->with('web/default/no_route', ScopeInterface::SCOPE_STORE)
-            ->willReturn($expectedRedirectUrl);
+            ->withConsecutive(
+                [PredispatchReviewObserver::XML_PATH_REVIEW_ACTIVE, ScopeInterface::SCOPE_STORE],
+                ['web/default/no_route', ScopeInterface::SCOPE_STORE]
+            )->willReturnOnConsecutiveCalls(false, $expectedRedirectUrl);
 
         $this->urlMock->expects($this->once())
             ->method('getUrl')

--- a/app/code/Magento/Rss/Test/Unit/App/Action/Plugin/BackendAuthenticationTest.php
+++ b/app/code/Magento/Rss/Test/Unit/App/Action/Plugin/BackendAuthenticationTest.php
@@ -21,7 +21,10 @@ use PHPUnit\Framework\TestCase;
 
 class BackendAuthenticationTest extends TestCase
 {
-    public function testAroundDispatch()
+    /**
+     * @return void
+     */
+    public function testAroundDispatch(): void
     {
         /** @var AbstractAction|MockObject $subject */
         $subject = $this->createMock(AbstractAction::class);
@@ -41,8 +44,9 @@ class BackendAuthenticationTest extends TestCase
 
         /** @var StorageInterface|MockObject $session */
         $session = $this->getMockForAbstractClass(StorageInterface::class);
-        $session->expects($this->at(0))->method('isLoggedIn')->willReturn(false);
-        $session->expects($this->at(1))->method('isLoggedIn')->willReturn(true);
+        $session
+            ->method('isLoggedIn')
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $username = 'admin';
         $password = '123123qa';
@@ -57,10 +61,10 @@ class BackendAuthenticationTest extends TestCase
         $httpAuthentication->expects($this->once())->method('setAuthenticationFailed')->with('RSS Feeds');
 
         $authorization = $this->getMockForAbstractClass(AuthorizationInterface::class);
-        $authorization->expects($this->at(0))->method('isAllowed')->with('Magento_Rss::rss')
-            ->willReturn(true);
-        $authorization->expects($this->at(1))->method('isAllowed')->with('Magento_Catalog::catalog_inventory')
-            ->willReturn(false);
+        $authorization
+            ->method('isAllowed')
+            ->withConsecutive(['Magento_Rss::rss'], ['Magento_Catalog::catalog_inventory'])
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $aclResources = [
             'feed' => 'Magento_Rss::rss',

--- a/app/code/Magento/Rss/Test/Unit/Controller/Adminhtml/Feed/IndexTest.php
+++ b/app/code/Magento/Rss/Test/Unit/Controller/Adminhtml/Feed/IndexTest.php
@@ -58,6 +58,9 @@ class IndexTest extends TestCase
      */
     protected $response;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->rssManager = $this->createPartialMock(RssManager::class, ['getProvider']);
@@ -68,7 +71,8 @@ class IndexTest extends TestCase
         $request->expects($this->once())->method('getParam')->with('type')->willReturn('rss_feed');
 
         $this->response = $this->getMockBuilder(ResponseInterface::class)
-            ->setMethods(['setHeader', 'setBody', 'sendResponse'])
+            ->onlyMethods(['sendResponse'])
+            ->addMethods(['setHeader', 'setBody'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -85,7 +89,9 @@ class IndexTest extends TestCase
         );
         $objectManager = $controllerArguments['context']->getObjectManager();
         $urlInterface = $this->getMockForAbstractClass(UrlInterface::class);
-        $objectManager->expects($this->at(0))->method('get')->with(UrlInterface::class)
+        $objectManager
+            ->method('get')
+            ->with(UrlInterface::class)
             ->willReturn($urlInterface);
         $this->controller = $objectManagerHelper->getObject(
             AdminIndex::class,
@@ -93,7 +99,10 @@ class IndexTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $this->scopeConfigInterface->expects($this->once())->method('getValue')->willReturn(true);
         $dataProvider = $this->getMockForAbstractClass(DataProviderInterface::class);
@@ -112,7 +121,10 @@ class IndexTest extends TestCase
         $this->controller->execute();
     }
 
-    public function testExecuteWithException()
+    /**
+     * @return void
+     */
+    public function testExecuteWithException(): void
     {
         $this->scopeConfigInterface->expects($this->once())->method('getValue')->willReturn(true);
         $dataProvider = $this->getMockForAbstractClass(DataProviderInterface::class);

--- a/app/code/Magento/Rule/Test/Unit/Model/Condition/Sql/BuilderTest.php
+++ b/app/code/Magento/Rule/Test/Unit/Model/Condition/Sql/BuilderTest.php
@@ -25,8 +25,11 @@ class BuilderTest extends TestCase
     /**
      * @var Builder|MockObject
      */
-    protected $_builder;
+    protected $builder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $expressionMock = $this->createMock(Expression::class);
@@ -37,13 +40,16 @@ class BuilderTest extends TestCase
         $expressionFactory->expects($this->any())
             ->method('create')
             ->willReturn($expressionMock);
-        $this->_builder = (new ObjectManagerHelper($this))->getObject(
+        $this->builder = (new ObjectManagerHelper($this))->getObject(
             Builder::class,
             ['expressionFactory' => $expressionFactory]
         );
     }
 
-    public function testAttachConditionToCollection()
+    /**
+     * @return void
+     */
+    public function testAttachConditionToCollection(): void
     {
         $collection = $this->getMockBuilder(AbstractCollection::class)
             ->addMethods(['getStoreId', 'getDefaultStoreId'])
@@ -78,16 +84,15 @@ class BuilderTest extends TestCase
             ->method('getConditions')
             ->willReturn([]);
 
-        $this->_builder->attachConditionToCollection($collection, $combine);
+        $this->builder->attachConditionToCollection($collection, $combine);
     }
 
     /**
      * Test for attach condition to collection with operator in html format
      *
-     * @covers \Magento\Rule\Model\Condition\Sql\Builder::attachConditionToCollection()
-     * @return void;
+     * @return void
      */
-    public function testAttachConditionAsHtmlToCollection()
+    public function testAttachConditionAsHtmlToCollection(): void
     {
         $abstractCondition = $this->getMockForAbstractClass(
             AbstractCondition::class,
@@ -101,8 +106,9 @@ class BuilderTest extends TestCase
 
         $abstractCondition->expects($this->once())->method('getMappedSqlField')->willReturn('argument');
         $abstractCondition->expects($this->once())->method('getOperatorForValidate')->willReturn('&gt;');
-        $abstractCondition->expects($this->at(1))->method('getAttribute')->willReturn('attribute');
-        $abstractCondition->expects($this->at(2))->method('getAttribute')->willReturn('attribute');
+        $abstractCondition
+            ->method('getAttribute')
+            ->willReturnOnConsecutiveCalls('attribute', 'attribute');
         $abstractCondition->expects($this->once())->method('getBindArgumentValue')->willReturn(10);
 
         $conditions = [$abstractCondition];
@@ -135,11 +141,10 @@ class BuilderTest extends TestCase
         $resource->expects($this->once())->method('getConnection')->willReturn($connection);
         $combine->expects($this->once())->method('getValue')->willReturn('attribute');
         $combine->expects($this->once())->method('getAggregator')->willReturn(' AND ');
-        $combine->expects($this->at(0))->method('getConditions')->willReturn($conditions);
-        $combine->expects($this->at(1))->method('getConditions')->willReturn($conditions);
-        $combine->expects($this->at(2))->method('getConditions')->willReturn($conditions);
-        $combine->expects($this->at(3))->method('getConditions')->willReturn($conditions);
+        $combine
+            ->method('getConditions')
+            ->willReturnOnConsecutiveCalls($conditions, $conditions, $conditions, $conditions);
 
-        $this->_builder->attachConditionToCollection($collection, $combine);
+        $this->builder->attachConditionToCollection($collection, $combine);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Items/AbstractItemsTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Items/AbstractItemsTest.php
@@ -26,10 +26,14 @@ use PHPUnit\Framework\TestCase;
  */
 class AbstractItemsTest extends TestCase
 {
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $stockItemMock;
 
     /**
@@ -37,12 +41,15 @@ class AbstractItemsTest extends TestCase
      */
     protected $stockRegistry;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->stockRegistry = $this->getMockBuilder(StockRegistry::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->getMock();
 
         $this->stockItemMock = $this->createPartialMock(
@@ -55,7 +62,10 @@ class AbstractItemsTest extends TestCase
             ->willReturn($this->stockItemMock);
     }
 
-    public function testGetItemRenderer()
+    /**
+     * @return void
+     */
+    public function testGetItemRenderer(): void
     {
         $layout = $this->createPartialMock(
             Layout::class,
@@ -88,7 +98,10 @@ class AbstractItemsTest extends TestCase
         $this->assertSame($renderer, $renderer->getColumnRenderer('block-name'));
     }
 
-    public function testGetItemRendererThrowsExceptionForNonexistentRenderer()
+    /**
+     * @return void
+     */
+    public function testGetItemRendererThrowsExceptionForNonexistentRenderer(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Renderer for type "some-type" does not exist.');
@@ -97,12 +110,10 @@ class AbstractItemsTest extends TestCase
             Layout::class,
             ['getChildName', 'getBlock']
         );
-        $layout->expects($this->at(0))
-            ->method('getChildName')
+        $layout->method('getChildName')
             ->with(null, 'some-type')
             ->willReturn('some-block-name');
-        $layout->expects($this->at(1))
-            ->method('getBlock')
+        $layout->method('getBlock')
             ->with('some-block-name')
             ->willReturn($renderer);
 
@@ -124,12 +135,14 @@ class AbstractItemsTest extends TestCase
      * @param bool $canReturnToStock
      * @param array $itemConfig
      * @param bool $result
+     *
+     * @return void
      * @dataProvider canReturnItemToStockDataProvider
      */
-    public function testCanReturnItemToStock($canReturnToStock, $itemConfig, $result)
+    public function testCanReturnItemToStock(bool $canReturnToStock, array $itemConfig, bool $result): void
     {
-        $productId = isset($itemConfig['product_id']) ? $itemConfig['product_id'] : null;
-        $manageStock = isset($itemConfig['manage_stock']) ? $itemConfig['manage_stock'] : null;
+        $productId = $itemConfig['product_id'] ?? null;
+        $manageStock = $itemConfig['manage_stock'] ?? false;
         $item = $this->getMockBuilder(\Magento\Sales\Model\Order\Creditmemo\Item::class)->addMethods(
             ['hasCanReturnToStock', 'setCanReturnToStock', 'getCanReturnToStock']
         )
@@ -160,8 +173,13 @@ class AbstractItemsTest extends TestCase
      * @param array $itemConfig
      * @return array
      */
-    protected function prepareServiceMockDependency($item, $canReturnToStock, $productId, $manageStock, $itemConfig)
-    {
+    protected function prepareServiceMockDependency(
+        MockObject $item,
+        bool $canReturnToStock,
+        ?int $productId,
+        bool $manageStock,
+        array $itemConfig
+    ): array {
         $dependencies = [];
 
         $this->stockItemMock->expects($this->any())
@@ -208,11 +226,14 @@ class AbstractItemsTest extends TestCase
         return $dependencies;
     }
 
-    public function testCanReturnItemToStockEmpty()
+    /**
+     * @return void
+     */
+    public function testCanReturnItemToStockEmpty(): void
     {
         $stockConfiguration = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
-            ->setMethods(['canSubtractQty'])
+            ->onlyMethods(['canSubtractQty'])
             ->getMock();
         $stockConfiguration->expects($this->once())
             ->method('canSubtractQty')
@@ -232,13 +253,13 @@ class AbstractItemsTest extends TestCase
     /**
      * @return array
      */
-    public function canReturnItemToStockDataProvider()
+    public function canReturnItemToStockDataProvider(): array
     {
         return [
             [true, ['has_can_return_to_stock' => true], true],
             [false, ['has_can_return_to_stock' => true], false],
             [false, ['has_can_return_to_stock' => false, 'product_id' => 2, 'manage_stock' => false], false],
-            [true, ['has_can_return_to_stock' => false, 'product_id' => 2, 'manage_stock' => true], true],
+            [true, ['has_can_return_to_stock' => false, 'product_id' => 2, 'manage_stock' => true], true]
         ];
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Items/AbstractTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Items/AbstractTest.php
@@ -16,40 +16,35 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractTest extends TestCase
 {
-    /** @var ObjectManager  */
+    /**
+     * @var ObjectManager
+     */
     protected $_objectManager;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_objectManager = new ObjectManager($this);
     }
 
-    public function testGetItemRenderer()
+    /**
+     * @return void
+     */
+    public function testGetItemRenderer(): void
     {
         $renderer = $this->createMock(AbstractBlock::class);
         $layout = $this->createPartialMock(
             Layout::class,
             ['getChildName', 'getBlock', 'getGroupChildNames']
         );
-        $layout->expects(
-            $this->at(0)
-        )->method(
-            'getChildName'
-        )->with(
-            null,
-            'some-type'
-        )->willReturn(
-            'some-block-name'
-        );
-        $layout->expects(
-            $this->at(1)
-        )->method(
-            'getBlock'
-        )->with(
-            'some-block-name'
-        )->willReturn(
-            $renderer
-        );
+        $layout->method('getChildName')
+            ->with(null, 'some-type')
+            ->willReturn('some-block-name');
+        $layout->method('getBlock')
+            ->with('some-block-name')
+            ->willReturn($renderer);
 
         /** @var AbstractItems $block */
         $block = $this->_objectManager->getObject(
@@ -65,7 +60,10 @@ class AbstractTest extends TestCase
         $this->assertSame($renderer, $block->getItemRenderer('some-type'));
     }
 
-    public function testGetItemRendererThrowsExceptionForNonexistentRenderer()
+    /**
+     * @return void
+     */
+    public function testGetItemRendererThrowsExceptionForNonexistentRenderer(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Renderer for type "some-type" does not exist.');
@@ -74,25 +72,12 @@ class AbstractTest extends TestCase
             Layout::class,
             ['getChildName', 'getBlock']
         );
-        $layout->expects(
-            $this->at(0)
-        )->method(
-            'getChildName'
-        )->with(
-            null,
-            'some-type'
-        )->willReturn(
-            'some-block-name'
-        );
-        $layout->expects(
-            $this->at(1)
-        )->method(
-            'getBlock'
-        )->with(
-            'some-block-name'
-        )->willReturn(
-            $renderer
-        );
+        $layout->method('getChildName')
+            ->with(null, 'some-type')
+            ->willReturn('some-block-name');
+        $layout->method('getBlock')
+            ->with('some-block-name')
+            ->willReturn($renderer);
 
         /** @var AbstractItems $block */
         $block = $this->_objectManager->getObject(

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Form/AddressTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Create/Form/AddressTest.php
@@ -114,7 +114,8 @@ class AddressTest extends TestCase
 
         $this->quoteSession = $this->getMockBuilder(QuoteSession::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStore', 'getCustomerId'])
+            ->onlyMethods(['getStore'])
+            ->addMethods(['getCustomerId'])
             ->getMock();
         $this->store = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
@@ -127,35 +128,35 @@ class AddressTest extends TestCase
             ->willReturn($this->customerId);
         $this->directoryHelper = $this->getMockBuilder(DirectoryHelper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getDefaultCountry'])
+            ->onlyMethods(['getDefaultCountry'])
             ->getMock();
         $this->directoryHelper->expects($this->any())
             ->method('getDefaultCountry')
             ->willReturn($this->defaultCountryId);
         $this->formFactory = $this->getMockBuilder(FormFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->filterBuilder = $this->getMockBuilder(FilterBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setField', 'setValue', 'setConditionType', 'create'])
+            ->onlyMethods(['setField', 'setValue', 'setConditionType', 'create'])
             ->getMock();
         $this->criteriaBuilder = $this->getMockBuilder(SearchCriteriaBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create', 'addFilters'])
+            ->onlyMethods(['create', 'addFilters'])
             ->getMock();
         $this->addressService = $this->getMockBuilder(AddressRepositoryInterface::class)
-            ->setMethods(['getList'])
+            ->onlyMethods(['getList'])
             ->getMockForAbstractClass();
         $this->addressItem = $this->getMockBuilder(AddressInterface::class)
-            ->setMethods(['getId'])
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $this->addressItem->expects($this->any())
             ->method('getId')
             ->willReturn($this->addressId);
         $this->addressMapper = $this->getMockBuilder(Mapper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['toFlatArray'])
+            ->onlyMethods(['toFlatArray'])
             ->getMock();
 
         $this->address = $this->objectManager->getObject(
@@ -172,12 +173,15 @@ class AddressTest extends TestCase
         );
     }
 
-    public function testGetAddressCollectionJson()
+    /**
+     * @return void
+     */
+    public function testGetAddressCollectionJson(): void
     {
         /** @var Form|MockObject $emptyForm */
         $emptyForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
-            ->setMethods(['outputData'])
+            ->onlyMethods(['outputData'])
             ->getMock();
         $emptyForm->expects($this->once())
             ->method('outputData')
@@ -217,7 +221,7 @@ class AddressTest extends TestCase
 
         /** @var AddressSearchResultsInterface|MockObject $result */
         $result = $this->getMockBuilder(AddressSearchResultsInterface::class)
-            ->setMethods(['getList'])
+            ->addMethods(['getList'])
             ->getMockForAbstractClass();
         $result->expects($this->once())
             ->method('getItems')
@@ -230,7 +234,7 @@ class AddressTest extends TestCase
         /** @var Form|MockObject $emptyForm */
         $addressForm = $this->getMockBuilder(Form::class)
             ->disableOriginalConstructor()
-            ->setMethods(['outputData'])
+            ->onlyMethods(['outputData'])
             ->getMock();
         $addressForm->expects($this->once())
             ->method('outputData')
@@ -245,18 +249,22 @@ class AddressTest extends TestCase
             ->method('getDefaultCountry')
             ->with($this->store)
             ->willReturn($this->defaultCountryId);
-        $this->formFactory->expects($this->at(0))
+        $this->formFactory
             ->method('create')
-            ->with(
-                'customer_address',
-                'adminhtml_customer_address',
-                [AddressInterface::COUNTRY_ID => $this->defaultCountryId]
-            )
-            ->willReturn($emptyForm);
-        $this->formFactory->expects($this->at(1))
-            ->method('create')
-            ->with('customer_address', 'adminhtml_customer_address', [], false, false)
-            ->willReturn($addressForm);
+            ->withConsecutive(
+                [
+                    'customer_address',
+                    'adminhtml_customer_address',
+                    [AddressInterface::COUNTRY_ID => $this->defaultCountryId]
+                ],
+                [
+                    'customer_address',
+                    'adminhtml_customer_address',
+                    [],
+                    false,
+                    false
+                ]
+            )->willReturnOnConsecutiveCalls($emptyForm, $addressForm);
 
         $this->address->getAddressCollectionJson();
     }

--- a/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Status/Assign/FormTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Adminhtml/Order/Status/Assign/FormTest.php
@@ -39,6 +39,9 @@ class FormTest extends TestCase
      */
     protected $orderConfig;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -61,7 +64,10 @@ class FormTest extends TestCase
         );
     }
 
-    public function testToHtml()
+    /**
+     * @return void
+     */
+    public function testToHtml(): void
     {
         $statuses = ['status1', 'status2'];
         $states = ['state1', 'state2'];
@@ -92,45 +98,49 @@ class FormTest extends TestCase
             ->method('getStates')
             ->willReturn($states);
 
-        $fieldset->expects($this->at(0))
-            ->method('addField')
-            ->with(
-                'status',
-                'select',
+        $fieldset->method('addField')
+            ->withConsecutive(
                 [
-                    'name' => 'status',
-                    'label' => __('Order Status'),
-                    'class' => 'required-entry',
-                    'values' => $statusesForField,
-                    'required' => true
-                ]
-            );
-        $fieldset->expects($this->at(1))
-            ->method('addField')
-            ->with(
-                'state',
-                'select',
+                    'status',
+                    'select',
+                    [
+                        'name' => 'status',
+                        'label' => __('Order Status'),
+                        'class' => 'required-entry',
+                        'values' => $statusesForField,
+                        'required' => true
+                    ]
+                ],
                 [
-                    'name' => 'state',
-                    'label' => __('Order State'),
-                    'class' => 'required-entry',
-                    'values' => $statesForField,
-                    'required' => true
+                    'state',
+                    'select',
+                    [
+                        'name' => 'state',
+                        'label' => __('Order State'),
+                        'class' => 'required-entry',
+                        'values' => $statesForField,
+                        'required' => true
+                    ]
+                ],
+                [
+                    'is_default',
+                    'checkbox',
+                    [
+                        'name' => 'is_default',
+                        'label' => __('Use Order Status As Default'),
+                        'value' => 1
+                    ]
+                ],
+                [
+                    'visible_on_front',
+                    'checkbox',
+                    [
+                        'name' => 'visible_on_front',
+                        'label' => __('Visible On Storefront'),
+                        'value' => 1,
+                        'checked' => true
+                    ]
                 ]
-            );
-        $fieldset->expects($this->at(2))
-            ->method('addField')
-            ->with(
-                'is_default',
-                'checkbox',
-                ['name' => 'is_default', 'label' => __('Use Order Status As Default'), 'value' => 1]
-            );
-        $fieldset->expects($this->at(3))
-            ->method('addField')
-            ->with(
-                'visible_on_front',
-                'checkbox',
-                ['name' => 'visible_on_front', 'label' => __('Visible On Storefront'), 'value' => 1, 'checked' => true]
             );
 
         $this->block->toHtml();

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/Create/TotalsTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/Create/TotalsTest.php
@@ -47,7 +47,7 @@ class TotalsTest extends TestCase
     protected $quoteMock;
 
     /**
-     * Init
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -57,14 +57,13 @@ class TotalsTest extends TestCase
             ->getMock();
         $this->quoteMock = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'setTotalsCollectedFlag',
+            ->onlyMethods([
                 'collectTotals',
                 'getTotals',
                 'isVirtual',
                 'getBillingAddress',
                 'getShippingAddress'
-            ])
+            ])->addMethods(['setTotalsCollectedFlag'])
             ->getMock();
         $this->shippingAddressMock = $this->getMockBuilder(Address::class)
             ->disableOriginalConstructor()
@@ -87,12 +86,14 @@ class TotalsTest extends TestCase
     }
 
     /**
+     * @param bool $isVirtual
+     *
+     * @return void
      * @dataProvider totalsDataProvider
      */
-    public function testGetTotals($isVirtual)
+    public function testGetTotals(bool $isVirtual): void
     {
         $expected = 'expected';
-        $this->quoteMock->expects($this->at(1))->method('collectTotals');
         $this->quoteMock->expects($this->once())->method('isVirtual')->willReturn($isVirtual);
         if ($isVirtual) {
             $this->billingAddressMock->expects($this->once())->method('getTotals')->willReturn($expected);
@@ -105,7 +106,7 @@ class TotalsTest extends TestCase
     /**
      * @return array
      */
-    public function totalsDataProvider()
+    public function totalsDataProvider(): array
     {
         return [
             [true],

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/HistoryTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/HistoryTest.php
@@ -67,17 +67,22 @@ class HistoryTest extends TestCase
      */
     protected $pageTitleMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
         $this->orderCollectionFactory =
             $this->getMockBuilder(CollectionFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])->getMock();
+                ->onlyMethods(['create'])
+                ->getMock();
         $this->orderCollectionFactoryInterface =
             $this->getMockBuilder(CollectionFactoryInterface::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])->getMockForAbstractClass();
+                ->onlyMethods(['create'])
+                ->getMockForAbstractClass();
         $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->objectManager->expects($this->any())
             ->method('get')
@@ -85,11 +90,13 @@ class HistoryTest extends TestCase
         ObjectManager::setInstance($this->objectManager);
 
         $this->customerSession = $this->getMockBuilder(Session::class)
-            ->setMethods(['getCustomerId'])->disableOriginalConstructor()
+            ->onlyMethods(['getCustomerId'])
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->orderConfig = $this->getMockBuilder(Config::class)
-            ->setMethods(['getVisibleOnFrontStatuses'])->disableOriginalConstructor()
+            ->onlyMethods(['getVisibleOnFrontStatuses'])
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->pageConfig = $this->getMockBuilder(\Magento\Framework\View\Page\Config::class)
@@ -100,7 +107,10 @@ class HistoryTest extends TestCase
             ->getMock();
     }
 
-    public function testConstructMethod()
+    /**
+     * @return void
+     */
+    public function testConstructMethod(): void
     {
         $data = [];
 
@@ -123,15 +133,18 @@ class HistoryTest extends TestCase
             ->method('getPageConfig')
             ->willReturn($this->pageConfig);
 
-        $orderCollection->expects($this->at(0))
+        $orderCollection
             ->method('addFieldToSelect')
-            ->with('*')->willReturnSelf();
-        $orderCollection->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('status', ['in' => $statuses])->willReturnSelf();
-        $orderCollection->expects($this->at(2))
+            ->with('*')
+            ->willReturn($orderCollection);
+        $orderCollection
             ->method('setOrder')
-            ->with('created_at', 'desc')->willReturnSelf();
+            ->with('created_at', 'desc')
+            ->willReturn($orderCollection);
+        $orderCollection
+            ->method('addFieldToFilter')
+            ->with('status', ['in' => $statuses])
+            ->willReturn($orderCollection);
         $this->orderCollectionFactoryInterface->expects($this->atLeastOnce())
             ->method('create')
             ->willReturn($orderCollection);

--- a/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Block/Order/RecentTest.php
@@ -51,6 +51,9 @@ class RecentTest extends TestCase
      */
     protected $storeManagerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
@@ -67,7 +70,10 @@ class RecentTest extends TestCase
             ->getMockForAbstractClass();
     }
 
-    public function testConstructMethod()
+    /**
+     * @return void
+     */
+    public function testConstructMethod(): void
     {
         $attribute = ['customer_id', 'store_id', 'status'];
         $customerId = 25;
@@ -103,28 +109,28 @@ class RecentTest extends TestCase
         $this->orderCollectionFactory->expects($this->once())
             ->method('create')
             ->willReturn($orderCollection);
-        $orderCollection->expects($this->at(0))
+        $orderCollection
             ->method('addAttributeToSelect')
-            ->with('*')->willReturnSelf();
-        $orderCollection->expects($this->at(1))
-            ->method('addAttributeToFilter')
-            ->with($attribute[0], $customerId)
-            ->willReturnSelf();
-        $orderCollection->expects($this->at(2))
-            ->method('addAttributeToFilter')
-            ->with($attribute[1], $storeId)
-            ->willReturnSelf();
-        $orderCollection->expects($this->at(3))
-            ->method('addAttributeToFilter')
-            ->with($attribute[2], ['in' => $statuses])->willReturnSelf();
-        $orderCollection->expects($this->at(4))
-            ->method('addAttributeToSort')
-            ->with('created_at', 'desc')->willReturnSelf();
-        $orderCollection->expects($this->at(5))
+            ->with('*')
+            ->willReturn($orderCollection);
+        $orderCollection
+            ->method('load')
+            ->willReturn($orderCollection);
+        $orderCollection
             ->method('setPageSize')
-            ->with('5')->willReturnSelf();
-        $orderCollection->expects($this->at(6))
-            ->method('load')->willReturnSelf();
+            ->with('5')
+            ->willReturn($orderCollection);
+        $orderCollection
+            ->method('addAttributeToSort')
+            ->with('created_at', 'desc')
+            ->willReturn($orderCollection);
+        $orderCollection
+            ->method('addAttributeToFilter')
+            ->withConsecutive(
+                [$attribute[0], $customerId],
+                [$attribute[1], $storeId],
+                [$attribute[2], ['in' => $statuses]]
+            )->willReturnOnConsecutiveCalls($orderCollection, $orderCollection, $orderCollection);
         $this->block = new Recent(
             $this->context,
             $this->orderCollectionFactory,

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Invoice/AbstractInvoice/EmailTest.php
@@ -104,7 +104,7 @@ class EmailTest extends TestCase
     protected $invoiceManagement;
 
     /**
-     * Test setup
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -125,7 +125,7 @@ class EmailTest extends TestCase
             ->getMock();
         $this->resultRedirectFactory = $this->getMockBuilder(RedirectFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->context->expects($this->once())
@@ -161,22 +161,22 @@ class EmailTest extends TestCase
             ->getMock();
         $this->resultForwardFactory = $this->getMockBuilder(ForwardFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->invoiceEmail = $objectManagerHelper->getObject(
             OrderInvoiceEmail::class,
             [
                 'context' => $this->context,
-                'resultForwardFactory' => $this->resultForwardFactory,
+                'resultForwardFactory' => $this->resultForwardFactory
             ]
         );
     }
 
     /**
-     * testEmail
+     * @return void
      */
-    public function testEmail()
+    public function testEmail(): void
     {
         $invoiceId = 10000031;
         $orderId = 100000030;
@@ -201,18 +201,14 @@ class EmailTest extends TestCase
         $invoiceRepository->expects($this->any())
             ->method('get')
             ->willReturn($invoice);
-        $this->objectManager->expects($this->at(0))
-            ->method('create')
-            ->with(InvoiceRepositoryInterface::class)
-            ->willReturn($invoiceRepository);
 
         $invoice->expects($this->once())
             ->method('getOrder')
             ->willReturn($order);
-        $this->objectManager->expects($this->at(1))
+        $this->objectManager
             ->method('create')
-            ->with($cmNotifierClassName)
-            ->willReturn($this->invoiceManagement);
+            ->withConsecutive([InvoiceRepositoryInterface::class], [$cmNotifierClassName])
+            ->willReturnOnConsecutiveCalls($invoiceRepository, $this->invoiceManagement);
 
         $this->invoiceManagement->expects($this->once())
             ->method('notify')
@@ -233,9 +229,9 @@ class EmailTest extends TestCase
     }
 
     /**
-     * testEmailNoInvoiceId
+     * @return void
      */
-    public function testEmailNoInvoiceId()
+    public function testEmailNoInvoiceId(): void
     {
         $this->request->expects($this->once())
             ->method('getParam')
@@ -253,9 +249,9 @@ class EmailTest extends TestCase
     }
 
     /**
-     * testEmailNoInvoice
+     * @return void
      */
-    public function testEmailNoInvoice()
+    public function testEmailNoInvoice(): void
     {
         $invoiceId = 10000031;
         $this->request->expects($this->once())
@@ -269,7 +265,7 @@ class EmailTest extends TestCase
         $invoiceRepository->expects($this->any())
             ->method('get')
             ->willReturn(null);
-        $this->objectManager->expects($this->at(0))
+        $this->objectManager
             ->method('create')
             ->with(InvoiceRepositoryInterface::class)
             ->willReturn($invoiceRepository);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
@@ -112,19 +112,15 @@ class AddCommentTest extends TestCase
 
         $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->viewMock = $this->getMockBuilder(View::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->resultPageMock = $this->getMockBuilder(Page::class)
             ->disableOriginalConstructor()
@@ -137,12 +133,11 @@ class AddCommentTest extends TestCase
             ->getMock();
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -150,7 +145,7 @@ class AddCommentTest extends TestCase
                     'getResultRedirectFactory',
                     'getView'
                 ]
-            )
+            )->addMethods(['getTitle'])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -176,24 +171,21 @@ class AddCommentTest extends TestCase
 
         $this->resultPageFactoryMock = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->resultJsonMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->resultRawFactoryMock = $this->getMockBuilder(RawFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->resultJsonFactoryMock = $this->getMockBuilder(JsonFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
-        $this->commentSenderMock = $this->getMockBuilder(
-            InvoiceCommentSender::class
-        )->disableOriginalConstructor()
-            ->setMethods([])
+        $this->commentSenderMock = $this->getMockBuilder(InvoiceCommentSender::class)
+            ->disableOriginalConstructor()
             ->getMock();
         $this->invoiceRepository = $this->getMockBuilder(InvoiceRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -223,30 +215,23 @@ class AddCommentTest extends TestCase
      *
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $data = ['comment' => 'test comment'];
         $invoiceId = 2;
         $response = 'some result';
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('id')
-            ->willReturn($invoiceId);
-        $this->requestMock->expects($this->at(1))
-            ->method('setParam');
-        $this->requestMock->expects($this->at(2))
+            ->withConsecutive(['id'], ['invoice_id'])
+            ->willReturnOnConsecutiveCalls($invoiceId, $invoiceId);
+        $this->requestMock
             ->method('getPost')
             ->with('comment')
             ->willReturn($data);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('invoice_id')
-            ->willReturn($invoiceId);
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('addComment')
@@ -261,7 +246,6 @@ class AddCommentTest extends TestCase
 
         $commentsBlockMock = $this->getMockBuilder(Comments::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $commentsBlockMock->expects($this->once())
             ->method('toHtml')
@@ -269,7 +253,6 @@ class AddCommentTest extends TestCase
 
         $layoutMock = $this->getMockBuilder(Layout::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $layoutMock->expects($this->once())
             ->method('getBlock')
@@ -290,7 +273,6 @@ class AddCommentTest extends TestCase
 
         $resultRaw = $this->getMockBuilder(Raw::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRaw->expects($this->once())->method('setContents')->with($response);
 
@@ -303,7 +285,7 @@ class AddCommentTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteModelException()
+    public function testExecuteModelException(): void
     {
         $message = 'model exception';
         $response = ['error' => true, 'message' => $message];
@@ -326,7 +308,7 @@ class AddCommentTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $response = ['error' => true, 'message' => 'Cannot add new comment.'];
         $error = new \Exception('test');

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CancelTest.php
@@ -90,7 +90,7 @@ class CancelTest extends TestCase
     protected $invoiceRepository;
 
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -98,50 +98,41 @@ class CancelTest extends TestCase
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
         $this->messageManagerMock = $this->getMockBuilder(Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->sessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->actionFlagMock = $this->getMockBuilder(ActionFlag::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->helperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
-        $this->resultRedirectFactoryMock = $this->getMockBuilder(
-            RedirectFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $this->resultForwardFactoryMock = $this->getMockBuilder(
-            ForwardFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -190,7 +181,7 @@ class CancelTest extends TestCase
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $invoiceId = 2;
 
@@ -201,12 +192,11 @@ class CancelTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setIsInProcess'])
+            ->addMethods(['setIsInProcess'])
             ->getMock();
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('cancel');
@@ -216,16 +206,10 @@ class CancelTest extends TestCase
 
         $transactionMock = $this->getMockBuilder(Transaction::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
-        $transactionMock->expects($this->at(0))
-            ->method('addObject')
-            ->with($invoiceMock)->willReturnSelf();
-        $transactionMock->expects($this->at(1))
-            ->method('addObject')
-            ->with($orderMock)->willReturnSelf();
-        $transactionMock->expects($this->at(2))
-            ->method('save');
+        $transactionMock->method('addObject')
+            ->withConsecutive([$invoiceMock], [$orderMock])
+            ->willReturnOnConsecutiveCalls($transactionMock, $transactionMock);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addSuccessMessage')
@@ -246,9 +230,10 @@ class CancelTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
-        $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
+        $resultRedirect->expects($this->once())
+            ->method('setPath')
+            ->with('sales/*/view', ['invoice_id' => $invoiceId]);
 
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')
@@ -260,7 +245,7 @@ class CancelTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteNoInvoice()
+    public function testExecuteNoInvoice(): void
     {
         $invoiceId = 2;
 
@@ -275,7 +260,6 @@ class CancelTest extends TestCase
 
         $resultForward = $this->getMockBuilder(Forward::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultForward->expects($this->once())->method('forward')->with(('noroute'))->willReturnSelf();
 
@@ -289,7 +273,7 @@ class CancelTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteModelException()
+    public function testExecuteModelException(): void
     {
         $invoiceId = 2;
 
@@ -303,7 +287,6 @@ class CancelTest extends TestCase
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('cancel')
@@ -323,7 +306,6 @@ class CancelTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
 
@@ -337,7 +319,7 @@ class CancelTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $invoiceId = 2;
 
@@ -351,7 +333,6 @@ class CancelTest extends TestCase
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('cancel')
@@ -371,7 +352,6 @@ class CancelTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/CaptureTest.php
@@ -95,7 +95,7 @@ class CaptureTest extends TestCase
     protected $invoiceRepository;
 
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -126,21 +126,18 @@ class CaptureTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->resultRedirectFactoryMock = $this->getMockBuilder(
-            RedirectFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $this->resultForwardFactoryMock = $this->getMockBuilder(
-            ForwardFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -182,7 +179,7 @@ class CaptureTest extends TestCase
             Capture::class,
             [
                 'context' => $contextMock,
-                'resultForwardFactory' => $this->resultForwardFactoryMock,
+                'resultForwardFactory' => $this->resultForwardFactoryMock
             ]
         );
 
@@ -196,7 +193,7 @@ class CaptureTest extends TestCase
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $invoiceId = 2;
 
@@ -207,7 +204,7 @@ class CaptureTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setIsInProcess'])
+            ->addMethods(['setIsInProcess'])
             ->getMock();
 
         $this->invoiceManagement->expects($this->once())
@@ -216,7 +213,6 @@ class CaptureTest extends TestCase
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->any())
             ->method('getEntityId')
@@ -227,16 +223,10 @@ class CaptureTest extends TestCase
 
         $transactionMock = $this->getMockBuilder(Transaction::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
-        $transactionMock->expects($this->at(0))
-            ->method('addObject')
-            ->with($invoiceMock)->willReturnSelf();
-        $transactionMock->expects($this->at(1))
-            ->method('addObject')
-            ->with($orderMock)->willReturnSelf();
-        $transactionMock->expects($this->at(2))
-            ->method('save');
+        $transactionMock->method('addObject')
+            ->withConsecutive([$invoiceMock], [$orderMock])
+            ->willReturnOnConsecutiveCalls($transactionMock, $transactionMock);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addSuccessMessage')
@@ -250,7 +240,7 @@ class CaptureTest extends TestCase
             ->method('get')
             ->willReturn($invoiceMock);
 
-        $this->objectManagerMock->expects($this->at(1))
+        $this->objectManagerMock
             ->method('create')
             ->with(Transaction::class)
             ->willReturn($transactionMock);
@@ -270,7 +260,7 @@ class CaptureTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteNoInvoice()
+    public function testExecuteNoInvoice(): void
     {
         $invoiceId = 2;
 
@@ -298,7 +288,7 @@ class CaptureTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteModelException()
+    public function testExecuteModelException(): void
     {
         $invoiceId = 2;
 
@@ -349,7 +339,7 @@ class CaptureTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $invoiceId = 2;
 
@@ -387,7 +377,6 @@ class CaptureTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/NewActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/NewActionTest.php
@@ -118,17 +118,18 @@ class NewActionTest extends TestCase
      */
     private $orderRepositoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
 
         $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->viewMock = $this->getMockBuilder(View::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->messageManagerMock = $this->getMockForAbstractClass(ManagerInterface::class);
@@ -136,30 +137,25 @@ class NewActionTest extends TestCase
 
         $this->actionFlagMock = $this->getMockBuilder(ActionFlag::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->helperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->sessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCommentText', 'setIsUrlNotice'])
+            ->addMethods(['getCommentText', 'setIsUrlNotice'])
             ->getMock();
         $this->resultPageMock = $this->getMockBuilder(Page::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->pageConfigMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
@@ -169,31 +165,27 @@ class NewActionTest extends TestCase
             ->getMock();
         $this->resultPageFactoryMock = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $this->resultRedirectFactoryMock = $this->getMockBuilder(
-            RedirectFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getRequest',
-                    'getResponse',
-                    'getObjectManager',
-                    'getTitle',
-                    'getSession',
-                    'getHelper',
-                    'getActionFlag',
-                    'getMessageManager',
-                    'getResultRedirectFactory',
-                    'getView'
-                ]
-            )
+            ->onlyMethods([
+                'getRequest',
+                'getResponse',
+                'getObjectManager',
+                'getSession',
+                'getHelper',
+                'getActionFlag',
+                'getMessageManager',
+                'getResultRedirectFactory',
+                'getView'
+            ])->addMethods(['getTitle'])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -256,24 +248,22 @@ class NewActionTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $orderId = 1;
         $invoiceData = [];
         $commentText = 'comment test';
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('invoice', [])
-            ->willReturn($invoiceData);
+            ->withConsecutive(['order_id'], ['invoice', []])
+            ->willReturnOnConsecutiveCalls($orderId, $invoiceData);
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('getTotalQty')
@@ -281,7 +271,7 @@ class NewActionTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'canInvoice'])
+            ->onlyMethods(['load', 'canInvoice'])
             ->getMock();
         $orderMock->expects($this->once())
             ->method('canInvoice')
@@ -299,7 +289,8 @@ class NewActionTest extends TestCase
 
         $menuBlockMock = $this->getMockBuilder(Menu::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParentItems', 'getMenuModel'])
+            ->onlyMethods(['getMenuModel'])
+            ->addMethods(['getParentItems'])
             ->getMock();
         $menuBlockMock->expects($this->any())
             ->method('getMenuModel')->willReturnSelf();
@@ -326,23 +317,22 @@ class NewActionTest extends TestCase
         $this->assertSame($this->resultPageMock, $this->controller->execute());
     }
 
-    public function testExecuteNoOrder()
+    /**
+     * @return void
+     */
+    public function testExecuteNoOrder(): void
     {
         $orderId = 1;
         $invoiceData = [];
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('invoice', [])
-            ->willReturn($invoiceData);
+            ->withConsecutive(['order_id'], ['invoice', []])
+            ->willReturnOnConsecutiveCalls($orderId, $invoiceData);
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['canInvoice'])
+            ->onlyMethods(['canInvoice'])
             ->getMock();
 
         $this->orderRepositoryMock->expects($this->once())
@@ -352,7 +342,6 @@ class NewActionTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/order/view', ['order_id' => $orderId]);
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/PrintActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/PrintActionTest.php
@@ -61,34 +61,32 @@ class PrintActionTest extends TestCase
      */
     protected $controller;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->sessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->actionFlagMock = $this->getMockBuilder(ActionFlag::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -108,7 +106,6 @@ class PrintActionTest extends TestCase
 
         $this->fileFactory = $this->getMockBuilder(FileFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->controller = $objectManager->getObject(
@@ -120,7 +117,10 @@ class PrintActionTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $invoiceId = 2;
 
@@ -149,15 +149,13 @@ class PrintActionTest extends TestCase
             ->method('get')
             ->willReturn($invoiceMock);
 
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
-            ->with(InvoiceRepositoryInterface::class)
-            ->willReturn($invoiceRepository);
-        $this->objectManagerMock->expects($this->at(1))
-            ->method('create')
-            ->with(\Magento\Sales\Model\Order\Pdf\Invoice::class)
-            ->willReturn($pdfMock);
-        $this->objectManagerMock->expects($this->at(2))
+            ->withConsecutive(
+                [InvoiceRepositoryInterface::class],
+                [\Magento\Sales\Model\Order\Pdf\Invoice::class]
+            )->willReturnOnConsecutiveCalls($invoiceRepository, $pdfMock);
+        $this->objectManagerMock
             ->method('get')
             ->with(DateTime::class)
             ->willReturn($dateTimeMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/SaveTest.php
@@ -92,7 +92,6 @@ class SaveTest extends TestCase
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
@@ -100,7 +99,7 @@ class SaveTest extends TestCase
 
         $this->resultPageFactoryMock = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->formKeyValidatorMock = $this->getMockBuilder(Validator::class)
@@ -138,18 +137,18 @@ class SaveTest extends TestCase
             ->willReturn($this->objectManager);
         $this->invoiceSender = $this->getMockBuilder(InvoiceSender::class)
             ->disableOriginalConstructor()
-            ->setMethods(['send'])
+            ->onlyMethods(['send'])
             ->getMock();
         $this->invoiceSender->expects($this->any())
             ->method('send')
             ->willReturn(true);
         $this->salesData = $this->getMockBuilder(SalesData::class)
             ->disableOriginalConstructor()
-            ->setMethods(['canSendNewInvoiceEmail'])
+            ->onlyMethods(['canSendNewInvoiceEmail'])
             ->getMock();
         $this->invoiceService = $this->getMockBuilder(InvoiceService::class)
             ->disableOriginalConstructor()
-            ->setMethods(['prepareInvoice'])
+            ->onlyMethods(['prepareInvoice'])
             ->getMock();
 
         $this->controller = $objectManager->getObject(
@@ -168,7 +167,7 @@ class SaveTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteNotValidPost()
+    public function testExecuteNotValidPost(): void
     {
         $redirectMock = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
@@ -197,7 +196,7 @@ class SaveTest extends TestCase
     /**
      * @return array
      */
-    public function testExecuteEmailsDataProvider()
+    public function testExecuteEmailsDataProvider(): array
     {
         /**
         * string $sendEmail
@@ -216,14 +215,16 @@ class SaveTest extends TestCase
      * @param string $sendEmail
      * @param bool $emailEnabled
      * @param bool $shouldEmailBeSent
-     * @dataProvider testExecuteEmailsDataProvider
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider testExecuteEmailsDataProvider
      */
     public function testExecuteEmails(
-        $sendEmail,
-        $emailEnabled,
-        $shouldEmailBeSent
-    ) {
+        string $sendEmail,
+        bool $emailEnabled,
+        bool $shouldEmailBeSent
+    ): void {
         $redirectMock = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -262,7 +263,7 @@ class SaveTest extends TestCase
 
         $invoice = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTotalQty','getOrder','register'])
+            ->onlyMethods(['getTotalQty', 'getOrder', 'register'])
             ->getMock();
         $invoice->expects($this->any())
             ->method('getTotalQty')
@@ -280,20 +281,16 @@ class SaveTest extends TestCase
 
         $saveTransaction = $this->getMockBuilder(Transaction::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addObject','save'])
+            ->onlyMethods(['addObject', 'save'])
             ->getMock();
-        $saveTransaction->expects($this->at(0))
+        $saveTransaction
             ->method('addObject')
-            ->with($invoice)->willReturnSelf();
-        $saveTransaction->expects($this->at(1))
-            ->method('addObject')
-            ->with($order)->willReturnSelf();
-        $saveTransaction->expects($this->at(2))
-            ->method('save');
+            ->withConsecutive([$invoice], [$order])
+            ->willReturnOnConsecutiveCalls($saveTransaction, $saveTransaction);
 
         $session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCommentText'])
+            ->addMethods(['getCommentText'])
             ->getMock();
         $session->expects($this->once())
             ->method('getCommentText')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/UpdateQtyTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/UpdateQtyTest.php
@@ -109,13 +109,11 @@ class UpdateQtyTest extends TestCase
             ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->resultPageMock = $this->getMockBuilder(Page::class)
-            ->setMethods([])
             ->disableOriginalConstructor()
             ->getMock();
         $this->pageConfigMock = $this->getMockBuilder(Config::class)
@@ -138,12 +136,11 @@ class UpdateQtyTest extends TestCase
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -151,7 +148,7 @@ class UpdateQtyTest extends TestCase
                     'getResultRedirectFactory',
                     'getView'
                 ]
-            )
+            )->addMethods(['getTitle'])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -171,17 +168,17 @@ class UpdateQtyTest extends TestCase
 
         $this->resultPageFactoryMock = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->resultRawFactoryMock = $this->getMockBuilder(RawFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->resultJsonFactoryMock = $this->getMockBuilder(JsonFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->invoiceServiceMock = $this->getMockBuilder(InvoiceService::class)
@@ -205,24 +202,19 @@ class UpdateQtyTest extends TestCase
      *
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $orderId = 1;
         $invoiceData = ['comment_text' => 'test'];
         $response = 'test data';
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('invoice', [])
-            ->willReturn($invoiceData);
+            ->withConsecutive(['order_id'], ['invoice', []])
+            ->willReturnOnConsecutiveCalls($orderId, $invoiceData);
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $invoiceMock->expects($this->once())
             ->method('getTotalQty')
@@ -230,7 +222,7 @@ class UpdateQtyTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'canInvoice'])
+            ->onlyMethods(['load', 'getId', 'canInvoice'])
             ->getMock();
         $orderMock->expects($this->once())
             ->method('load')
@@ -248,14 +240,13 @@ class UpdateQtyTest extends TestCase
             ->with($orderMock, [])
             ->willReturn($invoiceMock);
 
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with(Order::class)
             ->willReturn($orderMock);
 
         $blockItemMock = $this->getMockBuilder(Items::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $blockItemMock->expects($this->once())
             ->method('toHtml')
@@ -263,7 +254,6 @@ class UpdateQtyTest extends TestCase
 
         $layoutMock = $this->getMockBuilder(Layout::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $layoutMock->expects($this->once())
             ->method('getBlock')
@@ -285,7 +275,6 @@ class UpdateQtyTest extends TestCase
 
         $resultRaw = $this->getMockBuilder(Raw::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRaw->expects($this->once())->method('setContents')->with($response);
 
@@ -299,21 +288,21 @@ class UpdateQtyTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteModelException()
+    public function testExecuteModelException(): void
     {
         $message = 'The order no longer exists.';
         $response = ['error' => true, 'message' => $message];
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'canInvoice'])
+            ->onlyMethods(['load', 'getId', 'canInvoice'])
             ->getMock();
         $orderMock->expects($this->once())
             ->method('load')->willReturnSelf();
         $orderMock->expects($this->once())
             ->method('getId')
             ->willReturn(null);
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with(Order::class)
             ->willReturn($orderMock);
@@ -325,7 +314,6 @@ class UpdateQtyTest extends TestCase
         /** @var Json|MockObject */
         $resultJsonMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultJsonMock->expects($this->once())->method('setData')->with($response);
 
@@ -341,21 +329,21 @@ class UpdateQtyTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $message = 'The order no longer exists.';
         $response = ['error' => true, 'message' => $message];
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'canInvoice'])
+            ->onlyMethods(['load', 'getId', 'canInvoice'])
             ->getMock();
         $orderMock->expects($this->once())
             ->method('load')->willReturnSelf();
         $orderMock->expects($this->once())
             ->method('getId')
             ->willReturn(null);
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with(Order::class)
             ->willReturn($orderMock);
@@ -367,7 +355,6 @@ class UpdateQtyTest extends TestCase
         /** @var Json|MockObject */
         $resultJsonMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultJsonMock->expects($this->once())->method('setData')->with($response);
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/ViewTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/ViewTest.php
@@ -116,29 +116,28 @@ class ViewTest extends TestCase
      */
     protected $invoiceRepository;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->viewMock = $this->getMockBuilder(\Magento\Framework\App\View::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->actionFlagMock = $this->getMockBuilder(ActionFlag::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->sessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCommentText', 'setIsUrlNotice'])
+            ->addMethods(['getCommentText', 'setIsUrlNotice'])
             ->getMock();
         $this->resultPageMock = $this->getMockBuilder(Page::class)
             ->disableOriginalConstructor()
@@ -152,12 +151,11 @@ class ViewTest extends TestCase
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -165,7 +163,7 @@ class ViewTest extends TestCase
                     'getResultRedirectFactory',
                     'getView'
                 ]
-            )
+            )->addMethods(['getTitle'])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -194,16 +192,15 @@ class ViewTest extends TestCase
 
         $this->resultPageFactoryMock = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
-        $this->resultForwardFactoryMock = $this->getMockBuilder(
-            ForwardFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
         $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->resultRedirectMock = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
@@ -229,22 +226,21 @@ class ViewTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $invoiceId = 2;
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('invoice_id')
-            ->willReturn($invoiceId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('come_from')
-            ->willReturn('anything');
+            ->withConsecutive(['invoice_id'], ['come_from'])
+            ->willReturnOnConsecutiveCalls($invoiceId, 'anything');
 
-        $menuBlockMock = $this->getMockBuilder(Menu::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParentItems', 'getMenuModel'])
+        $menuBlockMock = $this->getMockBuilder(Menu::class)->disableOriginalConstructor()
+            ->onlyMethods(['getMenuModel'])
+            ->addMethods(['getParentItems'])
             ->getMock();
         $menuBlockMock->expects($this->any())
             ->method('getMenuModel')->willReturnSelf();
@@ -255,15 +251,13 @@ class ViewTest extends TestCase
 
         $invoiceViewBlockMock = $this->getMockBuilder(\Magento\Sales\Block\Adminhtml\Order\Invoice\View::class)
             ->disableOriginalConstructor()
-            ->setMethods(['updateBackButtonUrl'])
+            ->onlyMethods(['updateBackButtonUrl'])
             ->getMock();
 
         $layoutMock = $this->getMockBuilder(Layout::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
-        $layoutMock->expects($this->at(0))
-            ->method('getBlock')
+        $layoutMock->method('getBlock')
             ->with('sales_invoice_view')
             ->willReturn($invoiceViewBlockMock);
 
@@ -273,7 +267,6 @@ class ViewTest extends TestCase
 
         $invoiceMock = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->invoiceRepository->expects($this->once())
@@ -289,7 +282,10 @@ class ViewTest extends TestCase
         $this->assertSame($this->resultPageMock, $this->controller->execute());
     }
 
-    public function testExecuteNoInvoice()
+    /**
+     * @return void
+     */
+    public function testExecuteNoInvoice(): void
     {
         $invoiceId = 2;
 
@@ -312,8 +308,10 @@ class ViewTest extends TestCase
 
     /**
      * prepareRedirect
+     *
+     * @return void
      */
-    protected function prepareRedirect()
+    protected function prepareRedirect(): void
     {
         $this->resultRedirectFactoryMock->expects($this->once())
             ->method('create')
@@ -323,8 +321,10 @@ class ViewTest extends TestCase
     /**
      * @param string $path
      * @param array $params
+     *
+     * @return void
      */
-    protected function setPath($path, $params = [])
+    protected function setPath(string $path, array $params = []): void
     {
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
@@ -110,50 +110,41 @@ class VoidActionTest extends TestCase
 
         $this->titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
         $this->messageManagerMock = $this->getMockBuilder(Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->actionFlagMock = $this->getMockBuilder(ActionFlag::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->helperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->sessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
-        $this->resultRedirectFactoryMock = $this->getMockBuilder(
-            RedirectFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultRedirectFactoryMock = $this->getMockBuilder(RedirectFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $this->resultForwardFactoryMock = $this->getMockBuilder(
-            ForwardFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->resultForwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->invoiceManagement = $this->getMockBuilder(InvoiceManagementInterface::class)
@@ -166,19 +157,18 @@ class VoidActionTest extends TestCase
 
         $contextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
                     'getMessageManager',
                     'getResultRedirectFactory'
                 ]
-            )
+            )->addMethods(['getTitle'])
             ->getMock();
         $contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
         $contextMock->expects($this->any())->method('getResponse')->willReturn($this->responseMock);
@@ -214,7 +204,7 @@ class VoidActionTest extends TestCase
     /**
      * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $invoiceId = 2;
 
@@ -225,7 +215,7 @@ class VoidActionTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setIsInProcess'])
+            ->addMethods(['setIsInProcess'])
             ->getMock();
 
         $this->invoiceManagement->expects($this->once())
@@ -249,20 +239,15 @@ class VoidActionTest extends TestCase
         $transactionMock = $this->getMockBuilder(Transaction::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $transactionMock->expects($this->at(0))
-            ->method('addObject')
-            ->with($invoiceMock)->willReturnSelf();
-        $transactionMock->expects($this->at(1))
-            ->method('addObject')
-            ->with($orderMock)->willReturnSelf();
-        $transactionMock->expects($this->at(2))
-            ->method('save');
+        $transactionMock->method('addObject')
+            ->withConsecutive([$invoiceMock], [$orderMock])
+            ->willReturnOnConsecutiveCalls($transactionMock, $transactionMock);
 
         $this->invoiceRepository->expects($this->once())
             ->method('get')
             ->willReturn($invoiceMock);
 
-        $this->objectManagerMock->expects($this->at(1))
+        $this->objectManagerMock
             ->method('create')
             ->with(Transaction::class)
             ->willReturn($transactionMock);
@@ -273,7 +258,6 @@ class VoidActionTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
 
@@ -287,7 +271,7 @@ class VoidActionTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteNoInvoice()
+    public function testExecuteNoInvoice(): void
     {
         $invoiceId = 2;
 
@@ -307,7 +291,6 @@ class VoidActionTest extends TestCase
 
         $resultForward = $this->getMockBuilder(Forward::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultForward->expects($this->once())->method('forward')->with(('noroute'))->willReturnSelf();
 
@@ -321,7 +304,7 @@ class VoidActionTest extends TestCase
     /**
      * @return void
      */
-    public function testExecuteModelException()
+    public function testExecuteModelException(): void
     {
         $invoiceId = 2;
         $message = 'test message';
@@ -356,7 +339,6 @@ class VoidActionTest extends TestCase
 
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $resultRedirect->expects($this->once())->method('setPath')->with('sales/*/view', ['invoice_id' => $invoiceId]);
 

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/ReviewPaymentTest.php
@@ -27,28 +27,44 @@ use Psr\Log\LoggerInterface;
  */
 class ReviewPaymentTest extends TestCase
 {
-    /** @var ReviewPayment|MockObject */
+    /**
+     * @var ReviewPayment|MockObject
+     */
     protected $reviewPayment;
 
-    /** @var  Context|MockObject */
+    /**
+     * @var  Context|MockObject
+     */
     protected $contextMock;
 
-    /** @var  OrderInterface|MockObject */
+    /**
+     * @var  OrderInterface|MockObject
+     */
     protected $orderMock;
 
-    /** @var  RedirectFactory|MockObject*/
+    /**
+     * @var  RedirectFactory|MockObject
+     */
     protected $resultRedirectFactoryMock;
 
-    /** @var Redirect|MockObject */
+    /**
+     * @var Redirect|MockObject
+     */
     protected $resultRedirectMock;
 
-    /**@var \Magento\Framework\App\Request\Http|MockObject */
+    /**
+     * @var Http|MockObject
+     */
     protected $requestMock;
 
-    /** @var  Payment|MockObject */
+    /**
+     * @var  Payment|MockObject
+     */
     protected $paymentMock;
 
-    /** @var Manager|MockObject */
+    /**
+     * @var Manager|MockObject
+     */
     protected $messageManagerMock;
 
     /**
@@ -67,7 +83,7 @@ class ReviewPaymentTest extends TestCase
     protected $loggerMock;
 
     /**
-     * Test setup
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -89,7 +105,7 @@ class ReviewPaymentTest extends TestCase
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
         $this->orderMock = $this->getMockBuilder(OrderInterface::class)
-            ->setMethods(['getPayment'])
+            ->onlyMethods(['getPayment'])
             ->getMockForAbstractClass();
         $this->messageManagerMock = $this->createPartialMock(
             Manager::class,
@@ -113,7 +129,7 @@ class ReviewPaymentTest extends TestCase
         );
 
         $this->requestMock = $this->getMockBuilder(Http::class)
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->contextMock->expects($this->once())->method('getRequest')->willReturn($this->requestMock);
@@ -133,15 +149,17 @@ class ReviewPaymentTest extends TestCase
     }
 
     /**
-     * testExecuteUpdateAction
+     * @return void
      */
-    public function testExecuteUpdateAction()
+    public function testExecuteUpdateAction(): void
     {
         $orderId = 30;
         $action = 'update';
 
-        $this->requestMock->expects($this->at(0))->method('getParam')->with('order_id')->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))->method('getParam')->with('action')->willReturn($action);
+        $this->requestMock
+            ->method('getParam')
+            ->withConsecutive(['order_id'], ['action'])
+            ->willReturnOnConsecutiveCalls($orderId, $action);
 
         $this->resultRedirectFactoryMock->expects($this->once())->method('create')
             ->willReturn($this->resultRedirectMock);

--- a/app/code/Magento/Sales/Test/Unit/CustomerData/LastOrderedItemsTest.php
+++ b/app/code/Magento/Sales/Test/Unit/CustomerData/LastOrderedItemsTest.php
@@ -81,13 +81,16 @@ class LastOrderedItemsTest extends TestCase
      */
     private $loggerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->orderCollectionFactoryMock =
             $this->getMockBuilder(CollectionFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $this->orderConfigMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
@@ -118,7 +121,10 @@ class LastOrderedItemsTest extends TestCase
         );
     }
 
-    public function testGetSectionData()
+    /**
+     * @return void
+     */
+    public function testGetSectionData(): void
     {
         $storeId = 1;
         $websiteId = 4;
@@ -126,13 +132,13 @@ class LastOrderedItemsTest extends TestCase
             'id' => 1,
             'name' => 'Product Name 1',
             'url' => 'http://example.com',
-            'is_saleable' => true,
+            'is_saleable' => true
         ];
         $expectedItem2 = [
             'id' => 2,
             'name' => 'Product Name 2',
             'url' => null,
-            'is_saleable' => true,
+            'is_saleable' => true
         ];
         $productIdVisible = 1;
         $productIdNotVisible = 2;
@@ -183,14 +189,14 @@ class LastOrderedItemsTest extends TestCase
             ->method('getById')
             ->willReturnMap([
                 [$productIdVisible, false, $storeId, false, $productVisible],
-                [$productIdNotVisible, false, $storeId, false, $productNotVisible],
+                [$productIdNotVisible, false, $storeId, false, $productNotVisible]
             ]);
         $this->stockRegistryMock
             ->expects($this->any())
             ->method('getStockItem')
             ->willReturnMap([
                 [$productIdVisible, $websiteId, $stockItemMock],
-                [$productIdNotVisible, $websiteId, $stockItemMock],
+                [$productIdNotVisible, $websiteId, $stockItemMock]
             ]);
         $stockItemMock->expects($this->exactly(2))->method('getIsInStock')->willReturn($expectedItem1['is_saleable']);
         $this->assertEquals(['items' => [$expectedItem1, $expectedItem2]], $this->section->getSectionData());
@@ -199,7 +205,7 @@ class LastOrderedItemsTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getLastOrderMock()
+    private function getLastOrderMock(): MockObject
     {
         $customerId = 1;
         $visibleOnFrontStatuses = ['complete'];
@@ -211,14 +217,11 @@ class LastOrderedItemsTest extends TestCase
             ->method('getVisibleOnFrontStatuses')
             ->willReturn($visibleOnFrontStatuses);
         $this->orderCollectionFactoryMock->expects($this->once())->method('create')->willReturn($orderCollectionMock);
-        $orderCollectionMock->expects($this->at(0))
-            ->method('addAttributeToFilter')
-            ->with('customer_id', $customerId)
-            ->willReturnSelf();
-        $orderCollectionMock->expects($this->at(1))
-            ->method('addAttributeToFilter')
-            ->with('status', ['in' => $visibleOnFrontStatuses])
-            ->willReturnSelf();
+        $orderCollectionMock->method('addAttributeToFilter')
+            ->withConsecutive(
+                ['customer_id', $customerId],
+                ['status', ['in' => $visibleOnFrontStatuses]]
+            )->willReturnOnConsecutiveCalls($orderCollectionMock, $orderCollectionMock);
         $orderCollectionMock->expects($this->once())
             ->method('addAttributeToSort')
             ->willReturnSelf();
@@ -228,7 +231,10 @@ class LastOrderedItemsTest extends TestCase
         return $this->orderMock;
     }
 
-    public function testGetSectionDataWithNotExistingProduct()
+    /**
+     * @return void
+     */
+    public function testGetSectionDataWithNotExistingProduct(): void
     {
         $storeId = 1;
         $websiteId = 4;
@@ -236,7 +242,7 @@ class LastOrderedItemsTest extends TestCase
         $exception = new NoSuchEntityException(__("Product doesn't exist"));
         $orderItemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProductId'])
+            ->onlyMethods(['getProductId'])
             ->getMock();
         $storeMock = $this->getMockBuilder(StoreInterface::class)
             ->getMockForAbstractClass();

--- a/app/code/Magento/Sales/Test/Unit/Helper/GuestTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Helper/GuestTest.php
@@ -14,9 +14,12 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\ViewInterface;
 use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Exception\InputException;
 use Magento\Framework\Message\ManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
+use Magento\Framework\Stdlib\Cookie\CookieSizeLimitReachedException;
+use Magento\Framework\Stdlib\Cookie\FailureToSendException;
 use Magento\Framework\Stdlib\Cookie\PublicCookieMetadata;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
@@ -36,31 +39,49 @@ use PHPUnit\Framework\TestCase;
  */
 class GuestTest extends TestCase
 {
-    /** @var Guest */
+    /**
+     * @var Guest
+     */
     protected $guest;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $sessionMock;
 
-    /** @var CookieManagerInterface|MockObject */
+    /**
+     * @var CookieManagerInterface|MockObject
+     */
     protected $cookieManagerMock;
 
-    /** @var CookieMetadataFactory|MockObject */
+    /**
+     * @var CookieMetadataFactory|MockObject
+     */
     protected $cookieMetadataFactoryMock;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     protected $managerInterfaceMock;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $orderFactoryMock;
 
-    /** @var ViewInterface|MockObject */
+    /**
+     * @var ViewInterface|MockObject
+     */
     protected $viewInterfaceMock;
 
-    /** @var Store|MockObject */
+    /**
+     * @var Store|MockObject
+     */
     protected $storeModelMock;
 
-    /** @var Order|MockObject */
+    /**
+     * @var Order|MockObject
+     */
     protected $salesOrderMock;
 
     /**
@@ -73,6 +94,9 @@ class GuestTest extends TestCase
      */
     private $searchCriteriaBuilder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $appContextHelperMock = $this->createMock(Context::class);
@@ -101,20 +125,20 @@ class GuestTest extends TestCase
             ]
         );
         $this->orderRepository = $this->getMockBuilder(OrderRepositoryInterface::class)
-            ->setMethods(['getList'])
+            ->onlyMethods(['getList'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->searchCriteriaBuilder = $this->getMockBuilder(SearchCriteriaBuilder::class)
-            ->setMethods(['addFilter', 'create'])
+            ->onlyMethods(['addFilter', 'create'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $orderSearchResult = $this->getMockBuilder(OrderSearchResultInterface::class)
-            ->setMethods(['getTotalCount', 'getItems'])
+            ->onlyMethods(['getTotalCount', 'getItems'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $resultRedirectFactory =
             $this->getMockBuilder(RedirectFactory::class)
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->disableOriginalConstructor()
                 ->getMock();
         $this->orderRepository->method('getList')->willReturn($orderSearchResult);
@@ -151,12 +175,14 @@ class GuestTest extends TestCase
      * Test load valid order with non empty post data.
      *
      * @param array $post
+     *
+     * @return void
+     * @throws InputException
+     * @throws CookieSizeLimitReachedException
+     * @throws FailureToSendException
      * @dataProvider loadValidOrderNotEmptyPostDataProvider
-     * @throws \Magento\Framework\Exception\InputException
-     * @throws \Magento\Framework\Stdlib\Cookie\CookieSizeLimitReachedException
-     * @throws \Magento\Framework\Stdlib\Cookie\FailureToSendException
      */
-    public function testLoadValidOrderNotEmptyPost($post)
+    public function testLoadValidOrderNotEmptyPost(array $post): void
     {
         $incrementId = $post['oar_order_id'];
         $protectedCode = 'protectedCode';
@@ -165,16 +191,11 @@ class GuestTest extends TestCase
         $requestMock->expects($this->once())->method('getPostValue')->willReturn($post);
 
         $this->searchCriteriaBuilder
-            ->expects($this->at(0))
             ->method('addFilter')
-            ->with('increment_id', trim($incrementId))
-            ->willReturnSelf();
-
-        $this->searchCriteriaBuilder
-            ->expects($this->at(1))
-            ->method('addFilter')
-            ->with('store_id', $this->storeModelMock->getId())
-            ->willReturnSelf();
+            ->withConsecutive(
+                ['increment_id', trim($incrementId)],
+                ['store_id', $this->storeModelMock->getId()]
+            )->willReturnOnConsecutiveCalls($this->searchCriteriaBuilder, $this->searchCriteriaBuilder);
 
         $this->salesOrderMock->expects($this->any())->method('getId')->willReturn($incrementId);
 
@@ -214,7 +235,7 @@ class GuestTest extends TestCase
      *
      * @return array
      */
-    public function loadValidOrderNotEmptyPostDataProvider()
+    public function loadValidOrderNotEmptyPostDataProvider(): array
     {
         return [
             [
@@ -223,8 +244,7 @@ class GuestTest extends TestCase
                     'oar_type' => 'email',
                     'oar_billing_lastname' => 'White',
                     'oar_email' => 'test@magento-test.com',
-                    'oar_zip' => '',
-
+                    'oar_zip' => ''
                 ]
             ],
             [
@@ -233,7 +253,7 @@ class GuestTest extends TestCase
                     'oar_type' => 'email',
                     'oar_billing_lastname' => 'Black  ',
                     'oar_email' => '        test1@magento-test.com  ',
-                    'oar_zip' => '',
+                    'oar_zip' => ''
                 ]
             ],
             [
@@ -242,13 +262,16 @@ class GuestTest extends TestCase
                     'oar_type' => 'zip',
                     'oar_billing_lastname' => 'Black  ',
                     'oar_email' => '        test1@magento-test.com  ',
-                    'oar_zip' => '123456  ',
+                    'oar_zip' => '123456  '
                 ]
             ]
         ];
     }
 
-    public function testLoadValidOrderStoredCookie()
+    /**
+     * @return void
+     */
+    public function testLoadValidOrderStoredCookie(): void
     {
         $protectedCode = 'protectedCode';
         $incrementId = '1';
@@ -261,16 +284,11 @@ class GuestTest extends TestCase
             ->willReturn($cookieDataHash);
 
         $this->searchCriteriaBuilder
-            ->expects($this->at(0))
             ->method('addFilter')
-            ->with('increment_id', trim($incrementId))
-            ->willReturnSelf();
-
-        $this->searchCriteriaBuilder
-            ->expects($this->at(1))
-            ->method('addFilter')
-            ->with('store_id', $this->storeModelMock->getId())
-            ->willReturnSelf();
+            ->withConsecutive(
+                ['increment_id', trim($incrementId)],
+                ['store_id', $this->storeModelMock->getId()]
+            )->willReturnOnConsecutiveCalls($this->searchCriteriaBuilder, $this->searchCriteriaBuilder);
 
         $this->salesOrderMock->expects($this->any())->method('getId')->willReturn($incrementId);
         $this->salesOrderMock->expects($this->once())->method('getProtectCode')->willReturn($protectedCode);

--- a/app/code/Magento/Sales/Test/Unit/Model/EmailSenderHandlerTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/EmailSenderHandlerTest.php
@@ -84,6 +84,9 @@ class EmailSenderHandlerTest extends TestCase
      */
     private $modifyStartFromDate = '-1 day';
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -146,36 +149,32 @@ class EmailSenderHandlerTest extends TestCase
      * @param int $configValue
      * @param array|null $collectionItems
      * @param bool|null $emailSendingResult
-     * @dataProvider executeDataProvider
+     *
      * @return void
+     * @dataProvider executeDataProvider
      */
-    public function testExecute($configValue, $collectionItems, $emailSendingResult)
-    {
+    public function testExecute(
+        int $configValue,
+        ?array $collectionItems,
+        ?bool $emailSendingResult
+    ): void {
         $path = 'sales_email/general/async_sending';
 
         $this->globalConfig
-            ->expects($this->at(0))
             ->method('getValue')
-            ->with($path)
-            ->willReturn($configValue);
+            ->withConsecutive([$path])
+            ->willReturnOnConsecutiveCalls($configValue);
 
         if ($configValue) {
-            $this->entityCollection
-                ->expects($this->at(0))
-                ->method('addFieldToFilter')
-                ->with('send_email', ['eq' => 1]);
-
-            $this->entityCollection
-                ->expects($this->at(1))
-                ->method('addFieldToFilter')
-                ->with('email_sent', ['null' => true]);
-
             $nowDate = date('Y-m-d H:i:s');
             $fromDate = date('Y-m-d H:i:s', strtotime($nowDate . ' ' . $this->modifyStartFromDate));
             $this->entityCollection
-                ->expects($this->at(2))
                 ->method('addFieldToFilter')
-                ->with('created_at', ['from' => $fromDate]);
+                ->withConsecutive(
+                    ['send_email', ['eq' => 1]],
+                    ['email_sent', ['null' => true]],
+                    ['created_at', ['from' => $fromDate]]
+                );
 
             $this->entityCollection
                 ->expects($this->any())
@@ -264,7 +263,7 @@ class EmailSenderHandlerTest extends TestCase
     /**
      * @return array
      */
-    public function executeDataProvider()
+    public function executeDataProvider(): array
     {
         $entityModel = $this->getMockForAbstractClass(
             AbstractModel::class,
@@ -280,22 +279,22 @@ class EmailSenderHandlerTest extends TestCase
             [
                 'configValue' => 1,
                 'collectionItems' => [clone $entityModel],
-                'emailSendingResult' => true,
+                'emailSendingResult' => true
             ],
             [
                 'configValue' => 1,
                 'collectionItems' => [clone $entityModel],
-                'emailSendingResult' => false,
+                'emailSendingResult' => false
             ],
             [
                 'configValue' => 1,
                 'collectionItems' => [],
-                'emailSendingResult' => null,
+                'emailSendingResult' => null
             ],
             [
                 'configValue' => 0,
                 'collectionItems' => null,
-                'emailSendingResult' => null,
+                'emailSendingResult' => null
             ]
         ];
     }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Sender/EmailSenderTest.php
@@ -121,6 +121,8 @@ class EmailSenderTest extends TestCase
     private $senderBuilderFactoryMock;
 
     /**
+     * @inheritDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -130,7 +132,7 @@ class EmailSenderTest extends TestCase
             ->getMock();
 
         $this->storeMock = $this->getMockBuilder(Store::class)
-            ->setMethods(['getStoreId'])
+            ->addMethods(['getStoreId'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -143,7 +145,7 @@ class EmailSenderTest extends TestCase
 
         $this->senderMock = $this->getMockBuilder(Sender::class)
             ->disableOriginalConstructor()
-            ->setMethods(['send', 'sendCopyTo'])
+            ->addMethods(['send', 'sendCopyTo'])
             ->getMock();
 
         $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
@@ -152,7 +154,8 @@ class EmailSenderTest extends TestCase
 
         $this->creditmemoMock = $this->getMockBuilder(\Magento\Sales\Model\Order\Creditmemo::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setSendEmail', 'setEmailSent'])
+            ->onlyMethods(['setEmailSent'])
+            ->addMethods(['setSendEmail'])
             ->getMock();
 
         $this->commentMock = $this->getMockBuilder(CreditmemoCommentCreationInterface::class)
@@ -227,11 +230,9 @@ class EmailSenderTest extends TestCase
             ->method('getStore')
             ->willReturn($this->storeMock);
 
-        $this->senderBuilderFactoryMock = $this->getMockBuilder(
-            SenderBuilderFactory::class
-        )
+        $this->senderBuilderFactoryMock = $this->getMockBuilder(SenderBuilderFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->subject = new EmailSender(
@@ -253,13 +254,16 @@ class EmailSenderTest extends TestCase
      * @param bool $isComment
      * @param bool $emailSendingResult
      *
-     * @dataProvider sendDataProvider
-     *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $isComment, $emailSendingResult)
-    {
+    public function testSend(
+        int $configValue,
+        bool $forceSyncMode,
+        bool $isComment,
+        bool $emailSendingResult
+    ): void {
         $this->globalConfigMock->expects($this->once())
             ->method('getValue')
             ->with('sales_email/general/async_sending')
@@ -292,8 +296,8 @@ class EmailSenderTest extends TestCase
                     'customer_name' => 'Customer name',
                     'is_not_virtual' => true,
                     'email_customer_note' => null,
-                    'frontend_status_label' => 'Pending',
-                ],
+                    'frontend_status_label' => 'Pending'
+                ]
             ];
             $transport = new DataObject($transport);
 
@@ -366,12 +370,12 @@ class EmailSenderTest extends TestCase
                 ->method('setEmailSent')
                 ->with(null);
 
-            $this->creditmemoResourceMock->expects($this->at(0))
+            $this->creditmemoResourceMock
                 ->method('saveAttribute')
-                ->with($this->creditmemoMock, 'email_sent');
-            $this->creditmemoResourceMock->expects($this->at(1))
-                ->method('saveAttribute')
-                ->with($this->creditmemoMock, 'send_email');
+                ->withConsecutive(
+                    [$this->creditmemoMock, 'email_sent'],
+                    [$this->creditmemoMock, 'send_email']
+                );
 
             $this->assertFalse(
                 $this->subject->send(
@@ -387,14 +391,14 @@ class EmailSenderTest extends TestCase
     /**
      * @return array
      */
-    public function sendDataProvider()
+    public function sendDataProvider(): array
     {
         return [
             'Successful sync sending with comment' => [0, false, true, true],
             'Successful sync sending without comment' => [0, false, false, true],
             'Failed sync sending with comment' => [0, false, true, false],
             'Successful forced sync sending with comment' => [1, true, true, true],
-            'Async sending' => [1, false, false, false],
+            'Async sending' => [1, false, false, false]
         ];
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoNotifierTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/CreditmemoNotifierTest.php
@@ -17,7 +17,6 @@ use Magento\Sales\Model\Order\Status\History;
 use Magento\Sales\Model\ResourceModel\Order\Status\History\Collection;
 use Magento\Sales\Model\ResourceModel\Order\Status\History\CollectionFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -48,6 +47,9 @@ class CreditmemoNotifierTest extends TestCase
      */
     protected $creditmemoSenderMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->historyCollectionFactory = $this->createPartialMock(
@@ -72,8 +74,10 @@ class CreditmemoNotifierTest extends TestCase
 
     /**
      * Test case for successful email sending
+     *
+     * @return void
      */
-    public function testNotifySuccess()
+    public function testNotifySuccess(): void
     {
         $historyCollection = $this->getMockBuilder(Collection::class)
             ->addMethods(['setIsCustomerNotified'])
@@ -84,11 +88,8 @@ class CreditmemoNotifierTest extends TestCase
             History::class,
             ['setIsCustomerNotified', 'save']
         );
-        $historyItem->expects($this->at(0))
-            ->method('setIsCustomerNotified')
+        $historyItem->method('setIsCustomerNotified')
             ->with(1);
-        $historyItem->expects($this->at(1))
-            ->method('save');
         $historyCollection->expects($this->once())
             ->method('getUnnotifiedForInstance')
             ->with($this->creditmemo)
@@ -109,8 +110,10 @@ class CreditmemoNotifierTest extends TestCase
 
     /**
      * Test case when email has not been sent
+     *
+     * @return void
      */
-    public function testNotifyFail()
+    public function testNotifyFail(): void
     {
         $this->creditmemo->expects($this->once())
             ->method('getEmailSent')
@@ -120,8 +123,10 @@ class CreditmemoNotifierTest extends TestCase
 
     /**
      * Test case when Mail Exception has been thrown
+     *
+     * @return void
      */
-    public function testNotifyException()
+    public function testNotifyException(): void
     {
         $exception = new MailException(__('Email has not been sent'));
         $this->creditmemoSenderMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/CreditmemoSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/CreditmemoSenderTest.php
@@ -40,6 +40,9 @@ class CreditmemoSenderTest extends AbstractSenderTest
      */
     protected $creditmemoResourceMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->stepMockSetup();
@@ -88,15 +91,20 @@ class CreditmemoSenderTest extends AbstractSenderTest
 
     /**
      * @param int $configValue
-     * @param bool|null $forceSyncMode
-     * @param bool|null $customerNoteNotify
+     * @param int|null $forceSyncMode
+     * @param int|null $customerNoteNotify
      * @param bool|null $emailSendingResult
-     * @dataProvider sendDataProvider
+     *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $customerNoteNotify, $emailSendingResult)
-    {
+    public function testSend(
+        int $configValue,
+        ?int $forceSyncMode,
+        ?int $customerNoteNotify,
+        ?bool $emailSendingResult
+    ): void {
         $comment = 'comment_test';
         $address = 'address_test';
         $configPath = 'sales_email/general/async_sending';
@@ -208,12 +216,12 @@ class CreditmemoSenderTest extends AbstractSenderTest
                 );
             }
         } else {
-            $this->creditmemoResourceMock->expects($this->at(0))
+            $this->creditmemoResourceMock
                 ->method('saveAttribute')
-                ->with($this->creditmemoMock, 'email_sent');
-            $this->creditmemoResourceMock->expects($this->at(1))
-                ->method('saveAttribute')
-                ->with($this->creditmemoMock, 'send_email');
+                ->withConsecutive(
+                    [$this->creditmemoMock, 'email_sent'],
+                    [$this->creditmemoMock, 'send_email']
+                );
 
             $this->assertFalse(
                 $this->sender->send($this->creditmemoMock)
@@ -224,7 +232,7 @@ class CreditmemoSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendDataProvider()
+    public function sendDataProvider(): array
     {
         return [
             [0, 0, 1, true],
@@ -245,8 +253,11 @@ class CreditmemoSenderTest extends AbstractSenderTest
      * @return void
      * @dataProvider sendVirtualOrderDataProvider
      */
-    public function testSendVirtualOrder($isVirtualOrder, $formatCallCount, $expectedShippingAddress)
-    {
+    public function testSendVirtualOrder(
+        bool $isVirtualOrder,
+        int $formatCallCount,
+        ?string $expectedShippingAddress
+    ): void {
         $billingAddress = 'address_test';
         $customerName = 'test customer';
         $frontendStatusLabel = 'Complete';
@@ -330,7 +341,7 @@ class CreditmemoSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendVirtualOrderDataProvider()
+    public function sendVirtualOrderDataProvider(): array
     {
         return [
             [true, 1, null],

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/InvoiceSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/InvoiceSenderTest.php
@@ -40,6 +40,9 @@ class InvoiceSenderTest extends AbstractSenderTest
      */
     protected $invoiceResourceMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->stepMockSetup();
@@ -89,15 +92,20 @@ class InvoiceSenderTest extends AbstractSenderTest
 
     /**
      * @param int $configValue
-     * @param bool|null $forceSyncMode
-     * @param bool|null $customerNoteNotify
+     * @param int|null $forceSyncMode
+     * @param int|null $customerNoteNotify
      * @param bool|null $emailSendingResult
-     * @dataProvider sendDataProvider
+     *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $customerNoteNotify, $emailSendingResult)
-    {
+    public function testSend(
+        int $configValue,
+        ?int $forceSyncMode,
+        ?int $customerNoteNotify,
+        ?bool $emailSendingResult
+    ): void {
         $comment = 'comment_test';
         $address = 'address_test';
         $configPath = 'sales_email/general/async_sending';
@@ -215,12 +223,12 @@ class InvoiceSenderTest extends AbstractSenderTest
                 );
             }
         } else {
-            $this->invoiceResourceMock->expects($this->at(0))
+            $this->invoiceResourceMock
                 ->method('saveAttribute')
-                ->with($this->invoiceMock, 'email_sent');
-            $this->invoiceResourceMock->expects($this->at(1))
-                ->method('saveAttribute')
-                ->with($this->invoiceMock, 'send_email');
+                ->withConsecutive(
+                    [$this->invoiceMock, 'email_sent'],
+                    [$this->invoiceMock, 'send_email']
+                );
 
             $this->assertFalse(
                 $this->sender->send($this->invoiceMock)
@@ -231,7 +239,7 @@ class InvoiceSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendDataProvider()
+    public function sendDataProvider(): array
     {
         return [
             [0, 0, 1, true],
@@ -248,10 +256,15 @@ class InvoiceSenderTest extends AbstractSenderTest
      * @param bool $isVirtualOrder
      * @param int $formatCallCount
      * @param string|null $expectedShippingAddress
+     *
+     * @return void
      * @dataProvider sendVirtualOrderDataProvider
      */
-    public function testSendVirtualOrder($isVirtualOrder, $formatCallCount, $expectedShippingAddress)
-    {
+    public function testSendVirtualOrder(
+        bool $isVirtualOrder,
+        int $formatCallCount,
+        ?string $expectedShippingAddress
+    ): void {
         $billingAddress = 'address_test';
         $this->orderMock->setData(OrderInterface::IS_VIRTUAL, $isVirtualOrder);
         $customerName = 'Test Customer';
@@ -332,7 +345,7 @@ class InvoiceSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendVirtualOrderDataProvider()
+    public function sendVirtualOrderDataProvider(): array
     {
         return [
             [true, 1, null],

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/OrderSenderTest.php
@@ -29,6 +29,9 @@ class OrderSenderTest extends AbstractSenderTest
      */
     protected $orderResourceMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->stepMockSetup();
@@ -64,15 +67,20 @@ class OrderSenderTest extends AbstractSenderTest
 
     /**
      * @param int $configValue
-     * @param bool|null $forceSyncMode
+     * @param int|null $forceSyncMode
      * @param bool|null $emailSendingResult
-     * @param $senderSendException
+     * @param bool $senderSendException
+     *
      * @return void
-     * @dataProvider sendDataProvider
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $emailSendingResult, $senderSendException)
-    {
+    public function testSend(
+        int $configValue,
+        ?int $forceSyncMode,
+        ?bool $emailSendingResult,
+        bool $senderSendException
+    ): void {
         $address = 'address_test';
         $configPath = 'sales_email/general/async_sending';
         $createdAtFormatted='Oct 14, 2019, 4:11:58 PM';
@@ -153,7 +161,6 @@ class OrderSenderTest extends AbstractSenderTest
                                 'email_customer_note' => '',
                                 'frontend_status_label' => $frontendStatusLabel
                             ]
-
                         ]
                     );
 
@@ -190,12 +197,12 @@ class OrderSenderTest extends AbstractSenderTest
                 );
             }
         } else {
-            $this->orderResourceMock->expects($this->at(0))
+            $this->orderResourceMock
                 ->method('saveAttribute')
-                ->with($this->orderMock, 'email_sent');
-            $this->orderResourceMock->expects($this->at(1))
-                ->method('saveAttribute')
-                ->with($this->orderMock, 'send_email');
+                ->withConsecutive(
+                    [$this->orderMock, 'email_sent'],
+                    [$this->orderMock, 'send_email']
+                );
 
             $this->assertFalse(
                 $this->sender->send($this->orderMock)
@@ -208,7 +215,7 @@ class OrderSenderTest extends AbstractSenderTest
      *
      * @return void
      */
-    protected function checkSenderSendExceptionCase()
+    protected function checkSenderSendExceptionCase(): void
     {
         $this->senderMock->expects($this->once())
             ->method('send')
@@ -226,7 +233,7 @@ class OrderSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendDataProvider()
+    public function sendDataProvider(): array
     {
         return [
             [0, 0, true, false],
@@ -246,10 +253,15 @@ class OrderSenderTest extends AbstractSenderTest
      * @param bool $isVirtualOrder
      * @param int $formatCallCount
      * @param string|null $expectedShippingAddress
+     *
+     * @return void
      * @dataProvider sendVirtualOrderDataProvider
      */
-    public function testSendVirtualOrder($isVirtualOrder, $formatCallCount, $expectedShippingAddress)
-    {
+    public function testSendVirtualOrder(
+        bool $isVirtualOrder,
+        int $formatCallCount,
+        ?string $expectedShippingAddress
+    ): void {
         $address = 'address_test';
         $this->orderMock->setData(OrderInterface::IS_VIRTUAL, $isVirtualOrder);
         $createdAtFormatted='Oct 14, 2019, 4:11:58 PM';
@@ -347,7 +359,7 @@ class OrderSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendVirtualOrderDataProvider()
+    public function sendVirtualOrderDataProvider(): array
     {
         return [
             [true, 1, null],

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/ShipmentSenderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Email/Sender/ShipmentSenderTest.php
@@ -43,6 +43,9 @@ class ShipmentSenderTest extends AbstractSenderTest
      */
     protected $shipmentResourceMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->stepMockSetup();
@@ -92,15 +95,20 @@ class ShipmentSenderTest extends AbstractSenderTest
 
     /**
      * @param int $configValue
-     * @param bool|null $forceSyncMode
-     * @param bool|null $customerNoteNotify
+     * @param int|null $forceSyncMode
+     * @param int|null $customerNoteNotify
      * @param bool|null $emailSendingResult
-     * @dataProvider sendDataProvider
+     *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider sendDataProvider
      */
-    public function testSend($configValue, $forceSyncMode, $customerNoteNotify, $emailSendingResult)
-    {
+    public function testSend(
+        int $configValue,
+        ?int $forceSyncMode,
+        ?int $customerNoteNotify,
+        ?bool $emailSendingResult
+    ): void {
         $comment = 'comment_test';
         $address = 'address_test';
         $configPath = 'sales_email/general/async_sending';
@@ -218,12 +226,12 @@ class ShipmentSenderTest extends AbstractSenderTest
                 );
             }
         } else {
-            $this->shipmentResourceMock->expects($this->at(0))
+            $this->shipmentResourceMock
                 ->method('saveAttribute')
-                ->with($this->shipmentMock, 'email_sent');
-            $this->shipmentResourceMock->expects($this->at(1))
-                ->method('saveAttribute')
-                ->with($this->shipmentMock, 'send_email');
+                ->withConsecutive(
+                    [$this->shipmentMock, 'email_sent'],
+                    [$this->shipmentMock, 'send_email']
+                );
 
             $this->assertFalse(
                 $this->sender->send($this->shipmentMock)
@@ -234,7 +242,7 @@ class ShipmentSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendDataProvider()
+    public function sendDataProvider(): array
     {
         return [
             [0, 0, 1, true],
@@ -251,10 +259,15 @@ class ShipmentSenderTest extends AbstractSenderTest
      * @param bool $isVirtualOrder
      * @param int $formatCallCount
      * @param string|null $expectedShippingAddress
+     *
+     * @return void
      * @dataProvider sendVirtualOrderDataProvider
      */
-    public function testSendVirtualOrder($isVirtualOrder, $formatCallCount, $expectedShippingAddress)
-    {
+    public function testSendVirtualOrder(
+        bool $isVirtualOrder,
+        int $formatCallCount,
+        ?string $expectedShippingAddress
+    ): void {
         $address = 'address_test';
         $this->orderMock->setData(OrderInterface::IS_VIRTUAL, $isVirtualOrder);
         $customerName = 'Test Customer';
@@ -335,7 +348,7 @@ class ShipmentSenderTest extends AbstractSenderTest
     /**
      * @return array
      */
-    public function sendVirtualOrderDataProvider()
+    public function sendVirtualOrderDataProvider(): array
     {
         return [
             [true, 1, null],

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceNotifierTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/InvoiceNotifierTest.php
@@ -47,6 +47,9 @@ class InvoiceNotifierTest extends TestCase
      */
     protected $invoiceSenderMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->historyCollectionFactory = $this->createPartialMock(
@@ -71,8 +74,10 @@ class InvoiceNotifierTest extends TestCase
 
     /**
      * Test case for successful email sending
+     *
+     * @return void
      */
-    public function testNotifySuccess()
+    public function testNotifySuccess(): void
     {
         $historyCollection = $this->getMockBuilder(Collection::class)
             ->addMethods(['setIsCustomerNotified'])
@@ -83,11 +88,8 @@ class InvoiceNotifierTest extends TestCase
             History::class,
             ['setIsCustomerNotified', 'save']
         );
-        $historyItem->expects($this->at(0))
-            ->method('setIsCustomerNotified')
+        $historyItem->method('setIsCustomerNotified')
             ->with(1);
-        $historyItem->expects($this->at(1))
-            ->method('save');
         $historyCollection->expects($this->once())
             ->method('getUnnotifiedForInstance')
             ->with($this->invoice)
@@ -108,8 +110,10 @@ class InvoiceNotifierTest extends TestCase
 
     /**
      * Test case when email has not been sent
+     *
+     * @return void
      */
-    public function testNotifyFail()
+    public function testNotifyFail(): void
     {
         $this->invoice->expects($this->once())
             ->method('getEmailSent')
@@ -119,8 +123,10 @@ class InvoiceNotifierTest extends TestCase
 
     /**
      * Test case when Mail Exception has been thrown
+     *
+     * @return void
      */
-    public function testNotifyException()
+    public function testNotifyException(): void
     {
         $exception = new MailException(__('Email has not been sent'));
         $this->invoiceSenderMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/InfoTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/InfoTest.php
@@ -80,12 +80,13 @@ class InfoTest extends TestCase
     /**
      * Get data cc number
      *
-     * @dataProvider ccKeysDataProvider
      * @param string $keyCc
      * @param string $keyCcEnc
+     *
      * @return void
+     * @dataProvider ccKeysDataProvider
      */
-    public function testGetDataCcNumber($keyCc, $keyCcEnc): void
+    public function testGetDataCcNumber(string $keyCc, string $keyCcEnc): void
     {
         // no data was set
         $this->assertNull($this->info->getData($keyCc));
@@ -152,18 +153,13 @@ class InfoTest extends TestCase
         $method = 'unreal_method';
         $this->info->setData('method', $method);
 
-        $this->paymentHelperMock->expects($this->at(0))
-            ->method('getMethodInstance')
-            ->with($method)
-            ->willThrowException(new \UnexpectedValueException());
-
         $this->methodInstanceMock->expects($this->once())
             ->method('setInfoInstance')
             ->with($this->info);
 
-        $this->paymentHelperMock->expects($this->at(1))
+        $this->paymentHelperMock
             ->method('getMethodInstance')
-            ->with(Substitution::CODE)
+            ->withConsecutive([$method], [Substitution::CODE])
             ->willReturn($this->methodInstanceMock);
 
         $this->info->getMethodInstance();
@@ -257,10 +253,11 @@ class InfoTest extends TestCase
     /**
      * Set additional info multiple types
      *
-     * @dataProvider additionalInformationDataProvider
      * @param mixed $key
      * @param mixed $value
+     *
      * @return void
+     * @dataProvider additionalInformationDataProvider
      */
     public function testSetAdditionalInformationMultipleTypes($key, $value = null): void
     {

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/Transaction/BuilderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Payment/Transaction/BuilderTest.php
@@ -38,6 +38,9 @@ class BuilderTest extends TestCase
      */
     protected $builder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -55,8 +58,7 @@ class BuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider createDataProvider
-     * @param string|null $transactionId
+     * @param int $transactionId
      * @param int $orderId
      * @param int $paymentId
      * @param bool $failSafe
@@ -65,19 +67,22 @@ class BuilderTest extends TestCase
      * @param array $additionalInfo
      * @param bool $document
      * @param bool $isTransactionExists
+     *
+     * @return void
+     * @dataProvider createDataProvider
      */
     public function testCreate(
-        $transactionId,
-        $orderId,
-        $paymentId,
-        $failSafe,
-        $type,
-        $isPaymentTransactionClosed,
-        $additionalInfo,
-        $document,
-        $isTransactionExists
-    ) {
-        $parentTransactionId = "12";
+        int $transactionId,
+        int $orderId,
+        int $paymentId,
+        bool $failSafe,
+        string $type,
+        bool $isPaymentTransactionClosed,
+        array $additionalInfo,
+        bool $document,
+        bool $isTransactionExists
+    ): void {
+        $parentTransactionId = '12';
         $shouldCloseParentTransaction = true;
         $parentTransactionIsClosed = false;
         if ($document) {
@@ -145,18 +150,20 @@ class BuilderTest extends TestCase
 
     /**
      * @param MockObject $transaction
-     * @param string|null $parentTransactionId
+     * @param string $parentTransactionId
      * @param bool $shouldCloseParentTransaction
      * @param MockObject $parentTransaction
      * @param bool $parentTransactionIsClosed
+     *
+     * @return void
      */
     protected function expectsLinkWithParentTransaction(
-        $transaction,
-        $parentTransactionId,
-        $shouldCloseParentTransaction,
-        $parentTransaction,
-        $parentTransactionIsClosed
-    ) {
+        MockObject $transaction,
+        string $parentTransactionId,
+        bool $shouldCloseParentTransaction,
+        MockObject $parentTransaction,
+        bool $parentTransactionIsClosed
+    ): void {
         $this->paymentMock->method('getParentTransactionId')->willReturn($parentTransactionId);
         if ($parentTransactionId) {
             $transaction->expects($this->once())->method('setParentTxnId')->with($parentTransactionId);
@@ -177,7 +184,9 @@ class BuilderTest extends TestCase
                         ->with(false)
                         ->willReturnSelf();
                 }
-                $this->orderMock->expects($this->at(2))->method('addRelatedObject')->with($parentTransaction);
+                $this->orderMock
+                    ->method('addRelatedObject')
+                    ->with($parentTransaction);
             }
         }
     }
@@ -185,9 +194,10 @@ class BuilderTest extends TestCase
     /**
      * @param int $orderId
      * @param int $paymentId
+     *
      * @return MockObject
      */
-    protected function expectTransaction($orderId, $paymentId)
+    protected function expectTransaction(int $orderId, int $paymentId): MockObject
     {
         $newTransaction = $this->getMockBuilder(Transaction::class)
             ->addMethods(['loadByTxnId', 'setPayment'])
@@ -219,10 +229,11 @@ class BuilderTest extends TestCase
     }
 
     /**
-     * @param string $transactionId
+     * @param int $transactionId
+     *
      * @return MockObject
      */
-    protected function expectDocument($transactionId)
+    protected function expectDocument(int $transactionId): MockObject
     {
         $document = $this->getMockBuilder(Order::class)
             ->addMethods(['setTransactionId'])
@@ -237,9 +248,14 @@ class BuilderTest extends TestCase
      * @param MockObject $newTransaction
      * @param string $type
      * @param bool $failSafe
+     *
+     * @return void
      */
-    protected function expectSetPaymentObject($newTransaction, $type, $failSafe)
-    {
+    protected function expectSetPaymentObject(
+        MockObject $newTransaction,
+        string $type,
+        bool $failSafe
+    ): void {
         $newTransaction->expects($this->once())->method('setOrderId')
             ->willReturnSelf();
         $newTransaction->expects($this->once())->method('setPaymentId')
@@ -255,9 +271,13 @@ class BuilderTest extends TestCase
     /**
      * @param bool $isPaymentTransactionClosed
      * @param MockObject $newTransaction
+     *
+     * @return void
      */
-    protected function expectsIsPaymentTransactionClosed($isPaymentTransactionClosed, $newTransaction)
-    {
+    protected function expectsIsPaymentTransactionClosed(
+        bool $isPaymentTransactionClosed,
+        MockObject $newTransaction
+    ): void {
         $this->paymentMock->expects($this->once())
             ->method('hasIsTransactionClosed')
             ->willReturn($isPaymentTransactionClosed);
@@ -271,7 +291,7 @@ class BuilderTest extends TestCase
     /**
      * @return array
      */
-    public function createDataProvider()
+    public function createDataProvider(): array
     {
         return [
             'transactionNotExists' => [

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/PaymentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/PaymentTest.php
@@ -32,6 +32,7 @@ use Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface;
 use Magento\Sales\Model\Order\Payment\Transaction\ManagerInterface;
 use Magento\Sales\Model\Order\Payment\Transaction\Repository;
 use Magento\Sales\Model\OrderRepository;
+use Magento\Sales\Model\ResourceModel\Order\Payment\Transaction\CollectionFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -173,21 +174,21 @@ class PaymentTest extends TestCase
 
         $this->helper = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getMethodInstance'])
+            ->onlyMethods(['getMethodInstance'])
             ->getMock();
 
         $this->priceCurrencyMock = $this->getMockBuilder(PriceCurrency::class)
             ->disableOriginalConstructor()
-            ->setMethods(['format'])
+            ->onlyMethods(['format'])
             ->getMock();
         $this->currencyMock = $this->getMockBuilder(Currency::class)
             ->disableOriginalConstructor()
-            ->setMethods(['formatTxt'])
+            ->onlyMethods(['formatTxt'])
             ->getMock();
         $transaction = Repository::class;
         $this->transactionRepositoryMock = $this->getMockBuilder($transaction)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'getByTransactionType', 'getByTransactionId'])
+            ->onlyMethods(['get', 'getByTransactionType', 'getByTransactionId'])
             ->getMock();
         $this->paymentProcessor = $this->createMock(Processor::class);
         $this->orderRepository = $this->createPartialMock(OrderRepository::class, ['get']);
@@ -206,7 +207,7 @@ class PaymentTest extends TestCase
 
         $this->invoice = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getTransactionId',
                     'load',
@@ -221,16 +222,15 @@ class PaymentTest extends TestCase
                     'getItemsCollection',
                     'getOrder',
                     'register',
-                    'capture',
+                    'capture'
                 ]
-            )
-            ->getMock();
+            )->getMock();
         $this->helper->method('getMethodInstance')
             ->willReturn($this->paymentMethod);
 
         $this->order = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getConfig',
                     'setState',
@@ -249,16 +249,13 @@ class PaymentTest extends TestCase
                     'registerCancellation',
                     'getCustomerNote',
                     'prepareInvoice',
-                    'getPaymentsCollection',
-                    'setIsCustomerNotified'
+                    'getPaymentsCollection'
                 ]
-            )
+            )->addMethods(['setIsCustomerNotified'])
             ->getMock();
 
-        $this->transactionCollectionFactory = $this->getMockBuilder(
-            \Magento\Sales\Model\ResourceModel\Order\Payment\Transaction\CollectionFactory::class
-        )
-            ->setMethods(['create'])
+        $this->transactionCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
+            ->onlyMethods(['create'])
             ->getMock();
         $this->creditmemoFactoryMock = $this->createMock(CreditmemoFactory::class);
         $this->transactionManagerMock = $this->createMock(
@@ -272,24 +269,26 @@ class PaymentTest extends TestCase
             ->getMockForAbstractClass();
         $this->creditMemoMock = $this->getMockBuilder(Creditmemo::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
-                    'setPaymentRefundDisallowed',
                     'getItemsCollection',
                     'getItems',
-                    'setAutomaticallyCreated',
-                    'register',
                     'addComment',
                     'save',
                     'getGrandTotal',
                     'getBaseGrandTotal',
-                    'getDoTransaction',
                     'getInvoice',
-                    'getOrder',
+                    'getOrder'
+                ]
+            )->addMethods(
+                [
+                    'setPaymentRefundDisallowed',
+                    'setAutomaticallyCreated',
+                    'register',
+                    'getDoTransaction',
                     'getPaymentRefundDisallowed'
                 ]
-            )
-            ->getMock();
+            )->getMock();
 
         $this->creditmemoManagerMock = $this->getMockBuilder(CreditmemoManagementInterface::class)
             ->disableOriginalConstructor()
@@ -303,12 +302,18 @@ class PaymentTest extends TestCase
         $this->transactionId = self::TRANSACTION_ID;
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         unset($this->payment);
     }
 
-    public function testCancel()
+    /**
+     * @return void
+     */
+    public function testCancel(): void
     {
         $this->helper->expects($this->once())
             ->method('getMethodInstance')
@@ -321,7 +326,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->payment, $this->payment->cancel());
     }
 
-    public function testPlace()
+    /**
+     * @return void
+     */
+    public function testPlace(): void
     {
         $newOrderStatus = 'new_status';
 
@@ -346,7 +354,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->payment, $this->payment->place());
     }
 
-    public function testPlaceActionOrder()
+    /**
+     * @return void
+     */
+    public function testPlaceActionOrder(): void
     {
         $newOrderStatus = 'new_status';
         $customerNote = 'blabla';
@@ -397,17 +408,23 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->payment, $this->payment->place());
     }
 
-    protected function mockPlaceEvents()
+    /**
+     * @return void
+     */
+    protected function mockPlaceEvents(): void
     {
-        $this->eventManagerMock->expects($this->at(0))
+        $this->eventManagerMock
             ->method('dispatch')
-            ->with('sales_order_payment_place_start', ['payment' => $this->payment]);
-        $this->eventManagerMock->expects($this->at(1))
-            ->method('dispatch')
-            ->with('sales_order_payment_place_end', ['payment' => $this->payment]);
+            ->withConsecutive(
+                ['sales_order_payment_place_start', ['payment' => $this->payment]],
+                ['sales_order_payment_place_end', ['payment' => $this->payment]]
+            );
     }
 
-    public function testPlaceActionAuthorizeInitializeNeeded()
+    /**
+     * @return void
+     */
+    public function testPlaceActionAuthorizeInitializeNeeded(): void
     {
         $newOrderStatus = 'new_status';
         $customerNote = 'blabla';
@@ -457,7 +474,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->payment, $this->payment->place());
     }
 
-    public function testPlaceActionAuthorizeFraud()
+    /**
+     * @return void
+     */
+    public function testPlaceActionAuthorizeFraud(): void
     {
         $newOrderStatus = 'new_status';
         $customerNote = 'blabla';
@@ -504,7 +524,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($sum, $this->payment->getAmountAuthorized());
     }
 
-    public function testPlaceActionAuthorizeCapture()
+    /**
+     * @return void
+     */
+    public function testPlaceActionAuthorizeCapture(): void
     {
         $newOrderStatus = 'new_status';
         $customerNote = 'blabla';
@@ -550,8 +573,10 @@ class PaymentTest extends TestCase
 
     /**
      * Tests place order flow with supported 'sale' payment operation.
+     *
+     * @return void
      */
-    public function testPlaceWithSaleOperationSupported()
+    public function testPlaceWithSaleOperationSupported(): void
     {
         $newOrderStatus = 'new_status';
         $customerNote = 'blabla';
@@ -597,9 +622,11 @@ class PaymentTest extends TestCase
     /**
      * @param bool $isOnline
      * @param float $amount
+     *
+     * @return void
      * @dataProvider authorizeDataProvider
      */
-    public function testAuthorize($isOnline, $amount)
+    public function testAuthorize(bool $isOnline, float $amount): void
     {
         $this->paymentProcessor->expects($this->once())
             ->method('authorize')
@@ -610,9 +637,10 @@ class PaymentTest extends TestCase
 
     /**
      * Data rpovider for testAuthorize
+     *
      * @return array
      */
-    public function authorizeDataProvider()
+    public function authorizeDataProvider(): array
     {
         return [
             [false, 9.99],
@@ -620,7 +648,10 @@ class PaymentTest extends TestCase
         ];
     }
 
-    public function testAcceptApprovePaymentTrue()
+    /**
+     * @return void
+     */
+    public function testAcceptApprovePaymentTrue(): void
     {
         $baseGrandTotal = 300.00;
         $message = sprintf('Approved the payment online. Transaction ID: "%s"', $this->transactionId);
@@ -652,7 +683,7 @@ class PaymentTest extends TestCase
     /**
      * @return array
      */
-    public function acceptPaymentFalseProvider()
+    public function acceptPaymentFalseProvider(): array
     {
         return [
             'Fraud = 1' => [
@@ -667,11 +698,13 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @dataProvider acceptPaymentFalseProvider
      * @param bool $isFraudDetected
-     * @param bool $status
+     * @param mixed $status
+     *
+     * @return void
+     * @dataProvider acceptPaymentFalseProvider
      */
-    public function testAcceptApprovePaymentFalse($isFraudDetected, $status)
+    public function testAcceptApprovePaymentFalse(bool $isFraudDetected, $status): void
     {
         $message = sprintf('There is no need to approve this payment. Transaction ID: "%s"', $this->transactionId);
         $acceptPayment = false;
@@ -703,11 +736,12 @@ class PaymentTest extends TestCase
     }
 
     /**
-     *
-     * @dataProvider acceptPaymentFalseProvider
      * @param bool $isFraudDetected
+     *
+     * @return void
+     * @dataProvider acceptPaymentFalseProvider
      */
-    public function testAcceptApprovePaymentFalseOrderState($isFraudDetected)
+    public function testAcceptApprovePaymentFalseOrderState(bool $isFraudDetected): void
     {
         $message = sprintf('There is no need to approve this payment. Transaction ID: "%s"', $this->transactionId);
         $acceptPayment = false;
@@ -742,7 +776,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->transactionId, $this->payment->getLastTransId());
     }
 
-    public function testDenyPaymentFalse()
+    /**
+     * @return void
+     */
+    public function testDenyPaymentFalse(): void
     {
         $denyPayment = true;
         $message = sprintf('Denied the payment online Transaction ID: "%s"', $this->transactionId);
@@ -769,8 +806,10 @@ class PaymentTest extends TestCase
 
     /**
      * Test offline IPN calls
+     *
+     * @return void
      */
-    public function testDenyPaymentIpn()
+    public function testDenyPaymentIpn(): void
     {
         $isOnline = false;
         $message = sprintf('Denied the payment online Transaction ID: "%s"', $this->transactionId);
@@ -788,11 +827,13 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @dataProvider acceptPaymentFalseProvider
      * @param bool $isFraudDetected
-     * @param bool $status
+     * @param mixed $status
+     *
+     * @return void
+     * @dataProvider acceptPaymentFalseProvider
      */
-    public function testDenyPaymentNegative($isFraudDetected, $status)
+    public function testDenyPaymentNegative(bool $isFraudDetected, $status): void
     {
         $denyPayment = false;
         $message = sprintf('There is no need to deny this payment. Transaction ID: "%s"', $this->transactionId);
@@ -823,7 +864,10 @@ class PaymentTest extends TestCase
         $this->payment->deny();
     }
 
-    public function testDenyPaymentNegativeStateReview()
+    /**
+     * @return void
+     */
+    public function testDenyPaymentNegativeStateReview(): void
     {
         $denyPayment = false;
         $message = sprintf('There is no need to deny this payment. Transaction ID: "%s"', $this->transactionId);
@@ -859,8 +903,10 @@ class PaymentTest extends TestCase
 
     /**
      * Test offline IPN call, negative
+     *
+     * @return void
      */
-    public function testDenyPaymentIpnNegativeStateReview()
+    public function testDenyPaymentIpnNegativeStateReview(): void
     {
         $isOnline = false;
         $message = sprintf('Registered notification about denied payment. Transaction ID: "%s"', $this->transactionId);
@@ -895,10 +941,12 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param int $transactionId
+     * @param string|null $transactionId
      * @param int $countCall
+     *
+     * @return void
      */
-    private function mockInvoice($transactionId, $countCall = 1)
+    private function mockInvoice(?string $transactionId, int $countCall = 1): void
     {
         $this->invoice->method('getTransactionId')
             ->willReturn($transactionId);
@@ -911,7 +959,10 @@ class PaymentTest extends TestCase
             ->willReturn([$this->invoice]);
     }
 
-    public function testUpdateOnlineTransactionApproved()
+    /**
+     * @return void
+     */
+    public function testUpdateOnlineTransactionApproved(): void
     {
         $message = sprintf('Registered update about approved payment. Transaction ID: "%s"', $this->transactionId);
 
@@ -945,8 +996,10 @@ class PaymentTest extends TestCase
 
     /**
      * Test update calls from IPN controller
+     *
+     * @return void
      */
-    public function testUpdateOnlineTransactionApprovedIpn()
+    public function testUpdateOnlineTransactionApprovedIpn(): void
     {
         $isOnline = false;
         $message = sprintf('Registered update about approved payment. Transaction ID: "%s"', $this->transactionId);
@@ -973,7 +1026,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($baseGrandTotal, $this->payment->getBaseAmountPaidOnline());
     }
 
-    public function testUpdateOnlineTransactionDenied()
+    /**
+     * @return void
+     */
+    public function testUpdateOnlineTransactionDenied(): void
     {
         $message = sprintf('Registered update about denied payment. Transaction ID: "%s"', $this->transactionId);
 
@@ -1003,11 +1059,13 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @dataProvider acceptPaymentFalseProvider
      * @param bool $isFraudDetected
-     * @param bool $status
+     * @param mixed $status
+     *
+     * @return void
+     * @dataProvider acceptPaymentFalseProvider
      */
-    public function testUpdateOnlineTransactionDeniedFalse($isFraudDetected, $status)
+    public function testUpdateOnlineTransactionDeniedFalse(bool $isFraudDetected, $status): void
     {
         $message = sprintf('There is no update for the payment. Transaction ID: "%s"', $this->transactionId);
 
@@ -1045,7 +1103,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($this->transactionId, $this->payment->getLastTransId());
     }
 
-    public function testUpdateOnlineTransactionDeniedFalseHistoryComment()
+    /**
+     * @return void
+     */
+    public function testUpdateOnlineTransactionDeniedFalseHistoryComment(): void
     {
         $message = sprintf('There is no update for the payment. Transaction ID: "%s"', $this->transactionId);
 
@@ -1088,12 +1149,17 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param int $transactionId
+     * @param string $transactionId
      * @param float $baseGrandTotal
      * @param string $message
+     *
+     * @return void
      */
-    protected function mockResultTrueMethods($transactionId, $baseGrandTotal, $message)
-    {
+    protected function mockResultTrueMethods(
+        string $transactionId,
+        float $baseGrandTotal,
+        string $message
+    ): void {
         $status = 'status';
 
         $this->invoice->expects($this->once())
@@ -1112,9 +1178,11 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param $message
+     * @param string $message
+     *
+     * @return void
      */
-    protected function mockResultFalseMethods($message)
+    protected function mockResultFalseMethods(string $message): void
     {
         $this->invoice->expects($this->once())
             ->method('cancel');
@@ -1126,7 +1194,10 @@ class PaymentTest extends TestCase
             ->with($message, false);
     }
 
-    public function testAcceptWithoutInvoiceResultTrue()
+    /**
+    * @return void
+    */
+    public function testAcceptWithoutInvoiceResultTrue(): void
     {
         $baseGrandTotal = null;
         $acceptPayment = true;
@@ -1160,7 +1231,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($baseGrandTotal, $this->payment->getBaseAmountPaidOnline());
     }
 
-    public function testDenyWithoutInvoiceResultFalse()
+    /**
+     * @return void
+     */
+    public function testDenyWithoutInvoiceResultFalse(): void
     {
         $baseGrandTotal = null;
         $denyPayment = true;
@@ -1194,7 +1268,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($baseGrandTotal, $this->payment->getBaseAmountPaidOnline());
     }
 
-    public function testCanCaptureNoAuthorizationTransaction()
+    /**
+     * @return void
+     */
+    public function testCanCaptureNoAuthorizationTransaction(): void
     {
         $this->paymentMethod->expects($this->once())
             ->method('canCapture')
@@ -1202,7 +1279,10 @@ class PaymentTest extends TestCase
         $this->assertTrue($this->payment->canCapture());
     }
 
-    public function testCanCaptureCreateTransaction()
+    /**
+     * @return void
+     */
+    public function testCanCaptureCreateTransaction(): void
     {
         $this->paymentMethod->expects($this->once())
             ->method('canCapture')
@@ -1225,7 +1305,10 @@ class PaymentTest extends TestCase
         $this->assertTrue($this->payment->canCapture());
     }
 
-    public function testCanCaptureAuthorizationTransaction()
+    /**
+     * @return void
+     */
+    public function testCanCaptureAuthorizationTransaction(): void
     {
         $paymentId = 1;
         $parentTransactionId = 1;
@@ -1249,7 +1332,10 @@ class PaymentTest extends TestCase
         $this->assertTrue($this->payment->canCapture());
     }
 
-    public function testCannotCapture()
+    /**
+     * @return void
+     */
+    public function testCannotCapture(): void
     {
         $this->paymentMethod->expects($this->once())->method('canCapture')->willReturn(false);
         $this->assertFalse($this->payment->canCapture());
@@ -1257,8 +1343,10 @@ class PaymentTest extends TestCase
 
     /**
      * Tests pay method and perform assertions for payment amount
+     *
+     * @return void
      */
-    public function testPay()
+    public function testPay(): void
     {
         $amountPaid = 10;
         $shippingCaptured = 5;
@@ -1280,8 +1368,10 @@ class PaymentTest extends TestCase
 
     /**
      * Checks if total paid amount correctly calculated for multiple order invoices.
+     *
+     * @return void
      */
-    public function testPayWithMultipleInvoices()
+    public function testPayWithMultipleInvoices(): void
     {
         $this->invoice->setGrandTotal(5);
         $this->invoice->setShippingAmount(5);
@@ -1289,7 +1379,7 @@ class PaymentTest extends TestCase
         /** @var Invoice|MockObject $invoice */
         $invoice = $this->getMockBuilder(Invoice::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getGrandTotal'])
+            ->onlyMethods(['getGrandTotal'])
             ->getMock();
         $invoice->setGrandTotal(5);
 
@@ -1302,7 +1392,10 @@ class PaymentTest extends TestCase
         self::assertEquals(5, $this->payment->getShippingCaptured());
     }
 
-    public function testGetOrder()
+    /**
+     * @return void
+     */
+    public function testGetOrder(): void
     {
         $payment = $this->initPayment();
         $this->orderRepository->expects($this->once())->method('get')->willReturn($this->order);
@@ -1310,26 +1403,35 @@ class PaymentTest extends TestCase
         $this->assertSame($this->order, $payment->getOrder());
     }
 
-    public function testGetOrderDefault()
+    /**
+     * @return void
+     */
+    public function testGetOrderDefault(): void
     {
         $this->orderRepository->expects($this->never())->method('get');
         $this->assertSame($this->order, $this->payment->getOrder());
     }
 
-    public function testGetOrderNull()
+    /**
+     * @return void
+     */
+    public function testGetOrderNull(): void
     {
         $payment = $this->initPayment();
         $this->orderRepository->expects($this->never())->method('get');
         $this->assertNull($payment->getOrder());
     }
 
-    public function testCancelInvoice()
+    /**
+     * @return void
+     */
+    public function testCancelInvoice(): void
     {
         $expects = [
             'amount_paid' => 10,
             'base_amount_paid' => 10,
             'shipping_captured' => 5,
-            'base_shipping_captured' => 5,
+            'base_shipping_captured' => 5
         ];
         $this->assertNull($this->payment->getData('amount_paid'));
         $this->invoice->expects($this->once())->method('getGrandTotal')->willReturn($expects['amount_paid']);
@@ -1356,7 +1458,10 @@ class PaymentTest extends TestCase
         );
     }
 
-    public function testRegisterRefundNotificationTransactionExists()
+    /**
+     * @return void
+     */
+    public function testRegisterRefundNotificationTransactionExists(): void
     {
         $amount = 10;
         $paymentId = 1;
@@ -1385,9 +1490,10 @@ class PaymentTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testRegisterRefundNotification()
+    public function testRegisterRefundNotification(): void
     {
         $message = 'Registered notification about refunded amount of . Transaction ID: "' .
             self::TRANSACTION_ID . '-refund"';
@@ -1456,7 +1562,10 @@ class PaymentTest extends TestCase
         $this->assertEquals($grandTotalCreditMemo, $this->payment->getData('amount_refunded'));
     }
 
-    public function testRegisterRefundNotificationWrongAmount()
+    /**
+     * @return void
+     */
+    public function testRegisterRefundNotificationWrongAmount(): void
     {
         $amount = 30;
         $grandTotalCreditMemo = 50;
@@ -1495,9 +1604,10 @@ class PaymentTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider boolProvider
      */
-    public function testCanRefund($canRefund)
+    public function testCanRefund($canRefund): void
     {
         $this->paymentMethod->expects($this->once())
             ->method('canRefund')
@@ -1506,9 +1616,9 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Sales\Model\Order\Payment::refund()
+     * @return void
      */
-    public function testRefund()
+    public function testRefund(): void
     {
         $amount = 204.04;
         $this->creditMemoMock->expects(static::once())
@@ -1536,7 +1646,7 @@ class PaymentTest extends TestCase
         $captureTranId = self::TRANSACTION_ID . '-' . Transaction::TYPE_CAPTURE;
         $captureTransaction = $this->getMockBuilder(Transaction::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTxnId'])
+            ->onlyMethods(['getTxnId'])
             ->getMock();
 
         $refundTranId = $captureTranId . '-' . Transaction::TYPE_REFUND;
@@ -1581,7 +1691,7 @@ class PaymentTest extends TestCase
     /**
      * @return array
      */
-    public function boolProvider()
+    public function boolProvider(): array
     {
         return [
             [true],
@@ -1593,7 +1703,7 @@ class PaymentTest extends TestCase
      * @covers \Magento\Sales\Model\Order\Payment::isCaptureFinal()
      * @return void
      */
-    public function testIsCaptureFinal()
+    public function testIsCaptureFinal(): void
     {
         $amount = 23.02;
         $partialAmount = 12.00;
@@ -1610,7 +1720,7 @@ class PaymentTest extends TestCase
      * @covers \Magento\Sales\Model\Order\Payment::getShouldCloseParentTransaction()
      * @return void
      */
-    public function testGetShouldCloseParentTransaction()
+    public function testGetShouldCloseParentTransaction(): void
     {
         $this->payment->setShouldCloseParentTransaction(1);
         static::assertTrue($this->payment->getShouldCloseParentTransaction());
@@ -1622,7 +1732,7 @@ class PaymentTest extends TestCase
     /**
      * @return object
      */
-    protected function initPayment()
+    protected function initPayment(): object
     {
         return (new ObjectManager($this))->getObject(
             Payment::class,
@@ -1643,17 +1753,17 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param $state
-     * @param null $status
-     * @param null $message
-     * @param null $isCustomerNotified
+     * @param string $state
+     * @param mixed $status
+     * @param mixed $message
+     * @param bool|null $isCustomerNotified
      */
     protected function assertOrderUpdated(
-        $state,
+        string $state,
         $status = null,
         $message = null,
-        $isCustomerNotified = null
-    ) {
+        bool $isCustomerNotified = null
+    ): void {
         $this->order->expects($this->any())
             ->method('setState')
             ->with($state)
@@ -1677,16 +1787,16 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param $state
-     * @param $status
+     * @param string $state
+     * @param mixed $status
      * @param array $allStatuses
      */
-    protected function mockGetDefaultStatus($state, $status, $allStatuses = [])
+    protected function mockGetDefaultStatus(string $state, $status, array $allStatuses = []): void
     {
-        /** @var Config|\PHPUnit\Framework\MockObject\MockObject $orderConfigMock */
+        /** @var Config|MockObject $orderConfigMock */
         $orderConfigMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStateStatuses', 'getStateDefaultStatus'])
+            ->onlyMethods(['getStateStatuses', 'getStateDefaultStatus'])
             ->getMock();
 
         if (!empty($allStatuses)) {
@@ -1707,10 +1817,10 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param $transactionId
+     * @param string $transactionId
      * @return MockObject
      */
-    protected function getTransactionMock($transactionId)
+    protected function getTransactionMock(string $transactionId): MockObject
     {
         $transaction = $this->getMockBuilder(Transaction::class)
             ->addMethods(['loadByTxnId'])
@@ -1737,17 +1847,19 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * @param $additionalInformation
-     * @param $failSafe
-     * @param $transactionType
-     * @param bool $transactionId
+     * @param array $additionalInformation
+     * @param bool $failSafe
+     * @param mixed $transactionType
+     * @param mixed $transactionId
+     *
+     * @return void
      */
     protected function getTransactionBuilderMock(
-        $additionalInformation,
-        $failSafe,
+        array $additionalInformation,
+        bool $failSafe,
         $transactionType,
         $transactionId = false
-    ) {
+    ): void {
         if (!$transactionId) {
             $transactionId = $this->transactionId;
         }
@@ -1776,13 +1888,5 @@ class PaymentTest extends TestCase
             ->method('build')
             ->with($transactionType)
             ->willReturn($transaction);
-    }
-
-    /**
-     * @return string
-     */
-    protected function getTransactionIdComment()
-    {
-        return __(' Transaction ID: "%1"', $this->transactionId);
     }
 }

--- a/app/code/Magento/Sales/Test/Unit/Model/OrderNotifierTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/OrderNotifierTest.php
@@ -17,7 +17,6 @@ use Magento\Sales\Model\OrderNotifier;
 use Magento\Sales\Model\ResourceModel\Order\Status\History\Collection;
 use Magento\Sales\Model\ResourceModel\Order\Status\History\CollectionFactory;
 use PHPUnit\Framework\MockObject\MockObject;
-
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -48,6 +47,9 @@ class OrderNotifierTest extends TestCase
      */
     protected $orderSenderMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->historyCollectionFactory = $this->createPartialMock(
@@ -69,8 +71,10 @@ class OrderNotifierTest extends TestCase
 
     /**
      * Test case for successful email sending
+     *
+     * @return void
      */
-    public function testNotifySuccess()
+    public function testNotifySuccess(): void
     {
         $historyCollection = $this->getMockBuilder(Collection::class)
             ->addMethods(['setIsCustomerNotified'])
@@ -81,11 +85,9 @@ class OrderNotifierTest extends TestCase
             History::class,
             ['setIsCustomerNotified', 'save']
         );
-        $historyItem->expects($this->at(0))
+        $historyItem
             ->method('setIsCustomerNotified')
             ->with(1);
-        $historyItem->expects($this->at(1))
-            ->method('save');
         $historyCollection->expects($this->once())
             ->method('getUnnotifiedForInstance')
             ->with($this->order)
@@ -107,7 +109,7 @@ class OrderNotifierTest extends TestCase
     /**
      * Test case when email has not been sent
      */
-    public function testNotifyFail()
+    public function testNotifyFail(): void
     {
         $this->order->expects($this->once())
             ->method('getEmailSent')
@@ -118,7 +120,7 @@ class OrderNotifierTest extends TestCase
     /**
      * Test case when Mail Exception has been thrown
      */
-    public function testNotifyException()
+    public function testNotifyException(): void
     {
         $exception = new MailException(__('Email has not been sent'));
         $this->orderSenderMock->expects($this->once())

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/AttributeTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/AttributeTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Sales\Test\Unit\Model\ResourceModel;
 
+use Exception;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Adapter\Pdo\Mysql;
@@ -43,6 +44,9 @@ class AttributeTest extends TestCase
      */
     protected $connectionMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->appResourceMock = $this->createMock(ResourceConnection::class);
@@ -82,9 +86,10 @@ class AttributeTest extends TestCase
     }
 
     /**
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testSave()
+    public function testSave(): void
     {
         $this->appResourceMock->expects($this->once())
             ->method('getConnection')
@@ -95,20 +100,26 @@ class AttributeTest extends TestCase
         $this->modelMock->expects($this->any())
             ->method('getEventObject')
             ->willReturn('event_object');
-        $this->eventManagerMock->expects($this->at(0))
+        $this->eventManagerMock
             ->method('dispatch')
-            ->with('event_prefix_save_attribute_before', [
-                'event_object' => $this->attribute,
-                'object' => $this->modelMock,
-                'attribute' => ['attribute']
-            ]);
-        $this->eventManagerMock->expects($this->at(1))
-            ->method('dispatch')
-            ->with('event_prefix_save_attribute_after', [
-                'event_object' => $this->attribute,
-                'object' => $this->modelMock,
-                'attribute' => ['attribute']
-            ]);
+            ->withConsecutive(
+                [
+                    'event_prefix_save_attribute_before',
+                    [
+                        'event_object' => $this->attribute,
+                        'object' => $this->modelMock,
+                        'attribute' => ['attribute']
+                    ]
+                ],
+                [
+                    'event_prefix_save_attribute_after',
+                    [
+                        'event_object' => $this->attribute,
+                        'object' => $this->modelMock,
+                        'attribute' => ['attribute']
+                    ]
+                ]
+            );
         $this->connectionMock->expects($this->once())
             ->method('beginTransaction');
         $this->connectionMock->expects($this->once())
@@ -117,9 +128,10 @@ class AttributeTest extends TestCase
     }
 
     /**
-     * @throws \Exception
+     * @return void
+     * @throws Exception
      */
-    public function testSaveFailed()
+    public function testSaveFailed(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Expected Exception');
@@ -132,7 +144,7 @@ class AttributeTest extends TestCase
         $this->appResourceMock->expects($this->once())
             ->method('getConnection')
             ->willReturn($this->connectionMock);
-        $exception  = new \Exception('Expected Exception');
+        $exception  = new Exception('Expected Exception');
         $this->modelMock->expects($this->any())
             ->method('getId')
             ->willThrowException($exception);

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/StatusTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/StatusTest.php
@@ -43,6 +43,9 @@ class StatusTest extends TestCase
      */
     protected $selectMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->selectMock = $this->createMock(Select::class);
@@ -57,10 +60,10 @@ class StatusTest extends TestCase
 
         $this->resourceMock = $this->createMock(ResourceConnection::class);
         $tableName = 'sales_order_status_state';
-        $this->resourceMock->expects($this->at(1))
+        $this->resourceMock
             ->method('getTableName')
-            ->with($tableName)
-            ->willReturn($tableName);
+            ->withConsecutive([], [$tableName])
+            ->willReturn(null, $tableName);
         $this->resourceMock->expects($this->any())
             ->method('getConnection')
             ->willReturn(
@@ -78,7 +81,10 @@ class StatusTest extends TestCase
         );
     }
 
-    public function testAssignState()
+    /**
+     * @return void
+     */
+    public function testAssignState(): void
     {
         $state = 'processing';
         $status = 'processing';
@@ -100,7 +106,7 @@ class StatusTest extends TestCase
                     'status' => $status,
                     'state' => $state,
                     'is_default' => $isDefault,
-                    'visible_on_front' => $visibleOnFront,
+                    'visible_on_front' => $visibleOnFront
                 ]
             );
         $this->model->assignState($status, $state, $isDefault, $visibleOnFront);

--- a/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultMergerTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ValidatorResultMergerTest.php
@@ -46,13 +46,14 @@ class ValidatorResultMergerTest extends TestCase
     protected function setUp(): void
     {
         $this->validatorResultFactoryMock = $this->getMockBuilder(ValidatorResultInterfaceFactory::class)
-            ->setMethods(['create'])->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->disableOriginalConstructor()
             ->getMock();
         $this->objectManager = new ObjectManager($this);
         $this->validatorResultMerger = $this->objectManager->getObject(
             ValidatorResultMerger::class,
             [
-                'validatorResultInterfaceFactory' => $this->validatorResultFactoryMock,
+                'validatorResultInterfaceFactory' => $this->validatorResultFactoryMock
             ]
         );
     }
@@ -62,7 +63,7 @@ class ValidatorResultMergerTest extends TestCase
      *
      * @return void
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $validatorResultMock = $this->getMockForAbstractClass(ValidatorResultInterface::class);
         $orderValidationResultMock = $this->getMockForAbstractClass(ValidatorResultInterface::class);
@@ -73,12 +74,9 @@ class ValidatorResultMergerTest extends TestCase
         $orderValidationResultMock->expects($this->once())->method('getMessages')->willReturn(['test01', 'test02']);
         $creditmemoValidationResultMock->expects($this->once())->method('getMessages')->willReturn(['test03']);
 
-        $validatorResultMock->expects($this->at(0))->method('addMessage')->with('test01');
-        $validatorResultMock->expects($this->at(1))->method('addMessage')->with('test02');
-        $validatorResultMock->expects($this->at(2))->method('addMessage')->with('test03');
-        $validatorResultMock->expects($this->at(3))->method('addMessage')->with('test04');
-        $validatorResultMock->expects($this->at(4))->method('addMessage')->with('test05');
-        $validatorResultMock->expects($this->at(5))->method('addMessage')->with('test06');
+        $validatorResultMock
+            ->method('addMessage')
+            ->withConsecutive(['test01'], ['test02'], ['test03'], ['test04'], ['test05'], ['test06']);
         $expected = $validatorResultMock;
         $actual = $this->validatorResultMerger->merge(
             $orderValidationResultMock,

--- a/app/code/Magento/Sales/Test/Unit/Plugin/Model/Service/Invoice/AddTransactionCommentAfterCaptureTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Plugin/Model/Service/Invoice/AddTransactionCommentAfterCaptureTest.php
@@ -65,8 +65,10 @@ class AddTransactionCommentAfterCaptureTest extends TestCase
         $this->invoiceRepository->method('get')->with($invoiceId)->willReturn($invoiceMock);
 
         $transactionMock = $this->createMock(Transaction::class);
-        $transactionMock->expects($this->at(0))->method('addObject')->with($invoiceMock)->willReturnSelf();
-        $transactionMock->expects($this->at(1))->method('addObject')->with($orderMock)->willReturnSelf();
+        $transactionMock
+            ->method('addObject')
+            ->withConsecutive([$invoiceMock], [$orderMock])
+            ->willReturnOnConsecutiveCalls($transactionMock, $transactionMock);
         $transactionMock->expects($this->once())->method('save');
         $this->transactionFactory->method('create')->willReturn($transactionMock);
 

--- a/app/code/Magento/Sales/Test/Unit/Setup/SerializedDataConverterTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Setup/SerializedDataConverterTest.php
@@ -31,6 +31,9 @@ class SerializedDataConverterTest extends TestCase
      */
     private $serializedDataConverter;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -45,7 +48,10 @@ class SerializedDataConverterTest extends TestCase
         );
     }
 
-    public function testConvert()
+    /**
+     * @return void
+     */
+    public function testConvert(): void
     {
         $serializedData = 'serialized data';
         $jsonEncodedData = 'json encoded data';
@@ -69,7 +75,10 @@ class SerializedDataConverterTest extends TestCase
         );
     }
 
-    public function testConvertBundleAttributes()
+    /**
+     * @return void
+     */
+    public function testConvertBundleAttributes(): void
     {
         $serializedData = 'serialized data';
         $serializedBundleAttributes = 'serialized bundle attributes';
@@ -90,29 +99,24 @@ class SerializedDataConverterTest extends TestCase
             ],
             'bundle_selection_attributes' => $jsonEncodedBundleAttributes
         ];
-        $this->serializeMock->expects($this->at(0))
+        $this->serializeMock
             ->method('unserialize')
-            ->with($serializedData)
-            ->willReturn($data);
-        $this->serializeMock->expects($this->at(1))
-            ->method('unserialize')
-            ->with($serializedBundleAttributes)
-            ->willReturn($bundleAttributes);
-        $this->jsonMock->expects($this->at(0))
+            ->withConsecutive([$serializedData], [$serializedBundleAttributes])
+            ->willReturnOnConsecutiveCalls($data, $bundleAttributes);
+        $this->jsonMock
             ->method('serialize')
-            ->with($bundleAttributes)
-            ->willReturn($jsonEncodedBundleAttributes);
-        $this->jsonMock->expects($this->at(1))
-            ->method('serialize')
-            ->with($dataWithJsonEncodedBundleAttributes)
-            ->willReturn($jsonEncodedData);
+            ->withConsecutive([$bundleAttributes], [$dataWithJsonEncodedBundleAttributes])
+            ->willReturnOnConsecutiveCalls($jsonEncodedBundleAttributes, $jsonEncodedData);
         $this->assertEquals(
             $jsonEncodedData,
             $this->serializedDataConverter->convert($serializedData)
         );
     }
 
-    public function testConvertCustomOptionsTypeFile()
+    /**
+     * @return void
+     */
+    public function testConvertCustomOptionsTypeFile(): void
     {
         $serializedData = 'serialized data';
         $serializedOptionValue = 'serialized option value';
@@ -151,29 +155,24 @@ class SerializedDataConverterTest extends TestCase
                 ]
             ]
         ];
-        $this->serializeMock->expects($this->at(0))
+        $this->serializeMock
             ->method('unserialize')
-            ->with($serializedData)
-            ->willReturn($data);
-        $this->serializeMock->expects($this->at(1))
-            ->method('unserialize')
-            ->with($serializedOptionValue)
-            ->willReturn($optionValue);
-        $this->jsonMock->expects($this->at(0))
+            ->withConsecutive([$serializedData], [$serializedOptionValue])
+            ->willReturnOnConsecutiveCalls($data, $optionValue);
+        $this->jsonMock
             ->method('serialize')
-            ->with($optionValue)
-            ->willReturn($jsonEncodedOptionValue);
-        $this->jsonMock->expects($this->at(1))
-            ->method('serialize')
-            ->with($dataWithJsonEncodedOptionValue)
-            ->willReturn($jsonEncodedData);
+            ->withConsecutive([$optionValue], [$dataWithJsonEncodedOptionValue])
+            ->willReturnOnConsecutiveCalls($jsonEncodedOptionValue, $jsonEncodedData);
         $this->assertEquals(
             $jsonEncodedData,
             $this->serializedDataConverter->convert($serializedData)
         );
     }
 
-    public function testConvertCorruptedData()
+    /**
+     * @return void
+     */
+    public function testConvertCorruptedData(): void
     {
         $this->expectException('Magento\Framework\DB\DataConverter\DataConversionException');
         $this->serializeMock->expects($this->once())
@@ -186,7 +185,10 @@ class SerializedDataConverterTest extends TestCase
         $this->serializedDataConverter->convert('serialized data');
     }
 
-    public function testConvertSkipConversion()
+    /**
+     * @return void
+     */
+    public function testConvertSkipConversion(): void
     {
         $serialized = '[]';
         $this->serializeMock->expects($this->never())

--- a/app/code/Magento/SalesRule/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/ResourceModel/Report/CollectionTest.php
@@ -67,6 +67,9 @@ class CollectionTest extends TestCase
      */
     protected $selectMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->entityFactory = $this->createMock(EntityFactory::class);
@@ -115,12 +118,18 @@ class CollectionTest extends TestCase
         );
     }
 
-    public function testAddRuleFilter()
+    /**
+     * @return void
+     */
+    public function testAddRuleFilter(): void
     {
         $this->assertInstanceOf(get_class($this->object), $this->object->addRuleFilter([]));
     }
 
-    public function testApplyAggregatedTableNegativeIsTotals()
+    /**
+     * @return void
+     */
+    public function testApplyAggregatedTableNegativeIsTotals(): void
     {
         $this->selectMock->expects($this->once())
             ->method('group')
@@ -128,7 +137,10 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(get_class($this->object), $this->object->loadWithFilter());
     }
 
-    public function testApplyAggregatedTableIsSubTotals()
+    /**
+     * @return void
+     */
+    public function testApplyAggregatedTableIsSubTotals(): void
     {
         $this->selectMock->expects($this->once())
             ->method('group')
@@ -138,7 +150,10 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(get_class($this->object), $this->object->loadWithFilter());
     }
 
-    public function testApplyRulesFilterNoRulesIdsFilter()
+    /**
+     * @return void
+     */
+    public function testApplyRulesFilterNoRulesIdsFilter(): void
     {
         $this->ruleFactory->expects($this->never())
             ->method('create');
@@ -146,7 +161,10 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(get_class($this->object), $this->object->loadWithFilter());
     }
 
-    public function testApplyRulesFilterEmptyRulesList()
+    /**
+     * @return void
+     */
+    public function testApplyRulesFilterEmptyRulesList(): void
     {
         $rulesList = [];
         $ruleMock = $this->getRuleMock();
@@ -163,21 +181,22 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(get_class($this->object), $this->object->loadWithFilter());
     }
 
-    public function testApplyRulesFilterWithRulesList()
+    /**
+     * @return void
+     */
+    public function testApplyRulesFilterWithRulesList(): void
     {
         $rulesList = [1 => 'test rule 1', 10 => 'test rule 10', 30 => 'test rule 30'];
-        $this->connection->expects($this->at(1))
+        $this->connection
             ->method('quoteInto')
-            ->with('rule_name = ?', $rulesList[1])
-            ->willReturn('test_1');
-        $this->connection->expects($this->at(2))
-            ->method('quoteInto')
-            ->with('rule_name = ?', $rulesList[30])
-            ->willReturn('test_2');
+            ->withConsecutive(
+                ['rule_name = ?', $rulesList[1]],
+                ['rule_name = ?', $rulesList[30]]
+            )->willReturnOnConsecutiveCalls('test_1', 'test_2');
 
-        $this->selectMock->expects($this->at(3))
+        $this->selectMock
             ->method('where')
-            ->with(implode(' OR ', ['test_1', 'test_2']));
+            ->withConsecutive([], [implode(' OR ', ['test_1', 'test_2'])]);
 
         $ruleMock = $this->getRuleMock();
         $ruleMock->expects($this->once())
@@ -196,7 +215,7 @@ class CollectionTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getRuleMock()
+    protected function getRuleMock(): MockObject
     {
         return $this->createPartialMock(
             Rule::class,

--- a/app/code/Magento/SalesRule/Test/Unit/Model/RulesApplierTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/RulesApplierTest.php
@@ -61,6 +61,9 @@ class RulesApplierTest extends TestCase
      */
     protected $childrenValidationLocator;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->calculatorFactory = $this->createMock(
@@ -92,10 +95,13 @@ class RulesApplierTest extends TestCase
      * @param bool $isChildren
      * @param bool $isContinue
      *
+     * @return void
      * @dataProvider dataProviderChildren
      */
-    public function testApplyRulesWhenRuleWithStopRulesProcessingIsUsed($isChildren, $isContinue)
-    {
+    public function testApplyRulesWhenRuleWithStopRulesProcessingIsUsed(
+        bool $isChildren,
+        bool $isContinue
+    ): void {
         $positivePrice = 1;
         $skipValidation = false;
         $item = $this->getPreparedItem();
@@ -156,24 +162,23 @@ class RulesApplierTest extends TestCase
         $ruleWithStopFurtherProcessing->expects($this->atLeastOnce())
             ->method('getActions')
             ->willReturn($actionMock);
-        $actionMock->expects($this->at(0))
-            ->method('validate')
-            ->with($item)
-            ->willReturn(!$isChildren);
 
         // if there are child elements, check them
         if ($isChildren) {
             $item->expects($this->atLeastOnce())
                 ->method('getChildren')
                 ->willReturn([$item]);
-            $actionMock->expects($this->at(1))
-                ->method('validate')
+            $actionMock->method('validate')
                 ->with($item)
                 ->willReturn(!$isContinue);
             $product = $this->createPartialMock(Product::class, []);
             $item->expects($this->atLeastOnce())
                 ->method('getProduct')
                 ->willReturn($product);
+        } else {
+            $actionMock->method('validate')
+                ->with($item)
+                ->willReturn(!$isChildren);
         }
 
         if (!$isContinue || !$isChildren) {
@@ -192,7 +197,10 @@ class RulesApplierTest extends TestCase
         $this->assertEquals($appliedRuleIds, $result);
     }
 
-    public function testAddCouponDescriptionWithRuleDescriptionIsUsed()
+    /**
+     * @return void
+     */
+    public function testAddCouponDescriptionWithRuleDescriptionIsUsed(): void
     {
         $ruleId = 1;
         $ruleDescription = 'Rule description';
@@ -226,18 +234,18 @@ class RulesApplierTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderChildren()
+    public function dataProviderChildren(): array
     {
         return [
             ['isChildren' => true, 'isContinue' => false],
-            ['isChildren' => false, 'isContinue' => true],
+            ['isChildren' => false, 'isContinue' => true]
         ];
     }
 
     /**
      * @return AbstractItem|MockObject
      */
-    protected function getPreparedItem()
+    protected function getPreparedItem(): AbstractItem
     {
         /**
          * @var Address|MockObject $address
@@ -255,9 +263,9 @@ class RulesApplierTest extends TestCase
             ->onlyMethods(['getAddress', 'getChildren', 'getExtensionAttributes', 'getProduct'])
             ->disableOriginalConstructor()
             ->getMock();
-        $itemExtension = $this->getMockBuilder(
-            ExtensionAttributesInterface::class
-        )->setMethods(['setDiscounts', 'getDiscounts'])->getMock();
+        $itemExtension = $this->getMockBuilder(ExtensionAttributesInterface::class)
+            ->addMethods(['setDiscounts', 'getDiscounts'])
+            ->getMock();
         $itemExtension->method('getDiscounts')->willReturn([]);
         $itemExtension->expects($this->any())
             ->method('setDiscounts')
@@ -273,10 +281,12 @@ class RulesApplierTest extends TestCase
     }
 
     /**
-     * @param $item
-     * @param $rule
+     * @param MockObject $item
+     * @param MockObject $rule
+     *
+     * @return void
      */
-    protected function applyRule($item, $rule)
+    protected function applyRule(MockObject $item, MockObject $rule): void
     {
         $qty = 2;
         $discountCalc = $this->createPartialMock(

--- a/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
@@ -91,6 +91,9 @@ class UtilityTest extends TestCase
      */
     protected $priceCurrency;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->usageFactory = $this->createPartialMock(
@@ -165,8 +168,10 @@ class UtilityTest extends TestCase
 
     /**
      * Check rule for specific address
+     *
+     * @return void
      */
-    public function testCanProcessRuleValidAddress()
+    public function testCanProcessRuleValidAddress(): void
     {
         $this->rule->expects($this->once())
             ->method('hasIsValidForAddress')
@@ -184,8 +189,10 @@ class UtilityTest extends TestCase
 
     /**
      * Check coupon entire usage limit
+     *
+     * @return void
      */
-    public function testCanProcessRuleCouponUsageLimitFail()
+    public function testCanProcessRuleCouponUsageLimitFail(): void
     {
         $couponCode = 111;
         $couponId = 4;
@@ -219,8 +226,10 @@ class UtilityTest extends TestCase
 
     /**
      * Check coupon per customer usage limit
+     *
+     * @return void
      */
-    public function testCanProcessRuleCouponUsagePerCustomerFail()
+    public function testCanProcessRuleCouponUsagePerCustomerFail(): void
     {
         $couponCode = 111;
         $couponId = 4;
@@ -264,8 +273,10 @@ class UtilityTest extends TestCase
 
     /**
      * Check rule per customer usage limit
+     *
+     * @return void
      */
-    public function testCanProcessRuleUsagePerCustomer()
+    public function testCanProcessRuleUsagePerCustomer(): void
     {
         $customerId = 1;
         $usageLimit = 1;
@@ -288,8 +299,10 @@ class UtilityTest extends TestCase
 
     /**
      * Quote does not meet rule's conditions
+     *
+     * @return void
      */
-    public function testCanProcessRuleInvalidConditions()
+    public function testCanProcessRuleInvalidConditions(): void
     {
         $this->rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
         $this->assertFalse($this->utility->canProcessRule($this->rule, $this->address));
@@ -297,8 +310,10 @@ class UtilityTest extends TestCase
 
     /**
      * Quote does not meet rule's conditions
+     *
+     * @return void
      */
-    public function testCanProcessRule()
+    public function testCanProcessRule(): void
     {
         $this->rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
         $this->rule->expects($this->once())
@@ -307,13 +322,19 @@ class UtilityTest extends TestCase
         $this->assertTrue($this->utility->canProcessRule($this->rule, $this->address));
     }
 
-    public function testGetItemPrice()
+    /**
+     * @return void
+     */
+    public function testGetItemPrice(): void
     {
         $price = $this->getItemPrice();
         $this->assertEquals($price, $this->utility->getItemPrice($this->item));
     }
 
-    public function testGetItemPriceNull()
+    /**
+     * @return void
+     */
+    public function testGetItemPriceNull(): void
     {
         $price = 4;
 
@@ -326,13 +347,19 @@ class UtilityTest extends TestCase
         $this->assertEquals($price, $this->utility->getItemPrice($this->item));
     }
 
-    public function testGetItemBasePrice()
+    /**
+     * @return void
+     */
+    public function testGetItemBasePrice(): void
     {
         $price = $this->getItemBasePrice();
         $this->assertEquals($price, $this->utility->getItemBasePrice($this->item));
     }
 
-    public function testGetBaseItemPriceCalculation()
+    /**
+     * @return void
+     */
+    public function testGetBaseItemPriceCalculation(): void
     {
         $calcPrice = 5;
         $this->item->expects($this->once())
@@ -344,7 +371,10 @@ class UtilityTest extends TestCase
         $this->assertEquals($calcPrice, $this->utility->getItemBasePrice($this->item));
     }
 
-    public function testGetItemQtyMin()
+    /**
+     * @return void
+     */
+    public function testGetItemQtyMin(): void
     {
         $qty = 7;
         $discountQty = 4;
@@ -357,7 +387,10 @@ class UtilityTest extends TestCase
         $this->assertEquals(min($discountQty, $qty), $this->utility->getItemQty($this->item, $this->rule));
     }
 
-    public function testGetItemQty()
+    /**
+     * @return void
+     */
+    public function testGetItemQty(): void
     {
         $qty = 7;
         $this->item->expects($this->once())
@@ -370,14 +403,15 @@ class UtilityTest extends TestCase
     }
 
     /**
-     * @dataProvider mergeIdsDataProvider
-     *
-     * @param [] $a1
-     * @param [] $a2
+     * @param mixed $a1
+     * @param mixed $a2
      * @param bool $isSting
-     * @param [] $expected
+     * @param mixed $expected
+     *
+     * @return void
+     * @dataProvider mergeIdsDataProvider
      */
-    public function testMergeIds($a1, $a2, $isSting, $expected)
+    public function testMergeIds($a1, $a2, bool $isSting, $expected): void
     {
         $this->assertEquals($expected, $this->utility->mergeIds($a1, $a2, $isSting));
     }
@@ -385,7 +419,7 @@ class UtilityTest extends TestCase
     /**
      * @return array
      */
-    public function mergeIdsDataProvider()
+    public function mergeIdsDataProvider(): array
     {
         return [
             ['id1,id2', '', true, 'id1,id2'],
@@ -397,7 +431,10 @@ class UtilityTest extends TestCase
         ];
     }
 
-    public function testMinFix()
+    /**
+     * @return void
+     */
+    public function testMinFix(): void
     {
         $qty = 13;
         $amount = 10;
@@ -428,7 +465,7 @@ class UtilityTest extends TestCase
     /**
      * @return int
      */
-    protected function getItemPrice()
+    protected function getItemPrice(): int
     {
         $price = 4;
         $calcPrice = 5;
@@ -445,7 +482,7 @@ class UtilityTest extends TestCase
     /**
      * @return int
      */
-    protected function getItemBasePrice()
+    protected function getItemBasePrice(): int
     {
         $price = 4;
         $calcPrice = 5;
@@ -458,7 +495,10 @@ class UtilityTest extends TestCase
         return $price;
     }
 
-    public function testDeltaRoundignFix()
+    /**
+     * @return void
+     */
+    public function testDeltaRoundignFix(): void
     {
         $discountAmount = 10.003;
         $baseDiscountAmount = 12.465;
@@ -482,7 +522,7 @@ class UtilityTest extends TestCase
                     [$discountAmount, $roundedDiscount],
                     [$baseDiscountAmount, $roundedBaseDiscount],
                     [$discountAmount + $delta, $secondRoundedDiscount], //?
-                    [$baseDiscountAmount + $baseDelta, $secondRoundedBaseDiscount], //?
+                    [$baseDiscountAmount + $baseDelta, $secondRoundedBaseDiscount] //?
                 ]
             );
 
@@ -493,39 +533,24 @@ class UtilityTest extends TestCase
         $this->item->setDiscountPercent($percent);
 
         $discountData = $this->createMock(Data::class);
-        $discountData->expects($this->at(0))
-            ->method('getAmount')
-            ->willReturn($discountAmount);
-        $discountData->expects($this->at(1))
-            ->method('getBaseAmount')
-            ->willReturn($baseDiscountAmount);
 
-        $discountData->expects($this->at(2))
-            ->method('setAmount')
-            ->with($roundedDiscount);
-        $discountData->expects($this->at(3))
-            ->method('setBaseAmount')
-            ->with($roundedBaseDiscount);
-
-        $discountData->expects($this->at(4))
-            ->method('getAmount')
-            ->willReturn($discountAmount);
-        $discountData->expects($this->at(5))
-            ->method('getBaseAmount')
-            ->willReturn($baseDiscountAmount);
-
-        $discountData->expects($this->at(6))
-            ->method('setAmount')
-            ->with($secondRoundedDiscount);
-        $discountData->expects($this->at(7))
-            ->method('setBaseAmount')
-            ->with($secondRoundedBaseDiscount);
+        $discountData->method('getAmount')
+            ->willReturnOnConsecutiveCalls($discountAmount, $discountAmount);
+        $discountData->method('setBaseAmount')
+            ->withConsecutive([$roundedBaseDiscount], [$secondRoundedBaseDiscount]);
+        $discountData->method('setAmount')
+            ->withConsecutive([$roundedDiscount], [$secondRoundedDiscount]);
+        $discountData->method('getBaseAmount')
+            ->willReturnOnConsecutiveCalls($baseDiscountAmount, $baseDiscountAmount);
 
         $this->assertEquals($this->utility, $this->utility->deltaRoundingFix($discountData, $this->item));
         $this->assertEquals($this->utility, $this->utility->deltaRoundingFix($discountData, $this->item));
     }
 
-    public function testResetRoundingDeltas()
+    /**
+     * @return void
+     */
+    public function testResetRoundingDeltas(): void
     {
         $this->assertNull($this->utility->resetRoundingDeltas());
     }

--- a/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/ValidatorTest.php
@@ -102,6 +102,9 @@ class ValidatorTest extends TestCase
      */
     private $cartFixedDiscountHelper;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->helper = new ObjectManager($this);
@@ -112,16 +115,14 @@ class ValidatorTest extends TestCase
 
         $this->addressMock = $this->getMockBuilder(Address::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(['getQuote', 'getCustomAttributesCodes'])
+            ->addMethods(
                 [
                     'getShippingAmountForDiscount',
                     'getBaseShippingAmountForDiscount',
-                    'getQuote',
-                    'getCustomAttributesCodes',
                     'setCartFixedRules'
                 ]
-            )
-            ->getMock();
+            )->getMock();
 
         /** @var AbstractItem|MockObject $item */
         $this->item = $this->getMockBuilder(Item::class)
@@ -145,10 +146,10 @@ class ValidatorTest extends TestCase
         $ruleCollectionFactoryMock = $this->prepareRuleCollectionMock($this->ruleCollection);
         $this->priceCurrency = $this->getMockBuilder(PriceCurrencyInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['roundPrice'])
+            ->addMethods(['roundPrice'])
             ->getMockForAbstractClass();
         $this->cartFixedDiscountHelper = $this->getMockBuilder(CartFixedDiscount::class)
-            ->setMethods([
+            ->onlyMethods([
                 'calculateShippingAmountWhenAppliedToShipping',
                 'getDiscountAmount',
                 'getShippingDiscountAmount',
@@ -194,7 +195,7 @@ class ValidatorTest extends TestCase
      * @return Item|MockObject
      * @throws LocalizedException
      */
-    protected function getQuoteItemMock()
+    protected function getQuoteItemMock(): Item
     {
         $fixturePath = __DIR__ . '/_files/';
         $itemDownloadable = $this->createPartialMock(
@@ -221,7 +222,10 @@ class ValidatorTest extends TestCase
         return $itemDownloadable;
     }
 
-    public function testCanApplyRules()
+    /**
+     * @return void
+     */
+    public function testCanApplyRules(): void
     {
         $this->model->init(
             $this->model->getWebsiteId(),
@@ -263,7 +267,10 @@ class ValidatorTest extends TestCase
         $this->assertTrue($this->model->canApplyRules($item));
     }
 
-    public function testProcess()
+    /**
+     * @return void
+     */
+    public function testProcess(): void
     {
         $negativePrice = -1;
 
@@ -280,7 +287,10 @@ class ValidatorTest extends TestCase
         $this->model->process($this->item);
     }
 
-    public function testProcessWhenItemPriceIsNegativeDiscountsAreZeroed()
+    /**
+     * @return void
+     */
+    public function testProcessWhenItemPriceIsNegativeDiscountsAreZeroed(): void
     {
         $negativePrice = -1;
         $nonZeroDiscount = 123;
@@ -304,7 +314,10 @@ class ValidatorTest extends TestCase
         $this->assertEquals(0, $this->item->getDiscountPercent());
     }
 
-    public function testApplyRulesThatAppliedRuleIdsAreCollected()
+    /**
+     * @return void
+     */
+    public function testApplyRulesThatAppliedRuleIdsAreCollected(): void
     {
         $positivePrice = 1;
         $ruleId1 = 123;
@@ -339,7 +352,10 @@ class ValidatorTest extends TestCase
         $this->model->process($this->item);
     }
 
-    public function testInit()
+    /**
+     * @return void
+     */
+    public function testInit(): void
     {
         $this->assertInstanceOf(
             Validator::class,
@@ -351,10 +367,13 @@ class ValidatorTest extends TestCase
         );
     }
 
-    public function testCanApplyDiscount()
+    /**
+     * @return void
+     */
+    public function testCanApplyDiscount(): void
     {
         $validator = $this->getMockBuilder(AbstractValidator::class)
-            ->setMethods(['isValid'])
+            ->onlyMethods(['isValid'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -375,7 +394,10 @@ class ValidatorTest extends TestCase
         $this->assertFalse($this->model->canApplyDiscount($this->item));
     }
 
-    public function testInitTotalsCanApplyDiscount()
+    /**
+     * @return void
+     */
+    public function testInitTotalsCanApplyDiscount(): void
     {
         $rule = $this->getMockBuilder(Rule::class)
             ->addMethods(['getSimpleAction'])
@@ -409,14 +431,15 @@ class ValidatorTest extends TestCase
         $iterator = new \ArrayIterator([$rule]);
         $this->ruleCollection->expects($this->once())->method('getIterator')->willReturn($iterator);
         $validator = $this->getMockBuilder(AbstractValidator::class)
-            ->setMethods(['isValid'])
+            ->onlyMethods(['isValid'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
         $this->validators->expects($this->atLeastOnce())->method('getValidators')->with('discount')
             ->willReturn([$validator]);
-        $validator->expects($this->at(0))->method('isValid')->with($item1)->willReturn(false);
-        $validator->expects($this->at(1))->method('isValid')->with($item2)->willReturn(true);
+        $validator->method('isValid')
+            ->withConsecutive([$item1], [$item2])
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $item1->expects($this->any())->method('getParentItemId')->willReturn(null);
         $item1->expects($this->any())->method('getParentItem')->willReturn(null);
@@ -441,8 +464,9 @@ class ValidatorTest extends TestCase
             ->addMethods(['validate'])
             ->disableOriginalConstructor()
             ->getMock();
-        $actionsCollection->expects($this->at(0))->method('validate')->with($item1)->willReturn(true);
-        $actionsCollection->expects($this->at(1))->method('validate')->with($item2)->willReturn(true);
+        $actionsCollection->method('validate')
+            ->withConsecutive([$item1], [$item2])
+            ->willReturnOnConsecutiveCalls(true, true);
         $rule->expects($this->any())->method('getActions')->willReturn($actionsCollection);
         $rule->expects($this->any())->method('getId')->willReturn(1);
 
@@ -458,7 +482,10 @@ class ValidatorTest extends TestCase
         $this->assertEquals(1, $this->model->getRuleItemTotalsInfo($rule->getId())['items_count']);
     }
 
-    public function testInitTotalsNoItems()
+    /**
+     * @return void
+     */
+    public function testInitTotalsNoItems(): void
     {
         $address = $this->createMock(Address::class);
         $this->item->expects($this->never())
@@ -472,10 +499,11 @@ class ValidatorTest extends TestCase
     }
 
     /**
-     * @param $ruleCollection
+     * @param MockObject $ruleCollection
+     *
      * @return MockObject
      */
-    protected function prepareRuleCollectionMock($ruleCollection)
+    protected function prepareRuleCollectionMock(MockObject $ruleCollection): MockObject
     {
         $this->ruleCollection->expects($this->any())
             ->method('addFieldToFilter')
@@ -486,7 +514,7 @@ class ValidatorTest extends TestCase
         $ruleCollectionFactoryMock =
             $this->getMockBuilder(CollectionFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $ruleCollectionFactoryMock->expects($this->any())
             ->method('create')
@@ -494,7 +522,10 @@ class ValidatorTest extends TestCase
         return $ruleCollectionFactoryMock;
     }
 
-    public function testProcessShippingAmountNoRules()
+    /**
+     * @return void
+     */
+    public function testProcessShippingAmountNoRules(): void
     {
         $iterator = new \ArrayIterator([]);
         $this->ruleCollection->expects($this->any())
@@ -511,11 +542,13 @@ class ValidatorTest extends TestCase
         );
     }
 
-    public function testProcessShippingAmountProcessDisabled()
+    /**
+     * @return void
+     */
+    public function testProcessShippingAmountProcessDisabled(): void
     {
         $ruleMock = $this->getMockBuilder(Rule::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
         $iterator = new \ArrayIterator([$ruleMock]);
         $this->ruleCollection->expects($this->any())
@@ -537,18 +570,23 @@ class ValidatorTest extends TestCase
      *
      * @param string $action
      * @param int $ruleDiscount
-     * @param int $shippingDiscount
-     * @dataProvider dataProviderActions
+     * @param float $shippingDiscount
+     *
+     * @return void
      * @throws Zend_Db_Select_Exception
+     * @dataProvider dataProviderActions
      */
-    public function testProcessShippingAmountActions($action, $ruleDiscount, $shippingDiscount): void
-    {
+    public function testProcessShippingAmountActions(
+        string $action,
+        int $ruleDiscount,
+        float $shippingDiscount
+    ): void {
         $shippingAmount = 5.0;
         $quoteBaseSubTotal = 10.0;
 
         $ruleMock = $this->getMockBuilder(Rule::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getApplyToShipping', 'getSimpleAction', 'getDiscountAmount'])
+            ->addMethods(['getApplyToShipping', 'getSimpleAction', 'getDiscountAmount'])
             ->getMock();
         $ruleMock->method('getApplyToShipping')
             ->willReturn(true);
@@ -585,28 +623,30 @@ class ValidatorTest extends TestCase
     /**
      * @return array
      */
-    public static function dataProviderActions()
+    public static function dataProviderActions(): array
     {
         return [
             [Rule::TO_PERCENT_ACTION, 50, 2.5],
             [Rule::BY_PERCENT_ACTION, 50, 2.5],
             [Rule::TO_FIXED_ACTION, 5, 0],
             [Rule::BY_FIXED_ACTION, 5, 5],
-            [Rule::CART_FIXED_ACTION, 5, 0],
+            [Rule::CART_FIXED_ACTION, 5, 0]
         ];
     }
 
     /**
      * Tests shipping amount with full discount action.
      *
-     * @dataProvider dataProviderForFullShippingDiscount
      * @param string $action
      * @param float $ruleDiscount
      * @param float $shippingDiscount
      * @param float $shippingAmount
      * @param float $quoteBaseSubTotal
+     *
+     * @return void
      * @throws Zend_Db_Select_Exception
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider dataProviderForFullShippingDiscount
      */
     public function testProcessShippingAmountWithFullFixedPercentDiscount(
         string $action,
@@ -617,7 +657,7 @@ class ValidatorTest extends TestCase
     ): void {
         $ruleMock = $this->getMockBuilder(Rule::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getApplyToShipping', 'getSimpleAction', 'getDiscountAmount'])
+            ->addMethods(['getApplyToShipping', 'getSimpleAction', 'getDiscountAmount'])
             ->getMock();
         $ruleMock->method('getApplyToShipping')
             ->willReturn(true);
@@ -679,29 +719,27 @@ class ValidatorTest extends TestCase
     /**
      * @param float $shippingAmount
      * @param float $quoteBaseSubTotal
-     * @return MockObject
+     *
+     * @return Address|MockObject
      */
-    protected function setupAddressMock($shippingAmount = 0.0, $quoteBaseSubTotal = 0.0)
-    {
+    protected function setupAddressMock(
+        float $shippingAmount = 0.0,
+        float $quoteBaseSubTotal = 0.0
+    ): Address {
         $shippingAssignments = ['test_assignment_1'];
         $storeMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMock();
 
         $quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'setAppliedRuleIds',
-                'getStore',
-                'getBaseSubtotal',
-                'getExtensionAttributes',
-                'isVirtual'
-            ])
+            ->onlyMethods(['getStore', 'getExtensionAttributes', 'isVirtual'])
+            ->addMethods(['setAppliedRuleIds', 'getBaseSubtotal'])
             ->getMock();
         $cartExtensionMock = $this->getMockBuilder(CartExtensionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getShippingAssignments'])
+            ->onlyMethods(['getShippingAssignments'])
             ->getMockForAbstractClass();
 
         $quoteMock->method('getStore')
@@ -745,7 +783,10 @@ class ValidatorTest extends TestCase
         return $this->addressMock;
     }
 
-    public function testReset()
+    /**
+     * @return void
+     */
+    public function testReset(): void
     {
         $this->utility->expects($this->once())
             ->method('resetRoundingDeltas');

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/SaveTest.php
@@ -26,27 +26,44 @@ use PHPUnit\Framework\TestCase;
  */
 class SaveTest extends TestCase
 {
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var Redirect|MockObject */
+    /**
+     * @var Redirect|MockObject
+     */
     private $redirect;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     private $messageManager;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     private $session;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     private $context;
 
-    /** @var Query|MockObject */
+    /**
+     * @var Query|MockObject
+     */
     private $query;
 
-    /** @var Save */
+    /**
+     * @var Save
+     */
     private $controller;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
@@ -56,11 +73,11 @@ class SaveTest extends TestCase
             ->getMock();
 
         $this->redirect = $this->getMockBuilder(Redirect::class)
-            ->setMethods(['setPath'])
+            ->onlyMethods(['setPath'])
             ->disableOriginalConstructor()
             ->getMock();
         $redirectFactory = $this->getMockBuilder(ResultFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $redirectFactory->expects($this->any())
@@ -75,7 +92,7 @@ class SaveTest extends TestCase
 
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPostValue', 'isPost', 'getPost'])
+            ->addMethods(['getPostValue', 'isPost', 'getPost'])
             ->getMockForAbstractClass();
         $this->context->expects($this->atLeastOnce())
             ->method('getRequest')
@@ -83,7 +100,7 @@ class SaveTest extends TestCase
 
         $objectManager = $this->getMockBuilder(ObjectManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
         $this->context->expects($this->any())
             ->method('getObjectManager')
@@ -91,7 +108,7 @@ class SaveTest extends TestCase
 
         $this->messageManager = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccessMessage', 'addErrorMessage', 'addExceptionMessage'])
+            ->onlyMethods(['addSuccessMessage', 'addErrorMessage', 'addExceptionMessage'])
             ->getMockForAbstractClass();
         $this->context->expects($this->any())
             ->method('getMessageManager')
@@ -99,7 +116,7 @@ class SaveTest extends TestCase
 
         $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setPageData'])
+            ->addMethods(['setPageData'])
             ->getMock();
         $this->context->expects($this->any())
             ->method('getSession')
@@ -107,10 +124,11 @@ class SaveTest extends TestCase
 
         $this->query = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'load', 'addData', 'setIsProcessed', 'save', 'loadByQueryText', 'setStoreId'])
+            ->onlyMethods(['getId', 'load', 'addData', 'save', 'loadByQueryText', 'setStoreId'])
+            ->addMethods(['setIsProcessed'])
             ->getMock();
         $queryFactory = $this->getMockBuilder(QueryFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $queryFactory->expects($this->any())
@@ -129,12 +147,18 @@ class SaveTest extends TestCase
     /**
      * @param bool $isPost
      * @param array $data
+     *
+     * @return void
      * @dataProvider executeIsPostDataDataProvider
      */
-    public function testExecuteIsPostData($isPost, $data)
+    public function testExecuteIsPostData(bool $isPost, array $data): void
     {
-        $this->request->expects($this->at(0))->method('getPostValue')->willReturn($data);
-        $this->request->expects($this->at(1))->method('isPost')->willReturn($isPost);
+        $this->request
+            ->method('getPostValue')
+            ->willReturn($data);
+        $this->request
+            ->method('isPost')
+            ->willReturn($isPost);
         $this->redirect->expects($this->once())->method('setPath')->willReturnSelf();
         $this->assertSame($this->redirect, $this->controller->execute());
     }
@@ -142,7 +166,7 @@ class SaveTest extends TestCase
     /**
      * @return array
      */
-    public function executeIsPostDataDataProvider()
+    public function executeIsPostDataDataProvider(): array
     {
         return [
             [false, ['0' => '0']],
@@ -150,11 +174,14 @@ class SaveTest extends TestCase
         ];
     }
 
-    public function testExecuteLoadQueryQueryId()
+    /**
+     * @return void
+     */
+    public function testExecuteLoadQueryQueryId(): void
     {
         $queryId = 1;
         $queryText = '';
-        $this->mockGetRequestData($queryText, $queryId);
+        $this->mockGetRequestData($queryText, $queryId, false);
 
         $this->query->expects($this->once())->method('getId')->willReturn(false);
         $this->query->expects($this->once())->method('load')->with($queryId);
@@ -165,13 +192,14 @@ class SaveTest extends TestCase
         $this->assertSame($this->redirect, $this->controller->execute());
     }
 
-    public function testExecuteLoadQueryQueryIdQueryText()
+    /**
+     * @return void
+     */
+    public function testExecuteLoadQueryQueryIdQueryText(): void
     {
         $queryId = 1;
         $queryText = 'search';
         $this->mockGetRequestData($queryText, $queryId);
-
-        $this->request->expects($this->at(4))->method('getPost')->with('store_id', false)->willReturn(1);
 
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
@@ -183,13 +211,14 @@ class SaveTest extends TestCase
         $this->assertSame($this->redirect, $this->controller->execute());
     }
 
-    public function testExecuteLoadQueryQueryIdQueryText2()
+    /**
+     * @return void
+     */
+    public function testExecuteLoadQueryQueryIdQueryText2(): void
     {
         $queryId = 1;
         $queryText = 'search';
         $this->mockGetRequestData($queryText, $queryId);
-
-        $this->request->expects($this->at(4))->method('getPost')->with('store_id', false)->willReturn(1);
 
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
@@ -202,14 +231,15 @@ class SaveTest extends TestCase
         $this->assertSame($this->redirect, $this->controller->execute());
     }
 
-    public function testExecuteLoadQueryQueryIdQueryTextException()
+    /**
+     * @return void
+     */
+    public function testExecuteLoadQueryQueryIdQueryTextException(): void
     {
         $queryId = 1;
         $anotherQueryId = 2;
         $queryText = 'search';
         $this->mockGetRequestData($queryText, $queryId);
-
-        $this->request->expects($this->at(4))->method('getPost')->with('store_id', false)->willReturn(1);
 
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->with($queryText);
@@ -221,13 +251,14 @@ class SaveTest extends TestCase
         $this->assertSame($this->redirect, $this->controller->execute());
     }
 
-    public function testExecuteException()
+    /**
+     * @return void
+     */
+    public function testExecuteException(): void
     {
         $queryId = 1;
         $queryText = 'search';
         $this->mockGetRequestData($queryText, $queryId);
-
-        $this->request->expects($this->at(4))->method('getPost')->with('store_id', false)->willReturn(1);
 
         $this->query->expects($this->once())->method('setStoreId');
         $this->query->expects($this->once())->method('loadByQueryText')->willThrowException(new \Exception());
@@ -241,12 +272,31 @@ class SaveTest extends TestCase
     /**
      * @param string $queryText
      * @param int $queryId
+     * @param bool $withStoreId
+     *
+     * @return void
      */
-    private function mockGetRequestData($queryText, $queryId)
-    {
-        $this->request->expects($this->at(0))->method('getPostValue')->willReturn(['0' => '0']);
-        $this->request->expects($this->at(1))->method('isPost')->willReturn(true);
-        $this->request->expects($this->at(2))->method('getPost')->with('query_text', false)->willReturn($queryText);
-        $this->request->expects($this->at(3))->method('getPost')->with('query_id', null)->willReturn($queryId);
+    private function mockGetRequestData(
+        string $queryText,
+        int $queryId,
+        bool $withStoreId = true
+    ): void {
+        $this->request
+            ->method('getPostValue')
+            ->willReturn(['0' => '0']);
+        $this->request
+            ->method('isPost')
+            ->willReturn(true);
+        if ($withStoreId) {
+            $this->request
+                ->method('getPost')
+                ->withConsecutive(['query_text', false], ['query_id', null], ['store_id', false])
+                ->willReturnOnConsecutiveCalls($queryText, $queryId, 1);
+        } else {
+            $this->request
+                ->method('getPost')
+                ->withConsecutive(['query_text', false], ['query_id', null])
+                ->willReturnOnConsecutiveCalls($queryText, $queryId);
+        }
     }
 }

--- a/app/code/Magento/Search/Test/Unit/Model/SynonymGroupRepositoryTest.php
+++ b/app/code/Magento/Search/Test/Unit/Model/SynonymGroupRepositoryTest.php
@@ -31,6 +31,9 @@ class SynonymGroupRepositoryTest extends TestCase
      */
     private $resourceModel;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->factory = $this->createPartialMock(SynonymGroupFactory::class, ['create']);
@@ -38,7 +41,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object = new SynonymGroupRepository($this->factory, $this->resourceModel);
     }
 
-    public function testSaveCreate()
+    /**
+     * @return void
+     */
+    public function testSaveCreate(): void
     {
         $synonymGroupModel = $this->createMock(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->expects($this->once())->method('load')->with(null);
@@ -60,7 +66,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object->save($data);
     }
 
-    public function testSaveCreateMergeConflict()
+    /**
+     * @return void
+     */
+    public function testSaveCreateMergeConflict(): void
     {
         $this->expectException('Magento\Search\Model\Synonym\MergeConflictException');
         $this->expectExceptionMessage('Merge conflict with existing synonym group(s): (a,b,c)');
@@ -82,7 +91,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object->save($data, true);
     }
 
-    public function testSaveCreateMerge()
+    /**
+     * @return void
+     */
+    public function testSaveCreateMerge(): void
     {
         $synonymGroupModel = $this->createMock(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->expects($this->once())->method('load')->with(null);
@@ -99,9 +111,13 @@ class SynonymGroupRepositoryTest extends TestCase
         // merged result
         $newSynonymGroupModel->expects($this->once())->method('setSynonymGroup')->with('a,b,c,d,e');
 
-        $this->factory->expects($this->at(0))->method('create')->willReturn($synonymGroupModel);
-        $this->factory->expects($this->at(1))->method('create')->willReturn($existingSynonymGroupModel);
-        $this->factory->expects($this->at(2))->method('create')->willReturn($newSynonymGroupModel);
+        $this->factory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(
+                $synonymGroupModel,
+                $existingSynonymGroupModel,
+                $newSynonymGroupModel
+            );
 
         $this->resourceModel->expects($this->once())
             ->method('getByScope')
@@ -118,7 +134,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object->save($data);
     }
 
-    public function testSaveUpdate()
+    /**
+     * @return void
+     */
+    public function testSaveUpdate(): void
     {
         $synonymGroupModel = $this->createMock(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->expects($this->once())->method('load')->with(1);
@@ -143,7 +162,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object->save($data);
     }
 
-    public function testSaveUpdateMergeConflict()
+    /**
+     * @return void
+     */
+    public function testSaveUpdateMergeConflict(): void
     {
         $this->expectException('Magento\Search\Model\Synonym\MergeConflictException');
         $this->expectExceptionMessage('(d,h,i)');
@@ -167,7 +189,10 @@ class SynonymGroupRepositoryTest extends TestCase
         $this->object->save($data, true);
     }
 
-    public function testSaveUpdateMerge()
+    /**
+     * @return void
+     */
+    public function testSaveUpdateMerge(): void
     {
         $synonymGroupModel = $this->createMock(\Magento\Search\Model\SynonymGroup::class);
         $synonymGroupModel->expects($this->once())->method('load')->with(1);
@@ -184,8 +209,9 @@ class SynonymGroupRepositoryTest extends TestCase
         // merged result
         $synonymGroupModel->expects($this->once())->method('setSynonymGroup')->with('d,e,f,a,z');
 
-        $this->factory->expects($this->at(0))->method('create')->willReturn($synonymGroupModel);
-        $this->factory->expects($this->at(1))->method('create')->willReturn($existingSynonymGroupModel);
+        $this->factory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($synonymGroupModel, $existingSynonymGroupModel);
 
         $this->resourceModel->expects($this->once())
             ->method('getByScope')

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/CreateLabelTest.php
@@ -65,6 +65,9 @@ class CreateLabelTest extends TestCase
      */
     protected $controller;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->shipmentLoaderMock = $this->getMockBuilder(ShipmentLoader::class)
@@ -125,29 +128,17 @@ class CreateLabelTest extends TestCase
      *
      * @return void
      */
-    protected function loadShipment()
+    protected function loadShipment(): void
     {
         $orderId = 1;
         $shipmentId = 1;
         $shipment = [];
         $tracking = [];
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->willReturn($shipmentId);
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with('shipment')
-            ->willReturn($shipment);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('tracking')
-            ->willReturn($tracking);
+            ->withConsecutive(['order_id'], ['shipment_id'], ['shipment'], ['tracking'])
+            ->willReturnOnConsecutiveCalls($orderId, $shipmentId, $shipment, $tracking);
         $this->shipmentLoaderMock->expects($this->once())
             ->method('setOrderId')
             ->with($orderId);
@@ -164,8 +155,10 @@ class CreateLabelTest extends TestCase
 
     /**
      * Run test execute method
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->shipmentLoaderMock->expects($this->once())
             ->method('load')
@@ -183,8 +176,10 @@ class CreateLabelTest extends TestCase
 
     /**
      * Run test execute method (exception load shipment)
+     *
+     * @return void
      */
-    public function testExecuteLoadException()
+    public function testExecuteLoadException(): void
     {
         $this->shipmentLoaderMock->expects($this->once())
             ->method('load')
@@ -196,8 +191,10 @@ class CreateLabelTest extends TestCase
 
     /**
      * Run test execute method (exception save shipment)
+     *
+     * @return void
      */
-    public function testExecuteSaveException()
+    public function testExecuteSaveException(): void
     {
         $loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
 
@@ -221,8 +218,10 @@ class CreateLabelTest extends TestCase
 
     /**
      * Run test execute method (fail generate label)
+     *
+     * @return void
      */
-    public function testExecuteLabelGenerateFail()
+    public function testExecuteLabelGenerateFail(): void
     {
         $this->shipmentLoaderMock->expects($this->once())
             ->method('load')

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/EmailTest.php
@@ -90,6 +90,9 @@ class EmailTest extends TestCase
      */
     protected $shipmentLoader;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
@@ -117,9 +120,8 @@ class EmailTest extends TestCase
             ->onlyMethods(['sendResponse'])
             ->getMockForAbstractClass();
         $this->request = $this->getMockBuilder(RequestInterface::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
-                    'isPost',
                     'getModuleName',
                     'setModuleName',
                     'getActionName',
@@ -127,7 +129,7 @@ class EmailTest extends TestCase
                     'getParam',
                     'getCookie',
                 ]
-            )
+            )->addMethods(['isPost'])
             ->getMockForAbstractClass();
         $this->objectManager = $this->createPartialMock(
             ObjectManager::class,
@@ -170,7 +172,10 @@ class EmailTest extends TestCase
         );
     }
 
-    public function testEmail()
+    /**
+     * @return void
+     */
+    public function testEmail(): void
     {
         $shipmentId = 1000012;
         $orderId = 10003;
@@ -189,7 +194,7 @@ class EmailTest extends TestCase
                     ['order_id', null, $orderId],
                     ['shipment_id', null, $shipmentId],
                     ['shipment', null, $shipment],
-                    ['tracking', null, $tracking],
+                    ['tracking', null, $tracking]
                 ]
             );
         $this->shipmentLoader->expects($this->once())
@@ -222,7 +227,7 @@ class EmailTest extends TestCase
             ->with('You sent the shipment.');
         $path = '*/*/view';
         $arguments = ['shipment_id' => $shipmentId];
-        $this->prepareRedirect($path, $arguments, 0);
+        $this->prepareRedirect($path, $arguments);
 
         $this->shipmentEmail->execute();
         $this->assertEquals($this->response, $this->shipmentEmail->getResponse());
@@ -231,9 +236,10 @@ class EmailTest extends TestCase
     /**
      * @param string $path
      * @param array $arguments
-     * @param int $index
+     *
+     * @return void
      */
-    protected function prepareRedirect($path, $arguments, $index)
+    protected function prepareRedirect(string $path, array $arguments): void
     {
         $this->actionFlag->expects($this->any())
             ->method('get')
@@ -242,7 +248,7 @@ class EmailTest extends TestCase
         $this->session->expects($this->any())
             ->method('setIsUrlNotice')
             ->with(true);
-        $this->resultRedirect->expects($this->at($index))
+        $this->resultRedirect
             ->method('setPath')
             ->with($path, ['shipment_id' => $arguments['shipment_id']]);
     }

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/GetShippingItemsGridTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/GetShippingItemsGridTest.php
@@ -44,6 +44,9 @@ class GetShippingItemsGridTest extends TestCase
      */
     protected $controller;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->requestMock = $this->getMockBuilder(Http::class)
@@ -84,8 +87,10 @@ class GetShippingItemsGridTest extends TestCase
 
     /**
      * Run test execute method
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $orderId = 1;
         $shipmentId = 1;
@@ -100,22 +105,6 @@ class GetShippingItemsGridTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->willReturn($shipmentId);
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with('shipment')
-            ->willReturn($shipment);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('tracking')
-            ->willReturn($tracking);
         $this->shipmentLoaderMock->expects($this->once())->method('setOrderId')->with($orderId);
         $this->shipmentLoaderMock->expects($this->once())->method('setShipmentId')->with($shipmentId);
         $this->shipmentLoaderMock->expects($this->once())->method('setShipment')->with($shipment);
@@ -131,9 +120,10 @@ class GetShippingItemsGridTest extends TestCase
         $this->responseMock->expects($this->once())
             ->method('setBody')
             ->with($result)->willReturnSelf();
-        $this->requestMock->expects($this->at(4))
+        $this->requestMock
             ->method('getParam')
-            ->with('index');
+            ->withConsecutive(['order_id'], ['shipment_id'], ['shipment'], ['tracking'], ['index'])
+            ->willReturnOnConsecutiveCalls($orderId, $shipmentId, $shipment, $tracking);
         $gridMock->expects($this->once())
             ->method('setIndex')->willReturnSelf();
         $gridMock->expects($this->once())

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintPackageTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/PrintPackageTest.php
@@ -73,6 +73,9 @@ class PrintPackageTest extends TestCase
      */
     protected $controller;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $orderId = 1;
@@ -112,22 +115,10 @@ class PrintPackageTest extends TestCase
         $contextMock->expects($this->any())->method('getSession')->willReturn($this->sessionMock);
         $contextMock->expects($this->any())->method('getActionFlag')->willReturn($this->actionFlag);
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->willReturn($shipmentId);
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with('shipment')
-            ->willReturn($shipment);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('tracking')
-            ->willReturn($tracking);
+            ->withConsecutive(['order_id'], ['shipment_id'], ['shipment'], ['tracking'])
+            ->willReturnOnConsecutiveCalls($orderId, $shipmentId, $shipment, $tracking);
         $this->shipmentLoaderMock->expects($this->once())
             ->method('setOrderId')
             ->with($orderId);
@@ -150,8 +141,10 @@ class PrintPackageTest extends TestCase
 
     /**
      * Run test execute method
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $date = '9999-99-99_77-77-77';
         $content = 'PDF content';
@@ -191,8 +184,10 @@ class PrintPackageTest extends TestCase
 
     /**
      * Run test execute method (fail print)
+     *
+     * @return void
      */
-    public function testExecuteFail()
+    public function testExecuteFail(): void
     {
         $this->shipmentLoaderMock->expects($this->once())
             ->method('load')

--- a/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/RemoveTrackTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Controller/Adminhtml/Order/Shipment/RemoveTrackTest.php
@@ -84,6 +84,9 @@ class RemoveTrackTest extends TestCase
      */
     protected $controller;
 
+    /**
+     * @return void
+     */
     protected function setUp(): void
     {
         $this->requestMock = $this->createPartialMock(Http::class, ['getParam']);
@@ -155,7 +158,7 @@ class RemoveTrackTest extends TestCase
      *
      * @return void
      */
-    protected function shipmentLoad()
+    protected function shipmentLoad(): void
     {
         $orderId = 1;
         $shipmentId = 1;
@@ -169,26 +172,10 @@ class RemoveTrackTest extends TestCase
         $this->shipmentTrackMock->expects($this->once())
             ->method('getId')
             ->willReturn($trackId);
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('track_id')
-            ->willReturn($trackId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('order_id')
-            ->willReturn($orderId);
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with('shipment_id')
-            ->willReturn($shipmentId);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with('shipment')
-            ->willReturn($shipment);
-        $this->requestMock->expects($this->at(4))
-            ->method('getParam')
-            ->with('tracking')
-            ->willReturn($tracking);
+            ->withConsecutive(['track_id'], ['order_id'], ['shipment_id'], ['shipment'], ['tracking'])
+            ->willReturnOnConsecutiveCalls($trackId, $orderId, $shipmentId, $shipment, $tracking);
         $this->shipmentLoaderMock->expects($this->once())->method('setOrderId')->with($orderId);
         $this->shipmentLoaderMock->expects($this->once())->method('setShipmentId')->with($shipmentId);
         $this->shipmentLoaderMock->expects($this->once())->method('setShipment')->with($shipment);
@@ -199,9 +186,10 @@ class RemoveTrackTest extends TestCase
      * Represent json json section
      *
      * @param array $errors
+     *
      * @return void
      */
-    protected function representJson(array $errors)
+    protected function representJson(array $errors): void
     {
         $jsonHelper = $this->createPartialMock(Data::class, ['jsonEncode']);
         $jsonHelper->expects($this->once())
@@ -219,8 +207,10 @@ class RemoveTrackTest extends TestCase
 
     /**
      * Run test execute method
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $response = 'html-data';
         $this->shipmentLoad();
@@ -255,8 +245,10 @@ class RemoveTrackTest extends TestCase
 
     /**
      * Run test execute method (fail track load)
+     *
+     * @return void
      */
-    public function testExecuteTrackIdFail()
+    public function testExecuteTrackIdFail(): void
     {
         $trackId = null;
         $errors = ['error' => true, 'message' => 'We can\'t load track with retrieving identifier right now.'];
@@ -274,8 +266,10 @@ class RemoveTrackTest extends TestCase
 
     /**
      * Run test execute method (fail load shipment)
+     *
+     * @return void
      */
-    public function testExecuteShipmentLoadFail()
+    public function testExecuteShipmentLoadFail(): void
     {
         $errors = [
             'error' => true,
@@ -293,8 +287,10 @@ class RemoveTrackTest extends TestCase
 
     /**
      * Run test execute method (delete exception)
+     *
+     * @return void
      */
-    public function testExecuteDeleteFail()
+    public function testExecuteDeleteFail(): void
     {
         $errors = ['error' => true, 'message' => 'We can\'t delete tracking number.'];
         $this->shipmentLoad();

--- a/app/code/Magento/Shipping/Test/Unit/Model/ShipmentNotifierTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/ShipmentNotifierTest.php
@@ -51,6 +51,9 @@ class ShipmentNotifierTest extends TestCase
      */
     protected $shipmentSenderMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->historyCollectionFactory = $this->createPartialMock(
@@ -75,8 +78,10 @@ class ShipmentNotifierTest extends TestCase
 
     /**
      * Test case for successful email sending
+     *
+     * @return void
      */
-    public function testNotifySuccess()
+    public function testNotifySuccess(): void
     {
         $historyCollection = $this->getMockBuilder(Collection::class)
             ->addMethods(['setIsCustomerNotified'])
@@ -87,11 +92,9 @@ class ShipmentNotifierTest extends TestCase
             History::class,
             ['setIsCustomerNotified', 'save', '__wakeUp']
         );
-        $historyItem->expects($this->at(0))
+        $historyItem
             ->method('setIsCustomerNotified')
             ->with(1);
-        $historyItem->expects($this->at(1))
-            ->method('save');
         $historyCollection->expects($this->once())
             ->method('getUnnotifiedForInstance')
             ->with($this->shipment)
@@ -112,8 +115,10 @@ class ShipmentNotifierTest extends TestCase
 
     /**
      * Test case when email has not been sent
+     *
+     * @return void
      */
-    public function testNotifyFail()
+    public function testNotifyFail(): void
     {
         $this->shipment->expects($this->once())
             ->method('getEmailSent')
@@ -123,8 +128,10 @@ class ShipmentNotifierTest extends TestCase
 
     /**
      * Test case when Mail Exception has been thrown
+     *
+     * @return void
      */
-    public function testNotifyException()
+    public function testNotifyException(): void
     {
         $exception = new MailException(__('Email has not been sent'));
         $this->shipmentSenderMock->expects($this->once())

--- a/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Controller/Adminhtml/Sitemap/SaveTest.php
@@ -94,6 +94,9 @@ class SaveTest extends TestCase
      */
     private $session;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->getMockBuilder(Context::class)
@@ -101,7 +104,7 @@ class SaveTest extends TestCase
             ->getMock();
         $this->requestMock = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPostValue'])
+            ->addMethods(['getPostValue'])
             ->getMockForAbstractClass();
         $this->resultRedirectMock = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
@@ -122,7 +125,7 @@ class SaveTest extends TestCase
             ->willReturn($this->resultRedirectMock);
         $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFormData'])
+            ->addMethods(['setFormData'])
             ->getMock();
 
         $this->contextMock->expects($this->once())
@@ -158,7 +161,10 @@ class SaveTest extends TestCase
         );
     }
 
-    public function testSaveEmptyDataShouldRedirectToDefault()
+    /**
+     * @return void
+     */
+    public function testSaveEmptyDataShouldRedirectToDefault(): void
     {
         $this->requestMock->expects($this->once())
             ->method('getPostValue')
@@ -171,7 +177,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->saveController->execute());
     }
 
-    public function testTryToSaveInvalidDataShouldFailWithErrors()
+    /**
+     * @return void
+     */
+    public function testTryToSaveInvalidDataShouldFailWithErrors(): void
     {
         $validPaths = [];
         $messages = ['message1', 'message2'];
@@ -207,13 +216,9 @@ class SaveTest extends TestCase
             ->with($data)
             ->willReturnSelf();
 
-        $this->messageManagerMock->expects($this->at(0))
+        $this->messageManagerMock
             ->method('addErrorMessage')
-            ->withConsecutive(
-                [$messages[0]],
-                [$messages[1]]
-            )
-            ->willReturnSelf();
+            ->willReturn($this->messageManagerMock);
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')
@@ -223,7 +228,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->saveController->execute());
     }
 
-    public function testTryToSaveInvalidFileNameShouldFailWithErrors()
+    /**
+     * @return void
+     */
+    public function testTryToSaveInvalidFileNameShouldFailWithErrors(): void
     {
         $validPaths = [];
         $messages = ['message1', 'message2'];
@@ -264,13 +272,9 @@ class SaveTest extends TestCase
             ->with($data)
             ->willReturnSelf();
 
-        $this->messageManagerMock->expects($this->at(0))
+        $this->messageManagerMock
             ->method('addErrorMessage')
-            ->withConsecutive(
-                [$messages[0]],
-                [$messages[1]]
-            )
-            ->willReturnSelf();
+            ->willReturn($this->messageManagerMock);
 
         $this->resultRedirectMock->expects($this->once())
             ->method('setPath')

--- a/app/code/Magento/Sitemap/Test/Unit/Model/EmailNotificationTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/EmailNotificationTest.php
@@ -56,6 +56,9 @@ class EmailNotificationTest extends TestCase
      */
     private $objectManagerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerMock = $this->getMockBuilder(ObjectManagerInterface::class)
@@ -74,23 +77,23 @@ class EmailNotificationTest extends TestCase
             [
                 'inlineTranslation' => $this->inlineTranslationMock,
                 'scopeConfig' => $this->scopeConfigMock,
-                'transportBuilder' => $this->transportBuilderMock,
+                'transportBuilder' => $this->transportBuilderMock
             ]
         );
     }
 
-    public function testSendErrors()
+    /**
+     * @return void
+     */
+    public function testSendErrors(): void
     {
         $exception = 'Sitemap Exception';
         $transport = $this->getMockForAbstractClass(TransportInterface::class);
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                Observer::XML_PATH_ERROR_TEMPLATE,
-                ScopeInterface::SCOPE_STORE
-            )
-            ->willReturn('error-recipient@example.com');
+            ->withConsecutive([Observer::XML_PATH_ERROR_TEMPLATE, ScopeInterface::SCOPE_STORE])
+            ->willReturn(['error-recipient@example.com']);
 
         $this->inlineTranslationMock->expects($this->once())
             ->method('suspend');

--- a/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
+++ b/app/code/Magento/Sitemap/Test/Unit/Model/ObserverTest.php
@@ -70,16 +70,18 @@ class ObserverTest extends TestCase
      */
     private $emailNotificationMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerMock = $this->getMockBuilder(ObjectManagerInterface::class)
             ->getMock();
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
             ->getMock();
-        $this->collectionFactoryMock = $this->getMockBuilder(
-            CollectionFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->collectionFactoryMock = $this->getMockBuilder(CollectionFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
         $this->sitemapCollectionMock = $this->createPartialMock(
             Collection::class,
@@ -105,7 +107,10 @@ class ObserverTest extends TestCase
         );
     }
 
-    public function testScheduledGenerateSitemapsSendsExceptionEmail()
+    /**
+     * @return void
+     */
+    public function testScheduledGenerateSitemapsSendsExceptionEmail(): void
     {
         $exception = 'Sitemap Exception';
         $storeId = 1;
@@ -120,7 +125,7 @@ class ObserverTest extends TestCase
             ->method('getIterator')
             ->willReturn(new \ArrayIterator([$this->sitemapMock]));
 
-        $this->sitemapMock->expects($this->at(0))
+        $this->sitemapMock
             ->method('getStoreId')
             ->willReturn($storeId);
 
@@ -128,12 +133,9 @@ class ObserverTest extends TestCase
             ->method('generateXml')
             ->willThrowException(new \Exception($exception));
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                Observer::XML_PATH_ERROR_RECIPIENT,
-                ScopeInterface::SCOPE_STORE
-            )
+            ->with(Observer::XML_PATH_ERROR_RECIPIENT, ScopeInterface::SCOPE_STORE)
             ->willReturn('error-recipient@example.com');
 
         $this->emailNotificationMock->expects($this->once())
@@ -146,9 +148,10 @@ class ObserverTest extends TestCase
     /**
      * Test if cron scheduled XML sitemap generation will start and stop the store environment emulation
      *
+     * @return void
      * @throws \Exception
      */
-    public function testCronGenerateSitemapEnvironmentEmulation()
+    public function testCronGenerateSitemapEnvironmentEmulation(): void
     {
         $storeId = 1;
 
@@ -162,7 +165,7 @@ class ObserverTest extends TestCase
             ->method('getIterator')
             ->willReturn(new \ArrayIterator([$this->sitemapMock]));
 
-        $this->sitemapMock->expects($this->at(0))
+        $this->sitemapMock
             ->method('getStoreId')
             ->willReturn($storeId);
 

--- a/app/code/Magento/Store/Test/Unit/Model/Config/Reader/Source/Dynamic/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/Config/Reader/Source/Dynamic/StoreTest.php
@@ -65,18 +65,21 @@ class StoreTest extends TestCase
      */
     private $storeSource;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->collectionFactory = $this->getMockBuilder(ScopedFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
         $this->converter = $this->getMockBuilder(Converter::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->websiteFactory = $this->getMockBuilder(WebsiteFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
         $this->website = $this->getMockBuilder(\Magento\Store\Model\Website::class)
             ->disableOriginalConstructor()
@@ -99,7 +102,10 @@ class StoreTest extends TestCase
         );
     }
 
-    public function testGet()
+    /**
+     * @return void
+     */
+    public function testGet(): void
     {
         $scopeCode = 'myStore';
         $expectedResult = [
@@ -128,17 +134,9 @@ class StoreTest extends TestCase
             ->with(1)
             ->willReturn([]);
 
-        $this->converter->expects($this->at(0))
+        $this->converter
             ->method('convert')
-            ->with([
-                'config/key1' => 'default_db_value1',
-                'config/key3' => 'default_db_value3'
-            ])
-            ->willReturnArgument(0);
-
-        $this->converter->expects($this->at(1))
-            ->method('convert')
-            ->with($expectedResult)
+            ->withConsecutive([$expectedResult], [$expectedResult])
             ->willReturnArgument(0);
 
         $this->assertEquals($expectedResult, $this->storeSource->get($scopeCode));


### PR DESCRIPTION
### Description (*)
This PR fixes CE project codebase compatibility problems with the PHPUnit v.9.3.0.
See changes here: [PHPUnit 9.3.0 ChangeLog](https://github.com/sebastianbergmann/phpunit/blob/9.3.0/ChangeLog-9.3.md#configuration-of-code-coverage-and-logging-in-phpunitxml)

In this PR was changed 90 files where the main problem was using at() matcher that has been deprecated.

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/576
https://github.com/magento/partners-magento2b2b/pull/579
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#33707

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)