### PR TITLE
CE-33707: Fixed deprecated methods for PHPUnit v9.3.0

### DIFF
--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * @covers Directive
+ * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DirectiveTest extends TestCase
@@ -206,7 +206,7 @@ class DirectiveTest extends TestCase
 
     /**
      * @return void
-     * @covers Directive::execute
+     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
      */
     public function testExecute(): void
     {
@@ -249,7 +249,7 @@ class DirectiveTest extends TestCase
 
     /**
      * @return void
-     * @covers Directive::execute
+     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
      */
     public function testExecuteException(): void
     {
@@ -331,7 +331,7 @@ class DirectiveTest extends TestCase
      * Test Execute With Deleted Image
      *
      * @return void
-     * @covers Directive::execute
+     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
      */
     public function testExecuteWithDeletedImage(): void
     {

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
@@ -107,7 +107,7 @@ class DirectiveTest extends TestCase
     private $driverMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Wysiwyg/DirectiveTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Cms\Test\Unit\Controller\Adminhtml\Wysiwyg;
 
+use Exception;
 use Magento\Backend\App\Action\Context;
 use Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive;
 use Magento\Cms\Model\Template\Filter;
@@ -17,7 +18,6 @@ use Magento\Framework\Controller\Result\Raw;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
-use Magento\Framework\Filesystem\Driver\File;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Image\Adapter\AdapterInterface;
 use Magento\Framework\Image\AdapterFactory;
@@ -29,7 +29,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive
+ * @covers Directive
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DirectiveTest extends TestCase
@@ -106,6 +106,9 @@ class DirectiveTest extends TestCase
      */
     private $driverMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->actionContextMock = $this->getMockBuilder(Context::class)
@@ -128,9 +131,8 @@ class DirectiveTest extends TestCase
             ->getMock();
         $this->imageAdapterMock = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
-                    'getMimeType',
                     'getColorAt',
                     'getImage',
                     'watermark',
@@ -144,10 +146,12 @@ class DirectiveTest extends TestCase
                     'rotate'
                 ]
             )
+            ->addMethods(['getMimeType'])
             ->getMockForAbstractClass();
         $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHeader', 'setBody', 'sendResponse'])
+            ->onlyMethods(['sendResponse'])
+            ->addMethods(['setHeader', 'setBody'])
             ->getMockForAbstractClass();
         $this->wysiwygConfigMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
@@ -156,7 +160,7 @@ class DirectiveTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->rawFactoryMock = $this->getMockBuilder(RawFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->rawMock = $this->getMockBuilder(Raw::class)
@@ -201,9 +205,10 @@ class DirectiveTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
+     * @return void
+     * @covers Directive::execute
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $mimeType = 'image/jpeg';
         $imageBody = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -243,26 +248,24 @@ class DirectiveTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
+     * @return void
+     * @covers Directive::execute
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
-        $exception = new \Exception('epic fail');
+        $exception = new Exception('epic fail');
         $placeholderPath = 'pub/static/adminhtml/Magento/backend/en_US/Magento_Cms/images/wysiwyg_skin_image.png';
         $mimeType = 'image/png';
         $imageBody = '0123456789abcdefghijklmnopqrstuvwxyz';
         $this->prepareExecuteTest();
 
-        $this->imageAdapterMock->expects($this->at(0))
-            ->method('open')
-            ->with(self::IMAGE_PATH)
-            ->willThrowException($exception);
         $this->wysiwygConfigMock->expects($this->once())
             ->method('getSkinImagePlaceholderPath')
             ->willReturn($placeholderPath);
-        $this->imageAdapterMock->expects($this->at(1))
+        $this->imageAdapterMock
             ->method('open')
-            ->with($placeholderPath);
+            ->withConsecutive([self::IMAGE_PATH])
+            ->willThrowException($exception);
         $this->imageAdapterMock->expects($this->atLeastOnce())
             ->method('getMimeType')
             ->willReturn($mimeType);
@@ -297,7 +300,10 @@ class DirectiveTest extends TestCase
         );
     }
 
-    protected function prepareExecuteTest()
+    /**
+     * @return void
+     */
+    protected function prepareExecuteTest(): void
     {
         $directiveParam = 'e3ttZWRpYSB1cmw9Ind5c2l3eWcvYnVubnkuanBnIn19';
         $directive = '{{media url="wysiwyg/image.jpg"}}';
@@ -324,11 +330,12 @@ class DirectiveTest extends TestCase
     /**
      * Test Execute With Deleted Image
      *
-     * @covers \Magento\Cms\Controller\Adminhtml\Wysiwyg\Directive::execute
+     * @return void
+     * @covers Directive::execute
      */
-    public function testExecuteWithDeletedImage()
+    public function testExecuteWithDeletedImage(): void
     {
-        $exception = new \Exception('epic fail');
+        $exception = new Exception('epic fail');
         $placeholderPath = 'pub/static/adminhtml/Magento/backend/en_US/Magento_Cms/images/wysiwyg_skin_image.png';
         $this->prepareExecuteTest();
 

--- a/app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php
@@ -20,27 +20,44 @@ use PHPUnit\Framework\TestCase;
 
 class InlineEditTest extends TestCase
 {
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $request;
 
-    /** @var Block|MockObject */
+    /**
+     * @var Block|MockObject
+     */
     protected $cmsBlock;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     protected $context;
 
-    /** @var BlockRepositoryInterface|MockObject */
+    /**
+     * @var BlockRepositoryInterface|MockObject
+     */
     protected $blockRepository;
 
-    /** @var JsonFactory|MockObject */
+    /**
+     * @var JsonFactory|MockObject
+     */
     protected $jsonFactory;
 
-    /** @var Json|MockObject */
+    /**
+     * @var Json|MockObject
+     */
     protected $resultJson;
 
-    /** @var InlineEdit */
+    /**
+     * @var InlineEdit
+     */
     protected $controller;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
@@ -76,7 +93,10 @@ class InlineEditTest extends TestCase
         );
     }
 
-    public function prepareMocksForTestExecute()
+    /**
+     * @return void
+     */
+    public function prepareMocksForTestExecute(): void
     {
         $postData = [
             1 => [
@@ -85,14 +105,10 @@ class InlineEditTest extends TestCase
             ]
         ];
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with('isAjax')
-            ->willReturn(true);
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('items', [])
-            ->willReturn($postData);
+            ->withConsecutive(['isAjax'], ['items', []])
+            ->willReturnOnConsecutiveCalls(true, $postData);
         $this->blockRepository->expects($this->once())
             ->method('getById')
             ->with(1)
@@ -116,7 +132,10 @@ class InlineEditTest extends TestCase
             ->willReturn($this->resultJson);
     }
 
-    public function testExecuteWithException()
+    /**
+     * @return void
+     */
+    public function testExecuteWithException(): void
     {
         $this->prepareMocksForTestExecute();
         $this->blockRepository->expects($this->once())
@@ -125,38 +144,37 @@ class InlineEditTest extends TestCase
             ->willThrowException(new \Exception('Exception'));
         $this->resultJson->expects($this->once())
             ->method('setData')
-            ->with([
-                'messages' => [
-                    '[Block ID: 1] Exception'
-                ],
-                'error' => true
-            ])
+            ->with(
+                [
+                    'messages' => ['[Block ID: 1] Exception'],
+                    'error' => true
+                ]
+            )
             ->willReturnSelf();
 
         $this->controller->execute();
     }
 
-    public function testExecuteWithoutData()
+    /**
+     * @return void
+     */
+    public function testExecuteWithoutData(): void
     {
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with('isAjax')
-            ->willReturn(true);
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('items', [])
-            ->willReturn([]);
+            ->withConsecutive(['isAjax'], ['items', []])
+            ->willReturnOnConsecutiveCalls(true, []);
         $this->jsonFactory->expects($this->once())
             ->method('create')
             ->willReturn($this->resultJson);
         $this->resultJson->expects($this->once())
             ->method('setData')
-            ->with([
-                'messages' => [
-                    'Please correct the data sent.'
-                ],
-                'error' => true
-            ])
+            ->with(
+                [
+                    'messages' => ['Please correct the data sent.'],
+                    'error' => true
+                ]
+            )
             ->willReturnSelf();
 
         $this->controller->execute();

--- a/app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Block/InlineEditTest.php
@@ -56,7 +56,7 @@ class InlineEditTest extends TestCase
     protected $controller;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Cms/Test/Unit/Controller/Noroute/IndexTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Noroute/IndexTest.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 namespace Magento\Cms\Test\Unit\Controller\Noroute;
 
 use Magento\Cms\Controller\Noroute\Index;
+use Magento\Cms\Helper\Page as CmsPage;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Request\Http as RequestHttp;
 use Magento\Framework\App\Response\Http;
 use Magento\Framework\Controller\Result\Forward;
 use Magento\Framework\Controller\Result\ForwardFactory;
@@ -54,6 +56,9 @@ class IndexTest extends TestCase
      */
     protected $resultPageMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
@@ -63,7 +68,7 @@ class IndexTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->forwardFactoryMock = $this->getMockBuilder(ForwardFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->forwardMock = $this->getMockBuilder(Forward::class)
@@ -74,14 +79,15 @@ class IndexTest extends TestCase
             ->willReturn($this->forwardMock);
 
         $scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
-        $this->_requestMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
-        $this->_cmsHelperMock = $this->createMock(\Magento\Cms\Helper\Page::class);
+        $this->_requestMock = $this->createMock(RequestHttp::class);
+        $this->_cmsHelperMock = $this->createMock(CmsPage::class);
         $valueMap = [
-            [ScopeConfigInterface::class,
+            [
+                ScopeConfigInterface::class,
                 ScopeInterface::SCOPE_STORE,
                 $scopeConfigMock,
             ],
-            [\Magento\Cms\Helper\Page::class, $this->_cmsHelperMock],
+            [CmsPage::class, $this->_cmsHelperMock]
         ];
         $objectManagerMock->expects($this->any())->method('get')->willReturnMap($valueMap);
         $scopeConfigMock->expects(
@@ -89,33 +95,34 @@ class IndexTest extends TestCase
         )->method(
             'getValue'
         )->with(
-            \Magento\Cms\Helper\Page::XML_PATH_NO_ROUTE_PAGE
+            CmsPage::XML_PATH_NO_ROUTE_PAGE
         )->willReturn(
             'pageId'
         );
         $this->_controller = $helper->getObject(
             Index::class,
-            ['response' => $responseMock, 'objectManager' => $objectManagerMock, 'request' => $this->_requestMock,
+            [
+                'response' => $responseMock,
+                'objectManager' => $objectManagerMock,
+                'request' => $this->_requestMock,
                 'resultForwardFactory' => $this->forwardFactoryMock
             ]
         );
     }
 
-    public function testExecuteResultPage()
+    /**
+     * @return void
+     */
+    public function testExecuteResultPage(): void
     {
-        $this->resultPageMock->expects(
-            $this->at(0)
-        )->method(
-            'setStatusHeader'
-        )->with(404, '1.1', 'Not Found')->willReturnSelf();
-        $this->resultPageMock->expects(
-            $this->at(1)
-        )->method(
-            'setHeader'
-        )->with(
-            'Status',
-            '404 File not found'
-        )->willReturnSelf();
+        $this->resultPageMock
+            ->method('setStatusHeader')
+            ->with(404, '1.1', 'Not Found')
+            ->willReturn($this->resultPageMock);
+        $this->resultPageMock
+            ->method('setHeader')
+            ->with('Status', '404 File not found')
+            ->willReturn($this->resultPageMock);
         $this->_cmsHelperMock->expects(
             $this->once()
         )->method(
@@ -129,7 +136,10 @@ class IndexTest extends TestCase
         );
     }
 
-    public function testExecuteResultForward()
+    /**
+     * @return void
+     */
+    public function testExecuteResultForward(): void
     {
         $this->forwardMock->expects(
             $this->once()

--- a/app/code/Magento/Cms/Test/Unit/Controller/Noroute/IndexTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Noroute/IndexTest.php
@@ -57,7 +57,7 @@ class IndexTest extends TestCase
     protected $resultPageMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlRewriteGeneratorTest.php
+++ b/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlRewriteGeneratorTest.php
@@ -46,7 +46,7 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
     private $urlRewriteGenerator;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlRewriteGeneratorTest.php
+++ b/app/code/Magento/CmsUrlRewrite/Test/Unit/Model/CmsPageUrlRewriteGeneratorTest.php
@@ -46,7 +46,7 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
     private $urlRewriteGenerator;
 
     /**
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -54,7 +54,7 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->getMockForAbstractClass();
         $this->urlRewriteFactory = $this->getMockBuilder(UrlRewriteFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->urlPathGenerator = $this->getMockBuilder(CmsPageUrlPathGenerator::class)
@@ -70,7 +70,10 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
         );
     }
 
-    public function testGenerateForAllStores()
+    /**
+     * @return void
+     */
+    public function testGenerateForAllStores(): void
     {
         $initializesStores = [0];
         $cmsPageId = 1;
@@ -79,7 +82,7 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
             ->getMock();
         $cmsPage->expects($this->any())->method('getStores')->willReturn($initializesStores);
         $store = $this->getMockBuilder(StoreInterface::class)
-            ->setMethods(['getStoreId'])
+            ->addMethods(['getStoreId'])
             ->getMockForAbstractClass();
         $this->storeManager->expects($this->any())->method('getStores')->willReturn([$store]);
         $store->expects($this->any())->method('getStoreId')->willReturn($initializesStores[0]);
@@ -96,7 +99,10 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
         $this->assertArrayNotHasKey(1, $urls);
     }
 
-    public function testGenerateForSpecificStores()
+    /**
+     * @return void
+     */
+    public function testGenerateForSpecificStores(): void
     {
         $initializesStores = [1, 2];
         $cmsPageId = 1;
@@ -105,10 +111,10 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
             ->getMock();
         $cmsPage->expects($this->any())->method('getStores')->willReturn($initializesStores);
         $firstStore = $this->getMockBuilder(StoreInterface::class)
-            ->setMethods(['getStoreId'])
+            ->addMethods(['getStoreId'])
             ->getMockForAbstractClass();
         $secondStore = $this->getMockBuilder(StoreInterface::class)
-            ->setMethods(['getStoreId'])
+            ->addMethods(['getStoreId'])
             ->getMockForAbstractClass();
         $this->storeManager->expects($this->any())->method('getStores')->willReturn(
             [
@@ -123,8 +129,9 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
             ->getMockForAbstractClass();
         $urlRewriteSecond = $this->getMockBuilder(UrlRewrite::class)
             ->getMockForAbstractClass();
-        $this->urlRewriteFactory->expects($this->at(0))->method('create')->willReturn($urlRewriteFirst);
-        $this->urlRewriteFactory->expects($this->at(1))->method('create')->willReturn($urlRewriteSecond);
+        $this->urlRewriteFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($urlRewriteFirst, $urlRewriteSecond);
 
         $cmsPage->expects($this->any())->method('getId')->willReturn($cmsPageId);
         $cmsPage->expects($this->any())->method('getIdentifier')->willReturn('request_path');
@@ -138,7 +145,7 @@ class CmsPageUrlRewriteGeneratorTest extends TestCase
             ],
             [
                 $urls[0]->getStoreId(),
-                $urls[1]->getStoreId(),
+                $urls[1]->getStoreId()
             ]
         );
     }

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShow/ValueProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShow/ValueProcessorTest.php
@@ -54,7 +54,7 @@ class ValueProcessorTest extends TestCase
     private $valueProcessor;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShow/ValueProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShow/ValueProcessorTest.php
@@ -53,6 +53,9 @@ class ValueProcessorTest extends TestCase
      */
     private $valueProcessor;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->valueFactoryMock = $this->getMockBuilder(ValueFactory::class)
@@ -60,9 +63,8 @@ class ValueProcessorTest extends TestCase
             ->getMock();
         $this->scopeMock = $this->getMockBuilder(ScopeInterface::class)
             ->getMockForAbstractClass();
-        $this->structureFactoryMock = $this->getMockBuilder(StructureFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->structureFactoryMock = $this->getMockBuilder(StructureFactory::class)->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
         $this->jsonSerializerMock = $this->getMockBuilder(JsonSerializer::class)
             ->disableOriginalConstructor()
@@ -91,6 +93,8 @@ class ValueProcessorTest extends TestCase
      * @param string $className
      * @param string $value
      * @param string|array $processedValue
+     *
+     * @return void
      * @dataProvider processDataProvider
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
@@ -109,7 +113,7 @@ class ValueProcessorTest extends TestCase
         $className,
         $value,
         $processedValue
-    ) {
+    ): void {
         $scope = 'someScope';
         $scopeCode = 'someScopeCode';
         $path = 'some/config/path';
@@ -118,12 +122,9 @@ class ValueProcessorTest extends TestCase
         $this->scopeMock->expects($this->once())
             ->method('getCurrentScope')
             ->willReturn($oldConfigScope);
-        $this->scopeMock->expects($this->at(1))
+        $this->scopeMock
             ->method('setCurrentScope')
-            ->with(Area::AREA_ADMINHTML);
-        $this->scopeMock->expects($this->at(2))
-            ->method('setCurrentScope')
-            ->with($oldConfigScope);
+            ->withConsecutive([Area::AREA_ADMINHTML], [$oldConfigScope]);
 
         /** @var Structure|MockObject $structureMock */
         $structureMock = $this->getMockBuilder(Structure::class)
@@ -136,7 +137,8 @@ class ValueProcessorTest extends TestCase
         /** @var Value|Encrypted|MockObject $valueMock */
         $backendModelMock = $this->getMockBuilder($className)
             ->disableOriginalConstructor()
-            ->setMethods(['setPath', 'setScope', 'setScopeId', 'setValue', 'getValue', 'afterLoad'])
+            ->addMethods(['setPath', 'setScope', 'setScopeId', 'setValue', 'getValue'])
+            ->onlyMethods(['afterLoad'])
             ->getMock();
         $backendModelMock->expects($expectsSetPath)
             ->method('setPath')
@@ -191,7 +193,7 @@ class ValueProcessorTest extends TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function processDataProvider()
+    public function processDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
@@ -80,12 +80,13 @@ class ImporterTest extends TestCase
     private $saveProcessorMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->flagManagerMock = $this->getMockBuilder(FlagManager::class)
-            ->setMethods(['create', 'getFlagData', 'saveFlag'])
+            ->onlyMethods(['getFlagData', 'saveFlag'])
+            ->addMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->flagMock = $this->getMockBuilder(Flag::class)
@@ -125,7 +126,10 @@ class ImporterTest extends TestCase
         );
     }
 
-    public function testImport()
+    /**
+     * @return void
+     */
+    public function testImport(): void
     {
         $data = [];
         $currentData = ['current' => '2'];
@@ -153,15 +157,9 @@ class ImporterTest extends TestCase
         $this->saveProcessorMock->expects($this->once())
             ->method('process')
             ->with([]);
-        $this->scopeMock->expects($this->at(1))
+        $this->scopeMock
             ->method('setCurrentScope')
-            ->with(Area::AREA_ADMINHTML);
-        $this->scopeMock->expects($this->at(2))
-            ->method('setCurrentScope')
-            ->with('oldScope');
-        $this->scopeMock->expects($this->at(3))
-            ->method('setCurrentScope')
-            ->with('oldScope');
+            ->withConsecutive([Area::AREA_ADMINHTML], ['oldScope'], ['oldScope']);
         $this->flagManagerMock->expects($this->once())
             ->method('saveFlag')
             ->with(Importer::FLAG_CODE, $data);
@@ -169,7 +167,10 @@ class ImporterTest extends TestCase
         $this->assertSame(['System config was processed'], $this->model->import($data));
     }
 
-    public function testImportWithException()
+    /**
+     * @return void
+     */
+    public function testImportWithException(): void
     {
         $this->expectException('Magento\Framework\Exception\State\InvalidTransitionException');
         $this->expectExceptionMessage('Some error');

--- a/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/ImporterTest.php
@@ -80,7 +80,7 @@ class ImporterTest extends TestCase
     private $saveProcessorMock;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Source/Admin/PageTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Source/Admin/PageTest.php
@@ -43,7 +43,7 @@ class PageTest extends TestCase
     protected $_model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Source/Admin/PageTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Source/Admin/PageTest.php
@@ -42,6 +42,9 @@ class PageTest extends TestCase
      */
     protected $_model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $logger = $this->getMockForAbstractClass(LoggerInterface::class);
@@ -78,27 +81,25 @@ class PageTest extends TestCase
         $this->_model = new Page($this->_factoryMock, $menuConfig);
     }
 
-    public function testToOptionArray()
+    /**
+     * @return void
+     */
+    public function testToOptionArray(): void
     {
-        $this->_factoryMock->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            ['iterator' => $this->_menuModel->getIterator()]
-        )->willReturn(
-            new Iterator($this->_menuModel->getIterator())
-        );
-
-        $this->_factoryMock->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            ['iterator' => $this->_menuSubModel->getIterator()]
-        )->willReturn(
-            new Iterator($this->_menuSubModel->getIterator())
-        );
+        $this->_factoryMock
+            ->method('create')
+            ->withConsecutive(
+                [
+                    ['iterator' => $this->_menuModel->getIterator()]
+                ],
+                [
+                    ['iterator' => $this->_menuSubModel->getIterator()]
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                new Iterator($this->_menuModel->getIterator()),
+                new Iterator($this->_menuSubModel->getIterator())
+            );
 
         $nonEscapableNbspChar = html_entity_decode('&#160;', ENT_NOQUOTES, 'UTF-8');
         $paddingString = str_repeat($nonEscapableNbspChar, 4);

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Iterator/FieldTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Iterator/FieldTest.php
@@ -30,7 +30,7 @@ class FieldTest extends TestCase
     protected $_groupMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -52,7 +52,7 @@ class FieldTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Iterator/FieldTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Iterator/FieldTest.php
@@ -29,6 +29,9 @@ class FieldTest extends TestCase
      */
     protected $_groupMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_fieldMock = $this->createMock(\Magento\Config\Model\Config\Structure\Element\Field::class);
@@ -48,6 +51,9 @@ class FieldTest extends TestCase
         );
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         unset($this->_fieldMock);
@@ -55,48 +61,44 @@ class FieldTest extends TestCase
         unset($this->_model);
     }
 
-    public function testIteratorInitializesCorrespondingFlyweights()
+    /**
+     * @return void
+     */
+    public function testIteratorInitializesCorrespondingFlyweights(): void
     {
-        $this->_groupMock->expects(
-            $this->at(0)
-        )->method(
-            'setData'
-        )->with(
-            ['_elementType' => 'group', 'id' => 'someGroup_1'],
-            'scope'
-        );
-        $this->_groupMock->expects(
-            $this->at(2)
-        )->method(
-            'setData'
-        )->with(
-            ['_elementType' => 'group', 'id' => 'someGroup_2'],
-            'scope'
-        );
+        $this->_groupMock
+            ->method('setData')
+            ->withConsecutive(
+                [
+                    ['_elementType' => 'group', 'id' => 'someGroup_1'],
+                    'scope'
+                ],
+                [
+                    ['_elementType' => 'group', 'id' => 'someGroup_2'],
+                    'scope'
+                ]
+            );
         $this->_groupMock->expects($this->any())->method('isVisible')->willReturn(true);
 
-        $this->_fieldMock->expects(
-            $this->at(0)
-        )->method(
-            'setData'
-        )->with(
-            ['_elementType' => 'field', 'id' => 'someField_1'],
-            'scope'
-        );
-        $this->_fieldMock->expects(
-            $this->at(2)
-        )->method(
-            'setData'
-        )->with(
-            ['_elementType' => 'field', 'id' => 'someField_2'],
-            'scope'
-        );
+        $this->_fieldMock
+            ->method('setData')
+            ->withConsecutive(
+                [
+                    ['_elementType' => 'field', 'id' => 'someField_1'],
+                    'scope'
+                ],
+                [
+                    ['_elementType' => 'field', 'id' => 'someField_2'],
+                    'scope'
+                ]
+            );
         $this->_fieldMock->expects($this->any())->method('isVisible')->willReturn(true);
-
         $items = [];
+
         foreach ($this->_model as $item) {
             $items[] = $item;
         }
+
         $this->assertEquals($this->_groupMock, $items[0]);
         $this->assertEquals($this->_fieldMock, $items[1]);
         $this->assertEquals($this->_groupMock, $items[2]);

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/IteratorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/IteratorTest.php
@@ -26,7 +26,7 @@ class IteratorTest extends TestCase
     protected $_flyweightMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -38,7 +38,7 @@ class IteratorTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/IteratorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/IteratorTest.php
@@ -25,6 +25,9 @@ class IteratorTest extends TestCase
      */
     protected $_flyweightMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $elementData = ['group1' => ['id' => 1], 'group2' => ['id' => 2], 'group3' => ['id' => 3]];
@@ -34,17 +37,23 @@ class IteratorTest extends TestCase
         $this->_model->setElements($elementData, 'scope');
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         unset($this->_model);
         unset($this->_flyweightMock);
     }
 
-    public function testIteratorInitializesFlyweight()
+    /**
+     * @return void
+     */
+    public function testIteratorInitializesFlyweight(): void
     {
-        $this->_flyweightMock->expects($this->at(0))->method('setData')->with(['id' => 1], 'scope');
-        $this->_flyweightMock->expects($this->at(2))->method('setData')->with(['id' => 2], 'scope');
-        $this->_flyweightMock->expects($this->at(4))->method('setData')->with(['id' => 3], 'scope');
+        $this->_flyweightMock
+            ->method('setData')
+            ->withConsecutive([['id' => 1], 'scope'], [['id' => 2], 'scope'], [['id' => 3], 'scope']);
         $this->_flyweightMock->expects($this->any())->method('isVisible')->willReturn(true);
         $counter = 0;
         foreach ($this->_model as $item) {
@@ -54,7 +63,7 @@ class IteratorTest extends TestCase
         $this->assertEquals(3, $counter);
     }
 
-    public function testIteratorSkipsNonValidElements()
+    public function testIteratorSkipsNonValidElements(): void
     {
         $this->_flyweightMock->expects($this->exactly(3))->method('isVisible')->willReturn(false);
         $this->_flyweightMock->expects($this->exactly(3))->method('setData');
@@ -69,7 +78,7 @@ class IteratorTest extends TestCase
      * @param bool $result
      * @dataProvider isLastDataProvider
      */
-    public function testIsLast($elementId, $result)
+    public function testIsLast($elementId, $result): void
     {
         $elementMock = $this->createMock(Field::class);
         $elementMock->expects($this->once())->method('getId')->willReturn($elementId);
@@ -79,7 +88,7 @@ class IteratorTest extends TestCase
     /**
      * @return array
      */
-    public function isLastDataProvider()
+    public function isLastDataProvider(): array
     {
         return [[1, false], [2, false], [3, true]];
     }

--- a/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
@@ -106,7 +106,7 @@ class ConfigTest extends TestCase
     private $scopeTypeNormalizer;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
@@ -105,6 +105,9 @@ class ConfigTest extends TestCase
      */
     private $scopeTypeNormalizer;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->eventManagerMock = $this->getMockForAbstractClass(ManagerInterface::class);
@@ -167,13 +170,19 @@ class ConfigTest extends TestCase
         );
     }
 
-    public function testSaveDoesNotDoAnythingIfGroupsAreNotPassed()
+    /**
+     * @return void
+     */
+    public function testSaveDoesNotDoAnythingIfGroupsAreNotPassed(): void
     {
         $this->configLoaderMock->expects($this->never())->method('getConfigByPath');
         $this->model->save();
     }
 
-    public function testSaveEmptiesNonSetArguments()
+    /**
+     * @return void
+     */
+    public function testSaveEmptiesNonSetArguments(): void
     {
         $this->structureReaderMock->expects($this->never())->method('getConfiguration');
         $this->assertNull($this->model->getSection());
@@ -185,7 +194,10 @@ class ConfigTest extends TestCase
         $this->assertSame('', $this->model->getStore());
     }
 
-    public function testSaveToCheckAdminSystemConfigChangedSectionEvent()
+    /**
+     * @return void
+     */
+    public function testSaveToCheckAdminSystemConfigChangedSectionEvent(): void
     {
         $transactionMock = $this->createMock(Transaction::class);
 
@@ -193,29 +205,27 @@ class ConfigTest extends TestCase
 
         $this->configLoaderMock->expects($this->any())->method('getConfigByPath')->willReturn([]);
 
-        $this->eventManagerMock->expects(
-            $this->at(0)
-        )->method(
-            'dispatch'
-        )->with(
-            'admin_system_config_changed_section_',
-            $this->arrayHasKey('website')
-        );
-
-        $this->eventManagerMock->expects(
-            $this->at(0)
-        )->method(
-            'dispatch'
-        )->with(
-            'admin_system_config_changed_section_',
-            $this->arrayHasKey('store')
-        );
+        $this->eventManagerMock
+            ->method('dispatch')
+            ->withConsecutive(
+                [
+                    'admin_system_config_changed_section_',
+                    $this->arrayHasKey('website')
+                ],
+                [
+                    'admin_system_config_changed_section_',
+                    $this->arrayHasKey('store')
+                ]
+            );
 
         $this->model->setGroups(['1' => ['data']]);
         $this->model->save();
     }
 
-    public function testDoNotSaveReadOnlyFields()
+    /**
+     * @return void
+     */
+    public function testDoNotSaveReadOnlyFields(): void
     {
         $transactionMock = $this->createMock(Transaction::class);
         $this->transFactoryMock->expects($this->any())->method('create')->willReturn($transactionMock);
@@ -233,18 +243,10 @@ class ConfigTest extends TestCase
         $field->method('getGroupPath')->willReturn('section/1');
         $field->method('getId')->willReturn('key');
 
-        $this->configStructure->expects($this->at(0))
+        $this->configStructure
             ->method('getElement')
-            ->with('section/1')
-            ->willReturn($group);
-        $this->configStructure->expects($this->at(1))
-            ->method('getElement')
-            ->with('section/1')
-            ->willReturn($group);
-        $this->configStructure->expects($this->at(2))
-            ->method('getElement')
-            ->with('section/1/key')
-            ->willReturn($field);
+            ->withConsecutive(['section/1'], ['section/1'], ['section/1/key'])
+            ->willReturnOnConsecutiveCalls($group, $group, $field);
 
         $backendModel = $this->createPartialMock(
             Value::class,
@@ -258,24 +260,27 @@ class ConfigTest extends TestCase
         $this->model->save();
     }
 
-    public function testSaveToCheckScopeDataSet()
+    /**
+     * @return void
+     */
+    public function testSaveToCheckScopeDataSet(): void
     {
         $transactionMock = $this->createMock(Transaction::class);
         $this->transFactoryMock->expects($this->any())->method('create')->willReturn($transactionMock);
 
         $this->configLoaderMock->expects($this->any())->method('getConfigByPath')->willReturn([]);
 
-        $this->eventManagerMock->expects($this->at(0))
+        $this->eventManagerMock
             ->method('dispatch')
-            ->with(
-                'admin_system_config_changed_section_section',
-                $this->arrayHasKey('website')
-            );
-        $this->eventManagerMock->expects($this->at(0))
-            ->method('dispatch')
-            ->with(
-                'admin_system_config_changed_section_section',
-                $this->arrayHasKey('store')
+            ->withConsecutive(
+                [
+                    'admin_system_config_changed_section_section',
+                    $this->arrayHasKey('website')
+                ],
+                [
+                    'admin_system_config_changed_section_section',
+                    $this->arrayHasKey('store')
+                ]
             );
 
         $group = $this->createMock(Group::class);
@@ -285,26 +290,10 @@ class ConfigTest extends TestCase
         $field->method('getGroupPath')->willReturn('section/1');
         $field->method('getId')->willReturn('key');
 
-        $this->configStructure->expects($this->at(0))
+        $this->configStructure
             ->method('getElement')
-            ->with('section/1')
-            ->willReturn($group);
-        $this->configStructure->expects($this->at(1))
-            ->method('getElement')
-            ->with('section/1')
-            ->willReturn($group);
-        $this->configStructure->expects($this->at(2))
-            ->method('getElement')
-            ->with('section/1/key')
-            ->willReturn($field);
-        $this->configStructure->expects($this->at(3))
-            ->method('getElement')
-            ->with('section/1')
-            ->willReturn($group);
-        $this->configStructure->expects($this->at(4))
-            ->method('getElement')
-            ->with('section/1/key')
-            ->willReturn($field);
+            ->withConsecutive(['section/1'], ['section/1'], ['section/1/key'], ['section/1'], ['section/1/key'])
+            ->willReturnOnConsecutiveCalls($group, $group, $field, $group, $field);
 
         $this->scopeResolver->expects($this->atLeastOnce())
             ->method('getScope')
@@ -346,7 +335,7 @@ class ConfigTest extends TestCase
                 'scope_id' => 1,
                 'scope_code' => 'website_code',
                 'field_config' => null,
-                'fieldset_data' => ['key' => null],
+                'fieldset_data' => ['key' => null]
             ]);
         $backendModel->expects($this->once())
             ->method('setPath')
@@ -363,9 +352,11 @@ class ConfigTest extends TestCase
      * @param string $value
      * @param string $section
      * @param array $groups
+     *
+     * @return void
      * @dataProvider setDataByPathDataProvider
      */
-    public function testSetDataByPath(string $path, string $value, string $section, array $groups)
+    public function testSetDataByPath(string $path, string $value, string $section, array $groups): void
     {
         $this->model->setDataByPath($path, $value);
         $this->assertEquals($section, $this->model->getData('section'));
@@ -385,7 +376,7 @@ class ConfigTest extends TestCase
                 [
                     'b' => [
                         'fields' => [
-                            'c' => ['value' => 'value1'],
+                            'c' => ['value' => 'value1']
                         ],
                     ],
                 ],
@@ -401,7 +392,7 @@ class ConfigTest extends TestCase
                                 'groups' => [
                                     'd' => [
                                         'fields' => [
-                                            'e' => ['value' => 'value1'],
+                                            'e' => ['value' => 'value1']
                                         ],
                                     ],
                                 ],
@@ -413,7 +404,10 @@ class ConfigTest extends TestCase
         ];
     }
 
-    public function testSetDataByPathEmpty()
+    /**
+     * @return void
+     */
+    public function testSetDataByPathEmpty(): void
     {
         $this->expectException('UnexpectedValueException');
         $this->expectExceptionMessage('Path must not be empty');
@@ -422,9 +416,11 @@ class ConfigTest extends TestCase
 
     /**
      * @param string $path
+     *
+     * @return void
      * @dataProvider setDataByPathWrongDepthDataProvider
      */
-    public function testSetDataByPathWrongDepth(string $path)
+    public function testSetDataByPathWrongDepth(string $path): void
     {
         $currentDepth = count(explode('/', $path));
         $expectedException = 'Minimal depth of configuration is 3. Your configuration depth is ' . $currentDepth;
@@ -441,7 +437,7 @@ class ConfigTest extends TestCase
     {
         return [
             'depth 2' => ['section/group'],
-            'depth 1' => ['section'],
+            'depth 1' => ['section']
         ];
     }
 }

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -23,6 +23,7 @@ use Magento\Framework\EntityManager\EntityMetadata;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\ImportExport\Test\Unit\Model\Import\AbstractImportTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
 
 /**
  * Configurable import export tests
@@ -94,7 +95,7 @@ class ConfigurableTest extends AbstractImportTestCase
     protected $productEntityLinkField = 'entity_id';
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -115,11 +116,13 @@ class ConfigurableTest extends AbstractImportTestCase
             $this->setCollection
         );
 
-        $item = new DataObject([
+        $item = new DataObject(
+            [
             'id' => 1,
             'attribute_set_name' => 'Default',
             '_attribute_set' => 'Default'
-        ]);
+            ]
+        );
 
         $this->setCollection->expects($this->any())
             ->method('setEntityTypeFilter')
@@ -138,7 +141,7 @@ class ConfigurableTest extends AbstractImportTestCase
         $superAttributes = [];
         foreach ($this->_getSuperAttributes() as $superAttribute) {
             $item = $this->getMockBuilder(AbstractAttribute::class)
-                ->setMethods(['isStatic'])
+                ->onlyMethods(['isStatic'])
                 ->disableOriginalConstructor()
                 ->setConstructorArgs($superAttribute)
                 ->getMock();
@@ -156,16 +159,19 @@ class ConfigurableTest extends AbstractImportTestCase
             ->method('setAttributeSetFilter')
             ->willReturn($superAttributes);
 
-        $this->_entityModel = $this->createPartialMock(Product::class, [
-            'getNewSku',
-            'getOldSku',
-            'getNextBunch',
-            'isRowAllowedToImport',
-            'getConnection',
-            'getAttrSetIdToName',
-            'getErrorAggregator',
-            'getAttributeOptions'
-        ]);
+        $this->_entityModel = $this->createPartialMock(
+            Product::class,
+            [
+                'getNewSku',
+                'getOldSku',
+                'getNextBunch',
+                'isRowAllowedToImport',
+                'getConnection',
+                'getAttrSetIdToName',
+                'getErrorAggregator',
+                'getAttributeOptions'
+            ]
+        );
         $this->_entityModel->method('getErrorAggregator')->willReturn($this->getErrorAggregatorObject());
 
         $this->params = [
@@ -175,23 +181,28 @@ class ConfigurableTest extends AbstractImportTestCase
 
         $this->_connection = $this->getMockBuilder(Mysql::class)
             ->addMethods(['joinLeft'])
-            ->onlyMethods([
-                'select',
-                'fetchAll',
-                'fetchPairs',
-                'insertOnDuplicate',
-                'quoteIdentifier',
-                'delete',
-                'quoteInto'
-            ])
+            ->onlyMethods(
+                [
+                    'select',
+                    'fetchAll',
+                    'fetchPairs',
+                    'insertOnDuplicate',
+                    'quoteIdentifier',
+                    'delete',
+                    'quoteInto'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
-        $this->select = $this->createPartialMock(Select::class, [
-            'from',
-            'where',
-            'joinLeft',
-            'getConnection',
-        ]);
+        $this->select = $this->createPartialMock(
+            Select::class,
+            [
+                'from',
+                'where',
+                'joinLeft',
+                'getConnection'
+            ]
+        );
         $this->select->expects($this->any())->method('from')->willReturnSelf();
         $this->select->expects($this->any())->method('where')->willReturnSelf();
         $this->select->expects($this->any())->method('joinLeft')->willReturnSelf();
@@ -204,10 +215,13 @@ class ConfigurableTest extends AbstractImportTestCase
         $this->_connection->expects($this->any())->method('quoteInto')->willReturn('');
         $this->_connection->expects($this->any())->method('fetchAll')->willReturn([]);
 
-        $this->resource = $this->createPartialMock(ResourceConnection::class, [
-            'getConnection',
-            'getTableName',
-        ]);
+        $this->resource = $this->createPartialMock(
+            ResourceConnection::class,
+            [
+                'getConnection',
+                'getTableName'
+                ]
+        );
         $this->resource->expects($this->any())->method('getConnection')->willReturn(
             $this->_connection
         );
@@ -232,7 +246,7 @@ class ConfigurableTest extends AbstractImportTestCase
         $testProducts = [
             ['id' => 1, 'attribute_set_id' => 4, 'testattr2'=> 1, 'testattr3'=> 1],
             ['id' => 2, 'attribute_set_id' => 4, 'testattr2'=> 1, 'testattr3'=> 1],
-            ['id' => 20, 'attribute_set_id' => 4, 'testattr2'=> 1, 'testattr3'=> 1],
+            ['id' => 20, 'attribute_set_id' => 4, 'testattr2'=> 1, 'testattr3'=> 1]
         ];
         foreach ($testProducts as $product) {
             $item = $this->getMockBuilder(DataObject::class)
@@ -264,7 +278,7 @@ class ConfigurableTest extends AbstractImportTestCase
             'testattr3v1' => '4',
             'testattr30v1' => '4',
             'testattr3v2' => '5',
-            'testattr3v3' => '6',
+            'testattr3v3' => '6'
         ]);
 
         $metadataPoolMock = $this->createMock(MetadataPool::class);
@@ -288,7 +302,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 'params' => $this->params,
                 'resource' => $this->resource,
                 'productColFac' => $this->productCollectionFactory,
-                'metadataPool' => $metadataPoolMock,
+                'metadataPool' => $metadataPoolMock
             ]
         );
     }
@@ -320,7 +334,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'testSimple',
@@ -332,7 +346,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'simple',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'testSimpleToSkip',
@@ -344,7 +358,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'simple',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'configurableskuI22withoutLabels',
@@ -362,7 +376,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'configurableskuI22withoutVariations',
@@ -374,7 +388,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'configurableskuI22Duplicated',
@@ -402,7 +416,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             [
                 'sku' => 'testSimpleOld',
@@ -414,7 +428,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'simple',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ]
         ];
     }
@@ -444,10 +458,9 @@ class ConfigurableTest extends AbstractImportTestCase
                 'options' => [
                     'attr2val1' => '6',
                     'attr2val2' => '7',
-                    'attr2val3' => '8',
+                    'attr2val3' => '8'
                 ]
             ],
-
             'testattr3' => [
                 'id' => '132',
                 'code' => 'testattr3',
@@ -465,8 +478,8 @@ class ConfigurableTest extends AbstractImportTestCase
                 'options' => [
                     'testattr3v1' => '9',
                     'testattr3v2' => '10',
-                    'testattr3v3' => '11',
-                ],
+                    'testattr3v3' => '11'
+                ]
             ]
         ];
     }
@@ -474,9 +487,10 @@ class ConfigurableTest extends AbstractImportTestCase
     /**
      * Verify save mtethod
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSaveData()
+    public function testSaveData(): void
     {
         $newSkus = array_change_key_case([
             'configurableskuI22' => [
@@ -499,7 +513,10 @@ class ConfigurableTest extends AbstractImportTestCase
                 'type_id' => 'simple',
                 'attr_set_code' => 'Default'
             ],
-            'testSimple' => [$this->productEntityLinkField => 4, 'type_id' => 'simple', 'attr_set_code' => 'Default'],
+            'testSimple' => [
+                $this->productEntityLinkField => 4,
+                'type_id' => 'simple', 'attr_set_code' => 'Default'
+            ],
             'testSimpleToSkip' => [
                 $this->productEntityLinkField => 5,
                 'type_id' => 'simple',
@@ -524,52 +541,49 @@ class ConfigurableTest extends AbstractImportTestCase
                 $this->productEntityLinkField => 9,
                 'type_id' => 'configurable',
                 'attr_set_code' => 'Default'
-            ],
+            ]
         ]);
         $this->_entityModel->expects($this->any())
             ->method('getNewSku')
             ->willReturn($newSkus);
 
         // at(0) is select() call, quoteIdentifier() is invoked at(1) and at(2)
-        $this->_connection->expects($this->at(1))
+        $this->_connection
             ->method('quoteIdentifier')
-            ->with('m.attribute_id')
-            ->willReturn('a');
-        $this->_connection->expects($this->at(2))
-            ->method('quoteIdentifier')
-            ->with('o.attribute_id')
-            ->willReturn('b');
+            ->withConsecutive(['m.attribute_id'], ['o.attribute_id'])
+            ->willReturnOnConsecutiveCalls('a', 'b');
 
         $this->_connection->expects($this->any())->method('select')->willReturn($this->select);
-        $this->_connection->expects($this->any())->method('fetchAll')->with($this->select)->willReturn([
-            ['attribute_id' => 131, 'product_id' => 1, 'option_id' => 1, 'product_super_attribute_id' => 131],
-
-            ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 1, 'product_super_attribute_id' => 131],
-            ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 2, 'product_super_attribute_id' => 131],
-            ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 3, 'product_super_attribute_id' => 131],
-
-            ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 1, 'product_super_attribute_id' => 131],
-            ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 2, 'product_super_attribute_id' => 131],
-            ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 3, 'product_super_attribute_id' => 131],
-
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 1, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 2, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 3, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 4, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 5, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 6, 'product_super_attribute_id' => 132],
-
-            ['attribute_id' => 132, 'product_id' => 3, 'option_id' => 3, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 4, 'option_id' => 4, 'product_super_attribute_id' => 132],
-            ['attribute_id' => 132, 'product_id' => 5, 'option_id' => 5, 'product_super_attribute_id' => 132],
-        ]);
         $this->_connection->expects($this->any())->method('fetchAll')->with($this->select)->willReturn(
-            []
+            [
+                ['attribute_id' => 131, 'product_id' => 1, 'option_id' => 1, 'product_super_attribute_id' => 131],
+
+                ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 1, 'product_super_attribute_id' => 131],
+                ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 2, 'product_super_attribute_id' => 131],
+                ['attribute_id' => 131, 'product_id' => 2, 'option_id' => 3, 'product_super_attribute_id' => 131],
+
+                ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 1, 'product_super_attribute_id' => 131],
+                ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 2, 'product_super_attribute_id' => 131],
+                ['attribute_id' => 131, 'product_id' => 20, 'option_id' => 3, 'product_super_attribute_id' => 131],
+
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 1, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 2, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 3, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 4, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 5, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 1, 'option_id' => 6, 'product_super_attribute_id' => 132],
+
+                ['attribute_id' => 132, 'product_id' => 3, 'option_id' => 3, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 4, 'option_id' => 4, 'product_super_attribute_id' => 132],
+                ['attribute_id' => 132, 'product_id' => 5, 'option_id' => 5, 'product_super_attribute_id' => 132]
+            ]
         );
+        $this->_connection->expects($this->any())->method('fetchAll')->with($this->select)->willReturn([]);
 
         $bunch = $this->_getBunch();
-        $this->_entityModel->expects($this->at(2))->method('getNextBunch')->willReturn($bunch);
-        $this->_entityModel->expects($this->at(3))->method('getNextBunch')->willReturn([]);
+        $this->_entityModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($bunch, []);
         $this->_entityModel->expects($this->any())
             ->method('isRowAllowedToImport')
             ->willReturnCallback([$this, 'isRowAllowedToImport']);
@@ -592,10 +606,11 @@ class ConfigurableTest extends AbstractImportTestCase
      *
      * @param $rowData
      * @param $rowNum
+     *
      * @return bool
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function isRowAllowedToImport($rowData, $rowNum)
+    public function isRowAllowedToImport($rowData, $rowNum): bool
     {
         if ($rowNum == 2) {
             return false;
@@ -608,6 +623,7 @@ class ConfigurableTest extends AbstractImportTestCase
      *
      * @dataProvider getProductDataIsValidRow
      * @param array $productData
+     *
      * @return void
      */
     public function testIsRowValid(array $productData): void
@@ -684,14 +700,14 @@ class ConfigurableTest extends AbstractImportTestCase
                         '_store' => null,
                         '_attribute_set' => 'Default',
                         '_type' => 'configurable',
-                        '_product_websites' => 'website_1',
+                        '_product_websites' => 'website_1'
                     ],
                     'super_attributes' => [
                         'testattr2' => ['options' => ['attr2val1' => 1]],
                         'testattr3' => [
                             'options' => [
                                 'testattr3v2' => 1,
-                                'testattr3v1=sx=sl' => 1,
+                                'testattr3v1=sx=sl' => 1
                             ],
                         ],
                     ]
@@ -719,7 +735,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 'testattr2' => [
                     'options' => [
                         'attr2val1' => 1,
-                        'attr2val2' => 2,
+                        'attr2val2' => 2
                     ]
                 ],
             ]
@@ -761,7 +777,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ],
             'nonDuplicateProduct' => [
                 'sku' => 'configurableNumericalSkuNonDuplicateVariation',
@@ -779,7 +795,7 @@ class ConfigurableTest extends AbstractImportTestCase
                 '_store' => null,
                 '_attribute_set' => 'Default',
                 '_type' => 'configurable',
-                '_product_websites' => 'website_1',
+                '_product_websites' => 'website_1'
             ]
         ];
     }
@@ -793,7 +809,7 @@ class ConfigurableTest extends AbstractImportTestCase
      */
     protected function setPropertyValue(&$object, $property, $value)
     {
-        $reflection = new \ReflectionClass(get_class($object));
+        $reflection = new ReflectionClass(get_class($object));
         $reflectionProperty = $reflection->getProperty($property);
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($object, $value);

--- a/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableImportExport/Test/Unit/Model/Import/Product/Type/ConfigurableTest.php
@@ -95,7 +95,7 @@ class ConfigurableTest extends AbstractImportTestCase
     protected $productEntityLinkField = 'entity_id';
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Attribute/LockValidatorTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Attribute/LockValidatorTest.php
@@ -48,7 +48,7 @@ class LockValidatorTest extends TestCase
     private $metadataPoolMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Attribute/LockValidatorTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Attribute/LockValidatorTest.php
@@ -47,6 +47,9 @@ class LockValidatorTest extends TestCase
      */
     private $metadataPoolMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
@@ -56,12 +59,12 @@ class LockValidatorTest extends TestCase
             ->getMock();
 
         $this->connectionMock = $this->getMockBuilder(AdapterInterface::class)
-            ->setMethods(['select', 'fetchOne'])
+            ->onlyMethods(['select', 'fetchOne'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
         $this->select = $this->getMockBuilder(Select::class)
-            ->setMethods(['reset', 'from', 'join', 'where', 'group', 'limit'])
+            ->onlyMethods(['reset', 'from', 'join', 'where', 'group', 'limit'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -76,9 +79,7 @@ class LockValidatorTest extends TestCase
 
         $this->model = $helper->getObject(
             LockValidator::class,
-            [
-                'resource' => $this->resource
-            ]
+            ['resource' => $this->resource]
         );
         $refClass = new \ReflectionClass(LockValidator::class);
         $refProperty = $refClass->getProperty('metadataPool');
@@ -86,7 +87,10 @@ class LockValidatorTest extends TestCase
         $refProperty->setValue($this->model, $this->metadataPoolMock);
     }
 
-    public function testValidate()
+    /**
+     * @return void
+     */
+    public function testValidate(): void
     {
         $this->validate(false);
     }
@@ -94,7 +98,7 @@ class LockValidatorTest extends TestCase
     /**
      * @return EntityMetadata|MockObject
      */
-    private function getMetaDataMock()
+    private function getMetaDataMock(): EntityMetadata
     {
         $metadata = $this->getMockBuilder(EntityMetadata::class)
             ->disableOriginalConstructor()
@@ -107,7 +111,10 @@ class LockValidatorTest extends TestCase
         return $metadata;
     }
 
-    public function testValidateException()
+    /**
+     * @return void
+     */
+    public function testValidateException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('This attribute is used in configurable products.');
@@ -116,9 +123,11 @@ class LockValidatorTest extends TestCase
 
     /**
      * @param $exception
+     *
+     * @return void
      * @throws LocalizedException
      */
-    public function validate($exception)
+    public function validate($exception): void
     {
         $attrTable = 'someAttributeTable';
         $productTable = 'someProductTable';
@@ -129,19 +138,17 @@ class LockValidatorTest extends TestCase
 
         /** @var AbstractModel|MockObject $object */
         $object = $this->getMockBuilder(AbstractModel::class)
-            ->setMethods(['getAttributeId'])
+            ->addMethods(['getAttributeId'])
             ->disableOriginalConstructor()
             ->getMock();
         $object->expects($this->once())->method('getAttributeId')->willReturn($attributeId);
 
         $this->resource->expects($this->once())->method('getConnection')
             ->willReturn($this->connectionMock);
-        $this->resource->expects($this->at(1))->method('getTableName')
-            ->with('catalog_product_super_attribute')
-            ->willReturn($attrTable);
-        $this->resource->expects($this->at(2))->method('getTableName')
-            ->with('catalog_product_entity')
-            ->willReturn($productTable);
+        $this->resource
+            ->method('getTableName')
+            ->withConsecutive(['catalog_product_super_attribute'], ['catalog_product_entity'])
+            ->willReturnOnConsecutiveCalls($attrTable, $productTable);
 
         $this->connectionMock->expects($this->once())->method('select')
             ->willReturn($this->select);

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/LinkManagementTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/LinkManagementTest.php
@@ -64,14 +64,14 @@ class LinkManagementTest extends TestCase
      */
     protected $dataObjectHelperMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->productRepository = $this->getMockForAbstractClass(ProductRepositoryInterface::class);
         $this->objectManagerHelper = new ObjectManager($this);
-        $this->productFactory = $this->createPartialMock(
-            ProductInterfaceFactory::class,
-            ['create']
-        );
+        $this->productFactory = $this->createPartialMock(ProductInterfaceFactory::class, ['create']);
         $this->dataObjectHelperMock = $this->getMockBuilder(DataObjectHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -87,12 +87,15 @@ class LinkManagementTest extends TestCase
                 'productRepository' => $this->productRepository,
                 'productFactory' => $this->productFactory,
                 'configurableType' => $this->configurableType,
-                'dataObjectHelper' => $this->dataObjectHelperMock,
+                'dataObjectHelper' => $this->dataObjectHelperMock
             ]
         );
     }
 
-    public function testGetChildren()
+    /**
+     * @return void
+     */
+    public function testGetChildren(): void
     {
         $productId = 'test';
 
@@ -144,7 +147,10 @@ class LinkManagementTest extends TestCase
         $this->assertEquals($productMock, $products[0]);
     }
 
-    public function testGetWithNonConfigurableProduct()
+    /**
+     * @return void
+     */
+    public function testGetWithNonConfigurableProduct(): void
     {
         $productId= 'test';
         $product = $this->getMockBuilder(Product::class)
@@ -158,22 +164,25 @@ class LinkManagementTest extends TestCase
         $this->assertEmpty($this->object->getChildren($productId));
     }
 
-    public function testAddChild()
+    /**
+     * @return void
+     */
+    public function testAddChild(): void
     {
         $productSku = 'configurable-sku';
         $childSku = 'simple-sku';
 
         $configurable = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getExtensionAttributes'])
+            ->onlyMethods(['getId', 'getExtensionAttributes'])
             ->getMock();
         $simple = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getData'])
+            ->onlyMethods(['getId', 'getData'])
             ->getMock();
         $extensionAttributesMock = $this->getMockBuilder(ProductExtensionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->addMethods(
                 [
                     'getConfigurableProductOptions',
                     'setConfigurableProductOptions',
@@ -183,15 +192,16 @@ class LinkManagementTest extends TestCase
             ->getMockForAbstractClass();
         $optionMock = $this->getMockBuilder(OptionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProductAttribute', 'getPosition', 'getAttributeId'])
+            ->onlyMethods(['getPosition', 'getAttributeId'])
+            ->addMethods(['getProductAttribute'])
             ->getMockForAbstractClass();
         $productAttributeMock = $this->getMockBuilder(AbstractAttribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributeCode'])
+            ->onlyMethods(['getAttributeCode'])
             ->getMock();
         $optionsFactoryMock = $this->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $reflectionClass = new \ReflectionClass(LinkManagement::class);
         $optionsFactoryReflectionProperty = $reflectionClass->getProperty('optionsFactory');
@@ -200,7 +210,7 @@ class LinkManagementTest extends TestCase
 
         $attributeFactoryMock = $this->getMockBuilder(AttributeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $attributeFactoryReflectionProperty = $reflectionClass->getProperty('attributeFactory');
         $attributeFactoryReflectionProperty->setAccessible(true);
@@ -208,21 +218,21 @@ class LinkManagementTest extends TestCase
 
         $attributeMock = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCollection', 'getOptions', 'getId', 'getAttributeCode', 'getStoreLabel'])
+            ->onlyMethods(['getCollection', 'getOptions', 'getId', 'getAttributeCode', 'getStoreLabel'])
             ->getMock();
         $attributeOptionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getValue', 'getLabel'])
+            ->onlyMethods(['getValue', 'getLabel'])
             ->getMock();
-        $attributeCollectionMock = $this->getMockBuilder(
-            Collection::class
-        )
+        $attributeCollectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFieldToFilter', 'getItems'])
+            ->onlyMethods(['addFieldToFilter', 'getItems'])
             ->getMock();
 
-        $this->productRepository->expects($this->at(0))->method('get')->with($productSku)->willReturn($configurable);
-        $this->productRepository->expects($this->at(1))->method('get')->with($childSku)->willReturn($simple);
+        $this->productRepository
+            ->method('get')
+            ->withConsecutive([$productSku], [$childSku])
+            ->willReturnOnConsecutiveCalls($configurable, $simple);
 
         $this->configurableType->expects($this->once())->method('getChildrenIds')->with(666)
             ->willReturn(
@@ -255,7 +265,10 @@ class LinkManagementTest extends TestCase
         $this->assertTrue($this->object->addChild($productSku, $childSku));
     }
 
-    public function testAddChildStateException()
+    /**
+     * @return void
+     */
+    public function testAddChildStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $this->expectExceptionMessage('The product is already attached.');
@@ -274,8 +287,10 @@ class LinkManagementTest extends TestCase
 
         $simple->expects($this->any())->method('getId')->willReturn(1);
 
-        $this->productRepository->expects($this->at(0))->method('get')->with($productSku)->willReturn($configurable);
-        $this->productRepository->expects($this->at(1))->method('get')->with($childSku)->willReturn($simple);
+        $this->productRepository
+            ->method('get')
+            ->withConsecutive([$productSku], [$childSku])
+            ->willReturnOnConsecutiveCalls($configurable, $simple);
 
         $this->configurableType->expects($this->once())->method('getChildrenIds')->with(666)
             ->willReturn(
@@ -285,18 +300,21 @@ class LinkManagementTest extends TestCase
         $this->object->addChild($productSku, $childSku);
     }
 
-    public function testRemoveChild()
+    /**
+     * @return void
+     */
+    public function testRemoveChild(): void
     {
         $productSku = 'configurable';
         $childSku = 'simple_10';
 
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['getTypeInstance', 'save', 'getTypeId', 'addData', 'getExtensionAttributes'])
+            ->onlyMethods(['getTypeInstance', 'save', 'getTypeId', 'addData', 'getExtensionAttributes'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $productType = $this->getMockBuilder(Configurable::class)
-            ->setMethods(['getUsedProducts'])
+            ->onlyMethods(['getUsedProducts'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->once())->method('getTypeInstance')->willReturn($productType);
@@ -310,7 +328,7 @@ class LinkManagementTest extends TestCase
             ->willReturn($product);
 
         $option = $this->getMockBuilder(Product::class)
-            ->setMethods(['getSku', 'getId'])
+            ->onlyMethods(['getSku', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $option->expects($this->any())->method('getSku')->willReturn($childSku);
@@ -320,7 +338,7 @@ class LinkManagementTest extends TestCase
             ->willReturn([$option]);
 
         $extensionAttributesMock = $this->getMockBuilder(ExtensionAttributesInterface::class)
-            ->setMethods(['setConfigurableProductLinks'])
+            ->addMethods(['setConfigurableProductLinks'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -329,7 +347,10 @@ class LinkManagementTest extends TestCase
         $this->assertTrue($this->object->removeChild($productSku, $childSku));
     }
 
-    public function testRemoveChildForbidden()
+    /**
+     * @return void
+     */
+    public function testRemoveChildForbidden(): void
     {
         $this->expectException('Magento\Framework\Exception\InputException');
         $productSku = 'configurable';
@@ -344,21 +365,24 @@ class LinkManagementTest extends TestCase
         $this->object->removeChild($productSku, $childSku);
     }
 
-    public function testRemoveChildInvalidChildSku()
+    /**
+     * @return void
+     */
+    public function testRemoveChildInvalidChildSku(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $productSku = 'configurable';
         $childSku = 'simple_10';
 
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['getTypeInstance', 'save', 'getTypeId', 'addData'])
+            ->onlyMethods(['getTypeInstance', 'save', 'getTypeId', 'addData'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->any())
             ->method('getTypeId')
             ->willReturn(Configurable::TYPE_CODE);
         $productType = $this->getMockBuilder(Configurable::class)
-            ->setMethods(['getUsedProducts'])
+            ->onlyMethods(['getUsedProducts'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->once())->method('getTypeInstance')->willReturn($productType);
@@ -366,7 +390,7 @@ class LinkManagementTest extends TestCase
         $this->productRepository->expects($this->any())->method('get')->willReturn($product);
 
         $option = $this->getMockBuilder(Product::class)
-            ->setMethods(['getSku', 'getId'])
+            ->onlyMethods(['getSku', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $option->expects($this->any())->method('getSku')->willReturn($childSku . '_invalid');

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/LinkManagementTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/LinkManagementTest.php
@@ -65,7 +65,7 @@ class LinkManagementTest extends TestCase
     protected $dataObjectHelperMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\ConfigurableProduct\Test\Unit\Model\Product\Type;
 
+use ArrayIterator;
 use Magento\Catalog\Api\Data\ProductExtensionInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
@@ -43,6 +44,7 @@ use Magento\Quote\Model\Quote\Item\Option;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)
@@ -71,7 +73,7 @@ class ConfigurableTest extends TestCase
             'attribute_id' => 111,
             'position' => 0,
             'label' => 'Some Super Attribute',
-            'values' => [],
+            'values' => []
         ]
     ];
 
@@ -146,6 +148,8 @@ class ConfigurableTest extends TestCase
     private $catalogConfig;
 
     /**
+     * @inheirtDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -168,19 +172,20 @@ class ConfigurableTest extends TestCase
             ->getMockForAbstractClass();
         $this->typeConfigurableFactory = $this->getMockBuilder(ConfigurableFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create', 'saveProducts'])
+            ->onlyMethods(['create'])
+            ->addMethods(['saveProducts'])
             ->getMock();
         $this->configurableAttributeFactoryMock = $this->getMockBuilder(AttributeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->productCollectionFactory = $this->getMockBuilder(ProductCollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->attributeCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->productRepository = $this->getMockBuilder(ProductRepositoryInterface::class)
             ->disableOriginalConstructor()
@@ -212,7 +217,7 @@ class ConfigurableTest extends TestCase
             ->with(ProductInterface::class)
             ->willReturn($this->entityMetadata);
         $this->productFactory = $this->getMockBuilder(ProductInterfaceFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -241,38 +246,32 @@ class ConfigurableTest extends TestCase
                 'serializer' => $this->serializer,
                 'salableProcessor' => $this->salableProcessor,
                 'metadataPool' => $this->metadataPool,
-                'productFactory' => $this->productFactory,
+                'productFactory' => $this->productFactory
             ]
         );
-        $refClass = new \ReflectionClass(Configurable::class);
+        $refClass = new ReflectionClass(Configurable::class);
         $refProperty = $refClass->getProperty('metadataPool');
         $refProperty->setAccessible(true);
         $refProperty->setValue($this->model, $this->metadataPool);
     }
 
-    public function testHasWeightTrue()
+    /**
+     * @return void
+     */
+    public function testHasWeightTrue(): void
     {
         $this->assertTrue($this->model->hasWeight(), 'This product has not weight, but it should');
     }
 
     /**
-     * Test `Save` method
+     * @return void
      */
-    public function testSave()
+    public function testSave(): void
     {
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
-                [
-                    'getIsDuplicate',
-                    'dataHasChangedFor',
-                    'getConfigurableAttributesData',
-                    'getStoreId',
-                    'getId',
-                    'getData',
-                    'hasData',
-                    'getAssociatedProductIds',
-                ]
-            )->disableOriginalConstructor()
+            ->onlyMethods(['dataHasChangedFor', 'getStoreId', 'getId', 'getData', 'hasData'])
+            ->addMethods(['getIsDuplicate', 'getConfigurableAttributesData', 'getAssociatedProductIds'])
+            ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->once())->method('dataHasChangedFor')->willReturn('false');
         $product->expects($this->once())
@@ -286,12 +285,7 @@ class ConfigurableTest extends TestCase
             ->with('_cache_instance_used_product_attribute_ids')
             ->willReturn(true);
         $extensionAttributes = $this->getMockBuilder(ProductExtensionInterface::class)
-            ->setMethods(
-                [
-                    'getConfigurableProductOptions',
-                    'getConfigurableProductLinks'
-                ]
-            )
+            ->addMethods(['getConfigurableProductOptions', 'getConfigurableProductLinks'])
             ->getMockForAbstractClass();
         $this->entityMetadata->expects($this->any())
             ->method('getLinkField')
@@ -304,9 +298,9 @@ class ConfigurableTest extends TestCase
         $product->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturnMap($dataMap);
-        $attribute = $this->getMockBuilder(Attribute::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addData', 'setStoreId', 'setProductId', 'save', '__sleep'])
+        $attribute = $this->getMockBuilder(Attribute::class)->disableOriginalConstructor()
+            ->onlyMethods(['addData', 'setProductId', 'save', '__sleep'])
+            ->addMethods(['setStoreId'])
             ->getMock();
         $expectedAttributeData = $this->attributeData[1];
         unset($expectedAttributeData['id']);
@@ -334,7 +328,10 @@ class ConfigurableTest extends TestCase
         $this->model->save($product);
     }
 
-    public function testGetRelationInfo()
+    /**
+     * @return void
+     */
+    public function testGetRelationInfo(): void
     {
         $info = $this->model->getRelationInfo();
         $this->assertInstanceOf(DataObject::class, $info);
@@ -343,7 +340,10 @@ class ConfigurableTest extends TestCase
         $this->assertEquals('product_id', $info->getData('child_field_name'));
     }
 
-    public function testCanUseAttribute()
+    /**
+     * @return void
+     */
+    public function testCanUseAttribute(): void
     {
         $attribute = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class)
             ->disableOriginalConstructor()
@@ -364,7 +364,10 @@ class ConfigurableTest extends TestCase
         $this->assertTrue($this->model->canUseAttribute($attribute));
     }
 
-    public function testGetUsedProducts()
+    /**
+     * @return void
+     */
+    public function testGetUsedProducts(): void
     {
         $productCollectionItem = $this->createMock(Product::class);
         $attributeCollection = $this->createMock(Collection::class);
@@ -379,7 +382,7 @@ class ConfigurableTest extends TestCase
             ->willReturnMap(
                 [
                     ['_cache_instance_products', null],
-                    ['_cache_instance_used_product_attributes', 1],
+                    ['_cache_instance_used_product_attributes', 1]
                 ]
             );
         $product->expects($this->any())
@@ -405,9 +408,10 @@ class ConfigurableTest extends TestCase
     /**
      * @param int $productStore
      *
+     * @return void
      * @dataProvider getConfigurableAttributesAsArrayDataProvider
      */
-    public function testGetConfigurableAttributesAsArray($productStore)
+    public function testGetConfigurableAttributesAsArray($productStore): void
     {
         $attributeSource = $this->getMockBuilder(AbstractSource::class)
             ->disableOriginalConstructor()
@@ -425,27 +429,27 @@ class ConfigurableTest extends TestCase
         $eavAttribute->expects($this->once())->method('getSource')->willReturn($attributeSource);
         $eavAttribute->expects($this->atLeastOnce())->method('getStoreLabel')->willReturn('Store Label');
 
-        $attribute = $this->getMockBuilder(Attribute::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getProductAttribute', '__sleep'])
+        $attribute = $this->getMockBuilder(Attribute::class)->disableOriginalConstructor()
+            ->onlyMethods(['__sleep'])
+            ->addMethods(['getProductAttribute'])
             ->getMock();
         $attribute->expects($this->any())->method('getProductAttribute')->willReturn($eavAttribute);
 
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['getStoreId', 'getData', 'hasData', '__sleep'])
+            ->onlyMethods(['getStoreId', 'getData', 'hasData', '__sleep'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->atLeastOnce())->method('getStoreId')->willReturn($productStore);
         $product->expects($this->atLeastOnce())->method('hasData')
             ->willReturnMap(
                 [
-                    ['_cache_instance_configurable_attributes', 1],
+                    ['_cache_instance_configurable_attributes', 1]
                 ]
             );
         $product->expects($this->any())->method('getData')
             ->willReturnMap(
                 [
-                    ['_cache_instance_configurable_attributes', null, [$attribute]],
+                    ['_cache_instance_configurable_attributes', null, [$attribute]]
                 ]
             );
 
@@ -456,7 +460,7 @@ class ConfigurableTest extends TestCase
     /**
      * @return array
      */
-    public function getConfigurableAttributesAsArrayDataProvider()
+    public function getConfigurableAttributesAsArrayDataProvider(): array
     {
         return [
             [5],
@@ -464,13 +468,16 @@ class ConfigurableTest extends TestCase
         ];
     }
 
-    public function testGetConfigurableAttributesNewProduct()
+    /**
+     * @return void
+     */
+    public function testGetConfigurableAttributesNewProduct(): void
     {
         $configurableAttributes = '_cache_instance_configurable_attributes';
 
         /** @var Product|MockObject $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['hasData', 'getId'])
+            ->onlyMethods(['hasData', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -480,13 +487,16 @@ class ConfigurableTest extends TestCase
         $this->assertEquals([], $this->model->getConfigurableAttributes($product));
     }
 
-    public function testGetConfigurableAttributes()
+    /**
+     * @return void
+     */
+    public function testGetConfigurableAttributes(): void
     {
         $configurableAttributes = '_cache_instance_configurable_attributes';
 
         /** @var Product|MockObject $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['getData', 'hasData', 'setData', 'getId'])
+            ->onlyMethods(['getData', 'hasData', 'setData', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -494,7 +504,7 @@ class ConfigurableTest extends TestCase
         $product->expects($this->once())->method('getId')->willReturn(1);
 
         $attributeCollection = $this->getMockBuilder(Collection::class)
-            ->setMethods(['setProductFilter', 'orderByPosition', 'load'])
+            ->onlyMethods(['setProductFilter', 'orderByPosition', 'load'])
             ->disableOriginalConstructor()
             ->getMock();
         $attributeCollection->expects($this->once())->method('setProductFilter')->willReturnSelf();
@@ -516,10 +526,13 @@ class ConfigurableTest extends TestCase
         $this->assertEquals($attributeCollection, $this->model->getConfigurableAttributes($product));
     }
 
-    public function testResetConfigurableAttributes()
+    /**
+     * @return void
+     */
+    public function testResetConfigurableAttributes(): void
     {
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(['unsetData'])
+            ->onlyMethods(['unsetData'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->once())
@@ -530,10 +543,13 @@ class ConfigurableTest extends TestCase
         $this->assertEquals($this->model, $this->model->resetConfigurableAttributes($product));
     }
 
-    public function testHasOptions()
+    /**
+     * @return void
+     */
+    public function testHasOptions(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getOptions'])
+            ->onlyMethods(['getOptions'])
             ->disableOriginalConstructor()
             ->getMock();
         $productMock->expects($this->once())->method('getOptions')->willReturn([true]);
@@ -541,10 +557,14 @@ class ConfigurableTest extends TestCase
         $this->assertTrue($this->model->hasOptions($productMock));
     }
 
-    public function testHasOptionsConfigurableAttribute()
+    /**
+     * @return void
+     */
+    public function testHasOptionsConfigurableAttribute(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getAttributeCode', 'getOptions', 'hasData', 'getData'])
+            ->onlyMethods(['getOptions', 'hasData', 'getData'])
+            ->addMethods(['getAttributeCode'])
             ->disableOriginalConstructor()
             ->getMock();
         $attributeMock = $this->getMockBuilder(Attribute::class)
@@ -562,10 +582,13 @@ class ConfigurableTest extends TestCase
         $this->assertTrue($this->model->hasOptions($productMock));
     }
 
-    public function testHasOptionsFalse()
+    /**
+     * @return void
+     */
+    public function testHasOptionsFalse(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getOptions', 'hasData', 'getData'])
+            ->onlyMethods(['getOptions', 'hasData', 'getData'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -580,32 +603,26 @@ class ConfigurableTest extends TestCase
         $this->assertFalse($this->model->hasOptions($productMock));
     }
 
-    public function testIsSalable()
+    /**
+     * @return void
+     */
+    public function testIsSalable(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getStatus', 'hasData', 'getData', 'getStoreId', 'setData', 'getSku'])
+            ->onlyMethods(['getStatus', 'hasData', 'getData', 'getStoreId', 'setData', 'getSku'])
             ->disableOriginalConstructor()
             ->getMock();
-        $productMock
-            ->expects($this->at(0))
-            ->method('getData')
-            ->with('_cache_instance_store_filter')
-            ->willReturn(0);
         $productMock->expects($this->once())->method('getStatus')->willReturn(1);
         $productMock->expects($this->any())->method('hasData')->willReturn(true);
-        $productMock->expects($this->at(1))->method('getSku')->willReturn('SKU-CODE');
-        $productMock->expects($this->at(4))->method('getData')->with('is_salable')->willReturn(true);
-        $productCollection = $this->getMockBuilder(
-            \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection::class
-        )
-            ->setMethods(
-                [
-                    'setFlag',
-                    'setProductFilter',
-                    'addStoreFilter',
-                    'getSize'
-                ]
-            )
+        $productMock
+            ->method('getData')
+            ->withConsecutive(['_cache_instance_store_filter'], ['is_salable'])
+            ->willReturnOnConsecutiveCalls(0, true);
+        $productMock
+            ->method('getSku')
+            ->willReturn('SKU-CODE');
+        $productCollection = $this->getMockBuilder(ProductCollection::class)
+            ->onlyMethods(['setFlag', 'setProductFilter', 'addStoreFilter', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         $productCollection->expects($this->any())->method('setFlag')->willReturnSelf();
@@ -632,7 +649,10 @@ class ConfigurableTest extends TestCase
         $this->assertTrue($this->model->isSalable($productMock));
     }
 
-    public function testGetSelectedAttributesInfo()
+    /**
+     * @return void
+     */
+    public function testGetSelectedAttributesInfo(): void
     {
         $this->serializer->expects($this->any())
             ->method('serialize')
@@ -656,10 +676,8 @@ class ConfigurableTest extends TestCase
         $optionMock = $this->getMockBuilder(OptionInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $usedAttributeMock = $this->getMockBuilder(
-            Attribute::class
-        )
-            ->setMethods(['getProductAttribute'])
+        $usedAttributeMock = $this->getMockBuilder(Attribute::class)
+            ->addMethods(['getProductAttribute'])
             ->disableOriginalConstructor()
             ->getMock();
         $attributeMock = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class)
@@ -669,8 +687,9 @@ class ConfigurableTest extends TestCase
         $optionMock->expects($this->once())->method('getValue')->willReturn(json_encode($this->attributeData));
         $productMock->expects($this->once())->method('getCustomOption')->with('attributes')->willReturn($optionMock);
         $productMock->expects($this->once())->method('hasData')->willReturn(true);
-        $productMock->expects($this->at(2))->method('getData')->willReturn(true);
-        $productMock->expects($this->at(3))->method('getData')->willReturn([1 => $usedAttributeMock]);
+        $productMock
+            ->method('getData')
+            ->willReturnOnConsecutiveCalls(true, [1 => $usedAttributeMock]);
         $usedAttributeMock->expects($this->once())->method('getProductAttribute')->willReturn($attributeMock);
         $attributeMock->expects($this->once())->method('getStoreLabel')->willReturn('attr_store_label');
         $attributeMock->expects($this->once())->method('getSourceModel')->willReturn(false);
@@ -689,12 +708,15 @@ class ConfigurableTest extends TestCase
     }
 
     /**
+     *
+     * @return void
      * @covers \Magento\ConfigurableProduct\Model\Product\Type\Configurable::checkProductBuyState()
      */
-    public function testCheckProductBuyState()
+    public function testCheckProductBuyState(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getSkipCheckRequiredOption', 'getCustomOption'])
+            ->onlyMethods(['getCustomOption'])
+            ->addMethods(['getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock = $this->getMockBuilder(Option::class)
@@ -721,14 +743,16 @@ class ConfigurableTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\ConfigurableProduct\Model\Product\Type\Configurable::checkProductBuyState()
      */
-    public function testCheckProductBuyStateException()
+    public function testCheckProductBuyStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('You need to choose options for your item.');
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getSkipCheckRequiredOption', 'getCustomOption'])
+            ->onlyMethods(['getCustomOption'])
+            ->addMethods(['getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionMock = $this->getMockBuilder(Option::class)
@@ -752,7 +776,10 @@ class ConfigurableTest extends TestCase
         $this->model->checkProductBuyState($productMock);
     }
 
-    public function testGetProductByAttributesReturnUsedProduct()
+    /**
+     * @return void
+     */
+    public function testGetProductByAttributesReturnUsedProduct(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -777,11 +804,11 @@ class ConfigurableTest extends TestCase
         $productCollection->expects($this->once())->method('addAttributeToFilter')->willReturnSelf();
         $productCollection->expects($this->once())->method('getFirstItem')->willReturn($firstItemMock);
         $productCollection->expects($this->once())->method('getIterator')->willReturn(
-            new \ArrayIterator([$usedProductMock])
+            new ArrayIterator([$usedProductMock])
         );
 
         $firstItemMock->expects($this->once())->method('getId')->willReturn(false);
-        $productMock->expects($this->at(0))
+        $productMock
             ->method('getData')
             ->with('_cache_instance_store_filter')
             ->willReturn('some_filter');
@@ -799,7 +826,10 @@ class ConfigurableTest extends TestCase
         );
     }
 
-    public function testGetProductByAttributesReturnFirstItem()
+    /**
+     * @return void
+     */
+    public function testGetProductByAttributesReturnFirstItem(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -826,10 +856,14 @@ class ConfigurableTest extends TestCase
         );
     }
 
-    public function testSetImageFromChildProduct()
+    /**
+     * @return void
+     */
+    public function testSetImageFromChildProduct(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['hasData', 'getData', 'setImage'])
+            ->onlyMethods(['hasData', 'getData'])
+            ->addMethods(['setImage'])
             ->disableOriginalConstructor()
             ->getMock();
         $childProductMock = $this->getMockBuilder(Product::class)

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Type/ConfigurableTest.php
@@ -148,7 +148,7 @@ class ConfigurableTest extends TestCase
     private $catalogConfig;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Validator/PluginTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Validator/PluginTest.php
@@ -72,7 +72,7 @@ class PluginTest extends TestCase
     protected $subjectMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Validator/PluginTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/Product/Validator/PluginTest.php
@@ -71,6 +71,9 @@ class PluginTest extends TestCase
      */
     protected $subjectMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->eventManagerMock = $this->createMock(Manager::class);
@@ -99,7 +102,10 @@ class PluginTest extends TestCase
         );
     }
 
-    public function testBeforeValidate()
+    /**
+     * @return void
+     */
+    public function testBeforeValidate(): void
     {
         $this->requestMock->expects(static::once())->method('has')->with('attributes')->willReturn(true);
         $this->productMock->expects(static::once())->method('setTypeId')->willReturnSelf();
@@ -112,36 +118,33 @@ class PluginTest extends TestCase
         );
     }
 
-    public function testAfterValidateWithVariationsValid()
+    /**
+     * @return void
+     */
+    public function testAfterValidateWithVariationsValid(): void
     {
         $matrix = ['products'];
 
         $plugin = $this->getMockBuilder(Plugin::class)
-            ->setMethods(['_validateProductVariations'])
-            ->setConstructorArgs([$this->eventManagerMock, $this->productFactoryMock, $this->jsonHelperMock])
+            ->onlyMethods(['_validateProductVariations'])
+            ->setConstructorArgs(
+                [
+                    $this->eventManagerMock,
+                    $this->productFactoryMock,
+                    $this->jsonHelperMock
+                ]
+            )
             ->getMock();
 
-        $plugin->expects(
-            $this->once()
-        )->method(
-            '_validateProductVariations'
-        )->with(
-            $this->productMock,
-            $matrix,
-            $this->requestMock
-        )->willReturn(
-            null
-        );
+        $plugin->expects($this->once())
+            ->method('_validateProductVariations')
+            ->with($this->productMock, $matrix, $this->requestMock)
+            ->willReturn(null);
 
-        $this->requestMock->expects(
-            $this->once()
-        )->method(
-            'getPost'
-        )->with(
-            'variations-matrix'
-        )->willReturn(
-            $matrix
-        );
+        $this->requestMock->expects($this->once())
+            ->method('getPost')
+            ->with('variations-matrix')
+            ->willReturn($matrix);
 
         $this->responseMock->expects($this->never())->method('setError');
 
@@ -157,36 +160,33 @@ class PluginTest extends TestCase
         );
     }
 
-    public function testAfterValidateWithVariationsInvalid()
+    /**
+     * @return void
+     */
+    public function testAfterValidateWithVariationsInvalid(): void
     {
         $matrix = ['products'];
 
         $plugin = $this->getMockBuilder(Plugin::class)
-            ->setMethods(['_validateProductVariations'])
-            ->setConstructorArgs([$this->eventManagerMock, $this->productFactoryMock, $this->jsonHelperMock])
+            ->onlyMethods(['_validateProductVariations'])
+            ->setConstructorArgs(
+                [
+                    $this->eventManagerMock,
+                    $this->productFactoryMock,
+                    $this->jsonHelperMock
+                ]
+            )
             ->getMock();
 
-        $plugin->expects(
-            $this->once()
-        )->method(
-            '_validateProductVariations'
-        )->with(
-            $this->productMock,
-            $matrix,
-            $this->requestMock
-        )->willReturn(
-            true
-        );
+        $plugin->expects($this->once())
+            ->method('_validateProductVariations')
+            ->with($this->productMock, $matrix, $this->requestMock)
+            ->willReturn(true);
 
-        $this->requestMock->expects(
-            $this->once()
-        )->method(
-            'getPost'
-        )->with(
-            'variations-matrix'
-        )->willReturn(
-            $matrix
-        );
+        $this->requestMock->expects($this->once())
+            ->method('getPost')
+            ->with('variations-matrix')
+            ->willReturn($matrix);
 
         $this->responseMock->expects($this->once())->method('setError')->with(true)->willReturnSelf();
         $this->responseMock->expects($this->once())->method('setMessage')->willReturnSelf();
@@ -203,17 +203,15 @@ class PluginTest extends TestCase
         );
     }
 
-    public function testAfterValidateIfVariationsNotExist()
+    /**
+     * @return void
+     */
+    public function testAfterValidateIfVariationsNotExist(): void
     {
-        $this->requestMock->expects(
-            $this->once()
-        )->method(
-            'getPost'
-        )->with(
-            'variations-matrix'
-        )->willReturn(
-            null
-        );
+        $this->requestMock->expects($this->once())
+            ->method('getPost')
+            ->with('variations-matrix')
+            ->willReturn(null);
         $this->eventManagerMock->expects($this->never())->method('dispatch');
         $this->plugin->afterValidate(
             $this->subjectMock,
@@ -224,12 +222,15 @@ class PluginTest extends TestCase
         );
     }
 
-    public function testAfterValidateWithVariationsAndRequiredAttributes()
+    /**
+     * @return void
+     */
+    public function testAfterValidateWithVariationsAndRequiredAttributes(): void
     {
         $matrix = [
             ['data1', 'data2', 'configurable_attribute' => ['data1']],
             ['data3', 'data4', 'configurable_attribute' => ['data3']],
-            ['data5', 'data6', 'configurable_attribute' => ['data5']],
+            ['data5', 'data6', 'configurable_attribute' => ['data5']]
         ];
 
         $this->productMock->expects($this->any())
@@ -240,19 +241,14 @@ class PluginTest extends TestCase
                     ['code2', null, 'value_code_2'],
                     ['code3', null, 'value_code_3'],
                     ['code4', null, 'value_code_4'],
-                    ['code5', null, 'value_code_5'],
+                    ['code5', null, 'value_code_5']
                 ]
             );
 
-        $this->requestMock->expects(
-            $this->once()
-        )->method(
-            'getPost'
-        )->with(
-            'variations-matrix'
-        )->willReturn(
-            $matrix
-        );
+        $this->requestMock->expects($this->once())
+            ->method('getPost')
+            ->with('variations-matrix')
+            ->willReturn($matrix);
 
         $attribute1 = $this->createAttribute('code1', true, true);
         $attribute2 = $this->createAttribute('code2', true, false);
@@ -265,35 +261,31 @@ class PluginTest extends TestCase
             $attribute2,
             $attribute3,
             $attribute4,
-            $attribute5,
+            $attribute5
         ];
 
         $requiredAttributes = [
             'code1' => 'value_code_1',
-            'code5' => 'value_code_5',
+            'code5' => 'value_code_5'
         ];
 
-        $product1 = $this->createProduct(0, 1);
-        $product1->expects($this->at(1))
+        $product1 = $this->createProduct();
+        $product1
             ->method('addData')
-            ->with($requiredAttributes)->willReturnSelf();
-        $product1->expects($this->at(2))
+            ->withConsecutive([$requiredAttributes], [$matrix[0]])
+            ->willReturnOnConsecutiveCalls($product1, $product1);
+
+        $product2 = $this->createProduct();
+        $product2
             ->method('addData')
-            ->with($matrix[0])->willReturnSelf();
-        $product2 = $this->createProduct(1, 2);
-        $product2->expects($this->at(1))
+            ->withConsecutive([$requiredAttributes], [$matrix[1]])
+            ->willReturnOnConsecutiveCalls($product2, $product2);
+
+        $product3 = $this->createProduct();
+        $product3
             ->method('addData')
-            ->with($requiredAttributes)->willReturnSelf();
-        $product2->expects($this->at(2))
-            ->method('addData')
-            ->with($matrix[1])->willReturnSelf();
-        $product3 = $this->createProduct(2, 3);
-        $product3->expects($this->at(1))
-            ->method('addData')
-            ->with($requiredAttributes)->willReturnSelf();
-        $product3->expects($this->at(2))
-            ->method('addData')
-            ->with($matrix[2])->willReturnSelf();
+            ->withConsecutive([$requiredAttributes], [$matrix[2]])
+            ->willReturnOnConsecutiveCalls($product3, $product3);
 
         $this->productMock->expects($this->exactly(3))
             ->method('getAttributes')
@@ -308,32 +300,28 @@ class PluginTest extends TestCase
             $this->requestMock,
             $this->responseMock
         );
-        $this->assertEquals(
-            $this->proceedResult,
-            $result
-        );
+        $this->assertEquals($this->proceedResult, $result);
     }
 
     /**
-     * @param $index
-     * @param $id
-     * @param bool $isValid
-     * @internal param array $attributes
      * @return MockObject|Product
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @internal param array $attributes
      */
-    private function createProduct($index, $id, $isValid = true)
+    private function createProduct(): Product
     {
         $productMock = $this->createPartialMock(
             Product::class,
             ['getAttributes', 'addData', 'setAttributeSetId', 'validate']
         );
-        $this->productFactoryMock->expects($this->at($index))
+
+        $this->productFactoryMock
             ->method('create')
             ->willReturn($productMock);
-        $productMock->expects($this->once())
+
+        $productMock->expects($this->any())
             ->method('validate')
-            ->willReturn($isValid);
+            ->willReturn(true);
 
         return $productMock;
     }
@@ -342,13 +330,23 @@ class PluginTest extends TestCase
      * @param $attributeCode
      * @param $isUserDefined
      * @param $isRequired
+     *
      * @return MockObject|AbstractAttribute
      */
-    private function createAttribute($attributeCode, $isUserDefined, $isRequired)
-    {
+    private function createAttribute(
+        $attributeCode,
+        $isUserDefined,
+        $isRequired
+    ): AbstractAttribute {
         $attribute = $this->getMockBuilder(AbstractAttribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributeCode', 'getIsUserDefined', 'getIsRequired'])
+            ->onlyMethods(
+                [
+                    'getAttributeCode',
+                    'getIsUserDefined',
+                    'getIsRequired'
+                ]
+            )
             ->getMock();
         $attribute->expects($this->any())
             ->method('getAttributeCode')

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductVariationsBuilderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductVariationsBuilderTest.php
@@ -45,7 +45,7 @@ class ProductVariationsBuilderTest extends TestCase
     protected $product;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductVariationsBuilderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ProductVariationsBuilderTest.php
@@ -44,6 +44,9 @@ class ProductVariationsBuilderTest extends TestCase
      */
     protected $product;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->customAttributeFactory = $this->createMock(AttributeValueFactory::class);
@@ -66,7 +69,10 @@ class ProductVariationsBuilderTest extends TestCase
         );
     }
 
-    public function testCreate()
+    /**
+     * @return void
+     */
+    public function testCreate(): void
     {
         $output = $this->createPartialMock(
             Product::class,
@@ -74,7 +80,7 @@ class ProductVariationsBuilderTest extends TestCase
         );
         $attributes = [10 => ['attribute_code' => 'sort_order']];
         $variations = [
-            [10 => ['value' => 15, 'price' => ['pricing_value' => 10]]],
+            [10 => ['value' => 15, 'price' => ['pricing_value' => 10]]]
         ];
         $this->variationMatrix->expects($this->once())
             ->method('getVariations')
@@ -87,8 +93,6 @@ class ProductVariationsBuilderTest extends TestCase
         $this->product->expects($this->once())->method('getName')->willReturn('simple');
         $this->product->expects($this->once())->method('getSku')->willReturn('simple-sku');
         $this->product->expects($this->once())->method('getPrice')->willReturn(10);
-
-        $output->expects($this->at(0))->method('setData')->with($productData);
 
         $attribute = $this->getMockForAbstractClass(AttributeInterface::class);
         $attribute->expects($this->once())
@@ -107,7 +111,9 @@ class ProductVariationsBuilderTest extends TestCase
 
         $output->expects($this->once())->method('getCustomAttributes')->willReturn([]);
 
-        $output->expects($this->at(2))->method('setData')->with('custom_attributes', ['sort_order' => $attribute]);
+        $output
+            ->method('setData')
+            ->withConsecutive([$productData], ['custom_attributes', ['sort_order' => $attribute]]);
         $output->expects($this->once())->method('setPrice')->with(10);
         $output->expects($this->once())->method('setName')->with('simple-15');
         $output->expects($this->once())->method('setSku')->with('simple-sku-15');

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/Type/Configurable/AttributeTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/Type/Configurable/AttributeTest.php
@@ -44,7 +44,7 @@ class AttributeTest extends TestCase
     protected $relation;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/Type/Configurable/AttributeTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ResourceModel/Product/Type/Configurable/AttributeTest.php
@@ -43,6 +43,9 @@ class AttributeTest extends TestCase
      */
     protected $relation;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->connection = $this->getMockBuilder(AdapterInterface::class)
@@ -61,7 +64,10 @@ class AttributeTest extends TestCase
         );
     }
 
-    public function testSaveNewLabel()
+    /**
+     * @return void
+     */
+    public function testSaveNewLabel(): void
     {
         $attributeId = 4354;
 
@@ -70,8 +76,9 @@ class AttributeTest extends TestCase
             ->getMock();
         $this->connection->expects($this->once())->method('select')->willReturn($select);
         $select->expects($this->once())->method('from')->willReturnSelf();
-        $select->expects($this->at(1))->method('where')->willReturnSelf();
-        $select->expects($this->at(2))->method('where')->willReturnSelf();
+        $select
+            ->method('where')
+            ->willReturnOnConsecutiveCalls($select, $select);
         $this->connection->expects($this->once())->method('fetchOne')->with(
             $select,
             [
@@ -90,9 +97,9 @@ class AttributeTest extends TestCase
             ]
         );
         $attributeMock = $this->getMockBuilder(AttributeModel::class)
-            ->setMethods(
-                ['getId', 'getUseDefault', 'getLabel']
-            )->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'getLabel'])
+            ->addMethods(['getUseDefault'])
+            ->disableOriginalConstructor()
             ->getMock();
         $attributeMock->expects($this->atLeastOnce())->method('getId')->willReturn($attributeId);
         $attributeMock->expects($this->atLeastOnce())->method('getUseDefault')->willReturn(0);
@@ -100,22 +107,25 @@ class AttributeTest extends TestCase
         $this->assertEquals($this->attribute, $this->attribute->saveLabel($attributeMock));
     }
 
-    public function testSaveExistingLabel()
+    /**
+     * @return void
+     */
+    public function testSaveExistingLabel(): void
     {
         $attributeId = 4354;
-
         $select = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->connection->expects($this->once())->method('select')->willReturn($select);
         $select->expects($this->once())->method('from')->willReturnSelf();
-        $select->expects($this->at(1))->method('where')->willReturnSelf();
-        $select->expects($this->at(2))->method('where')->willReturnSelf();
+        $select
+            ->method('where')
+            ->willReturnOnConsecutiveCalls($select, $select);
         $this->connection->expects($this->once())->method('fetchOne')->with(
             $select,
             [
                 'product_super_attribute_id' => $attributeId,
-                'store_id' => Store::DEFAULT_STORE_ID,
+                'store_id' => Store::DEFAULT_STORE_ID
             ]
         )->willReturn(1);
 
@@ -125,13 +135,13 @@ class AttributeTest extends TestCase
                 'product_super_attribute_id' => $attributeId,
                 'use_default' => 0,
                 'store_id' => 1,
-                'value' => 'test',
+                'value' => 'test'
             ]
         );
         $attributeMock = $this->getMockBuilder(AttributeModel::class)
-            ->setMethods(
-                ['getId', 'getUseDefault', 'getLabel', 'getStoreId']
-            )->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'getLabel'])
+            ->addMethods(['getUseDefault', 'getStoreId'])
+            ->disableOriginalConstructor()
             ->getMock();
         $attributeMock->expects($this->atLeastOnce())->method('getId')->willReturn($attributeId);
         $attributeMock->expects($this->atLeastOnce())->method('getStoreId')->willReturn(1);

--- a/app/code/Magento/Cron/Test/Unit/Model/DeadlockRetrierTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/DeadlockRetrierTest.php
@@ -13,9 +13,10 @@ use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Adapter\DeadlockException;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class DeadlockRetrierTest extends \PHPUnit\Framework\TestCase
+class DeadlockRetrierTest extends TestCase
 {
 
     /**
@@ -39,7 +40,7 @@ class DeadlockRetrierTest extends \PHPUnit\Framework\TestCase
     private $modelMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -50,10 +51,11 @@ class DeadlockRetrierTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @return void
      */
     public function testInsideTransaction(): void
     {
-        $this->expectException(\Magento\Framework\DB\Adapter\DeadlockException::class);
+        $this->expectException(DeadlockException::class);
 
         $this->adapterMock->expects($this->once())
             ->method('getTransactionLevel')
@@ -71,10 +73,11 @@ class DeadlockRetrierTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @return void
      */
     public function testRetry(): void
     {
-        $this->expectException(\Magento\Framework\DB\Adapter\DeadlockException::class);
+        $this->expectException(DeadlockException::class);
 
         $this->adapterMock->expects($this->once())
             ->method('getTransactionLevel')
@@ -93,19 +96,18 @@ class DeadlockRetrierTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testRetrySecond(): void
     {
         $this->adapterMock->expects($this->once())
             ->method('getTransactionLevel')
             ->willReturn(0);
-        $this->modelMock->expects($this->at(0))
+
+        $this->modelMock
             ->method('getId')
-            ->willThrowException(new DeadlockException());
-        $this->modelMock->expects($this->at(1))
-            ->method('getId')
-            ->willReturn(2);
-        $this->loggerMock->expects($this->once())
-            ->method('warning');
+            ->willReturnOnConsecutiveCalls($this->throwException(new DeadlockException()),2);
 
         $this->retrier->execute(
             function () {

--- a/app/code/Magento/Cron/Test/Unit/Model/DeadlockRetrierTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Model/DeadlockRetrierTest.php
@@ -40,7 +40,7 @@ class DeadlockRetrierTest extends TestCase
     private $modelMock;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Cron\Test\Unit\Observer;
 
+use Exception;
 use Magento\Cron\Model\Config;
 use Magento\Cron\Model\DeadlockRetrierInterface;
 use Magento\Cron\Model\ResourceModel\Schedule as ScheduleResourceModel;
@@ -23,6 +24,7 @@ use Magento\Framework\App\State;
 use Magento\Framework\App\State as AppState;
 use Magento\Framework\DataObject;
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Framework\Model\AbstractModel;
@@ -36,6 +38,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
+use TypeError;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -119,7 +122,7 @@ class ProcessCronQueueObserverTest extends TestCase
     private $scheduleResourceMock;
 
     /**
-     * @var \Magento\Framework\Event\ManagerInterface|MockObject
+     * @var ManagerInterface|MockObject
      */
     private $eventManager;
 
@@ -144,7 +147,7 @@ class ProcessCronQueueObserverTest extends TestCase
     protected $time = 1501538400;
 
     /**
-     * Prepare parameters
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -159,31 +162,22 @@ class ProcessCronQueueObserverTest extends TestCase
             ScopeConfigInterface::class
         )->disableOriginalConstructor()
             ->getMock();
-        $this->scheduleCollectionMock = $this->getMockBuilder(
-            ScheduleCollection::class
-        )->setMethods(
-            ['addFieldToFilter', 'load', '__wakeup']
-        )->disableOriginalConstructor()
+        $this->scheduleCollectionMock = $this->getMockBuilder(ScheduleCollection::class)
+            ->onlyMethods(['addFieldToFilter', 'load', '__wakeup'])->disableOriginalConstructor()
             ->getMock();
         $this->scheduleCollectionMock->expects($this->any())->method('addFieldToFilter')->willReturnSelf();
         $this->scheduleCollectionMock->expects($this->any())->method('load')->willReturnSelf();
 
-        $this->scheduleFactoryMock = $this->getMockBuilder(
-            ScheduleFactory::class
-        )->setMethods(
-            ['create']
-        )->disableOriginalConstructor()
+        $this->scheduleFactoryMock = $this->getMockBuilder(ScheduleFactory::class)
+            ->onlyMethods(['create'])->disableOriginalConstructor()
             ->getMock();
         $this->consoleRequestMock = $this->getMockBuilder(
             ConsoleRequest::class
         )->disableOriginalConstructor()
             ->getMock();
-        $this->shellMock = $this->getMockBuilder(
-            ShellInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['execute']
-            )->getMock();
+        $this->shellMock = $this->getMockBuilder(ShellInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['execute'])->getMock();
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
 
         $this->appStateMock = $this->getMockBuilder(AppState::class)
@@ -197,7 +191,7 @@ class ProcessCronQueueObserverTest extends TestCase
         $this->lockManagerMock->method('unlock')->willReturn(true);
 
         $this->observerMock = $this->createMock(Observer::class);
-        $this->eventManager = $this->createMock(\Magento\Framework\Event\ManagerInterface::class);
+        $this->eventManager = $this->createMock(ManagerInterface::class);
 
         $this->dateTimeMock = $this->getMockBuilder(DateTime::class)
             ->disableOriginalConstructor()
@@ -214,7 +208,7 @@ class ProcessCronQueueObserverTest extends TestCase
             ->getMock();
 
         $this->statFactory = $this->getMockBuilder(StatFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -245,9 +239,11 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case for not existed cron jobs in files but in data base is presented
+     * Test case for not existed cron jobs in files but in data base is presented.
+     *
+     * @return void
      */
-    public function testDispatchNoJobConfig()
+    public function testDispatchNoJobConfig(): void
     {
         $this->eventManager->expects($this->never())->method('dispatch');
         $lastRun = $this->time + 10000000;
@@ -288,9 +284,11 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case checks if some job can't be locked
+     * Test case checks if some job can't be locked.
+     *
+     * @return void
      */
-    public function testDispatchCanNotLock()
+    public function testDispatchCanNotLock(): void
     {
         $lastRun = $this->time + 10000000;
         $this->eventManager->expects($this->never())->method('dispatch');
@@ -301,11 +299,9 @@ class ProcessCronQueueObserverTest extends TestCase
             ->method('getParam')->willReturn('test_group');
 
         $dateScheduledAt = date('Y-m-d H:i:s', $this->time - 86400);
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            ['getJobCode', 'tryLockJob', 'getScheduledAt', '__wakeup', 'save', 'setFinishedAt', 'getResource']
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['tryLockJob', '__wakeup', 'save', 'getResource'])
+            ->addMethods(['getJobCode', 'getScheduledAt', 'setFinishedAt'])->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('test_job1');
         $schedule->expects($this->atLeastOnce())->method('getScheduledAt')->willReturn($dateScheduledAt);
@@ -350,9 +346,11 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case catch exception if too late for schedule
+     * Test case catch exception if too late for schedule.
+     *
+     * @return void
      */
-    public function testDispatchExceptionTooLate()
+    public function testDispatchExceptionTooLate(): void
     {
         $exceptionMessage = 'Cron Job test_job1 is missed at 2017-07-30 15:00:00';
         $jobCode = 'test_job1';
@@ -364,23 +362,19 @@ class ProcessCronQueueObserverTest extends TestCase
         $this->consoleRequestMock->expects($this->any())->method('getParam')->willReturn('test_group');
 
         $dateScheduledAt = date('Y-m-d H:i:s', $this->time - 86400);
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            [
-                'getJobCode',
-                'tryLockJob',
-                'getScheduledAt',
-                'save',
-                'setStatus',
-                'setMessages',
-                '__wakeup',
-                'getStatus',
-                'getMessages',
-                'getScheduleId',
-                'getResource',
-            ]
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['tryLockJob', 'save', '__wakeup', 'getResource'])
+            ->addMethods(
+                [
+                    'getJobCode',
+                    'getScheduledAt',
+                    'setStatus',
+                    'setMessages',
+                    'getStatus',
+                    'getMessages',
+                    'getScheduleId'
+                ]
+            )->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->atLeastOnce())->method('getJobCode')->willReturn($jobCode);
         $schedule->expects($this->atLeastOnce())->method('getScheduledAt')->willReturn($dateScheduledAt);
@@ -441,32 +435,23 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case catch exception if callback not exist
+     * Test case catch exception if callback not exist.
+     *
+     * @return void
      */
-    public function testDispatchExceptionNoCallback()
+    public function testDispatchExceptionNoCallback(): void
     {
         $jobName = 'test_job1';
         $exceptionMessage = 'No callbacks found for cron job ' . $jobName;
-        $exception = new \Exception($exceptionMessage);
+        $exception = new Exception($exceptionMessage);
 
         $this->eventManager->expects($this->never())->method('dispatch');
 
         $dateScheduledAt = date('Y-m-d H:i:s', $this->time - 86400);
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            [
-                'getJobCode',
-                'tryLockJob',
-                'getScheduledAt',
-                'save',
-                'setStatus',
-                'setMessages',
-                '__wakeup',
-                'getStatus',
-                'getResource'
-            ]
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['tryLockJob', 'save', '__wakeup', 'getResource'])
+            ->addMethods(['getJobCode', 'getScheduledAt', 'setStatus', 'setMessages', 'getStatus'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('test_job1');
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn($dateScheduledAt);
@@ -514,7 +499,7 @@ class ProcessCronQueueObserverTest extends TestCase
             ->willReturn($this->time + 86400);
 
         $scheduleMock = $this->getMockBuilder(
-            \Magento\Cron\Model\Schedule::class
+            Schedule::class
         )->disableOriginalConstructor()->getMock();
         $scheduleMock->expects($this->any())->method('getCollection')->willReturn($this->scheduleCollectionMock);
         $scheduleMock->expects($this->any())->method('getResource')->willReturn($this->scheduleResourceMock);
@@ -534,15 +519,16 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case catch exception if callback is not callable or throws exception
+     * Test case catch exception if callback is not callable or throws exception.
      *
      * @param string $cronJobType
      * @param mixed $cronJobObject
      * @param string $exceptionMessage
      * @param int $saveCalls
      * @param int $dispatchCalls
-     * @param \Exception $exception
+     * @param Exception $exception
      *
+     * @return void
      * @dataProvider dispatchExceptionInCallbackDataProvider
      */
     public function testDispatchExceptionInCallback(
@@ -552,10 +538,10 @@ class ProcessCronQueueObserverTest extends TestCase
         $saveCalls,
         $dispatchCalls,
         $exception
-    ) {
+    ): void {
         $jobConfig = [
             'test_group' => [
-                'test_job1' => ['instance' => $cronJobType, 'method' => 'execute'],
+                'test_job1' => ['instance' => $cronJobType, 'method' => 'execute']
             ],
         ];
 
@@ -566,21 +552,10 @@ class ProcessCronQueueObserverTest extends TestCase
             ->method('getParam')->willReturn('test_group');
 
         $dateScheduledAt = date('Y-m-d H:i:s', $this->time - 86400);
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            [
-                'getJobCode',
-                'tryLockJob',
-                'getScheduledAt',
-                'save',
-                'setStatus',
-                'setMessages',
-                '__wakeup',
-                'getStatus',
-                'getResource'
-            ]
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['tryLockJob', 'save', '__wakeup', 'getResource'])
+            ->addMethods(['getJobCode', 'getScheduledAt', 'setStatus', 'setMessages', 'getStatus'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('test_job1');
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn($dateScheduledAt);
@@ -640,9 +615,9 @@ class ProcessCronQueueObserverTest extends TestCase
     /**
      * @return array
      */
-    public function dispatchExceptionInCallbackDataProvider()
+    public function dispatchExceptionInCallbackDataProvider(): array
     {
-        $throwable = new \TypeError();
+        $throwable = new TypeError();
         return [
             'non-callable callback' => [
                 'Not_Existed_Class',
@@ -650,7 +625,7 @@ class ProcessCronQueueObserverTest extends TestCase
                 'Invalid callback: Not_Existed_Class::execute can\'t be called',
                 1,
                 0,
-                new \Exception('Invalid callback: Not_Existed_Class::execute can\'t be called')
+                new Exception('Invalid callback: Not_Existed_Class::execute can\'t be called')
             ],
             'exception in execution' => [
                 'CronJobException',
@@ -658,7 +633,7 @@ class ProcessCronQueueObserverTest extends TestCase
                 'Test exception',
                 2,
                 1,
-                new \Exception('Test exception')
+                new Exception('Test exception')
             ],
             'throwable in execution' => [
                 'CronJobException',
@@ -678,14 +653,15 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case, successfully run job
+     * Test case, successfully run job.
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testDispatchRunJob()
+    public function testDispatchRunJob(): void
     {
         $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]
         ];
         $this->consoleRequestMock->expects($this->any())->method('getParam')->willReturn('test_group');
 
@@ -704,7 +680,7 @@ class ProcessCronQueueObserverTest extends TestCase
             'setExecutedAt',
             'setFinishedAt',
             '__wakeup',
-            'getResource',
+            'getResource'
         ];
         /** @var Schedule|MockObject $schedule */
         $schedule = $this->getMockBuilder(
@@ -746,7 +722,7 @@ class ProcessCronQueueObserverTest extends TestCase
             Schedule::STATUS_SUCCESS
         )->willReturnSelf();
 
-        $schedule->expects($this->at(8))->method('save');
+        $schedule->method('save');
 
         $this->scheduleCollectionMock->addItem($schedule);
 
@@ -782,55 +758,36 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Testing _generate(), iterate over saved cron jobs
+     * Testing _generate(), iterate over saved cron jobs.
+     *
+     * @return void
      */
-    public function testDispatchNotGenerate()
+    public function testDispatchNotGenerate(): void
     {
         $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]
         ];
 
         $this->eventManager->expects($this->never())->method('dispatch');
-        $this->configMock->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
-        $this->configMock->expects(
-            $this->at(1)
-        )->method(
-            'getJobs'
-        )->willReturn(
-            ['test_group' => []]
-        );
-        $this->configMock->expects($this->at(2))
-            ->method('getJobs')->willReturn($jobConfig);
-        $this->configMock->expects($this->at(3))
-            ->method('getJobs')->willReturn($jobConfig);
+        $this->configMock
+            ->method('getJobs')
+            ->willReturnOnConsecutiveCalls($jobConfig, ['test_group' => []], $jobConfig, $jobConfig);
         $this->consoleRequestMock->expects($this->any())
             ->method('getParam')->willReturn('test_group');
-        $this->cacheMock->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'test_group'
-        )->willReturn(
-            $this->time + 10000000
-        );
-        $this->cacheMock->expects(
-            $this->at(1)
-        )->method(
-            'load'
-        )->with(
-            ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'test_group'
-        )->willReturn(
-            $this->time - 10000000
-        );
+        $this->cacheMock
+            ->method('load')
+            ->withConsecutive(
+                [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'test_group'],
+                [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'test_group']
+            )
+            ->willReturnOnConsecutiveCalls($this->time + 10000000, $this->time - 10000000);
 
         $this->scopeConfigMock->expects($this->any())->method('getValue')->willReturn(0);
 
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            ['getJobCode', 'getScheduledAt', '__wakeup']
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getJobCode', 'getScheduledAt'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('job_code1');
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn('* * * * *');
@@ -854,15 +811,17 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Testing _generate(), iterate over saved cron jobs and generate jobs
+     * Testing _generate(), iterate over saved cron jobs and generate jobs.
+     *
+     * @return void
      */
-    public function testDispatchGenerate()
+    public function testDispatchGenerate(): void
     {
         $jobConfig = [
             'default' => [
                 'test_job1' => [
                     'instance' => 'CronJob',
-                    'method' => 'execute',
+                    'method' => 'execute'
                 ],
             ],
         ];
@@ -871,29 +830,21 @@ class ProcessCronQueueObserverTest extends TestCase
             'default' => [
                 'job1' => ['config_path' => 'test/path'],
                 'job2' => ['schedule' => ''],
-                'job3' => ['schedule' => '* * * * *'],
+                'job3' => ['schedule' => '* * * * *']
             ],
         ];
         $this->eventManager->expects($this->never())->method('dispatch');
-        $this->configMock->expects($this->at(0))->method('getJobs')->willReturn($jobConfig);
-        $this->configMock->expects($this->at(1))->method('getJobs')->willReturn($jobs);
-        $this->configMock->expects($this->at(2))->method('getJobs')->willReturn($jobs);
-        $this->configMock->expects($this->at(3))->method('getJobs')->willReturn($jobs);
+        $this->configMock
+            ->method('getJobs')
+            ->willReturnOnConsecutiveCalls($jobConfig, $jobs, $jobs, $jobs);
         $this->consoleRequestMock->expects($this->any())->method('getParam')->willReturn('default');
-        $this->cacheMock->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default'
-        )->willReturn($this->time + 10000000);
-        $this->cacheMock->expects(
-            $this->at(1)
-        )->method(
-            'load'
-        )->with(
-            ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default'
-        )->willReturn($this->time - 10000000);
+        $this->cacheMock
+            ->method('load')
+            ->withConsecutive(
+                [ProcessCronQueueObserver::CACHE_KEY_LAST_HISTORY_CLEANUP_AT . 'default'],
+                [ProcessCronQueueObserver::CACHE_KEY_LAST_SCHEDULE_GENERATE_AT . 'default']
+            )
+            ->willReturnOnConsecutiveCalls($this->time + 10000000, $this->time - 10000000);
 
         $this->scopeConfigMock->expects($this->any())->method('getValue')->willReturnMap(
             [
@@ -912,11 +863,10 @@ class ProcessCronQueueObserverTest extends TestCase
             ]
         );
 
-        $schedule = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(
-            ['getJobCode', 'save', 'getScheduledAt', 'unsScheduleId', 'trySchedule', 'getCollection', 'getResource']
-        )->disableOriginalConstructor()
+        $schedule = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['save', 'trySchedule', 'getCollection', 'getResource'])
+            ->addMethods(['getJobCode', 'getScheduledAt', 'unsScheduleId'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schedule->expects($this->any())->method('getJobCode')->willReturn('job_code1');
         $schedule->expects($this->once())->method('getScheduledAt')->willReturn('* * * * *');
@@ -937,19 +887,22 @@ class ProcessCronQueueObserverTest extends TestCase
     }
 
     /**
-     * Test case without saved cron jobs in data base
+     * Test case without saved cron jobs in data base.
+     *
+     * @return void
      */
-    public function testDispatchCleanup()
+    public function testDispatchCleanup(): void
     {
         $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]
         ];
 
         $this->eventManager->expects($this->never())->method('dispatch');
         $dateExecutedAt = date('Y-m-d H:i:s', $this->time - 86400);
         $schedule = $this->getMockBuilder(Schedule::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getExecutedAt', 'getStatus', 'delete', '__wakeup'])->getMock();
+            ->onlyMethods(['delete', '__wakeup'])
+            ->addMethods(['getExecutedAt', 'getStatus'])->getMock();
         $schedule->expects($this->any())->method('getExecutedAt')->willReturn($dateExecutedAt);
         $schedule->expects($this->any())->method('getStatus')->willReturn('success');
         $this->consoleRequestMock->expects($this->any())
@@ -958,10 +911,9 @@ class ProcessCronQueueObserverTest extends TestCase
 
         $this->configMock->expects($this->atLeastOnce())->method('getJobs')->willReturn($jobConfig);
 
-        $this->cacheMock->expects($this->at(0))
-            ->method('load')->willReturn($this->time + 10000000);
-        $this->cacheMock->expects($this->at(1))
-            ->method('load')->willReturn($this->time - 10000000);
+        $this->cacheMock
+            ->method('load')
+            ->willReturnOnConsecutiveCalls($this->time + 10000000, $this->time - 10000000);
 
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')->willReturn(0);
@@ -972,11 +924,12 @@ class ProcessCronQueueObserverTest extends TestCase
             ->getMock();
         $scheduleMock->expects($this->any())
             ->method('getCollection')->willReturn($this->scheduleCollectionMock);
-        $this->scheduleFactoryMock->expects($this->at(0))
-            ->method('create')->willReturn($scheduleMock);
+        $this->scheduleFactoryMock
+            ->method('create')
+            ->willReturn($scheduleMock);
 
         $collection = $this->getMockBuilder(ScheduleCollection::class)
-            ->setMethods(['addFieldToFilter', 'load', '__wakeup'])
+            ->onlyMethods(['addFieldToFilter', 'load', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $collection->expects($this->any())
@@ -985,9 +938,9 @@ class ProcessCronQueueObserverTest extends TestCase
             ->method('load')->willReturnSelf();
         $collection->addItem($schedule);
 
-        $scheduleMock = $this->getMockBuilder(
-            Schedule::class
-        )->setMethods(['getCollection', 'getResource'])->disableOriginalConstructor()
+        $scheduleMock = $this->getMockBuilder(Schedule::class)
+            ->onlyMethods(['getCollection', 'getResource'])
+            ->disableOriginalConstructor()
             ->getMock();
         $scheduleMock->expects($this->any())
             ->method('getCollection')->willReturn($collection);
@@ -999,7 +952,10 @@ class ProcessCronQueueObserverTest extends TestCase
         $this->cronQueueObserver->execute($this->observerMock);
     }
 
-    public function testMissedJobsCleanedInTime()
+    /**
+     * @return void
+     */
+    public function testMissedJobsCleanedInTime(): void
     {
         $tableName = 'cron_schedule';
 
@@ -1012,33 +968,34 @@ class ProcessCronQueueObserverTest extends TestCase
             ->getMock();
         $scheduleMock->expects($this->any())
             ->method('getCollection')->willReturn($this->scheduleCollectionMock);
-        //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_cleanup()"
-        $this->cacheMock->expects($this->at(0))
-            ->method('load')->willReturn($this->time - 10000000);
 
         /* 2. Initialize dependencies of _generate() method which is called second */
         $jobConfig = [
-            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']],
+            'test_group' => ['test_job1' => ['instance' => 'CronJob', 'method' => 'execute']]
         ];
         //get configuration value CACHE_KEY_LAST_HISTORY_CLEANUP_AT in the "_generate()"
-        $this->cacheMock->expects($this->at(2))
-            ->method('load')->willReturn($this->time + 10000000);
-        $this->scheduleFactoryMock->expects($this->at(2))
-            ->method('create')->willReturn($scheduleMock);
+        $this->cacheMock
+            ->method('load')
+            ->willReturnOnConsecutiveCalls($this->time - 10000000, $this->time + 10000000);
+        $this->scheduleFactoryMock
+            ->method('create')
+            ->willReturn($scheduleMock);
 
         $this->configMock->expects($this->atLeastOnce())
             ->method('getJobs')->willReturn($jobConfig);
 
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
-            ->willReturnMap([
-                ['system/cron/test_group/use_separate_process', 0],
-                ['system/cron/test_group/history_cleanup_every', 10],
-                ['system/cron/test_group/schedule_lifetime', 2 * 24 * 60],
-                ['system/cron/test_group/history_success_lifetime', 0],
-                ['system/cron/test_group/history_failure_lifetime', 0],
-                ['system/cron/test_group/schedule_generate_every', 0],
-            ]);
+            ->willReturnMap(
+                [
+                    ['system/cron/test_group/use_separate_process', 0],
+                    ['system/cron/test_group/history_cleanup_every', 10],
+                    ['system/cron/test_group/schedule_lifetime', 2 * 24 * 60],
+                    ['system/cron/test_group/history_success_lifetime', 0],
+                    ['system/cron/test_group/history_failure_lifetime', 0],
+                    ['system/cron/test_group/schedule_generate_every', 0]
+                ]
+            );
 
         $this->scheduleCollectionMock->expects($this->any())->method('addFieldToFilter')->willReturnSelf();
         $this->scheduleCollectionMock->expects($this->any())->method('load')->willReturnSelf();
@@ -1070,9 +1027,10 @@ class ProcessCronQueueObserverTest extends TestCase
 
     /**
      * @param string $tableName
+     *
      * @return AdapterInterface|MockObject
      */
-    private function prepareConnectionMock(string $tableName)
+    private function prepareConnectionMock(string $tableName): AdapterInterface
     {
         $connectionMock = $this->getMockForAbstractClass(AdapterInterface::class);
 
@@ -1105,8 +1063,8 @@ class ProcessCronQueueObserverTest extends TestCase
         $connectionMock->expects($this->any())
             ->method('quoteInto')
             ->withConsecutive(
-                ['status = ?', \Magento\Cron\Model\Schedule::STATUS_RUNNING],
-                ['job_code IN (?)', ['test_job1']],
+                ['status = ?', Schedule::STATUS_RUNNING],
+                ['job_code IN (?)', ['test_job1']]
             )
             ->willReturnOnConsecutiveCalls(
                 "status = 'running'",

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -147,7 +147,7 @@ class ProcessCronQueueObserverTest extends TestCase
     protected $time = 1501538400;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Block/Adminhtml/System/CurrencyTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Block/Adminhtml/System/CurrencyTest.php
@@ -31,7 +31,7 @@ class CurrencyTest extends TestCase
     protected $objectManagerHelper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -39,7 +39,7 @@ class CurrencyTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/CurrencySymbol/Test/Unit/Block/Adminhtml/System/CurrencyTest.php
+++ b/app/code/Magento/CurrencySymbol/Test/Unit/Block/Adminhtml/System/CurrencyTest.php
@@ -11,10 +11,10 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Backend\Block\Widget\Button;
 use Magento\CurrencySymbol\Block\Adminhtml\System\Currency;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\BlockInterface;
 use Magento\Framework\View\LayoutInterface;
 use PHPUnit\Framework\TestCase;
-use Magento\Framework\UrlInterface;
 
 class CurrencyTest extends TestCase
 {
@@ -30,17 +30,26 @@ class CurrencyTest extends TestCase
      */
     protected $objectManagerHelper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManager($this);
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         unset($this->objectManagerHelper);
     }
 
-    public function testPrepareLayout()
+    /**
+     * @return void
+     */
+    public function testPrepareLayout(): void
     {
         $childBlockMock = $this->getMockBuilder(BlockInterface::class)
             ->addMethods(['addChild'])
@@ -63,20 +72,6 @@ class CurrencyTest extends TestCase
         $layoutMock->expects($this->any())->method('getBlock')->willReturn($childBlockMock);
         $layoutMock->expects($this->any())->method('createBlock')->willReturn($blockMock);
 
-        $childBlockMock->expects($this->at(0))
-            ->method('addChild')
-            ->with(
-                'save_button',
-                Button::class,
-                [
-                    'label' => __('Save Currency Rates'),
-                    'class' => 'save primary save-currency-rates',
-                    'data_attribute' => [
-                        'mage-init' => ['button' => ['event' => 'save', 'target' => '#rate-form']],
-                    ]
-                ]
-            );
-
         $contextMock = $this->createMock(Context::class);
         $urlBuilderMock = $this->createMock(UrlInterface::class);
 
@@ -90,23 +85,42 @@ class CurrencyTest extends TestCase
             ]
         )->willReturn(self::STUB_OPTION_LINK_URL);
 
-        $childBlockMock->expects($this->at(1))
+        $childBlockMock
             ->method('addChild')
-            ->with(
-                'options_button',
-                Button::class,
-                ['label' => __('Options'), 'onclick' => 'setLocation(\''.self::STUB_OPTION_LINK_URL.'\')']
+            ->withConsecutive(
+                [
+                    'save_button',
+                    Button::class,
+                    [
+                        'label' => __('Save Currency Rates'),
+                        'class' => 'save primary save-currency-rates',
+                        'data_attribute' => [
+                            'mage-init' => [
+                                'button' => ['event' => 'save', 'target' => '#rate-form']
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'options_button',
+                    Button::class,
+                    [
+                        'label' => __('Options'),
+                        'onclick' => 'setLocation(\'' . self::STUB_OPTION_LINK_URL . '\')'
+                    ]
+                ],
+                [
+                    'reset_button',
+                    Button::class,
+                    [
+                        'label' => __('Reset'),
+                        'onclick' => 'document.location.reload()',
+                        'class' => 'reset'
+                    ]
+                ]
             );
 
-        $childBlockMock->expects($this->at(2))
-            ->method('addChild')
-            ->with(
-                'reset_button',
-                Button::class,
-                ['label' => __('Reset'), 'onclick' => 'document.location.reload()', 'class' => 'reset']
-            );
-
-        /** @var \Magento\CurrencySymbol\Block\Adminhtml\System\Currency $block */
+        /** @var Currency $block */
         $block = $this->objectManagerHelper->getObject(
             Currency::class,
             [

--- a/app/code/Magento/Customer/Test/Unit/Block/Address/EditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Address/EditTest.php
@@ -75,6 +75,9 @@ class EditTest extends TestCase
      */
     protected $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -87,7 +90,8 @@ class EditTest extends TestCase
 
         $this->customerSessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAddressFormData', 'getCustomerId'])
+            ->onlyMethods(['getCustomerId'])
+            ->addMethods(['getAddressFormData'])
             ->getMock();
 
         $this->pageConfigMock = $this->getMockBuilder(Config::class)
@@ -99,7 +103,7 @@ class EditTest extends TestCase
             ->getMock();
 
         $this->addressDataFactoryMock = $this->getMockBuilder(AddressInterfaceFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -116,19 +120,22 @@ class EditTest extends TestCase
                 'pageConfig' => $this->pageConfigMock,
                 'dataObjectHelper' => $this->dataObjectHelperMock,
                 'addressDataFactory' => $this->addressDataFactoryMock,
-                'currentCustomer' => $this->currentCustomerMock,
+                'currentCustomer' => $this->currentCustomerMock
             ]
         );
     }
 
-    public function testSetLayoutWithOwnAddressAndPostedData()
+    /**
+     * @return void
+     */
+    public function testSetLayoutWithOwnAddressAndPostedData(): void
     {
         $addressId = 1;
         $customerId = 1;
         $title = __('Edit Address');
         $postedData = [
             'region_id' => 1,
-            'region' => 'region',
+            'region' => 'region'
         ];
         $newPostedData = $postedData;
         $newPostedData['region'] = $postedData;
@@ -152,10 +159,6 @@ class EditTest extends TestCase
             ->method('getCustomerId')
             ->willReturn($customerId);
 
-        $this->customerSessionMock->expects($this->at(0))
-            ->method('getCustomerId')
-            ->willReturn($customerId);
-
         $addressMock->expects($this->exactly(2))
             ->method('getId')
             ->willReturn($addressId);
@@ -172,7 +175,10 @@ class EditTest extends TestCase
             ->with($title)
             ->willReturnSelf();
 
-        $this->customerSessionMock->expects($this->at(1))
+        $this->customerSessionMock
+            ->method('getCustomerId')
+            ->willReturn($customerId);
+        $this->customerSessionMock
             ->method('getAddressFormData')
             ->with(true)
             ->willReturn($postedData);
@@ -190,10 +196,11 @@ class EditTest extends TestCase
     }
 
     /**
+     * @return void
      * @throws LocalizedException
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSetLayoutWithAlienAddress()
+    public function testSetLayoutWithAlienAddress(): void
     {
         $addressId = 1;
         $customerId = 1;
@@ -223,7 +230,7 @@ class EditTest extends TestCase
             ->method('getCustomerId')
             ->willReturn($customerId);
 
-        $this->customerSessionMock->expects($this->at(0))
+        $this->customerSessionMock
             ->method('getCustomerId')
             ->willReturn($customerId + 1);
 
@@ -296,7 +303,10 @@ class EditTest extends TestCase
         $this->assertEquals($layoutMock, $this->model->getLayout());
     }
 
-    public function testSetLayoutWithoutAddressId()
+    /**
+     * @return void
+     */
+    public function testSetLayoutWithoutAddressId(): void
     {
         $customerPrefix = 'prefix';
         $customerFirstName = 'firstname';
@@ -380,7 +390,10 @@ class EditTest extends TestCase
         $this->assertEquals($layoutMock, $this->model->getLayout());
     }
 
-    public function testSetLayoutWithoutAddress()
+    /**
+     * @return void
+     */
+    public function testSetLayoutWithoutAddress(): void
     {
         $addressId = 1;
         $customerPrefix = 'prefix';

--- a/app/code/Magento/Customer/Test/Unit/Block/Address/EditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Address/EditTest.php
@@ -76,7 +76,7 @@ class EditTest extends TestCase
     protected $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
@@ -123,6 +123,9 @@ class ConfirmTest extends TestCase
      */
     protected $redirectResultMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->customerSessionMock = $this->createMock(Session::class);
@@ -192,12 +195,15 @@ class ConfirmTest extends TestCase
                 'customerAccountManagement' => $this->customerAccountManagementMock,
                 'customerRepository' => $this->customerRepositoryMock,
                 'addressHelper' => $this->addressHelperMock,
-                'urlFactory' => $urlFactoryMock,
+                'urlFactory' => $urlFactoryMock
             ]
         );
     }
 
-    public function testIsLoggedIn()
+    /**
+     * @return void
+     */
+    public function testIsLoggedIn(): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -212,22 +218,19 @@ class ConfirmTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider getParametersDataProvider
      */
-    public function testNoCustomerIdInRequest($customerId, $key)
+    public function testNoCustomerIdInRequest($customerId, $key): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
             ->willReturn(false);
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('id', false)
-            ->willReturn($customerId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('key', false)
-            ->willReturn($key);
+            ->withConsecutive(['id', false], ['key', false])
+            ->willReturnOnConsecutiveCalls($customerId, $key);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addErrorMessage')
@@ -255,7 +258,7 @@ class ConfirmTest extends TestCase
     /**
      * @return array
      */
-    public function getParametersDataProvider()
+    public function getParametersDataProvider(): array
     {
         return [
             [true, false],
@@ -269,11 +272,17 @@ class ConfirmTest extends TestCase
      * @param $vatValidationEnabled
      * @param $addressType
      * @param Phrase $successMessage
-     * @throws \ReflectionException
+     *
+     * @return void
      * @dataProvider getSuccessMessageDataProvider
      */
-    public function testSuccessMessage($customerId, $key, $vatValidationEnabled, $addressType, Phrase $successMessage)
-    {
+    public function testSuccessMessage(
+        $customerId,
+        $key,
+        $vatValidationEnabled,
+        $addressType,
+        Phrase $successMessage
+    ): void {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
             ->willReturn(false);
@@ -283,7 +292,7 @@ class ConfirmTest extends TestCase
             ->willReturnMap(
                 [
                     ['id', false, $customerId],
-                    ['key', false, $key],
+                    ['key', false, $key]
                 ]
             );
 
@@ -375,7 +384,7 @@ class ConfirmTest extends TestCase
     /**
      * @return array
      */
-    public function getSuccessMessageDataProvider()
+    public function getSuccessMessageDataProvider(): array
     {
         return [
             [1, 1, false, null, __('Thank you for registering with %1.', 'frontend')],
@@ -400,7 +409,7 @@ class ConfirmTest extends TestCase
                     . ' to enter your shipping address for proper VAT calculation.',
                     'http://store.web/customer/address/edit'
                 )
-            ],
+            ]
         ];
     }
 
@@ -412,7 +421,8 @@ class ConfirmTest extends TestCase
      * @param $resultUrl
      * @param $isSetFlag
      * @param Phrase $successMessage
-     * @throws \ReflectionException
+     *
+     * @return void
      * @dataProvider getSuccessRedirectDataProvider
      */
     public function testSuccessRedirect(
@@ -423,7 +433,7 @@ class ConfirmTest extends TestCase
         $resultUrl,
         $isSetFlag,
         Phrase $successMessage
-    ) {
+    ): void {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
             ->willReturn(false);
@@ -434,7 +444,7 @@ class ConfirmTest extends TestCase
                 [
                     ['id', false, $customerId],
                     ['key', false, $key],
-                    ['back_url', false, $backUrl],
+                    ['back_url', false, $backUrl]
                 ]
             );
 
@@ -514,7 +524,7 @@ class ConfirmTest extends TestCase
     /**
      * @return array
      */
-    public function getSuccessRedirectDataProvider()
+    public function getSuccessRedirectDataProvider(): array
     {
         return [
             [
@@ -543,7 +553,7 @@ class ConfirmTest extends TestCase
                 'http://example.com/success',
                 false,
                 __('Thank you for registering with %1.', 'frontend'),
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Account/ConfirmTest.php
@@ -124,7 +124,7 @@ class ConfirmTest extends TestCase
     protected $redirectResultMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/DataProviderTest.php
@@ -84,7 +84,7 @@ class DataProviderTest extends TestCase
     private $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/DataProviderTest.php
@@ -58,8 +58,8 @@ class DataProviderTest extends TestCase
      */
     private $eavConfig;
 
-    /*
-     * @var ContextInterface|\PHPUnit\Framework\MockObject\MockObject
+    /**
+     * @var ContextInterface|MockObject
      */
     private $context;
 
@@ -83,6 +83,9 @@ class DataProviderTest extends TestCase
      */
     private $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManager($this);
@@ -94,7 +97,7 @@ class DataProviderTest extends TestCase
             ->getMock();
         $this->addressCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->collection = $this->getMockBuilder(AddressCollection::class)
             ->disableOriginalConstructor()
@@ -115,9 +118,9 @@ class DataProviderTest extends TestCase
         $this->address = $this->getMockBuilder(AddressModel::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->attributeMetadataResolver->expects($this->at(0))
+        $this->attributeMetadataResolver
             ->method('getAttributesMeta')
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
                 [
                     'arguments' => [
                         'data' => [
@@ -131,15 +134,11 @@ class DataProviderTest extends TestCase
                                 'sortOrder' => 'sort_order',
                                 'default' => 'default_value',
                                 'size' => 'multiline_count',
-                                'componentType' => Field::NAME,
-                            ],
-                        ],
-                    ],
-                ]
-            );
-        $this->attributeMetadataResolver->expects($this->at(1))
-            ->method('getAttributesMeta')
-            ->willReturn(
+                                'componentType' => Field::NAME
+                            ]
+                        ]
+                    ]
+                ],
                 [
                     'arguments' => [
                         'data' => [
@@ -156,19 +155,19 @@ class DataProviderTest extends TestCase
                                 'prefer' => 'toggle',
                                 'valueMap' => [
                                     'true' => 1,
-                                    'false' => 0,
-                                ],
-                            ],
-                        ],
-                    ],
+                                    'false' => 0
+                                ]
+                            ]
+                        ]
+                    ]
                 ]
             );
         $this->model = $objectManagerHelper->getObject(
             DataProvider::class,
             [
-                'name'                      => 'test-name',
-                'primaryFieldName'          => 'primary-field-name',
-                'requestFieldName'          => 'request-field-name',
+                'name' => 'test-name',
+                'primaryFieldName' => 'primary-field-name',
+                'requestFieldName' => 'request-field-name',
                 'addressCollectionFactory' => $this->addressCollectionFactory,
                 'customerRepository' => $this->customerRepository,
                 'eavConfig' => $this->eavConfig,
@@ -182,6 +181,9 @@ class DataProviderTest extends TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testGetDefaultData(): void
     {
         $expectedData = [
@@ -212,6 +214,9 @@ class DataProviderTest extends TestCase
         $this->assertEquals($expectedData, $this->model->getData());
     }
 
+    /**
+     * @return void
+     */
     public function testGetData(): void
     {
         $expectedData = [
@@ -272,7 +277,7 @@ class DataProviderTest extends TestCase
      * @param array $customerAttributes
      * @return Type|MockObject
      */
-    protected function getTypeAddressMock($customerAttributes = [])
+    protected function getTypeAddressMock(array $customerAttributes = []): Type
     {
         $typeAddressMock = $this->getMockBuilder(Type::class)
             ->disableOriginalConstructor()
@@ -295,23 +300,23 @@ class DataProviderTest extends TestCase
      * Get attribute mock
      *
      * @param array $options
+     *
      * @return AbstractAttribute[]|MockObject[]
      */
-    protected function getAttributeMock($options = []): array
+    protected function getAttributeMock(array $options = []): array
     {
         $attributeMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getSource',
                     'getIsUserDefined',
-                    'getUsedInForms',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -325,18 +330,17 @@ class DataProviderTest extends TestCase
             ->willReturn($attributeCode);
 
         $attributeBooleanMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getIsUserDefined',
-                    'getUsedInForms',
                     'getSource',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -350,6 +354,7 @@ class DataProviderTest extends TestCase
             ->willReturn($booleanAttributeCode);
 
         $mocks = [$attributeMock, $attributeBooleanMock];
+
         return $mocks;
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Test\Unit\Model\Customer;
 
+use Closure;
 use Magento\Customer\Api\CustomerMetadataInterface;
 use Magento\Customer\Model\Address;
 use Magento\Customer\Model\Config\Share;
@@ -71,7 +72,7 @@ class DataProviderTest extends TestCase
     private $fileUploaderDataResolver;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -83,9 +84,8 @@ class DataProviderTest extends TestCase
             ->getMockBuilder(EavValidationRules::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->sessionMock = $this
-            ->getMockBuilder(SessionManagerInterface::class)
-            ->setMethods(['getCustomerFormData', 'unsCustomerFormData'])
+        $this->sessionMock = $this->getMockBuilder(SessionManagerInterface::class)
+            ->addMethods(['getCustomerFormData', 'unsCustomerFormData'])
             ->getMockForAbstractClass();
 
         $this->fileProcessor = $this->getMockBuilder(FileProcessor::class)
@@ -93,7 +93,7 @@ class DataProviderTest extends TestCase
             ->getMock();
         $this->fileUploaderDataResolver = $this->getMockBuilder(FileUploaderDataResolver::class)
             ->disableOriginalConstructor()
-            ->setMethods(['overrideFileUploaderMetadata', 'overrideFileUploaderData'])
+            ->onlyMethods(['overrideFileUploaderMetadata', 'overrideFileUploaderData'])
             ->getMock();
     }
 
@@ -105,7 +105,7 @@ class DataProviderTest extends TestCase
      *
      * @dataProvider getAttributesMetaDataProvider
      */
-    public function testGetAttributesMetaWithOptions(array $expected)
+    public function testGetAttributesMetaWithOptions(array $expected): void
     {
         $helper = new ObjectManager($this);
         /** @var CustomerDataProvider $dataProvider */
@@ -118,7 +118,7 @@ class DataProviderTest extends TestCase
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->getCustomerCollectionFactoryMock(),
                 'eavConfig' => $this->getEavConfigMock(),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
             ]
         );
 
@@ -133,7 +133,7 @@ class DataProviderTest extends TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function getAttributesMetaDataProvider()
+    public function getAttributesMetaDataProvider(): array
     {
         return [
             [
@@ -154,10 +154,10 @@ class DataProviderTest extends TestCase
                                             'notice' => 'note',
                                             'default' => 'default_value',
                                             'size' => 'multiline_count',
-                                            'componentType' => Field::NAME,
-                                        ],
-                                    ],
-                                ],
+                                            'componentType' => Field::NAME
+                                        ]
+                                    ]
+                                ]
                             ],
                             'test-code-boolean' => [
                                 'arguments' => [
@@ -176,13 +176,13 @@ class DataProviderTest extends TestCase
                                             'prefer' => 'toggle',
                                             'valueMap' => [
                                                 'true' => 1,
-                                                'false' => 0,
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
+                                                'false' => 0
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
                     ],
                     'address' => [
                         'children' => [
@@ -200,10 +200,10 @@ class DataProviderTest extends TestCase
                                             'notice' => 'note',
                                             'default' => 'default_value',
                                             'size' => 'multiline_count',
-                                            'componentType' => Field::NAME,
-                                        ],
-                                    ],
-                                ],
+                                            'componentType' => Field::NAME
+                                        ]
+                                    ]
+                                ]
                             ],
                             'test-code-boolean' => [
                                 'arguments' => [
@@ -222,11 +222,11 @@ class DataProviderTest extends TestCase
                                             'prefer' => 'toggle',
                                             'valueMap' => [
                                                 'true' => 1,
-                                                'false' => 0,
-                                            ],
-                                        ],
-                                    ],
-                                ],
+                                                'false' => 0
+                                            ]
+                                        ]
+                                    ]
+                                ]
                             ],
                             'country_id' => [
                                 'arguments' => [
@@ -246,14 +246,14 @@ class DataProviderTest extends TestCase
                                             'filterBy' => [
                                                 'target' => '${ $.provider }:data.customer.website_id',
                                                 '__disableTmpl' => ['target' => false],
-                                                'field' => 'website_ids',
-                                            ],
-                                        ],
-                                    ],
-                                ],
+                                                'field' => 'website_ids'
+                                            ]
+                                        ]
+                                    ]
+                                ]
                             ]
-                        ],
-                    ],
+                        ]
+                    ]
                 ]
             ]
         ];
@@ -262,7 +262,7 @@ class DataProviderTest extends TestCase
     /**
      * @return CollectionFactory|MockObject
      */
-    protected function getCustomerCollectionFactoryMock()
+    protected function getCustomerCollectionFactoryMock(): CollectionFactory
     {
         $collectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -280,26 +280,24 @@ class DataProviderTest extends TestCase
     }
 
     /**
+     * @param array $customerAttributes
      * @return Config|MockObject
      */
-    protected function getEavConfigMock($customerAttributes = [])
+    protected function getEavConfigMock(array $customerAttributes = []): Config
     {
-        $this->eavConfigMock->expects($this->at(0))
+        $this->eavConfigMock
             ->method('getEntityType')
-            ->with('customer')
-            ->willReturn($this->getTypeCustomerMock($customerAttributes));
-        $this->eavConfigMock->expects($this->at(1))
-            ->method('getEntityType')
-            ->with('customer_address')
-            ->willReturn($this->getTypeAddressMock());
+            ->withConsecutive(['customer'], ['customer_address'])
+            ->willReturnOnConsecutiveCalls($this->getTypeCustomerMock($customerAttributes), $this->getTypeAddressMock());
 
         return $this->eavConfigMock;
     }
 
     /**
+     * @param array $customerAttributes
      * @return Type|MockObject
      */
-    protected function getTypeCustomerMock($customerAttributes = [])
+    protected function getTypeCustomerMock(array $customerAttributes = []): Type
     {
         $typeCustomerMock = $this->getMockBuilder(Type::class)
             ->disableOriginalConstructor()
@@ -324,7 +322,7 @@ class DataProviderTest extends TestCase
     /**
      * @return Type|MockObject
      */
-    protected function getTypeAddressMock()
+    protected function getTypeAddressMock(): Type
     {
         $typeAddressMock = $this->getMockBuilder(Type::class)
             ->disableOriginalConstructor()
@@ -341,12 +339,14 @@ class DataProviderTest extends TestCase
      * @param MockObject $attributeMock
      * @param MockObject $attributeBooleanMock
      * @param array $options
+     *
+     * @return void
      */
     private function injectVisibilityProps(
         MockObject $attributeMock,
         MockObject $attributeBooleanMock,
         array $options = []
-    ) {
+    ): void {
         if (isset($options[self::ATTRIBUTE_CODE]['visible'])) {
             $attributeMock->expects($this->any())
                 ->method('getIsVisible')
@@ -385,24 +385,25 @@ class DataProviderTest extends TestCase
     }
 
     /**
+     * @param string $type
+     * @param array $options
      * @return AbstractAttribute[]|MockObject[]
      */
-    protected function getAttributeMock($type = 'customer', $options = [])
+    protected function getAttributeMock(string $type = 'customer', array $options = []): array
     {
         $attributeMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'usesSource',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getSource',
                     'getIsUserDefined',
-                    'getUsedInForms',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $sourceMock = $this->getMockBuilder(AbstractSource::class)
@@ -434,19 +435,18 @@ class DataProviderTest extends TestCase
             ->willReturn($sourceMock);
 
         $attributeBooleanMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'usesSource',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getIsUserDefined',
-                    'getUsedInForms',
                     'getSource',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -482,15 +482,16 @@ class DataProviderTest extends TestCase
         if ($type == "address") {
             $mocks[] = $this->getCountryAttrMock();
         }
+
         return $mocks;
     }
 
     /**
      * Callback for ::getDataUsingMethod.
      *
-     * @return \Closure
+     * @return Closure
      */
-    private function attributeGetUsingMethodCallback()
+    private function attributeGetUsingMethodCallback(): Closure
     {
         return function ($origName) {
             return $origName;
@@ -500,7 +501,7 @@ class DataProviderTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getCountryAttrMock()
+    private function getCountryAttrMock(): MockObject
     {
         $countryByWebsiteMock = $this->getMockBuilder(CountryWithWebsites::class)
             ->disableOriginalConstructor()
@@ -522,7 +523,8 @@ class DataProviderTest extends TestCase
             );
         \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
         $countryAttrMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(['getAttributeCode', 'getDataUsingMethod', 'usesSource', 'getSource', 'getLabel'])
+            ->onlyMethods(['getAttributeCode', 'getDataUsingMethod', 'usesSource', 'getSource'])
+            ->addMethods(['getLabel'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -554,7 +556,7 @@ class DataProviderTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetData()
+    public function testGetData(): void
     {
         $customerData = [
             'email' => 'test@test.ua',
@@ -562,12 +564,12 @@ class DataProviderTest extends TestCase
             'default_shipping' => 2,
             'password_hash' => 'password_hash',
             'rp_token' => 'rp_token',
-            'confirmation' => 'confirmation',
+            'confirmation' => 'confirmation'
         ];
         $addressData = [
             'firstname' => 'firstname',
             'lastname' => 'lastname',
-            'street' => "street\nstreet",
+            'street' => "street\nstreet"
         ];
 
         $customer = $this->getMockBuilder(Customer::class)
@@ -618,7 +620,7 @@ class DataProviderTest extends TestCase
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->customerCollectionFactoryMock,
                 'eavConfig' => $this->getEavConfigMock(),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
             ]
         );
 
@@ -637,7 +639,7 @@ class DataProviderTest extends TestCase
                     'customer' => [
                         'email' => 'test@test.ua',
                         'default_billing' => 2,
-                        'default_shipping' => 2,
+                        'default_shipping' => 2
                     ],
                     'address' => [
                         2 => [
@@ -646,7 +648,7 @@ class DataProviderTest extends TestCase
                             // Won't be an array because it isn't defined as a multiline field in this test
                             'street' => "street\nstreet",
                             'default_billing' => 2,
-                            'default_shipping' => 2,
+                            'default_shipping' => 2
                         ],
                     ],
                 ],
@@ -659,7 +661,7 @@ class DataProviderTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetDataWithCustomerFormData()
+    public function testGetDataWithCustomerFormData(): void
     {
         $customerId = 11;
         $customerFormData = [
@@ -667,7 +669,7 @@ class DataProviderTest extends TestCase
                 'email' => 'test1@test1.ua',
                 'default_billing' => 3,
                 'default_shipping' => 3,
-                'entity_id' => $customerId,
+                'entity_id' => $customerId
             ],
             'address' => [
                 3 => [
@@ -675,12 +677,12 @@ class DataProviderTest extends TestCase
                     'lastname' => 'lastname1',
                     'street' => [
                         'street1',
-                        'street2',
+                        'street2'
                     ],
                     'default_billing' => 3,
-                    'default_shipping' => 3,
-                ],
-            ],
+                    'default_shipping' => 3
+                ]
+            ]
         ];
 
         $customer = $this->getMockBuilder(Customer::class)
@@ -710,7 +712,7 @@ class DataProviderTest extends TestCase
                 [
                     'email' => 'test@test.ua',
                     'default_billing' => 2,
-                    'default_shipping' => 2,
+                    'default_shipping' => 2
                 ]
             );
         $customer->expects($this->once())
@@ -732,7 +734,7 @@ class DataProviderTest extends TestCase
                 [
                     'firstname' => 'firstname',
                     'lastname' => 'lastname',
-                    'street' => "street\nstreet",
+                    'street' => "street\nstreet"
                 ]
             );
         $helper = new ObjectManager($this);
@@ -745,7 +747,7 @@ class DataProviderTest extends TestCase
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->customerCollectionFactoryMock,
                 'eavConfig' => $this->getEavConfigMock(),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
             ]
         );
 
@@ -764,10 +766,10 @@ class DataProviderTest extends TestCase
     }
 
     /**
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @return void
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetDataWithCustomAttributeImage()
+    public function testGetDataWithCustomAttributeImage(): void
     {
         $customerId = 1;
         $customerEmail = 'user1@example.com';
@@ -782,7 +784,7 @@ class DataProviderTest extends TestCase
             ->willReturn(
                 [
                     'email' => $customerEmail,
-                    'img1' => $filename,
+                    'img1' => $filename
                 ]
             );
         $customerMock->expects($this->once())
@@ -816,7 +818,7 @@ class DataProviderTest extends TestCase
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->customerCollectionFactoryMock,
                 'eavConfig' => $this->getEavConfigMock(),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
             ]
         );
 
@@ -841,7 +843,7 @@ class DataProviderTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetAttributesMetaWithCustomAttributeImage()
+    public function testGetAttributesMetaWithCustomAttributeImage(): void
     {
         $maxFileSize = 1000;
         $allowedExtension = 'ext1 ext2';
@@ -860,13 +862,7 @@ class DataProviderTest extends TestCase
             ->willReturn($collectionMock);
 
         $attributeMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
-                [
-                    'getAttributeCode',
-                    'getFrontendInput',
-                    'getDataUsingMethod',
-                ]
-            )
+            ->onlyMethods(['getAttributeCode', 'getFrontendInput', 'getDataUsingMethod'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $attributeMock->expects($this->any())
@@ -900,14 +896,10 @@ class DataProviderTest extends TestCase
             ->method('getAttributeCollection')
             ->willReturn([]);
 
-        $this->eavConfigMock->expects($this->at(0))
+        $this->eavConfigMock
             ->method('getEntityType')
-            ->with('customer')
-            ->willReturn($typeCustomerMock);
-        $this->eavConfigMock->expects($this->at(1))
-            ->method('getEntityType')
-            ->with('customer_address')
-            ->willReturn($typeAddressMock);
+            ->withConsecutive(['customer'], ['customer_address'])
+            ->willReturnOnConsecutiveCalls($typeCustomerMock, $typeAddressMock);
 
         $this->eavValidationRulesMock->expects($this->once())
             ->method('build')
@@ -922,13 +914,13 @@ class DataProviderTest extends TestCase
                     'notice' => 'note',
                     'default' => 'default_value',
                     'size' => 'multiline_count',
-                    'label' => __('frontend_label'),
+                    'label' => __('frontend_label')
                 ]
             )
             ->willReturn(
                 [
                     'max_file_size' => $maxFileSize,
-                    'file_extensions' => 'ext1, eXt2 ', // Added spaces and upper-cases
+                    'file_extensions' => 'ext1, eXt2 ' // Added spaces and upper-cases
                 ]
             );
 
@@ -941,7 +933,7 @@ class DataProviderTest extends TestCase
                 'requestFieldName' => 'request-field-name',
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->customerCollectionFactoryMock,
-                'eavConfig' => $this->eavConfigMock,
+                'eavConfig' => $this->eavConfigMock
             ]
         );
 
@@ -962,24 +954,24 @@ class DataProviderTest extends TestCase
                                     'maxFileSize' => $maxFileSize,
                                     'allowedExtensions' => $allowedExtension,
                                     'uploaderConfig' => [
-                                        'url' => 'customer/file/customer_upload',
+                                        'url' => 'customer/file/customer_upload'
                                     ],
                                     'sortOrder' => 'sort_order',
                                     'required' => 'is_required',
                                     'visible' => null,
                                     'validation' => [
                                         'max_file_size' => $maxFileSize,
-                                        'file_extensions' => 'ext1, eXt2 ',
+                                        'file_extensions' => 'ext1, eXt2 '
                                     ],
-                                    'label' => __('frontend_label'),
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
+                                    'label' => __('frontend_label')
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
             ],
             'address' => [
-                'children' => [],
+                'children' => []
             ],
         ];
 
@@ -989,7 +981,7 @@ class DataProviderTest extends TestCase
     /**
      * @return void
      */
-    public function testGetDataWithVisibleAttributes()
+    public function testGetDataWithVisibleAttributes(): void
     {
         $firstAttributesBundle = $this->getAttributeMock(
             'customer',
@@ -998,13 +990,13 @@ class DataProviderTest extends TestCase
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_edit'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_1",
+                    'specific_code_prefix' => "_1"
                 ],
                 'test-code-boolean' => [
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_1",
+                    'specific_code_prefix' => "_1"
                 ]
             ]
         );
@@ -1015,13 +1007,13 @@ class DataProviderTest extends TestCase
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => false,
-                    'specific_code_prefix' => "_2",
+                    'specific_code_prefix' => "_2"
                 ],
                 'test-code-boolean' => [
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_2",
+                    'specific_code_prefix' => "_2"
                 ]
             ]
         );
@@ -1037,7 +1029,7 @@ class DataProviderTest extends TestCase
                 'eavValidationRules' => $this->eavValidationRulesMock,
                 'customerCollectionFactory' => $this->getCustomerCollectionFactoryMock(),
                 'eavConfig' => $this->getEavConfigMock(array_merge($firstAttributesBundle, $secondAttributesBundle)),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
             ]
         );
 
@@ -1049,7 +1041,7 @@ class DataProviderTest extends TestCase
     /**
      * @return void
      */
-    public function testGetDataWithVisibleAttributesWithAccountEdit()
+    public function testGetDataWithVisibleAttributesWithAccountEdit(): void
     {
         $firstAttributesBundle = $this->getAttributeMock(
             'customer',
@@ -1058,13 +1050,13 @@ class DataProviderTest extends TestCase
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_edit'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_1",
+                    'specific_code_prefix' => "_1"
                 ],
                 'test-code-boolean' => [
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_1",
+                    'specific_code_prefix' => "_1"
                 ]
             ]
         );
@@ -1075,20 +1067,20 @@ class DataProviderTest extends TestCase
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => false,
-                    'specific_code_prefix' => "_2",
+                    'specific_code_prefix' => "_2"
                 ],
                 'test-code-boolean' => [
                     'visible' => true,
                     'is_used_in_forms' => ['customer_account_create'],
                     'user_defined' => true,
-                    'specific_code_prefix' => "_2",
+                    'specific_code_prefix' => "_2"
                 ]
             ]
         );
 
         $helper = new ObjectManager($this);
         $context = $this->getMockBuilder(ContextInterface::class)
-            ->setMethods(['getRequestParam'])
+            ->onlyMethods(['getRequestParam'])
             ->getMockForAbstractClass();
         $context->expects($this->any())
             ->method('getRequestParam')
@@ -1105,7 +1097,7 @@ class DataProviderTest extends TestCase
                 'customerCollectionFactory' => $this->getCustomerCollectionFactoryMock(),
                 'context' => $context,
                 'eavConfig' => $this->getEavConfigMock(array_merge($firstAttributesBundle, $secondAttributesBundle)),
-                'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
+                'fileUploaderDataResolver' => $this->fileUploaderDataResolver
 
             ]
         );
@@ -1120,7 +1112,7 @@ class DataProviderTest extends TestCase
      *
      * @return array
      */
-    private function getCustomerAttributeExpectations()
+    private function getCustomerAttributeExpectations(): array
     {
         return [
             self::ATTRIBUTE_CODE . "_1" => [
@@ -1137,10 +1129,10 @@ class DataProviderTest extends TestCase
                             'notice' => 'note',
                             'default' => 'default_value',
                             'size' => 'multiline_count',
-                            'componentType' => Field::NAME,
-                        ],
-                    ],
-                ],
+                            'componentType' => Field::NAME
+                        ]
+                    ]
+                ]
             ],
             self::ATTRIBUTE_CODE . "_2" => [
                 'arguments' => [
@@ -1157,9 +1149,9 @@ class DataProviderTest extends TestCase
                             'default' => 'default_value',
                             'size' => 'multiline_count',
                             'componentType' => Field::NAME,
-                        ],
-                    ],
-                ],
+                        ]
+                    ]
+                ]
             ],
             'test-code-boolean_1' => [
                 'arguments' => [
@@ -1178,11 +1170,11 @@ class DataProviderTest extends TestCase
                             'prefer' => 'toggle',
                             'valueMap' => [
                                 'true' => 1,
-                                'false' => 0,
-                            ],
-                        ],
-                    ],
-                ],
+                                'false' => 0
+                            ]
+                        ]
+                    ]
+                ]
             ],
             'test-code-boolean_2' => [
                 'arguments' => [
@@ -1201,12 +1193,12 @@ class DataProviderTest extends TestCase
                             'prefer' => 'toggle',
                             'valueMap' => [
                                 'true' => 1,
-                                'false' => 0,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+                                'false' => 0
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 
@@ -1215,7 +1207,7 @@ class DataProviderTest extends TestCase
      *
      * @return  array
      */
-    private function getExpectationForVisibleAttributes()
+    private function getExpectationForVisibleAttributes(): array
     {
         return [
             'customer' => [
@@ -1237,10 +1229,10 @@ class DataProviderTest extends TestCase
                                     'notice' => 'note',
                                     'default' => 'default_value',
                                     'size' => 'multiline_count',
-                                    'componentType' => Field::NAME,
-                                ],
-                            ],
-                        ],
+                                    'componentType' => Field::NAME
+                                ]
+                            ]
+                        ]
                     ],
                     'test-code-boolean' => [
                         'arguments' => [
@@ -1259,11 +1251,11 @@ class DataProviderTest extends TestCase
                                     'prefer' => 'toggle',
                                     'valueMap' => [
                                         'true' => 1,
-                                        'false' => 0,
-                                    ],
-                                ],
-                            ],
-                        ],
+                                        'false' => 0
+                                    ]
+                                ]
+                            ]
+                        ]
                     ],
                     'country_id' => [
                         'arguments' => [
@@ -1283,14 +1275,14 @@ class DataProviderTest extends TestCase
                                     'filterBy' => [
                                         'target' => '${ $.provider }:data.customer.website_id',
                                         '__disableTmpl' => ['target' => false],
-                                        'field' => 'website_ids',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+                                        'field' => 'website_ids'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderTest.php
@@ -72,7 +72,7 @@ class DataProviderTest extends TestCase
     private $fileUploaderDataResolver;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
@@ -79,7 +79,8 @@ class DataProviderWithDefaultAddressesTest extends TestCase
     private $dataProvider;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -87,11 +88,12 @@ class DataProviderWithDefaultAddressesTest extends TestCase
         $this->eavConfigMock = $this->getMockBuilder(Config::class)->disableOriginalConstructor()->getMock();
         $this->customerCollectionFactoryMock = $this->createPartialMock(CustomerCollectionFactory::class, ['create']);
         $this->sessionMock = $this->getMockBuilder(SessionManagerInterface::class)
-            ->setMethods(['getCustomerFormData', 'unsCustomerFormData'])
+            ->addMethods(['getCustomerFormData', 'unsCustomerFormData'])
             ->getMockForAbstractClass();
         $this->countryFactoryMock = $this->getMockBuilder(CountryFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create', 'loadByCode', 'getName'])
+            ->onlyMethods(['create'])
+            ->addMethods(['loadByCode','getName'])
             ->getMock();
         $this->customerMock = $this->getMockBuilder(Customer::class)
             ->disableOriginalConstructor()
@@ -112,11 +114,11 @@ class DataProviderWithDefaultAddressesTest extends TestCase
             ->getMock();
         $this->attributeMetadataResolver = $this->getMockBuilder(AttributeMetadataResolver::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributesMeta'])
+            ->onlyMethods(['getAttributesMeta'])
             ->getMock();
-        $this->attributeMetadataResolver->expects($this->at(0))
+        $this->attributeMetadataResolver
             ->method('getAttributesMeta')
-            ->willReturn(
+            ->willReturnOnConsecutiveCalls(
                 [
                     'arguments' => [
                         'data' => [
@@ -131,15 +133,11 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                                 'notice' => 'note',
                                 'default' => 'default_value',
                                 'size' => 'multiline_count',
-                                'componentType' => Field::NAME,
-                            ],
-                        ],
-                    ],
-                ]
-            );
-        $this->attributeMetadataResolver->expects($this->at(1))
-            ->method('getAttributesMeta')
-            ->willReturn(
+                                'componentType' => Field::NAME
+                            ]
+                        ]
+                    ]
+                ],
                 [
                     'arguments' => [
                         'data' => [
@@ -157,11 +155,11 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                                 'prefer' => 'toggle',
                                 'valueMap' => [
                                     'true' => 1,
-                                    'false' => 0,
-                                ],
-                            ],
-                        ],
-                    ],
+                                    'false' => 0
+                                ]
+                            ]
+                        ]
+                    ]
                 ]
             );
 
@@ -178,7 +176,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                 'session' => $this->sessionMock,
                 'fileUploaderDataResolver' => $this->fileUploaderDataResolver,
                 'attributeMetadataResolver' => $this->attributeMetadataResolver,
-                'allowToShowHiddenAttributes' => true,
+                'allowToShowHiddenAttributes' => true
             ]
         );
     }
@@ -224,10 +222,10 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                                             'notice' => 'note',
                                             'default' => 'default_value',
                                             'size' => 'multiline_count',
-                                            'componentType' => Field::NAME,
-                                        ],
-                                    ],
-                                ],
+                                            'componentType' => Field::NAME
+                                        ]
+                                    ]
+                                ]
                             ],
                             'test-code-boolean' => [
                                 'arguments' => [
@@ -246,14 +244,14 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                                             'prefer' => 'toggle',
                                             'valueMap' => [
                                                 'true' => 1,
-                                                'false' => 0,
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
+                                                'false' => 0
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ]
             ]
         ];
@@ -263,7 +261,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
      * @param array $customerAttributes
      * @return Type|MockObject
      */
-    protected function getTypeCustomerMock($customerAttributes = [])
+    protected function getTypeCustomerMock($customerAttributes = []): Type
     {
         $typeCustomerMock = $this->getMockBuilder(Type::class)
             ->disableOriginalConstructor()
@@ -286,21 +284,20 @@ class DataProviderWithDefaultAddressesTest extends TestCase
      * @param array $options
      * @return AbstractAttribute[]|MockObject[]
      */
-    protected function getAttributeMock($options = []): array
+    protected function getAttributeMock(array $options = []): array
     {
         $attributeMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getSource',
                     'getIsUserDefined',
-                    'getUsedInForms',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -314,18 +311,17 @@ class DataProviderWithDefaultAddressesTest extends TestCase
             ->willReturn($attributeCode);
 
         $attributeBooleanMock = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
                     'getDataUsingMethod',
                     'getFrontendInput',
-                    'getIsVisible',
                     'getIsUserDefined',
-                    'getUsedInForms',
                     'getSource',
-                    'getEntityType',
+                    'getEntityType'
                 ]
             )
+            ->addMethods(['getIsVisible', 'getUsedInForms'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -353,14 +349,14 @@ class DataProviderWithDefaultAddressesTest extends TestCase
             'default_billing' => 2,
             'default_shipping' => 2,
             'password_hash' => 'password_hash',
-            'rp_token' => 'rp_token',
+            'rp_token' => 'rp_token'
         ];
         $addressData = [
             'country_id' => 'code',
             'entity_id' => 2,
             'parent_id' => $customerId,
             'street' => "line 1\nline 2",
-            'region' => 'Region Name',
+            'region' => 'Region Name'
         ];
         $localeRegionName = 'Locale Region Name';
 
@@ -395,7 +391,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                     'customer' => [
                         'email' => 'test@test.ua',
                         'default_billing' => 2,
-                        'default_shipping' => 2,
+                        'default_shipping' => 2
                     ],
                     'default_billing_address' => [
                         'country' => 'Ukraine',
@@ -403,7 +399,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                         'entity_id' => 2,
                         'parent_id' => $customerId,
                         'street' => ['line 1', 'line 2'],
-                        'region' => $localeRegionName,
+                        'region' => $localeRegionName
                     ],
                     'default_shipping_address' => [],
                     'customer_id' => $customerId
@@ -424,7 +420,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                 'email' => 'test1@test1.ua',
                 'default_billing' => 3,
                 'default_shipping' => 3,
-                'entity_id' => $customerId,
+                'entity_id' => $customerId
             ],
             'address' => [
                 3 => [
@@ -432,10 +428,10 @@ class DataProviderWithDefaultAddressesTest extends TestCase
                     'lastname' => 'lastname1',
                     'street' => [
                         'street1',
-                        'street2',
+                        'street2'
                     ],
                     'default_billing' => 3,
-                    'default_shipping' => 3,
+                    'default_shipping' => 3
                 ],
             ],
         ];
@@ -443,11 +439,13 @@ class DataProviderWithDefaultAddressesTest extends TestCase
         $this->customerCollectionMock->expects($this->once())->method('getItems')->willReturn([$this->customerMock]);
         $this->customerMock->expects($this->once())
             ->method('getData')
-            ->willReturn([
-                'email' => 'test@test.ua',
-                'default_billing' => 2,
-                'default_shipping' => 2,
-            ]);
+            ->willReturn(
+                [
+                    'email' => 'test@test.ua',
+                    'default_billing' => 2,
+                    'default_shipping' => 2
+                ]
+            );
         $this->customerMock->expects($this->atLeastOnce())->method('getId')->willReturn($customerId);
 
         $this->sessionMock->expects($this->once())->method('getCustomerFormData')->willReturn($customerFormData);

--- a/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Customer/DataProviderWithDefaultAddressesTest.php
@@ -79,7 +79,7 @@ class DataProviderWithDefaultAddressesTest extends TestCase
     private $dataProvider;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
@@ -120,7 +120,7 @@ class EmailNotificationTest extends TestCase
     private $emulation;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/EmailNotificationTest.php
@@ -120,7 +120,7 @@ class EmailNotificationTest extends TestCase
     private $emulation;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -146,7 +146,7 @@ class EmailNotificationTest extends TestCase
         $this->storeMock = $this->createMock(Store::class);
 
         $this->senderResolverMock = $this->getMockBuilder(SenderResolverInterface::class)
-            ->setMethods(['resolve'])
+            ->onlyMethods(['resolve'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->emulation = $this->createMock(Emulation::class);
@@ -163,7 +163,7 @@ class EmailNotificationTest extends TestCase
                 'dataProcessor' => $this->dataProcessorMock,
                 'scopeConfig' => $this->scopeConfigMock,
                 'senderResolver' => $this->senderResolverMock,
-                'emulation' => $this->emulation,
+                'emulation' => $this->emulation
             ]
         );
     }
@@ -187,7 +187,7 @@ class EmailNotificationTest extends TestCase
         $oldEmail,
         $newEmail,
         $isPasswordChanged
-    ):void {
+    ): void {
         $customerData = ['key' => 'value'];
         $senderValues = ['name' => self::STUB_SENDER, 'email' => self::STUB_SENDER];
 
@@ -357,7 +357,6 @@ class EmailNotificationTest extends TestCase
     /**
      * Provides Emails Data Provider
      *
-     * @param void
      * @return array
      */
     public function sendNotificationEmailsDataProvider(): array
@@ -412,11 +411,12 @@ class EmailNotificationTest extends TestCase
      * Test Password Reminder Email Notify
      *
      * @param int $customerStoreId
-     * @dataProvider customerStoreIdDataProvider
+     *
      * @return void
+     * @dataProvider customerStoreIdDataProvider
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPasswordReminder($customerStoreId):void
+    public function testPasswordReminder(int $customerStoreId): void
     {
         $customerData = ['key' => 'value'];
         $senderValues = ['name' => self::STUB_SENDER, 'email' => self::STUB_SENDER];
@@ -451,7 +451,7 @@ class EmailNotificationTest extends TestCase
             ->method('getId')
             ->willReturn($customerStoreId);
 
-        $this->storeManagerMock->expects($this->at(0))
+        $this->storeManagerMock
             ->method('getStore')
             ->willReturn($this->storeMock);
 
@@ -489,20 +489,13 @@ class EmailNotificationTest extends TestCase
             ->with('name', self::STUB_CUSTOMER_NAME)
             ->willReturnSelf();
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_REMIND_EMAIL_TEMPLATE,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_EMAIL_IDENTIFIER);
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_SENDER);
+            ->withConsecutive(
+                [EmailNotification::XML_PATH_REMIND_EMAIL_TEMPLATE, ScopeInterface::SCOPE_STORE, $customerStoreId],
+                [EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY, ScopeInterface::SCOPE_STORE, $customerStoreId]
+            )
+            ->willReturnOnConsecutiveCalls(self::STUB_EMAIL_IDENTIFIER, self::STUB_SENDER);
 
         $this->mockDefaultTransportBuilder(
             self::STUB_EMAIL_IDENTIFIER,
@@ -527,9 +520,10 @@ class EmailNotificationTest extends TestCase
     /**
      * Test password reminder customer withouer store id info
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPasswordReminderCustomerWithoutStoreId():void
+    public function testPasswordReminderCustomerWithoutStoreId(): void
     {
         $customerStoreId = null;
         $customerData = ['key' => 'value'];
@@ -560,13 +554,10 @@ class EmailNotificationTest extends TestCase
         $this->storeMock->expects($this->any())
             ->method('getId')
             ->willReturn($defaultStoreId);
-        $this->storeManagerMock->expects($this->at(0))
-            ->method('getStore')
-            ->willReturn($this->storeMock);
-        $this->storeManagerMock->expects($this->at(1))
+        $this->storeManagerMock
             ->method('getStore')
             ->with($defaultStoreId)
-            ->willReturn($this->storeMock);
+            ->willReturnOnConsecutiveCalls($this->storeMock, $this->storeMock);
         $websiteMock = $this->createPartialMock(Website::class, ['getStoreIds']);
         $websiteMock->expects($this->any())
             ->method('getStoreIds')
@@ -596,20 +587,13 @@ class EmailNotificationTest extends TestCase
             ->method('setData')
             ->with('name', self::STUB_CUSTOMER_NAME)
             ->willReturnSelf();
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_REMIND_EMAIL_TEMPLATE,
-                ScopeInterface::SCOPE_STORE,
-                $defaultStoreId
-            )->willReturn(self::STUB_EMAIL_IDENTIFIER);
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY,
-                ScopeInterface::SCOPE_STORE,
-                $defaultStoreId
-            )->willReturn(self::STUB_SENDER);
+            ->withConsecutive(
+                [EmailNotification::XML_PATH_REMIND_EMAIL_TEMPLATE, ScopeInterface::SCOPE_STORE, $defaultStoreId],
+                [EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY, ScopeInterface::SCOPE_STORE, $defaultStoreId]
+            )
+            ->willReturnOnConsecutiveCalls(self::STUB_EMAIL_IDENTIFIER, self::STUB_SENDER);
         $this->mockDefaultTransportBuilder(
             self::STUB_EMAIL_IDENTIFIER,
             $defaultStoreId,
@@ -634,10 +618,11 @@ class EmailNotificationTest extends TestCase
      *
      * @dataProvider customerStoreIdDataProvider
      * @param int $customerStoreId
+     *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPasswordResetConfirmation($customerStoreId):void
+    public function testPasswordResetConfirmation(int $customerStoreId): void
     {
         $customerData = ['key' => 'value'];
         $senderValues = ['name' => self::STUB_SENDER, 'email' => self::STUB_SENDER];
@@ -670,7 +655,7 @@ class EmailNotificationTest extends TestCase
             ->method('getId')
             ->willReturn($customerStoreId);
 
-        $this->storeManagerMock->expects($this->at(0))
+        $this->storeManagerMock
             ->method('getStore')
             ->willReturn($this->storeMock);
 
@@ -698,20 +683,13 @@ class EmailNotificationTest extends TestCase
             ->with('name', self::STUB_CUSTOMER_NAME)
             ->willReturnSelf();
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_FORGOT_EMAIL_TEMPLATE,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_EMAIL_IDENTIFIER);
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_SENDER);
+            ->withConsecutive(
+                [EmailNotification::XML_PATH_FORGOT_EMAIL_TEMPLATE, ScopeInterface::SCOPE_STORE, $customerStoreId],
+                [EmailNotification::XML_PATH_FORGOT_EMAIL_IDENTITY, ScopeInterface::SCOPE_STORE, $customerStoreId]
+            )
+            ->willReturnOnConsecutiveCalls(self::STUB_EMAIL_IDENTIFIER, self::STUB_SENDER);
 
         $this->mockDefaultTransportBuilder(
             self::STUB_EMAIL_IDENTIFIER,
@@ -737,10 +715,11 @@ class EmailNotificationTest extends TestCase
      *
      * @dataProvider customerStoreIdDataProvider
      * @param int $customerStoreId
-     * @return  void
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testNewAccount($customerStoreId):void
+    public function testNewAccount(int $customerStoreId): void
     {
         $customerData = ['key' => 'value'];
         $senderValues = ['name' => self::STUB_SENDER, 'email' => self::STUB_SENDER];
@@ -800,20 +779,13 @@ class EmailNotificationTest extends TestCase
             ->with('name', self::STUB_CUSTOMER_NAME)
             ->willReturnSelf();
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_REGISTER_EMAIL_TEMPLATE,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_EMAIL_IDENTIFIER);
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                EmailNotification::XML_PATH_REGISTER_EMAIL_IDENTITY,
-                ScopeInterface::SCOPE_STORE,
-                $customerStoreId
-            )->willReturn(self::STUB_SENDER);
+            ->withConsecutive(
+                [EmailNotification::XML_PATH_REGISTER_EMAIL_TEMPLATE, ScopeInterface::SCOPE_STORE, $customerStoreId],
+                [EmailNotification::XML_PATH_REGISTER_EMAIL_IDENTITY, ScopeInterface::SCOPE_STORE, $customerStoreId]
+            )
+            ->willReturnOnConsecutiveCalls(self::STUB_EMAIL_IDENTIFIER, self::STUB_SENDER);
 
         $this->mockDefaultTransportBuilder(
             self::STUB_EMAIL_IDENTIFIER,
@@ -871,7 +843,7 @@ class EmailNotificationTest extends TestCase
         string $customerEmail,
         string $customerName,
         array $templateVars = []
-    ):void {
+    ): void {
         $transportMock = $this->getMockForAbstractClass(TransportInterface::class);
 
         $this->transportBuilderMock->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
@@ -60,6 +60,9 @@ class FileProcessorTest extends TestCase
      */
     private $mime;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->mediaDirectory = $this->getMockBuilder(WriteInterface::class)
@@ -74,7 +77,7 @@ class FileProcessorTest extends TestCase
             ->willReturn($this->mediaDirectory);
 
         $this->uploaderFactory = $this->getMockBuilder(UploaderFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -94,6 +97,7 @@ class FileProcessorTest extends TestCase
      * @param array $allowedExtensions
      * @param string|null $customerFileUrlPath
      * @param string|null $customerAddressFileUrlPath
+     *
      * @return FileProcessor
      */
     private function getModel(
@@ -101,7 +105,7 @@ class FileProcessorTest extends TestCase
         array $allowedExtensions = [],
         string $customerFileUrlPath = null,
         string $customerAddressFileUrlPath = null
-    ) {
+    ): FileProcessor {
         $model = new FileProcessor(
             $this->filesystem,
             $this->uploaderFactory,
@@ -116,7 +120,10 @@ class FileProcessorTest extends TestCase
         return $model;
     }
 
-    public function testGetStat()
+    /**
+     * @return void
+     */
+    public function testGetStat(): void
     {
         $fileName = '/filename.ext1';
 
@@ -133,7 +140,10 @@ class FileProcessorTest extends TestCase
         $this->assertEquals(1, $result['size']);
     }
 
-    public function testIsExist()
+    /**
+     * @return void
+     */
+    public function testIsExist(): void
     {
         $fileName = '/filename.ext1';
 
@@ -150,6 +160,8 @@ class FileProcessorTest extends TestCase
      * @param array $params
      * @param string $filePath
      * @param string $expectedUrl
+     *
+     * @return void
      * @dataProvider getViewUrlDataProvider
      */
     public function testGetViewUrlTest(
@@ -183,7 +195,7 @@ class FileProcessorTest extends TestCase
     }
 
     /**
-     * @return array[]
+     * @return array
      */
     public function getViewUrlDataProvider(): array
     {
@@ -192,7 +204,7 @@ class FileProcessorTest extends TestCase
                 [
                     'entityTypeCode' => CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                     'customerFileUrlPath' => 'customer/index/viewfile',
-                    'addressFileUrlPath' => 'customer/address/viewfile',
+                    'addressFileUrlPath' => 'customer/address/viewfile'
                 ],
                 '/i/m/image1.jpeg',
                 'http://example.com/customer/index/viewfile/file/57523c876842c97ab9d5fd92f8d8d9ec'
@@ -201,7 +213,7 @@ class FileProcessorTest extends TestCase
                 [
                     'entityTypeCode' => AddressMetadataInterface::ENTITY_TYPE_ADDRESS,
                     'customerFileUrlPath' => 'customer/index/viewfile',
-                    'addressFileUrlPath' => 'customer/address/viewfile',
+                    'addressFileUrlPath' => 'customer/address/viewfile'
                 ],
                 '/i/m/image2.png',
                 'http://example.com/customer/address/viewfile/file/4498819248a7f824893bd3dac4babdfc'
@@ -210,7 +222,7 @@ class FileProcessorTest extends TestCase
                 [
                     'entityTypeCode' => CustomerMetadataInterface::ENTITY_TYPE_CUSTOMER,
                     'customerFileUrlPath' => 'custom_module/customer/preview',
-                    'addressFileUrlPath' => 'custom_module/address/preview',
+                    'addressFileUrlPath' => 'custom_module/address/preview'
                 ],
                 '/i/m/image1.jpeg',
                 'http://example.com/custom_module/customer/preview/file/57523c876842c97ab9d5fd92f8d8d9ec'
@@ -219,7 +231,7 @@ class FileProcessorTest extends TestCase
                 [
                     'entityTypeCode' => AddressMetadataInterface::ENTITY_TYPE_ADDRESS,
                     'customerFileUrlPath' => 'custom_module/customer/preview',
-                    'addressFileUrlPath' => 'custom_module/address/preview',
+                    'addressFileUrlPath' => 'custom_module/address/preview'
                 ],
                 '/i/m/image2.png',
                 'http://example.com/custom_module/address/preview/file/4498819248a7f824893bd3dac4babdfc'
@@ -227,7 +239,10 @@ class FileProcessorTest extends TestCase
         ];
     }
 
-    public function testRemoveUploadedFile()
+    /**
+     * @return void
+     */
+    public function testRemoveUploadedFile(): void
     {
         $fileName = '/filename.ext1';
 
@@ -240,19 +255,22 @@ class FileProcessorTest extends TestCase
         $this->assertTrue($model->removeUploadedFile($fileName));
     }
 
-    public function testSaveTemporaryFile()
+    /**
+     * @return void
+     */
+    public function testSaveTemporaryFile(): void
     {
         $attributeCode = 'img1';
 
         $allowedExtensions = [
             'ext1',
-            'ext2',
+            'ext2'
         ];
 
         $absolutePath = '/absolute/filepath';
 
         $expectedResult = [
-            'file' => 'filename.ext1',
+            'file' => 'filename.ext1'
         ];
         $resultWithPath = [
             'file' => 'filename.ext1',
@@ -299,7 +317,10 @@ class FileProcessorTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testSaveTemporaryFileWithError()
+    /**
+     * @return void
+     */
+    public function testSaveTemporaryFileWithError(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('File can not be saved to the destination folder.');
@@ -308,7 +329,7 @@ class FileProcessorTest extends TestCase
 
         $allowedExtensions = [
             'ext1',
-            'ext2',
+            'ext2'
         ];
 
         $absolutePath = '/absolute/filepath';
@@ -351,7 +372,10 @@ class FileProcessorTest extends TestCase
         $model->saveTemporaryFile('customer[' . $attributeCode . ']');
     }
 
-    public function testMoveTemporaryFileUnableToCreateDirectory()
+    /**
+     * @return void
+     */
+    public function testMoveTemporaryFileUnableToCreateDirectory(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Unable to create directory customer/f/i');
@@ -366,7 +390,10 @@ class FileProcessorTest extends TestCase
         $model->moveTemporaryFile($filePath);
     }
 
-    public function testMoveTemporaryFileDestinationFolderDoesNotExists()
+    /**
+     * @return void
+     */
+    public function testMoveTemporaryFileDestinationFolderDoesNotExists(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Destination folder is not writable or does not exists');
@@ -385,7 +412,10 @@ class FileProcessorTest extends TestCase
         $model->moveTemporaryFile($filePath);
     }
 
-    public function testMoveTemporaryFile()
+    /**
+     * @return void
+     */
+    public function testMoveTemporaryFile(): void
     {
         $filePath = '/filename.ext1';
 
@@ -421,7 +451,10 @@ class FileProcessorTest extends TestCase
         $this->assertEquals('/f/i' . $filePath, $model->moveTemporaryFile($filePath));
     }
 
-    public function testMoveTemporaryFileNewFileName()
+    /**
+     * @return void
+     */
+    public function testMoveTemporaryFileNewFileName(): void
     {
         $filePath = '/filename.ext1';
 
@@ -456,7 +489,10 @@ class FileProcessorTest extends TestCase
         $this->assertEquals('/f/i/filename_2.ext1', $model->moveTemporaryFile($filePath));
     }
 
-    public function testMoveTemporaryFileWithException()
+    /**
+     * @return void
+     */
+    public function testMoveTemporaryFileWithException(): void
     {
         $objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $mockFileSystem = $this->createMock(Filesystem::class);
@@ -495,7 +531,10 @@ class FileProcessorTest extends TestCase
         $model->moveTemporaryFile($filePath);
     }
 
-    public function testGetMimeType()
+    /**
+     * @return void
+     */
+    public function testGetMimeType(): void
     {
         $fileName = '/filename.ext1';
         $absoluteFilePath = '/absolute_path/customer/filename.ext1';
@@ -522,17 +561,15 @@ class FileProcessorTest extends TestCase
      *
      * @param string $destinationPath
      * @param bool $directoryCreated
+     *
+     * @return void
      */
     private function configureMediaDirectoryMock(string $destinationPath, bool $directoryCreated): void
     {
-        $this->mediaDirectory->expects($this->at(0))
+        $this->mediaDirectory
             ->method('isExist')
-            ->with('customer/tmp/filename.ext1')
-            ->willReturn(true);
-        $this->mediaDirectory->expects($this->at(1))
-            ->method('isExist')
-            ->with('customer/filename.ext1')
-            ->willReturn(false);
+            ->withConsecutive(['customer/tmp/filename.ext1'], ['customer/filename.ext1'])
+            ->willReturnOnConsecutiveCalls(true, false);
         $this->mediaDirectory->expects($this->once())
             ->method('create')
             ->with($destinationPath)

--- a/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/FileProcessorTest.php
@@ -61,7 +61,7 @@ class FileProcessorTest extends TestCase
     private $mime;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
@@ -64,7 +64,7 @@ class AttributeMetadataCacheTest extends TestCase
     private $storeManagerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataCacheTest.php
@@ -63,6 +63,9 @@ class AttributeMetadataCacheTest extends TestCase
      */
     private $storeManagerMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -86,7 +89,10 @@ class AttributeMetadataCacheTest extends TestCase
         );
     }
 
-    public function testLoadCacheDisabled()
+    /**
+     * @return void
+     */
+    public function testLoadCacheDisabled(): void
     {
         $entityType = 'EntityType';
         $suffix = 'none';
@@ -101,7 +107,10 @@ class AttributeMetadataCacheTest extends TestCase
         $this->attributeMetadataCache->load($entityType, $suffix);
     }
 
-    public function testLoadNoCache()
+    /**
+     * @return void
+     */
+    public function testLoadNoCache(): void
     {
         $entityType = 'EntityType';
         $suffix = 'none';
@@ -118,7 +127,10 @@ class AttributeMetadataCacheTest extends TestCase
         $this->assertFalse($this->attributeMetadataCache->load($entityType, $suffix));
     }
 
-    public function testLoad()
+    /**
+     * @return void
+     */
+    public function testLoad(): void
     {
         $entityType = 'EntityType';
         $suffix = 'none';
@@ -144,7 +156,7 @@ class AttributeMetadataCacheTest extends TestCase
             ->willReturn($attributesMetadataData);
         /** @var AttributeMetadataInterface|MockObject $attributeMetadataMock */
         $attributeMetadataMock = $this->getMockForAbstractClass(AttributeMetadataInterface::class);
-        $this->attributeMetadataHydratorMock->expects($this->at(0))
+        $this->attributeMetadataHydratorMock
             ->method('hydrate')
             ->with($attributeMetadataOneData)
             ->willReturn($attributeMetadataMock);
@@ -154,7 +166,10 @@ class AttributeMetadataCacheTest extends TestCase
         $this->assertInstanceOf(AttributeMetadataInterface::class, $attributesMetadata[0]);
     }
 
-    public function testSaveCacheDisabled()
+    /**
+     * @return void
+     */
+    public function testSaveCacheDisabled(): void
     {
         $entityType = 'EntityType';
         $suffix = 'none';
@@ -170,7 +185,10 @@ class AttributeMetadataCacheTest extends TestCase
         );
     }
 
-    public function testSave()
+    /**
+     * @return void
+     */
+    public function testSave(): void
     {
         $entityType = 'EntityType';
         $suffix = 'none';
@@ -215,7 +233,10 @@ class AttributeMetadataCacheTest extends TestCase
         );
     }
 
-    public function testCleanCacheDisabled()
+    /**
+     * @return void
+     */
+    public function testCleanCacheDisabled(): void
     {
         $this->stateMock->expects($this->once())
             ->method('isEnabled')
@@ -226,7 +247,10 @@ class AttributeMetadataCacheTest extends TestCase
         $this->attributeMetadataCache->clean();
     }
 
-    public function testClean()
+    /**
+     * @return void
+     */
+    public function testClean(): void
     {
         $this->stateMock->expects($this->once())
             ->method('isEnabled')

--- a/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
@@ -74,7 +74,7 @@ class SessionTest extends TestCase
     protected $_model;
 
     /**
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -86,13 +86,12 @@ class SessionTest extends TestCase
         $this->_eventManagerMock = $this->getMockForAbstractClass(ManagerInterface::class);
         $this->_httpContextMock = $this->createMock(Context::class);
         $this->urlFactoryMock = $this->createMock(UrlFactory::class);
-        $this->customerFactoryMock = $this->getMockBuilder(CustomerFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create', 'save'])
+        $this->customerFactoryMock = $this->getMockBuilder(CustomerFactory::class)->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->addMethods(['save'])
             ->getMock();
-        $this->_customerResourceMock = $this->getMockBuilder(ResourceCustomer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['load', 'save'])
+        $this->_customerResourceMock = $this->getMockBuilder(ResourceCustomer::class)->disableOriginalConstructor()
+            ->onlyMethods(['load', 'save'])
             ->getMock();
         $this->customerRepositoryMock = $this->getMockForAbstractClass(CustomerRepositoryInterface::class);
         $helper = new ObjectManagerHelper($this);
@@ -107,7 +106,7 @@ class SessionTest extends TestCase
                 'urlFactory' => $this->urlFactoryMock,
                 'customerRepository' => $this->customerRepositoryMock,
                 'response' => $this->responseMock,
-                '_customerResource' => $this->_customerResourceMock,
+                '_customerResource' => $this->_customerResourceMock
             ]
         );
     }
@@ -115,7 +114,7 @@ class SessionTest extends TestCase
     /**
      * @return void
      */
-    public function testSetCustomerAsLoggedIn()
+    public function testSetCustomerAsLoggedIn(): void
     {
         $customer = $this->createMock(Customer::class);
         $customerDto = $this->getMockForAbstractClass(CustomerInterface::class);
@@ -123,12 +122,12 @@ class SessionTest extends TestCase
             ->method('getDataModel')
             ->willReturn($customerDto);
 
-        $this->_eventManagerMock->expects($this->at(0))
+        $this->_eventManagerMock
             ->method('dispatch')
-            ->with('customer_login', ['customer' => $customer]);
-        $this->_eventManagerMock->expects($this->at(1))
-            ->method('dispatch')
-            ->with('customer_data_object_login', ['customer' => $customerDto]);
+            ->withConsecutive(
+                ['customer_login', ['customer' => $customer]],
+                ['customer_data_object_login', ['customer' => $customerDto]]
+            );
 
         $_SESSION = [];
         $this->_model->setCustomerAsLoggedIn($customer);
@@ -138,7 +137,7 @@ class SessionTest extends TestCase
     /**
      * @return void
      */
-    public function testSetCustomerDataAsLoggedIn()
+    public function testSetCustomerDataAsLoggedIn(): void
     {
         $customer = $this->createMock(Customer::class);
         $customerDto = $this->getMockForAbstractClass(CustomerInterface::class);
@@ -151,12 +150,12 @@ class SessionTest extends TestCase
             ->with($customerDto)
             ->willReturnSelf();
 
-        $this->_eventManagerMock->expects($this->at(0))
+        $this->_eventManagerMock
             ->method('dispatch')
-            ->with('customer_login', ['customer' => $customer]);
-        $this->_eventManagerMock->expects($this->at(1))
-            ->method('dispatch')
-            ->with('customer_data_object_login', ['customer' => $customerDto]);
+            ->withConsecutive(
+                ['customer_login', ['customer' => $customer]],
+                ['customer_data_object_login', ['customer' => $customerDto]]
+            );
 
         $this->_model->setCustomerDataAsLoggedIn($customerDto);
         $this->assertSame($customer, $this->_model->getCustomer());
@@ -165,7 +164,7 @@ class SessionTest extends TestCase
     /**
      * @return void
      */
-    public function testAuthenticate()
+    public function testAuthenticate(): void
     {
         $urlMock = $this->createMock(Url::class);
         $urlMock->expects($this->exactly(2))
@@ -192,7 +191,7 @@ class SessionTest extends TestCase
     /**
      * @return void
      */
-    public function testLoginById()
+    public function testLoginById(): void
     {
         $customerId = 1;
 
@@ -208,9 +207,10 @@ class SessionTest extends TestCase
 
     /**
      * @param int $customerId
+     *
      * @return MockObject
      */
-    protected function prepareLoginDataMock($customerId)
+    protected function prepareLoginDataMock(int $customerId): MockObject
     {
         $customerDataMock = $this->getMockForAbstractClass(CustomerInterface::class);
         $customerDataMock->expects($this->once())
@@ -246,10 +246,15 @@ class SessionTest extends TestCase
      * @param bool $expectedResult
      * @param bool $isCustomerIdValid
      * @param bool $isCustomerEmulated
+     *
+     * @return void
      * @dataProvider getIsLoggedInDataProvider
      */
-    public function testIsLoggedIn($expectedResult, $isCustomerIdValid, $isCustomerEmulated)
-    {
+    public function testIsLoggedIn(
+        bool $expectedResult,
+        bool $isCustomerIdValid,
+        bool $isCustomerEmulated
+    ): void {
         $customerId = 1;
         $this->_storageMock->expects($this->any())->method('getData')->with('customer_id')
             ->willReturn($customerId);
@@ -272,20 +277,20 @@ class SessionTest extends TestCase
     /**
      * @return array
      */
-    public function getIsLoggedInDataProvider()
+    public function getIsLoggedInDataProvider(): array
     {
         return [
             ['expectedResult' => true, 'isCustomerIdValid' => true, 'isCustomerEmulated' => false],
             ['expectedResult' => false, 'isCustomerIdValid' => true, 'isCustomerEmulated' => true],
             ['expectedResult' => false, 'isCustomerIdValid' => false, 'isCustomerEmulated' => false],
-            ['expectedResult' => false, 'isCustomerIdValid' => false, 'isCustomerEmulated' => true],
+            ['expectedResult' => false, 'isCustomerIdValid' => false, 'isCustomerEmulated' => true]
         ];
     }
 
     /**
      * @return void
      */
-    public function testSetCustomerRemovesFlagThatShowsIfCustomerIsEmulated()
+    public function testSetCustomerRemovesFlagThatShowsIfCustomerIsEmulated(): void
     {
         $customerMock = $this->createMock(Customer::class);
         $this->_storageMock->expects($this->once())->method('unsIsCustomerEmulated');
@@ -297,7 +302,7 @@ class SessionTest extends TestCase
      *
      * @return void
      */
-    public function testGetCustomerForGuestUser()
+    public function testGetCustomerForGuestUser(): void
     {
         $customerMock = $this->getMockBuilder(Customer::class)
             ->disableOriginalConstructor()
@@ -316,7 +321,7 @@ class SessionTest extends TestCase
      *
      * @return void
      */
-    public function testGetCustomerForRegisteredUser()
+    public function testGetCustomerForRegisteredUser(): void
     {
         $customerId = 1;
 

--- a/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/SessionTest.php
@@ -74,7 +74,7 @@ class SessionTest extends TestCase
     protected $_model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/ColumnsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/ColumnsTest.php
@@ -56,7 +56,7 @@ class ColumnsTest extends TestCase
     protected $component;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/ColumnsTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Ui/Component/Listing/ColumnsTest.php
@@ -20,27 +20,44 @@ use PHPUnit\Framework\TestCase;
 
 class ColumnsTest extends TestCase
 {
-    /** @var ContextInterface|MockObject */
+    /**
+     * @var ContextInterface|MockObject
+     */
     protected $context;
 
-    /** @var ColumnFactory|MockObject */
+    /**
+     * @var ColumnFactory|MockObject
+     */
     protected $columnFactory;
 
-    /** @var AttributeRepository|MockObject */
+    /**
+     * @var AttributeRepository|MockObject
+     */
     protected $attributeRepository;
 
-    /** @var Attribute|MockObject */
+    /**
+     * @var Attribute|MockObject
+     */
     protected $attribute;
 
-    /** @var ColumnInterface|MockObject */
+    /**
+     * @var ColumnInterface|MockObject
+     */
     protected $column;
 
-    /** @var InlineEditUpdater|MockObject */
+    /**
+     * @var InlineEditUpdater|MockObject
+     */
     protected $inlineEditUpdater;
 
-    /** @var Columns */
+    /**
+     * @var Columns
+     */
     protected $component;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->context = $this->getMockBuilder(ContextInterface::class)
@@ -77,7 +94,10 @@ class ColumnsTest extends TestCase
         );
     }
 
-    public function testPrepareWithAddColumn()
+    /**
+     * @return void
+     */
+    public function testPrepareWithAddColumn(): void
     {
         $attributeCode = 'attribute_code';
 
@@ -102,7 +122,7 @@ class ColumnsTest extends TestCase
                         'is_searchable_in_grid' => true,
                         'validation_rules' => [],
                         'required'=> false,
-                        'entity_type_code' => 'customer_address',
+                        'entity_type_code' => 'customer_address'
                     ]
                 ]
             );
@@ -115,7 +135,10 @@ class ColumnsTest extends TestCase
         $this->component->prepare();
     }
 
-    public function testPrepareWithUpdateColumn()
+    /**
+     * @return void
+     */
+    public function testPrepareWithUpdateColumn(): void
     {
         $attributeCode = 'billing_attribute_code';
         $backendType = 'backend-type';
@@ -136,7 +159,7 @@ class ColumnsTest extends TestCase
             'is_searchable_in_grid' => true,
             'validation_rules' => [],
             'required'=> false,
-            'entity_type_code' => 'customer',
+            'entity_type_code' => 'customer'
         ];
 
         $this->attributeRepository->expects($this->atLeastOnce())
@@ -151,28 +174,28 @@ class ColumnsTest extends TestCase
             ->method('getData')
             ->with('config')
             ->willReturn([]);
-        $this->column->expects($this->at(3))
+        $this->column
             ->method('setData')
-            ->with(
-                'config',
+            ->withConsecutive(
                 [
-                    'options' => [
-                        [
-                            'label' => 'Label',
-                            'value' => 'Value'
+                    'config',
+                    [
+                        'options' => [
+                            [
+                                'label' => 'Label',
+                                'value' => 'Value'
+                            ]
                         ]
                     ]
-                ]
-            );
-        $this->column->expects($this->at(5))
-            ->method('setData')
-            ->with(
-                'config',
+                ],
                 [
-                    'name' => $attributeCode,
-                    'dataType' => $backendType,
-                    'filter' => 'text',
-                    'visible' => true
+                    'config',
+                    [
+                        'name' => $attributeCode,
+                        'dataType' => $backendType,
+                        'filter' => 'text',
+                        'visible' => true
+                    ]
                 ]
             );
 
@@ -180,7 +203,10 @@ class ColumnsTest extends TestCase
         $this->component->prepare();
     }
 
-    public function testPrepareWithUpdateStaticColumn()
+    /**
+     * @return void
+     */
+    public function testPrepareWithUpdateStaticColumn(): void
     {
         $attributeCode = 'billing_attribute_code';
         $backendType = 'static';
@@ -201,7 +227,7 @@ class ColumnsTest extends TestCase
             'is_searchable_in_grid' => true,
             'validation_rules' => [],
             'required'=> false,
-            'entity_type_code' => 'customer',
+            'entity_type_code' => 'customer'
         ];
         $this->inlineEditUpdater->expects($this->once())
             ->method('applyEditing')
@@ -218,30 +244,28 @@ class ColumnsTest extends TestCase
         $this->column->expects($this->atLeastOnce())
             ->method('getData')
             ->with('config')
-            ->willReturn([
-                'editor' => 'text'
-            ]);
-        $this->column->expects($this->at(3))
+            ->willReturn(['editor' => 'text']);
+        $this->column
             ->method('setData')
-            ->with(
-                'config',
+            ->withConsecutive(
                 [
-                    'editor' => 'text',
-                    'options' => [
-                        [
-                            'label' => 'Label',
-                            'value' => 'Value'
+                    'config',
+                    [
+                        'editor' => 'text',
+                        'options' => [
+                            [
+                                'label' => 'Label',
+                                'value' => 'Value'
+                            ]
                         ]
                     ]
-                ]
-            );
-        $this->column->expects($this->at(6))
-            ->method('setData')
-            ->with(
-                'config',
+                ],
                 [
-                    'editor' => 'text',
-                    'visible' => true
+                    'config',
+                    [
+                        'editor' => 'text',
+                        'visible' => true
+                    ]
                 ]
             );
 

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImport/ProcessorTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImport/ProcessorTest.php
@@ -78,7 +78,7 @@ class ProcessorTest extends TestCase
     private $processor;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImport/ProcessorTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Console/Command/App/ConfigImport/ProcessorTest.php
@@ -77,6 +77,9 @@ class ProcessorTest extends TestCase
      */
     private $processor;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->importerFactoryMock = $this->getMockBuilder(ImporterFactory::class)
@@ -120,9 +123,11 @@ class ProcessorTest extends TestCase
      * @param bool $doImport
      * @param bool $skipImport
      * @param array $warningMessages
+     *
+     * @return void
      * @dataProvider importDataProvider
      */
-    public function testImport($doImport, $skipImport, array $warningMessages)
+    public function testImport(bool $doImport, bool $skipImport, array $warningMessages): void
     {
         $configData = ['some data'];
         $messages = ['The import is complete'];
@@ -168,12 +173,12 @@ class ProcessorTest extends TestCase
             $this->configHashMock->expects($this->never())
                 ->method('regenerate');
         } else {
-            $this->outputMock->expects($this->at(0))
+            $this->outputMock
                 ->method('writeln')
-                ->with('<info>Processing configurations data from configuration file...</info>');
-            $this->outputMock->expects($this->at(1))
-                ->method('writeln')
-                ->with($expectsMessages);
+                ->withConsecutive(
+                    ['<info>Processing configurations data from configuration file...</info>'],
+                    [$expectsMessages]
+                );
             $importerMock->expects($this->once())
                 ->method('import')
                 ->with($configData)
@@ -188,33 +193,36 @@ class ProcessorTest extends TestCase
     /**
      * @return array
      */
-    public function importDataProvider()
+    public function importDataProvider(): array
     {
         return [
             [
                 'doImport' => false,
                 'skipImport' => false,
-                'warningMessages' => [],
+                'warningMessages' => []
             ],
             [
                 'doImport' => true,
                 'skipImport' => false,
-                'warningMessages' => [],
+                'warningMessages' => []
             ],
             [
                 'doImport' => true,
                 'skipImport' => false,
-                'warningMessages' => ['Some message'],
+                'warningMessages' => ['Some message']
             ],
             [
                 'doImport' => false,
                 'skipImport' => true,
-                'warningMessages' => ['Some message'],
+                'warningMessages' => ['Some message']
             ],
         ];
     }
 
-    public function testImportWithException()
+    /**
+     * @return void
+     */
+    public function testImportWithException(): void
     {
         $this->expectException('Magento\Framework\Exception\RuntimeException');
         $this->expectExceptionMessage('Import failed: Some error');
@@ -237,7 +245,10 @@ class ProcessorTest extends TestCase
         $this->processor->execute($this->inputMock, $this->outputMock);
     }
 
-    public function testImportWithValidation()
+    /**
+     * @return void
+     */
+    public function testImportWithValidation(): void
     {
         $this->expectException('Magento\Framework\Exception\RuntimeException');
         $this->expectExceptionMessage('Import failed: error message');
@@ -280,9 +291,11 @@ class ProcessorTest extends TestCase
     /**
      * @param array $importers
      * @param bool $isValid
+     *
+     * @return void
      * @dataProvider importNothingToImportDataProvider
      */
-    public function testImportNothingToImport(array $importers, $isValid)
+    public function testImportNothingToImport(array $importers, bool $isValid): void
     {
         $this->configImporterPoolMock->expects($this->once())
             ->method('getImporters')
@@ -297,7 +310,7 @@ class ProcessorTest extends TestCase
         $this->loggerMock->expects($this->never())
             ->method('error');
 
-        $this->outputMock->expects($this->at(0))
+        $this->outputMock
             ->method('writeln')
             ->with('<info>Nothing to import.</info>');
 
@@ -307,12 +320,12 @@ class ProcessorTest extends TestCase
     /**
      * @return array
      */
-    public function importNothingToImportDataProvider()
+    public function importNothingToImportDataProvider(): array
     {
         return [
             ['importers' => [], 'isValid' => false],
             ['importers' => [], 'isValid' => true],
-            ['importers' => ['someImporter'], 'isValid' => false],
+            ['importers' => ['someImporter'], 'isValid' => false]
         ];
     }
 }

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/GeneratePatchCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/GeneratePatchCommandTest.php
@@ -44,6 +44,9 @@ class GeneratePatchCommandTest extends TestCase
      */
     private $command;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->componentRegistrarMock = $this->createMock(ComponentRegistrar::class);
@@ -59,7 +62,10 @@ class GeneratePatchCommandTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $this->componentRegistrarMock->expects($this->once())
             ->method('getPath')
@@ -67,7 +73,7 @@ class GeneratePatchCommandTest extends TestCase
             ->willReturn('/long/path/to/Vendor/Module');
 
         $read = $this->createMock(Read::class);
-        $read->expects($this->at(0))
+        $read
             ->method('readFile')
             ->with('patch_template.php.dist')
             ->willReturn('something');
@@ -89,7 +95,10 @@ class GeneratePatchCommandTest extends TestCase
         $this->assertStringContainsString('successfully generated', $commandTester->getDisplay());
     }
 
-    public function testWrongParameter()
+    /**
+     * @return void
+     */
+    public function testWrongParameter(): void
     {
         $this->expectExceptionMessage('Not enough arguments');
         $this->expectException(\RuntimeException::class);
@@ -98,7 +107,10 @@ class GeneratePatchCommandTest extends TestCase
         $commandTester->execute([]);
     }
 
-    public function testBadModule()
+    /**
+     * @return void
+     */
+    public function testBadModule(): void
     {
         $this->componentRegistrarMock->expects($this->once())
             ->method('getPath')

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/GeneratePatchCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/GeneratePatchCommandTest.php
@@ -45,7 +45,7 @@ class GeneratePatchCommandTest extends TestCase
     private $command;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/SourceThemeDeployCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/SourceThemeDeployCommandTest.php
@@ -56,7 +56,7 @@ class SourceThemeDeployCommandTest extends TestCase
     private $assetRepositoryMock;
 
     /**
-     * Set up
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -79,8 +79,10 @@ class SourceThemeDeployCommandTest extends TestCase
 
     /**
      * Run test for execute method
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         /** @var OutputInterface|MockObject $outputMock */
         $outputMock = $this->getMockBuilder(OutputInterface::class)
@@ -88,7 +90,7 @@ class SourceThemeDeployCommandTest extends TestCase
         $assetMock = $this->getMockBuilder(LocalInterface::class)
             ->getMockForAbstractClass();
 
-        $this->validatorMock->expects(self::once())
+        $this->validatorMock->expects($this->once())
             ->method('isValid')
             ->with(self::LOCALE_TEST_VALUE)
             ->willReturn(true);
@@ -101,17 +103,15 @@ class SourceThemeDeployCommandTest extends TestCase
             self::TYPE_TEST_VALUE
         );
 
-        $outputMock->expects(self::at(0))
+        $outputMock
             ->method('writeln')
-            ->with($message);
-        $outputMock->expects(self::at(1))
-            ->method('writeln')
-            ->with('<comment>-> file-test-value/test/file</comment>');
-        $outputMock->expects(self::at(2))
-            ->method('writeln')
-            ->with('<info>Successfully processed.</info>');
+            ->withConsecutive(
+                [$message],
+                ['<comment>-> file-test-value/test/file</comment>'],
+                ['<info>Successfully processed.</info>']
+            );
 
-        $this->assetRepositoryMock->expects(self::once())
+        $this->assetRepositoryMock->expects($this->once())
             ->method('createAsset')
             ->with(
                 'file-test-value/test' . DIRECTORY_SEPARATOR . 'file' . '.' . self::TYPE_TEST_VALUE,
@@ -122,11 +122,11 @@ class SourceThemeDeployCommandTest extends TestCase
                 ]
             )->willReturn($assetMock);
 
-        $this->assetPublisherMock->expects(self::once())
+        $this->assetPublisherMock->expects($this->once())
             ->method('publish')
             ->with($assetMock);
 
-        $assetMock->expects(self::once())
+        $assetMock->expects($this->once())
             ->method('getFilePath')
             ->willReturn(self::FILE_TEST_VALUE);
 
@@ -136,7 +136,7 @@ class SourceThemeDeployCommandTest extends TestCase
     /**
      * Run test for execute method with incorrect theme value
      */
-    public function testExecuteIncorrectThemeFormat()
+    public function testExecuteIncorrectThemeFormat(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage(
@@ -145,7 +145,7 @@ class SourceThemeDeployCommandTest extends TestCase
         /** @var OutputInterface|MockObject $outputMock */
         $outputMock = $this->getMockBuilder(OutputInterface::class)
             ->getMockForAbstractClass();
-        $this->validatorMock->expects(self::once())
+        $this->validatorMock->expects($this->once())
             ->method('isValid')
             ->with(self::LOCALE_TEST_VALUE)
             ->willReturn(true);
@@ -166,7 +166,7 @@ class SourceThemeDeployCommandTest extends TestCase
     /**
      * Run test for execute method with non existing theme
      */
-    public function testExecuteNonExistingValue()
+    public function testExecuteNonExistingValue(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Verify entered values of the argument and options.');
@@ -176,23 +176,23 @@ class SourceThemeDeployCommandTest extends TestCase
         $assetMock = $this->getMockBuilder(LocalInterface::class)
             ->getMockForAbstractClass();
 
-        $this->validatorMock->expects(self::once())
+        $this->validatorMock->expects($this->once())
             ->method('isValid')
             ->with(self::LOCALE_TEST_VALUE)
             ->willReturn(true);
 
-        $this->assetRepositoryMock->expects(self::once())
+        $this->assetRepositoryMock->expects($this->once())
             ->method('createAsset')
             ->with(
                 'file-test-value/test' . DIRECTORY_SEPARATOR . 'file' . '.' . self::TYPE_TEST_VALUE,
                 [
                     'area' => self::AREA_TEST_VALUE,
                     'theme' => self::THEME_NONEXISTING_VALUE,
-                    'locale' => self::LOCALE_TEST_VALUE,
+                    'locale' => self::LOCALE_TEST_VALUE
                 ]
             )->willReturn($assetMock);
 
-        $this->assetPublisherMock->expects(self::once())
+        $this->assetPublisherMock->expects($this->once())
             ->method('publish')
             ->with($assetMock)
             ->willThrowException(new NotFoundException());
@@ -213,7 +213,7 @@ class SourceThemeDeployCommandTest extends TestCase
     /**
      * @return InputInterface|MockObject
      */
-    private function getInputMock(array $valueMap = [])
+    private function getInputMock(array $valueMap = []): MockObject
     {
         $inputMock = $this->getMockBuilder(InputInterface::class)
             ->getMockForAbstractClass();
@@ -226,12 +226,12 @@ class SourceThemeDeployCommandTest extends TestCase
         ];
         $valueMap = empty($valueMap) ? $defaultValueMap : $valueMap;
 
-        $inputMock->expects(self::exactly(4))
+        $inputMock->expects($this->exactly(4))
             ->method('getOption')
             ->willReturnMap(
                 $valueMap
             );
-        $inputMock->expects(self::once())
+        $inputMock->expects($this->once())
             ->method('getArgument')
             ->with('file')
             ->willReturn([self::FILE_TEST_VALUE]);

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/SourceThemeDeployCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/SourceThemeDeployCommandTest.php
@@ -56,7 +56,7 @@ class SourceThemeDeployCommandTest extends TestCase
     private $assetRepositoryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/XmlCatalogGenerateCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/XmlCatalogGenerateCommandTest.php
@@ -23,17 +23,17 @@ class XmlCatalogGenerateCommandTest extends TestCase
      */
     private $command;
 
-    public function testExecuteBadType()
+    /**
+     * @return void
+     */
+    public function testExecuteBadType(): void
     {
         $fixtureXmlFile = __DIR__ . '/_files/test.xml';
 
         $filesMock = $this->createPartialMock(Files::class, ['getXmlCatalogFiles']);
-        $filesMock->expects($this->at(0))
+        $filesMock
             ->method('getXmlCatalogFiles')
-            ->willReturn([[$fixtureXmlFile]]);
-        $filesMock->expects($this->at(1))
-            ->method('getXmlCatalogFiles')
-            ->willReturn([]);
+            ->willReturnOnConsecutiveCalls([[$fixtureXmlFile]], []);
         $urnResolverMock = $this->createMock(UrnResolver::class);
         $urnResolverMock->expects($this->once())
             ->method('getRealPath')
@@ -74,17 +74,17 @@ class XmlCatalogGenerateCommandTest extends TestCase
         $this->assertEquals('', $commandTester->getDisplay());
     }
 
-    public function testExecuteVsCodeFormat()
+    /**
+     * @return void
+     */
+    public function testExecuteVsCodeFormat(): void
     {
         $fixtureXmlFile = __DIR__ . '/_files/test.xml';
 
         $filesMock = $this->createPartialMock(Files::class, ['getXmlCatalogFiles']);
-        $filesMock->expects($this->at(0))
+        $filesMock
             ->method('getXmlCatalogFiles')
-            ->willReturn([[$fixtureXmlFile]]);
-        $filesMock->expects($this->at(1))
-            ->method('getXmlCatalogFiles')
-            ->willReturn([]);
+            ->willReturnOnConsecutiveCalls([[$fixtureXmlFile]], []);
         $urnResolverMock = $this->createMock(UrnResolver::class);
         $urnResolverMock->expects($this->once())
             ->method('getRealPath')
@@ -121,10 +121,12 @@ class XmlCatalogGenerateCommandTest extends TestCase
         );
 
         $commandTester = new CommandTester($this->command);
-        $commandTester->execute([
-            '--' . XmlCatalogGenerateCommand::IDE_OPTION => 'vscode',
-            XmlCatalogGenerateCommand::IDE_FILE_PATH_ARGUMENT => 'test',
-        ]);
+        $commandTester->execute(
+            [
+                '--' . XmlCatalogGenerateCommand::IDE_OPTION => 'vscode',
+                XmlCatalogGenerateCommand::IDE_FILE_PATH_ARGUMENT => 'test'
+            ]
+        );
         $this->assertEquals('', $commandTester->getDisplay());
     }
 }

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/XmlConverterCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/XmlConverterCommandTest.php
@@ -37,7 +37,7 @@ class XmlConverterCommandTest extends TestCase
     private $xsltProcessorFactory;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/XmlConverterCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/XmlConverterCommandTest.php
@@ -36,6 +36,9 @@ class XmlConverterCommandTest extends TestCase
      */
     private $xsltProcessorFactory;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         if (!function_exists('libxml_set_external_entity_loader')) {
@@ -48,15 +51,19 @@ class XmlConverterCommandTest extends TestCase
         $this->command = new XmlConverterCommand($this->formatter, $this->domFactory, $this->xsltProcessorFactory);
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $domXml = $this->createMock(\DOMDocument::class);
         $domXsl = clone $domXml;
         $domXml->expects($this->once())->method('load')->with('file.xml');
         $domXsl->expects($this->once())->method('load')->with('file.xsl');
 
-        $this->domFactory->expects($this->at(0))->method('create')->willReturn($domXml);
-        $this->domFactory->expects($this->at(1))->method('create')->willReturn($domXsl);
+        $this->domFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($domXml, $domXsl);
 
         $xsltProcessor = $this->createMock(\XSLTProcessor::class);
         $xsltProcessor->expects($this->once())->method('transformToXml')->with($domXml)->willReturn('XML');
@@ -75,7 +82,10 @@ class XmlConverterCommandTest extends TestCase
         $this->assertStringContainsString('result', $commandTester->getDisplay());
     }
 
-    public function testWrongParameter()
+    /**
+     * @return void
+     */
+    public function testWrongParameter(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Not enough arguments');

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/Source/ServiceTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/Source/ServiceTest.php
@@ -25,7 +25,7 @@ class ServiceTest extends TestCase
     protected $_importConfig;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/Source/ServiceTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/Source/ServiceTest.php
@@ -24,13 +24,19 @@ class ServiceTest extends TestCase
      */
     protected $_importConfig;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_importConfig = $this->createMock(Config::class);
         $this->_model = new Service($this->_importConfig);
     }
 
-    public function testToOptionArray()
+    /**
+     * @return void
+     */
+    public function testToOptionArray(): void
     {
         $this->_importConfig->expects(
             $this->once()
@@ -39,24 +45,10 @@ class ServiceTest extends TestCase
         )->willReturn(
             ['service_one', 'service_two']
         );
-        $this->_importConfig->expects(
-            $this->at(1)
-        )->method(
-            'getServiceLabel'
-        )->with(
-            'service_one'
-        )->willReturn(
-            'Service One'
-        );
-        $this->_importConfig->expects(
-            $this->at(2)
-        )->method(
-            'getServiceLabel'
-        )->with(
-            'service_two'
-        )->willReturn(
-            'Service Two'
-        );
+        $this->_importConfig
+            ->method('getServiceLabel')
+            ->withConsecutive(['service_one'], ['service_two'])
+            ->willReturnOnConsecutiveCalls('Service One', 'Service Two');
         $expectedResult = [
             ['value' => 'service_one', 'label' => 'Service One'],
             ['value' => 'service_two', 'label' => 'Service Two'],

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
@@ -58,7 +58,7 @@ class LinkTest extends TestCase
     protected $downloadHelper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/LinkTest.php
@@ -19,7 +19,9 @@ use PHPUnit\Framework\TestCase;
 
 class LinkTest extends TestCase
 {
-    /** @var Link */
+    /**
+     * @var Link
+     */
     protected $link;
 
     /** @var ObjectManagerHelper */
@@ -55,6 +57,9 @@ class LinkTest extends TestCase
      */
     protected $downloadHelper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
@@ -66,36 +71,45 @@ class LinkTest extends TestCase
             ->addMethods(['setHttpResponseCode', 'clearBody', 'sendHeaders', 'setHeader'])
             ->onlyMethods(['sendResponse'])
             ->getMockForAbstractClass();
-        $this->fileHelper = $this->createPartialMock(File::class, [
-            'getFilePath'
-        ]);
-        $this->downloadHelper = $this->createPartialMock(Download::class, [
-            'setResource',
-            'getFilename',
-            'getContentType',
-            'output',
-            'getFileSize',
-            'getContentDisposition'
-        ]);
+        $this->fileHelper = $this->createPartialMock(
+            File::class,
+            ['getFilePath']
+        );
+        $this->downloadHelper = $this->createPartialMock(
+            Download::class,
+            [
+                'setResource',
+                'getFilename',
+                'getContentType',
+                'output',
+                'getFileSize',
+                'getContentDisposition'
+            ]
+        );
         $this->linkModel = $this->getMockBuilder(Link::class)
-            ->addMethods([
-                'load',
-                'getId',
-                'getLinkType',
-                'getLinkUrl',
-                'getSampleUrl',
-                'getSampleType',
-                'getBasePath',
-                'getBaseSamplePath',
-                'getLinkFile',
-                'getSampleFile'
-            ])
+            ->addMethods(
+                [
+                    'load',
+                    'getId',
+                    'getLinkType',
+                    'getLinkUrl',
+                    'getSampleUrl',
+                    'getSampleType',
+                    'getBasePath',
+                    'getBaseSamplePath',
+                    'getLinkFile',
+                    'getSampleFile'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
-        $this->objectManager = $this->createPartialMock(ObjectManager::class, [
-            'create',
-            'get'
-        ]);
+        $this->objectManager = $this->createPartialMock(
+            ObjectManager::class,
+            [
+                'create',
+                'get'
+            ]
+        );
 
         $this->link = $this->objectManagerHelper->getObject(
             Link::class,
@@ -108,17 +122,19 @@ class LinkTest extends TestCase
     }
 
     /**
-     * @dataProvider executeDataProvider
      * @param string $fileType
+     *
+     * @return void
+     * @dataProvider executeDataProvider
      */
-    public function testExecuteFile($fileType)
+    public function testExecuteFile(string $fileType): void
     {
         $fileSize = 58493;
         $fileName = 'link.jpg';
-        $this->request->expects($this->at(0))->method('getParam')->with('id', 0)
-            ->willReturn(1);
-        $this->request->expects($this->at(1))->method('getParam')->with('type', 0)
-            ->willReturn($fileType);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['id', 0], ['type', 0])
+            ->willReturnOnConsecutiveCalls(1, $fileType);
         $this->response->expects($this->once())->method('setHttpResponseCode')->willReturnSelf();
         $this->response->expects($this->once())->method('clearBody')->willReturnSelf();
         $this->response
@@ -129,19 +145,17 @@ class LinkTest extends TestCase
                 [
                     'Cache-Control',
                     'must-revalidate, post-check=0, pre-check=0',
-                    true,
+                    true
                 ],
                 ['Content-type', 'text/html'],
                 ['Content-Length', $fileSize],
                 ['Content-Disposition', 'attachment; filename=' . $fileName]
             )->willReturnSelf();
         $this->response->expects($this->once())->method('sendHeaders')->willReturnSelf();
-        $this->objectManager->expects($this->at(1))->method('get')->with(File::class)
-            ->willReturn($this->fileHelper);
-        $this->objectManager->expects($this->at(2))->method('get')->with(\Magento\Downloadable\Model\Link::class)
-            ->willReturn($this->linkModel);
-        $this->objectManager->expects($this->at(3))->method('get')->with(Download::class)
-            ->willReturn($this->downloadHelper);
+        $this->objectManager
+            ->method('get')
+            ->withConsecutive([File::class], [\Magento\Downloadable\Model\Link::class], [Download::class])
+            ->willReturnOnConsecutiveCalls($this->fileHelper, $this->linkModel, $this->downloadHelper);
         $this->fileHelper->expects($this->once())->method('getFilePath')
             ->willReturn('filepath/' . $fileType . '.jpg');
         $this->downloadHelper->expects($this->once())->method('setResource')
@@ -169,20 +183,24 @@ class LinkTest extends TestCase
     }
 
     /**
-     * @dataProvider executeDataProvider
      * @param string $fileType
+     *
+     * @return void
+     * @dataProvider executeDataProvider
      */
-    public function testExecuteUrl($fileType)
+    public function testExecuteUrl(string $fileType): void
     {
-        $this->request->expects($this->at(0))->method('getParam')
-            ->with('id', 0)->willReturn(1);
-        $this->request->expects($this->at(1))->method('getParam')
-            ->with('type', 0)->willReturn($fileType);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['id', 0], ['type', 0])
+            ->willReturnOnConsecutiveCalls(1, $fileType);
         $this->response->expects($this->once())->method('setHttpResponseCode')->willReturnSelf();
         $this->response->expects($this->once())->method('clearBody')->willReturnSelf();
         $this->response->expects($this->any())->method('setHeader')->willReturnSelf();
         $this->response->expects($this->once())->method('sendHeaders')->willReturnSelf();
-        $this->objectManager->expects($this->at(1))->method('get')->with(Download::class)
+        $this->objectManager
+            ->method('get')
+            ->with(Download::class)
             ->willReturn($this->downloadHelper);
         $this->downloadHelper->expects($this->once())->method('setResource')
             ->willReturnSelf();
@@ -213,7 +231,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function executeDataProvider()
+    public function executeDataProvider(): array
     {
         return [
             ['link'],

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
@@ -59,7 +59,7 @@ class SampleTest extends TestCase
     protected $downloadHelper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Adminhtml/Downloadable/Product/Edit/SampleTest.php
@@ -18,10 +18,14 @@ use PHPUnit\Framework\TestCase;
 
 class SampleTest extends TestCase
 {
-    /** @var Sample */
+    /**
+     * @var Sample
+     */
     protected $sample;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
     /**
@@ -54,6 +58,9 @@ class SampleTest extends TestCase
      */
     protected $downloadHelper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
@@ -65,33 +72,42 @@ class SampleTest extends TestCase
             ->addMethods(['setHttpResponseCode', 'clearBody', 'sendHeaders', 'setHeader'])
             ->onlyMethods(['sendResponse'])
             ->getMockForAbstractClass();
-        $this->fileHelper = $this->createPartialMock(File::class, [
-            'getFilePath'
-        ]);
-        $this->downloadHelper = $this->createPartialMock(Download::class, [
-            'setResource',
-            'getFilename',
-            'getContentType',
-            'output',
-            'getFileSize',
-            'getContentDisposition'
-        ]);
+        $this->fileHelper = $this->createPartialMock(
+            File::class,
+            ['getFilePath']
+        );
+        $this->downloadHelper = $this->createPartialMock(
+            Download::class,
+            [
+                'setResource',
+                'getFilename',
+                'getContentType',
+                'output',
+                'getFileSize',
+                'getContentDisposition'
+            ]
+        );
         $this->sampleModel = $this->getMockBuilder(Sample::class)
-            ->addMethods([
-                'load',
-                'getId',
-                'getSampleType',
-                'getSampleUrl',
-                'getBasePath',
-                'getBaseSamplePath',
-                'getSampleFile'
-            ])
+            ->addMethods(
+                [
+                    'load',
+                    'getId',
+                    'getSampleType',
+                    'getSampleUrl',
+                    'getBasePath',
+                    'getBaseSamplePath',
+                    'getSampleFile'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
-        $this->objectManager = $this->createPartialMock(ObjectManager::class, [
-            'create',
-            'get'
-        ]);
+        $this->objectManager = $this->createPartialMock(
+            ObjectManager::class,
+            [
+                'create',
+                'get'
+            ]
+        );
         $this->sample = $this->objectManagerHelper->getObject(
             Sample::class,
             [
@@ -104,10 +120,14 @@ class SampleTest extends TestCase
 
     /**
      * Execute download sample file action
+     *
+     * @return void
      */
-    public function testExecuteFile()
+    public function testExecuteFile(): void
     {
-        $this->request->expects($this->at(0))->method('getParam')->with('id', 0)
+        $this->request
+            ->method('getParam')
+            ->with('id', 0)
             ->willReturn(1);
         $this->response->expects($this->once())->method('setHttpResponseCode')
             ->willReturnSelf();
@@ -117,12 +137,18 @@ class SampleTest extends TestCase
             ->willReturnSelf();
         $this->response->expects($this->once())->method('sendHeaders')
             ->willReturnSelf();
-        $this->objectManager->expects($this->at(1))->method('get')->with(File::class)
-            ->willReturn($this->fileHelper);
-        $this->objectManager->expects($this->at(2))->method('get')->with(\Magento\Downloadable\Model\Sample::class)
-            ->willReturn($this->sampleModel);
-        $this->objectManager->expects($this->at(3))->method('get')->with(Download::class)
-            ->willReturn($this->downloadHelper);
+        $this->objectManager
+            ->method('get')
+            ->withConsecutive(
+                [File::class],
+                [\Magento\Downloadable\Model\Sample::class],
+                [Download::class]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->fileHelper,
+                $this->sampleModel,
+                $this->downloadHelper
+            );
         $this->fileHelper->expects($this->once())->method('getFilePath')
             ->willReturn('filepath/sample.jpg');
         $this->downloadHelper->expects($this->once())->method('setResource')
@@ -151,10 +177,14 @@ class SampleTest extends TestCase
 
     /**
      * Execute download sample url action
+     *
+     * @return void
      */
-    public function testExecuteUrl()
+    public function testExecuteUrl(): void
     {
-        $this->request->expects($this->at(0))->method('getParam')->with('id', 0)
+        $this->request
+            ->method('getParam')
+            ->with('id', 0)
             ->willReturn(1);
         $this->response->expects($this->once())->method('setHttpResponseCode')
             ->willReturnSelf();
@@ -164,7 +194,9 @@ class SampleTest extends TestCase
             ->willReturnSelf();
         $this->response->expects($this->once())->method('sendHeaders')
             ->willReturnSelf();
-        $this->objectManager->expects($this->at(1))->method('get')->with(Download::class)
+        $this->objectManager
+            ->method('get')
+            ->with(Download::class)
             ->willReturn($this->downloadHelper);
         $this->downloadHelper->expects($this->once())->method('setResource')
             ->willReturnSelf();

--- a/app/code/Magento/Downloadable/Test/Unit/Observer/IsAllowedGuestCheckoutObserverTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Observer/IsAllowedGuestCheckoutObserverTest.php
@@ -65,7 +65,7 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
     private $storeManagerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Downloadable/Test/Unit/Observer/IsAllowedGuestCheckoutObserverTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Observer/IsAllowedGuestCheckoutObserverTest.php
@@ -65,29 +65,24 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
     private $storeManagerMock;
 
     /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
-        $this->scopeConfigMock = $this->getMockBuilder(Config::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isSetFlag', 'getValue'])
+        $this->scopeConfigMock = $this->getMockBuilder(Config::class)->disableOriginalConstructor()
+            ->onlyMethods(['isSetFlag', 'getValue'])
             ->getMock();
 
-        $this->resultMock = $this->getMockBuilder(DataObject::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setIsAllowed'])
+        $this->resultMock = $this->getMockBuilder(DataObject::class)->disableOriginalConstructor()
+            ->addMethods(['setIsAllowed'])
             ->getMock();
 
-        $this->eventMock = $this->getMockBuilder(Event::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getStore', 'getResult', 'getQuote', 'getOrder'])
+        $this->eventMock = $this->getMockBuilder(Event::class)->disableOriginalConstructor()
+            ->addMethods(['getStore', 'getResult', 'getQuote', 'getOrder'])
             ->getMock();
 
-        $this->observerMock = $this->getMockBuilder(Observer::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEvent'])
+        $this->observerMock = $this->getMockBuilder(Observer::class)->disableOriginalConstructor()
+            ->onlyMethods(['getEvent'])
             ->getMock();
 
         $this->storeMock = $this->getMockBuilder(DataObject::class)
@@ -111,41 +106,38 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
     }
 
     /**
-     *
-     * @dataProvider dataProviderForTestisAllowedGuestCheckoutConfigSetToTrue
-     *
      * @param $productType
      * @param $isAllowed
+     *
+     * @return void
+     * @dataProvider dataProviderForTestisAllowedGuestCheckoutConfigSetToTrue
      */
     public function testIsAllowedGuestCheckoutConfigSetToTrue($productType, $isAllowed): void
     {
         if ($isAllowed) {
-            $this->resultMock->expects($this->at(0))
+            $this->resultMock
                 ->method('setIsAllowed')
                 ->with(false);
         }
 
-        $product = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getTypeId'])
+        $product = $this->getMockBuilder(Product::class)->disableOriginalConstructor()
+            ->onlyMethods(['getTypeId'])
             ->getMock();
 
         $product->expects($this->once())
             ->method('getTypeId')
             ->willReturn($productType);
 
-        $item = $this->getMockBuilder(QuoteItem::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getProduct'])
+        $item = $this->getMockBuilder(QuoteItem::class)->disableOriginalConstructor()
+            ->onlyMethods(['getProduct'])
             ->getMock();
 
         $item->expects($this->once())
             ->method('getProduct')
             ->willReturn($product);
 
-        $quote = $this->getMockBuilder(Quote::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getAllItems'])
+        $quote = $this->getMockBuilder(Quote::class)->disableOriginalConstructor()
+            ->onlyMethods(['getAllItems'])
             ->getMock();
 
         $quote->expects($this->once())
@@ -194,15 +186,18 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
     {
         return [
             1 => [Type::TYPE_DOWNLOADABLE, true],
-            2 => ['unknown', false],
+            2 => ['unknown', false]
         ];
     }
 
+    /**
+     * @return void
+     */
     public function testIsAllowedGuestCheckoutConfigSetToFalse(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTypeId'])
+            ->onlyMethods(['getTypeId'])
             ->getMock();
 
         $product->expects($this->once())
@@ -211,7 +206,7 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
 
         $item = $this->getMockBuilder(QuoteItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProduct'])
+            ->onlyMethods(['getProduct'])
             ->getMock();
 
         $item->expects($this->once())
@@ -220,7 +215,7 @@ class IsAllowedGuestCheckoutObserverTest extends TestCase
 
         $quote = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAllItems'])
+            ->onlyMethods(['getAllItems'])
             ->getMock();
 
         $quote->expects($this->once())

--- a/app/code/Magento/Eav/Test/Unit/Model/Validator/Attribute/DataTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Validator/Attribute/DataTest.php
@@ -42,13 +42,13 @@ class DataTest extends TestCase
     private $objectManager;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->attrDataFactory = $this->getMockBuilder(AttributeDataFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->setConstructorArgs(
                 [
                     'objectManager' => $this->getMockForAbstractClass(ObjectManagerInterface::class),
@@ -59,9 +59,7 @@ class DataTest extends TestCase
 
         $this->model = $this->objectManager->getObject(
             Data::class,
-            [
-                '_attrDataFactory' => $this->attrDataFactory
-            ]
+            ['_attrDataFactory' => $this->attrDataFactory]
         );
     }
 
@@ -75,6 +73,8 @@ class DataTest extends TestCase
      * @param bool $expected
      * @param array $messages
      * @param array $data
+     *
+     * @return void
      */
     public function testIsValid(
         $attributeData,
@@ -82,11 +82,11 @@ class DataTest extends TestCase
         $expected,
         $messages,
         $data = ['attribute' => 'new_test']
-    ) {
+    ): void {
         $entity = $this->_getEntityMock();
         $attribute = $this->_getAttributeMock($attributeData);
         $attrDataFactory = $this->getMockBuilder(AttributeDataFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->setConstructorArgs(
                 [
                     'objectManager' => $this->getMockForAbstractClass(ObjectManagerInterface::class),
@@ -113,7 +113,7 @@ class DataTest extends TestCase
      *
      * @return array
      */
-    public function isValidDataProvider()
+    public function isValidDataProvider(): array
     {
         return [
             'is_valid' => [
@@ -121,65 +121,65 @@ class DataTest extends TestCase
                     'attribute_code' => 'attribute',
                     'data_model' => $this->_getDataModelMock(null),
                     'frontend_input' => 'text',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => true,
                 'isValid' => true,
-                'messages' => [],
+                'messages' => []
             ],
             'is_invalid' => [
                 'attributeData' => [
                     'attribute_code' => 'attribute',
                     'data_model' => $this->_getDataModelMock(null),
                     'frontend_input' => 'text',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => ['Error'],
                 'isValid' => false,
-                'messages' => ['attribute' => ['Error']],
+                'messages' => ['attribute' => ['Error']]
             ],
             'no_data_models' => [
                 'attributeData' => [
                     'attribute_code' => 'attribute',
                     'frontend_input' => 'text',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => ['Error'],
                 'isValid' => false,
-                'messages' => ['attribute' => ['Error']],
+                'messages' => ['attribute' => ['Error']]
             ],
             'no_data_models_no_frontend_input' => [
                 'attributeData' => [
                     'attribute_code' => 'attribute',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => ['Error'],
                 'isValid' => true,
-                'messages' => [],
+                'messages' => []
             ],
             'no_data_for attribute' => [
                 'attributeData' => [
                     'attribute_code' => 'attribute',
                     'data_model' => $this->_getDataModelMock(null),
                     'frontend_input' => 'text',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => true,
                 'isValid' => true,
                 'messages' => [],
-                'setData' => ['attribute2' => 'new_test'],
+                'setData' => ['attribute2' => 'new_test']
             ],
             'is_valid_data_from_entity' => [
                 'attributeData' => [
                     'attribute_code' => 'attribute',
                     'data_model' => $this->_getDataModelMock(null),
                     'frontend_input' => 'text',
-                    'is_visible' => true,
+                    'is_visible' => true
                 ],
                 'attributeReturns' => true,
                 'isValid' => true,
                 'messages' => [],
-                'setData' => [],
+                'setData' => []
             ],
             'is_invisible' => [
                 'attributeData' => [
@@ -190,7 +190,7 @@ class DataTest extends TestCase
                 ],
                 'attributeReturns' => ['Error'],
                 'isValid' => true,
-                'messages' => [],
+                'messages' => []
             ],
         ];
     }
@@ -199,8 +199,10 @@ class DataTest extends TestCase
      * Testing \Magento\Eav\Model\Validator\Attribute\Data::isValid
      *
      * In this test entity attributes are got from attribute collection.
+     *
+     * @return void
      */
-    public function testIsValidAttributesFromCollection()
+    public function testIsValidAttributesFromCollection(): void
     {
         /** @var AbstractEntity $resource */
         $resource = $this->getMockForAbstractClass(AbstractEntity::class, [], '', false);
@@ -213,10 +215,10 @@ class DataTest extends TestCase
             ]
         );
         $collection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getItems'])->getMock();
+            ->addMethods(['getItems'])->getMock();
         $collection->expects($this->once())->method('getItems')->willReturn([$attribute]);
         $entityType = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getAttributeCollection'])
+            ->addMethods(['getAttributeCollection'])
             ->getMock();
         $entityType->expects($this->once())->method('getAttributeCollection')->willReturn($collection);
         $entity = $this->_getEntityMock();
@@ -224,7 +226,7 @@ class DataTest extends TestCase
         $entity->expects($this->once())->method('getEntityType')->willReturn($entityType);
         $dataModel = $this->_getDataModelMock(true);
         $attrDataFactory = $this->getMockBuilder(AttributeDataFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->setConstructorArgs(
                 [
                     'objectManager' => $this->getMockForAbstractClass(ObjectManagerInterface::class),
@@ -249,17 +251,19 @@ class DataTest extends TestCase
     }
 
     /**
-     * @dataProvider allowDenyListProvider
      * @param callable $callback
+     *
+     * @return void
+     * @dataProvider allowDenyListProvider
      */
-    public function testIsValidExclusionInclusionListChecks($callback)
+    public function testIsValidExclusionInclusionListChecks($callback): void
     {
         $attribute = $this->_getAttributeMock(
             [
                 'attribute_code' => 'attribute',
                 'data_model' => $this->_getDataModelMock(null),
                 'frontend_input' => 'text',
-                'is_visible' => true,
+                'is_visible' => true
             ]
         );
         $secondAttribute = $this->_getAttributeMock(
@@ -267,14 +271,14 @@ class DataTest extends TestCase
                 'attribute_code' => 'attribute2',
                 'data_model' => $this->_getDataModelMock(null),
                 'frontend_input' => 'text',
-                'is_visible' => true,
+                'is_visible' => true
             ]
         );
         $data = ['attribute' => 'new_test_data', 'attribute2' => 'some data'];
         $entity = $this->_getEntityMock();
         $dataModel = $this->_getDataModelMock(true, $data['attribute']);
         $attrDataFactory = $this->getMockBuilder(AttributeDataFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->setConstructorArgs(
                 [
                     'objectManager' => $this->getMockForAbstractClass(ObjectManagerInterface::class),
@@ -302,7 +306,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function allowDenyListProvider()
+    public function allowDenyListProvider(): array
     {
         $allowedCallbackList = function ($validator) {
             $validator->setAllowedAttributesList(['attribute']);
@@ -314,7 +318,10 @@ class DataTest extends TestCase
         return ['allowed' => [$allowedCallbackList], 'denied' => [$deniedCallbackList]];
     }
 
-    public function testSetAttributesAllowedList()
+    /**
+     * @return void
+     */
+    public function testSetAttributesAllowedList(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -335,7 +342,10 @@ class DataTest extends TestCase
         $this->assertEquals($validator, $result);
     }
 
-    public function testSetAttributesDeniedList()
+    /**
+     * @return void
+     */
+    public function testSetAttributesDeniedList(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -355,7 +365,10 @@ class DataTest extends TestCase
         $this->assertEquals($validator, $result);
     }
 
-    public function testAddErrorMessages()
+    /**
+     * @return void
+     */
+    public function testAddErrorMessages(): void
     {
         $data = ['attribute1' => 'new_test', 'attribute2' => 'some data'];
         $entity = $this->_getEntityMock();
@@ -364,7 +377,7 @@ class DataTest extends TestCase
                 'attribute_code' => 'attribute1',
                 'data_model' => $firstDataModel = $this->_getDataModelMock(['Error1']),
                 'frontend_input' => 'text',
-                'is_visible' => true,
+                'is_visible' => true
             ]
         );
         $secondAttribute = $this->_getAttributeMock(
@@ -372,13 +385,13 @@ class DataTest extends TestCase
                 'attribute_code' => 'attribute2',
                 'data_model' => $secondDataModel = $this->_getDataModelMock(['Error2']),
                 'frontend_input' => 'text',
-                'is_visible' => true,
+                'is_visible' => true
             ]
         );
         $expectedMessages = ['attribute1' => ['Error1'], 'attribute2' => ['Error2']];
         $expectedDouble = ['attribute1' => ['Error1', 'Error1'], 'attribute2' => ['Error2', 'Error2']];
         $factory = $this->getMockBuilder(AttributeDataFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->setConstructorArgs(
                 [
                     'objectManager' => $this->getMockForAbstractClass(ObjectManagerInterface::class),
@@ -389,46 +402,20 @@ class DataTest extends TestCase
         $validator = new Data($factory);
         $validator->setAttributes([$firstAttribute, $secondAttribute])->setData($data);
 
-        $factory->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            $firstAttribute,
-            $entity
-        )->willReturn(
-            $firstDataModel
-        );
-        $factory->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            $secondAttribute,
-            $entity
-        )->willReturn(
-            $secondDataModel
-        );
-        $factory->expects(
-            $this->at(2)
-        )->method(
-            'create'
-        )->with(
-            $firstAttribute,
-            $entity
-        )->willReturn(
-            $firstDataModel
-        );
-        $factory->expects(
-            $this->at(3)
-        )->method(
-            'create'
-        )->with(
-            $secondAttribute,
-            $entity
-        )->willReturn(
-            $secondDataModel
-        );
+        $factory
+            ->method('create')
+            ->withConsecutive(
+                [$firstAttribute, $entity],
+                [$secondAttribute, $entity],
+                [$firstAttribute, $entity],
+                [$secondAttribute, $entity]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $firstDataModel,
+                $secondDataModel,
+                $firstDataModel,
+                $secondDataModel
+            );
 
         $this->assertFalse($validator->isValid($entity));
         $this->assertEquals($expectedMessages, $validator->getMessages());
@@ -438,20 +425,21 @@ class DataTest extends TestCase
 
     /**
      * @param array $attributeData
+     *
      * @return MockObject
      */
-    protected function _getAttributeMock($attributeData)
+    protected function _getAttributeMock($attributeData): MockObject
     {
         $attribute = $this->getMockBuilder(Attribute::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getAttributeCode',
-                    'getDataModel',
                     'getFrontendInput',
                     '__wakeup',
-                    'getIsVisible',
+                    'getIsVisible'
                 ]
             )
+            ->addMethods(['getDataModel'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -493,16 +481,13 @@ class DataTest extends TestCase
     /**
      * @param boolean $returnValue
      * @param string|null $argument
+     *
      * @return MockObject
      */
-    protected function _getDataModelMock($returnValue, $argument = null)
+    protected function _getDataModelMock($returnValue, $argument = null): MockObject
     {
-        $dataModel = $this->getMockBuilder(
-            AbstractData::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['setExtractedData', 'validateValue']
-            )->getMockForAbstractClass();
+        $dataModel = $this->getMockBuilder(AbstractData::class)->disableOriginalConstructor()
+            ->onlyMethods(['setExtractedData', 'validateValue'])->getMockForAbstractClass();
         if ($argument) {
             $dataModel->expects(
                 $this->once()
@@ -522,14 +507,14 @@ class DataTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function _getEntityMock()
+    protected function _getEntityMock(): MockObject
     {
-        $entity = $this->getMockBuilder(
-            AbstractModel::class
-        )->setMethods(
-            ['getAttribute', 'getResource', 'getEntityType', '__wakeup']
-        )->disableOriginalConstructor()
+        $entity = $this->getMockBuilder(AbstractModel::class)
+            ->onlyMethods(['getResource', '__wakeup'])
+            ->addMethods(['getAttribute', 'getEntityType'])
+            ->disableOriginalConstructor()
             ->getMock();
+
         return $entity;
     }
 

--- a/app/code/Magento/Eav/Test/Unit/Model/Validator/Attribute/DataTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Validator/Attribute/DataTest.php
@@ -42,7 +42,7 @@ class DataTest extends TestCase
     private $objectManager;
 
     /**
-     * @inheritDoc
+     * @inheritdoc 
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
@@ -9,10 +9,12 @@ namespace Magento\Elasticsearch\Test\Unit\Model\Adapter;
 
 use Elasticsearch\Client;
 use Elasticsearch\Namespaces\IndicesNamespace;
+use Exception;
 use Magento\AdvancedSearch\Model\Client\ClientInterface as ElasticsearchClient;
 use Magento\AdvancedSearch\Model\Client\ClientOptionsInterface;
 use Magento\Catalog\Api\ProductAttributeRepositoryInterface;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Elasticsearch\Elasticsearch5\Model\Client\Elasticsearch;
 use Magento\Elasticsearch\Model\Adapter\BatchDataMapperInterface;
 use Magento\Elasticsearch\Model\Adapter\Elasticsearch as ElasticsearchAdapter;
 use Magento\Elasticsearch\Model\Adapter\FieldMapperInterface;
@@ -101,29 +103,21 @@ class ElasticsearchTest extends TestCase
     private $arrayManager;
 
     /**
-     * Setup
-     *
-     * @return void
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManagerHelper($this);
         $this->connectionManager = $this->getMockBuilder(ConnectionManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getConnection'])
+            ->onlyMethods(['getConnection'])
             ->getMock();
         $this->fieldMapper = $this->getMockBuilder(FieldMapperInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->clientConfig = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getIndexPrefix',
-                    'getEntityType',
-                ]
-            )->getMock();
+            ->onlyMethods(['getIndexPrefix', 'getEntityType'])->getMock();
         $this->indexBuilder = $this->getMockBuilder(BuilderInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -131,35 +125,28 @@ class ElasticsearchTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $elasticsearchClientMock = $this->getMockBuilder(Client::class)
-            ->setMethods(
-                [
-                    'indices',
-                    'ping',
-                    'bulk',
-                    'search',
-                ]
-            )
+            ->onlyMethods(['indices', 'ping', 'bulk', 'search'])
             ->disableOriginalConstructor()
             ->getMock();
         $indicesMock = $this->getMockBuilder(IndicesNamespace::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'exists',
                     'getSettings',
                     'create',
                     'putMapping',
-                    'deleteMapping',
                     'existsAlias',
                     'updateAliases',
                     'stats'
                 ]
             )
+            ->addMethods(['deleteMapping'])
             ->disableOriginalConstructor()
             ->getMock();
         $elasticsearchClientMock->expects($this->any())
             ->method('indices')
             ->willReturn($indicesMock);
-        $this->client = $this->getMockBuilder(\Magento\Elasticsearch\Elasticsearch5\Model\Client\Elasticsearch::class)
+        $this->client = $this->getMockBuilder(Elasticsearch::class)
             ->setConstructorArgs(
                 [
                     'options' => $this->getClientOptions(),
@@ -178,10 +165,10 @@ class ElasticsearchTest extends TestCase
                         'type' => 'string',
                         'fields' => [
                             'keyword' => [
-                                'type' => "keyword",
-                            ],
-                        ],
-                    ],
+                                'type' => "keyword"
+                            ]
+                        ]
+                    ]
                 ]
             );
         $this->clientConfig->expects($this->any())
@@ -190,15 +177,13 @@ class ElasticsearchTest extends TestCase
         $this->clientConfig->expects($this->any())
             ->method('getEntityType')
             ->willReturn('product');
-        $this->indexNameResolver = $this->getMockBuilder(
-            IndexNameResolver::class
-        )
-            ->setMethods(
+        $this->indexNameResolver = $this->getMockBuilder(IndexNameResolver::class)
+            ->onlyMethods(
                 [
                     'getIndexName',
                     'getIndexNamespace',
                     'getIndexFromAlias',
-                    'getIndexNameForAlias',
+                    'getIndexNameForAlias'
                 ]
             )
             ->disableOriginalConstructor()
@@ -216,7 +201,7 @@ class ElasticsearchTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->model = $this->objectManager->getObject(
-            \Magento\Elasticsearch\Model\Adapter\Elasticsearch::class,
+            ElasticsearchAdapter::class,
             [
                 'connectionManager' => $this->connectionManager,
                 'batchDocumentDataMapper' => $this->batchDocumentDataMapper,
@@ -228,15 +213,17 @@ class ElasticsearchTest extends TestCase
                 'options' => [],
                 'productAttributeRepository' => $this->productAttributeRepository,
                 'staticFieldProvider' => $this->staticFieldProvider,
-                'arrayManager' => $this->arrayManager,
+                'arrayManager' => $this->arrayManager
             ]
         );
     }
 
     /**
      * Test ping() method
+     *
+     * @return void
      */
-    public function testPing()
+    public function testPing(): void
     {
         $this->client->expects($this->once())
             ->method('ping')
@@ -246,29 +233,35 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test ping() method
+     *
+     * @return void
      */
-    public function testPingFailure()
+    public function testPingFailure(): void
     {
         $this->expectException(LocalizedException::class);
 
         $this->client->expects($this->once())
             ->method('ping')
-            ->willThrowException(new \Exception('Something went wrong'));
+            ->willThrowException(new Exception('Something went wrong'));
         $this->model->ping();
     }
 
     /**
      * Test prepareDocsPerStore() method
+     *
+     * @return void
      */
-    public function testPrepareDocsPerStoreEmpty()
+    public function testPrepareDocsPerStoreEmpty(): void
     {
         $this->assertEquals([], $this->model->prepareDocsPerStore([], 1));
     }
 
     /**
      * Test prepareDocsPerStore() method
+     *
+     * @return void
      */
-    public function testPrepareDocsPerStore()
+    public function testPrepareDocsPerStore(): void
     {
         $this->batchDocumentDataMapper->expects($this->once())
             ->method('map')
@@ -278,10 +271,7 @@ class ElasticsearchTest extends TestCase
                 ]
             );
         $this->assertIsArray($this->model->prepareDocsPerStore(
-            [
-                '1' => [
-                    'name' => 'Product Name',
-                ],
+            ['1' => ['name' => 'Product Name'],
             ],
             1
         ));
@@ -289,18 +279,17 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test addDocs() method
+     *
+     * @return void
      */
-    public function testAddDocs()
+    public function testAddDocs(): void
     {
         $this->client->expects($this->once())
             ->method('bulkQuery');
         $this->assertSame(
             $this->model,
             $this->model->addDocs(
-                [
-                    '1' => [
-                        'name' => 'Product Name',
-                    ],
+                ['1' => ['name' => 'Product Name'],
                 ],
                 1,
                 'product'
@@ -310,20 +299,18 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test addDocs() method
+     *
+     * @return void
      */
-    public function testAddDocsFailure()
+    public function testAddDocsFailure(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->client->expects($this->once())
             ->method('bulkQuery')
-            ->willThrowException(new \Exception('Something went wrong'));
+            ->willThrowException(new Exception('Something went wrong'));
         $this->model->addDocs(
-            [
-                '1' => [
-                    'name' => 'Product Name',
-                ],
-            ],
+            ['1' => ['name' => 'Product Name']],
             1,
             'product'
         );
@@ -331,8 +318,10 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test cleanIndex() method
+     *
+     * @return void
      */
-    public function testCleanIndex()
+    public function testCleanIndex(): void
     {
         $this->indexNameResolver->expects($this->any())
             ->method('getIndexName')
@@ -353,8 +342,10 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test deleteDocs() method
+     *
+     * @return void
      */
-    public function testDeleteDocs()
+    public function testDeleteDocs(): void
     {
         $this->client->expects($this->once())
             ->method('bulkQuery');
@@ -366,24 +357,28 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test deleteDocs() method
+     *
+     * @return void
      */
-    public function testDeleteDocsFailure()
+    public function testDeleteDocsFailure(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $this->client->expects($this->once())
             ->method('bulkQuery')
-            ->willThrowException(new \Exception('Something went wrong'));
+            ->willThrowException(new Exception('Something went wrong'));
         $this->model->deleteDocs(['1' => 1], 1, 'product');
     }
 
     /**
      * Test updateAlias() method
+     *
+     * @return void
      */
-    public function testUpdateAliasEmpty()
+    public function testUpdateAliasEmpty(): void
     {
         $model = $this->objectManager->getObject(
-            \Magento\Elasticsearch\Model\Adapter\Elasticsearch::class,
+            ElasticsearchAdapter::class,
             [
                 'connectionManager' => $this->connectionManager,
                 'batchDocumentDataMapper' => $this->batchDocumentDataMapper,
@@ -402,25 +397,23 @@ class ElasticsearchTest extends TestCase
         $this->assertEquals($model, $model->updateAlias(1, 'product'));
     }
 
-    public function testConnectException()
+    /**
+     * @return void
+     */
+    public function testConnectException(): void
     {
         $this->expectException(LocalizedException::class);
 
-        $connectionManager = $this->getMockBuilder(ConnectionManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getConnection',
-                ]
-            )
+        $connectionManager = $this->getMockBuilder(ConnectionManager::class)->disableOriginalConstructor()
+            ->onlyMethods(['getConnection'])
             ->getMock();
 
         $connectionManager->expects($this->any())
             ->method('getConnection')
-            ->willThrowException(new \Exception('Something went wrong'));
+            ->willThrowException(new Exception('Something went wrong'));
 
         $this->objectManager->getObject(
-            \Magento\Elasticsearch\Model\Adapter\Elasticsearch::class,
+            ElasticsearchAdapter::class,
             [
                 'connectionManager' => $connectionManager,
                 'batchDocumentDataMapper' => $this->batchDocumentDataMapper,
@@ -436,8 +429,10 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test updateAlias() method
+     *
+     * @return void
      */
-    public function testUpdateAlias()
+    public function testUpdateAlias(): void
     {
         $this->client->expects($this->atLeastOnce())
             ->method('updateAlias');
@@ -451,8 +446,10 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test updateAlias() method
+     *
+     * @return void
      */
-    public function testUpdateAliasWithOldIndex()
+    public function testUpdateAliasWithOldIndex(): void
     {
         $this->model->cleanIndex(1, 'product');
 
@@ -479,8 +476,10 @@ class ElasticsearchTest extends TestCase
 
     /**
      * Test updateAlias() method
+     *
+     * @return void
      */
-    public function testUpdateAliasWithoutOldIndex()
+    public function testUpdateAliasWithoutOldIndex(): void
     {
         $this->model->cleanIndex(1, 'product');
         $this->client->expects($this->any())
@@ -587,9 +586,9 @@ class ElasticsearchTest extends TestCase
                     ]
             ]
         ];
-        $this->client->expects($this->at(1))
+        $this->client
             ->method('createIndex')
-            ->with(null, ['settings' => $settings]);
+            ->withConsecutive([null, ['settings' => $settings]]);
         $this->model->cleanIndex(1, 'product');
     }
 
@@ -598,7 +597,7 @@ class ElasticsearchTest extends TestCase
      *
      * @return array
      */
-    protected function getClientOptions()
+    protected function getClientOptions(): array
     {
         return [
             'hostname' => 'localhost',
@@ -607,7 +606,7 @@ class ElasticsearchTest extends TestCase
             'index' => 'magento2',
             'enableAuth' => 1,
             'username' => 'user',
-            'password' => 'my-password',
+            'password' => 'my-password'
         ];
     }
 }

--- a/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/ElasticsearchTest.php
@@ -103,7 +103,7 @@ class ElasticsearchTest extends TestCase
     private $arrayManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/ResponseFactoryTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/ResponseFactoryTest.php
@@ -39,7 +39,7 @@ class ResponseFactoryTest extends TestCase
     private $objectManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/ResponseFactoryTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/ResponseFactoryTest.php
@@ -39,21 +39,17 @@ class ResponseFactoryTest extends TestCase
     private $objectManager;
 
     /**
-     * Set up test environment.
-     *
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
         $this->documentFactory = $this->getMockBuilder(DocumentFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->aggregationFactory = $this->getMockBuilder(
-            AggregationFactory::class
-        )
-            ->setMethods(['create'])
+        $this->aggregationFactory = $this->getMockBuilder(AggregationFactory::class)
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -70,20 +66,23 @@ class ResponseFactoryTest extends TestCase
         );
     }
 
-    public function testCreate()
+    /**
+     * @return void
+     */
+    public function testCreate(): void
     {
         $documents = [
             ['title' => 'oneTitle', 'description' => 'oneDescription'],
-            ['title' => 'twoTitle', 'description' => 'twoDescription'],
+            ['title' => 'twoTitle', 'description' => 'twoDescription']
         ];
         $aggregations = [
             'aggregation1' => [
                 'itemOne' => 10,
-                'itemTwo' => 20,
+                'itemTwo' => 20
             ],
             'aggregation2' => [
                 'itemOne' => 5,
-                'itemTwo' => 45,
+                'itemTwo' => 45
             ]
         ];
         $rawResponse = ['documents' => $documents, 'aggregations' => $aggregations, 'total' => 2];
@@ -92,11 +91,11 @@ class ResponseFactoryTest extends TestCase
             'documents' => [
                 [
                     ['name' => 'title', 'value' => 'oneTitle'],
-                    ['name' => 'description', 'value' => 'oneDescription'],
+                    ['name' => 'description', 'value' => 'oneDescription']
                 ],
                 [
                     ['name' => 'title', 'value' => 'twoTitle'],
-                    ['name' => 'description', 'value' => 'twoDescription'],
+                    ['name' => 'description', 'value' => 'twoDescription']
                 ],
             ],
             'aggregations' => [
@@ -109,17 +108,16 @@ class ResponseFactoryTest extends TestCase
                     'itemTwo' => 45
                 ],
             ],
-            'total' => 2,
+            'total' => 2
         ];
 
-        $this->documentFactory->expects($this->at(0))->method('create')
-            ->with($documents[0])
-            ->willReturn('document1');
-        $this->documentFactory->expects($this->at(1))->method('create')
-            ->with($documents[1])
-            ->willReturn('document2');
+        $this->documentFactory
+            ->method('create')
+            ->withConsecutive([$documents[0]], [$documents[1]])
+            ->willReturnOnConsecutiveCalls('document1', 'document2');
 
-        $this->aggregationFactory->expects($this->at(0))->method('create')
+        $this->aggregationFactory
+            ->method('create')
             ->with($exceptedResponse['aggregations'])
             ->willReturn('aggregationsData');
 

--- a/app/code/Magento/Elasticsearch/Test/Unit/Setup/InstallConfigTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Setup/InstallConfigTest.php
@@ -26,7 +26,7 @@ class InstallConfigTest extends TestCase
     private $configWriterMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setup(): void
     {

--- a/app/code/Magento/Elasticsearch/Test/Unit/Setup/InstallConfigTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/Setup/InstallConfigTest.php
@@ -25,6 +25,9 @@ class InstallConfigTest extends TestCase
      */
     private $configWriterMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setup(): void
     {
         $this->configWriterMock = $this->getMockBuilder(WriterInterface::class)->getMockForAbstractClass();
@@ -41,13 +44,16 @@ class InstallConfigTest extends TestCase
                     'elasticsearch-index-prefix' => 'elasticsearch5_index_prefix',
                     'elasticsearch-enable-auth' => 'elasticsearch5_enable_auth',
                     'elasticsearch-username' => 'elasticsearch5_username',
-                    'elasticsearch-password' => 'elasticsearch5_password',
+                    'elasticsearch-password' => 'elasticsearch5_password'
                 ]
             ]
         );
     }
 
-    public function testConfigure()
+    /**
+     * @return void
+     */
+    public function testConfigure(): void
     {
         $inputOptions = [
             'search-engine' => 'elasticsearch5',
@@ -56,22 +62,20 @@ class InstallConfigTest extends TestCase
         ];
 
         $this->configWriterMock
-            ->expects($this->at(0))
             ->method('save')
-            ->with('catalog/search/engine', 'elasticsearch5');
-        $this->configWriterMock
-            ->expects($this->at(1))
-            ->method('save')
-            ->with('catalog/search/elasticsearch5_server_hostname', 'localhost');
-        $this->configWriterMock
-            ->expects($this->at(2))
-            ->method('save')
-            ->with('catalog/search/elasticsearch5_server_port', '9200');
+            ->withConsecutive(
+                ['catalog/search/engine', 'elasticsearch5'],
+                ['catalog/search/elasticsearch5_server_hostname', 'localhost'],
+                ['catalog/search/elasticsearch5_server_port', '9200']
+            );
 
         $this->installConfig->configure($inputOptions);
     }
 
-    public function testConfigureWithEmptyInput()
+    /**
+     * @return void
+     */
+    public function testConfigureWithEmptyInput(): void
     {
         $this->configWriterMock->expects($this->never())->method('save');
         $this->installConfig->configure([]);

--- a/app/code/Magento/Email/Test/Unit/Controller/Adminhtml/Email/Template/IndexTest.php
+++ b/app/code/Magento/Email/Test/Unit/Controller/Adminhtml/Email/Template/IndexTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index
+ * @covers Index
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class IndexTest extends TestCase
@@ -83,6 +83,9 @@ class IndexTest extends TestCase
      */
     private $registryMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->registryMock = $this->getMockBuilder(Registry::class)
@@ -91,25 +94,22 @@ class IndexTest extends TestCase
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->viewMock = $this->getMockBuilder(View::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['loadLayout', 'getLayout', 'getPage', 'renderLayout'])
+        $this->viewMock = $this->getMockBuilder(View::class)->disableOriginalConstructor()
+            ->onlyMethods(['loadLayout', 'getLayout', 'getPage', 'renderLayout'])
             ->getMock();
-        $this->layoutMock = $this->getMockBuilder(Layout::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getBlock'])
+        $this->layoutMock = $this->getMockBuilder(Layout::class)->disableOriginalConstructor()
+            ->onlyMethods(['getBlock'])
             ->getMock();
-        $this->menuBlockMock = $this->getMockBuilder(Menu::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setActive', 'getMenuModel', 'getParentItems'])
+        $this->menuBlockMock = $this->getMockBuilder(Menu::class)->disableOriginalConstructor()
+            ->onlyMethods(['getMenuModel'])
+            ->addMethods(['setActive', 'getParentItems'])
             ->getMock();
-        $this->breadcrumbsBlockMock = $this->getMockBuilder(Breadcrumbs::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addLink'])
+        $this->breadcrumbsBlockMock = $this->getMockBuilder(Breadcrumbs::class)->disableOriginalConstructor()
+            ->onlyMethods(['addLink'])
             ->getMock();
-        $this->resultPageMock = $this->getMockBuilder(Page::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setActiveMenu', 'getConfig', 'addBreadcrumb'])
+        $this->resultPageMock = $this->getMockBuilder(Page::class)->disableOriginalConstructor()
+            ->onlyMethods(['getConfig'])
+            ->addMethods(['setActiveMenu', 'addBreadcrumb'])
             ->getMock();
         $this->pageConfigMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
@@ -135,19 +135,17 @@ class IndexTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index::execute
+     * @covers Index::execute
+     *
+     * @return void
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $this->prepareExecute();
 
         $this->viewMock->expects($this->atLeastOnce())
             ->method('getLayout')
             ->willReturn($this->layoutMock);
-        $this->layoutMock->expects($this->at(0))
-            ->method('getBlock')
-            ->with('menu')
-            ->willReturn($this->menuBlockMock);
         $this->menuBlockMock->expects($this->any())
             ->method('getMenuModel')->willReturnSelf();
         $this->menuBlockMock->expects($this->any())
@@ -165,10 +163,10 @@ class IndexTest extends TestCase
         $this->pageTitleMock->expects($this->once())
             ->method('prepend')
             ->with('Email Templates');
-        $this->layoutMock->expects($this->at(1))
+        $this->layoutMock
             ->method('getBlock')
-            ->with('breadcrumbs')
-            ->willReturn($this->breadcrumbsBlockMock);
+            ->withConsecutive(['menu'], ['breadcrumbs'])
+            ->willReturnOnConsecutiveCalls($this->menuBlockMock, $this->breadcrumbsBlockMock);
         $this->breadcrumbsBlockMock->expects($this->any())
             ->method('addLink')
             ->willReturnSelf();
@@ -177,13 +175,15 @@ class IndexTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index::execute
+     * @covers Index::execute
+     *
+     * @return void
      */
-    public function testExecuteAjax()
+    public function testExecuteAjax(): void
     {
         $this->prepareExecute(true);
         $indexController = $this->getMockBuilder(Index::class)
-            ->setMethods(['getRequest', '_forward'])
+            ->onlyMethods(['getRequest', '_forward'])
             ->disableOriginalConstructor()
             ->getMock();
         $indexController->expects($this->once())
@@ -197,8 +197,10 @@ class IndexTest extends TestCase
 
     /**
      * @param bool $ajax
+     *
+     * @return void
      */
-    protected function prepareExecute($ajax = false)
+    protected function prepareExecute(bool $ajax = false): void
     {
         $this->requestMock->expects($this->once())
             ->method('getQuery')

--- a/app/code/Magento/Email/Test/Unit/Controller/Adminhtml/Email/Template/IndexTest.php
+++ b/app/code/Magento/Email/Test/Unit/Controller/Adminhtml/Email/Template/IndexTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Index
+ * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class IndexTest extends TestCase
@@ -84,7 +84,7 @@ class IndexTest extends TestCase
     private $registryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -135,7 +135,7 @@ class IndexTest extends TestCase
     }
 
     /**
-     * @covers Index::execute
+     * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index::execute
      *
      * @return void
      */
@@ -175,7 +175,7 @@ class IndexTest extends TestCase
     }
 
     /**
-     * @covers Index::execute
+     * @covers \Magento\Email\Controller\Adminhtml\Email\Template\Index::execute
      *
      * @return void
      */

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Config/ReaderTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Config/ReaderTest.php
@@ -55,7 +55,7 @@ class ReaderTest extends TestCase
     protected $_paths;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Config/ReaderTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Config/ReaderTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Email\Test\Unit\Model\Template\Config;
 
 use Magento\Catalog\Model\Attribute\Config\Converter as AttributeConverter;
+use Magento\Email\Model\Template\Config\Converter;
 use Magento\Email\Model\Template\Config\FileIterator;
 use Magento\Email\Model\Template\Config\FileResolver;
 use Magento\Email\Model\Template\Config\Reader;
@@ -53,16 +54,19 @@ class ReaderTest extends TestCase
      */
     protected $_paths;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $fileResolver = $this->createMock(FileResolver::class);
         $this->_paths = [
             __DIR__ . '/_files/Fixture/ModuleOne/etc/email_templates_one.xml',
-            __DIR__ . '/_files/Fixture/ModuleTwo/etc/email_templates_two.xml',
+            __DIR__ . '/_files/Fixture/ModuleTwo/etc/email_templates_two.xml'
         ];
 
         $this->_converter = $this->createPartialMock(
-            \Magento\Email\Model\Template\Config\Converter::class,
+            Converter::class,
             ['convert']
         );
 
@@ -113,40 +117,21 @@ class ReaderTest extends TestCase
         );
     }
 
-    public function testRead()
+    /**
+     * @return void
+     */
+    public function testRead(): void
     {
-        $this->read->expects(
-            $this->at(0)
-        )->method(
-            'readAll'
-        )->willReturn(
-            file_get_contents($this->_paths[0])
-        );
-        $this->read->expects(
-            $this->at(1)
-        )->method(
-            'readAll'
-        )->willReturn(
-            file_get_contents($this->_paths[1])
-        );
-        $this->_moduleDirResolver->expects(
-            $this->at(0)
-        )->method(
-            'getModuleName'
-        )->with(
-            __DIR__ . '/_files/Fixture/ModuleOne/etc/email_templates_one.xml'
-        )->willReturn(
-            'Fixture_ModuleOne'
-        );
-        $this->_moduleDirResolver->expects(
-            $this->at(1)
-        )->method(
-            'getModuleName'
-        )->with(
-            __DIR__ . '/_files/Fixture/ModuleTwo/etc/email_templates_two.xml'
-        )->willReturn(
-            'Fixture_ModuleTwo'
-        );
+        $this->read
+            ->method('readAll')
+            ->willReturnOnConsecutiveCalls(file_get_contents($this->_paths[0]), file_get_contents($this->_paths[1]));
+        $this->_moduleDirResolver
+            ->method('getModuleName')
+            ->withConsecutive(
+                [__DIR__ . '/_files/Fixture/ModuleOne/etc/email_templates_one.xml'],
+                [__DIR__ . '/_files/Fixture/ModuleTwo/etc/email_templates_two.xml']
+            )
+            ->willReturnOnConsecutiveCalls('Fixture_ModuleOne', 'Fixture_ModuleTwo');
         $constraint = function (\DOMDocument $actual) {
             try {
                 $expected = file_get_contents(__DIR__ . '/_files/email_templates_merged.xml');
@@ -172,7 +157,10 @@ class ReaderTest extends TestCase
         $this->assertSame($expectedResult, $this->_model->read('scope'));
     }
 
-    public function testReadUnknownModule()
+    /**
+     * @return void
+     */
+    public function testReadUnknownModule(): void
     {
         $this->expectException('UnexpectedValueException');
         $this->expectExceptionMessage('Unable to determine a module');

--- a/app/code/Magento/EncryptionKey/Test/Unit/Controller/Adminhtml/Crypt/Key/SaveTest.php
+++ b/app/code/Magento/EncryptionKey/Test/Unit/Controller/Adminhtml/Crypt/Key/SaveTest.php
@@ -24,52 +24,69 @@ use PHPUnit\Framework\TestCase;
  */
 class SaveTest extends TestCase
 {
-    /** @var EncryptorInterface|MockObject */
+    /**
+     * @var EncryptorInterface|MockObject
+     */
     protected $encryptMock;
 
-    /** @var Change|MockObject */
+    /**
+     * @var Change|MockObject
+     */
     protected $changeMock;
 
-    /** @var CacheInterface|MockObject */
+    /**
+     * @var CacheInterface|MockObject
+     */
     protected $cacheMock;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $requestMock;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     protected $managerMock;
 
-    /** @var ResponseInterface|MockObject */
+    /**
+     * @var ResponseInterface|MockObject
+     */
     protected $responseMock;
 
-    /** @var Save */
+    /**
+     * @var Save
+     */
     protected $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->encryptMock = $this->getMockBuilder(EncryptorInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->changeMock = $this->getMockBuilder(Change::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['changeEncryptionKey'])
             ->getMock();
         $this->cacheMock = $this->getMockBuilder(CacheInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->requestMock = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPost'])
+            ->addMethods(['getPost'])
             ->getMockForAbstractClass();
         $this->managerMock = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->responseMock = $this->getMockBuilder(ResponseInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setRedirect'])
+            ->addMethods(['setRedirect'])
             ->getMockForAbstractClass();
 
         $helper = new ObjectManager($this);
@@ -82,26 +99,23 @@ class SaveTest extends TestCase
                 'cache' => $this->cacheMock,
                 'request' => $this->requestMock,
                 'messageManager' => $this->managerMock,
-                'response' => $this->responseMock,
+                'response' => $this->responseMock
             ]
         );
     }
 
-    public function testExecuteNonRandomAndWithCryptKey()
+    /**
+     * @return void
+     */
+    public function testExecuteNonRandomAndWithCryptKey(): void
     {
         $expectedMessage = 'The encryption key has been changed.';
         $key = 1;
         $newKey = 'RSASHA9000VERYSECURESUPERMANKEY';
         $this->requestMock
-            ->expects($this->at(0))
             ->method('getPost')
-            ->with('generate_random')
-            ->willReturn(0);
-        $this->requestMock
-            ->expects($this->at(1))
-            ->method('getPost')
-            ->with('crypt_key')
-            ->willReturn($key);
+            ->withConsecutive(['generate_random'], ['crypt_key'])
+            ->willReturnOnConsecutiveCalls(0, $key);
         $this->encryptMock->expects($this->once())->method('validateKey');
         $this->changeMock->expects($this->once())->method('changeEncryptionKey')->willReturn($newKey);
         $this->managerMock->expects($this->once())->method('addSuccessMessage')->with($expectedMessage);
@@ -111,32 +125,32 @@ class SaveTest extends TestCase
         $this->model->execute();
     }
 
-    public function testExecuteNonRandomAndWithoutCryptKey()
+    /**
+     * @return void
+     */
+    public function testExecuteNonRandomAndWithoutCryptKey(): void
     {
         $key = null;
         $this->requestMock
-            ->expects($this->at(0))
             ->method('getPost')
-            ->with('generate_random')
-            ->willReturn(0);
-        $this->requestMock
-            ->expects($this->at(1))
-            ->method('getPost')
-            ->with('crypt_key')
-            ->willReturn($key);
+            ->withConsecutive(['generate_random'], ['crypt_key'])
+            ->willReturnOnConsecutiveCalls(0, $key);
         $this->managerMock->expects($this->once())->method('addErrorMessage');
 
         $this->model->execute();
     }
 
-    public function testExecuteRandom()
+    /**
+     * @return void
+     */
+    public function testExecuteRandom(): void
     {
         $newKey = 'RSASHA9000VERYSECURESUPERMANKEY';
         $this->requestMock
-            ->expects($this->at(0))
             ->method('getPost')
-            ->with('generate_random')
-            ->willReturn(1);
+            ->withConsecutive(['generate_random'])
+            ->willReturnOnConsecutiveCalls(1);
+
         $this->changeMock->expects($this->once())->method('changeEncryptionKey')->willReturn($newKey);
         $this->managerMock->expects($this->once())->method('addSuccessMessage');
         $this->managerMock->expects($this->once())->method('addNoticeMessage');

--- a/app/code/Magento/EncryptionKey/Test/Unit/Controller/Adminhtml/Crypt/Key/SaveTest.php
+++ b/app/code/Magento/EncryptionKey/Test/Unit/Controller/Adminhtml/Crypt/Key/SaveTest.php
@@ -60,7 +60,7 @@ class SaveTest extends TestCase
     protected $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -30,6 +30,9 @@ class DataTest extends TestCase
      */
     protected $_helper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $className = Data::class;
@@ -45,7 +48,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestIsActive()
+    public function dataProviderForTestIsActive(): array
     {
         return [
             [true, 1234, true],
@@ -59,9 +62,11 @@ class DataTest extends TestCase
      * @param bool $isActive
      * @param string $returnConfigValue
      * @param bool $returnValue
+     *
+     * @return void
      * @dataProvider dataProviderForTestIsActive
      */
-    public function testIsGoogleAdwordsActive($isActive, $returnConfigValue, $returnValue)
+    public function testIsGoogleAdwordsActive($isActive, $returnConfigValue, $returnValue): void
     {
         $this->_scopeConfigMock->expects(
             $this->any()
@@ -81,7 +86,10 @@ class DataTest extends TestCase
         $this->assertEquals($returnValue, $this->_helper->isGoogleAdwordsActive());
     }
 
-    public function testGetLanguageCodes()
+    /**
+     * @return void
+     */
+    public function testGetLanguageCodes(): void
     {
         $languages = ['en', 'ru', 'uk'];
         $this->_scopeConfigMock->expects(
@@ -100,7 +108,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestConvertLanguage()
+    public function dataProviderForTestConvertLanguage(): array
     {
         return [
             ['some-language', 'some-language'],
@@ -113,9 +121,11 @@ class DataTest extends TestCase
     /**
      * @param string $language
      * @param string $returnLanguage
+     *
+     * @return void
      * @dataProvider dataProviderForTestConvertLanguage
      */
-    public function testConvertLanguageCodeToLocaleCode($language, $returnLanguage)
+    public function testConvertLanguageCodeToLocaleCode(string $language, string $returnLanguage): void
     {
         $convertArray = ['zh_TW' => 'zh_Hant', 'iw' => 'he', 'zh_CN' => 'zh_Hans'];
         $this->_scopeConfigMock->expects(
@@ -131,7 +141,10 @@ class DataTest extends TestCase
         $this->assertEquals($returnLanguage, $this->_helper->convertLanguageCodeToLocaleCode($language));
     }
 
-    public function testGetConversionImgSrc()
+    /**
+     * @return void
+     */
+    public function testGetConversionImgSrc(): void
     {
         $conversionId = 123;
         $label = 'LabEl';
@@ -140,20 +153,17 @@ class DataTest extends TestCase
             $conversionId,
             $label
         );
-        $this->_scopeConfigMock->expects(
-            $this->at(0)
-        )->method(
-            'getValue'
-        )->with(
-            Data::XML_PATH_CONVERSION_IMG_SRC,
-            'default'
-        )->willReturn(
-            $imgSrc
-        );
+        $this->_scopeConfigMock
+            ->method('getValue')
+            ->withConsecutive([Data::XML_PATH_CONVERSION_IMG_SRC, 'default'])
+            ->willReturnOnConsecutiveCalls($imgSrc);
         $this->assertEquals($imgSrc, $this->_helper->getConversionImgSrc());
     }
 
-    public function testGetConversionJsSrc()
+    /**
+     * @return void
+     */
+    public function testGetConversionJsSrc(): void
     {
         $jsSrc = 'some-js-src';
         $this->_scopeConfigMock->expects(
@@ -171,7 +181,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestStoreConfig()
+    public function dataProviderForTestStoreConfig(): array
     {
         return [
             ['getConversionId', Data::XML_PATH_CONVERSION_ID, 123],
@@ -180,7 +190,7 @@ class DataTest extends TestCase
             ['getConversionColor', Data::XML_PATH_CONVERSION_COLOR, 'ffffff'],
             ['getConversionLabel', Data::XML_PATH_CONVERSION_LABEL, 'Label'],
             ['getConversionValueType', Data::XML_PATH_CONVERSION_VALUE_TYPE, '1'],
-            ['getConversionValueConstant', Data::XML_PATH_CONVERSION_VALUE, '0'],
+            ['getConversionValueConstant', Data::XML_PATH_CONVERSION_VALUE, '0']
         ];
     }
 
@@ -188,9 +198,11 @@ class DataTest extends TestCase
      * @param string $method
      * @param string $xmlPath
      * @param string $returnValue
+     *
+     * @return void
      * @dataProvider dataProviderForTestStoreConfig
      */
-    public function testGetStoreConfigValue($method, $xmlPath, $returnValue)
+    public function testGetStoreConfigValue($method, $xmlPath, $returnValue): void
     {
         $this->_scopeConfigMock->expects(
             $this->once()
@@ -205,14 +217,20 @@ class DataTest extends TestCase
         $this->assertEquals($returnValue, $this->_helper->{$method}());
     }
 
-    public function testHasSendConversionValueCurrency()
+    /**
+     * @return void
+     */
+    public function testHasSendConversionValueCurrency(): void
     {
         $this->_scopeConfigMock->expects($this->once())->method('isSetFlag')->willReturn(true);
 
         $this->assertTrue($this->_helper->hasSendConversionValueCurrency());
     }
 
-    public function testGetConversionValueDynamic()
+    /**
+     * @return void
+     */
+    public function testGetConversionValueDynamic(): void
     {
         $returnValue = 4.1;
         $this->_scopeConfigMock->expects(
@@ -237,7 +255,10 @@ class DataTest extends TestCase
         $this->assertEquals($returnValue, $this->_helper->getConversionValue());
     }
 
-    public function testGetConversionValueCurrency()
+    /**
+     * @return void
+     */
+    public function testGetConversionValueCurrency(): void
     {
         $returnValueCurrency = 'USD';
         $this->_scopeConfigMock->expects($this->once())->method('isSetFlag')->willReturn(true);
@@ -257,7 +278,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestConversionValueConstant()
+    public function dataProviderForTestConversionValueConstant(): array
     {
         return [[1.4, 1.4], ['', Data::CONVERSION_VALUE_DEFAULT]];
     }
@@ -265,29 +286,17 @@ class DataTest extends TestCase
     /**
      * @param string $conversionValueConst
      * @param string $returnValue
+     *
+     * @return void
      * @dataProvider dataProviderForTestConversionValueConstant
      */
-    public function testGetConversionValueConstant($conversionValueConst, $returnValue)
+    public function testGetConversionValueConstant($conversionValueConst, $returnValue): void
     {
-        $this->_scopeConfigMock->expects(
-            $this->at(0)
-        )->method(
-            'getValue'
-        )->with(
-            Data::XML_PATH_CONVERSION_VALUE_TYPE
-        )->willReturn(
-            Data::CONVERSION_VALUE_TYPE_CONSTANT
-        );
         $this->_registryMock->expects($this->never())->method('registry');
-        $this->_scopeConfigMock->expects(
-            $this->at(1)
-        )->method(
-            'getValue'
-        )->with(
-            Data::XML_PATH_CONVERSION_VALUE
-        )->willReturn(
-            $conversionValueConst
-        );
+        $this->_scopeConfigMock
+            ->method('getValue')
+            ->withConsecutive([Data::XML_PATH_CONVERSION_VALUE_TYPE], [Data::XML_PATH_CONVERSION_VALUE])
+            ->willReturnOnConsecutiveCalls(Data::CONVERSION_VALUE_TYPE_CONSTANT, $conversionValueConst);
 
         $this->assertEquals($returnValue, $this->_helper->getConversionValue());
     }

--- a/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/GoogleAdwords/Test/Unit/Helper/DataTest.php
@@ -31,7 +31,7 @@ class DataTest extends TestCase
     protected $_helper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/GoogleOptimizer/Test/Unit/Helper/FormTest.php
+++ b/app/code/Magento/GoogleOptimizer/Test/Unit/Helper/FormTest.php
@@ -38,7 +38,7 @@ class FormTest extends TestCase
     protected $_experimentCodeMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/GoogleOptimizer/Test/Unit/Helper/FormTest.php
+++ b/app/code/Magento/GoogleOptimizer/Test/Unit/Helper/FormTest.php
@@ -37,6 +37,9 @@ class FormTest extends TestCase
      */
     protected $_experimentCodeMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_formMock = $this->getMockBuilder(\Magento\Framework\Data\Form::class)
@@ -55,7 +58,10 @@ class FormTest extends TestCase
         $this->_helper = $objectManagerHelper->getObject(Form::class, $data);
     }
 
-    public function testAddFieldsWithExperimentCode()
+    /**
+     * @return void
+     */
+    public function testAddFieldsWithExperimentCode(): void
     {
         $experimentCode = 'some-code';
         $experimentCodeId = 'code-id';
@@ -78,20 +84,25 @@ class FormTest extends TestCase
         $this->_helper->addGoogleoptimizerFields($this->_formMock, $this->_experimentCodeMock);
     }
 
-    public function testAddFieldsWithoutExperimentCode()
+    /**
+     * @return void
+     */
+    public function testAddFieldsWithoutExperimentCode(): void
     {
         $experimentCode = '';
         $experimentCodeId = '';
         $this->_prepareFormMock($experimentCode, $experimentCodeId);
 
-        $this->_helper->addGoogleoptimizerFields($this->_formMock, null);
+        $this->_helper->addGoogleoptimizerFields($this->_formMock);
     }
 
     /**
      * @param string|array $experimentCode
      * @param string $experimentCodeId
+     *
+     * @return void
      */
-    protected function _prepareFormMock($experimentCode, $experimentCodeId)
+    protected function _prepareFormMock($experimentCode, $experimentCodeId): void
     {
         $this->_formMock->expects(
             $this->once()
@@ -104,38 +115,32 @@ class FormTest extends TestCase
             $this->_fieldsetMock
         );
 
-        $this->_fieldsetMock->expects(
-            $this->at(0)
-        )->method(
-            'addField'
-        )->with(
-            'experiment_script',
-            'textarea',
-            [
-                'name' => 'experiment_script',
-                'label' => 'Experiment Code',
-                'value' => $experimentCode,
-                'class' => 'textarea googleoptimizer',
-                'required' => false,
-                'note' => 'Experiment code should be added to the original page only.',
-                'data-form-part' => ''
-            ]
-        );
-
-        $this->_fieldsetMock->expects(
-            $this->at(1)
-        )->method(
-            'addField'
-        )->with(
-            'code_id',
-            'hidden',
-            [
-                'name' => 'code_id',
-                'value' => $experimentCodeId,
-                'required' => false,
-                'data-form-part' => ''
-            ]
-        );
+        $this->_fieldsetMock
+            ->method('addField')
+            ->withConsecutive(
+                [
+                    'experiment_script',
+                    'textarea',
+                    [
+                        'name' => 'experiment_script',
+                        'label' => 'Experiment Code',
+                        'value' => $experimentCode,
+                        'class' => 'textarea googleoptimizer',
+                        'required' => false,
+                        'note' => 'Experiment code should be added to the original page only.',
+                        'data-form-part' => '']
+                ],
+                [
+                    'code_id',
+                    'hidden',
+                    [
+                        'name' => 'code_id',
+                        'value' => $experimentCodeId,
+                        'required' => false,
+                        'data-form-part' => ''
+                    ]
+                ]
+            );
         $this->_formMock->expects($this->once())->method('setFieldNameSuffix')->with('google_experiment');
     }
 }

--- a/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
+++ b/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
@@ -28,7 +28,9 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class GroupedTest extends AbstractImportTestCase
 {
-    /** @var GroupedImportExport\Model\Import\Product\Type\Grouped */
+    /**
+     * @var GroupedImportExport\Model\Import\Product\Type\Grouped
+     */
     protected $grouped;
 
     /**
@@ -77,6 +79,8 @@ class GroupedTest extends AbstractImportTestCase
     protected $entityModel;
 
     /**
+     * @inheirtDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -179,16 +183,19 @@ class GroupedTest extends AbstractImportTestCase
      * @param array $skus
      * @param array $bunch
      *
+     * @return void
      * @dataProvider saveDataProvider
      */
-    public function testSaveData($skus, $bunch)
+    public function testSaveData($skus, $bunch): void
     {
         $this->entityModel->expects($this->once())->method('getNewSku')->willReturn($skus['newSku']);
         $this->entityModel->expects($this->once())->method('getOldSku')->willReturn($skus['oldSku']);
         $attributes = ['position' => ['id' => 0], 'qty' => ['id' => 0]];
         $this->links->expects($this->once())->method('getAttributes')->willReturn($attributes);
 
-        $this->entityModel->expects($this->at(2))->method('getNextBunch')->willReturn([$bunch]);
+        $this->entityModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls([$bunch]);
         $this->entityModel->expects($this->any())->method('isRowAllowedToImport')->willReturn(true);
         $this->entityModel->expects($this->any())->method('getRowScope')->willReturn(Product::SCOPE_DEFAULT);
 
@@ -201,7 +208,7 @@ class GroupedTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function saveDataProvider()
+    public function saveDataProvider(): array
     {
         return [
             [
@@ -258,8 +265,10 @@ class GroupedTest extends AbstractImportTestCase
 
     /**
      * Test saveData() with store row scope
+     *
+     * @return void
      */
-    public function testSaveDataScopeStore()
+    public function testSaveDataScopeStore(): void
     {
         $this->entityModel->expects($this->once())->method('getNewSku')->willReturn(
             [
@@ -282,10 +291,13 @@ class GroupedTest extends AbstractImportTestCase
                 'product_type' => 'grouped'
             ]
         ];
-        $this->entityModel->expects($this->at(2))->method('getNextBunch')->willReturn($bunch);
         $this->entityModel->expects($this->any())->method('isRowAllowedToImport')->willReturn(true);
-        $this->entityModel->expects($this->at(4))->method('getRowScope')->willReturn(Product::SCOPE_DEFAULT);
-        $this->entityModel->expects($this->at(5))->method('getRowScope')->willReturn(Product::SCOPE_STORE);
+        $this->entityModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($bunch);
+        $this->entityModel
+            ->method('getRowScope')
+            ->willReturnOnConsecutiveCalls(Product::SCOPE_DEFAULT, Product::SCOPE_STORE);
 
         $this->links->expects($this->once())->method('saveLinksData');
         $this->grouped->saveData();

--- a/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
+++ b/app/code/Magento/GroupedImportExport/Test/Unit/Model/Import/Product/Type/GroupedTest.php
@@ -79,7 +79,7 @@ class GroupedTest extends AbstractImportTestCase
     protected $entityModel;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/GroupedProduct/Test/Unit/Controller/Adminhtml/Edit/PopupTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Controller/Adminhtml/Edit/PopupTest.php
@@ -61,6 +61,9 @@ class PopupTest extends TestCase
      */
     protected $resultLayoutMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockForAbstractClass(RequestInterface::class);
@@ -96,7 +99,10 @@ class PopupTest extends TestCase
         );
     }
 
-    public function testPopupActionNoProductId()
+    /**
+     * @return void
+     */
+    public function testPopupActionNoProductId(): void
     {
         $storeId = 12;
         $typeId = 4;
@@ -107,30 +113,23 @@ class PopupTest extends TestCase
             ['setStoreId', 'setTypeId', 'setData', '__wakeup']
         );
 
-        $this->request->expects($this->at(0))->method('getParam')->with('id')->willReturn($productId);
         $this->factory->expects($this->once())->method('create')->willReturn($product);
-        $this->request->expects(
-            $this->at(1)
-        )->method(
-            'getParam'
-        )->with(
-            'store',
-            0
-        )->willReturn(
-            $storeId
-        );
-
         $product->expects($this->once())->method('setStoreId')->with($storeId);
-        $this->request->expects($this->at(2))->method('getParam')->with('type')->willReturn($typeId);
         $product->expects($this->once())->method('setTypeId')->with($typeId);
         $product->expects($this->once())->method('setData')->with('_edit_mode', true);
-        $this->request->expects($this->at(3))->method('getParam')->with('set')->willReturn($setId);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['id'], ['store', 0], ['type'], ['set'])
+            ->willReturnOnConsecutiveCalls($productId, $storeId, $typeId, $setId);
         $this->registry->expects($this->once())->method('register')->with('current_product', $product);
 
         $this->assertSame($this->resultLayoutMock, $this->action->execute());
     }
 
-    public function testPopupActionWithProductIdNoSetId()
+    /**
+     * @return void
+     */
+    public function testPopupActionWithProductIdNoSetId(): void
     {
         $storeId = 12;
         $typeId = 4;
@@ -141,24 +140,15 @@ class PopupTest extends TestCase
             ['setStoreId', 'setTypeId', 'setData', 'load', '__wakeup']
         );
 
-        $this->request->expects($this->at(0))->method('getParam')->with('id')->willReturn($productId);
         $this->factory->expects($this->once())->method('create')->willReturn($product);
-        $this->request->expects(
-            $this->at(1)
-        )->method(
-            'getParam'
-        )->with(
-            'store',
-            0
-        )->willReturn(
-            $storeId
-        );
         $product->expects($this->once())->method('setStoreId')->with($storeId);
-        $this->request->expects($this->at(2))->method('getParam')->with('type')->willReturn($typeId);
         $product->expects($this->never())->method('setTypeId');
         $product->expects($this->once())->method('setData')->with('_edit_mode', true);
         $product->expects($this->once())->method('load')->with($productId);
-        $this->request->expects($this->at(3))->method('getParam')->with('set')->willReturn($setId);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['id'], ['store', 0], ['type'], ['set'])
+            ->willReturnOnConsecutiveCalls($productId, $storeId, $typeId, $setId);
         $this->registry->expects($this->once())->method('register')->with('current_product', $product);
 
         $this->assertSame($this->resultLayoutMock, $this->action->execute());

--- a/app/code/Magento/GroupedProduct/Test/Unit/Controller/Adminhtml/Edit/PopupTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Controller/Adminhtml/Edit/PopupTest.php
@@ -62,7 +62,7 @@ class PopupTest extends TestCase
     protected $resultLayoutMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc 
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
@@ -54,7 +54,7 @@ class CatalogPriceTest extends TestCase
     protected $associatedProductMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc 
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/CatalogPriceTest.php
@@ -53,10 +53,13 @@ class CatalogPriceTest extends TestCase
      */
     protected $associatedProductMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->storeManagerMock = $this->getMockForAbstractClass(StoreManagerInterface::class);
-        $this->commonPriceMock = $this->createMock(\Magento\Catalog\Model\Product\CatalogPrice::class);
+        $this->commonPriceMock = $this->createMock(Product\CatalogPrice::class);
         $this->productMock = $this->getMockBuilder(Product::class)
             ->addMethods(['getWebsiteId', 'getCustomerGroupId', 'setTaxClassId'])
             ->onlyMethods(['__wakeup', 'getTypeInstance'])
@@ -79,7 +82,10 @@ class CatalogPriceTest extends TestCase
         );
     }
 
-    public function testGetCatalogPriceWithDefaultStoreAndWhenProductDoesNotHaveAssociatedProducts()
+    /**
+     * @return void
+     */
+    public function testGetCatalogPriceWithDefaultStoreAndWhenProductDoesNotHaveAssociatedProducts(): void
     {
         $this->productMock->expects(
             $this->once()
@@ -102,7 +108,10 @@ class CatalogPriceTest extends TestCase
         $this->assertNull($this->catalogPrice->getCatalogPrice($this->productMock));
     }
 
-    public function testGetCatalogPriceWithDefaultStoreAndSubProductIsNotSalable()
+    /**
+     * @return void
+     */
+    public function testGetCatalogPriceWithDefaultStoreAndSubProductIsNotSalable(): void
     {
         $this->productMock->expects(
             $this->once()
@@ -145,7 +154,10 @@ class CatalogPriceTest extends TestCase
         $this->assertNull($this->catalogPrice->getCatalogPrice($this->productMock));
     }
 
-    public function testGetCatalogPriceWithCustomStoreAndSubProductIsSalable()
+    /**
+     * @return void
+     */
+    public function testGetCatalogPriceWithCustomStoreAndSubProductIsSalable(): void
     {
         $storeMock = $this->getMockForAbstractClass(StoreInterface::class);
         $storeMock->expects($this->once())->method('getId')->willReturn('store_id');
@@ -205,14 +217,20 @@ class CatalogPriceTest extends TestCase
         );
         $this->productMock->expects($this->once())->method('setTaxClassId')->with('tax_class');
 
-        $this->storeManagerMock->expects($this->at(0))->method('getStore')->willReturn($currentStoreMock);
-        $this->storeManagerMock->expects($this->at(1))->method('setCurrentStore')->with('store_id');
-        $this->storeManagerMock->expects($this->at(2))->method('setCurrentStore')->with('current_store_id');
+        $this->storeManagerMock
+            ->method('getStore')
+            ->willReturn($currentStoreMock);
+        $this->storeManagerMock
+            ->method('setCurrentStore')
+            ->withConsecutive(['store_id'], ['current_store_id']);
 
         $this->assertEquals(15, $this->catalogPrice->getCatalogPrice($this->productMock, $storeMock, true));
     }
 
-    public function testGetCatalogRegularPrice()
+    /**
+     * @return void
+     */
+    public function testGetCatalogRegularPrice(): void
     {
         $this->assertNull($this->catalogPrice->getCatalogRegularPrice($this->productMock));
     }

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
@@ -27,7 +27,7 @@ class ItemTest extends TestCase
     protected $model;
 
     /**
-     * @var \Magento\Catalog\Model\Product|MockObject
+     * @var Product|MockObject
      */
     protected $productMock;
 
@@ -37,7 +37,7 @@ class ItemTest extends TestCase
     protected $subjectMock;
 
     /**
-     * Init Mock Objects
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -66,8 +66,10 @@ class ItemTest extends TestCase
 
     /**
      * Test Before Represent Product method
+     *
+     * @return void
      */
-    public function testBeforeRepresentProduct()
+    public function testBeforeRepresentProduct(): void
     {
         $testSimpleProdId = 34;
         $prodInitQty = 2;
@@ -93,9 +95,7 @@ class ItemTest extends TestCase
 
         $wishlistItemProductMock = $this->createPartialMock(
             Product::class,
-            [
-                'getId',
-            ]
+            ['getId']
         );
         $wishlistItemProductMock->expects($this->once())->method('getId')->willReturn($testSimpleProdId);
 
@@ -112,14 +112,14 @@ class ItemTest extends TestCase
 
     /**
      * Test Before Compare Options method with same keys
+     *
+     * @return void
      */
-    public function testBeforeCompareOptionsSameKeys()
+    public function testBeforeCompareOptionsSameKeys(): void
     {
         $infoBuyRequestMock = $this->createPartialMock(
-            \Magento\Catalog\Model\Product\Configuration\Item\Option::class,
-            [
-                'getValue',
-            ]
+            Product\Configuration\Item\Option::class,
+            ['getValue']
         );
 
         $infoBuyRequestMock->expects($this->atLeastOnce())
@@ -142,8 +142,10 @@ class ItemTest extends TestCase
 
     /**
      * Test Before Compare Options method with diff keys
+     *
+     * @return void
      */
-    public function testBeforeCompareOptionsDiffKeys()
+    public function testBeforeCompareOptionsDiffKeys(): void
     {
         $options1 = ['associated_product_1' => 3];
         $options2 = ['associated_product_34' => 2];
@@ -160,20 +162,20 @@ class ItemTest extends TestCase
      * @param int $initVal
      * @param int $resVal
      * @param int $prodId
+     *
      * @return array
      */
-    private function getWishlistAssocOption($initVal, $resVal, $prodId)
+    private function getWishlistAssocOption(int $initVal, int $resVal, int $prodId): array
     {
         $items = [];
 
         $optionMock = $this->createPartialMock(
             Option::class,
-            [
-                'getValue',
-            ]
+            ['getValue']
         );
-        $optionMock->expects($this->at(0))->method('getValue')->willReturn($initVal);
-        $optionMock->expects($this->at(1))->method('getValue')->willReturn($resVal);
+        $optionMock
+            ->method('getValue')
+            ->willReturnOnConsecutiveCalls($initVal, $resVal);
 
         $items['associated_product_' . $prodId] = $optionMock;
 
@@ -185,23 +187,20 @@ class ItemTest extends TestCase
      *
      * @param int $initVal
      * @param int $prodId
+     *
      * @return array
      */
-    private function getProductAssocOption($initVal, $prodId)
+    private function getProductAssocOption(int $initVal, int $prodId): array
     {
         $items = [];
 
         $associatedProductMock = $this->createPartialMock(
-            \Magento\Catalog\Model\Product\Configuration\Item\Option::class,
-            [
-                'getValue',
-            ]
+            Product\Configuration\Item\Option::class,
+            ['getValue']
         );
         $infoBuyRequestMock = $this->createPartialMock(
-            \Magento\Catalog\Model\Product\Configuration\Item\Option::class,
-            [
-                'getValue',
-            ]
+            Product\Configuration\Item\Option::class,
+            ['getValue']
         );
 
         $associatedProductMock->expects($this->once())->method('getValue')->willReturn($initVal);

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Wishlist/Product/ItemTest.php
@@ -37,7 +37,7 @@ class ItemTest extends TestCase
     protected $subjectMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ImportExport/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/DownloadTest.php
@@ -42,7 +42,7 @@ class DownloadTest extends TestCase
     private $escaperMock;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/ImportExport/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/DownloadTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/DownloadTest.php
@@ -42,7 +42,7 @@ class DownloadTest extends TestCase
     private $escaperMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -66,19 +66,17 @@ class DownloadTest extends TestCase
 
     /**
      * Test _getValue()
+     *
+     * @return void
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $data = ['imported_file' => 'file.csv'];
         $row = new DataObject($data);
-        $this->escaperMock->expects($this->at(0))
+        $this->escaperMock
             ->method('escapeHtml')
-            ->with('file.csv')
-            ->willReturn('file.csv');
-        $this->escaperMock->expects($this->at(1))
-            ->method('escapeHtml')
-            ->with('Download')
-            ->willReturn('Download');
+            ->withConsecutive(['file.csv'], ['Download'])
+            ->willReturnOnConsecutiveCalls('file.csv', 'Download');
         $this->assertEquals('<p> file.csv</p><a href="url">Download</a>', $this->download->_getValue($row));
     }
 }

--- a/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Widget/Grid/Column/Renderer/LinkTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Widget/Grid/Column/Renderer/LinkTest.php
@@ -44,6 +44,9 @@ class LinkTest extends TestCase
      */
     protected $linkRenderer;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->escaperMock = $this->createMock(Escaper::class);
@@ -68,13 +71,15 @@ class LinkTest extends TestCase
 
     /**
      * Test the basic render action.
+     *
+     * @return void
      */
-    public function testRender()
+    public function testRender(): void
     {
         $expectedResult = '<a href="http://magento.loc/linkurl" title="Link Caption">Link Caption</a>';
-        $column = $this->getMockBuilder(Column::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCaption', 'getId'])
+        $column = $this->getMockBuilder(Column::class)->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->addMethods(['getCaption'])
             ->getMock();
         $column->expects($this->any())
             ->method('getCaption')
@@ -82,7 +87,9 @@ class LinkTest extends TestCase
         $column->expects($this->any())
             ->method('getId')
             ->willReturn('1');
-        $this->escaperMock->expects($this->at(0))->method('escapeHtmlAttr')->willReturn('Link Caption');
+        $this->escaperMock
+            ->method('escapeHtmlAttr')
+            ->willReturn('Link Caption');
         $this->linkRenderer->setColumn($column);
         $object = new DataObject(['id' => '1']);
         $actualResult = $this->linkRenderer->render($object);

--- a/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Widget/Grid/Column/Renderer/LinkTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Block/Adminhtml/Widget/Grid/Column/Renderer/LinkTest.php
@@ -45,7 +45,7 @@ class LinkTest extends TestCase
     protected $linkRenderer;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Integration/Test/Unit/Model/IntegrationServiceTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/IntegrationServiceTest.php
@@ -26,44 +26,45 @@ class IntegrationServiceTest extends TestCase
     const VALUE_INTEGRATION_ENDPOINT = 'http://magento.ll/endpoint';
     const VALUE_INTEGRATION_CONSUMER_ID = 1;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $_integrationFactory;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $_integrationMock;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $_emptyIntegrationMock;
 
-    /** @var IntegrationService */
+    /**
+     * @var IntegrationService
+     */
     private $_service;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $_integrationData;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_integrationFactory = $this->getMockBuilder(IntegrationFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
-        $this->_integrationMock = $this->getMockBuilder(
-            Integration::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getData',
-                    'getId',
-                    'getName',
-                    'getEmail',
-                    'getEndpoint',
-                    'load',
-                    'loadByName',
-                    'save',
-                    'delete',
-                    '__wakeup',
-                ]
-            )->getMock();
+        $this->_integrationMock = $this->getMockBuilder(Integration::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getData', 'getId', 'load', 'save', 'delete', '__wakeup'])
+            ->addMethods(['getName', 'getEmail', 'getEndpoint', 'loadByName'])
+            ->getMock();
         $this->_integrationData = [
             Integration::ID => self::VALUE_INTEGRATION_ID,
             Integration::NAME => self::VALUE_INTEGRATION_NAME,
@@ -100,27 +101,18 @@ class IntegrationServiceTest extends TestCase
             $this->_integrationFactory,
             $oauthConsumerHelper
         );
-        $this->_emptyIntegrationMock = $this->getMockBuilder(
-            Integration::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getData',
-                    'getId',
-                    'getName',
-                    'getEmail',
-                    'getEndpoint',
-                    'load',
-                    'loadByName',
-                    'save',
-                    'delete',
-                    '__wakeup',
-                ]
-            )->getMock();
+        $this->_emptyIntegrationMock = $this->getMockBuilder(Integration::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getData', 'getId', 'load', 'save', 'delete', '__wakeup'])
+            ->addMethods(['getName', 'getEmail', 'getEndpoint', 'loadByName'])
+            ->getMock();
         $this->_emptyIntegrationMock->expects($this->any())->method('getId')->willReturn(null);
     }
 
-    public function testCreateSuccess()
+    /**
+     * @return void
+     */
+    public function testCreateSuccess(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -152,7 +144,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertSame($this->_integrationData, $resultData);
     }
 
-    public function testCreateIntegrationAlreadyExistsException()
+    /**
+     * @return void
+     */
+    public function testCreateIntegrationAlreadyExistsException(): void
     {
         $this->expectException('Magento\Framework\Exception\IntegrationException');
         $this->expectExceptionMessage('The integration with name "Integration Name" exists.');
@@ -184,7 +179,10 @@ class IntegrationServiceTest extends TestCase
         $this->_service->create($this->_integrationData);
     }
 
-    public function testUpdateSuccess()
+    /**
+     * @return void
+     */
+    public function testUpdateSuccess(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -200,22 +198,20 @@ class IntegrationServiceTest extends TestCase
         )->willReturn(
             $this->_integrationData
         );
-        $this->_integrationMock->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            self::VALUE_INTEGRATION_ID
-        )->willReturn(
-            $this->_integrationMock
-        );
+        $this->_integrationMock
+            ->method('load')
+            ->with(self::VALUE_INTEGRATION_ID)
+            ->willReturn($this->_integrationMock);
         $this->_integrationMock->expects($this->once())->method('save')->willReturnSelf();
         $this->_setValidIntegrationData();
         $integrationData = $this->_service->update($this->_integrationData)->getData();
         $this->assertEquals($this->_integrationData, $integrationData);
     }
 
-    public function testUpdateSuccessNameChanged()
+    /**
+     * @return void
+     */
+    public function testUpdateSuccessNameChanged(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -245,7 +241,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertEquals($integrationData, $updatedData);
     }
 
-    public function testUpdateException()
+    /**
+     * @return void
+     */
+    public function testUpdateException(): void
     {
         $this->expectException('Magento\Framework\Exception\IntegrationException');
         $this->expectExceptionMessage('The integration with name "Another Integration Name" exists.');
@@ -274,7 +273,10 @@ class IntegrationServiceTest extends TestCase
         $this->_service->update($integrationData);
     }
 
-    public function testGet()
+    /**
+     * @return void
+     */
+    public function testGet(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -296,7 +298,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertEquals($this->_integrationData, $integrationData);
     }
 
-    public function testGetException()
+    /**
+     * @return void
+     */
+    public function testGetException(): void
     {
         $this->expectException('Magento\Framework\Exception\IntegrationException');
         $this->expectExceptionMessage('The integration with ID "1" doesn\'t exist.');
@@ -306,7 +311,10 @@ class IntegrationServiceTest extends TestCase
         $this->_service->get(self::VALUE_INTEGRATION_ID)->getData();
     }
 
-    public function testFindByName()
+    /**
+     * @return void
+     */
+    public function testFindByName(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -329,7 +337,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertEquals($this->_integrationData[Integration::NAME], $integration->getData()[Integration::NAME]);
     }
 
-    public function testFindByNameNotFound()
+    /**
+     * @return void
+     */
+    public function testFindByNameNotFound(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -346,7 +357,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertNull($integration->getData());
     }
 
-    public function testDelete()
+    /**
+     * @return void
+     */
+    public function testDelete(): void
     {
         $this->_integrationMock->expects(
             $this->once()
@@ -382,7 +396,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertEquals($this->_integrationData[Integration::ID], $integrationData[Integration::ID]);
     }
 
-    public function testDeleteException()
+    /**
+     * @return void
+     */
+    public function testDeleteException(): void
     {
         $this->expectException('Magento\Framework\Exception\IntegrationException');
         $this->expectExceptionMessage('The integration with ID "1" doesn\'t exist.');
@@ -392,7 +409,10 @@ class IntegrationServiceTest extends TestCase
         $this->_service->delete(self::VALUE_INTEGRATION_ID);
     }
 
-    public function testFindByConsumerId()
+    /**
+     * @return void
+     */
+    public function testFindByConsumerId(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -417,7 +437,10 @@ class IntegrationServiceTest extends TestCase
         $this->assertEquals($this->_integrationData[Integration::NAME], $integration->getData()[Integration::NAME]);
     }
 
-    public function testFindByConsumerIdNotFound()
+    /**
+     * @return void
+     */
+    public function testFindByConsumerIdNotFound(): void
     {
         $this->_emptyIntegrationMock->expects($this->any())->method('getData')->willReturn(null);
 
@@ -438,8 +461,10 @@ class IntegrationServiceTest extends TestCase
 
     /**
      * Set valid integration data
+     *
+     * @return void
      */
-    private function _setValidIntegrationData()
+    private function _setValidIntegrationData(): void
     {
         $this->_integrationMock->expects(
             $this->any()
@@ -469,29 +494,17 @@ class IntegrationServiceTest extends TestCase
      *
      * @param string $name
      * @param int $integrationId
+     *
      * @return mixed
      */
     private function _getAnotherIntegrationMock(
-        $name = self::VALUE_INTEGRATION_NAME,
-        $integrationId = self::VALUE_INTEGRATION_ID
+        string $name = self::VALUE_INTEGRATION_NAME,
+        int $integrationId = self::VALUE_INTEGRATION_ID
     ) {
-        $integrationMock = $this->getMockBuilder(
-            Integration::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getData',
-                    'getId',
-                    'getName',
-                    'getEmail',
-                    'getEndpoint',
-                    'load',
-                    'loadByName',
-                    'save',
-                    'delete',
-                    '__wakeup',
-                ]
-            )->getMock();
+        $integrationMock = $this->getMockBuilder(Integration::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getData', 'getId', 'load', 'save', 'delete', '__wakeup'])
+            ->addMethods(['getName', 'getEmail', 'getEndpoint', 'loadByName'])->getMock();
         $integrationMock->expects($this->any())->method('getId')->willReturn($integrationId);
         $integrationMock->expects($this->any())->method('getName')->willReturn($name);
         $integrationMock->expects(

--- a/app/code/Magento/Integration/Test/Unit/Model/IntegrationServiceTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/IntegrationServiceTest.php
@@ -52,7 +52,7 @@ class IntegrationServiceTest extends TestCase
     private $_integrationData;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
@@ -81,7 +81,7 @@ class ConsumerTest extends TestCase
     protected $validDataArray;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Oauth/ConsumerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Integration\Test\Unit\Model\Oauth;
 
+use Exception;
 use Laminas\Validator\Uri as LaminasUriValidator;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Event\ManagerInterface;
@@ -21,6 +22,7 @@ use Magento\Integration\Model\Oauth\Consumer\Validator\KeyLength;
 use Magento\Integration\Model\Oauth\Consumer\Validator\KeyLengthFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * Test for \Magento\Integration\Model\Oauth\Consumer
@@ -78,6 +80,9 @@ class ConsumerTest extends TestCase
      */
     protected $validDataArray;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->createPartialMock(Context::class, ['getEventDispatcher']);
@@ -133,23 +138,32 @@ class ConsumerTest extends TestCase
         ];
     }
 
-    public function testBeforeSave()
+    /**
+     * @return void
+     */
+    public function testBeforeSave(): void
     {
         try {
             $this->consumerModel->setData($this->validDataArray);
             $this->consumerModel->beforeSave();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->fail('Exception not expected for beforeSave with valid data.');
         }
     }
 
-    public function testValidate()
+    /**
+     * @return void
+     */
+    public function testValidate(): void
     {
         $this->consumerModel->setData($this->validDataArray);
         $this->assertTrue($this->consumerModel->validate());
     }
 
-    public function testValidateInvalidData()
+    /**
+     * @return void
+     */
+    public function testValidateInvalidData(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Invalid Callback URL');
@@ -158,7 +172,10 @@ class ConsumerTest extends TestCase
         $this->consumerModel->validate();
     }
 
-    public function testValidateInvalidCallback()
+    /**
+     * @return void
+     */
+    public function testValidateInvalidCallback(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Invalid Callback URL');
@@ -167,7 +184,10 @@ class ConsumerTest extends TestCase
         $this->consumerModel->validate();
     }
 
-    public function testValidateInvalidRejectedCallback()
+    /**
+     * @return void
+     */
+    public function testValidateInvalidRejectedCallback(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Invalid Rejected Callback URL');
@@ -176,7 +196,10 @@ class ConsumerTest extends TestCase
         $this->consumerModel->validate();
     }
 
-    public function testValidateInvalidConsumerKey()
+    /**
+     * @return void
+     */
+    public function testValidateInvalidConsumerKey(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Consumer Key \'invalid\' is less than 32 characters long');
@@ -185,7 +208,10 @@ class ConsumerTest extends TestCase
         $this->consumerModel->validate();
     }
 
-    public function testValidateInvalidConsumerSecret()
+    /**
+     * @return void
+     */
+    public function testValidateInvalidConsumerSecret(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Consumer Secret \'invalid\' is less than 32 characters long');
@@ -194,31 +220,39 @@ class ConsumerTest extends TestCase
         $this->consumerModel->validate();
     }
 
-    public function testGetConsumerExpirationPeriodValid()
+    /**
+     * @return void
+     */
+    public function testGetConsumerExpirationPeriodValid(): void
     {
         $dateHelperMock = $this->getMockBuilder(DateTime::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $dateHelperMock->expects($this->at(0))->method('gmtTimestamp')->willReturn(time());
-        $dateHelperMock->expects($this->at(1))->method('gmtTimestamp')->willReturn(time() - 100);
+        $dateHelperMock
+            ->method('gmtTimestamp')
+            ->willReturnOnConsecutiveCalls(time(), time() - 100);
 
-        $dateHelper = new \ReflectionProperty(Consumer::class, '_dateHelper');
+        $dateHelper = new ReflectionProperty(Consumer::class, '_dateHelper');
         $dateHelper->setAccessible(true);
         $dateHelper->setValue($this->consumerModel, $dateHelperMock);
 
-        $this->consumerModel->setUpdatedAt((string)time());
+        $this->consumerModel->setUpdatedAt((string) time());
         $this->assertTrue($this->consumerModel->isValidForTokenExchange());
     }
 
-    public function testGetConsumerExpirationPeriodExpired()
+    /**
+     * @return void
+     */
+    public function testGetConsumerExpirationPeriodExpired(): void
     {
         $dateHelperMock = $this->getMockBuilder(DateTime::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $dateHelperMock->expects($this->at(0))->method('gmtTimestamp')->willReturn(time());
-        $dateHelperMock->expects($this->at(1))->method('gmtTimestamp')->willReturn(time() - 1000);
+        $dateHelperMock
+            ->method('gmtTimestamp')
+            ->willReturnOnConsecutiveCalls(time(), time() - 1000);
 
-        $dateHelper = new \ReflectionProperty(Consumer::class, '_dateHelper');
+        $dateHelper = new ReflectionProperty(Consumer::class, '_dateHelper');
         $dateHelper->setAccessible(true);
         $dateHelper->setValue($this->consumerModel, $dateHelperMock);
 

--- a/app/code/Magento/Integration/Test/Unit/Model/ResourceModel/Integration/CollectionTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/ResourceModel/Integration/CollectionTest.php
@@ -31,7 +31,7 @@ class CollectionTest extends TestCase
     protected $collection;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Integration/Test/Unit/Model/ResourceModel/Integration/CollectionTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/ResourceModel/Integration/CollectionTest.php
@@ -30,6 +30,9 @@ class CollectionTest extends TestCase
      */
     protected $collection;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->select = $this->getMockBuilder(Select::class)
@@ -45,7 +48,7 @@ class CollectionTest extends TestCase
 
         $resource = $this->getMockBuilder(AbstractDb::class)
             ->disableOriginalConstructor()
-            ->setMethods(['__wakeup', 'getConnection'])
+            ->onlyMethods(['__wakeup', 'getConnection'])
             ->getMockForAbstractClass();
         $resource->expects($this->any())
             ->method('getConnection')
@@ -57,24 +60,20 @@ class CollectionTest extends TestCase
             ['resource' => $resource]
         );
 
-        $this->collection = $this->getMockBuilder(
-            Collection::class
-        )->setConstructorArgs($arguments)
-            ->setMethods(['addFilter', '_translateCondition', 'getMainTable'])
+        $this->collection = $this->getMockBuilder(Collection::class)->setConstructorArgs($arguments)
+            ->onlyMethods(['addFilter', '_translateCondition', 'getMainTable'])
             ->getMock();
     }
 
-    public function testAddUnsecureUrlsFilter()
+    /**
+     * @return void
+     */
+    public function testAddUnsecureUrlsFilter(): void
     {
-        $this->collection->expects($this->at(0))
+        $this->collection
             ->method('_translateCondition')
-            ->with('endpoint', ['like' => 'http:%'])
-            ->willReturn('endpoint like \'http:%\'');
-
-        $this->collection->expects($this->at(1))
-            ->method('_translateCondition')
-            ->with('identity_link_url', ['like' => 'http:%'])
-            ->willReturn('identity_link_url like \'http:%\'');
+            ->withConsecutive(['endpoint', ['like' => 'http:%']], ['identity_link_url', ['like' => 'http:%']])
+            ->willReturnOnConsecutiveCalls('endpoint like \'http:%\'', 'identity_link_url like \'http:%\'');
 
         $this->select->expects($this->once())
             ->method('where')

--- a/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
+++ b/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
@@ -46,6 +46,9 @@ class NavigationTest extends TestCase
      */
     protected $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->catalogLayerMock = $this->createMock(Layer::class);
@@ -55,7 +58,7 @@ class NavigationTest extends TestCase
         /** @var MockObject|Resolver $layerResolver */
         $layerResolver = $this->getMockBuilder(Resolver::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'create'])
+            ->onlyMethods(['get', 'create'])
             ->getMock();
         $layerResolver->expects($this->any())
             ->method($this->anything())
@@ -73,11 +76,15 @@ class NavigationTest extends TestCase
         $this->layoutMock = $this->getMockForAbstractClass(LayoutInterface::class);
     }
 
-    public function testGetStateHtml()
+    /**
+     * @return void
+     */
+    public function testGetStateHtml(): void
     {
         $stateHtml = 'I feel good';
         $this->filterListMock->expects($this->any())->method('getFilters')->willReturn([]);
-        $this->layoutMock->expects($this->at(0))->method('getChildName')
+        $this->layoutMock
+            ->method('getChildName')
             ->with(null, 'state')
             ->willReturn('state block');
 
@@ -93,8 +100,10 @@ class NavigationTest extends TestCase
      * @covers \Magento\LayeredNavigation\Block\Navigation::getLayer()
      * @covers \Magento\LayeredNavigation\Block\Navigation::getFilters()
      * @covers \Magento\LayeredNavigation\Block\Navigation::canShowBlock()
+     *
+     * @return void
      */
-    public function testCanShowBlock()
+    public function testCanShowBlock(): void
     {
         // getFilers()
         $filters = ['To' => 'be', 'or' => 'not', 'to' => 'be'];
@@ -125,9 +134,10 @@ class NavigationTest extends TestCase
      * @param string $mode
      * @param bool $result
      *
+     * @return void
      * @dataProvider canShowBlockDataProvider
      */
-    public function testCanShowBlockWithDifferentDisplayModes(string $mode, bool $result)
+    public function testCanShowBlockWithDifferentDisplayModes(string $mode, bool $result): void
     {
         $filters = ['To' => 'be', 'or' => 'not', 'to' => 'be'];
 
@@ -151,25 +161,28 @@ class NavigationTest extends TestCase
     /**
      * @return array
      */
-    public function canShowBlockDataProvider()
+    public function canShowBlockDataProvider(): array
     {
         return [
             [
                 Category::DM_PRODUCT,
-                true,
+                true
             ],
             [
                 Category::DM_PAGE,
-                false,
+                false
             ],
             [
                 Category::DM_MIXED,
-                true,
+                true
             ],
         ];
     }
 
-    public function testGetClearUrl()
+    /**
+     * @return void
+     */
+    public function testGetClearUrl(): void
     {
         $this->filterListMock->expects($this->any())->method('getFilters')->willReturn([]);
         $this->model->setLayout($this->layoutMock);

--- a/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
+++ b/app/code/Magento/LayeredNavigation/Test/Unit/Block/NavigationTest.php
@@ -47,7 +47,7 @@ class NavigationTest extends TestCase
     protected $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Newsletter/Test/Unit/Model/ProblemTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/ProblemTest.php
@@ -65,7 +65,7 @@ class ProblemTest extends TestCase
     private $problemModel;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -102,7 +102,7 @@ class ProblemTest extends TestCase
                 'subscriberFactory' => $this->subscriberFactoryMock,
                 'resource' => $this->resourceModelMock,
                 'resourceCollection' => $this->abstractDbMock,
-                'data' => [],
+                'data' => []
             ]
         );
     }
@@ -110,7 +110,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testAddSubscriberData()
+    public function testAddSubscriberData(): void
     {
         $subscriberId = 1;
         $this->subscriberMock->expects($this->once())
@@ -126,7 +126,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testAddQueueData()
+    public function testAddQueueData(): void
     {
         $queueId = 1;
         $queueMock =  $this->getMockBuilder(Queue::class)
@@ -145,7 +145,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testAddErrorData()
+    public function testAddErrorData(): void
     {
         $exceptionMessage = 'Some message';
         $exceptionCode = 111;
@@ -161,7 +161,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testGetSubscriberWithNoSubscriberId()
+    public function testGetSubscriberWithNoSubscriberId(): void
     {
         self::assertNull($this->problemModel->getSubscriber());
     }
@@ -169,7 +169,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testGetSubscriber()
+    public function testGetSubscriber(): void
     {
         $this->setSubscriber();
         self::assertEquals($this->subscriberMock, $this->problemModel->getSubscriber());
@@ -178,7 +178,7 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testUnsubscribeWithNoSubscriber()
+    public function testUnsubscribeWithNoSubscriber(): void
     {
         $this->subscriberMock->expects($this->never())
             ->method('__call')
@@ -192,17 +192,13 @@ class ProblemTest extends TestCase
     /**
      * @return void
      */
-    public function testUnsubscribe()
+    public function testUnsubscribe(): void
     {
         $this->setSubscriber();
-        $this->subscriberMock->expects($this->at(1))
+        $this->subscriberMock
             ->method('__call')
-            ->with('setSubscriberStatus', [Subscriber::STATUS_UNSUBSCRIBED])
-            ->willReturnSelf();
-        $this->subscriberMock->expects($this->at(2))
-            ->method('__call')
-            ->with('setIsStatusChanged')
-            ->willReturnSelf();
+            ->withConsecutive(['setSubscriberStatus', [Subscriber::STATUS_UNSUBSCRIBED]], ['setIsStatusChanged'])
+            ->willReturnOnConsecutiveCalls($this->subscriberMock, $this->subscriberMock);
         $this->subscriberMock->expects($this->once())
             ->method('save');
 
@@ -214,7 +210,7 @@ class ProblemTest extends TestCase
     /**
      * Sets subscriber to the Problem model
      */
-    private function setSubscriber()
+    private function setSubscriber(): void
     {
         $subscriberId = 1;
         $this->problemModel->setSubscriberId($subscriberId);

--- a/app/code/Magento/Newsletter/Test/Unit/Model/ProblemTest.php
+++ b/app/code/Magento/Newsletter/Test/Unit/Model/ProblemTest.php
@@ -65,7 +65,7 @@ class ProblemTest extends TestCase
     private $problemModel;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/Carrier/FreeshippingTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/Carrier/FreeshippingTest.php
@@ -55,7 +55,7 @@ class FreeshippingTest extends TestCase
     private $helper;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -80,7 +80,7 @@ class FreeshippingTest extends TestCase
             [
                 'scopeConfig' => $this->scopeConfigMock,
                 '_rateResultFactory' => $this->resultFactoryMock,
-                '_rateMethodFactory' => $this->methodFactoryMock,
+                '_rateMethodFactory' => $this->methodFactoryMock
             ]
         );
     }
@@ -113,39 +113,50 @@ class FreeshippingTest extends TestCase
                     'getPackageQty',
                     'getFreeShipping',
                     'getBaseSubtotalWithDiscountInclTax',
-                    'getPackageValueWithDiscount',
+                    'getPackageValueWithDiscount'
                 ]
             )
             ->getMock();
         $item = $this->getMockBuilder(QuoteItem::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('isSetFlag')
-            ->willReturn(true);
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('isSetFlag')
-            ->with(
-                'carriers/freeshipping/tax_including',
-                ScopeInterface::SCOPE_STORE,
-                null
+            ->withConsecutive(
+                [],
+                [
+                    'carriers/freeshipping/tax_including',
+                    ScopeInterface::SCOPE_STORE, null
+                ]
             )
-            ->willReturn($subtotalInclTax);
-        $this->scopeConfigMock->expects($this->at(2))
+            ->willReturnOnConsecutiveCalls(true, $subtotalInclTax);
+
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                'carriers/freeshipping/free_shipping_subtotal',
-                ScopeInterface::SCOPE_STORE,
-                null
+            ->withConsecutive(
+                [
+                    'carriers/freeshipping/free_shipping_subtotal',
+                    ScopeInterface::SCOPE_STORE,
+                    null
+                ]
             )
-            ->willReturn($minOrderAmount);
+            ->willReturnOnConsecutiveCalls($minOrderAmount);
         $method = $this->getMockBuilder(Method::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCarrier', 'setCarrierTitle', 'setMethod', 'setMethodTitle', 'setPrice', 'setCost'])
+            ->addMethods(
+                [
+                    'setCarrier',
+                    'setCarrierTitle',
+                    'setMethod',
+                    'setMethodTitle',
+                    'setCost'
+                ]
+            )
+            ->onlyMethods([ 'setPrice'])
             ->getMock();
         $resultModel = $this->getMockBuilder(Result::class)
             ->disableOriginalConstructor()
-            ->setMethods(['append'])
+            ->onlyMethods(['append'])
             ->getMock();
         $this->resultFactoryMock->method('create')
             ->willReturn($resultModel);
@@ -177,7 +188,7 @@ class FreeshippingTest extends TestCase
                 'minOrderAmount' => 10,
                 'packageValueWithDiscount' => 8,
                 'baseSubtotalWithDiscountInclTax' => 15,
-                'expectedCallAppend' => $this->once(),
+                'expectedCallAppend' => $this->once()
 
             ],
             [
@@ -185,7 +196,7 @@ class FreeshippingTest extends TestCase
                 'minOrderAmount' => 20,
                 'packageValueWithDiscount' => 8,
                 'baseSubtotalWithDiscountInclTax' => 15,
-                'expectedCallAppend' => $this->never(),
+                'expectedCallAppend' => $this->never()
 
             ],
             [
@@ -193,9 +204,9 @@ class FreeshippingTest extends TestCase
                 'minOrderAmount' => 10,
                 'packageValueWithDiscount' => 8,
                 'baseSubtotalWithDiscountInclTax' => 15,
-                'expectedCallAppend' => $this->never(),
+                'expectedCallAppend' => $this->never()
 
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/Carrier/FreeshippingTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/Carrier/FreeshippingTest.php
@@ -55,7 +55,7 @@ class FreeshippingTest extends TestCase
     private $helper;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
@@ -69,7 +69,7 @@ class BuiltinPluginTest extends TestCase
     protected $requestMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/App/FrontController/BuiltinPluginTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\PageCache\Test\Unit\Model\App\FrontController;
 
+use Closure;
 use Laminas\Http\Header\GenericHeader;
 use Magento\Framework\App\FrontControllerInterface;
 use Magento\Framework\App\PageCache\Kernel;
@@ -58,7 +59,7 @@ class BuiltinPluginTest extends TestCase
     protected $frontControllerMock;
 
     /**
-     * @var \Closure
+     * @var Closure
      */
     protected $closure;
 
@@ -68,7 +69,7 @@ class BuiltinPluginTest extends TestCase
     protected $requestMock;
 
     /**
-     * SetUp
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -92,9 +93,10 @@ class BuiltinPluginTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataProvider
      */
-    public function testAroundDispatchProcessIfCacheMissed($state)
+    public function testAroundDispatchProcessIfCacheMissed($state): void
     {
         $header = GenericHeader::fromString('Cache-Control: no-cache');
         $this->configMock
@@ -115,12 +117,12 @@ class BuiltinPluginTest extends TestCase
             ->method('getMode')
             ->willReturn($state);
         if ($state == State::MODE_DEVELOPER) {
-            $this->responseMock->expects($this->at(1))
+            $this->responseMock
                 ->method('setHeader')
-                ->with('X-Magento-Cache-Control');
-            $this->responseMock->expects($this->at(2))
-                ->method('setHeader')
-                ->with('X-Magento-Cache-Debug', 'MISS', true);
+                ->withConsecutive(
+                    ['X-Magento-Cache-Control'],
+                    ['X-Magento-Cache-Debug', 'MISS', true]
+                );
         } else {
             $this->responseMock->expects($this->never())
                 ->method('setHeader');
@@ -141,9 +143,10 @@ class BuiltinPluginTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataProvider
      */
-    public function testAroundDispatchReturnsResultInterfaceProcessIfCacheMissed($state)
+    public function testAroundDispatchReturnsResultInterfaceProcessIfCacheMissed($state): void
     {
         $this->configMock
             ->expects($this->once())
@@ -176,9 +179,10 @@ class BuiltinPluginTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataProvider
      */
-    public function testAroundDispatchReturnsCache($state)
+    public function testAroundDispatchReturnsCache($state): void
     {
         $this->configMock
             ->expects($this->once())
@@ -213,9 +217,10 @@ class BuiltinPluginTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataProvider
      */
-    public function testAroundDispatchDisabled($state)
+    public function testAroundDispatchDisabled($state): void
     {
         $this->configMock
             ->expects($this->any())
@@ -241,11 +246,11 @@ class BuiltinPluginTest extends TestCase
     /**
      * @return array
      */
-    public function dataProvider()
+    public function dataProvider(): array
     {
         return [
             'developer_mode' => [State::MODE_DEVELOPER],
-            'production' => [State::MODE_PRODUCTION],
+            'production' => [State::MODE_PRODUCTION]
         ];
     }
 }

--- a/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
@@ -56,7 +56,7 @@ class ConfigTest extends TestCase
     private $serializerMock;
 
     /**
-     * setUp all mocks and data function
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -90,7 +90,7 @@ class ConfigTest extends TestCase
                     Config::XML_VARNISH_PAGECACHE_BACKEND_HOST,
                     ScopeConfigInterface::SCOPE_TYPE_DEFAULT,
                     null,
-                    'example.com',
+                    'example.com'
                 ],
                 [
                     Config::XML_VARNISH_PAGECACHE_BACKEND_PORT,
@@ -129,17 +129,15 @@ class ConfigTest extends TestCase
         $this->serializerMock = $this->createMock(Json::class);
 
         /** @var MockObject $vclTemplateLocator */
-        $vclTemplateLocator = $this->getMockBuilder(VclTemplateLocator::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getTemplate'])
+        $vclTemplateLocator = $this->getMockBuilder(VclTemplateLocator::class)->disableOriginalConstructor()
+            ->onlyMethods(['getTemplate'])
             ->getMock();
         $vclTemplateLocator->expects($this->any())
             ->method('getTemplate')
             ->willReturn(file_get_contents(__DIR__ . '/_files/test.vcl'));
         /** @var MockObject $vclTemplateLocator */
-        $vclGeneratorFactory = $this->getMockBuilder(VclGeneratorFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $vclGeneratorFactory = $this->getMockBuilder(VclGeneratorFactory::class)->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
         $expectedParams = [
             'backendHost' => 'example.com',
@@ -176,8 +174,10 @@ class ConfigTest extends TestCase
 
     /**
      * test for getVcl method
+     *
+     * @return void
      */
-    public function testGetVcl()
+    public function testGetVcl(): void
     {
         $this->serializerMock->expects($this->once())
             ->method('unserialize')
@@ -187,7 +187,10 @@ class ConfigTest extends TestCase
         $this->assertEquals(file_get_contents(__DIR__ . '/_files/result.vcl'), $test);
     }
 
-    public function testGetTll()
+    /**
+     * @return void
+     */
+    public function testGetTll(): void
     {
         $this->coreConfigMock->expects($this->once())->method('getValue')->with(Config::XML_PAGECACHE_TTL);
         $this->config->getTtl();
@@ -195,17 +198,15 @@ class ConfigTest extends TestCase
 
     /**
      * Whether a cache type is enabled
+     *
+     * @return void
      */
-    public function testIsEnabled()
+    public function testIsEnabled(): void
     {
-        $this->cacheState->expects($this->at(0))
+        $this->cacheState
             ->method('isEnabled')
-            ->with(Type::TYPE_IDENTIFIER)
-            ->willReturn(true);
-        $this->cacheState->expects($this->at(1))
-            ->method('isEnabled')
-            ->with(Type::TYPE_IDENTIFIER)
-            ->willReturn(false);
+            ->withConsecutive([Type::TYPE_IDENTIFIER], [Type::TYPE_IDENTIFIER])
+            ->willReturnOnConsecutiveCalls(true, false);
         $this->assertTrue($this->config->isEnabled());
         $this->assertFalse($this->config->isEnabled());
     }

--- a/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/ConfigTest.php
@@ -56,7 +56,7 @@ class ConfigTest extends TestCase
     private $serializerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Http/Client/SoapTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Http/Client/SoapTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Payment\Test\Unit\Gateway\Http\Client;
 
+use Exception;
 use Magento\Framework\Webapi\Soap\ClientFactory;
 use Magento\Payment\Gateway\Http\Client\Soap;
 use Magento\Payment\Gateway\Http\ConverterInterface;
@@ -14,6 +15,8 @@ use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Model\Method\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use SoapClient;
+use StdClass;
 
 class SoapTest extends TestCase
 {
@@ -42,6 +45,9 @@ class SoapTest extends TestCase
      */
     private $gatewayClient;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->logger = $this->getMockBuilder(
@@ -55,8 +61,8 @@ class SoapTest extends TestCase
         $this->converter = $this->getMockBuilder(
             ConverterInterface::class
         )->getMockForAbstractClass();
-        $this->client = $this->getMockBuilder(\SoapClient::class)
-            ->setMethods(['__setSoapHeaders', '__soapCall', '__getLastRequest'])
+        $this->client = $this->getMockBuilder(SoapClient::class)
+            ->onlyMethods(['__setSoapHeaders', '__soapCall', '__getLastRequest'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -67,18 +73,16 @@ class SoapTest extends TestCase
         );
     }
 
-    public function testPlaceRequest()
+    /**
+     * @return void
+     */
+    public function testPlaceRequest(): void
     {
         $expectedResult = [
             'result' => []
         ];
-        $soapResult = new \StdClass();
+        $soapResult = new StdClass();
 
-        $this->logger->expects(static::at(0))
-            ->method('debug')
-            ->with(
-                ['request' => ['body']]
-            );
         $this->clientFactory->expects(static::once())
             ->method('create')
             ->with('path_to_wsdl', ['trace' => true])
@@ -95,9 +99,16 @@ class SoapTest extends TestCase
             ->method('convert')
             ->with($soapResult)
             ->willReturn($expectedResult);
-        $this->logger->expects(static::at(1))
+        $this->logger
             ->method('debug')
-            ->with(['response' => $expectedResult]);
+            ->withConsecutive(
+                [
+                    ['request' => ['body']]
+                ],
+                [
+                    ['response' => $expectedResult]
+                ]
+            );
 
         static::assertEquals(
             $expectedResult,
@@ -105,15 +116,13 @@ class SoapTest extends TestCase
         );
     }
 
-    public function testPlaceRequestSoapException()
+    /**
+     * @return void
+     */
+    public function testPlaceRequestSoapException(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
-        $this->logger->expects(static::at(0))
-            ->method('debug')
-            ->with(
-                ['request' => ['body']]
-            );
         $this->clientFactory->expects(static::once())
             ->method('create')
             ->with('path_to_wsdl', ['trace' => true])
@@ -125,15 +134,13 @@ class SoapTest extends TestCase
         $this->client->expects(static::once())
             ->method('__soapCall')
             ->with('soapMethod', [['body']])
-            ->willThrowException(new \Exception());
+            ->willThrowException(new Exception());
         $this->client->expects(static::once())
             ->method('__getLastRequest')
             ->willReturn('RequestTrace');
-        $this->logger->expects(static::at(1))
+        $this->logger
             ->method('debug')
-            ->with(
-                ['trace' => 'RequestTrace']
-            );
+            ->withConsecutive([['request' => ['body']]], [['trace' => 'RequestTrace']]);
 
         $this->gatewayClient->placeRequest($transferObject);
     }
@@ -143,11 +150,11 @@ class SoapTest extends TestCase
      *
      * @return MockObject
      */
-    private function getTransferObject()
+    private function getTransferObject(): MockObject
     {
-        $transferObject = $this->getMockBuilder(
-            TransferInterface::class
-        )->setMethods(['__setSoapHeaders', 'getBody', 'getClientConfig', 'getMethod'])->getMockForAbstractClass();
+        $transferObject = $this->getMockBuilder(TransferInterface::class)
+            ->onlyMethods(['getBody', 'getClientConfig', 'getMethod'])
+            ->addMethods(['__setSoapHeaders'])->getMockForAbstractClass();
 
         $transferObject->expects(static::any())
             ->method('getBody')

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Http/Client/SoapTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Http/Client/SoapTest.php
@@ -46,7 +46,7 @@ class SoapTest extends TestCase
     private $gatewayClient;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Validator/CountryValidatorTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Validator/CountryValidatorTest.php
@@ -37,7 +37,7 @@ class CountryValidatorTest extends TestCase
     protected $resultMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Validator/CountryValidatorTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Validator/CountryValidatorTest.php
@@ -16,7 +16,9 @@ use PHPUnit\Framework\TestCase;
 
 class CountryValidatorTest extends TestCase
 {
-    /** @var CountryValidator */
+    /**
+     * @var CountryValidator
+     */
     protected $model;
 
     /**
@@ -34,13 +36,15 @@ class CountryValidatorTest extends TestCase
      */
     protected $resultMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->configMock = $this->getMockBuilder(ConfigInterface::class)
             ->getMockForAbstractClass();
-        $this->resultFactoryMock = $this->getMockBuilder(
-            ResultInterfaceFactory::class
-        )->setMethods(['create'])
+        $this->resultFactoryMock = $this->getMockBuilder(ResultInterfaceFactory::class)
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->resultMock = $this->getMockBuilder(Result::class)
@@ -54,20 +58,28 @@ class CountryValidatorTest extends TestCase
     }
 
     /**
+     * @param $storeId
+     * @param $country
+     * @param $allowspecific
+     * @param $specificcountry
+     * @param $isValid
+     *
+     * @return void
      * @dataProvider validateAllowspecificTrueDataProvider
      */
-    public function testValidateAllowspecificTrue($storeId, $country, $allowspecific, $specificcountry, $isValid)
-    {
+    public function testValidateAllowspecificTrue(
+        $storeId,
+        $country,
+        $allowspecific,
+        $specificcountry,
+        $isValid
+    ): void {
         $validationSubject = ['storeId' => $storeId, 'country' => $country];
 
-        $this->configMock->expects($this->at(0))
+        $this->configMock
             ->method('getValue')
-            ->with('allowspecific', $storeId)
-            ->willReturn($allowspecific);
-        $this->configMock->expects($this->at(1))
-            ->method('getValue')
-            ->with('specificcountry', $storeId)
-            ->willReturn($specificcountry);
+            ->withConsecutive(['allowspecific', $storeId], ['specificcountry', $storeId])
+            ->willReturnOnConsecutiveCalls($allowspecific, $specificcountry);
 
         $this->resultFactoryMock->expects($this->once())
             ->method('create')
@@ -80,7 +92,7 @@ class CountryValidatorTest extends TestCase
     /**
      * @return array
      */
-    public function validateAllowspecificTrueDataProvider()
+    public function validateAllowspecificTrueDataProvider(): array
     {
         return [
             [1, 'US', 1, 'US,UK,CA', true], //$storeId, $country, $allowspecific, $specificcountry, $isValid
@@ -91,11 +103,11 @@ class CountryValidatorTest extends TestCase
     /**
      * @dataProvider validateAllowspecificFalseDataProvider
      */
-    public function testValidateAllowspecificFalse($storeId, $allowspecific, $isValid)
+    public function testValidateAllowspecificFalse($storeId, $allowspecific, $isValid): void
     {
         $validationSubject = ['storeId' => $storeId];
 
-        $this->configMock->expects($this->at(0))
+        $this->configMock
             ->method('getValue')
             ->with('allowspecific', $storeId)
             ->willReturn($allowspecific);
@@ -111,7 +123,7 @@ class CountryValidatorTest extends TestCase
     /**
      * @return array
      */
-    public function validateAllowspecificFalseDataProvider()
+    public function validateAllowspecificFalseDataProvider(): array
     {
         return [
             [1, 0, true] //$storeId, $allowspecific, $isValid

--- a/app/code/Magento/Payment/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Helper/DataTest.php
@@ -22,16 +22,24 @@ use PHPUnit\Framework\TestCase;
 
 class DataTest extends TestCase
 {
-    /** @var Data */
+    /**
+     * @var Data
+     */
     private $helper;
 
-    /**  @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $scopeConfig;
 
-    /**  @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $initialConfig;
 
-    /**  @var MockObject */
+    /**
+     * @var MockObject
+     */
     private $methodFactory;
 
     /**
@@ -44,6 +52,9 @@ class DataTest extends TestCase
      */
     private $appEmulation;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManager($this);
@@ -63,7 +74,10 @@ class DataTest extends TestCase
         $this->helper = $objectManagerHelper->getObject($className, $arguments);
     }
 
-    public function testGetMethodInstance()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstance(): void
     {
         list($code, $class, $methodInstance) = ['method_code', 'method_class', 'method_instance'];
 
@@ -87,7 +101,10 @@ class DataTest extends TestCase
         $this->assertEquals($methodInstance, $this->helper->getMethodInstance($code));
     }
 
-    public function testGetMethodInstanceWithException()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstanceWithException(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $this->scopeConfig->expects($this->once())
@@ -101,9 +118,10 @@ class DataTest extends TestCase
      * @param array $methodA
      * @param array $methodB
      *
+     * @return void
      * @dataProvider getSortMethodsDataProvider
      */
-    public function testSortMethods(array $methodA, array $methodB)
+    public function testSortMethods(array $methodA, array $methodB): void
     {
         $this->initialConfig->expects($this->once())
             ->method('getData')
@@ -112,8 +130,7 @@ class DataTest extends TestCase
                     Data::XML_PATH_PAYMENT_METHODS => [
                         $methodA['code'] => $methodA['data'],
                         $methodB['code'] => $methodB['data'],
-                        'empty' => [],
-
+                        'empty' => []
                     ]
                 ]
             );
@@ -153,13 +170,9 @@ class DataTest extends TestCase
             ->with('sort_order', null)
             ->willReturn($methodB['data']['sort_order']);
 
-        $this->methodFactory->expects($this->at(0))
+        $this->methodFactory
             ->method('create')
-            ->willReturn($methodInstanceMockA);
-
-        $this->methodFactory->expects($this->at(1))
-            ->method('create')
-            ->willReturn($methodInstanceMockB);
+            ->willReturnOnConsecutiveCalls($methodInstanceMockA, $methodInstanceMockB);
 
         $sortedMethods = $this->helper->getStoreMethods();
 
@@ -169,19 +182,21 @@ class DataTest extends TestCase
         );
     }
 
-    public function testGetMethodFormBlock()
+    /**
+     * @return void
+     */
+    public function testGetMethodFormBlock(): void
     {
         list($blockType, $methodCode) = ['method_block_type', 'method_code'];
 
         $methodMock = $this->getMockBuilder(MethodInterface::class)
             ->getMockForAbstractClass();
-        $layoutMock = $this->getMockBuilder(LayoutInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods([])
+        $layoutMock = $this->getMockBuilder(LayoutInterface::class)->disableOriginalConstructor()
+            ->addMethods([])
             ->getMockForAbstractClass();
-        $blockMock = $this->getMockBuilder(BlockInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setMethod', 'toHtml'])
+        $blockMock = $this->getMockBuilder(BlockInterface::class)->disableOriginalConstructor()
+            ->onlyMethods(['toHtml'])
+            ->addMethods(['setMethod'])
             ->getMockForAbstractClass();
 
         $methodMock->expects($this->once())->method('getFormBlockType')->willReturn($blockType);
@@ -194,19 +209,21 @@ class DataTest extends TestCase
         $this->assertSame($blockMock, $this->helper->getMethodFormBlock($methodMock, $layoutMock));
     }
 
-    public function testGetInfoBlock()
+    /**
+     * @return void
+     */
+    public function testGetInfoBlock(): void
     {
         $blockType = 'method_block_type';
 
         $methodMock = $this->getMockBuilder(MethodInterface::class)
             ->getMockForAbstractClass();
-        $infoMock = $this->getMockBuilder(Info::class)
-            ->disableOriginalConstructor()
-            ->setMethods([])
+        $infoMock = $this->getMockBuilder(Info::class)->disableOriginalConstructor()
+            ->onlyMethods(['getMethodInstance'])
             ->getMock();
-        $blockMock = $this->getMockBuilder(BlockInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setInfo', 'toHtml'])
+        $blockMock = $this->getMockBuilder(BlockInterface::class)->disableOriginalConstructor()
+            ->onlyMethods(['toHtml'])
+            ->addMethods(['setInfo'])
             ->getMockForAbstractClass();
 
         $infoMock->expects($this->once())->method('getMethodInstance')->willReturn($methodMock);
@@ -219,24 +236,26 @@ class DataTest extends TestCase
         $this->assertSame($blockMock, $this->helper->getInfoBlock($infoMock));
     }
 
-    public function testGetInfoBlockHtml()
+    /**
+     * @return void
+     */
+    public function testGetInfoBlockHtml(): void
     {
         list($storeId, $blockHtml, $secureMode, $blockType) = [1, 'HTML MARKUP', true, 'method_block_type'];
 
         $methodMock = $this->getMockBuilder(MethodInterface::class)
             ->getMockForAbstractClass();
-        $infoMock = $this->getMockBuilder(Info::class)
-            ->disableOriginalConstructor()
-            ->setMethods([])
+        $infoMock = $this->getMockBuilder(Info::class)->disableOriginalConstructor()
+            ->onlyMethods(['getMethodInstance'])
             ->getMock();
-        $paymentBlockMock = $this->getMockBuilder(BlockInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setArea', 'setIsSecureMode', 'getMethod', 'setStore', 'toHtml', 'setInfo'])
+        $paymentBlockMock = $this->getMockBuilder(BlockInterface::class)->disableOriginalConstructor()
+            ->onlyMethods(['toHtml'])
+            ->addMethods(['setArea', 'setIsSecureMode', 'getMethod', 'setStore', 'setInfo'])
             ->getMockForAbstractClass();
 
         $this->appEmulation->expects($this->once())
             ->method('startEnvironmentEmulation')
-            ->with($storeId, \Magento\Framework\App\Area::AREA_FRONTEND, true);
+            ->with($storeId, Area::AREA_FRONTEND, true);
         $infoMock->expects($this->once())->method('getMethodInstance')->willReturn($methodMock);
         $methodMock->expects($this->once())->method('getInfoBlockType')->willReturn($blockType);
         $this->layoutMock->expects($this->once())->method('createBlock')
@@ -261,7 +280,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function getSortMethodsDataProvider()
+    public function getSortMethodsDataProvider(): array
     {
         return [
             [
@@ -270,7 +289,7 @@ class DataTest extends TestCase
             ],
             [
                 ['code' => 'methodA', 'data' => ['sort_order' => 2]],
-                ['code' => 'methodB', 'data' => ['sort_order' => 1]],
+                ['code' => 'methodB', 'data' => ['sort_order' => 1]]
             ]
         ];
     }

--- a/app/code/Magento/Payment/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Helper/DataTest.php
@@ -53,7 +53,7 @@ class DataTest extends TestCase
     private $appEmulation;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Model/Checks/TotalMinMaxTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Checks/TotalMinMaxTest.php
@@ -28,25 +28,21 @@ class TotalMinMaxTest extends TestCase
      * @dataProvider paymentMethodDataProvider
      * @param int $baseGrandTotal
      * @param bool $expectation
+     *
+     * @return void
      */
-    public function testIsApplicable($baseGrandTotal, $expectation)
+    public function testIsApplicable(int $baseGrandTotal, bool $expectation): void
     {
-        $paymentMethod = $this->getMockBuilder(
-            MethodInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods([])->getMock();
-        $paymentMethod->expects($this->at(0))->method('getConfigData')->with(
-            TotalMinMax::MIN_ORDER_TOTAL
-        )->willReturn(self::PAYMENT_MIN_TOTAL);
-        $paymentMethod->expects($this->at(1))->method('getConfigData')->with(
-            TotalMinMax::MAX_ORDER_TOTAL
-        )->willReturn(self::PAYMENT_MAX_TOTAL);
+        $paymentMethod = $this->getMockBuilder(MethodInterface::class)->disableOriginalConstructor()
+            ->addMethods([])->getMock();
+        $paymentMethod
+            ->method('getConfigData')
+            ->withConsecutive([TotalMinMax::MIN_ORDER_TOTAL], [TotalMinMax::MAX_ORDER_TOTAL])
+            ->willReturnOnConsecutiveCalls(self::PAYMENT_MIN_TOTAL, self::PAYMENT_MAX_TOTAL);
 
-        $quote = $this->getMockBuilder(Quote::class)
-            ->disableOriginalConstructor()
-            ->setMethods(
-                ['getBaseGrandTotal', '__wakeup']
-            )->getMock();
+        $quote = $this->getMockBuilder(Quote::class)->disableOriginalConstructor()
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getBaseGrandTotal'])->getMock();
         $quote->expects($this->once())->method('getBaseGrandTotal')->willReturn($baseGrandTotal);
 
         $model = new TotalMinMax();
@@ -56,7 +52,7 @@ class TotalMinMaxTest extends TestCase
     /**
      * @return array
      */
-    public function paymentMethodDataProvider()
+    public function paymentMethodDataProvider(): array
     {
         return [[1, false], [6, false], [3, true]];
     }

--- a/app/code/Magento/Payment/Test/Unit/Model/InfoTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/InfoTest.php
@@ -15,7 +15,6 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHe
 use Magento\Payment\Helper\Data;
 use Magento\Payment\Model\Info;
 use Magento\Payment\Model\InfoInterface;
-use Magento\Payment\Model\Method;
 use Magento\Payment\Model\Method\Substitution;
 use Magento\Payment\Model\MethodInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -26,27 +25,44 @@ use PHPUnit\Framework\TestCase;
  */
 class InfoTest extends TestCase
 {
-    /** @var InfoInterface */
+    /**
+     * @var InfoInterface
+     */
     protected $info;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     protected $contextMock;
 
-    /** @var Registry|MockObject */
+    /**
+     * @var Registry|MockObject
+     */
     protected $registryMock;
 
-    /** @var Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $paymentHelperMock;
 
-    /** @var EncryptorInterface|MockObject */
+    /**
+     * @var EncryptorInterface|MockObject
+     */
     protected $encryptorInterfaceMock;
 
-    /** @var Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $methodInstanceMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
@@ -72,8 +88,10 @@ class InfoTest extends TestCase
      * @dataProvider ccKeysDataProvider
      * @param string $keyCc
      * @param string $keyCcEnc
+     *
+     * @return void
      */
-    public function testGetDataCcNumber($keyCc, $keyCcEnc)
+    public function testGetDataCcNumber(string $keyCc, string $keyCcEnc): void
     {
         // no data was set
         $this->assertNull($this->info->getData($keyCc));
@@ -91,7 +109,7 @@ class InfoTest extends TestCase
      *
      * @return array
      */
-    public function ccKeysDataProvider()
+    public function ccKeysDataProvider(): array
     {
         return [
             ['cc_number', 'cc_number_enc'],
@@ -99,7 +117,10 @@ class InfoTest extends TestCase
         ];
     }
 
-    public function testGetMethodInstanceWithRealMethod()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstanceWithRealMethod(): void
     {
         $method = 'real_method';
         $this->info->setData('method', $method);
@@ -116,29 +137,30 @@ class InfoTest extends TestCase
         $this->info->getMethodInstance();
     }
 
-    public function testGetMethodInstanceWithUnrealMethod()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstanceWithUnrealMethod(): void
     {
         $method = 'unreal_method';
         $this->info->setData('method', $method);
-
-        $this->paymentHelperMock->expects($this->at(0))
-            ->method('getMethodInstance')
-            ->with($method)
-            ->willThrowException(new \UnexpectedValueException());
 
         $this->methodInstanceMock->expects($this->once())
             ->method('setInfoInstance')
             ->with($this->info);
 
-        $this->paymentHelperMock->expects($this->at(1))
+        $this->paymentHelperMock
             ->method('getMethodInstance')
-            ->with(Substitution::CODE)
+            ->withConsecutive([$method], [Substitution::CODE])
             ->willReturn($this->methodInstanceMock);
 
         $this->info->getMethodInstance();
     }
 
-    public function testGetMethodInstanceWithNoMethod()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstanceWithNoMethod(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('The payment method you requested is not available.');
@@ -146,7 +168,10 @@ class InfoTest extends TestCase
         $this->info->getMethodInstance();
     }
 
-    public function testGetMethodInstanceRequestedMethod()
+    /**
+     * @return void
+     */
+    public function testGetMethodInstanceRequestedMethod(): void
     {
         $code = 'real_method';
         $this->info->setData('method', $code);
@@ -162,7 +187,10 @@ class InfoTest extends TestCase
         $this->assertSame($this->methodInstanceMock, $this->info->getMethodInstance());
     }
 
-    public function testEncrypt()
+    /**
+     * @return void
+     */
+    public function testEncrypt(): void
     {
         $data = 'data';
         $encryptedData = 'd1a2t3a4';
@@ -173,7 +201,10 @@ class InfoTest extends TestCase
         $this->assertEquals($encryptedData, $this->info->encrypt($data));
     }
 
-    public function testDecrypt()
+    /**
+     * @return void
+     */
+    public function testDecrypt(): void
     {
         $data = 'data';
         $encryptedData = 'd1a2t3a4';
@@ -184,7 +215,10 @@ class InfoTest extends TestCase
         $this->assertEquals($data, $this->info->decrypt($encryptedData));
     }
 
-    public function testSetAdditionalInformationException()
+    /**
+     * @return void
+     */
+    public function testSetAdditionalInformationException(): void
     {
         $this->expectException(LocalizedException::class);
         $this->info->setAdditionalInformation('object', new \StdClass());
@@ -194,8 +228,10 @@ class InfoTest extends TestCase
      * @dataProvider additionalInformationDataProvider
      * @param mixed $key
      * @param mixed $value
+     *
+     * @return void
      */
-    public function testSetAdditionalInformationMultipleTypes($key, $value = null)
+    public function testSetAdditionalInformationMultipleTypes($key, $value = null): void
     {
         $this->info->setAdditionalInformation($key, $value);
         $this->assertEquals($value ? [$key => $value] : $key, $this->info->getAdditionalInformation());
@@ -206,7 +242,7 @@ class InfoTest extends TestCase
      *
      * @return array
      */
-    public function additionalInformationDataProvider()
+    public function additionalInformationDataProvider(): array
     {
         return [
             [['key1' => 'data1', 'key2' => 'data2'], null],
@@ -214,7 +250,10 @@ class InfoTest extends TestCase
         ];
     }
 
-    public function testGetAdditionalInformationByKey()
+    /**
+     * @return void
+     */
+    public function testGetAdditionalInformationByKey(): void
     {
         $key = 'key';
         $value = 'value';
@@ -222,7 +261,10 @@ class InfoTest extends TestCase
         $this->assertEquals($value, $this->info->getAdditionalInformation($key));
     }
 
-    public function testUnsAdditionalInformation()
+    /**
+     * @return void
+     */
+    public function testUnsAdditionalInformation(): void
     {
         // set array to additional
         $data = ['key1' => 'data1', 'key2' => 'data2'];
@@ -238,7 +280,10 @@ class InfoTest extends TestCase
         $this->assertEmpty($this->info->unsAdditionalInformation()->getAdditionalInformation());
     }
 
-    public function testHasAdditionalInformation()
+    /**
+     * @return void
+     */
+    public function testHasAdditionalInformation(): void
     {
         $this->assertFalse($this->info->hasAdditionalInformation());
 
@@ -250,7 +295,10 @@ class InfoTest extends TestCase
         $this->assertTrue($this->info->hasAdditionalInformation());
     }
 
-    public function testInitAdditionalInformationWithUnserialize()
+    /**
+     * @return void
+     */
+    public function testInitAdditionalInformationWithUnserialize(): void
     {
         $data = ['key1' => 'data1', 'key2' => 'data2'];
         $this->info->setData('additional_information', $data);

--- a/app/code/Magento/Payment/Test/Unit/Model/InfoTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/InfoTest.php
@@ -61,7 +61,7 @@ class InfoTest extends TestCase
     protected $methodInstanceMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Model/Method/FreeTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Method/FreeTest.php
@@ -27,15 +27,24 @@ use Psr\Log\LoggerInterface;
  */
 class FreeTest extends TestCase
 {
-    /** @var Free */
+    /**
+     * @var Free
+     */
     protected $methodFree;
 
-    /**  @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $scopeConfig;
 
-    /**  @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $currencyPrice;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $paymentData  = $this->createMock(Data::class);
@@ -71,18 +80,17 @@ class FreeTest extends TestCase
      * @param string $orderStatus
      * @param string $paymentAction
      * @param mixed $result
+     *
+     * @return void
      * @dataProvider getConfigPaymentActionProvider
      */
-    public function testGetConfigPaymentAction($orderStatus, $paymentAction, $result)
+    public function testGetConfigPaymentAction($orderStatus, $paymentAction, $result): void
     {
-        $this->scopeConfig->expects($this->at(0))
-            ->method('getValue')
-            ->willReturn($orderStatus);
 
         if ($orderStatus != 'pending') {
-            $this->scopeConfig->expects($this->at(1))
+            $this->scopeConfig
                 ->method('getValue')
-                ->willReturn($paymentAction);
+                ->willReturnOnConsecutiveCalls($orderStatus, $paymentAction);
         }
         $this->assertEquals($result, $this->methodFree->getConfigPaymentAction());
     }
@@ -92,10 +100,16 @@ class FreeTest extends TestCase
      * @param bool $isActive
      * @param bool $notEmptyQuote
      * @param bool $result
+     *
+     * @return void
      * @dataProvider getIsAvailableProvider
      */
-    public function testIsAvailable($grandTotal, $isActive, $notEmptyQuote, $result)
-    {
+    public function testIsAvailable(
+        float $grandTotal,
+        bool $isActive,
+        bool $notEmptyQuote,
+        bool $result
+    ): void {
         $quote = null;
         if ($notEmptyQuote) {
             $quote = $this->createMock(Quote::class);
@@ -119,7 +133,7 @@ class FreeTest extends TestCase
     /**
      * @return array
      */
-    public function getIsAvailableProvider()
+    public function getIsAvailableProvider(): array
     {
         return [
             [0, true, true, true],
@@ -133,7 +147,7 @@ class FreeTest extends TestCase
     /**
      * @return array
      */
-    public function getConfigPaymentActionProvider()
+    public function getConfigPaymentActionProvider(): array
     {
         return [
             ['pending', 'action', null],

--- a/app/code/Magento/Payment/Test/Unit/Model/Method/FreeTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Method/FreeTest.php
@@ -43,7 +43,7 @@ class FreeTest extends TestCase
     protected $currencyPrice;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Model/Method/Specification/CompositeTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Method/Specification/CompositeTest.php
@@ -22,7 +22,7 @@ class CompositeTest extends TestCase
     protected $factoryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Payment/Test/Unit/Model/Method/Specification/CompositeTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Model/Method/Specification/CompositeTest.php
@@ -21,6 +21,9 @@ class CompositeTest extends TestCase
      */
     protected $factoryMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->factoryMock = $this->createMock(Factory::class);
@@ -28,9 +31,10 @@ class CompositeTest extends TestCase
 
     /**
      * @param array $specifications
-     * @return Composite
+     *
+     * @return object
      */
-    protected function createComposite($specifications = [])
+    protected function createComposite(array $specifications = [])
     {
         $objectManager = new ObjectManager($this);
 
@@ -44,10 +48,15 @@ class CompositeTest extends TestCase
      * @param bool $firstSpecificationResult
      * @param bool $secondSpecificationResult
      * @param bool $compositeResult
+     *
+     * @return void
      * @dataProvider compositeDataProvider
      */
-    public function testComposite($firstSpecificationResult, $secondSpecificationResult, $compositeResult)
-    {
+    public function testComposite(
+        bool $firstSpecificationResult,
+        bool $secondSpecificationResult,
+        bool $compositeResult
+    ): void {
         $method = 'method-name';
 
         $specificationFirst = $this->getMockForAbstractClass(SpecificationInterface::class);
@@ -72,24 +81,10 @@ class CompositeTest extends TestCase
             $secondSpecificationResult
         );
 
-        $this->factoryMock->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            'SpecificationFirst'
-        )->willReturn(
-            $specificationFirst
-        );
-        $this->factoryMock->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            'SpecificationSecond'
-        )->willReturn(
-            $specificationSecond
-        );
+        $this->factoryMock
+            ->method('create')
+            ->withConsecutive(['SpecificationFirst'], ['SpecificationSecond'])
+            ->willReturnOnConsecutiveCalls($specificationFirst, $specificationSecond);
 
         $composite = $this->createComposite(['SpecificationFirst', 'SpecificationSecond']);
 
@@ -103,7 +98,7 @@ class CompositeTest extends TestCase
     /**
      * @return array
      */
-    public function compositeDataProvider()
+    public function compositeDataProvider(): array
     {
         return [
             [true, true, true],

--- a/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Field/CountryTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Field/CountryTest.php
@@ -53,7 +53,7 @@ class CountryTest extends TestCase
     private $helper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Field/CountryTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Adminhtml/System/Config/Field/CountryTest.php
@@ -52,6 +52,9 @@ class CountryTest extends TestCase
      */
     private $helper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
@@ -103,14 +106,20 @@ class CountryTest extends TestCase
     }
 
     /**
-     * @param null|string $requestCountry
-     * @param null|string $requestDefaultCountry
+     * @param string|null $requestCountry
+     * @param string|null $requestDefaultCountry
      * @param bool $canUseDefault
      * @param bool $inherit
+     *
+     * @return void
      * @dataProvider renderDataProvider
      */
-    public function testRender($requestCountry, $requestDefaultCountry, $canUseDefault, $inherit)
-    {
+    public function testRender(
+        ?string $requestCountry,
+        ?string $requestDefaultCountry,
+        bool $canUseDefault,
+        bool $inherit
+    ): void {
         $this->_request->expects($this->any())
             ->method('getParam')
             ->willReturnCallback(function ($param) use ($requestCountry, $requestDefaultCountry) {
@@ -130,32 +139,32 @@ class CountryTest extends TestCase
                 '$("' . $this->_element->getHtmlId() . '").observe("change", function () {'
             ),
         ];
-        $this->_url->expects($this->at(0))
-            ->method('getUrl')
-            ->with(
-                '*/*/*',
-                [
-                    'section' => 'section',
-                    'website' => 'website',
-                    'store' => 'store',
-                    StructurePlugin::REQUEST_PARAM_COUNTRY => '__country__'
-                ]
-            );
         if ($canUseDefault && ($requestCountry == 'US') && $requestDefaultCountry) {
             $this->helper->method('getDefaultCountry')->willReturn($requestDefaultCountry);
             $constraints[] = new StringContains(
                 '$("' . $this->_element->getHtmlId() . '_inherit").observe("click", function () {'
             );
-            $this->_url->expects($this->at(1))
+            $this->_url
                 ->method('getUrl')
-                ->with(
-                    '*/*/*',
+                ->withConsecutive(
                     [
-                        'section' => 'section',
-                        'website' => 'website',
-                        'store' => 'store',
-                        StructurePlugin::REQUEST_PARAM_COUNTRY => '__country__',
-                        Country::REQUEST_PARAM_DEFAULT_COUNTRY => '__default__'
+                        '*/*/*',
+                        [
+                            'section' => 'section',
+                            'website' => 'website',
+                            'store' => 'store',
+                            StructurePlugin::REQUEST_PARAM_COUNTRY => '__country__'
+                        ]
+                    ],
+                    [
+                        '*/*/*',
+                        [
+                            'section' => 'section',
+                            'website' => 'website',
+                            'store' => 'store',
+                            StructurePlugin::REQUEST_PARAM_COUNTRY => '__country__',
+                            Country::REQUEST_PARAM_DEFAULT_COUNTRY => '__default__'
+                        ]
                     ]
                 );
         }
@@ -168,7 +177,7 @@ class CountryTest extends TestCase
     /**
      * @return array
      */
-    public function renderDataProvider()
+    public function renderDataProvider(): array
     {
         return [
             [null, null, false, false],
@@ -179,7 +188,7 @@ class CountryTest extends TestCase
             ['IT', 'GB', true, false],
             ['US', 'GB', true, true],
             ['US', 'GB', true, false],
-            ['US', null, true, false],
+            ['US', null, true, false]
         ];
     }
 }

--- a/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
@@ -15,6 +15,7 @@ use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\Context;
 use Magento\Framework\View\Element\Template\Context as TemplateContext;
 use Magento\Framework\View\LayoutInterface;
 use Magento\Paypal\Block\Billing\Agreements;
@@ -31,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 class AgreementsTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\View\Element\Context|MockObject
+     * @var Context|MockObject
      */
     private $context;
 
@@ -83,7 +84,7 @@ class AgreementsTest extends TestCase
     private $block;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -117,10 +118,10 @@ class AgreementsTest extends TestCase
         $this->context->expects($this->once())->method('getScopeConfig')->willReturn($this->scopeConfig);
         $this->cache = $this->getMockForAbstractClass(CacheInterface::class, [], '', false);
         $this->context->expects($this->once())->method('getCache')->willReturn($this->cache);
-        $this->agreementCollection = $this->getMockBuilder(
-            CollectionFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])->getMock();
+        $this->agreementCollection = $this->getMockBuilder(CollectionFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
         $this->helper = $this->createMock(Data::class);
         $objectManager = new ObjectManager($this);
 
@@ -129,12 +130,15 @@ class AgreementsTest extends TestCase
             [
                 'context' => $this->context,
                 'agreementCollection' => $this->agreementCollection,
-                'helper' => $this->helper,
+                'helper' => $this->helper
             ]
         );
     }
 
-    public function testGetBillingAgreements()
+    /**
+     * @return void
+     */
+    public function testGetBillingAgreements(): void
     {
         $collection = $this->createMock(Collection::class);
         $this->agreementCollection->expects($this->once())->method('create')->willReturn($collection);
@@ -145,7 +149,10 @@ class AgreementsTest extends TestCase
         $this->block->getBillingAgreements();
     }
 
-    public function testGetItemValueCreatedAt()
+    /**
+     * @return void
+     */
+    public function testGetItemValueCreatedAt(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml');
         $item = $this->createMock(Agreement::class);
@@ -153,7 +160,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'created_at');
     }
 
-    public function testGetItemValueCreatedAtNoData()
+    /**
+     * @return void
+     */
+    public function testGetItemValueCreatedAtNoData(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml');
         $item = $this->createMock(Agreement::class);
@@ -161,7 +171,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'created_at');
     }
 
-    public function testGetItemValueUpdatedAt()
+    /**
+     * @return void
+     */
+    public function testGetItemValueUpdatedAt(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml');
         $item = $this->createMock(Agreement::class);
@@ -169,7 +182,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'updated_at');
     }
 
-    public function testGetItemValueUpdatedAtNoData()
+    /**
+     * @return void
+     */
+    public function testGetItemValueUpdatedAtNoData(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml');
         $item = $this->createMock(Agreement::class);
@@ -177,7 +193,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'updated_at');
     }
 
-    public function testGetItemValueEditUrl()
+    /**
+     * @return void
+     */
+    public function testGetItemValueEditUrl(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml');
         $item = $this->getMockBuilder(Agreement::class)
@@ -192,7 +211,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'edit_url');
     }
 
-    public function testGetItemPaymentMethodLabel()
+    /**
+     * @return void
+     */
+    public function testGetItemPaymentMethodLabel(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml')->with('label', null);
         $item = $this->getMockBuilder(Agreement::class)
@@ -203,7 +225,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'payment_method_label');
     }
 
-    public function testGetItemStatus()
+    /**
+     * @return void
+     */
+    public function testGetItemStatus(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml')->with('status', null);
         $item = $this->createMock(Agreement::class);
@@ -211,7 +236,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'status');
     }
 
-    public function testGetItemDefault()
+    /**
+     * @return void
+     */
+    public function testGetItemDefault(): void
     {
         $this->escaper->expects($this->once())->method('escapeHtml')->with('value', null);
         $item = $this->createMock(Agreement::class);
@@ -219,7 +247,10 @@ class AgreementsTest extends TestCase
         $this->block->getItemValue($item, 'default');
     }
 
-    public function testGetWizardPaymentMethodOptions()
+    /**
+     * @return void
+     */
+    public function testGetWizardPaymentMethodOptions(): void
     {
         $method1 = $this->createPartialMock(
             \Magento\Paypal\Model\Method\Agreement::class,
@@ -247,17 +278,18 @@ class AgreementsTest extends TestCase
         $this->assertEquals(['code1' => 'title1', 'code3' => 'title3'], $this->block->getWizardPaymentMethodOptions());
     }
 
-    public function testToHtml()
+    /**
+     * @return void
+     */
+    public function testToHtml(): void
     {
-        $this->eventManager
-            ->expects($this->at(0))
-            ->method('dispatch')
-            ->with('view_block_abstract_to_html_before', ['block' => $this->block]);
         $transport = new DataObject(['html' => '']);
         $this->eventManager
-            ->expects($this->at(1))
             ->method('dispatch')
-            ->with('view_block_abstract_to_html_after', ['block' => $this->block, 'transport' => $transport]);
+            ->withConsecutive(
+                ['view_block_abstract_to_html_before', ['block' => $this->block]],
+                ['view_block_abstract_to_html_after', ['block' => $this->block, 'transport' => $transport]]
+            );
         $this->scopeConfig
             ->expects($this->once())
             ->method('getValue')

--- a/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Billing/AgreementsTest.php
@@ -84,7 +84,7 @@ class AgreementsTest extends TestCase
     private $block;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
@@ -100,7 +100,7 @@ class ReturnUrlTest extends TestCase
     private $paymentFailures;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -113,9 +113,8 @@ class ReturnUrlTest extends TestCase
         $this->view = $this->getMockBuilder(ViewInterface::class)
             ->getMock();
 
-        $this->request = $this->getMockBuilder(Http::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
+        $this->request = $this->getMockBuilder(Http::class)->disableOriginalConstructor()
+            ->addMethods(['getParam'])
             ->getMock();
 
         $this->layout = $this->getMockBuilder(LayoutInterface::class)
@@ -125,9 +124,8 @@ class ReturnUrlTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->orderFactory = $this->getMockBuilder(OrderFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->orderFactory = $this->getMockBuilder(OrderFactory::class)->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->checkoutHelper = $this->getMockBuilder(Checkout::class)
@@ -142,9 +140,9 @@ class ReturnUrlTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->checkoutSession = $this->getMockBuilder(Session::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['setLastRealOrderId', 'getLastRealOrder', 'restoreQuote'])
+        $this->checkoutSession = $this->getMockBuilder(Session::class)->disableOriginalConstructor()
+            ->onlyMethods(['getLastRealOrder', 'restoreQuote'])
+            ->addMethods(['setLastRealOrderId'])
             ->getMock();
 
         $this->paymentFailures = $this->getMockBuilder(PaymentFailuresInterface::class)
@@ -163,7 +161,7 @@ class ReturnUrlTest extends TestCase
                 'checkoutSession' => $this->checkoutSession,
                 'orderFactory' => $this->orderFactory,
                 'checkoutHelper' => $this->checkoutHelper,
-                'paymentFailures' => $this->paymentFailures,
+                'paymentFailures' => $this->paymentFailures
             ]
         );
     }
@@ -172,18 +170,22 @@ class ReturnUrlTest extends TestCase
      * Checks a test case when action processes order with allowed state.
      *
      * @param string $state
+     *
+     * @return void
      * @dataProvider allowedOrderStateDataProvider
      */
-    public function testExecuteAllowedOrderState($state)
+    public function testExecuteAllowedOrderState($state): void
     {
         $this->withLayout();
         $this->withOrder(self::LAST_REAL_ORDER_ID, $state);
 
         $this->request->method('getParam')
-            ->willReturnMap([
-                ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', self::SILENT_POST_HASH],
-            ]);
+            ->willReturnMap(
+                [
+                    ['INVNUM', self::LAST_REAL_ORDER_ID],
+                    ['USER2', self::SILENT_POST_HASH]
+                ]
+            );
 
         $this->checkoutSession->expects($this->once())
             ->method('setLastRealOrderId')
@@ -202,12 +204,12 @@ class ReturnUrlTest extends TestCase
      *
      * @return array
      */
-    public function allowedOrderStateDataProvider()
+    public function allowedOrderStateDataProvider(): array
     {
         return [
             [Order::STATE_PROCESSING],
             [Order::STATE_COMPLETE],
-            [Order::STATE_PAYMENT_REVIEW],
+            [Order::STATE_PAYMENT_REVIEW]
         ];
     }
 
@@ -216,18 +218,22 @@ class ReturnUrlTest extends TestCase
      *
      * @param string $requestHash
      * @param string $orderHash
+     *
+     * @return void
      * @dataProvider invalidHashVariations
      */
-    public function testFailedHashValidation(string $requestHash, string $orderHash)
+    public function testFailedHashValidation(string $requestHash, string $orderHash): void
     {
         $this->withLayout();
         $this->withOrder(self::LAST_REAL_ORDER_ID, Order::STATE_PROCESSING, $orderHash);
 
         $this->request->method('getParam')
-            ->willReturnMap([
-                ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', $requestHash],
-            ]);
+            ->willReturnMap(
+                [
+                    ['INVNUM', self::LAST_REAL_ORDER_ID],
+                    ['USER2', $requestHash]
+                ]
+            );
 
         $this->checkoutSession->expects($this->never())
             ->method('setLastRealOrderId')
@@ -241,12 +247,12 @@ class ReturnUrlTest extends TestCase
      *
      * @return array
      */
-    public function invalidHashVariations()
+    public function invalidHashVariations(): array
     {
         return [
             ['requestHash' => '', 'orderHash' => self::SILENT_POST_HASH],
             ['requestHash' => self::SILENT_POST_HASH, 'orderHash' => ''],
-            ['requestHash' => 'abcd', 'orderHash' => 'dcba'],
+            ['requestHash' => 'abcd', 'orderHash' => 'dcba']
         ];
     }
 
@@ -256,9 +262,11 @@ class ReturnUrlTest extends TestCase
      * @param string $state
      * @param bool $restoreQuote
      * @param string $expectedGotoSection
+     *
+     * @return void
      * @dataProvider notAllowedOrderStateDataProvider
      */
-    public function testExecuteNotAllowedOrderState($state, $restoreQuote, $expectedGotoSection)
+    public function testExecuteNotAllowedOrderState($state, $restoreQuote, $expectedGotoSection): void
     {
         $errMessage = 'Transaction has been canceled.';
         $this->withLayout();
@@ -269,7 +277,7 @@ class ReturnUrlTest extends TestCase
             ->willReturnMap([
                 ['RESPMSG', $errMessage],
                 ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', self::SILENT_POST_HASH],
+                ['USER2', self::SILENT_POST_HASH]
             ]);
 
         $this->payment->method('getMethod')
@@ -288,7 +296,7 @@ class ReturnUrlTest extends TestCase
      *
      * @return array
      */
-    public function notAllowedOrderStateDataProvider()
+    public function notAllowedOrderStateDataProvider(): array
     {
         return [
             [Order::STATE_NEW, false, ''],
@@ -300,14 +308,16 @@ class ReturnUrlTest extends TestCase
             [Order::STATE_CANCELED, false, ''],
             [Order::STATE_CANCELED, true, 'paymentMethod'],
             [Order::STATE_HOLDED, false, ''],
-            [Order::STATE_HOLDED, true, 'paymentMethod'],
+            [Order::STATE_HOLDED, true, 'paymentMethod']
         ];
     }
 
     /**
      * Checks a test case when action is triggered for unsupported payment method.
+     *
+     * @return void
      */
-    public function testCheckRejectByPaymentMethod()
+    public function testCheckRejectByPaymentMethod(): void
     {
         $this->withLayout();
         $this->withOrder(self::LAST_REAL_ORDER_ID, Order::STATE_NEW);
@@ -318,7 +328,7 @@ class ReturnUrlTest extends TestCase
         $this->request->method('getParam')
             ->willReturnMap([
                 ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', self::SILENT_POST_HASH],
+                ['USER2', self::SILENT_POST_HASH]
             ]);
 
         $this->withBlockContent(false, 'Requested payment method does not match with order.');
@@ -333,9 +343,11 @@ class ReturnUrlTest extends TestCase
     /**
      * @param string $errorMsg
      * @param string $errorMsgEscaped
+     *
+     * @return void
      * @dataProvider checkXSSEscapedDataProvider
      */
-    public function testCheckXSSEscaped($errorMsg, $errorMsgEscaped)
+    public function testCheckXSSEscaped($errorMsg, $errorMsgEscaped): void
     {
         $this->withLayout();
         $this->withOrder(self::LAST_REAL_ORDER_ID, Order::STATE_NEW);
@@ -345,7 +357,7 @@ class ReturnUrlTest extends TestCase
             ->willReturnMap([
                 ['RESPMSG', $errorMsg],
                 ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', self::SILENT_POST_HASH],
+                ['USER2', self::SILENT_POST_HASH]
             ]);
 
         $this->checkoutHelper->method('cancelCurrentOrder')
@@ -364,7 +376,7 @@ class ReturnUrlTest extends TestCase
      *
      * @return array
      */
-    public function checkXSSEscapedDataProvider()
+    public function checkXSSEscapedDataProvider(): array
     {
         return [
             ['simple', 'simple'],
@@ -374,33 +386,40 @@ class ReturnUrlTest extends TestCase
     }
 
     /**
-     * Checks a case when Payflow Advanced methods uses inherited behavior.
+     * Checks a case when Payflow Advanced methods uses inherited behavior
+     *
+     * @return void
      */
-    public function testCheckAdvancedAcceptingByPaymentMethod()
+    public function testCheckAdvancedAcceptingByPaymentMethod(): void
     {
         $this->withLayout();
         $this->withOrder(self::LAST_REAL_ORDER_ID, Order::STATE_NEW);
         $this->withCheckoutSession(self::LAST_REAL_ORDER_ID, true);
 
         $this->request->method('getParam')
-            ->willReturnMap([
-                ['RESPMSG', 'message'],
-                ['INVNUM', self::LAST_REAL_ORDER_ID],
-                ['USER2', self::SILENT_POST_HASH],
-            ]);
+            ->willReturnMap(
+                [
+                    ['RESPMSG', 'message'],
+                    ['INVNUM', self::LAST_REAL_ORDER_ID],
+                    ['USER2', self::SILENT_POST_HASH]
+                ]
+            );
 
         $this->withBlockContent('paymentMethod', 'Your payment has been declined. Please try again.');
 
         $this->payment->method('getMethod')
             ->willReturn(Config::METHOD_PAYFLOWADVANCED);
 
-        $returnUrl = $this->objectManager->getObject(PayflowadvancedReturnUrl::class, [
-            'context' => $this->context,
-            'checkoutSession' => $this->checkoutSession,
-            'orderFactory' => $this->orderFactory,
-            'checkoutHelper' => $this->checkoutHelper,
-            'paymentFailures' => $this->paymentFailures,
-        ]);
+        $returnUrl = $this->objectManager->getObject(
+            PayflowadvancedReturnUrl::class,
+            [
+                'context' => $this->context,
+                'checkoutSession' => $this->checkoutSession,
+                'orderFactory' => $this->orderFactory,
+                'checkoutHelper' => $this->checkoutHelper,
+                'paymentFailures' => $this->paymentFailures
+            ]
+        );
 
         $returnUrl->execute();
     }
@@ -411,9 +430,10 @@ class ReturnUrlTest extends TestCase
      * @param string $incrementId
      * @param string $state
      * @param string $hash
+     *
      * @return void
      */
-    private function withOrder($incrementId, $state, $hash = self::SILENT_POST_HASH)
+    private function withOrder($incrementId, $state, $hash = self::SILENT_POST_HASH): void
     {
         $this->orderFactory->method('create')
             ->willReturn($this->order);
@@ -439,7 +459,7 @@ class ReturnUrlTest extends TestCase
      *
      * @return void
      */
-    private function withLayout()
+    private function withLayout(): void
     {
         $this->view->method('getLayout')
             ->willReturn($this->layout);
@@ -453,8 +473,10 @@ class ReturnUrlTest extends TestCase
      *
      * @param int $orderId
      * @param bool $restoreQuote
+     *
+     * @return void
      */
-    private function withCheckoutSession($orderId, $restoreQuote)
+    private function withCheckoutSession($orderId, $restoreQuote): void
     {
         $this->checkoutSession->method('setLastRealOrderId')
             ->with($orderId);
@@ -471,18 +493,17 @@ class ReturnUrlTest extends TestCase
      *
      * @param bool $gotoSection
      * @param string $errMsg
+     *
      * @return void
      */
-    private function withBlockContent($gotoSection, $errMsg)
+    private function withBlockContent($gotoSection, $errMsg): void
     {
-        $this->block->expects(self::at(0))
+        $this->block
             ->method('setData')
-            ->with('goto_section', self::equalTo($gotoSection))
-            ->willReturnSelf();
-
-        $this->block->expects(self::at(1))
-            ->method('setData')
-            ->with('error_msg', self::equalTo(__($errMsg)))
-            ->willReturnSelf();
+            ->withConsecutive(
+                ['goto_section', self::equalTo($gotoSection)],
+                ['error_msg', self::equalTo(__($errMsg))]
+            )
+            ->willReturnOnConsecutiveCalls($this->block, $this->block);
     }
 }

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Payflow/ReturnUrlTest.php
@@ -100,7 +100,7 @@ class ReturnUrlTest extends TestCase
     private $paymentFailures;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Paypal/Test/Unit/Model/Config/Rules/ReaderTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Config/Rules/ReaderTest.php
@@ -18,28 +18,38 @@ use PHPUnit\Framework\TestCase;
 
 class ReaderTest extends TestCase
 {
-    /** @var  Reader */
+    /**
+     * @var  Reader
+     */
     protected $reader;
 
-    /** @var  FileResolverInterface|MockObject */
+    /**
+     * @var  FileResolverInterface|MockObject
+     */
     protected $fileResolver;
 
-    /** @var  Converter|MockObject */
+    /**
+     * @var  Converter|MockObject
+     */
     protected $converter;
 
-    /** @var  SchemaLocatorInterface|MockObject */
+    /**
+     * @var  SchemaLocatorInterface|MockObject
+     */
     protected $schemaLocator;
 
-    /** @var  ValidationStateInterface|MockObject */
+    /**
+     * @var  ValidationStateInterface|MockObject
+     */
     protected $validationState;
 
-    /** @var Backend|MockObject */
+    /**
+     * @var Backend|MockObject
+     */
     protected $helper;
 
     /**
-     * Set up
-     *
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -60,9 +70,11 @@ class ReaderTest extends TestCase
      * @param string $countryCode
      * @param string $xml
      * @param string $expected
+     *
+     * @return void
      * @dataProvider dataProviderReadExistingCountryConfig
      */
-    public function testReadExistingCountryConfig($countryCode, $xml, $expected)
+    public function testReadExistingCountryConfig($countryCode, $xml, $expected): void
     {
         $this->helper->expects($this->once())
             ->method('getConfigurationCountryCode')
@@ -88,21 +100,20 @@ class ReaderTest extends TestCase
      * @param string $countryCode
      * @param string $xml
      * @param string $expected
+     *
+     * @return void
      * @dataProvider dataProviderReadOtherCountryConfig
      */
-    public function testReadOtherCountryConfig($countryCode, $xml, $expected)
+    public function testReadOtherCountryConfig($countryCode, $xml, $expected): void
     {
         $this->helper->expects($this->once())
             ->method('getConfigurationCountryCode')
             ->willReturn($countryCode);
 
-        $this->fileResolver->expects($this->at(0))
+        $this->fileResolver
             ->method('get')
-            ->willReturn([]);
-        $this->fileResolver->expects($this->at(1))
-            ->method('get')
-            ->with($expected)
-            ->willReturn($xml);
+            ->withConsecutive([], [$expected])
+            ->willReturnOnConsecutiveCalls([], $xml);
 
         $this->reader = new Reader(
             $this->fileResolver,
@@ -118,7 +129,7 @@ class ReaderTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderReadExistingCountryConfig()
+    public function dataProviderReadExistingCountryConfig(): array
     {
         return [
             ['us', ['<payment/>'], 'adminhtml/rules/payment_us.xml'],
@@ -131,17 +142,17 @@ class ReaderTest extends TestCase
             ['es', ['<payment/>'], 'adminhtml/rules/payment_es.xml'],
             ['hk', ['<payment/>'], 'adminhtml/rules/payment_hk.xml'],
             ['nz', ['<payment/>'], 'adminhtml/rules/payment_nz.xml'],
-            ['de', ['<payment/>'], 'adminhtml/rules/payment_de.xml'],
+            ['de', ['<payment/>'], 'adminhtml/rules/payment_de.xml']
         ];
     }
 
     /**
      * @return array
      */
-    public function dataProviderReadOtherCountryConfig()
+    public function dataProviderReadOtherCountryConfig(): array
     {
         return [
-            ['no', ['<payment/>'], 'adminhtml/rules/payment_other.xml'],
+            ['no', ['<payment/>'], 'adminhtml/rules/payment_other.xml']
         ];
     }
 }

--- a/app/code/Magento/Paypal/Test/Unit/Model/Config/Rules/ReaderTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/Config/Rules/ReaderTest.php
@@ -49,7 +49,7 @@ class ReaderTest extends TestCase
     protected $helper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Store/Test/Unit/Model/StoreRepositoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreRepositoryTest.php
@@ -48,14 +48,17 @@ class StoreRepositoryTest extends TestCase
      */
     private $appConfigMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->storeFactory = $this->getMockBuilder(StoreFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->storeCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->storeRepository = new StoreRepository(
@@ -68,7 +71,10 @@ class StoreRepositoryTest extends TestCase
         $this->initDistroList();
     }
 
-    private function initDistroList()
+    /**
+     * @return void
+     */
+    private function initDistroList(): void
     {
         $repositoryReflection = new \ReflectionClass($this->storeRepository);
         $deploymentProperty = $repositoryReflection->getProperty('appConfig');
@@ -76,7 +82,10 @@ class StoreRepositoryTest extends TestCase
         $deploymentProperty->setValue($this->storeRepository, $this->appConfigMock);
     }
 
-    public function testGetWithException()
+    /**
+     * @return void
+     */
+    public function testGetWithException(): void
     {
         $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('The store that was requested wasn\'t found. Verify the store and try again.');
@@ -90,7 +99,10 @@ class StoreRepositoryTest extends TestCase
         $this->storeRepository->get('some_code');
     }
 
-    public function testGetWithAvailableStoreFromScope()
+    /**
+     * @return void
+     */
+    public function testGetWithAvailableStoreFromScope(): void
     {
         $storeMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
@@ -105,7 +117,10 @@ class StoreRepositoryTest extends TestCase
         $this->assertEquals($storeMock, $this->storeRepository->get('some_code'));
     }
 
-    public function testGetByIdWithAvailableStoreFromScope()
+    /**
+     * @return void
+     */
+    public function testGetByIdWithAvailableStoreFromScope(): void
     {
         $storeMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
@@ -126,7 +141,10 @@ class StoreRepositoryTest extends TestCase
         $this->assertEquals($storeMock, $this->storeRepository->getById(1));
     }
 
-    public function testGetByIdWithException()
+    /**
+     * @return void
+     */
+    public function testGetByIdWithException(): void
     {
         $this->expectException(NoSuchEntityException::class);
         $this->expectExceptionMessage('The store that was requested wasn\'t found. Verify the store and try again.');
@@ -142,7 +160,10 @@ class StoreRepositoryTest extends TestCase
         $this->storeRepository->getById(1);
     }
 
-    public function testGetList()
+    /**
+     * @return void
+     */
+    public function testGetList(): void
     {
         $storeMock1 = $this->getMockForAbstractClass(StoreInterface::class);
         $storeMock1->expects($this->once())
@@ -168,12 +189,9 @@ class StoreRepositoryTest extends TestCase
                     'code' => 'some_code_2'
                 ]
             ]);
-        $this->storeFactory->expects($this->at(0))
+        $this->storeFactory
             ->method('create')
-            ->willReturn($storeMock1);
-        $this->storeFactory->expects($this->at(1))
-            ->method('create')
-            ->willReturn($storeMock2);
+            ->willReturnOnConsecutiveCalls($storeMock1, $storeMock2);
 
         $this->assertEquals(
             ['some_code' => $storeMock1, 'some_code_2' => $storeMock2],

--- a/app/code/Magento/Store/Test/Unit/Model/StoreRepositoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreRepositoryTest.php
@@ -49,7 +49,7 @@ class StoreRepositoryTest extends TestCase
     private $appConfigMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Store/Test/Unit/Model/StoresConfigTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoresConfigTest.php
@@ -42,6 +42,9 @@ class StoresConfigTest extends TestCase
      */
     protected $_config;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_storeOne = $this->createMock(Store::class);
@@ -55,27 +58,24 @@ class StoresConfigTest extends TestCase
         );
     }
 
-    public function testGetStoresConfigByPath()
+    /**
+     * @return void
+     */
+    public function testGetStoresConfigByPath(): void
     {
         $path = 'config/path';
 
         $this->_storeOne
-            ->expects($this->at(0))
             ->method('getCode')
             ->willReturn('code_0');
-
         $this->_storeOne
-            ->expects($this->at(1))
             ->method('getId')
             ->willReturn(0);
 
         $this->_storeTwo
-            ->expects($this->at(0))
             ->method('getCode')
             ->willReturn('code_1');
-
         $this->_storeTwo
-            ->expects($this->at(1))
             ->method('getId')
             ->willReturn(1);
 
@@ -86,16 +86,9 @@ class StoresConfigTest extends TestCase
             ->willReturn([0 => $this->_storeOne, 1 => $this->_storeTwo]);
 
         $this->_config
-            ->expects($this->at(0))
             ->method('getValue')
-            ->with($path, 'store', 'code_0')
-            ->willReturn(0);
-
-        $this->_config
-            ->expects($this->at(1))
-            ->method('getValue')
-            ->with($path, 'store', 'code_1')
-            ->willReturn(1);
+            ->withConsecutive([$path, 'store', 'code_0'], [$path, 'store', 'code_1'])
+            ->willReturnOnConsecutiveCalls(0, 1);
 
         $this->assertEquals([0 => 0, 1 => 1], $this->_model->getStoresConfigByPath($path));
     }

--- a/app/code/Magento/Store/Test/Unit/Model/StoresConfigTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoresConfigTest.php
@@ -43,7 +43,7 @@ class StoresConfigTest extends TestCase
     protected $_config;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Store/Test/Unit/Model/WebsiteRepositoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/WebsiteRepositoryTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Store\Test\Unit\Model;
 
+use DomainException;
 use Magento\Framework\App\Config;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\WebsiteInterface;
@@ -15,6 +16,7 @@ use Magento\Store\Model\WebsiteFactory;
 use Magento\Store\Model\WebsiteRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class WebsiteRepositoryTest extends TestCase
 {
@@ -38,18 +40,21 @@ class WebsiteRepositoryTest extends TestCase
      */
     private $appConfigMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
         $this->websiteFactoryMock =
             $this->getMockBuilder(WebsiteFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $this->websiteCollectionFactoryMock =
             $this->getMockBuilder(CollectionFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $this->model = $objectManager->getObject(
             WebsiteRepository::class,
@@ -64,19 +69,25 @@ class WebsiteRepositoryTest extends TestCase
         $this->initDistroList();
     }
 
-    private function initDistroList()
+    /**
+     * @return void
+     */
+    private function initDistroList(): void
     {
-        $repositoryReflection = new \ReflectionClass($this->model);
+        $repositoryReflection = new ReflectionClass($this->model);
         $deploymentProperty = $repositoryReflection->getProperty('appConfig');
         $deploymentProperty->setAccessible(true);
         $deploymentProperty->setValue($this->model, $this->appConfigMock);
     }
 
-    public function testGetDefault()
+    /**
+     * @return void
+     */
+    public function testGetDefault(): void
     {
         $websiteMock = $this->getMockBuilder(WebsiteInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->appConfigMock->expects($this->once())
             ->method('get')
@@ -91,7 +102,7 @@ class WebsiteRepositoryTest extends TestCase
                     'is_default' => 0
                 ]
             ]);
-        $this->websiteFactoryMock->expects($this->at(0))
+        $this->websiteFactoryMock
             ->method('create')
             ->willReturn($websiteMock);
 
@@ -100,12 +111,15 @@ class WebsiteRepositoryTest extends TestCase
         $this->assertEquals($websiteMock, $website);
     }
 
-    public function testGetDefaultIsSeveral()
+    /**
+     * @return void
+     */
+    public function testGetDefaultIsSeveral(): void
     {
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $websiteMock = $this->getMockBuilder(WebsiteInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->appConfigMock->expects($this->once())
             ->method('get')
@@ -129,13 +143,16 @@ class WebsiteRepositoryTest extends TestCase
         );
     }
 
-    public function testGetDefaultIsZero()
+    /**
+     * @return void
+     */
+    public function testGetDefaultIsZero(): void
     {
-        $this->expectException(\DomainException::class);
+        $this->expectException(DomainException::class);
         $this->expectExceptionMessage('The default website isn\'t defined. Set the website and try again.');
         $websiteMock = $this->getMockBuilder(WebsiteInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->appConfigMock->expects($this->once())
             ->method('get')

--- a/app/code/Magento/Store/Test/Unit/Model/WebsiteRepositoryTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/WebsiteRepositoryTest.php
@@ -41,7 +41,7 @@ class WebsiteRepositoryTest extends TestCase
     private $appConfigMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Swatches/Test/Unit/Block/Adminhtml/Attribute/Edit/Options/AbstractSwatchTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Block/Adminhtml/Attribute/Edit/Options/AbstractSwatchTest.php
@@ -69,6 +69,9 @@ class AbstractSwatchTest extends TestCase
      */
     protected $connectionMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
@@ -81,10 +84,8 @@ class AbstractSwatchTest extends TestCase
         $this->universalFactoryMock = $this->createMock(UniversalFactory::class);
         $this->swatchHelperMock = $this->createMock(Media::class);
 
-        $this->block = $this->getMockBuilder(
-            AbstractSwatch::class
-        )
-            ->setMethods(['getData'])
+        $this->block = $this->getMockBuilder(AbstractSwatch::class)
+            ->onlyMethods(['getData'])
             ->setConstructorArgs(
                 [
                     'context' => $this->contextMock,
@@ -99,14 +100,15 @@ class AbstractSwatchTest extends TestCase
             ->getMock();
         $this->connectionMock = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['quoteInto'])
+            ->onlyMethods(['quoteInto'])
             ->getMockForAbstractClass();
     }
 
     /**
+     * @return void
      * @dataProvider dataForGetStoreOptionValues
      */
-    public function testGetStoreOptionValues($values)
+    public function testGetStoreOptionValues($values): void
     {
         $this->block->expects($this->once())->method('getData')->with('store_option_values_1')->willReturn($values);
         if ($values === null) {
@@ -159,20 +161,21 @@ class AbstractSwatchTest extends TestCase
             $attrOptionCollectionMock->expects($this->any())->method('getSelect')->willReturn($zendDbSelectMock);
             $zendDbSelectMock->expects($this->any())->method('joinLeft')->willReturnSelf();
 
-            $option->expects($this->at(0))->method('getId')->willReturn(14);
-            $option->expects($this->at(1))->method('getValue')->willReturn('Blue');
-            $option->expects($this->at(2))->method('getId')->willReturn(14);
-            $option->expects($this->at(3))->method('getLabel')->willReturn('#0000FF');
-            $option->expects($this->at(4))->method('getId')->willReturn(15);
-            $option->expects($this->at(5))->method('getValue')->willReturn('Black');
-            $option->expects($this->at(6))->method('getId')->willReturn(15);
-            $option->expects($this->at(7))->method('getLabel')->willReturn('#000000');
+            $option
+                ->method('getId')
+                ->willReturnOnConsecutiveCalls(14, 14, 15, 15);
+            $option
+                ->method('getLabel')
+                ->willReturnOnConsecutiveCalls('#0000FF', '#000000');
+            $option
+                ->method('getValue')
+                ->willReturnOnConsecutiveCalls('Blue', 'Black');
 
             $values = [
                 14 => 'Blue',
                 'swatch' => [
                     14 => '#0000FF',
-                    15 => '#000000',
+                    15 => '#000000'
                 ],
                 15 =>'Black'
             ];
@@ -184,18 +187,18 @@ class AbstractSwatchTest extends TestCase
     /**
      * @return array
      */
-    public function dataForGetStoreOptionValues()
+    public function dataForGetStoreOptionValues(): array
     {
         return [
             [
                 [
                     14 => 'Blue',
-                    15 => 'Black',
-                ],
+                    15 => 'Black'
+                ]
             ],
             [
-                null,
-            ],
+                null
+            ]
         ];
     }
 }

--- a/app/code/Magento/Swatches/Test/Unit/Block/Adminhtml/Attribute/Edit/Options/AbstractSwatchTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Block/Adminhtml/Attribute/Edit/Options/AbstractSwatchTest.php
@@ -70,7 +70,7 @@ class AbstractSwatchTest extends TestCase
     protected $connectionMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Swatches/Test/Unit/Plugin/Catalog/CacheInvalidateTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Plugin/Catalog/CacheInvalidateTest.php
@@ -38,7 +38,7 @@ class CacheInvalidateTest extends TestCase
     private $cacheInvalidate;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Swatches/Test/Unit/Plugin/Catalog/CacheInvalidateTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Plugin/Catalog/CacheInvalidateTest.php
@@ -37,6 +37,9 @@ class CacheInvalidateTest extends TestCase
      */
     private $cacheInvalidate;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->typeList = $this->getMockForAbstractClass(TypeListInterface::class);
@@ -53,16 +56,23 @@ class CacheInvalidateTest extends TestCase
         );
     }
 
-    public function testAfterSaveSwatch()
+    /**
+     * @return void
+     */
+    public function testAfterSaveSwatch(): void
     {
         $this->swatchHelper->expects($this->atLeastOnce())->method('isSwatchAttribute')->with($this->attribute)
             ->willReturn(true);
-        $this->typeList->expects($this->at(0))->method('invalidate')->with('block_html');
-        $this->typeList->expects($this->at(1))->method('invalidate')->with('collections');
+        $this->typeList
+            ->method('invalidate')
+            ->withConsecutive(['block_html'], ['collections']);
         $this->assertSame($this->attribute, $this->cacheInvalidate->afterSave($this->attribute, $this->attribute));
     }
 
-    public function testAfterSaveNotSwatch()
+    /**
+     * @return void
+     */
+    public function testAfterSaveNotSwatch(): void
     {
         $this->swatchHelper->expects($this->atLeastOnce())->method('isSwatchAttribute')->with($this->attribute)
             ->willReturn(false);

--- a/app/code/Magento/Tax/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/ConfigTest.php
@@ -23,10 +23,11 @@ class ConfigTest extends TestCase
      *
      * @param string $setterMethod
      * @param string $getterMethod
+     *
      * @param bool $value
      * @dataProvider dataProviderDirectSettersGettersMethods
      */
-    public function testDirectSettersGettersMethods($setterMethod, $getterMethod, $value)
+    public function testDirectSettersGettersMethods($setterMethod, $getterMethod, $value): void
     {
         // Need a mocked object with only dummy methods.  It is just needed for construction.
         // The setter/getter methods do not use this object (for this set of tests).
@@ -41,7 +42,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderDirectSettersGettersMethods()
+    public function dataProviderDirectSettersGettersMethods(): array
     {
         return [
             ['setShippingPriceIncludeTax', 'shippingPriceIncludesTax', true],
@@ -60,17 +61,16 @@ class ConfigTest extends TestCase
      * @param bool $applyTaxAfterDiscount
      * @param bool $discountTaxIncl
      * @param string $expectedValue
+     *
+     * @return void
      * @dataProvider dataProviderGetCalculationSequence
      */
-    public function testGetCalculationSequence($applyTaxAfterDiscount, $discountTaxIncl, $expectedValue)
+    public function testGetCalculationSequence($applyTaxAfterDiscount, $discountTaxIncl, $expectedValue): void
     {
         $scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
-        $scopeConfigMock->expects($this->at(0))
+        $scopeConfigMock
             ->method('getValue')
-            ->willReturn($applyTaxAfterDiscount);
-        $scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->willReturn($discountTaxIncl);
+            ->willReturnOnConsecutiveCalls($applyTaxAfterDiscount, $discountTaxIncl);
 
         /** @var Config */
         $model = new Config($scopeConfigMock);
@@ -80,7 +80,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderGetCalculationSequence()
+    public function dataProviderGetCalculationSequence(): array
     {
         return [
             [true,  true,  Calculation::CALC_TAX_AFTER_DISCOUNT_ON_INCL],
@@ -97,9 +97,11 @@ class ConfigTest extends TestCase
      * @param string $path
      * @param bool|int $configValue
      * @param bool $expectedValue
+     *
+     * @return void
      * @dataProvider dataProviderScopeConfigMethods
      */
-    public function testScopeConfigMethods($method, $path, $configValue, $expectedValue)
+    public function testScopeConfigMethods($method, $path, $configValue, $expectedValue): void
     {
         $scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
         $scopeConfigMock->expects($this->once())
@@ -116,14 +118,14 @@ class ConfigTest extends TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function dataProviderScopeConfigMethods()
+    public function dataProviderScopeConfigMethods(): array
     {
         return [
             [
                 'priceIncludesTax',
                 Config::CONFIG_XML_PATH_PRICE_INCLUDES_TAX,
                 true,
-                true,
+                true
             ],
             [
                 'applyTaxAfterDiscount',

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/TopmenuTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/TopmenuTest.php
@@ -7,59 +7,72 @@ declare(strict_types=1);
 
 namespace Magento\Theme\Test\Unit\Block\Html;
 
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\ResourceModel\Category\Tree as CategoryTree;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Data\Tree;
+use Magento\Framework\Data\Tree\Node;
+use Magento\Framework\Data\Tree\Node\Collection;
 use Magento\Framework\Data\Tree\NodeFactory;
 use Magento\Framework\Data\TreeFactory;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Registry;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template\Context;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\Theme\Block\Html\Topmenu;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class TopmenuTest extends \PHPUnit\Framework\TestCase
+class TopmenuTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\UrlInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var UrlInterface|MockObject
      */
     protected $urlBuilder;
 
     /**
-     * @var Registry|\PHPUnit\Framework\MockObject\MockObject
+     * @var Registry|MockObject
      */
     protected $registry;
 
     /**
-     * @var Context|\PHPUnit\Framework\MockObject\MockObject
+     * @var Context|MockObject
      */
     protected $context;
 
     /**
-     * @var NodeFactory|\PHPUnit\Framework\MockObject\MockObject
+     * @var NodeFactory|MockObject
      */
     protected $nodeFactory;
 
     /**
-     * @var TreeFactory|\PHPUnit\Framework\MockObject\MockObject
+     * @var TreeFactory|MockObject
      */
     protected $treeFactory;
 
     /**
-     * @var \Magento\Catalog\Model\Category|\PHPUnit\Framework\MockObject\MockObject
+     * @var Category|MockObject
      */
     protected $category;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var StoreManagerInterface|MockObject
      */
     protected $storeManager;
 
     /**
-     * @var \Magento\Framework\Event\ManagerInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var ManagerInterface|MockObject
      */
     private $eventManagerMock;
 
     /**
-     * @var \Magento\Framework\App\RequestInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var RequestInterface|MockObject
      */
     private $requestMock;
 
@@ -77,35 +90,38 @@ HTML;
 
     // @codingStandardsIgnoreEnd
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->storeManager = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
+        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->getMockForAbstractClass();
 
-        $this->urlBuilder = $this->getMockBuilder(\Magento\Framework\UrlInterface::class)
+        $this->urlBuilder = $this->getMockBuilder(UrlInterface::class)
             ->getMockForAbstractClass();
 
-        $this->eventManagerMock = $this->getMockBuilder(\Magento\Framework\Event\ManagerInterface::class)
+        $this->eventManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->getMockForAbstractClass();
 
-        $this->requestMock = $this->getMockBuilder(\Magento\Framework\App\RequestInterface::class)
+        $this->requestMock = $this->getMockBuilder(RequestInterface::class)
             ->getMockForAbstractClass();
 
-        $this->nodeFactory = $this->getMockBuilder(\Magento\Framework\Data\Tree\NodeFactory::class)
+        $this->nodeFactory = $this->getMockBuilder(NodeFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->treeFactory = $this->getMockBuilder(\Magento\Framework\Data\TreeFactory::class)
+        $this->treeFactory = $this->getMockBuilder(TreeFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $objectManager = new ObjectManager($this);
         $this->context = $objectManager->getObject(
-            \Magento\Framework\View\Element\Template\Context::class,
+            Context::class,
             [
                 'urlBuilder' => $this->urlBuilder,
                 'storeManager' => $this->storeManager,
                 'eventManager' => $this->eventManagerMock,
-                'request' => $this->requestMock,
+                'request' => $this->requestMock
             ]
         );
     }
@@ -113,18 +129,21 @@ HTML;
     /**
      * @return Topmenu
      */
-    protected function getTopmenu()
+    protected function getTopmenu(): Topmenu
     {
         return new Topmenu($this->context, $this->nodeFactory, $this->treeFactory);
     }
 
-    public function testGetHtmlWithoutSelectedCategory()
+    /**
+     * @return void
+     */
+    public function testGetHtmlWithoutSelectedCategory(): void
     {
         $topmenuBlock = $this->getTopmenu();
 
         $treeNode = $this->buildTree(false);
 
-        $transportObject = new \Magento\Framework\DataObject(['html' => $this->htmlWithoutCategory]);
+        $transportObject = new DataObject(['html' => $this->htmlWithoutCategory]);
 
         $this->eventManagerMock->expects($this->exactly(2))
             ->method('dispatch')
@@ -134,7 +153,7 @@ HTML;
                     [
                         'menu' => $treeNode,
                         'block' => $topmenuBlock,
-                        'request' => $this->requestMock,
+                        'request' => $this->requestMock
                     ],
                     $this->eventManagerMock
                 ],
@@ -142,7 +161,7 @@ HTML;
                     'page_block_html_topmenu_gethtml_after',
                     [
                         'menu' => $treeNode,
-                        'transportObject' => $transportObject,
+                        'transportObject' => $transportObject
                     ],
                     $this->eventManagerMock
                 ],
@@ -151,13 +170,16 @@ HTML;
         $this->assertEquals($this->htmlWithoutCategory, $topmenuBlock->getHtml());
     }
 
-    public function testGetHtmlWithSelectedCategory()
+    /**
+     * @return void
+     */
+    public function testGetHtmlWithSelectedCategory(): void
     {
         $topmenuBlock = $this->getTopmenu();
 
         $treeNode = $this->buildTree(true);
 
-        $transportObject = new \Magento\Framework\DataObject(['html' => $this->htmlWithCategory]);
+        $transportObject = new DataObject(['html' => $this->htmlWithCategory]);
 
         $this->eventManagerMock->expects($this->exactly(2))
             ->method('dispatch')
@@ -167,7 +189,7 @@ HTML;
                     [
                         'menu' => $treeNode,
                         'block' => $topmenuBlock,
-                        'request' => $this->requestMock,
+                        'request' => $this->requestMock
                     ],
                     $this->eventManagerMock
                 ],
@@ -175,7 +197,7 @@ HTML;
                     'page_block_html_topmenu_gethtml_after',
                     [
                         'menu' => $treeNode,
-                        'transportObject' => $transportObject,
+                        'transportObject' => $transportObject
                     ],
                     $this->eventManagerMock
                 ],
@@ -184,16 +206,18 @@ HTML;
         $this->assertEquals($this->htmlWithCategory, $topmenuBlock->getHtml());
     }
 
-    public function testGetCacheKeyInfo()
+    /**
+     * @return void
+     */
+    public function testGetCacheKeyInfo(): void
     {
-        $nodeFactory = $this->createMock(\Magento\Framework\Data\Tree\NodeFactory::class);
-        $treeFactory = $this->createMock(\Magento\Framework\Data\TreeFactory::class);
+        $nodeFactory = $this->createMock(NodeFactory::class);
+        $treeFactory = $this->createMock(TreeFactory::class);
 
         $topmenu =  new Topmenu($this->context, $nodeFactory, $treeFactory);
         $this->urlBuilder->expects($this->once())->method('getBaseUrl')->willReturn('baseUrl');
-        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCode'])
+        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)->disableOriginalConstructor()
+            ->onlyMethods(['getCode'])
             ->getMock();
         $store->expects($this->once())->method('getCode')->willReturn('321');
         $this->storeManager->expects($this->once())->method('getStore')->willReturn($store);
@@ -210,25 +234,25 @@ HTML;
      * Helper method, that provides unified logic of creation of Tree Node mock objects.
      *
      * @param bool $isCurrentItem
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      */
-    private function buildTree($isCurrentItem)
+    private function buildTree($isCurrentItem): MockObject
     {
-        $treeMock = $this->getMockBuilder(\Magento\Framework\Data\Tree::class)
+        $treeMock = $this->getMockBuilder(Tree::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $container = $this->createMock(\Magento\Catalog\Model\ResourceModel\Category\Tree::class);
+        $container = $this->createMock(CategoryTree::class);
 
-        $children = $this->getMockBuilder(\Magento\Framework\Data\Tree\Node\Collection::class)
-            ->setMethods(['count'])
+        $children = $this->getMockBuilder(Collection::class)
+            ->onlyMethods(['count'])
             ->setConstructorArgs(['container' => $container])
             ->getMock();
 
         for ($i = 0; $i < 10; $i++) {
             $id = "category-node-$i";
             $categoryNode = $this->createPartialMock(
-                \Magento\Framework\Data\Tree\Node::class,
+                Node::class,
                 ['getId', 'hasChildren']
             );
             $categoryNode->expects($this->once())->method('getId')->willReturn($id);
@@ -239,7 +263,7 @@ HTML;
                     'id' => $id,
                     'url' => "http://magento2/category-$i.html",
                     'is_active' => $i == 0 ? $isCurrentItem : false,
-                    'is_current_item' => $i == 0 ? $isCurrentItem : false,
+                    'is_current_item' => $i == 0 ? $isCurrentItem : false
 
                 ]
             );
@@ -248,21 +272,17 @@ HTML;
 
         $children->expects($this->once())->method('count')->willReturn(10);
 
-        $nodeMock = $this->getMockBuilder(\Magento\Framework\Data\Tree\Node::class)
+        $nodeMock = $this->getMockBuilder(Node::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getChildren', '__call'])
+            ->onlyMethods(['getChildren', '__call'])
             ->getMock();
         $nodeMock->expects($this->once())
             ->method('getChildren')
             ->willReturn($children);
-        $nodeMock->expects($this->at(0))
+        $nodeMock
             ->method('__call')
-            ->with('setOutermostClass')
-            ->willReturn(null);
-        $nodeMock->expects($this->at(3))
-            ->method('__call')
-            ->with('getLevel', [])
-            ->willReturn(null);
+            ->withConsecutive(['setOutermostClass'], [], ['getLevel', []])
+            ->willReturnOnConsecutiveCalls(null, [], null);
 
         $nodeMockData = [
             'data' => [],
@@ -282,19 +302,22 @@ HTML;
         return $nodeMock;
     }
 
-    public function testGetMenu()
+    /**
+     * @return void
+     */
+    public function testGetMenu(): void
     {
-        $treeMock = $this->getMockBuilder(\Magento\Framework\Data\Tree::class)
+        $treeMock = $this->getMockBuilder(Tree::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $nodeMockData = [
             'data' => [],
             'idField' => 'root',
-            'tree' => $treeMock,
+            'tree' => $treeMock
         ];
 
-        $nodeMock = $this->getMockBuilder(\Magento\Framework\Data\Tree\Node::class)
+        $nodeMock = $this->getMockBuilder(Node::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/TopmenuTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/TopmenuTest.php
@@ -91,7 +91,7 @@ HTML;
     // @codingStandardsIgnoreEnd
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Console/Command/ThemeUninstallCommandTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Console/Command/ThemeUninstallCommandTest.php
@@ -97,7 +97,7 @@ class ThemeUninstallCommandTest extends TestCase
     private $tester;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Console/Command/ThemeUninstallCommandTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Console/Command/ThemeUninstallCommandTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Theme\Test\Unit\Console\Command;
 
+use ArrayIterator;
 use Magento\Framework\App\Cache;
 use Magento\Framework\App\Console\MaintenanceModeEnabler;
 use Magento\Framework\App\MaintenanceMode;
@@ -95,6 +96,9 @@ class ThemeUninstallCommandTest extends TestCase
      */
     private $tester;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->maintenanceMode = $this->createMock(MaintenanceMode::class);
@@ -128,10 +132,14 @@ class ThemeUninstallCommandTest extends TestCase
         $this->tester = new CommandTester($this->command);
     }
 
-    public function testExecuteFailedValidationNotPackage()
+    /**
+     * @return void
+     */
+    public function testExecuteFailedValidationNotPackage(): void
     {
-        $this->themePackageInfo->expects($this->at(0))->method('getPackageName')->willReturn('dummy');
-        $this->themePackageInfo->expects($this->at(1))->method('getPackageName')->willReturn('magento/theme-a');
+        $this->themePackageInfo
+            ->method('getPackageName')
+            ->willReturnOnConsecutiveCalls('dummy', 'magento/theme-a');
         $this->collection->expects($this->any())
             ->method('getThemeByFullPath')
             ->willReturn(
@@ -154,7 +162,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function testExecuteFailedValidationNotTheme()
+    /**
+     * @return void
+     */
+    public function testExecuteFailedValidationNotTheme(): void
     {
         $this->themePackageInfo->expects($this->exactly(2))->method('getPackageName')->willReturn('');
         $this->collection->expects($this->any())
@@ -175,7 +186,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function testExecuteFailedValidationMixed()
+    /**
+     * @return void
+     */
+    public function testExecuteFailedValidationMixed(): void
     {
         $this->themePackageInfo->expects($this->exactly(4))
             ->method('getPackageName')
@@ -184,7 +198,7 @@ class ThemeUninstallCommandTest extends TestCase
                     ['area/vendor/test1', 'dummy1'],
                     ['area/vendor/test2', 'magento/theme-b'],
                     ['area/vendor/test3', ''],
-                    ['area/vendor/test4', 'dummy2'],
+                    ['area/vendor/test4', 'dummy2']
                 ]
             );
         $this->collection->expects($this->any())
@@ -197,16 +211,15 @@ class ThemeUninstallCommandTest extends TestCase
                     false
                 )
             );
-        $this->collection->expects($this->at(1))->method('hasTheme')->willReturn(true);
-        $this->collection->expects($this->at(3))->method('hasTheme')->willReturn(true);
-        $this->collection->expects($this->at(5))->method('hasTheme')->willReturn(false);
-        $this->collection->expects($this->at(7))->method('hasTheme')->willReturn(true);
+        $this->collection
+            ->method('hasTheme')
+            ->willReturnOnConsecutiveCalls(true, true, false, true);
         $this->tester->execute([
             'theme' => [
                 'area/vendor/test1',
                 'area/vendor/test2',
                 'area/vendor/test3',
-                'area/vendor/test4',
+                'area/vendor/test4'
             ],
         ]);
         $this->assertStringContainsString(
@@ -223,7 +236,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function setUpPassValidation()
+    /**
+     * @return void
+     */
+    public function setUpPassValidation(): void
     {
         $this->themePackageInfo->expects($this->any())->method('getPackageName')->willReturn('magento/theme-a');
         $this->collection->expects($this->any())
@@ -240,24 +256,36 @@ class ThemeUninstallCommandTest extends TestCase
         $this->collection->expects($this->any())->method('hasTheme')->willReturn(true);
     }
 
-    public function setupPassChildThemeCheck()
+    /**
+     * @return void
+     */
+    public function setupPassChildThemeCheck(): void
     {
         $theme = $this->createMock(Theme::class);
         $theme->expects($this->any())->method('hasChildThemes')->willReturn(false);
-        $this->collection->expects($this->any())->method('getIterator')->willReturn(new \ArrayIterator([]));
+        $this->collection->expects($this->any())->method('getIterator')->willReturn(new ArrayIterator([]));
     }
 
-    public function setupPassThemeInUseCheck()
+    /**
+     * @return void
+     */
+    public function setupPassThemeInUseCheck(): void
     {
         $this->themeValidator->expects($this->once())->method('validateIsThemeInUse')->willReturn([]);
     }
 
-    public function setupPassDependencyCheck()
+    /**
+     * @return void
+     */
+    public function setupPassDependencyCheck(): void
     {
         $this->dependencyChecker->expects($this->once())->method('checkDependencies')->willReturn([]);
     }
 
-    public function testExecuteFailedThemeInUseCheck()
+    /**
+     * @return void
+     */
+    public function testExecuteFailedThemeInUseCheck(): void
     {
         $this->setUpPassValidation();
         $this->setupPassChildThemeCheck();
@@ -274,7 +302,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function testExecuteFailedDependencyCheck()
+    /**
+     * @return void
+     */
+    public function testExecuteFailedDependencyCheck(): void
     {
         $this->setUpPassValidation();
         $this->setupPassThemeInUseCheck();
@@ -291,7 +322,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function setUpExecute()
+    /**
+     * @return void
+     */
+    public function setUpExecute(): void
     {
         $this->setUpPassValidation();
         $this->setupPassThemeInUseCheck();
@@ -307,7 +341,10 @@ class ThemeUninstallCommandTest extends TestCase
             ->with($this->isInstanceOf(OutputInterface::class), $this->anything());
     }
 
-    public function testExecuteWithBackupCode()
+    /**
+     * @return void
+     */
+    public function testExecuteWithBackupCode(): void
     {
         $this->setUpExecute();
         $backupRollback = $this->createMock(BackupRollback::class);
@@ -318,7 +355,10 @@ class ThemeUninstallCommandTest extends TestCase
         $this->tester->getDisplay();
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $this->setUpExecute();
         $this->cleanupFiles->expects($this->never())->method('clearMaterializedViewFiles');
@@ -335,7 +375,10 @@ class ThemeUninstallCommandTest extends TestCase
         );
     }
 
-    public function testExecuteCleanStaticFiles()
+    /**
+     * @return void
+     */
+    public function testExecuteCleanStaticFiles(): void
     {
         $this->setUpExecute();
         $this->cleanupFiles->expects($this->once())->method('clearMaterializedViewFiles');
@@ -354,9 +397,11 @@ class ThemeUninstallCommandTest extends TestCase
 
     /**
      * @param $themePath
+     *
+     * @return void
      * @dataProvider dataProviderThemeFormat
      */
-    public function testExecuteWrongThemeFormat($themePath)
+    public function testExecuteWrongThemeFormat($themePath): void
     {
         $this->tester->execute(['theme' => [$themePath]]);
         $this->assertStringContainsString(
@@ -368,7 +413,7 @@ class ThemeUninstallCommandTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderThemeFormat()
+    public function dataProviderThemeFormat(): array
     {
         return [
             ['test1'],
@@ -380,7 +425,7 @@ class ThemeUninstallCommandTest extends TestCase
             ['vendor/test1/'],
             ['/vendor/test1/'],
             ['area/vendor/test1/'],
-            ['/area/vendor/test1'],
+            ['/area/vendor/test1']
         ];
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/EditTest.php
@@ -25,13 +25,18 @@ use Psr\Log\LoggerInterface;
  */
 class EditTest extends ThemeTest
 {
-    /** @var string  */
+    /**
+     * @var string
+     */
     protected $name = 'Edit';
 
-    public function testExecuteWithoutLoadedTheme()
+    /**
+     * @return void
+     */
+    public function testExecuteWithoutLoadedTheme(): void
     {
         $themeId = 23;
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
@@ -80,10 +85,13 @@ class EditTest extends ThemeTest
         $this->_model->execute();
     }
 
-    public function testExecuteWithException()
+    /**
+     * @return void
+     */
+    public function testExecuteWithException(): void
     {
         $themeId = 23;
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
@@ -147,9 +155,10 @@ class EditTest extends ThemeTest
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecute()
+    public function testExecute(): void
     {
         $themeId = 23;
 
@@ -171,7 +180,7 @@ class EditTest extends ThemeTest
         $resultPage = $this->createMock(Page::class);
         $pageConfig = $this->createMock(Config::class);
         $pageTitle = $this->createMock(Title::class);
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
@@ -216,10 +225,6 @@ class EditTest extends ThemeTest
         $tab->expects($this->once())
             ->method('setFiles')
             ->with($cssAsset);
-        $layout->expects($this->at(0))
-            ->method('getBlock')
-            ->with('theme_edit_tabs_tab_css_tab')
-            ->willReturn($tab);
         $menu->expects($this->once())
             ->method('setActive')
             ->with('Magento_Theme::system_design_theme');
@@ -234,10 +239,10 @@ class EditTest extends ThemeTest
             ->method('getTitle')
             ->willReturn('Title');
 
-        $layout->expects($this->at(1))
+        $layout
             ->method('getBlock')
-            ->with('menu')
-            ->willReturn($menu);
+            ->withConsecutive(['theme_edit_tabs_tab_css_tab'], ['menu'])
+            ->willReturnOnConsecutiveCalls($tab, $menu);
         $this->view->expects($this->atLeastOnce())
             ->method('getLayout')
             ->willReturn($layout);

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/SaveTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/SaveTest.php
@@ -23,39 +23,32 @@ class SaveTest extends ThemeTest
     protected $name = 'Save';
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSaveAction()
+    public function testSaveAction(): void
     {
         $themeData = ['theme_id' => 123];
         $customCssContent = 'custom css content';
         $jsRemovedFiles = [3, 4];
         $jsOrder = [1 => '1', 2 => 'test'];
 
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
-            ->with('back', false)
-            ->willReturn(true);
-
-        $this->_request->expects($this->at(1))
-            ->method('getParam')
-            ->with('theme')
-            ->willReturn($themeData);
-
-        $this->_request->expects($this->at(2))
-            ->method('getParam')
-            ->with('custom_css_content')
-            ->willReturn($customCssContent);
-
-        $this->_request->expects($this->at(3))
-            ->method('getParam')
-            ->with('js_removed_files')
-            ->willReturn($jsRemovedFiles);
-
-        $this->_request->expects($this->at(4))
-            ->method('getParam')
-            ->with('js_order')
-            ->willReturn($jsOrder);
+            ->withConsecutive(
+                ['back', false],
+                ['theme'],
+                ['custom_css_content'],
+                ['js_removed_files'],
+                ['js_order']
+            )
+            ->willReturnOnConsecutiveCalls(
+                true,
+                $themeData,
+                $customCssContent,
+                $jsRemovedFiles,
+                $jsOrder
+            );
 
         $this->_request->expects($this->once())->method('getPostValue')->willReturn(true);
 
@@ -74,17 +67,11 @@ class SaveTest extends ThemeTest
         );
         $themeFactory->expects($this->once())->method('create')->willReturn($themeMock);
 
-        $this->_objectManagerMock->expects($this->at(0))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(FlyweightFactory::class)
-            ->willReturn($themeFactory);
-
-        $this->_objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(CustomCss::class)
-            ->willReturn(null);
-
-        $this->_objectManagerMock->expects($this->at(2))
+            ->withConsecutive([FlyweightFactory::class], [CustomCss::class])
+            ->willReturnOnConsecutiveCalls($themeFactory, null);
+        $this->_objectManagerMock
             ->method('create')
             ->with(SingleFile::class)
             ->willReturn(null);

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/UploadCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/UploadCssTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Theme\Test\Unit\Controller\Adminhtml\System\Design\Theme;
 
+use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Json\Helper\Data;
 use Magento\Framework\Phrase;
@@ -16,10 +17,15 @@ use Psr\Log\LoggerInterface;
 
 class UploadCssTest extends ThemeTest
 {
-    /** @var string  */
+    /**
+     * @var string
+     */
     protected $name = 'UploadCss';
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $serviceModel = $this->createMock(Service::class);
         $serviceModel->expects($this->once())
@@ -27,21 +33,16 @@ class UploadCssTest extends ThemeTest
             ->with('css_file_uploader')
             ->willReturn(['filename' => 'filename', 'content' => 'content']);
 
-        $this->_objectManagerMock->expects($this->at(0))
-            ->method('get')
-            ->with(Service::class)
-            ->willReturn($serviceModel);
-
         $jsonData = $this->createMock(Data::class);
         $jsonData->expects($this->once())
             ->method('jsonEncode')
             ->with(['error' => false, 'content' => 'content'])
             ->willReturn('{"filename":"filename","content":"content"}');
 
-        $this->_objectManagerMock->expects($this->at(1))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
+            ->withConsecutive([Service::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($serviceModel, $jsonData);
 
         $this->response
             ->expects($this->once())
@@ -51,7 +52,10 @@ class UploadCssTest extends ThemeTest
         $this->_model->execute();
     }
 
-    public function testExecuteWithLocalizedException()
+    /**
+     * @return void
+     */
+    public function testExecuteWithLocalizedException(): void
     {
         $exception = new LocalizedException(new Phrase('Message'));
         $serviceModel = $this->createMock(Service::class);
@@ -60,46 +64,35 @@ class UploadCssTest extends ThemeTest
             ->with('css_file_uploader')
             ->willThrowException($exception);
 
-        $this->_objectManagerMock->expects($this->at(0))
-            ->method('get')
-            ->with(Service::class)
-            ->willReturn($serviceModel);
-
         $jsonData = $this->createMock(Data::class);
         $jsonData->expects($this->once())
             ->method('jsonEncode')
             ->with(['error' => true, 'message' => 'Message'])
             ->willReturn('{"error":"true","message":"Message"}');
 
-        $this->_objectManagerMock->expects($this->at(1))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
+            ->withConsecutive([Service::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($serviceModel, $jsonData);
 
         $this->_model->execute();
     }
 
-    public function testExecuteWithException()
+    /**
+     * @return void
+     */
+    public function testExecuteWithException(): void
     {
-        $exception = new \Exception('Message');
+        $exception = new Exception('Message');
         $serviceModel = $this->createMock(Service::class);
         $serviceModel->expects($this->once())
             ->method('uploadCssFile')
             ->with('css_file_uploader')
             ->willThrowException($exception);
 
-        $this->_objectManagerMock->expects($this->at(0))
-            ->method('get')
-            ->with(Service::class)
-            ->willReturn($serviceModel);
-
         $logger = $this->getMockForAbstractClass(LoggerInterface::class, [], '', false);
         $logger->expects($this->once())
             ->method('critical');
-        $this->_objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(LoggerInterface::class)
-            ->willReturn($logger);
 
         $jsonData = $this->createMock(Data::class);
         $jsonData->expects($this->once())
@@ -107,10 +100,10 @@ class UploadCssTest extends ThemeTest
             ->with(['error' => true, 'message' => 'We can\'t upload the CSS file right now.'])
             ->willReturn('{"error":"true","message":"Message"}');
 
-        $this->_objectManagerMock->expects($this->at(2))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
+            ->withConsecutive([Service::class], [LoggerInterface::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($serviceModel, $logger, $jsonData);
 
         $this->_model->execute();
     }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/ContentsTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/ContentsTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Theme\Test\Unit\Controller\Adminhtml\System\Design\Wysiwyg\Files;
 
+use Exception;
 use Magento\Backend\Model\Session;
 use Magento\Framework\App\Response\Http;
 use Magento\Framework\App\ViewInterface;
@@ -18,6 +19,7 @@ use Magento\Framework\View\LayoutInterface;
 use Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg\Files;
 use Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg\Files\Contents;
 use Magento\Theme\Helper\Storage;
+use Magento\Theme\Model\Wysiwyg\Storage as WysiwygStorage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -26,24 +28,39 @@ use PHPUnit\Framework\TestCase;
  */
 class ContentsTest extends TestCase
 {
-    /** @var Files */
+    /**
+     * @var Files
+     */
     protected $controller;
 
-    /** @var ViewInterface|MockObject */
+    /**
+     * @var ViewInterface|MockObject
+     */
     protected $view;
 
-    /** @var MockObject|MockObject*/
+    /**
+     * @var MockObject|MockObject
+     */
     protected $objectManager;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $session;
 
-    /** @var Http|MockObject */
+    /**
+     * @var Http|MockObject
+     */
     protected $response;
 
-    /** @var Storage|MockObject */
+    /**
+     * @var Storage|MockObject
+     */
     protected $storage;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->view = $this->getMockForAbstractClass(ViewInterface::class);
@@ -65,10 +82,13 @@ class ContentsTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $layout = $this->getMockForAbstractClass(LayoutInterface::class, [], '', false);
-        $storage = $this->createMock(\Magento\Theme\Model\Wysiwyg\Storage::class);
+        $storage = $this->createMock(WysiwygStorage::class);
         $block = $this->getMockForAbstractClass(
             BlockInterface::class,
             [],
@@ -92,13 +112,9 @@ class ContentsTest extends TestCase
         $block->expects($this->once())
             ->method('setStorage')
             ->with($storage);
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(\Magento\Theme\Model\Wysiwyg\Storage::class)
-            ->willReturn($storage);
         $this->storage->expects($this->once())
             ->method('getCurrentPath')
-            ->willThrowException(new \Exception('Message'));
+            ->willThrowException(new Exception('Message'));
 
         $jsonData = $this->createMock(Data::class);
         $jsonData->expects($this->once())
@@ -106,10 +122,10 @@ class ContentsTest extends TestCase
             ->with(['error' => true, 'message' => 'Message'])
             ->willReturn('{"error":"true","message":"Message"}');
 
-        $this->objectManager->expects($this->at(1))
+        $this->objectManager
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
+            ->withConsecutive([WysiwygStorage::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($storage, $jsonData);
 
         $this->response->expects($this->once())
             ->method('representJson');

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFilesTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFilesTest.php
@@ -14,27 +14,41 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg\Files;
 use Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg\Files\DeleteFiles;
+use Magento\Theme\Helper\Storage;
 use Magento\Theme\Model\Wysiwyg\Storage as WisiwygStorage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class DeleteFilesTest extends TestCase
 {
-    /** @var Files */
+    /**
+     * @var Files
+     */
     protected $controller;
 
-    /** @var MockObject|MockObject*/
+    /**
+     * @var MockObject|MockObject
+     */
     protected $objectManager;
 
-    /** @var \Magento\Theme\Helper\Storage|MockObject */
+    /**
+     * @var Storage|MockObject
+     */
     protected $storage;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $request;
 
-    /** @var Http|MockObject */
+    /**
+     * @var Http|MockObject
+     */
     protected $response;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
@@ -56,12 +70,15 @@ class DeleteFilesTest extends TestCase
             [
                 'objectManager' => $this->objectManager,
                 'request' => $this->request,
-                'response' => $this->response,
+                'response' => $this->response
             ]
         );
     }
 
-    public function testExecuteWithWrongRequest()
+    /**
+     * @return void
+     */
+    public function testExecuteWithWrongRequest(): void
     {
         $this->request->expects($this->once())
             ->method('isPost')
@@ -85,7 +102,10 @@ class DeleteFilesTest extends TestCase
         $this->controller->execute();
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $this->request->expects($this->once())
             ->method('isPost')
@@ -100,14 +120,10 @@ class DeleteFilesTest extends TestCase
             ->method('jsonDecode')
             ->with('{"files":"file"}')
             ->willReturn(['files' => 'file']);
-        $this->objectManager->expects($this->at(0))
+        $this->objectManager
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
-        $this->objectManager->expects($this->at(1))
-            ->method('get')
-            ->with(WisiwygStorage::class)
-            ->willReturn($this->storage);
+            ->withConsecutive([Data::class], [WisiwygStorage::class])
+            ->willReturnOnConsecutiveCalls($jsonData, $this->storage);
         $this->storage->expects($this->once())
             ->method('deleteFile')
             ->with('file');

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFilesTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFilesTest.php
@@ -47,7 +47,7 @@ class DeleteFilesTest extends TestCase
     protected $response;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFolderTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFolderTest.php
@@ -16,29 +16,43 @@ use Magento\Theme\Controller\Adminhtml\System\Design\Wysiwyg\Files\DeleteFolder;
 use Magento\Theme\Helper\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Magento\Theme\Model\Wysiwyg\Storage as WysiwygStorage;
 
 class DeleteFolderTest extends TestCase
 {
-    /** @var Files */
+    /**
+     * @var Files
+     */
     protected $controller;
 
-    /** @var MockObject|MockObject*/
+    /**
+     * @var MockObject|MockObject
+     */
     protected $objectManager;
 
-    /** @var Http|MockObject */
+    /**
+     * @var Http|MockObject
+     */
     protected $response;
 
-    /** @var Storage|MockObject */
+    /**
+     * @var Storage|MockObject
+     */
     protected $storage;
 
-    /** @var Storage|MockObject */
+    /**
+     * @var Storage|MockObject
+     */
     protected $storageHelper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->response = $this->createMock(Http::class);
-        $this->storage = $this->createMock(\Magento\Theme\Model\Wysiwyg\Storage::class);
+        $this->storage = $this->createMock(WysiwygStorage::class);
         $this->storageHelper = $this->createMock(Storage::class);
 
         $helper = new ObjectManager($this);
@@ -52,16 +66,15 @@ class DeleteFolderTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $this->storageHelper->expects($this->once())
             ->method('getCurrentPath')
             ->willReturn('/current/path/');
 
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(\Magento\Theme\Model\Wysiwyg\Storage::class)
-            ->willReturn($this->storage);
         $this->storage->expects($this->once())
             ->method('deleteDirectory')
             ->with('/current/path/')
@@ -73,10 +86,10 @@ class DeleteFolderTest extends TestCase
             ->with(['error' => true, 'message' => 'Message'])
             ->willReturn('{"error":"true","message":"Message"}');
 
-        $this->objectManager->expects($this->at(1))
+        $this->objectManager
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($jsonData);
+            ->withConsecutive([WysiwygStorage::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($this->storage, $jsonData);
 
         $this->controller->execute();
     }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFolderTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Wysiwyg/Files/DeleteFolderTest.php
@@ -46,7 +46,7 @@ class DeleteFolderTest extends TestCase
     protected $storageHelper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ConfigTest.php
@@ -28,43 +28,46 @@ class ConfigTest extends TestCase
     /**
      * @var MockObject
      */
-    protected $_themeMock;
+    protected $themeMock;
 
     /**
      * @var MockObject
      */
-    protected $_configData;
+    protected $configData;
 
     /**
      * @var MockObject
      */
-    protected $_storeManagerMock;
+    protected $storeManagerMock;
 
     /**
      * @var MockObject
      */
-    protected $_configCacheMock;
+    protected $configCacheMock;
 
     /**
      * @var MockObject
      */
-    protected $_layoutCacheMock;
+    protected $layoutCacheMock;
 
     /**
      * @var WriterInterface
      */
-    protected $_scopeConfigWriter;
+    protected $scopeConfigWriter;
 
     /**
      * @var Config
      */
-    protected $_model;
+    protected $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        /** @var $this->_themeMock \Magento\Theme\Model\Theme */
-        $this->_themeMock = $this->createMock(Theme::class);
-        $this->_storeManagerMock = $this->getMockForAbstractClass(
+        /** @var $this->themeMock Theme */
+        $this->themeMock = $this->createMock(Theme::class);
+        $this->storeManagerMock = $this->getMockForAbstractClass(
             StoreManagerInterface::class,
             [],
             '',
@@ -73,137 +76,108 @@ class ConfigTest extends TestCase
             true,
             ['getStores', 'isSingleStoreMode']
         );
-        $this->_configData = $this->getMockBuilder(Value::class)
+        $this->configData = $this->getMockBuilder(Value::class)
             ->addMethods(['addFieldToFilter'])
             ->onlyMethods(['getCollection', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->_configCacheMock = $this->getMockForAbstractClass(FrontendInterface::class);
-        $this->_layoutCacheMock = $this->getMockForAbstractClass(FrontendInterface::class);
+        $this->configCacheMock = $this->getMockForAbstractClass(FrontendInterface::class);
+        $this->layoutCacheMock = $this->getMockForAbstractClass(FrontendInterface::class);
 
-        $this->_scopeConfigWriter = $this->createPartialMock(
+        $this->scopeConfigWriter = $this->createPartialMock(
             WriterInterface::class,
             ['save', 'delete']
         );
 
-        $this->_model = new Config(
-            $this->_configData,
-            $this->_scopeConfigWriter,
-            $this->_storeManagerMock,
+        $this->model = new Config(
+            $this->configData,
+            $this->scopeConfigWriter,
+            $this->storeManagerMock,
             $this->getMockForAbstractClass(ManagerInterface::class),
-            $this->_configCacheMock,
-            $this->_layoutCacheMock
+            $this->configCacheMock,
+            $this->layoutCacheMock
         );
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
-        $this->_themeMock = null;
-        $this->_configData = null;
-        $this->_configCacheMock = null;
-        $this->_layoutCacheMock = null;
-        $this->_model = null;
+        $this->themeMock = null;
+        $this->configData = null;
+        $this->configCacheMock = null;
+        $this->layoutCacheMock = null;
+        $this->model = null;
     }
 
     /**
-     * cover \Magento\Theme\Model\Config::assignToStore
+     * @return void
+     * cover Config::assignToStore
      */
-    public function testAssignToStoreInSingleStoreMode()
+    public function testAssignToStoreInSingleStoreMode(): void
     {
-        $this->_storeManagerMock->expects($this->once())->method('isSingleStoreMode')->willReturn(true);
+        $this->storeManagerMock->expects($this->once())
+            ->method('isSingleStoreMode')
+            ->willReturn(true);
 
         $themePath = 'Magento/blank';
         /** Unassign themes from store */
         $configEntity = new DataObject(['value' => 6, 'scope_id' => 8]);
 
-        $this->_configData->expects(
-            $this->once()
-        )->method(
-            'getCollection'
-        )->willReturn(
-            $this->_configData
-        );
+        $this->configData->expects($this->once())
+            ->method('getCollection')
+            ->willReturn($this->configData);
 
-        $this->_configData->expects(
-            $this->at(1)
-        )->method(
-            'addFieldToFilter'
-        )->with(
-            'scope',
-            ScopeInterface::SCOPE_STORES
-        )->willReturn(
-            $this->_configData
-        );
+        $this->configData
+            ->method('addFieldToFilter')
+            ->withConsecutive(
+                ['scope', ScopeInterface::SCOPE_STORES],
+                ['path', DesignInterface::XML_PATH_THEME_ID]
+            )
+            ->willReturnOnConsecutiveCalls($this->configData, [$configEntity]);
 
-        $this->_configData->expects(
-            $this->at(2)
-        )->method(
-            'addFieldToFilter'
-        )->with(
-            'path',
-            DesignInterface::XML_PATH_THEME_ID
-        )->willReturn(
-            [$configEntity]
-        );
+        $this->themeMock->expects($this->any())->method('getId')->willReturn(6);
+        $this->themeMock->expects($this->any())->method('getThemePath')->willReturn($themePath);
 
-        $this->_themeMock->expects($this->any())->method('getId')->willReturn(6);
-        $this->_themeMock->expects($this->any())->method('getThemePath')->willReturn($themePath);
+        $this->scopeConfigWriter->expects($this->once())->method('delete');
 
-        $this->_scopeConfigWriter->expects($this->once())->method('delete');
+        $this->scopeConfigWriter->expects($this->once())->method('save');
 
-        $this->_scopeConfigWriter->expects($this->once())->method('save');
-
-        $this->_model->assignToStore($this->_themeMock, [2, 3, 5]);
+        $this->model->assignToStore($this->themeMock, [2, 3, 5]);
     }
 
     /**
-     * cover \Magento\Theme\Model\Config::assignToStore
+     * @return void
+     * cover Config::assignToStore
      */
-    public function testAssignToStoreNonSingleStoreMode()
+    public function testAssignToStoreNonSingleStoreMode(): void
     {
-        $this->_storeManagerMock->expects($this->once())->method('isSingleStoreMode')->willReturn(false);
+        $this->storeManagerMock->expects($this->once())->method('isSingleStoreMode')->willReturn(false);
 
         $themePath = 'Magento/blank';
         /** Unassign themes from store */
         $configEntity = new DataObject(['value' => 6, 'scope_id' => 8]);
 
-        $this->_configData->expects(
-            $this->once()
-        )->method(
-            'getCollection'
-        )->willReturn(
-            $this->_configData
-        );
+        $this->configData->expects($this->once())
+            ->method('getCollection')
+            ->willReturn($this->configData);
 
-        $this->_configData->expects(
-            $this->at(1)
-        )->method(
-            'addFieldToFilter'
-        )->with(
-            'scope',
-            ScopeInterface::SCOPE_STORES
-        )->willReturn(
-            $this->_configData
-        );
+        $this->configData
+            ->method('addFieldToFilter')
+            ->withConsecutive(
+                ['scope', ScopeInterface::SCOPE_STORES],
+                ['path', DesignInterface::XML_PATH_THEME_ID]
+            )
+            ->willReturnOnConsecutiveCalls($this->configData, [$configEntity]);
 
-        $this->_configData->expects(
-            $this->at(2)
-        )->method(
-            'addFieldToFilter'
-        )->with(
-            'path',
-            DesignInterface::XML_PATH_THEME_ID
-        )->willReturn(
-            [$configEntity]
-        );
+        $this->themeMock->expects($this->any())->method('getId')->willReturn(6);
+        $this->themeMock->expects($this->any())->method('getThemePath')->willReturn($themePath);
 
-        $this->_themeMock->expects($this->any())->method('getId')->willReturn(6);
-        $this->_themeMock->expects($this->any())->method('getThemePath')->willReturn($themePath);
+        $this->scopeConfigWriter->expects($this->once())->method('delete');
 
-        $this->_scopeConfigWriter->expects($this->once())->method('delete');
+        $this->scopeConfigWriter->expects($this->exactly(3))->method('save');
 
-        $this->_scopeConfigWriter->expects($this->exactly(3))->method('save');
-
-        $this->_model->assignToStore($this->_themeMock, [2, 3, 5]);
+        $this->model->assignToStore($this->themeMock, [2, 3, 5]);
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ConfigTest.php
@@ -61,7 +61,7 @@ class ConfigTest extends TestCase
     protected $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -100,7 +100,7 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Favicon/FaviconTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Favicon/FaviconTest.php
@@ -52,7 +52,7 @@ class FaviconTest extends TestCase
     protected $mediaDir;
 
     /**
-     * Initialize testable object
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -92,17 +92,21 @@ class FaviconTest extends TestCase
     }
 
     /**
-     * cover negative case for getFaviconFile
+     * cover negative case for getFaviconFile.
+     *
+     * @return void
      */
-    public function testGetFaviconFileNegative()
+    public function testGetFaviconFileNegative(): void
     {
         $this->assertFalse($this->object->getFaviconFile());
     }
 
     /**
-     * cover positive case for getFaviconFile and checkIsFile
+     * cover positive case for getFaviconFile and checkIsFile.
+     *
+     * @return void
      */
-    public function testGetFaviconFile()
+    public function testGetFaviconFile(): void
     {
         $scopeConfigValue = 'path';
         $urlToMediaDir = 'http://magento.url/media/';
@@ -123,14 +127,10 @@ class FaviconTest extends TestCase
         $this->fileStorageDatabase->expects($this->once())
             ->method('saveFileToFilesystem')
             ->willReturn(true);
-        $this->mediaDir->expects($this->at(0))
+        $this->mediaDir
             ->method('isFile')
-            ->with($expectedFile)
-            ->willReturn(false);
-        $this->mediaDir->expects($this->at(1))
-            ->method('isFile')
-            ->with($expectedFile)
-            ->willReturn(true);
+            ->withConsecutive([$expectedFile], [$expectedFile])
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $results = $this->object->getFaviconFile();
         $this->assertEquals(
@@ -141,9 +141,11 @@ class FaviconTest extends TestCase
     }
 
     /**
-     * cover getDefaultFavicon
+     * cover getDefaultFavicon.
+     *
+     * @return void
      */
-    public function testGetDefaultFavicon()
+    public function testGetDefaultFavicon(): void
     {
         $this->assertEquals('Magento_Theme::favicon.ico', $this->object->getDefaultFavicon());
     }

--- a/app/code/Magento/Theme/Test/Unit/Model/Favicon/FaviconTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Favicon/FaviconTest.php
@@ -52,7 +52,7 @@ class FaviconTest extends TestCase
     protected $mediaDir;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Customization/File/CustomCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Customization/File/CustomCssTest.php
@@ -38,7 +38,7 @@ class CustomCssTest extends TestCase
     protected $object;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Customization/File/CustomCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Customization/File/CustomCssTest.php
@@ -38,7 +38,7 @@ class CustomCssTest extends TestCase
     protected $object;
 
     /**
-     * Initialize testable object
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -46,7 +46,7 @@ class CustomCssTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->fileFactory = $this->getMockBuilder(FileFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->filesystem = $this->getMockBuilder(Filesystem::class)
@@ -61,13 +61,14 @@ class CustomCssTest extends TestCase
     }
 
     /**
+     * @return void
      * cover _prepareSortOrder
      * cover _prepareFileName
      */
-    public function testPrepareFile()
+    public function testPrepareFile(): void
     {
         $file = $this->getMockBuilder(FileInterface::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'delete',
                     'save',
@@ -79,11 +80,10 @@ class CustomCssTest extends TestCase
                     'getTheme',
                     'setTheme',
                     'getCustomizationService',
-                    'setCustomizationService',
-                    'getId',
-                    'setData',
+                    'setCustomizationService'
                 ]
             )
+            ->addMethods(['getId', 'setData'])
             ->getMockForAbstractClass();
         $file->expects($this->any())
             ->method('setData')
@@ -91,18 +91,15 @@ class CustomCssTest extends TestCase
                 [
                     ['file_type', CustomCss::TYPE, $this->returnSelf()],
                     ['file_path', CustomCss::TYPE . '/' . CustomCss::FILE_NAME, $this->returnSelf()],
-                    ['sort_order', CustomCss::SORT_ORDER, $this->returnSelf()],
+                    ['sort_order', CustomCss::SORT_ORDER, $this->returnSelf()]
                 ]
             );
         $file->expects($this->once())
             ->method('getId')
             ->willReturn(null);
-        $file->expects($this->at(0))
+        $file
             ->method('getFileName')
-            ->willReturn(null);
-        $file->expects($this->at(1))
-            ->method('getFileName')
-            ->willReturn(CustomCss::FILE_NAME);
+            ->willReturnOnConsecutiveCalls(null, CustomCss::FILE_NAME);
         $file->expects($this->once())
             ->method('setFileName')
             ->with(CustomCss::FILE_NAME);

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
@@ -27,8 +27,8 @@ class VirtualTest extends TestCase
      * Test get existing staging theme.
      *
      * @return void
-     * @covers Virtual::__construct
-     * @covers Virtual::getStagingTheme
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::__construct
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getStagingTheme
      */
     public function testGetStagingThemeExisting(): void
     {
@@ -59,8 +59,8 @@ class VirtualTest extends TestCase
      * Test creating staging theme.
      *
      * @return void
-     * @covers Virtual::_createStagingTheme
-     * @covers Virtual::getStagingTheme
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::_createStagingTheme
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getStagingTheme
      */
     public function testGetStagingThemeNew(): void
     {
@@ -120,7 +120,7 @@ class VirtualTest extends TestCase
      * Test for is assigned method
      *
      * @return void
-     * @covers Virtual::isAssigned
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::isAssigned
      */
     public function testIsAssigned(): void
     {
@@ -171,7 +171,7 @@ class VirtualTest extends TestCase
      * @test
      * @return void
      * @dataProvider physicalThemeDataProvider
-     * @covers Virtual::getPhysicalTheme
+     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getPhysicalTheme
      */
     public function testGetPhysicalTheme($data): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/Domain/VirtualTest.php
@@ -18,24 +18,26 @@ use Magento\Theme\Model\Config\Customization;
 use Magento\Theme\Model\CopyService;
 use Magento\Theme\Model\Theme;
 use Magento\Theme\Model\Theme\Domain\Virtual;
+use Magento\Theme\Model\ThemeFactory;
 use PHPUnit\Framework\TestCase;
 
 class VirtualTest extends TestCase
 {
     /**
-     * Test get existing staging theme
+     * Test get existing staging theme.
      *
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::__construct
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getStagingTheme
+     * @return void
+     * @covers Virtual::__construct
+     * @covers Virtual::getStagingTheme
      */
-    public function testGetStagingThemeExisting()
+    public function testGetStagingThemeExisting(): void
     {
         $themeStaging = $this->createMock(Theme::class);
 
         $theme = $this->createPartialMock(Theme::class, ['__wakeup', 'getStagingVersion']);
         $theme->expects($this->once())->method('getStagingVersion')->willReturn($themeStaging);
 
-        $themeFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
+        $themeFactory = $this->createPartialMock(ThemeFactory::class, ['create']);
         $themeFactory->expects($this->never())->method('create');
 
         $themeCopyService = $this->createPartialMock(CopyService::class, ['copy']);
@@ -54,12 +56,13 @@ class VirtualTest extends TestCase
     }
 
     /**
-     * Test creating staging theme
+     * Test creating staging theme.
      *
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::_createStagingTheme
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getStagingTheme
+     * @return void
+     * @covers Virtual::_createStagingTheme
+     * @covers Virtual::getStagingTheme
      */
-    public function testGetStagingThemeNew()
+    public function testGetStagingThemeNew(): void
     {
         $theme = $this->createPartialMock(Theme::class, ['__wakeup', 'getStagingVersion']);
         $theme->expects($this->once())->method('getStagingVersion')->willReturn(null);
@@ -74,30 +77,27 @@ class VirtualTest extends TestCase
                 'theme_title' => 'fixture_theme_title',
                 'preview_image' => 'fixture_preview_image',
                 'is_featured' => 'fixture_is_featured',
-                'type' => ThemeInterface::TYPE_VIRTUAL,
+                'type' => ThemeInterface::TYPE_VIRTUAL
             ]
         );
         $appStateProperty->setValue($theme, $appState);
 
         $themeStaging = $this->createPartialMock(Theme::class, ['__wakeup', 'setData', 'save']);
-        $themeStaging->expects(
-            $this->at(0)
-        )->method(
-            'setData'
-        )->with(
-            [
+        $appStateProperty->setValue($themeStaging, $appState);
+        $themeStaging
+            ->method('setData')
+            ->with([
                 'parent_id' => 'fixture_theme_id',
                 'theme_path' => null,
                 'theme_title' => 'fixture_theme_title - Staging',
                 'preview_image' => 'fixture_preview_image',
                 'is_featured' => 'fixture_is_featured',
-                'type' => ThemeInterface::TYPE_STAGING,
-            ]
-        );
-        $appStateProperty->setValue($themeStaging, $appState);
-        $themeStaging->expects($this->at(1))->method('save');
+                'type' => ThemeInterface::TYPE_STAGING
+            ]);
+        $themeStaging
+            ->method('save');
 
-        $themeFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
+        $themeFactory = $this->createPartialMock(ThemeFactory::class, ['create']);
         $themeFactory->expects($this->once())->method('create')->willReturn($themeStaging);
 
         $themeCopyService = $this->createPartialMock(CopyService::class, ['copy']);
@@ -119,9 +119,10 @@ class VirtualTest extends TestCase
     /**
      * Test for is assigned method
      *
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::isAssigned
+     * @return void
+     * @covers Virtual::isAssigned
      */
-    public function testIsAssigned()
+    public function testIsAssigned(): void
     {
         $customizationConfig = $this->createPartialMock(
             Customization::class,
@@ -131,21 +132,16 @@ class VirtualTest extends TestCase
             Theme::class,
             ['__wakeup', 'getCollection', 'getId']
         );
-        $customizationConfig->expects(
-            $this->atLeastOnce()
-        )->method(
-            'isThemeAssignedToStore'
-        )->with(
-            $themeMock
-        )->willReturn(
-            true
-        );
+        $customizationConfig->expects($this->atLeastOnce())
+            ->method('isThemeAssignedToStore')
+            ->with($themeMock)
+            ->willReturn(true);
         $objectManagerHelper = new ObjectManager($this);
         $constructArguments = $objectManagerHelper->getConstructArguments(
             Virtual::class,
             ['theme' => $themeMock, 'customizationConfig' => $customizationConfig]
         );
-        /** @var \Magento\Theme\Model\Theme\Domain\Virtual $model */
+        /** @var Virtual $model */
         $model = $objectManagerHelper->getObject(Virtual::class, $constructArguments);
         $this->assertTrue($model->isAssigned());
     }
@@ -153,10 +149,10 @@ class VirtualTest extends TestCase
     /**
      * @return array
      */
-    public function physicalThemeDataProvider()
+    public function physicalThemeDataProvider(): array
     {
         $physicalTheme = $this->getMockBuilder(ThemeInterface::class)
-            ->setMethods(['isPhysical', 'getId'])
+            ->onlyMethods(['isPhysical', 'getId'])
             ->getMockForAbstractClass();
         $physicalTheme->expects($this->once())
             ->method('isPhysical')
@@ -164,9 +160,10 @@ class VirtualTest extends TestCase
         $physicalTheme->expects($this->once())
             ->method('getId')
             ->willReturn(1);
+
         return [
             'empty' => [null],
-            'theme' => [$physicalTheme],
+            'theme' => [$physicalTheme]
         ];
     }
 
@@ -174,9 +171,9 @@ class VirtualTest extends TestCase
      * @test
      * @return void
      * @dataProvider physicalThemeDataProvider
-     * @covers \Magento\Theme\Model\Theme\Domain\Virtual::getPhysicalTheme
+     * @covers Virtual::getPhysicalTheme
      */
-    public function testGetPhysicalTheme($data)
+    public function testGetPhysicalTheme($data): void
     {
         $themeMock = $this->createPartialMock(Theme::class, ['__wakeup', 'getParentTheme']);
         $parentThemeMock = $this->createPartialMock(
@@ -199,7 +196,7 @@ class VirtualTest extends TestCase
             Virtual::class,
             ['theme' => $themeMock]
         );
-        /** @var \Magento\Theme\Model\Theme\Domain\Virtual $object */
+        /** @var Virtual $object */
         $this->assertEquals($data, $object->getPhysicalTheme());
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemeUninstallerTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemeUninstallerTest.php
@@ -43,6 +43,9 @@ class ThemeUninstallerTest extends TestCase
      */
     private $output;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->themePackageInfo = $this->createMock(ThemePackageInfo::class);
@@ -57,7 +60,10 @@ class ThemeUninstallerTest extends TestCase
         );
     }
 
-    public function testUninstallRegistry()
+    /**
+     * @return void
+     */
+    public function testUninstallRegistry(): void
     {
         $this->output->expects($this->atLeastOnce())->method('writeln');
         $this->themePackageInfo->expects($this->never())->method($this->anything());
@@ -71,12 +77,15 @@ class ThemeUninstallerTest extends TestCase
         );
     }
 
-    public function testUninstallCode()
+    /**
+     * @return void
+     */
+    public function testUninstallCode(): void
     {
         $this->output->expects($this->atLeastOnce())->method('writeln');
-        $this->themePackageInfo->expects($this->at(0))->method('getPackageName')->willReturn('packageA');
-        $this->themePackageInfo->expects($this->at(1))->method('getPackageName')->willReturn('packageB');
-        $this->themePackageInfo->expects($this->at(2))->method('getPackageName')->willReturn('packageC');
+        $this->themePackageInfo
+            ->method('getPackageName')
+            ->willReturnOnConsecutiveCalls('packageA', 'packageB', 'packageC');
         $this->remove->expects($this->once())
             ->method('remove')
             ->with(['packageA', 'packageB', 'packageC'])

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemeUninstallerTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ThemeUninstallerTest.php
@@ -44,7 +44,7 @@ class ThemeUninstallerTest extends TestCase
     private $output;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -12,6 +12,7 @@ namespace Magento\Theme\Test\Unit\Model;
 
 use Magento\Framework\App\State;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\View\Design\Theme\CustomizationFactory;
 use Magento\Framework\View\Design\Theme\CustomizationInterface;
 use Magento\Framework\View\Design\Theme\Domain\Factory;
 use Magento\Framework\View\Design\Theme\FlyweightFactory;
@@ -21,6 +22,7 @@ use Magento\Framework\View\Design\ThemeInterface;
 use Magento\Theme\Model\Config\Customization;
 use Magento\Theme\Model\ResourceModel\Theme\Collection;
 use Magento\Theme\Model\Theme;
+use Magento\Theme\Model\ThemeFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +62,7 @@ class ThemeTest extends TestCase
     protected $validator;
 
     /**
-     * @var MockObject|\Magento\Framework\View\Design\Theme\CustomizationFactory
+     * @var MockObject|CustomizationFactory
      */
     protected $customizationFactory;
 
@@ -70,15 +72,18 @@ class ThemeTest extends TestCase
     protected $appState;
 
     /**
-     * @var MockObject|\Magento\Theme\Model\ThemeFactory
+     * @var MockObject|ThemeFactory
      */
     private $themeModelFactory;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $customizationConfig = $this->createMock(Customization::class);
         $this->customizationFactory = $this->createPartialMock(
-            \Magento\Framework\View\Design\Theme\CustomizationFactory::class,
+            CustomizationFactory::class,
             ['create']
         );
         $this->resourceCollection = $this->createMock(Collection::class);
@@ -94,7 +99,7 @@ class ThemeTest extends TestCase
             Factory::class,
             ['create']
         );
-        $this->themeModelFactory = $this->createPartialMock(\Magento\Theme\Model\ThemeFactory::class, ['create']);
+        $this->themeModelFactory = $this->createPartialMock(ThemeFactory::class, ['create']);
         $this->validator = $this->createMock(Validator::class);
         $this->appState = $this->createMock(State::class);
 
@@ -117,27 +122,33 @@ class ThemeTest extends TestCase
         $this->_model = $objectManagerHelper->getObject(Theme::class, $arguments);
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         $this->_model = null;
     }
 
     /**
-     * @covers \Magento\Theme\Model\Theme::getThemeImage
+     * @return void
+     * @covers Theme::getThemeImage
      */
-    public function testThemeImageGetter()
+    public function testThemeImageGetter(): void
     {
         $this->_imageFactory->expects($this->once())->method('create')->with(['theme' => $this->_model]);
         $this->_model->getThemeImage();
     }
 
     /**
-     * @dataProvider isVirtualDataProvider
      * @param int $type
      * @param string $isVirtual
-     * @covers \Magento\Theme\Model\Theme::isVirtual
+     *
+     * @return void
+     * @dataProvider isVirtualDataProvider
+     * @covers Theme::isVirtual
      */
-    public function testIsVirtual($type, $isVirtual)
+    public function testIsVirtual($type, $isVirtual): void
     {
         $this->_model->setType($type);
         $this->assertEquals($isVirtual, $this->_model->isVirtual());
@@ -146,7 +157,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function isVirtualDataProvider()
+    public function isVirtualDataProvider(): array
     {
         return [
             ['type' => ThemeInterface::TYPE_VIRTUAL, 'isVirtual' => true],
@@ -156,12 +167,14 @@ class ThemeTest extends TestCase
     }
 
     /**
-     * @dataProvider isPhysicalDataProvider
      * @param int $type
      * @param string $isPhysical
-     * @covers \Magento\Theme\Model\Theme::isPhysical
+     *
+     * @return void
+     * @dataProvider isPhysicalDataProvider
+     * @covers Theme::isPhysical
      */
-    public function testIsPhysical($type, $isPhysical)
+    public function testIsPhysical($type, $isPhysical): void
     {
         $this->_model->setType($type);
         $this->assertEquals($isPhysical, $this->_model->isPhysical());
@@ -170,7 +183,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function isPhysicalDataProvider()
+    public function isPhysicalDataProvider(): array
     {
         return [
             ['type' => ThemeInterface::TYPE_VIRTUAL, 'isPhysical' => false],
@@ -180,12 +193,14 @@ class ThemeTest extends TestCase
     }
 
     /**
-     * @dataProvider isVisibleDataProvider
      * @param int $type
      * @param string $isVisible
-     * @covers \Magento\Theme\Model\Theme::isVisible
+     *
+     * @return void
+     * @dataProvider isVisibleDataProvider
+     * @covers Theme::isVisible
      */
-    public function testIsVisible($type, $isVisible)
+    public function testIsVisible($type, $isVisible): void
     {
         $this->_model->setType($type);
         $this->assertEquals($isVisible, $this->_model->isVisible());
@@ -194,7 +209,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function isVisibleDataProvider()
+    public function isVisibleDataProvider(): array
     {
         return [
             ['type' => ThemeInterface::TYPE_VIRTUAL, 'isVisible' => true],
@@ -204,28 +219,30 @@ class ThemeTest extends TestCase
     }
 
     /**
-     * Test id deletable
+     * Test id deletable.
      *
-     * @dataProvider isDeletableDataProvider
      * @param string $themeType
      * @param bool $isDeletable
-     * @covers \Magento\Theme\Model\Theme::isDeletable
+     *
+     * @return void
+     * @dataProvider isDeletableDataProvider
+     * @covers Theme::isDeletable
      */
-    public function testIsDeletable($themeType, $isDeletable)
+    public function testIsDeletable($themeType, $isDeletable): void
     {
         $themeModel = $this->getMockBuilder(Theme::class)
             ->addMethods(['getType'])
             ->disableOriginalConstructor()
             ->getMock();
         $themeModel->expects($this->once())->method('getType')->willReturn($themeType);
-        /** @var \Magento\Theme\Model\Theme $themeModel */
+        /** @var Theme $themeModel */
         $this->assertEquals($isDeletable, $themeModel->isDeletable());
     }
 
     /**
      * @return array
      */
-    public function isDeletableDataProvider()
+    public function isDeletableDataProvider(): array
     {
         return [
             [ThemeInterface::TYPE_VIRTUAL, true],
@@ -237,9 +254,11 @@ class ThemeTest extends TestCase
     /**
      * @param mixed $originalCode
      * @param string $expectedCode
+     *
+     * @return void
      * @dataProvider getCodeDataProvider
      */
-    public function testGetCode($originalCode, $expectedCode)
+    public function testGetCode($originalCode, $expectedCode): void
     {
         $this->_model->setCode($originalCode);
         $this->assertSame($expectedCode, $this->_model->getCode());
@@ -248,7 +267,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function getCodeDataProvider()
+    public function getCodeDataProvider(): array
     {
         return [
             'string code' => ['theme/code', 'theme/code'],
@@ -261,7 +280,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetInheritedThemes()
+    public function testGetInheritedThemes(): void
     {
         $inheritedTheme = $this->getMockBuilder(ThemeInterface::class)
             ->getMock();
@@ -283,11 +302,12 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $expectId = 101;
         $theme = $this->getMockBuilder(ThemeInterface::class)
-            ->setMethods(['delete', 'getId'])
+            ->onlyMethods(['getId'])
+            ->addMethods(['delete'])
             ->getMockForAbstractClass();
         $theme->expects($this->once())
             ->method('getId')
@@ -297,14 +317,10 @@ class ThemeTest extends TestCase
             ->willReturnSelf();
 
         $this->_model->setId(1);
-        $this->resourceCollection->expects($this->at(0))
+        $this->resourceCollection
             ->method('addFieldToFilter')
-            ->with('parent_id', 1)
-            ->willReturnSelf();
-        $this->resourceCollection->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('type', Theme::TYPE_STAGING)
-            ->willReturnSelf();
+            ->withConsecutive(['parent_id', 1], ['type', Theme::TYPE_STAGING])
+            ->willReturnOnConsecutiveCalls($this->resourceCollection, $this->resourceCollection);
         $this->resourceCollection->expects($this->once())
             ->method('getFirstItem')
             ->willReturn($theme);
@@ -319,24 +335,20 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetStagingVersion()
+    public function testGetStagingVersion(): void
     {
         $theme = $this->getMockBuilder(ThemeInterface::class)
-            ->setMethods(['getId'])
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $theme->expects($this->once())
             ->method('getId')
             ->willReturn(null);
 
         $this->_model->setId(1);
-        $this->resourceCollection->expects($this->at(0))
+        $this->resourceCollection
             ->method('addFieldToFilter')
-            ->with('parent_id', 1)
-            ->willReturnSelf();
-        $this->resourceCollection->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('type', Theme::TYPE_STAGING)
-            ->willReturnSelf();
+            ->withConsecutive(['parent_id', 1], ['type', Theme::TYPE_STAGING])
+            ->willReturnOnConsecutiveCalls($this->resourceCollection, $this->resourceCollection);
         $this->resourceCollection->expects($this->once())
             ->method('getFirstItem')
             ->willReturn($theme);
@@ -348,7 +360,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetStagingVersionWithoutTheme()
+    public function testGetStagingVersionWithoutTheme(): void
     {
         $this->assertNull($this->_model->getStagingVersion());
     }
@@ -357,7 +369,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetDomainModel()
+    public function testGetDomainModel(): void
     {
         $result = 'res';
         $this->domainFactory->expects($this->once())
@@ -371,7 +383,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetDomainModelWithIncorrectType()
+    public function testGetDomainModelWithIncorrectType(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->_model->getDomainModel('bla-bla-bla');
@@ -381,7 +393,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testValidate()
+    public function testValidate(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('testMessage');
@@ -399,7 +411,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testValidatePass()
+    public function testValidatePass(): void
     {
         $this->validator->expects($this->once())
             ->method('validate')
@@ -412,7 +424,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testHasChildThemes()
+    public function testHasChildThemes(): void
     {
         $this->_model->setId(1);
         $this->resourceCollection->expects($this->once())
@@ -433,7 +445,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetCustomization()
+    public function testGetCustomization(): void
     {
         $this->customizationFactory->expects($this->once())
             ->method('create')
@@ -451,7 +463,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function testIsEditable()
+    public function testIsEditable(): void
     {
         $this->_model->setType(Theme::TYPE_VIRTUAL);
         $this->assertTrue($this->_model->isEditable());
@@ -463,7 +475,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function getFullThemePath()
+    public function getFullThemePath(): void
     {
         $areaCode = 'frontend';
         $this->appState->expects($this->once())
@@ -480,7 +492,7 @@ class ThemeTest extends TestCase
      * @test
      * @return void
      */
-    public function getParentTheme()
+    public function getParentTheme(): void
     {
         $this->_model->setParentTheme('parent_theme');
         $this->assertEquals('parent_theme', $this->_model->getParentTheme());
@@ -489,9 +501,11 @@ class ThemeTest extends TestCase
     /**
      * @param array $themeData
      * @param array $expected
+     *
+     * @return void
      * @dataProvider toArrayDataProvider
      */
-    public function testToArray(array $themeData, array $expected)
+    public function testToArray(array $themeData, array $expected): void
     {
         $this->_model->setData($themeData);
         $this->assertEquals($expected, $this->_model->toArray());
@@ -500,7 +514,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function toArrayDataProvider()
+    public function toArrayDataProvider(): array
     {
         $parentTheme = $this->getMockBuilder(Theme::class)
             ->disableOriginalConstructor()
@@ -555,9 +569,10 @@ class ThemeTest extends TestCase
      * @param array $expected
      * @param int $expectedCallCount
      *
+     * @return void
      * @dataProvider populateFromArrayDataProvider
      */
-    public function testPopulateFromArray(array $value, array $expected, $expectedCallCount = 0)
+    public function testPopulateFromArray(array $value, array $expected, int $expectedCallCount = 0): void
     {
         $themeMock = $this->getMockBuilder(Theme::class)
             ->disableOriginalConstructor()
@@ -577,7 +592,7 @@ class ThemeTest extends TestCase
     /**
      * @return array
      */
-    public function populateFromArrayDataProvider()
+    public function populateFromArrayDataProvider(): array
     {
         return [
             'valid data' => [

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -77,7 +77,7 @@ class ThemeTest extends TestCase
     private $themeModelFactory;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -123,7 +123,7 @@ class ThemeTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {
@@ -132,7 +132,7 @@ class ThemeTest extends TestCase
 
     /**
      * @return void
-     * @covers Theme::getThemeImage
+     * @covers \Magento\Theme\Model\Theme::getThemeImage
      */
     public function testThemeImageGetter(): void
     {
@@ -146,7 +146,7 @@ class ThemeTest extends TestCase
      *
      * @return void
      * @dataProvider isVirtualDataProvider
-     * @covers Theme::isVirtual
+     * @covers \Magento\Theme\Model\Theme::isVirtual
      */
     public function testIsVirtual($type, $isVirtual): void
     {
@@ -172,7 +172,7 @@ class ThemeTest extends TestCase
      *
      * @return void
      * @dataProvider isPhysicalDataProvider
-     * @covers Theme::isPhysical
+     * @covers \Magento\Theme\Model\Theme::isPhysical
      */
     public function testIsPhysical($type, $isPhysical): void
     {
@@ -198,7 +198,7 @@ class ThemeTest extends TestCase
      *
      * @return void
      * @dataProvider isVisibleDataProvider
-     * @covers Theme::isVisible
+     * @covers \Magento\Theme\Model\Theme::isVisible
      */
     public function testIsVisible($type, $isVisible): void
     {
@@ -226,7 +226,7 @@ class ThemeTest extends TestCase
      *
      * @return void
      * @dataProvider isDeletableDataProvider
-     * @covers Theme::isDeletable
+     * @covers \Magento\Theme\Model\Theme::isDeletable
      */
     public function testIsDeletable($themeType, $isDeletable): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeValidatorTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeValidatorTest.php
@@ -44,7 +44,7 @@ class ThemeValidatorTest extends TestCase
     protected $configData;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeValidatorTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeValidatorTest.php
@@ -43,6 +43,9 @@ class ThemeValidatorTest extends TestCase
      */
     protected $configData;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->storeManager = $this->getMockForAbstractClass(StoreManagerInterface::class);
@@ -59,7 +62,10 @@ class ThemeValidatorTest extends TestCase
         );
     }
 
-    public function testValidateIsThemeInUse()
+    /**
+     * @return void
+     */
+    public function testValidateIsThemeInUse(): void
     {
         $theme = $this->createMock(Theme::class);
         $theme->expects($this->once())->method('getId')->willReturn(6);
@@ -69,13 +75,11 @@ class ThemeValidatorTest extends TestCase
         $this->themeProvider->expects($this->once())->method('getThemeByFullPath')->willReturn($theme);
         $this->configData->expects($this->once())->method('getCollection')->willReturn($this->configData);
         $this->configData
-            ->expects($this->at(1))
             ->method('addFieldToFilter')
-            ->willReturn($this->configData);
-        $this->configData
-            ->expects($this->at(2))
-            ->method('addFieldToFilter')
-            ->willReturn([$defaultEntity, $websitesEntity, $storesEntity]);
+            ->willReturnOnConsecutiveCalls(
+                $this->configData,
+                [$defaultEntity, $websitesEntity, $storesEntity]
+            );
         $website = $this->createPartialMock(Website::class, ['getName']);
         $website->expects($this->once())->method('getName')->willReturn('websiteA');
         $store = $this->createPartialMock(Store::class, ['getName']);

--- a/app/code/Magento/Theme/Test/Unit/Model/Wysiwyg/StorageTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Wysiwyg/StorageTest.php
@@ -84,7 +84,7 @@ class StorageTest extends TestCase
     private $filesystemDriver;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -147,7 +147,7 @@ class StorageTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Theme/Test/Unit/Model/Wysiwyg/StorageTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Wysiwyg/StorageTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 namespace Magento\Theme\Test\Unit\Model\Wysiwyg;
 
 use Magento\Backend\Model\Session;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\Write;
+use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\Image\Adapter\Gd2;
 use Magento\Framework\Image\AdapterFactory;
@@ -20,10 +22,11 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Url\DecoderInterface;
 use Magento\Framework\Url\EncoderInterface;
 use Magento\MediaStorage\Model\File\Uploader;
-use Magento\Theme\Helper\Storage;
+use Magento\Theme\Helper\Storage as HelperStorage;
+use Magento\Theme\Model\Wysiwyg\Storage;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Magento\Framework\Filesystem\DriverInterface;
+use ReflectionClass;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -33,32 +36,32 @@ class StorageTest extends TestCase
     /**
      * @var string
      */
-    protected $_storageRoot;
+    protected $storageRoot;
 
     /**
      * @var Filesystem|MockObject
      */
-    protected $_filesystem;
+    protected $filesystem;
 
     /**
-     * @var Storage|MockObject
+     * @var HelperStorage|MockObject
      */
-    protected $_helperStorage;
+    protected $helperStorage;
 
     /**
      * @var ObjectManagerInterface
      */
-    protected $_objectManager;
+    protected $objectManager;
 
     /**
-     * @var null|\Magento\Theme\Model\Wysiwyg\Storage
+     * @var null|Storage
      */
-    protected $_storageModel;
+    protected $storageModel;
 
     /**
      * @var AdapterFactory|MockObject
      */
-    protected $_imageFactory;
+    protected $imageFactory;
 
     /**
      * @var Write|MockObject
@@ -80,9 +83,12 @@ class StorageTest extends TestCase
      */
     private $filesystemDriver;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->_filesystem = $this->createMock(Filesystem::class);
+        $this->filesystem = $this->createMock(Filesystem::class);
 
         $file = $this->createPartialMock(File::class, ['getPathInfo']);
 
@@ -94,7 +100,7 @@ class StorageTest extends TestCase
                 }
             );
 
-        $this->_helperStorage = $this->getMockBuilder(Storage::class)
+        $this->helperStorage = $this->getMockBuilder(HelperStorage::class)
             ->addMethods(['urlEncode'])
             ->onlyMethods(
                 [
@@ -110,71 +116,62 @@ class StorageTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $reflection = new \ReflectionClass(Storage::class);
+        $reflection = new ReflectionClass(HelperStorage::class);
         $reflection_property = $reflection->getProperty('file');
         $reflection_property->setAccessible(true);
-        $reflection_property->setValue($this->_helperStorage, $file);
+        $reflection_property->setValue($this->helperStorage, $file);
 
-        $this->_objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
-        $this->_imageFactory = $this->createMock(AdapterFactory::class);
+        $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
+        $this->imageFactory = $this->createMock(AdapterFactory::class);
         $this->directoryWrite = $this->createMock(Write::class);
         $this->urlEncoder = $this->createPartialMock(EncoderInterface::class, ['encode']);
         $this->urlDecoder = $this->createPartialMock(DecoderInterface::class, ['decode']);
         $this->filesystemDriver = $this->createMock(DriverInterface::class);
 
-        $this->_filesystem->expects(
-            $this->once()
-        )->method(
-            'getDirectoryWrite'
-        )->willReturn(
-            $this->directoryWrite
-        );
+        $this->filesystem->expects($this->once())
+            ->method('getDirectoryWrite')
+            ->willReturn($this->directoryWrite);
 
-        $this->_storageModel = new \Magento\Theme\Model\Wysiwyg\Storage(
-            $this->_filesystem,
-            $this->_helperStorage,
-            $this->_objectManager,
-            $this->_imageFactory,
+        $this->storageModel = new Storage(
+            $this->filesystem,
+            $this->helperStorage,
+            $this->objectManager,
+            $this->imageFactory,
             $this->urlEncoder,
             $this->urlDecoder,
             null,
             $this->filesystemDriver
         );
 
-        $this->_storageRoot = '/root';
-    }
-
-    protected function tearDown(): void
-    {
-        $this->_filesystem = null;
-        $this->_helperStorage = null;
-        $this->_objectManager = null;
-        $this->_storageModel = null;
-        $this->_storageRoot = null;
+        $this->storageRoot = '/root';
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::_createThumbnail
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::uploadFile
+     * @inheirtDoc
      */
-    public function testUploadFile()
+    protected function tearDown(): void
     {
-        $uploader = $this->_prepareUploader();
+        $this->filesystem = null;
+        $this->helperStorage = null;
+        $this->objectManager = null;
+        $this->storageModel = null;
+        $this->storageRoot = null;
+    }
 
+    /**
+     * @return void
+     * cover Storage::_createThumbnail
+     * cover Storage::uploadFile
+     */
+    public function testUploadFile(): void
+    {
+        $uploader = $this->prepareUploader();
         $uploader->expects($this->once())->method('save')->willReturn(['not_empty', 'path' => 'absPath']);
-
-        $this->_helperStorage->expects(
-            $this->any()
-        )->method(
-            'getStorageType'
-        )->willReturn(
-            \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
-        );
+        $this->helperStorage->expects($this->any())->method('getStorageType')->willReturn(Storage::TYPE_IMAGE);
 
         /** Prepare filesystem */
 
         $this->directoryWrite->expects($this->any())->method('isFile')->willReturn(true);
-
         $this->directoryWrite->expects($this->once())->method('isReadable')->willReturn(true);
 
         /** Prepare image */
@@ -182,244 +179,188 @@ class StorageTest extends TestCase
         $image = $this->createMock(Gd2::class);
 
         $image->expects($this->once())->method('open')->willReturn(true);
-
         $image->expects($this->once())->method('keepAspectRatio')->willReturn(true);
-
         $image->expects($this->once())->method('resize')->willReturn(true);
-
         $image->expects($this->once())->method('save')->willReturn(true);
 
-        $this->_imageFactory->expects($this->at(0))->method('create')->willReturn($image);
+        $this->imageFactory
+            ->method('create')
+            ->willReturn($image);
 
         /** Prepare session */
 
         $session = $this->createMock(Session::class);
 
-        $this->_helperStorage->expects($this->any())->method('getSession')->willReturn($session);
+        $this->helperStorage->expects($this->any())->method('getSession')->willReturn($session);
+        $expectedResult = ['not_empty'];
 
-        $expectedResult = [
-            'not_empty'
-        ];
-
-        $this->assertEquals($expectedResult, $this->_storageModel->uploadFile($this->_storageRoot));
+        $this->assertEquals($expectedResult, $this->storageModel->uploadFile($this->storageRoot));
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::uploadFile
+     * @return void
+     * cover Storage::uploadFile
      */
-    public function testUploadInvalidFile()
+    public function testUploadInvalidFile(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
-        $uploader = $this->_prepareUploader();
+        $uploader = $this->prepareUploader();
 
         $uploader->expects($this->once())->method('save')->willReturn(null);
 
-        $this->_storageModel->uploadFile($this->_storageRoot);
+        $this->storageModel->uploadFile($this->storageRoot);
     }
 
     /**
      * @return MockObject
      */
-    protected function _prepareUploader()
+    protected function prepareUploader(): MockObject
     {
         $uploader = $this->createMock(Uploader::class);
 
-        $this->_objectManager->expects($this->once())->method('create')->willReturn($uploader);
-
+        $this->objectManager->expects($this->once())->method('create')->willReturn($uploader);
         $uploader->expects($this->once())->method('setAllowedExtensions')->willReturn($uploader);
-
         $uploader->expects($this->once())->method('setAllowRenameFiles')->willReturn($uploader);
-
         $uploader->expects($this->once())->method('setFilesDispersion')->willReturn($uploader);
 
         return $uploader;
     }
 
     /**
+     * @return void
      * @dataProvider booleanCasesDataProvider
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::createFolder
+     * cover Storage::createFolder
      */
-    public function testCreateFolder($isWritable)
+    public function testCreateFolder($isWritable): void
     {
         $newDirectoryName = 'dir1';
-        $fullNewPath = $this->_storageRoot . '/' . $newDirectoryName;
+        $fullNewPath = $this->storageRoot . '/' . $newDirectoryName;
 
-        $this->directoryWrite->expects(
-            $this->any()
-        )->method(
-            'isWritable'
-        )->with(
-            $this->_storageRoot
-        )->willReturn(
-            $isWritable
-        );
+        $this->directoryWrite->expects($this->any())
+            ->method('isWritable')
+            ->with($this->storageRoot)
+            ->willReturn($isWritable);
 
-        $this->directoryWrite->expects(
-            $this->once()
-        )->method(
-            'isExist'
-        )->with(
-            $fullNewPath
-        )->willReturn(
-            false
-        );
+        $this->directoryWrite->expects($this->once())
+            ->method('isExist')
+            ->with($fullNewPath)
+            ->willReturn(false);
 
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getShortFilename'
-        )->with(
-            $newDirectoryName
-        )->willReturn(
-            $newDirectoryName
-        );
+        $this->helperStorage->expects($this->once())
+            ->method('getShortFilename')
+            ->with($newDirectoryName)
+            ->willReturn($newDirectoryName);
 
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'convertPathToId'
-        )->with(
-            $fullNewPath
-        )->willReturn(
-            $newDirectoryName
-        );
+        $this->helperStorage->expects($this->once())
+            ->method('convertPathToId')
+            ->with($fullNewPath)
+            ->willReturn($newDirectoryName);
 
-        $this->_helperStorage->expects(
-            $this->any()
-        )->method(
-            'getStorageRoot'
-        )->willReturn(
-            $this->_storageRoot
-        );
+        $this->helperStorage->expects($this->any())
+            ->method('getStorageRoot')
+            ->willReturn($this->storageRoot);
 
         $expectedResult = [
             'name' => $newDirectoryName,
             'short_name' => $newDirectoryName,
             'path' => '/' . $newDirectoryName,
-            'id' => $newDirectoryName,
+            'id' => $newDirectoryName
         ];
 
         $this->assertEquals(
             $expectedResult,
-            $this->_storageModel->createFolder($newDirectoryName, $this->_storageRoot)
+            $this->storageModel->createFolder($newDirectoryName, $this->storageRoot)
         );
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::createFolder
+     * @return void
+     * cover Storage::createFolder
      */
-    public function testCreateFolderWithInvalidName()
+    public function testCreateFolderWithInvalidName(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $newDirectoryName = 'dir2!#$%^&';
-        $this->_storageModel->createFolder($newDirectoryName, $this->_storageRoot);
+        $this->storageModel->createFolder($newDirectoryName, $this->storageRoot);
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::createFolder
+     * @return void
+     * cover Storage::createFolder
      */
-    public function testCreateFolderDirectoryAlreadyExist()
+    public function testCreateFolderDirectoryAlreadyExist(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $newDirectoryName = 'mew';
-        $fullNewPath = $this->_storageRoot . '/' . $newDirectoryName;
+        $fullNewPath = $this->storageRoot . '/' . $newDirectoryName;
 
-        $this->directoryWrite->expects(
-            $this->any()
-        )->method(
-            'isWritable'
-        )->with(
-            $this->_storageRoot
-        )->willReturn(
-            true
-        );
+        $this->directoryWrite->expects($this->any())
+            ->method('isWritable')
+            ->with($this->storageRoot)
+            ->willReturn(true);
 
-        $this->directoryWrite->expects(
-            $this->once()
-        )->method(
-            'isExist'
-        )->with(
-            $fullNewPath
-        )->willReturn(
-            true
-        );
+        $this->directoryWrite->expects($this->once())
+            ->method('isExist')
+            ->with($fullNewPath)
+            ->willReturn(true);
 
-        $this->_storageModel->createFolder($newDirectoryName, $this->_storageRoot);
+        $this->storageModel->createFolder($newDirectoryName, $this->storageRoot);
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::getDirsCollection
+     * @return void
+     * cover Storage::getDirsCollection
      */
-    public function testGetDirsCollection()
+    public function testGetDirsCollection(): void
     {
-        $dirs = [$this->_storageRoot . '/dir1', $this->_storageRoot . '/dir2'];
+        $dirs = [$this->storageRoot . '/dir1', $this->storageRoot . '/dir2'];
 
-        $this->directoryWrite->expects(
-            $this->any()
-        )->method(
-            'isExist'
-        )->with(
-            $this->_storageRoot
-        )->willReturn(
-            true
-        );
+        $this->directoryWrite->expects($this->any())
+            ->method('isExist')
+            ->with($this->storageRoot
+            )->willReturn(true);
 
         $this->directoryWrite->expects($this->once())->method('search')->willReturn($dirs);
 
         $this->directoryWrite->expects($this->any())->method('isDirectory')->willReturn(true);
 
-        $this->assertEquals($dirs, $this->_storageModel->getDirsCollection($this->_storageRoot));
+        $this->assertEquals($dirs, $this->storageModel->getDirsCollection($this->storageRoot));
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::getDirsCollection
+     * @return void
+     * cover Storage::getDirsCollection
      */
-    public function testGetDirsCollectionWrongDirName()
+    public function testGetDirsCollectionWrongDirName(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
-        $this->directoryWrite->expects(
-            $this->once()
-        )->method(
-            'isExist'
-        )->with(
-            $this->_storageRoot
-        )->willReturn(
-            false
-        );
+        $this->directoryWrite->expects($this->once())
+            ->method('isExist')
+            ->with($this->storageRoot)
+            ->willReturn(false);
 
-        $this->_storageModel->getDirsCollection($this->_storageRoot);
+        $this->storageModel->getDirsCollection($this->storageRoot);
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::getFilesCollection
+     * @return void
+     * cover Storage::getFilesCollection
      */
-    public function testGetFilesCollection()
+    public function testGetFilesCollection(): void
     {
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getCurrentPath'
-        )->willReturn(
-            $this->_storageRoot
-        );
+        $this->helperStorage->expects($this->once())
+            ->method('getCurrentPath')
+            ->willReturn($this->storageRoot);
 
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getStorageType'
-        )->willReturn(
-            \Magento\Theme\Model\Wysiwyg\Storage::TYPE_FONT
-        );
+        $this->helperStorage->expects($this->once())
+            ->method('getStorageType')
+            ->willReturn(Storage::TYPE_FONT);
 
-        $this->_helperStorage->expects($this->any())->method('urlEncode')->willReturnArgument(0);
-
-        $paths = [$this->_storageRoot . '/' . 'font1.ttf', $this->_storageRoot . '/' . 'font2.ttf'];
-
+        $this->helperStorage->expects($this->any())->method('urlEncode')->willReturnArgument(0);
+        $paths = [$this->storageRoot . '/' . 'font1.ttf', $this->storageRoot . '/' . 'font2.ttf'];
         $this->directoryWrite->expects($this->once())->method('search')->willReturn($paths);
-
         $this->directoryWrite->expects($this->any())->method('isFile')->willReturn(true);
-
-        $result = $this->_storageModel->getFilesCollection();
+        $result = $this->storageModel->getFilesCollection();
 
         $this->assertCount(2, $result);
         $this->assertEquals('font1.ttf', $result[0]['text']);
@@ -427,43 +368,23 @@ class StorageTest extends TestCase
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::getFilesCollection
+     * @return void
+     * cover Storage::getFilesCollection
      */
-    public function testGetFilesCollectionImageType()
+    public function testGetFilesCollectionImageType(): void
     {
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getCurrentPath'
-        )->willReturn(
-            $this->_storageRoot
-        );
+        $this->helperStorage->expects($this->once())->method('getCurrentPath')->willReturn($this->storageRoot);
+        $this->helperStorage->expects($this->once())->method('getStorageType')->willReturn(Storage::TYPE_IMAGE);
+        $this->helperStorage->expects($this->any())->method('urlEncode')->willReturnArgument(0);
 
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getStorageType'
-        )->willReturn(
-            \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
-        );
-
-        $this->_helperStorage->expects($this->any())->method('urlEncode')->willReturnArgument(0);
-
-        $paths = [$this->_storageRoot . '/picture1.jpg'];
-
+        $paths = [$this->storageRoot . '/picture1.jpg'];
         $this->directoryWrite->expects($this->once())->method('search')->willReturn($paths);
+        $this->directoryWrite->expects($this->once())
+            ->method('isFile')
+            ->with($this->storageRoot . '/picture1.jpg')
+            ->willReturn(true);
 
-        $this->directoryWrite->expects(
-            $this->once()
-        )->method(
-            'isFile'
-        )->with(
-            $this->_storageRoot . '/picture1.jpg'
-        )->willReturn(
-            true
-        );
-
-        $result = $this->_storageModel->getFilesCollection();
+        $result = $this->storageModel->getFilesCollection();
 
         $this->assertCount(1, $result);
         $this->assertEquals('picture1.jpg', $result[0]['text']);
@@ -471,131 +392,101 @@ class StorageTest extends TestCase
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::getTreeArray
+     * @return void
+     * cover Storage::getTreeArray
      */
-    public function testTreeArray()
+    public function testTreeArray(): void
     {
-        $currentPath = $this->_storageRoot . '/dir';
+        $currentPath = $this->storageRoot . '/dir';
         $dirs = [$currentPath . '/dir_one', $currentPath . '/dir_two'];
 
         $expectedResult = [
             ['text' => pathinfo($dirs[0], PATHINFO_BASENAME), 'id' => $dirs[0], 'cls' => 'folder'],
-            ['text' => pathinfo($dirs[1], PATHINFO_BASENAME), 'id' => $dirs[1], 'cls' => 'folder'],
+            ['text' => pathinfo($dirs[1], PATHINFO_BASENAME), 'id' => $dirs[1], 'cls' => 'folder']
         ];
 
-        $this->directoryWrite->expects(
-            $this->once()
-        )->method(
-            'isExist'
-        )->with(
-            $currentPath
-        )->willReturn(
-            true
-        );
-
+        $this->directoryWrite->expects($this->once())->method('isExist')->with($currentPath)->willReturn(true);
         $this->directoryWrite->expects($this->once())->method('search')->willReturn($dirs);
-
         $this->directoryWrite->expects($this->any())->method('isDirectory')->willReturn(true);
+        $this->helperStorage->expects($this->once())->method('getCurrentPath')->willReturn($currentPath);
+        $this->helperStorage->expects($this->any())->method('getShortFilename')->willReturnArgument(0);
+        $this->helperStorage->expects($this->any())->method('convertPathToId')->willReturnArgument(0);
 
-        $this->_helperStorage->expects(
-            $this->once()
-        )->method(
-            'getCurrentPath'
-        )->willReturn(
-            $currentPath
-        );
-
-        $this->_helperStorage->expects($this->any())->method('getShortFilename')->willReturnArgument(0);
-
-        $this->_helperStorage->expects($this->any())->method('convertPathToId')->willReturnArgument(0);
-
-        $result = $this->_storageModel->getTreeArray();
+        $result = $this->storageModel->getTreeArray();
         $this->assertEquals($expectedResult, $result);
     }
 
     /**
-     * @cover \Magento\Theme\Model\Wysiwyg\Storage::deleteFile
+     * @return void
+     * @cover Storage::deleteFile
      */
-    public function testDeleteFile()
+    public function testDeleteFile(): void
     {
         $image = 'image.jpg';
 
-        $this->_helperStorage->expects($this->once())
+        $this->helperStorage->expects($this->once())
             ->method('getCurrentPath')
-            ->willReturn($this->_storageRoot);
+            ->willReturn($this->storageRoot);
 
         $this->urlDecoder->expects($this->any())
             ->method('decode')
             ->with($image)
             ->willReturnArgument(0);
 
-        $this->directoryWrite->expects($this->at(0))
+        $this->directoryWrite
             ->method('getRelativePath')
-            ->with($this->_storageRoot)
-            ->willReturn($this->_storageRoot);
+            ->withConsecutive([$this->storageRoot], [$this->storageRoot . '/' . $image])
+            ->willReturnOnConsecutiveCalls($this->storageRoot, $this->storageRoot . '/' . $image);
 
-        $this->directoryWrite->expects($this->at(1))
-            ->method('getRelativePath')
-            ->with($this->_storageRoot . '/' . $image)
-            ->willReturn($this->_storageRoot . '/' . $image);
-
-        $this->_helperStorage->expects($this->once())
+        $this->helperStorage->expects($this->once())
             ->method('getStorageRoot')
             ->willReturn('/');
 
         $this->directoryWrite->expects($this->any())->method('delete');
-        $this->assertInstanceOf(\Magento\Theme\Model\Wysiwyg\Storage::class, $this->_storageModel->deleteFile($image));
+        $this->assertInstanceOf(Storage::class, $this->storageModel->deleteFile($image));
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::deleteDirectory
+     * @return void
+     * cover Storage::deleteDirectory
      */
-    public function testDeleteDirectory()
+    public function testDeleteDirectory(): void
     {
-        $directoryPath = $this->_storageRoot . '/../root';
+        $directoryPath = $this->storageRoot . '/../root';
 
-        $this->_helperStorage->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getStorageRoot'
-        )->willReturn(
-            $this->_storageRoot
-        );
-
+        $this->helperStorage->expects($this->atLeastOnce())->method('getStorageRoot')->willReturn($this->storageRoot);
         $this->directoryWrite->expects($this->once())->method('delete')->with($directoryPath);
 
-        $this->_storageModel->deleteDirectory($directoryPath);
+        $this->storageModel->deleteDirectory($directoryPath);
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::deleteDirectory
+     * @return void
+     * cover Storage::deleteDirectory
      */
-    public function testDeleteRootDirectory()
+    public function testDeleteRootDirectory(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
-        $directoryPath = $this->_storageRoot;
+        $directoryPath = $this->storageRoot;
 
-        $this->_helperStorage->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getStorageRoot'
-        )->willReturn(
-            $this->_storageRoot
-        );
+        $this->helperStorage->expects($this->atLeastOnce())
+            ->method('getStorageRoot')
+            ->willReturn($this->storageRoot);
 
-        $this->_storageModel->deleteDirectory($directoryPath);
+        $this->storageModel->deleteDirectory($directoryPath);
     }
 
     /**
-     * cover \Magento\Theme\Model\Wysiwyg\Storage::deleteDirectory
+     * @return void
+     * cover Storage::deleteDirectory
      */
-    public function testDeleteRootDirectoryRelative()
+    public function testDeleteRootDirectoryRelative(): void
     {
         $this->expectException(
-            \Magento\Framework\Exception\LocalizedException::class
+            LocalizedException::class
         );
 
-        $directoryPath = $this->_storageRoot;
+        $directoryPath = $this->storageRoot;
         $fakePath = 'fake/relative/path';
 
         $this->directoryWrite->method('getAbsolutePath')
@@ -606,17 +497,17 @@ class StorageTest extends TestCase
             ->with($directoryPath)
             ->willReturn($directoryPath);
 
-        $this->_helperStorage
+        $this->helperStorage
             ->method('getStorageRoot')
             ->willReturn($directoryPath);
 
-        $this->_storageModel->deleteDirectory($fakePath);
+        $this->storageModel->deleteDirectory($fakePath);
     }
 
     /**
      * @return array
      */
-    public function booleanCasesDataProvider()
+    public function booleanCasesDataProvider(): array
     {
         return [[true], [false]];
     }

--- a/app/code/Magento/Ui/Test/Unit/Component/ListingTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/ListingTest.php
@@ -27,7 +27,7 @@ class ListingTest extends TestCase
     protected $objectManager;
 
     /**
-     * Set up
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -46,7 +46,7 @@ class ListingTest extends TestCase
      *
      * @return void
      */
-    public function testGetComponentName()
+    public function testGetComponentName(): void
     {
         $this->contextMock->expects($this->never())->method('getProcessor');
         /** @var Listing $listing */
@@ -66,7 +66,7 @@ class ListingTest extends TestCase
      *
      * @return void
      */
-    public function testPrepare()
+    public function testPrepare(): void
     {
         $processor = $this->getMockBuilder(Processor::class)
             ->disableOriginalConstructor()
@@ -84,14 +84,14 @@ class ListingTest extends TestCase
                 'data' => [
                     'js_config' => [
                         'extends' => 'test_config_extends',
-                        'testData' => 'testValue',
+                        'testData' => 'testValue'
                     ],
                     'buttons' => $buttons
                 ]
             ]
         );
 
-        $this->contextMock->expects($this->at(0))
+        $this->contextMock
             ->method('getNamespace')
             ->willReturn(Listing::NAME);
         $this->contextMock->expects($this->once())

--- a/app/code/Magento/Ui/Test/Unit/Component/ListingTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/ListingTest.php
@@ -27,7 +27,7 @@ class ListingTest extends TestCase
     protected $objectManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
@@ -120,6 +120,9 @@ class RenderTest extends TestCase
      */
     private $escaperMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->requestMock = $this->getMockBuilder(Http::class)
@@ -208,12 +211,15 @@ class RenderTest extends TestCase
                 'contentTypeResolver' => $this->uiComponentTypeResolverMock,
                 'resultJsonFactory' => $this->resultJsonFactoryMock,
                 'logger' => $this->loggerMock,
-                'escaper' => $this->escaperMock,
+                'escaper' => $this->escaperMock
             ]
         );
     }
 
-    public function testExecuteAjaxRequestException()
+    /**
+     * @return void
+     */
+    public function testExecuteAjaxRequestException(): void
     {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
@@ -231,7 +237,7 @@ class RenderTest extends TestCase
 
         $jsonResultMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setData'])
+            ->onlyMethods(['setData'])
             ->getMock();
 
         $this->resultJsonFactoryMock->expects($this->once())
@@ -266,7 +272,10 @@ class RenderTest extends TestCase
         $this->render->executeAjaxRequest();
     }
 
-    public function testExecuteAjaxRequest()
+    /**
+     * @return void
+     */
+    public function testExecuteAjaxRequest(): void
     {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
@@ -311,35 +320,35 @@ class RenderTest extends TestCase
      * @param array $dataProviderConfig
      * @param bool|null $isAllowed
      * @param int $authCallCount
+     *
+     * @return void
      * @dataProvider executeAjaxRequestWithoutPermissionsDataProvider
      */
-    public function testExecuteAjaxRequestWithoutPermissions(array $dataProviderConfig, $isAllowed, $authCallCount = 1)
-    {
+    public function testExecuteAjaxRequestWithoutPermissions(
+        array $dataProviderConfig,
+        ?bool $isAllowed,
+        int $authCallCount = 1
+    ): void {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
 
         if (false === $isAllowed) {
             $jsonResultMock = $this->getMockBuilder(Json::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['setStatusHeader', 'setData'])
+                ->onlyMethods(['setStatusHeader', 'setData'])
                 ->getMock();
 
-            $jsonResultMock->expects($this->at(0))
+            $jsonResultMock
                 ->method('setStatusHeader')
-                ->with(
-                    Response::STATUS_CODE_403,
-                    AbstractMessage::VERSION_11,
-                    'Forbidden'
-                )
-                ->willReturnSelf();
-
-            $jsonResultMock->expects($this->at(1))
+                ->with(Response::STATUS_CODE_403, AbstractMessage::VERSION_11, 'Forbidden')
+                ->willReturn($jsonResultMock);
+            $jsonResultMock
                 ->method('setData')
                 ->with([
                     'error' => 'Forbidden',
                     'errorcode' => 403
                 ])
-                ->willReturnSelf();
+                ->willReturn($jsonResultMock);
 
             $this->resultJsonFactoryMock->expects($this->any())
                 ->method('create')
@@ -392,7 +401,7 @@ class RenderTest extends TestCase
     /**
      * @return array
      */
-    public function executeAjaxRequestWithoutPermissionsDataProvider()
+    public function executeAjaxRequestWithoutPermissionsDataProvider(): array
     {
         $aclResource = 'Magento_Test::index_index';
         return [
@@ -408,7 +417,7 @@ class RenderTest extends TestCase
                 'dataProviderConfig' => [],
                 'isAllowed' => null,
                 'authCallCount' => 0
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Adminhtml/Index/RenderTest.php
@@ -121,7 +121,7 @@ class RenderTest extends TestCase
     private $escaperMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Ui/Test/Unit/Controller/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Index/RenderTest.php
@@ -122,7 +122,7 @@ class RenderTest extends TestCase
     private $escaperMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Ui/Test/Unit/Controller/Index/RenderTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Controller/Index/RenderTest.php
@@ -28,6 +28,7 @@ use Magento\Ui\Model\UiComponentTypeResolver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Magento\Framework\App\Response\Http as ResponseHttp;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -120,12 +121,15 @@ class RenderTest extends TestCase
      */
     private $escaperMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
+        $this->responseMock = $this->getMockBuilder(ResponseHttp::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->contextMock = $this->getMockBuilder(Context::class)
@@ -161,9 +165,7 @@ class RenderTest extends TestCase
             ['render']
         );
 
-        $this->resultJsonFactoryMock = $this->getMockBuilder(
-            JsonFactory::class
-        )
+        $this->resultJsonFactoryMock = $this->getMockBuilder(JsonFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -208,12 +210,15 @@ class RenderTest extends TestCase
                 'contentTypeResolver' => $this->uiComponentTypeResolverMock,
                 'resultJsonFactory' => $this->resultJsonFactoryMock,
                 'logger' => $this->loggerMock,
-                'escaper' => $this->escaperMock,
+                'escaper' => $this->escaperMock
             ]
         );
     }
 
-    public function testExecuteException()
+    /**
+     * @return void
+     */
+    public function testExecuteException(): void
     {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
@@ -231,7 +236,7 @@ class RenderTest extends TestCase
 
         $jsonResultMock = $this->getMockBuilder(Json::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setData'])
+            ->onlyMethods(['setData'])
             ->getMock();
 
         $this->resultJsonFactoryMock->expects($this->once())
@@ -266,7 +271,10 @@ class RenderTest extends TestCase
         $this->render->execute();
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
@@ -311,37 +319,35 @@ class RenderTest extends TestCase
      * @param array $dataProviderConfig
      * @param bool|null $isAllowed
      * @param int $authCallCount
+     *
+     * @return void
      * @dataProvider executeAjaxRequestWithoutPermissionsDataProvider
      */
-    public function testExecuteWithoutPermissions(array $dataProviderConfig, $isAllowed, $authCallCount = 1)
-    {
+    public function testExecuteWithoutPermissions(
+        array $dataProviderConfig,
+        ?bool $isAllowed,
+        int $authCallCount = 1
+    ): void {
         $name = 'test-name';
         $renderedData = '<html>data</html>';
 
         if (false === $isAllowed) {
             $jsonResultMock = $this->getMockBuilder(Json::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['setStatusHeader', 'setData'])
+                ->onlyMethods(['setStatusHeader', 'setData'])
                 ->getMock();
 
-            $jsonResultMock->expects($this->at(0))
+            $jsonResultMock
                 ->method('setStatusHeader')
-                ->with(
-                    Response::STATUS_CODE_403,
-                    AbstractMessage::VERSION_11,
-                    'Forbidden'
-                )
-                ->willReturnSelf();
-
-            $jsonResultMock->expects($this->at(1))
+                ->with(Response::STATUS_CODE_403, AbstractMessage::VERSION_11, 'Forbidden')
+                ->willReturn($jsonResultMock);
+            $jsonResultMock
                 ->method('setData')
-                ->with(
-                    [
-                        'error' => 'Forbidden',
-                        'errorcode' => 403
-                    ]
-                )
-                ->willReturnSelf();
+                ->with([
+                    'error' => 'Forbidden',
+                    'errorcode' => 403
+                ])
+                ->willReturn($jsonResultMock);
 
             $this->resultJsonFactoryMock->expects($this->any())
                 ->method('create')
@@ -394,7 +400,7 @@ class RenderTest extends TestCase
     /**
      * @return array
      */
-    public function executeAjaxRequestWithoutPermissionsDataProvider()
+    public function executeAjaxRequestWithoutPermissionsDataProvider(): array
     {
         $aclResource = 'Magento_Test::index_index';
         return [
@@ -410,7 +416,7 @@ class RenderTest extends TestCase
                 'dataProviderConfig' => [],
                 'isAllowed' => null,
                 'authCallCount' => 0
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Model/BookmarkManagementTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/BookmarkManagementTest.php
@@ -46,13 +46,16 @@ class BookmarkManagementTest extends TestCase
      */
     protected $userContext;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->bookmarkRepository = $this->getMockBuilder(BookmarkRepositoryInterface::class)
             ->getMockForAbstractClass();
         $this->filterBuilder = $this->getMockBuilder(FilterBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->searchCriteriaBuilder =$this->getMockBuilder(SearchCriteriaBuilder::class)
             ->disableOriginalConstructor()
@@ -67,7 +70,10 @@ class BookmarkManagementTest extends TestCase
         );
     }
 
-    public function testLoadByNamespace()
+    /**
+     * @return void
+     */
+    public function testLoadByNamespace(): void
     {
         $userId = 1;
         $namespace = 'some_namespace';
@@ -90,12 +96,9 @@ class BookmarkManagementTest extends TestCase
         );
         $searchCriteria = $this->getMockBuilder(SearchCriteriaInterface::class)
             ->getMockForAbstractClass();
-        $this->filterBuilder->expects($this->at(0))
+        $this->filterBuilder
             ->method('create')
-            ->willReturn($fieldUserId);
-        $this->filterBuilder->expects($this->at(1))
-            ->method('create')
-            ->willReturn($fieldNamespace);
+            ->willReturnOnConsecutiveCalls($fieldUserId, $fieldNamespace);
         $this->searchCriteriaBuilder->expects($this->exactly(2))
             ->method('addFilters')
             ->withConsecutive([[$fieldUserId]], [[$fieldNamespace]]);
@@ -111,7 +114,10 @@ class BookmarkManagementTest extends TestCase
         $this->assertEquals($searchResult, $this->bookmarkManagement->loadByNamespace($namespace));
     }
 
-    public function testGetByIdentifierNamespace()
+    /**
+     * @return void
+     */
+    public function testGetByIdentifierNamespace(): void
     {
         $userId = 1;
         $namespace = 'some_namespace';
@@ -146,15 +152,9 @@ class BookmarkManagementTest extends TestCase
         $bookmark->expects($this->once())->method('getId')->willReturn($bookmarkId);
         $searchCriteria = $this->getMockBuilder(SearchCriteriaInterface::class)
             ->getMockForAbstractClass();
-        $this->filterBuilder->expects($this->at(0))
+        $this->filterBuilder
             ->method('create')
-            ->willReturn($fieldUserId);
-        $this->filterBuilder->expects($this->at(1))
-            ->method('create')
-            ->willReturn($fieldIdentifier);
-        $this->filterBuilder->expects($this->at(2))
-            ->method('create')
-            ->willReturn($fieldNamespace);
+            ->willReturnOnConsecutiveCalls($fieldUserId, $fieldIdentifier, $fieldNamespace);
         $this->searchCriteriaBuilder->expects($this->exactly(3))
             ->method('addFilters')
             ->withConsecutive([[$fieldUserId]], [[$fieldIdentifier]], [[$fieldNamespace]]);

--- a/app/code/Magento/Ui/Test/Unit/Model/BookmarkManagementTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/BookmarkManagementTest.php
@@ -47,7 +47,7 @@ class BookmarkManagementTest extends TestCase
     protected $userContext;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
@@ -76,6 +76,9 @@ class ConvertToXmlTest extends TestCase
      */
     protected $component;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->directory = $this->getMockBuilder(DirectoryWriteInterface::class)
@@ -99,23 +102,19 @@ class ConvertToXmlTest extends TestCase
 
         $this->excelFactory = $this->getMockBuilder(ExcelFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->iteratorFactory = $this->getMockBuilder(SearchResultIteratorFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->component = $this->getMockBuilder(UiComponentInterface::class)
             ->getMockForAbstractClass();
 
         $this->stream = $this->getMockBuilder(FileWriteInterface::class)
-            ->setMethods([
-                'lock',
-                'unlock',
-                'close',
-            ])
+            ->onlyMethods(['lock', 'unlock', 'close'])
             ->getMockForAbstractClass();
 
         $this->model = new ConvertToXml(
@@ -127,7 +126,10 @@ class ConvertToXmlTest extends TestCase
         );
     }
 
-    public function testGetRowData()
+    /**
+     * @return void
+     */
+    public function testGetRowData(): void
     {
         $data = ['data_value'];
 
@@ -155,7 +157,10 @@ class ConvertToXmlTest extends TestCase
         $this->assertEquals($data, $result);
     }
 
-    public function testGetXmlFile()
+    /**
+     * @return void
+     */
+    public function testGetXmlFile(): void
     {
         $componentName = 'component_name';
 
@@ -186,7 +191,10 @@ class ConvertToXmlTest extends TestCase
         $this->assertStringContainsString('.xml', $result['value']);
     }
 
-    protected function mockStream()
+    /**
+     * @return void
+     */
+    protected function mockStream(): void
     {
         $this->stream->expects($this->once())
             ->method('lock')
@@ -202,8 +210,10 @@ class ConvertToXmlTest extends TestCase
     /**
      * @param string $componentName
      * @param DocumentInterface $document
+     *
+     * @return void
      */
-    protected function mockExcel($componentName, DocumentInterface $document)
+    protected function mockExcel(string $componentName, DocumentInterface $document): void
     {
         $searchResultIterator = $this->getMockBuilder(SearchResultIterator::class)
             ->disableOriginalConstructor()
@@ -239,19 +249,21 @@ class ConvertToXmlTest extends TestCase
     /**
      * @param string $componentName
      * @param DocumentInterface|null $document
+     *
+     * @return void
      */
-    protected function mockComponent($componentName, DocumentInterface $document = null)
+    protected function mockComponent(string $componentName, ?DocumentInterface $document = null): void
     {
         $context = $this->getMockBuilder(ContextInterface::class)
-            ->setMethods(['getDataProvider'])
+            ->onlyMethods(['getDataProvider'])
             ->getMockForAbstractClass();
 
         $dataProvider = $this->getMockBuilder(DataProviderInterface::class)
-            ->setMethods(['getSearchResult', 'setLimit'])
+            ->onlyMethods(['getSearchResult', 'setLimit'])
             ->getMockForAbstractClass();
 
         $searchResult = $this->getMockBuilder(SearchResultInterface::class)
-            ->setMethods(['getItems'])
+            ->onlyMethods(['getItems'])
             ->getMockForAbstractClass();
 
         $this->component->expects($this->any())
@@ -274,17 +286,20 @@ class ConvertToXmlTest extends TestCase
             ->with(0, 0);
 
         if ($document) {
-            $searchResult->expects($this->at(0))
+            $searchResult
                 ->method('getItems')
                 ->willReturn([$document]);
         } else {
-            $searchResult->expects($this->at(0))
+            $searchResult
                 ->method('getItems')
                 ->willReturn([]);
         }
     }
 
-    protected function mockFilter()
+    /**
+     * @return void
+     */
+    protected function mockFilter(): void
     {
         $this->filter->expects($this->once())
             ->method('getComponent')
@@ -298,7 +313,10 @@ class ConvertToXmlTest extends TestCase
             ->willReturnSelf();
     }
 
-    protected function mockDirectory()
+    /**
+     * @return void
+     */
+    protected function mockDirectory(): void
     {
         $this->directory->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/Export/ConvertToXmlTest.php
@@ -77,7 +77,7 @@ class ConvertToXmlTest extends TestCase
     protected $component;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/UrlRewrite/Test/Unit/Block/Catalog/Edit/FormTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Block/Catalog/Edit/FormTest.php
@@ -61,7 +61,7 @@ class FormTest extends TestCase
     protected $layout;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/UrlRewrite/Test/Unit/Block/Catalog/Edit/FormTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Block/Catalog/Edit/FormTest.php
@@ -11,12 +11,14 @@ use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryFactory;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ProductFactory;
+use Magento\Framework\Data\Form;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Framework\Data\Form\Element\Fieldset;
 use Magento\Framework\Data\Form\Element\Renderer\RendererInterface;
 use Magento\Framework\Data\FormFactory;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\LayoutInterface;
+use Magento\UrlRewrite\Block\Catalog\Edit\Form as CatalogEditForm;
 use Magento\UrlRewrite\Block\Edit\Form as EditFormBlock;
 use Magento\UrlRewrite\Model\UrlRewrite;
 use Magento\UrlRewrite\Model\UrlRewriteFactory;
@@ -28,24 +30,39 @@ use PHPUnit\Framework\TestCase;
  */
 class FormTest extends TestCase
 {
-    /** @var EditFormBlock */
+    /**
+     * @var EditFormBlock
+     */
     protected $form;
 
-    /** @var FormFactory|MockObject */
+    /**
+     * @var FormFactory|MockObject
+     */
     protected $formFactory;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $urlRewriteFactory;
 
-    /** @var ProductFactory|MockObject */
+    /**
+     * @var ProductFactory|MockObject
+     */
     protected $productFactory;
 
-    /** @var CategoryFactory|MockObject */
+    /**
+     * @var CategoryFactory|MockObject
+     */
     protected $categoryFactory;
 
-    /** @var LayoutInterface|MockObject */
+    /**
+     * @var LayoutInterface|MockObject
+     */
     protected $layout;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->layout = $this->getMockForAbstractClass(LayoutInterface::class);
@@ -60,21 +77,24 @@ class FormTest extends TestCase
         $this->productFactory = $this->createPartialMock(ProductFactory::class, ['create']);
 
         $this->form = (new ObjectManager($this))->getObject(
-            \Magento\UrlRewrite\Block\Catalog\Edit\Form::class,
+            CatalogEditForm::class,
             [
                 'layout' => $this->layout,
                 'productFactory' => $this->productFactory,
                 'categoryFactory' => $this->categoryFactory,
                 'formFactory' => $this->formFactory,
                 'rewriteFactory' => $this->urlRewriteFactory,
-                'data' => ['template' => null],
+                'data' => ['template' => null]
             ]
         );
     }
 
-    public function testAddErrorMessageWhenProductWithoutStores()
+    /**
+     * @return void
+     */
+    public function testAddErrorMessageWhenProductWithoutStores(): void
     {
-        $form = $this->createMock(\Magento\Framework\Data\Form::class);
+        $form = $this->createMock(Form::class);
         $form->expects($this->any())->method('getElement')->willReturn(
             $this->getMockForAbstractClass(
                 AbstractElement::class,
@@ -94,20 +114,24 @@ class FormTest extends TestCase
             ->addMethods(['setAfterElementHtml', 'setValues'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $fieldset->expects($this->at(2))
+        $fieldset
             ->method('addField')
-            ->with(
-                'store_id',
-                'select',
+            ->withConsecutive(
+                [],
+                [],
                 [
-                    'label' => 'Store',
-                    'title' => 'Store',
-                    'name' => 'store_id',
-                    'required' => true,
-                    'value' => 0
+                    'store_id',
+                    'select',
+                    [
+                        'label' => 'Store',
+                        'title' => 'Store',
+                        'name' => 'store_id',
+                        'required' => true,
+                        'value' => 0
+                    ]
                 ]
             )
-            ->willReturn($storeElement);
+            ->willReturnOnConsecutiveCalls(null, null, $storeElement);
 
         $product = $this->createMock(Product::class);
         $product->expects($this->any())->method('getId')->willReturn('product_id');

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/AbstractStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/AbstractStorageTest.php
@@ -32,10 +32,13 @@ class AbstractStorageTest extends TestCase
      */
     protected $storage;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->urlRewriteFactory = $this->getMockBuilder(UrlRewriteFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->dataObjectHelper = $this->getMockBuilder(DataObjectHelper::class)
@@ -52,7 +55,10 @@ class AbstractStorageTest extends TestCase
         );
     }
 
-    public function testFindAllByData()
+    /**
+     * @return void
+     */
+    public function testFindAllByData(): void
     {
         $data = [['field1' => 'value1']];
         $rows = [['row1'], ['row2']];
@@ -63,26 +69,25 @@ class AbstractStorageTest extends TestCase
             ->with($data)
             ->willReturn($rows);
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
-            ->with($urlRewrites[0], $rows[0], UrlRewrite::class)->willReturnSelf();
+            ->withConsecutive(
+                [$urlRewrites[0], $rows[0], UrlRewrite::class],
+                [$urlRewrites[1], $rows[1], UrlRewrite::class]
+            )
+            ->willReturnOnConsecutiveCalls($this->dataObjectHelper, $this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
-            ->willReturn($urlRewrites[0]);
-
-        $this->dataObjectHelper->expects($this->at(1))
-            ->method('populateWithArray')
-            ->with($urlRewrites[1], $rows[1], UrlRewrite::class)->willReturnSelf();
-
-        $this->urlRewriteFactory->expects($this->at(1))
-            ->method('create')
-            ->willReturn($urlRewrites[1]);
+            ->willReturnOnConsecutiveCalls($urlRewrites[0], $urlRewrites[1]);
 
         $this->assertEquals($urlRewrites, $this->storage->findAllByData($data));
     }
 
-    public function testFindOneByDataIfNotFound()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataIfNotFound(): void
     {
         $data = [['field1' => 'value1']];
 
@@ -94,7 +99,10 @@ class AbstractStorageTest extends TestCase
         $this->assertNull($this->storage->findOneByData($data));
     }
 
-    public function testFindOneByDataIfFound()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataIfFound(): void
     {
         $data = [['field1' => 'value1']];
         $row = ['row1'];
@@ -116,14 +124,20 @@ class AbstractStorageTest extends TestCase
         $this->assertEquals($urlRewrite, $this->storage->findOneByData($data));
     }
 
-    public function testReplaceIfUrlsAreEmpty()
+    /**
+     * @return void
+     */
+    public function testReplaceIfUrlsAreEmpty(): void
     {
         $this->storage->expects($this->never())->method('doReplace');
 
         $this->storage->replace([]);
     }
 
-    public function testReplaceIfThrewDuplicateEntryExceptionWithCustomMessage()
+    /**
+     * @return void
+     */
+    public function testReplaceIfThrewDuplicateEntryExceptionWithCustomMessage(): void
     {
         $this->expectException('Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException');
         $this->expectExceptionMessage('Custom storage message');
@@ -135,7 +149,10 @@ class AbstractStorageTest extends TestCase
         $this->storage->replace([['UrlRewrite1']]);
     }
 
-    public function testReplaceIfThrewDuplicateEntryExceptionDefaultMessage()
+    /**
+     * @return void
+     */
+    public function testReplaceIfThrewDuplicateEntryExceptionDefaultMessage(): void
     {
         $this->expectException('Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException');
         $this->expectExceptionMessage('URL key for specified store already exists');
@@ -147,7 +164,10 @@ class AbstractStorageTest extends TestCase
         $this->storage->replace([['UrlRewrite1']]);
     }
 
-    public function testReplace()
+    /**
+     * @return void
+     */
+    public function testReplace(): void
     {
         $urls = [['UrlRewrite1'], ['UrlRewrite2']];
 

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/AbstractStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/AbstractStorageTest.php
@@ -33,7 +33,7 @@ class AbstractStorageTest extends TestCase
     protected $storage;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
@@ -52,7 +52,7 @@ class DbStorageTest extends TestCase
     private $storage;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\UrlRewrite\Test\Unit\Model\Storage;
 
+use Exception;
 use Magento\Framework\Api\DataObjectHelper;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
@@ -50,10 +51,13 @@ class DbStorageTest extends TestCase
      */
     private $storage;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->urlRewriteFactory = $this->getMockBuilder(UrlRewriteFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->dataObjectHelper = $this->createMock(DataObjectHelper::class);
@@ -73,22 +77,21 @@ class DbStorageTest extends TestCase
             [
                 'urlRewriteFactory' => $this->urlRewriteFactory,
                 'dataObjectHelper' => $this->dataObjectHelper,
-                'resource' => $this->resource,
+                'resource' => $this->resource
             ]
         );
     }
 
-    public function testFindAllByData()
+    /**
+     * @return void
+     */
+    public function testFindAllByData(): void
     {
         $data = ['col1' => 'val1', 'col2' => 'val2'];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
+            ->withConsecutive(['col1 IN (?)', 'val1'], ['col2 IN (?)', 'val2']);
 
         $this->connectionMock
             ->method('quoteIdentifier')
@@ -99,36 +102,31 @@ class DbStorageTest extends TestCase
             ->with($this->select)
             ->willReturn([['row1'], ['row2']]);
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
-            ->with(['urlRewrite1'], ['row1'], UrlRewrite::class)->willReturnSelf();
+            ->withConsecutive(
+                [['urlRewrite1'], ['row1'], UrlRewrite::class],
+                [['urlRewrite2'], ['row2'], UrlRewrite::class]
+            )
+            ->willReturnOnConsecutiveCalls($this->dataObjectHelper, $this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
-            ->willReturn(['urlRewrite1']);
-
-        $this->dataObjectHelper->expects($this->at(1))
-            ->method('populateWithArray')
-            ->with(['urlRewrite2'], ['row2'], UrlRewrite::class)->willReturnSelf();
-
-        $this->urlRewriteFactory->expects($this->at(1))
-            ->method('create')
-            ->willReturn(['urlRewrite2']);
+            ->willReturnOnConsecutiveCalls(['urlRewrite1'], ['urlRewrite2']);
 
         $this->assertEquals([['urlRewrite1'], ['urlRewrite2']], $this->storage->findAllByData($data));
     }
 
-    public function testFindOneByData()
+    /**
+     * @return void
+     */
+    public function testFindOneByData(): void
     {
         $data = ['col1' => 'val1', 'col2' => 'val2'];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
+            ->withConsecutive(['col1 IN (?)', 'val1'], ['col2 IN (?)', 'val2']);
 
         $this->connectionMock->method('quoteIdentifier')
             ->willReturnArgument(0);
@@ -140,37 +138,37 @@ class DbStorageTest extends TestCase
 
         $this->connectionMock->expects($this->never())->method('fetchAll');
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
-            ->with(['urlRewrite1'], ['row1'], UrlRewrite::class)->willReturnSelf();
+            ->with(['urlRewrite1'], ['row1'], UrlRewrite::class)
+            ->willReturn($this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
             ->willReturn(['urlRewrite1']);
 
         $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
     }
 
-    public function testFindOneByDataWithRequestPath()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataWithRequestPath(): void
     {
         $origRequestPath = 'page-one';
         $data = [
             'col1' => 'val1',
             'col2' => 'val2',
-            UrlRewrite::REQUEST_PATH => $origRequestPath,
+            UrlRewrite::REQUEST_PATH => $origRequestPath
         ];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
-            ->method('where')
-            ->with('request_path IN (?)', [$origRequestPath, $origRequestPath . '/']);
+            ->withConsecutive(
+                ['col1 IN (?)', 'val1'],
+                ['col2 IN (?)', 'val2'],
+                ['request_path IN (?)', [$origRequestPath, $origRequestPath . '/']]
+            );
 
         $this->connectionMock->method('quoteIdentifier')
             ->willReturnArgument(0);
@@ -189,38 +187,37 @@ class DbStorageTest extends TestCase
             ->with($this->select)
             ->willReturn([$urlRewriteRowInDb]);
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
             ->with(['urlRewrite1'], $urlRewriteRowInDb, UrlRewrite::class)
-            ->willReturnSelf();
+            ->willReturn($this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
             ->willReturn(['urlRewrite1']);
 
         $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
     }
 
-    public function testFindOneByDataWithRequestPathIsDifferent()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataWithRequestPathIsDifferent(): void
     {
         $origRequestPath = 'page-one';
         $data = [
             'col1' => 'val1',
             'col2' => 'val2',
-            UrlRewrite::REQUEST_PATH => $origRequestPath,
+            UrlRewrite::REQUEST_PATH => $origRequestPath
         ];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
-            ->method('where')
-            ->with('request_path IN (?)', [$origRequestPath, $origRequestPath . '/']);
+            ->withConsecutive(
+                ['col1 IN (?)', 'val1'],
+                ['col2 IN (?)', 'val2'],
+                ['request_path IN (?)', [$origRequestPath, $origRequestPath . '/']]
+            );
 
         $this->connectionMock->method('quoteIdentifier')
             ->willReturnArgument(0);
@@ -232,7 +229,7 @@ class DbStorageTest extends TestCase
             UrlRewrite::REQUEST_PATH => $origRequestPath . '/',
             UrlRewrite::TARGET_PATH => $origRequestPath . '/',
             UrlRewrite::REDIRECT_TYPE => 0,
-            UrlRewrite::STORE_ID => 1,
+            UrlRewrite::STORE_ID => 1
         ];
 
         $this->connectionMock->expects($this->once())
@@ -249,40 +246,40 @@ class DbStorageTest extends TestCase
             'target_path' => $origRequestPath . '/',
             'description' => null,
             'is_autogenerated' => '0',
-            'metadata' => null,
+            'metadata' => null
         ];
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
-            ->with(['urlRewrite1'], $urlRewriteRedirect, UrlRewrite::class)->willReturnSelf();
+            ->with(['urlRewrite1'], $urlRewriteRedirect, UrlRewrite::class)
+            ->willReturn($this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
             ->willReturn(['urlRewrite1']);
 
         $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
     }
 
-    public function testFindOneByDataWithRequestPathIsDifferent2()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataWithRequestPathIsDifferent2(): void
     {
         $origRequestPath = 'page-one/';
         $data = [
             'col1' => 'val1',
             'col2' => 'val2',
-            UrlRewrite::REQUEST_PATH => $origRequestPath,
+            UrlRewrite::REQUEST_PATH => $origRequestPath
         ];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
-            ->method('where')
-            ->with('request_path IN (?)', [rtrim($origRequestPath, '/'), rtrim($origRequestPath, '/') . '/']);
+            ->withConsecutive(
+                ['col1 IN (?)', 'val1'],
+                ['col2 IN (?)', 'val2'],
+                ['request_path IN (?)', [rtrim($origRequestPath, '/'), rtrim($origRequestPath, '/') . '/']]
+            );
 
         $this->connectionMock
             ->method('quoteIdentifier')
@@ -295,7 +292,7 @@ class DbStorageTest extends TestCase
             UrlRewrite::REQUEST_PATH => rtrim($origRequestPath, '/'),
             UrlRewrite::TARGET_PATH => rtrim($origRequestPath, '/'),
             UrlRewrite::REDIRECT_TYPE => 0,
-            UrlRewrite::STORE_ID => 1,
+            UrlRewrite::STORE_ID => 1
         ];
 
         $this->connectionMock->expects($this->once())
@@ -312,21 +309,75 @@ class DbStorageTest extends TestCase
             'target_path' => rtrim($origRequestPath, '/'),
             'description' => null,
             'is_autogenerated' => '0',
-            'metadata' => null,
+            'metadata' => null
         ];
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
-            ->with(['urlRewrite1'], $urlRewriteRedirect, UrlRewrite::class)->willReturnSelf();
+            ->with(['urlRewrite1'], $urlRewriteRedirect, UrlRewrite::class)
+            ->willReturn($this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
             ->willReturn(['urlRewrite1']);
 
         $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
     }
 
-    public function testFindOneByDataWithRequestPathIsRedirect()
+    /**
+     * @return void
+     */
+    public function testFindOneByDataWithRequestPathIsRedirect(): void
+    {
+        $origRequestPath = 'page-one';
+        $data = [
+            'col1' => 'val1',
+            'col2' => 'val2',
+            UrlRewrite::REQUEST_PATH => $origRequestPath
+        ];
+
+        $this->select
+            ->method('where')
+            ->withConsecutive(
+                ['col1 IN (?)', 'val1'],
+                ['col2 IN (?)', 'val2'],
+                ['request_path IN (?)', [$origRequestPath, $origRequestPath . '/']]
+            );
+
+        $this->connectionMock->method('quoteIdentifier')
+            ->willReturnArgument(0);
+
+        $this->connectionMock->expects($this->never())
+            ->method('fetchRow');
+
+        $urlRewriteRowInDb = [
+            UrlRewrite::REQUEST_PATH => $origRequestPath . '/',
+            UrlRewrite::TARGET_PATH => 'page-A/',
+            UrlRewrite::REDIRECT_TYPE => 301,
+            UrlRewrite::STORE_ID => 1
+        ];
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->select)
+            ->willReturn([$urlRewriteRowInDb]);
+
+        $this->dataObjectHelper
+            ->method('populateWithArray')
+            ->with(['urlRewrite1'], $urlRewriteRowInDb, UrlRewrite::class)
+            ->willReturn($this->dataObjectHelper);
+
+        $this->urlRewriteFactory
+            ->method('create')
+            ->willReturn(['urlRewrite1']);
+
+        $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindOneByDataWithRequestPathTwoResults(): void
     {
         $origRequestPath = 'page-one';
         $data = [
@@ -335,17 +386,13 @@ class DbStorageTest extends TestCase
             UrlRewrite::REQUEST_PATH => $origRequestPath,
         ];
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
-            ->method('where')
-            ->with('request_path IN (?)', [$origRequestPath, $origRequestPath . '/']);
+            ->withConsecutive(
+                ['col1 IN (?)', 'val1'],
+                ['col2 IN (?)', 'val2'],
+                ['request_path IN (?)', [$origRequestPath, $origRequestPath . '/']]
+            );
 
         $this->connectionMock->method('quoteIdentifier')
             ->willReturnArgument(0);
@@ -357,65 +404,14 @@ class DbStorageTest extends TestCase
             UrlRewrite::REQUEST_PATH => $origRequestPath . '/',
             UrlRewrite::TARGET_PATH => 'page-A/',
             UrlRewrite::REDIRECT_TYPE => 301,
-            UrlRewrite::STORE_ID => 1,
-        ];
-
-        $this->connectionMock->expects($this->once())
-            ->method('fetchAll')
-            ->with($this->select)
-            ->willReturn([$urlRewriteRowInDb]);
-
-        $this->dataObjectHelper->expects($this->at(0))
-            ->method('populateWithArray')
-            ->with(['urlRewrite1'], $urlRewriteRowInDb, UrlRewrite::class)
-            ->willReturnSelf();
-
-        $this->urlRewriteFactory->expects($this->at(0))
-            ->method('create')
-            ->willReturn(['urlRewrite1']);
-
-        $this->assertEquals(['urlRewrite1'], $this->storage->findOneByData($data));
-    }
-
-    public function testFindOneByDataWithRequestPathTwoResults()
-    {
-        $origRequestPath = 'page-one';
-        $data = [
-            'col1'                   => 'val1',
-            'col2'                   => 'val2',
-            UrlRewrite::REQUEST_PATH => $origRequestPath,
-        ];
-
-        $this->select->expects($this->at(1))
-            ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
-            ->method('where')
-            ->with('request_path IN (?)', [$origRequestPath, $origRequestPath . '/']);
-
-        $this->connectionMock->method('quoteIdentifier')
-            ->willReturnArgument(0);
-
-        $this->connectionMock->expects($this->never())
-            ->method('fetchRow');
-
-        $urlRewriteRowInDb = [
-            UrlRewrite::REQUEST_PATH => $origRequestPath . '/',
-            UrlRewrite::TARGET_PATH => 'page-A/',
-            UrlRewrite::REDIRECT_TYPE => 301,
-            UrlRewrite::STORE_ID => 1,
+            UrlRewrite::STORE_ID => 1
         ];
 
         $urlRewriteRowInDb2 = [
             UrlRewrite::REQUEST_PATH => $origRequestPath,
             UrlRewrite::TARGET_PATH => 'page-B/',
             UrlRewrite::REDIRECT_TYPE => 301,
-            UrlRewrite::STORE_ID => 1,
+            UrlRewrite::STORE_ID => 1
         ];
 
         $this->connectionMock->expects($this->once())
@@ -423,12 +419,12 @@ class DbStorageTest extends TestCase
             ->with($this->select)
             ->willReturn([$urlRewriteRowInDb, $urlRewriteRowInDb2]);
 
-        $this->dataObjectHelper->expects($this->at(0))
+        $this->dataObjectHelper
             ->method('populateWithArray')
             ->with(['urlRewrite1'], $urlRewriteRowInDb2, UrlRewrite::class)
-            ->willReturnSelf();
+            ->willReturn($this->dataObjectHelper);
 
-        $this->urlRewriteFactory->expects($this->at(0))
+        $this->urlRewriteFactory
             ->method('create')
             ->willReturn(['urlRewrite1']);
 
@@ -436,9 +432,10 @@ class DbStorageTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testReplace()
+    public function testReplace(): void
     {
         $urlFirst = $this->createMock(UrlRewrite::class);
         $urlSecond = $this->createMock(UrlRewrite::class);
@@ -484,7 +481,10 @@ class DbStorageTest extends TestCase
         $this->assertEquals($urls, $this->storage->replace($urls));
     }
 
-    public function testReplaceIfThrewExceptionOnDuplicateUrl()
+    /**
+     * @return void
+     */
+    public function testReplaceIfThrewExceptionOnDuplicateUrl(): void
     {
         $this->expectException('Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException');
         $url = $this->createMock(UrlRewrite::class);
@@ -495,7 +495,7 @@ class DbStorageTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('insertMultiple')
             ->willThrowException(
-                new \Exception('SQLSTATE[23000]: test: 1062 test', DbStorage::ERROR_CODE_DUPLICATE_ENTRY)
+                new Exception('SQLSTATE[23000]: test: 1062 test', DbStorage::ERROR_CODE_DUPLICATE_ENTRY)
             );
         $conflictingUrl = [
             UrlRewrite::URL_REWRITE_ID => 'conflicting-url'
@@ -508,11 +508,13 @@ class DbStorageTest extends TestCase
     }
 
     /**
-     * Validates a case when DB errors on duplicate entry, but calculated URLs are not really duplicated
+     * Validates a case when DB errors on duplicate entry, but calculated URLs are not really duplicated.
      *
-     * An example is when URL length exceeds length of the DB field, so URLs are trimmed and become conflicting
+     * An example is when URL length exceeds length of the DB field, so URLs are trimmed and become conflicting.
+     *
+     * @return void
      */
-    public function testReplaceIfThrewExceptionOnDuplicateEntry()
+    public function testReplaceIfThrewExceptionOnDuplicateEntry(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('SQLSTATE[23000]: test: 1062 test');
@@ -524,13 +526,16 @@ class DbStorageTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('insertMultiple')
             ->willThrowException(
-                new \Exception('SQLSTATE[23000]: test: 1062 test', DbStorage::ERROR_CODE_DUPLICATE_ENTRY)
+                new Exception('SQLSTATE[23000]: test: 1062 test', DbStorage::ERROR_CODE_DUPLICATE_ENTRY)
             );
 
         $this->storage->replace([$url]);
     }
 
-    public function testReplaceIfThrewCustomException()
+    /**
+     * @return void
+     */
+    public function testReplaceIfThrewCustomException(): void
     {
         $this->expectException('RuntimeException');
         $url = $this->createMock(UrlRewrite::class);
@@ -545,22 +550,20 @@ class DbStorageTest extends TestCase
         $this->storage->replace([$url]);
     }
 
-    public function testDeleteByData()
+    /**
+     * @return void
+     */
+    public function testDeleteByData(): void
     {
         $data = ['col1' => 'val1', 'col2' => 'val2'];
 
         $this->connectionMock->method('quoteIdentifier')
             ->willReturnArgument(0);
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('col1 IN (?)', 'val1');
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('col2 IN (?)', 'val2');
-
-        $this->select->expects($this->at(3))
+            ->withConsecutive(['col1 IN (?)', 'val1'], ['col2 IN (?)', 'val2']);
+        $this->select
             ->method('deleteFromSelect')
             ->with('table_name')
             ->willReturn('sql delete query');

--- a/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/Role/DeleteTest.php
+++ b/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/Role/DeleteTest.php
@@ -98,7 +98,7 @@ class DeleteTest extends TestCase
     private $roleModelMock;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/Role/DeleteTest.php
+++ b/app/code/Magento/User/Test/Unit/Controller/Adminhtml/User/Role/DeleteTest.php
@@ -93,12 +93,12 @@ class DeleteTest extends TestCase
     private $messageManagerMock;
 
     /**
-     * @var \Magento\Authorization\Model\Role|MockObject
+     * @var Role|MockObject
      */
     private $roleModelMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -171,7 +171,7 @@ class DeleteTest extends TestCase
                 'userFactory' => $this->userFactoryMock,
                 'rulesFactory' => $this->rulesFactoryMock,
                 'authSession' => $this->authSessionMock,
-                'filterManager' => $this->filterManagerMock,
+                'filterManager' => $this->filterManagerMock
             ]
         );
     }
@@ -181,7 +181,7 @@ class DeleteTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteDeleteSelfAssignedRole()
+    public function testExecuteDeleteSelfAssignedRole(): void
     {
         $idUser = 1;
         $idUserRole = 3;
@@ -207,7 +207,7 @@ class DeleteTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteDeleteWithNormalScenario()
+    public function testExecuteDeleteWithNormalScenario(): void
     {
         $idUser = 1;
         $idUserRole = 3;
@@ -239,7 +239,7 @@ class DeleteTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteDeleteWithError()
+    public function testExecuteDeleteWithError(): void
     {
         $idUser = 1;
         $idUserRole = 3;
@@ -271,7 +271,7 @@ class DeleteTest extends TestCase
      *
      * @return void
      */
-    public function testExecuteWithoutRole()
+    public function testExecuteWithoutRole(): void
     {
         $idUser = 1;
         $idUserRole = 3;
@@ -281,8 +281,9 @@ class DeleteTest extends TestCase
         $this->checkUserAndRoleIds($idDeleteRole, $idUser, $idUserRole);
 
         $this->initRoleExecute($roleType);
-        $this->roleModelMock->expects($this->at(1))->method('getId')->willReturn($idDeleteRole);
-        $this->roleModelMock->expects($this->at(2))->method('getId')->willReturn(null);
+        $this->roleModelMock
+            ->method('getId')
+            ->willReturnOnConsecutiveCalls($idDeleteRole, null);
 
         $this->messageManagerMock->expects($this->once())
             ->method('addError')
@@ -303,9 +304,10 @@ class DeleteTest extends TestCase
      * @param int $id
      * @param int $userId
      * @param int $userRoleId
+     *
      * @return void
      */
-    private function checkUserAndRoleIds(int $id, int $userId, int $userRoleId)
+    private function checkUserAndRoleIds(int $id, int $userId, int $userRoleId): void
     {
         $this->requestMock->expects($this->atLeastOnce())->method('getParam')->with('rid')->willReturn($id);
 
@@ -323,9 +325,10 @@ class DeleteTest extends TestCase
      * Execute initialization Role.
      *
      * @param string|null $roleType
+     *
      * @return void
      */
-    private function initRoleExecute($roleType)
+    private function initRoleExecute(?string $roleType): void
     {
         $this->roleFactoryMock->expects($this->once())->method('create')->willReturn($this->roleModelMock);
         $this->roleModelMock->expects($this->once())->method('load')->willReturnSelf();

--- a/app/code/Magento/Webapi/Test/Unit/Model/Plugin/ManagerTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Plugin/ManagerTest.php
@@ -50,12 +50,14 @@ class ManagerTest extends TestCase
      */
     protected $integrationConfigMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->integrationServiceMock = $this->getMockBuilder(
-            IntegrationServiceInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(
+        $this->integrationServiceMock = $this->getMockBuilder(IntegrationServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
                 [
                     'findByName',
                     'update',
@@ -68,22 +70,16 @@ class ManagerTest extends TestCase
                 ]
             )->getMock();
 
-        $this->integrationAuthorizationServiceMock = $this->getMockBuilder(
-            AuthorizationServiceInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'grantPermissions',
-                    'grantAllPermissions',
-                    'removePermissions'
-                ]
-            )->getMock();
+        $this->integrationAuthorizationServiceMock = $this->getMockBuilder(AuthorizationServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['grantPermissions', 'grantAllPermissions', 'removePermissions'])
+            ->getMock();
 
         $this->subjectMock = $this->createMock(ConfigBasedIntegrationManager::class);
 
         $this->integrationConfigMock = $this->getMockBuilder(IntegrationConfig::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getIntegrations'])
             ->getMock();
 
         $this->apiSetupPlugin = new Manager(
@@ -93,7 +89,10 @@ class ManagerTest extends TestCase
         );
     }
 
-    public function testAfterProcessIntegrationConfigNoIntegrations()
+    /**
+     * @return void
+     */
+    public function testAfterProcessIntegrationConfigNoIntegrations(): void
     {
         $this->integrationConfigMock->expects($this->never())->method('getIntegrations');
         $this->integrationServiceMock->expects($this->never())->method('findByName');
@@ -104,13 +103,13 @@ class ManagerTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testAfterProcessIntegrationConfigSuccess()
+    public function testAfterProcessIntegrationConfigSuccess(): void
     {
         $testIntegration1Resource = [
             'Magento_Customer::manage',
             'Magento_Customer::online',
             'Magento_Sales::create',
-            'Magento_SalesRule::quote',
+            'Magento_SalesRule::quote'
         ];
         $testIntegration2Resource = ['Magento_Catalog::product_read'];
         $this->integrationConfigMock->expects(
@@ -120,7 +119,7 @@ class ManagerTest extends TestCase
         )->willReturn(
             [
                 'TestIntegration1' => ['resource' => $testIntegration1Resource],
-                'TestIntegration2' => ['resource' => $testIntegration2Resource],
+                'TestIntegration2' => ['resource' => $testIntegration2Resource]
             ]
         );
         $firstIntegrationId = 1;
@@ -130,7 +129,7 @@ class ManagerTest extends TestCase
                 Integration::NAME => 'TestIntegration1',
                 Integration::EMAIL => 'test-integration1@magento.com',
                 Integration::ENDPOINT => 'http://endpoint.com',
-                Integration::SETUP_TYPE => 1,
+                Integration::SETUP_TYPE => 1
             ]
         );
         $secondIntegrationId = 2;
@@ -139,34 +138,23 @@ class ManagerTest extends TestCase
                 'id' => $secondIntegrationId,
                 Integration::NAME => 'TestIntegration2',
                 Integration::EMAIL => 'test-integration2@magento.com',
-                Integration::SETUP_TYPE => 1,
+                Integration::SETUP_TYPE => 1
             ]
         );
-        $this->integrationServiceMock->expects(
-            $this->at(0)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration1'
-        )->willReturn(
-            $integrationsData1
-        );
-        $this->integrationServiceMock->expects(
-            $this->at(1)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration2'
-        )->willReturn(
-            $integrationsData2
-        );
+        $this->integrationServiceMock
+            ->method('findByName')
+            ->withConsecutive(['TestIntegration1'], ['TestIntegration2'])
+            ->willReturnOnConsecutiveCalls($integrationsData1, $integrationsData2);
         $this->apiSetupPlugin->afterProcessIntegrationConfig(
             $this->subjectMock,
             ['TestIntegration1', 'TestIntegration2']
         );
     }
 
-    public function testAfterProcessConfigBasedIntegrationsNoIntegrations()
+    /**
+     * @return void
+     */
+    public function testAfterProcessConfigBasedIntegrationsNoIntegrations(): void
     {
         $this->integrationServiceMock->expects($this->never())->method('findByName');
         $this->apiSetupPlugin->afterProcessConfigBasedIntegrations($this->subjectMock, []);
@@ -176,7 +164,7 @@ class ManagerTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testAfterProcessConfigBasedIntegrationsSuccess()
+    public function testAfterProcessConfigBasedIntegrationsSuccess(): void
     {
         $firstIntegrationId = 1;
         $integrationsData1 = [
@@ -189,7 +177,7 @@ class ManagerTest extends TestCase
                 'Magento_Customer::manage',
                 'Magento_Customer::online',
                 'Magento_Sales::create',
-                'Magento_SalesRule::quote',
+                'Magento_SalesRule::quote'
             ]
         ];
         $integrationsData1Object = new DataObject($integrationsData1);
@@ -204,25 +192,10 @@ class ManagerTest extends TestCase
         ];
         $integrationsData2Object = new DataObject($integrationsData2);
 
-        $this->integrationServiceMock->expects(
-            $this->at(0)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration1'
-        )->willReturn(
-            $integrationsData1Object
-        );
-
-        $this->integrationServiceMock->expects(
-            $this->at(1)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration2'
-        )->willReturn(
-            $integrationsData2Object
-        );
+        $this->integrationServiceMock
+            ->method('findByName')
+            ->withConsecutive(['TestIntegration1'], ['TestIntegration2'])
+            ->willReturnOnConsecutiveCalls($integrationsData1Object, $integrationsData2Object);
 
         $this->apiSetupPlugin->afterProcessConfigBasedIntegrations(
             $this->subjectMock,

--- a/app/code/Magento/Webapi/Test/Unit/Model/Plugin/ManagerTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Plugin/ManagerTest.php
@@ -51,7 +51,7 @@ class ManagerTest extends TestCase
     protected $integrationConfigMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Webapi/Test/Unit/Model/Soap/Wsdl/ComplexTypeStrategyTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Soap/Wsdl/ComplexTypeStrategyTest.php
@@ -7,11 +7,13 @@ declare(strict_types=1);
 
 namespace Magento\Webapi\Test\Unit\Model\Soap\Wsdl;
 
+use DOMDocument;
+use DOMElement;
 use Laminas\Soap\Wsdl;
 use Magento\Framework\Reflection\TypeProcessor;
+use Magento\Webapi\Model\Soap\Wsdl as WebapiWsdl;
 use Magento\Webapi\Model\Soap\Wsdl\ComplexTypeStrategy;
 use PHPUnit\Framework\MockObject\MockObject;
-
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,61 +21,65 @@ use PHPUnit\Framework\TestCase;
  */
 class ComplexTypeStrategyTest extends TestCase
 {
-    /** @var TypeProcessor|MockObject */
-    protected $_typeProcessor;
-
-    /** @var \Magento\Webapi\Model\Soap\Wsdl|MockObject */
-    protected $_wsdl;
-
-    /** @var ComplexTypeStrategy */
-    protected $_strategy;
+    /**
+     * @var TypeProcessor|MockObject
+     */
+    protected $typeProcessor;
 
     /**
-     * Set up strategy for test.
+     * @var WebapiWsdl|MockObject
+     */
+    protected $wsdl;
+
+    /**
+     * @var ComplexTypeStrategy
+     */
+    protected $strategy;
+
+    /**
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
-        $this->_typeProcessor = $this->getMockBuilder(
-            TypeProcessor::class
-        )->setMethods(
-            ['getTypeData']
-        )->disableOriginalConstructor()
+        $this->typeProcessor = $this->getMockBuilder(TypeProcessor::class)
+            ->onlyMethods(['getTypeData'])->disableOriginalConstructor()
             ->getMock();
-        $this->_wsdl = $this->getMockBuilder(
-            \Magento\Webapi\Model\Soap\Wsdl::class
-        )->setMethods(
-            ['toDomDocument', 'getTypes', 'getSchema']
-        )->disableOriginalConstructor()
+        $this->wsdl = $this->getMockBuilder(WebapiWsdl::class)
+            ->onlyMethods(['toDomDocument', 'getTypes', 'getSchema'])
+            ->disableOriginalConstructor()
             ->getMock();
-        $this->_strategy = new ComplexTypeStrategy($this->_typeProcessor);
-        $this->_strategy->setContext($this->_wsdl);
+        $this->strategy = new ComplexTypeStrategy($this->typeProcessor);
+        $this->strategy->setContext($this->wsdl);
+
         parent::setUp();
     }
 
     /**
-     * Clean up.
+     * @inheirtDoc
      */
     protected function tearDown(): void
     {
-        unset($this->_typeProcessor);
-        unset($this->_strategy);
-        unset($this->_wsdl);
+        unset($this->typeProcessor);
+        unset($this->strategy);
+        unset($this->wsdl);
 
         parent::tearDown();
     }
 
     /**
      * Test that addComplexType returns type WSDL name
-     * if it has already been processed (registered at includedTypes in WSDL)
+     * if it has already been processed (registered at includedTypes in WSDL).
+     *
+     * @return void
      */
-    public function testCheckTypeName()
+    public function testCheckTypeName(): void
     {
         $testType = 'testComplexTypeName';
         $testTypeWsdlName = 'tns:' . $testType;
         $includedTypes = [$testType => $testTypeWsdlName];
-        $this->_wsdl->expects($this->exactly(2))->method('getTypes')->willReturn($includedTypes);
+        $this->wsdl->expects($this->exactly(2))->method('getTypes')->willReturn($includedTypes);
 
-        $this->assertEquals($testTypeWsdlName, $this->_strategy->addComplexType($testType));
+        $this->assertEquals($testTypeWsdlName, $this->strategy->addComplexType($testType));
     }
 
     /**
@@ -81,31 +87,26 @@ class ComplexTypeStrategyTest extends TestCase
      *
      * @param string $type
      * @param array $data
+     *
+     * @return void
      * @dataProvider addComplexTypeDataProvider
      */
-    public function testAddComplexTypeSimpleParameters($type, $data)
+    public function testAddComplexTypeSimpleParameters($type, $data): void
     {
-        $this->_wsdl->expects($this->any())->method('getTypes')->willReturn([]);
-
-        $this->_wsdl->expects($this->any())->method('toDomDocument')->willReturn(new \DOMDocument());
-
-        $schemaMock = $this->getMockBuilder(\DOMElement::class)
+        $this->wsdl->expects($this->any())->method('getTypes')->willReturn([]);
+        $this->wsdl->expects($this->any())->method('toDomDocument')->willReturn(new DOMDocument());
+        $schemaMock = $this->getMockBuilder(DOMElement::class)
             ->setConstructorArgs(['a'])
             ->getMock();
         $schemaMock->expects($this->any())->method('appendChild');
-        $this->_wsdl->expects($this->any())->method('getSchema')->willReturn($schemaMock);
+        $this->wsdl->expects($this->any())->method('getSchema')->willReturn($schemaMock);
 
-        $this->_typeProcessor->expects(
-            $this->at(0)
-        )->method(
-            'getTypeData'
-        )->with(
-            $type
-        )->willReturn(
-            $data
-        );
+        $this->typeProcessor
+            ->method('getTypeData')
+            ->with($type)
+            ->willReturn($data);
 
-        $this->assertEquals(Wsdl::TYPES_NS . ':' . $type, $this->_strategy->addComplexType($type));
+        $this->assertEquals(Wsdl::TYPES_NS . ':' . $type, $this->strategy->addComplexType($type));
     }
 
     /**
@@ -113,7 +114,7 @@ class ComplexTypeStrategyTest extends TestCase
      *
      * @return array
      */
-    public static function addComplexTypeDataProvider()
+    public static function addComplexTypeDataProvider(): array
     {
         return [
             'simple parameters' => [
@@ -124,20 +125,20 @@ class ComplexTypeStrategyTest extends TestCase
                         'string_param' => [
                             'type' => 'string',
                             'required' => true,
-                            'documentation' => 'Required string param.',
+                            'documentation' => 'Required string param.'
                         ],
                         'int_param' => [
                             'type' => 'int',
                             'required' => true,
-                            'documentation' => 'Required int param.',
+                            'documentation' => 'Required int param.'
                         ],
                         'bool_param' => [
                             'type' => 'boolean',
                             'required' => false,
-                            'documentation' => 'Optional complex type param.{annotation:test}',
-                        ],
+                            'documentation' => 'Optional complex type param.{annotation:test}'
+                        ]
                     ]
-                ],
+                ]
             ],
             'type with call info' => [
                 'VendorModuleADataStructure',
@@ -147,14 +148,14 @@ class ComplexTypeStrategyTest extends TestCase
                         'string_param' => [
                             'type' => 'string',
                             'required' => false,
-                            'documentation' => '{callInfo:VendorModuleACreate:requiredInput:conditionally}',
+                            'documentation' => '{callInfo:VendorModuleACreate:requiredInput:conditionally}'
                         ],
                     ],
                     'callInfo' => [
                         'requiredInput' => ['yes' => ['calls' => ['VendorModuleACreate']]],
-                        'returned' => ['always' => ['calls' => ['VendorModuleAGet']]],
+                        'returned' => ['always' => ['calls' => ['VendorModuleAGet']]]
                     ]
-                ],
+                ]
             ],
             'parameter with call info' => [
                 'VendorModuleADataStructure',
@@ -165,10 +166,10 @@ class ComplexTypeStrategyTest extends TestCase
                             'type' => 'string',
                             'required' => false,
                             'documentation' => '{callInfo:VendorModuleACreate:requiredInput:conditionally}' .
-                            '{callInfo:allCallsExcept(VendorModuleAGet):returned:always}',
-                        ],
+                            '{callInfo:allCallsExcept(VendorModuleAGet):returned:always}'
+                        ]
                     ]
-                ],
+                ]
             ],
             'parameter with see link' => [
                 'VendorModuleADataStructure',
@@ -178,10 +179,10 @@ class ComplexTypeStrategyTest extends TestCase
                         'string_param' => [
                             'type' => 'string',
                             'required' => false,
-                            'documentation' => '{seeLink:http://google.com/:title:for}',
-                        ],
+                            'documentation' => '{seeLink:http://google.com/:title:for}'
+                        ]
                     ]
-                ],
+                ]
             ],
             'parameter with doc instructions' => [
                 'VendorModuleADataStructure',
@@ -191,18 +192,20 @@ class ComplexTypeStrategyTest extends TestCase
                         'string_param' => [
                             'type' => 'string',
                             'required' => false,
-                            'documentation' => '{docInstructions:output:noDoc}',
-                        ],
+                            'documentation' => '{docInstructions:output:noDoc}'
+                        ]
                     ]
-                ],
+                ]
             ]
         ];
     }
 
     /**
      * Test adding complex type with complex parameters and arrays.
+     *
+     * @return void
      */
-    public function testAddComplexTypeComplexParameters()
+    public function testAddComplexTypeComplexParameters(): void
     {
         $type = 'VendorModuleADataStructure';
         $parameterType = 'ComplexType';
@@ -212,9 +215,9 @@ class ComplexTypeStrategyTest extends TestCase
                 'complex_param' => [
                     'type' => $parameterType,
                     'required' => true,
-                    'documentation' => 'complex type param.',
-                ],
-            ],
+                    'documentation' => 'complex type param.'
+                ]
+            ]
         ];
         $parameterData = [
             'documentation' => 'test',
@@ -222,59 +225,45 @@ class ComplexTypeStrategyTest extends TestCase
                 'string_param' => [
                     'type' => 'ComplexTypeB[]',
                     'required' => true,
-                    'documentation' => 'string param.',
-                ],
-            ],
+                    'documentation' => 'string param.'
+                ]
+            ]
         ];
 
-        $this->_wsdl->expects($this->at(0))->method('getTypes')->willReturn([]);
-        $this->_wsdl->expects(
-            $this->any()
-        )->method(
-            'getTypes'
-        )->willReturn(
-            [$type => Wsdl::TYPES_NS . ':' . $type]
-        );
+        $this->wsdl
+            ->method('getTypes')
+            ->willReturn([]);
+        $this->wsdl->expects($this->any())
+            ->method('getTypes')
+            ->willReturn([$type => Wsdl::TYPES_NS . ':' . $type]);
 
-        $this->_wsdl->expects($this->any())->method('toDomDocument')->willReturn(new \DOMDocument());
-        $schemaMock = $this->getMockBuilder(\DOMElement::class)
+        $this->wsdl->expects($this->any())->method('toDomDocument')->willReturn(new DOMDocument());
+        $schemaMock = $this->getMockBuilder(DOMElement::class)
             ->setConstructorArgs(['a'])
             ->getMock();
         $schemaMock->expects($this->any())->method('appendChild');
-        $this->_wsdl->expects($this->any())->method('getSchema')->willReturn($schemaMock);
-        $this->_typeProcessor->expects(
-            $this->at(0)
-        )->method(
-            'getTypeData'
-        )->with(
-            $type
-        )->willReturn(
-            $typeData
-        );
-        $this->_typeProcessor->expects(
-            $this->at(1)
-        )->method(
-            'getTypeData'
-        )->with(
-            $parameterType
-        )->willReturn(
-            $parameterData
-        );
+        $this->wsdl->expects($this->any())->method('getSchema')->willReturn($schemaMock);
+        $this->typeProcessor
+            ->method('getTypeData')
+            ->withConsecutive([$type], [$parameterType])
+            ->willReturnOnConsecutiveCalls($typeData, $parameterData);
 
-        $this->assertEquals(Wsdl::TYPES_NS . ':' . $type, $this->_strategy->addComplexType($type));
+        $this->assertEquals(Wsdl::TYPES_NS . ':' . $type, $this->strategy->addComplexType($type));
     }
 
     /**
-     * Test to verify if annotations are added correctly
+     * Test to verify if annotations are added correctly.
+     *
+     * @return void
      */
-    public function testAddAnnotationToComplexType()
+    public function testAddAnnotationToComplexType(): void
     {
-        $dom = new \DOMDocument();
-        $this->_wsdl->expects($this->any())->method('toDomDocument')->willReturn($dom);
+        $dom = new DOMDocument();
+        $this->wsdl->expects($this->any())->method('toDomDocument')->willReturn($dom);
         $annotationDoc = "test doc";
         $complexType = $dom->createElement(Wsdl::XSD_NS . ':complexType');
         $complexType->setAttribute('name', 'testRequest');
-        $this->_strategy->addAnnotation($complexType, $annotationDoc);
+        $this->strategy->addAnnotation($complexType, $annotationDoc);
         $this->assertEquals(
             $annotationDoc,
             $complexType->getElementsByTagName("xsd:documentation")->item(0)->nodeValue

--- a/app/code/Magento/Webapi/Test/Unit/Model/Soap/Wsdl/ComplexTypeStrategyTest.php
+++ b/app/code/Magento/Webapi/Test/Unit/Model/Soap/Wsdl/ComplexTypeStrategyTest.php
@@ -37,7 +37,7 @@ class ComplexTypeStrategyTest extends TestCase
     protected $strategy;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -55,7 +55,7 @@ class ComplexTypeStrategyTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
@@ -94,7 +94,7 @@ class ContextPluginTest extends TestCase
     protected $contextPlugin;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
+++ b/app/code/Magento/Weee/Test/Unit/App/Action/ContextPluginTest.php
@@ -93,6 +93,9 @@ class ContextPluginTest extends TestCase
      */
     protected $contextPlugin;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -115,13 +118,13 @@ class ContextPluginTest extends TestCase
 
         $this->customerSessionMock = $this->getMockBuilder(CustomerSession::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(['isLoggedIn'])
+            ->addMethods(
                 [
                     'getDefaultTaxBillingAddress',
                     'getDefaultTaxShippingAddress',
                     'getCustomerTaxClassId',
-                    'getWebsiteId',
-                    'isLoggedIn'
+                    'getWebsiteId'
                 ]
             )
             ->getMock();
@@ -158,7 +161,10 @@ class ContextPluginTest extends TestCase
         );
     }
 
-    public function testBeforeExecuteBasedOnDefault()
+    /**
+     * @return void
+     */
+    public function testBeforeExecuteBasedOnDefault(): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -193,23 +199,13 @@ class ContextPluginTest extends TestCase
             ->method('getStore')
             ->willReturn($storeMock);
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY,
-                ScopeInterface::SCOPE_STORE,
-                null
+            ->withConsecutive(
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY, ScopeInterface::SCOPE_STORE, null],
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION, ScopeInterface::SCOPE_STORE, null]
             )
-            ->willReturn('US');
-
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION,
-                ScopeInterface::SCOPE_STORE,
-                null
-            )
-            ->willReturn(0);
+            ->willReturnOnConsecutiveCalls('US', 0);
 
         $this->weeeTaxMock->expects($this->once())
             ->method('isWeeeInLocation')
@@ -226,7 +222,10 @@ class ContextPluginTest extends TestCase
         $this->contextPlugin->beforeExecute($action);
     }
 
-    public function testBeforeExecuteBasedOnOrigin()
+    /**
+     * @return void
+     */
+    public function testBeforeExecuteBasedOnOrigin(): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -255,7 +254,10 @@ class ContextPluginTest extends TestCase
         $this->contextPlugin->beforeExecute($action);
     }
 
-    public function testBeforeExecuteBasedOnBilling()
+    /**
+     * @return void
+     */
+    public function testBeforeExecuteBasedOnBilling(): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -290,23 +292,13 @@ class ContextPluginTest extends TestCase
             ->method('getStore')
             ->willReturn($storeMock);
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY,
-                ScopeInterface::SCOPE_STORE,
-                null
+            ->withConsecutive(
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY, ScopeInterface::SCOPE_STORE, null],
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION, ScopeInterface::SCOPE_STORE, null]
             )
-            ->willReturn('US');
-
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION,
-                ScopeInterface::SCOPE_STORE,
-                null
-            )
-            ->willReturn(0);
+            ->willReturnOnConsecutiveCalls('US', 0);
 
         $this->customerSessionMock->expects($this->once())
             ->method('getDefaultTaxBillingAddress')
@@ -327,7 +319,10 @@ class ContextPluginTest extends TestCase
         $this->contextPlugin->beforeExecute($action);
     }
 
-    public function testBeforeExecuterBasedOnShipping()
+    /**
+     * @return void
+     */
+    public function testBeforeExecuterBasedOnShipping(): void
     {
         $this->customerSessionMock->expects($this->once())
             ->method('isLoggedIn')
@@ -362,23 +357,13 @@ class ContextPluginTest extends TestCase
             ->method('getStore')
             ->willReturn($storeMock);
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY,
-                ScopeInterface::SCOPE_STORE,
-                null
+            ->withConsecutive(
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_COUNTRY, ScopeInterface::SCOPE_STORE, null],
+                [TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION, ScopeInterface::SCOPE_STORE, null]
             )
-            ->willReturn('US');
-
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                TaxConfig::CONFIG_XML_PATH_DEFAULT_REGION,
-                ScopeInterface::SCOPE_STORE,
-                null
-            )
-            ->willReturn(0);
+            ->willReturnOnConsecutiveCalls('US', 0);
 
         $this->customerSessionMock->expects($this->once())
             ->method('getDefaultTaxShippingAddress')

--- a/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
@@ -15,8 +15,10 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Registry;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
 use Magento\Sales\Model\Order\Item;
 use Magento\Store\Model\Store;
+use Magento\Tax\Helper\Data;
 use Magento\Weee\Helper\Data as WeeeHelper;
 use Magento\Weee\Model\Config;
 use Magento\Weee\Model\Tax;
@@ -49,18 +51,23 @@ class DataTest extends TestCase
     protected $weeeTax;
 
     /**
-     * @var \Magento\Tax\Helper\Data
+     * @var Data
      */
     protected $taxData;
 
     /**
-     * @var \Magento\Weee\Helper\Data
+     * @var WeeeHelper
      */
     protected $helperData;
 
-    /** @var Json|MockObject */
+    /**
+     * @var Json|MockObject
+     */
     private $serializerMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->product = $this->createMock(Product::class);
@@ -70,7 +77,7 @@ class DataTest extends TestCase
         $this->weeeTax = $this->createMock(Tax::class);
         $this->weeeTax->method('getWeeeAmount')->willReturn('11.26');
         $this->taxData = $this->createPartialMock(
-            \Magento\Tax\Helper\Data::class,
+            Data::class,
             ['getPriceDisplayType', 'priceIncludesTax']
         );
 
@@ -84,10 +91,13 @@ class DataTest extends TestCase
             'serializer' => $this->serializerMock
         ];
         $helper = new ObjectManager($this);
-        $this->helperData = $helper->getObject(\Magento\Weee\Helper\Data::class, $arguments);
+        $this->helperData = $helper->getObject(WeeeHelper::class, $arguments);
     }
 
-    public function testGetAmount()
+    /**
+     * @return void
+     */
+    public function testGetAmount(): void
     {
         $this->product->method('hasData')->willReturn(false);
         $this->product->method('getData')->willReturn(11.26);
@@ -98,11 +108,11 @@ class DataTest extends TestCase
     /**
      * @return Item|MockObject
      */
-    private function setupOrderItem()
+    private function setupOrderItem(): Item
     {
         $orderItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['__wakeup'])
+            ->onlyMethods(['__wakeup'])
             ->getMock();
 
         $weeeTaxApplied = [
@@ -114,7 +124,7 @@ class DataTest extends TestCase
                 WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
                 WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
                 WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
-                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED
             ],
             [
                 WeeeHelper::KEY_WEEE_AMOUNT_INVOICED => self::ROW_AMOUNT_INVOICED,
@@ -124,7 +134,7 @@ class DataTest extends TestCase
                 WeeeHelper::KEY_WEEE_AMOUNT_REFUNDED => self::ROW_AMOUNT_REFUNDED,
                 WeeeHelper::KEY_BASE_WEEE_AMOUNT_REFUNDED => self::BASE_ROW_AMOUNT_REFUNDED,
                 WeeeHelper::KEY_WEEE_TAX_AMOUNT_REFUNDED => self::TAX_AMOUNT_REFUNDED,
-                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED,
+                WeeeHelper::KEY_BASE_WEEE_TAX_AMOUNT_REFUNDED => self::BASE_TAX_AMOUNT_REFUNDED
             ],
         ];
 
@@ -140,56 +150,80 @@ class DataTest extends TestCase
         return $orderItem;
     }
 
-    public function testGetWeeeAmountInvoiced()
+    /**
+     * @return void
+     */
+    public function testGetWeeeAmountInvoiced(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getWeeeAmountInvoiced($orderItem);
         $this->assertEquals(self::ROW_AMOUNT_INVOICED, $value);
     }
 
-    public function testGetBaseWeeeAmountInvoiced()
+    /**
+     * @return void
+     */
+    public function testGetBaseWeeeAmountInvoiced(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getBaseWeeeAmountInvoiced($orderItem);
         $this->assertEquals(self::BASE_ROW_AMOUNT_INVOICED, $value);
     }
 
-    public function testGetWeeeTaxAmountInvoiced()
+    /**
+     * @return void
+     */
+    public function testGetWeeeTaxAmountInvoiced(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getWeeeTaxAmountInvoiced($orderItem);
         $this->assertEquals(self::TAX_AMOUNT_INVOICED, $value);
     }
 
-    public function testGetWeeeBaseTaxAmountInvoiced()
+    /**
+     * @return void
+     */
+    public function testGetWeeeBaseTaxAmountInvoiced(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getBaseWeeeTaxAmountInvoiced($orderItem);
         $this->assertEquals(self::BASE_TAX_AMOUNT_INVOICED, $value);
     }
 
-    public function testGetWeeeAmountRefunded()
+    /**
+     * @return void
+     */
+    public function testGetWeeeAmountRefunded(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getWeeeAmountRefunded($orderItem);
         $this->assertEquals(self::ROW_AMOUNT_REFUNDED, $value);
     }
 
-    public function testGetBaseWeeeAmountRefunded()
+    /**
+     * @return void
+     */
+    public function testGetBaseWeeeAmountRefunded(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getBaseWeeeAmountRefunded($orderItem);
         $this->assertEquals(self::BASE_ROW_AMOUNT_REFUNDED, $value);
     }
 
-    public function testGetWeeeTaxAmountRefunded()
+    /**
+     * @return void
+     */
+    public function testGetWeeeTaxAmountRefunded(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getWeeeTaxAmountRefunded($orderItem);
         $this->assertEquals(self::TAX_AMOUNT_REFUNDED, $value);
     }
 
-    public function testGetBaseWeeeTaxAmountRefunded()
+    /**
+     * @return void
+     */
+    public function testGetBaseWeeeTaxAmountRefunded(): void
     {
         $orderItem = $this->setupOrderItem();
         $value = $this->helperData->getBaseWeeeTaxAmountRefunded($orderItem);
@@ -197,13 +231,18 @@ class DataTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderGetWeeeAttributesForBundle
-     * @param int $priceIncludesTax
-     * @param bool $priceDisplay
+     * @param int $priceDisplay
+     * @param bool $priceIncludesTax
      * @param array $expectedAmount
+     *
+     * @return void
+     * @dataProvider dataProviderGetWeeeAttributesForBundle
      */
-    public function testGetWeeeAttributesForBundle($priceDisplay, $priceIncludesTax, $expectedAmount)
-    {
+    public function testGetWeeeAttributesForBundle(
+        int $priceDisplay,
+        bool $priceIncludesTax,
+        array $expectedAmount
+    ): void {
         $prodId1 = 1;
         $prodId2 = 2;
         $fptCode1 = 'fpt' . $prodId1;
@@ -257,12 +296,9 @@ class DataTest extends TestCase
             ->addMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMock();
-        $productSimple->expects($this->at(0))
+        $productSimple
             ->method('getId')
-            ->willReturn($prodId1);
-        $productSimple->expects($this->at(1))
-            ->method('getId')
-            ->willReturn($prodId2);
+            ->willReturnOnConsecutiveCalls($prodId1, $prodId2);
 
         $productInstance = $this->createMock(Type::class);
         $productInstance
@@ -301,7 +337,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderGetWeeeAttributesForBundle()
+    public function dataProviderGetWeeeAttributesForBundle(): array
     {
         return [
             [2, false, ["16.00", "15.00"]],
@@ -309,14 +345,17 @@ class DataTest extends TestCase
             [1, false, ["15.00", "10.00"]],
             [1, true, ["15.0000", "10.0000"]],
             [3, false, ["16.00", "15.00"]],
-            [3, true, ["15.00", "10.00"]],
+            [3, true, ["15.00", "10.00"]]
         ];
     }
 
-    public function testGetAppliedSimple()
+    /**
+     * @return void
+     */
+    public function testGetAppliedSimple(): void
     {
         $testArray = ['key' => 'value'];
-        $itemProductSimple = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxApplied', 'getHasChildren'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -335,18 +374,21 @@ class DataTest extends TestCase
         $this->assertEquals($testArray, $this->helperData->getApplied($itemProductSimple));
     }
 
-    public function testGetAppliedBundle()
+    /**
+     * @return void
+     */
+    public function testGetAppliedBundle(): void
     {
         $testArray1 = ['key1' => 'value1'];
         $testArray2 = ['key2' => 'value2'];
 
         $testArray = array_merge($testArray1, $testArray2);
 
-        $itemProductSimple1 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple1 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxApplied'])
             ->disableOriginalConstructor()
             ->getMock();
-        $itemProductSimple2 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple2 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxApplied'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -359,7 +401,7 @@ class DataTest extends TestCase
             ->method('getWeeeTaxApplied')
             ->willReturn(json_encode($testArray2));
 
-        $itemProductBundle = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductBundle = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getHasChildren'])
             ->onlyMethods(['isChildrenCalculated', 'getChildren'])
             ->disableOriginalConstructor()
@@ -381,12 +423,15 @@ class DataTest extends TestCase
         $this->assertEquals($testArray, $this->helperData->getApplied($itemProductBundle));
     }
 
-    public function testGetRecursiveAmountSimple()
+    /**
+     * @return void
+     */
+    public function testGetRecursiveAmountSimple(): void
     {
         $testAmountUnit = 2;
         $testAmountRow = 34;
 
-        $itemProductSimple = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getHasChildren', 'getWeeeTaxAppliedAmount', 'getWeeeTaxAppliedRowAmount'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -405,7 +450,10 @@ class DataTest extends TestCase
         $this->assertEquals($testAmountRow, $this->helperData->getWeeeTaxAppliedRowAmount($itemProductSimple));
     }
 
-    public function testGetRecursiveAmountBundle()
+    /**
+     * @return void
+     */
+    public function testGetRecursiveAmountBundle(): void
     {
         $testAmountUnit1 = 1;
         $testAmountUnit2 = 2;
@@ -415,11 +463,11 @@ class DataTest extends TestCase
         $testAmountRow2 = 444;
         $testTotalRow = $testAmountRow1 + $testAmountRow2;
 
-        $itemProductSimple1 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple1 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxAppliedAmount', 'getWeeeTaxAppliedRowAmount'])
             ->disableOriginalConstructor()
             ->getMock();
-        $itemProductSimple2 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple2 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxAppliedAmount', 'getWeeeTaxAppliedRowAmount'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -438,7 +486,7 @@ class DataTest extends TestCase
             ->method('getWeeeTaxAppliedRowAmount')
             ->willReturn($testAmountRow2);
 
-        $itemProductBundle = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductBundle = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getHasChildren'])
             ->onlyMethods(['isChildrenCalculated', 'getChildren'])
             ->disableOriginalConstructor()
@@ -457,7 +505,10 @@ class DataTest extends TestCase
         $this->assertEquals($testTotalRow, $this->helperData->getWeeeTaxAppliedRowAmount($itemProductBundle));
     }
 
-    public function testGetProductWeeeAttributesForDisplay()
+    /**
+     * @return void
+     */
+    public function testGetProductWeeeAttributesForDisplay(): void
     {
         $store = $this->createMock(Store::class);
         $this->product
@@ -468,30 +519,36 @@ class DataTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testGetTaxDisplayConfig()
+    /**
+     * @return void
+     */
+    public function testGetTaxDisplayConfig(): void
     {
         $expected = 1;
-        $taxData = $this->createPartialMock(\Magento\Tax\Helper\Data::class, ['getPriceDisplayType']);
+        $taxData = $this->createPartialMock(Data::class, ['getPriceDisplayType']);
         $taxData->method('getPriceDisplayType')->willReturn($expected);
         $arguments = [
             'taxData' => $taxData,
         ];
         $helper = new ObjectManager($this);
-        $helperData = $helper->getObject(\Magento\Weee\Helper\Data::class, $arguments);
+        $helperData = $helper->getObject(WeeeHelper::class, $arguments);
 
         $this->assertEquals($expected, $helperData->getTaxDisplayConfig());
     }
 
-    public function testGetTotalAmounts()
+    /**
+     * @return void
+     */
+    public function testGetTotalAmounts(): void
     {
         $item1Weee = 5;
         $item2Weee = 7;
         $expected = $item1Weee + $item2Weee;
-        $itemProductSimple1 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple1 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxAppliedRowAmount'])
             ->disableOriginalConstructor()
             ->getMock();
-        $itemProductSimple2 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple2 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getWeeeTaxAppliedRowAmount'])
             ->disableOriginalConstructor()
             ->getMock();
@@ -507,16 +564,19 @@ class DataTest extends TestCase
         $this->assertEquals($expected, $this->helperData->getTotalAmounts($items));
     }
 
-    public function testGetBaseTotalAmounts()
+    /**
+     * @return void
+     */
+    public function testGetBaseTotalAmounts(): void
     {
         $item1BaseWeee = 4;
         $item2BaseWeee = 3;
         $expected = $item1BaseWeee + $item2BaseWeee;
-        $itemProductSimple1 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple1 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getBaseWeeeTaxAppliedRowAmnt'])
             ->disableOriginalConstructor()
             ->getMock();
-        $itemProductSimple2 = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        $itemProductSimple2 = $this->getMockBuilder(QuoteItem::class)
             ->addMethods(['getBaseWeeeTaxAppliedRowAmnt'])
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Helper/DataTest.php
@@ -66,7 +66,7 @@ class DataTest extends TestCase
     private $serializerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Weee/Test/Unit/Model/ResourceModel/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/ResourceModel/TaxTest.php
@@ -44,6 +44,9 @@ class TaxTest extends TestCase
      */
     protected $selectMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -72,27 +75,21 @@ class TaxTest extends TestCase
         $this->model = $objectManager->getObject(
             Tax::class,
             [
-                'context' => $contextMock,
+                'context' => $contextMock
             ]
         );
     }
 
-    public function testInWeeeLocation()
+    /**
+     * @return void
+     */
+    public function testInWeeeLocation(): void
     {
-        $this->selectMock->expects($this->at(1))
-            ->method('where')
-            ->with('website_id IN(?)', [1, 0])
-            ->willReturn($this->selectMock);
 
-        $this->selectMock->expects($this->at(2))
+        $this->selectMock
             ->method('where')
-            ->with('country = ?', 'US')
-            ->willReturn($this->selectMock);
-
-        $this->selectMock->expects($this->at(3))
-            ->method('where')
-            ->with('state = ?', 0)
-            ->willReturn($this->selectMock);
+            ->withConsecutive(['website_id IN(?)', [1, 0]], ['country = ?', 'US'], ['state = ?', 0])
+            ->willReturnOnConsecutiveCalls($this->selectMock, $this->selectMock, $this->selectMock);
 
         $this->selectMock->expects($this->any())
             ->method('from')
@@ -102,7 +99,10 @@ class TaxTest extends TestCase
         $this->model->isWeeeInLocation('US', 0, 1);
     }
 
-    public function testFetchWeeeTaxCalculationsByEntity()
+    /**
+     * @return void
+     */
+    public function testFetchWeeeTaxCalculationsByEntity(): void
     {
         $this->selectMock->expects($this->any())
             ->method('where')

--- a/app/code/Magento/Weee/Test/Unit/Model/ResourceModel/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/ResourceModel/TaxTest.php
@@ -45,7 +45,7 @@ class TaxTest extends TestCase
     protected $selectMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
@@ -113,7 +113,7 @@ class TaxTest extends TestCase
     protected $objectManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/TaxTest.php
@@ -27,6 +27,7 @@ use Magento\Tax\Helper\Data;
 use Magento\Tax\Model\Calculation;
 use Magento\Tax\Model\CalculationFactory;
 use Magento\Weee\Model\Config;
+use Magento\Weee\Model\ResourceModel\Tax as ResourceModelTax;
 use Magento\Weee\Model\Tax;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -112,7 +113,7 @@ class TaxTest extends TestCase
     protected $objectManager;
 
     /**
-     * Setup the test
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -135,11 +136,7 @@ class TaxTest extends TestCase
 
         $this->customerSession = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(
-                [
-                    'getCustomerId',
-                ]
-            )
+            ->onlyMethods(['getCustomerId'])
             ->addMethods(
                 [
 
@@ -160,7 +157,7 @@ class TaxTest extends TestCase
         $className = Data::class;
         $this->taxData = $this->createMock($className);
 
-        $className = \Magento\Weee\Model\ResourceModel\Tax::class;
+        $className = ResourceModelTax::class;
         $this->resource = $this->createMock($className);
 
         $className = Config::class;
@@ -186,17 +183,18 @@ class TaxTest extends TestCase
                 'resource' => $this->resource,
                 'weeeConfig' => $this->weeeConfig,
                 'priceCurrency' => $this->priceCurrency,
-                'resourceCollection' => $this->resourceCollection,
+                'resourceCollection' => $this->resourceCollection
             ]
         );
     }
 
     /**
-     * @dataProvider getProductWeeeAttributesDataProvider
      * @param array $weeeTaxCalculationsByEntity
      * @param mixed $websitePassed
      * @param string $expectedFptLabel
+     *
      * @return void
+     * @dataProvider getProductWeeeAttributesDataProvider
      */
     public function testGetProductWeeeAttributes(
         array $weeeTaxCalculationsByEntity,
@@ -297,29 +295,32 @@ class TaxTest extends TestCase
     }
 
     /**
-     * Test getWeeeAmountExclTax method
+     * Test getWeeeAmountExclTax method.
      *
      * @param string $productTypeId
      * @param string $productPriceType
+     *
+     * @return void
      * @dataProvider getWeeeAmountExclTaxDataProvider
      */
-    public function testGetWeeeAmountExclTax($productTypeId, $productPriceType)
+    public function testGetWeeeAmountExclTax($productTypeId, $productPriceType): void
     {
-        $product = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getTypeId', 'getPriceType'])
+        $product = $this->getMockBuilder(Product::class)->disableOriginalConstructor()
+            ->onlyMethods(['getTypeId'])
+            ->addMethods(['getPriceType'])
             ->getMock();
         $product->expects($this->any())->method('getTypeId')->willReturn($productTypeId);
         $product->expects($this->any())->method('getPriceType')->willReturn($productPriceType);
         $weeeDataHelper = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAmountExclTax'])
+            ->addMethods(['getAmountExclTax'])
             ->getMock();
-        $weeeDataHelper->expects($this->at(0))->method('getAmountExclTax')->willReturn(10);
-        $weeeDataHelper->expects($this->at(1))->method('getAmountExclTax')->willReturn(30);
+        $weeeDataHelper
+            ->method('getAmountExclTax')
+            ->willReturnOnConsecutiveCalls(10, 30);
         $tax = $this->getMockBuilder(Tax::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProductWeeeAttributes'])
+            ->onlyMethods(['getProductWeeeAttributes'])
             ->getMock();
         $tax->expects($this->once())->method('getProductWeeeAttributes')
             ->willReturn([$weeeDataHelper, $weeeDataHelper]);
@@ -327,13 +328,16 @@ class TaxTest extends TestCase
     }
 
     /**
-     * Test getWeeeAmountExclTax method for dynamic bundle product
+     * Test getWeeeAmountExclTax method for dynamic bundle product.
+     *
+     * @return void
      */
-    public function testGetWeeeAmountExclTaxForDynamicBundleProduct()
+    public function testGetWeeeAmountExclTaxForDynamicBundleProduct(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTypeId', 'getPriceType'])
+            ->onlyMethods(['getTypeId'])
+            ->addMethods(['getPriceType'])
             ->getMock();
         $product->expects($this->once())->method('getTypeId')->willReturn('bundle');
         $product->expects($this->once())->method('getPriceType')->willReturn(0);
@@ -342,7 +346,7 @@ class TaxTest extends TestCase
             ->getMock();
         $tax = $this->getMockBuilder(Tax::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProductWeeeAttributes'])
+            ->onlyMethods(['getProductWeeeAttributes'])
             ->getMock();
         $tax->expects($this->once())->method('getProductWeeeAttributes')->willReturn([$weeeDataHelper]);
         $this->assertEquals(0, $tax->getWeeeAmountExclTax($product));
@@ -351,7 +355,7 @@ class TaxTest extends TestCase
     /**
      * @return array
      */
-    public function getProductWeeeAttributesDataProvider()
+    public function getProductWeeeAttributesDataProvider(): array
     {
         return [
             'store_label_defined' => [
@@ -359,38 +363,38 @@ class TaxTest extends TestCase
                     'weee_value' => 1,
                     'label_value' => 'fpt_label',
                     'frontend_label' => 'fpt_label_frontend',
-                    'attribute_code' => 'fpt_code',
+                    'attribute_code' => 'fpt_code'
                 ],
                 'websitePassed' => 1,
-                'expectedFptLabel' => 'fpt_label',
+                'expectedFptLabel' => 'fpt_label'
             ],
             'store_label_not_defined' => [
                 'weeeTaxCalculationsByEntity' => [
                     'weee_value' => 1,
                     'label_value' => '',
                     'frontend_label' => 'fpt_label_frontend',
-                    'attribute_code' => 'fpt_code',
+                    'attribute_code' => 'fpt_code'
                 ],
                 'websitePassed' => 1,
-                'expectedFptLabel' => 'fpt_label_frontend',
+                'expectedFptLabel' => 'fpt_label_frontend'
             ],
             'website_not_passed' => [
                 'weeeTaxCalculationsByEntity' => [
                     'weee_value' => 1,
                     'label_value' => '',
                     'frontend_label' => 'fpt_label_frontend',
-                    'attribute_code' => 'fpt_code',
+                    'attribute_code' => 'fpt_code'
                 ],
                 'websitePassed' => null,
-                'expectedFptLabel' => 'fpt_label_frontend',
-            ],
+                'expectedFptLabel' => 'fpt_label_frontend'
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function getWeeeAmountExclTaxDataProvider()
+    public function getWeeeAmountExclTaxDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
+++ b/app/code/Magento/Weee/Test/Unit/Model/Total/Quote/WeeeTest.php
@@ -21,6 +21,7 @@ use Magento\Quote\Model\Quote\Item;
 use Magento\Store\Model\Store;
 use Magento\Tax\Helper\Data;
 use Magento\Tax\Model\Calculation;
+use Magento\Weee\Helper\Data as WeeeHelperData;
 use Magento\Weee\Model\Total\Quote\Weee;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -36,19 +37,23 @@ class WeeeTest extends TestCase
     protected $priceCurrency;
 
     /**
-     * @var \Magento\Weee\Model\Total\Quote\Weee
+     * @var Weee
      */
     protected $weeeCollector;
 
+    /**
+     * @var Json
+     */
     private $serializerMock;
 
     /**
-     * Setup tax helper with an array of methodName, returnValue
+     * Setup tax helper with an array of methodName, returnValue.
      *
      * @param array $taxConfig
-     * @return MockObject|\Magento\Tax\Helper\Data
+     *
+     * @return MockObject|Data
      */
-    protected function setupTaxHelper($taxConfig)
+    protected function setupTaxHelper(array $taxConfig): Data
     {
         $taxHelper = $this->createMock(Data::class);
 
@@ -60,12 +65,13 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Setup calculator to return tax rates
+     * Setup calculator to return tax rates.
      *
      * @param array $taxRates
+     *
      * @return MockObject|Calculation
      */
-    protected function setupTaxCalculation($taxRates)
+    protected function setupTaxCalculation(array $taxRates): Calculation
     {
         $storeTaxRate = $taxRates['store_tax_rate'];
         $customerTaxRate = $taxRates['customer_tax_rate'];
@@ -93,17 +99,17 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Setup weee helper with an array of methodName, returnValue
+     * Setup weee helper with an array of methodName, returnValue.
      *
      * @param array $weeeConfig
-     * @return MockObject|\Magento\Weee\Helper\Data
+     * @return MockObject|WeeeHelperData
      */
-    protected function setupWeeeHelper($weeeConfig)
+    protected function setupWeeeHelper($weeeConfig): WeeeHelperData
     {
         $this->serializerMock = $this->getMockBuilder(Json::class)
             ->getMock();
 
-        $weeeHelper = $this->getMockBuilder(\Magento\Weee\Helper\Data::class)
+        $weeeHelper = $this->getMockBuilder(WeeeHelperData::class)
             ->setConstructorArgs(['serializer' => $this->serializerMock])
             ->disableOriginalConstructor()
             ->getMock();
@@ -116,12 +122,13 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Setup the basics of an item mock
+     * Setup the basics of an item mock.
      *
      * @param float $itemTotalQty
+     *
      * @return MockObject|Item
      */
-    protected function setupItemMockBasics($itemTotalQty)
+    protected function setupItemMockBasics($itemTotalQty): Item
     {
         $itemMock = $this->getMockBuilder(Item::class)
             ->addMethods(['getHasChildren'])
@@ -147,12 +154,13 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Setup an item mock
+     * Setup an item mock.
      *
      * @param float $itemQty
+     *
      * @return MockObject|Item
      */
-    protected function setupItemMock($itemQty)
+    protected function setupItemMock(float $itemQty): Item
     {
         $itemMock = $this->setupItemMockBasics($itemQty);
 
@@ -169,9 +177,10 @@ class WeeeTest extends TestCase
      *
      * @param float $parentQty
      * @param float $itemQty
+     *
      * @return MockObject[]|Item[]
      */
-    protected function setupParentItemWithChildrenMock($parentQty, $itemQty)
+    protected function setupParentItemWithChildrenMock($parentQty, $itemQty): array
     {
         $items = [];
 
@@ -190,16 +199,18 @@ class WeeeTest extends TestCase
 
         $items[] = $parentItemMock;
         $items[] = $childItemMock;
+
         return $items;
     }
 
     /**
-     * Setup address mock
+     * Setup address mock.
      *
-     * @param MockObject[]|Item[] $items
+     * @param Item[]|MockObject[] $items
+     *
      * @return MockObject
      */
-    protected function setupAddressMock($items)
+    protected function setupAddressMock(array $items): MockObject
     {
         $addressMock = $this->createPartialMock(Address::class, [
             'getAllItems',
@@ -225,11 +236,13 @@ class WeeeTest extends TestCase
 
     /**
      * Setup shipping assignment mock.
+     *
      * @param MockObject $addressMock
      * @param MockObject $itemMock
+     *
      * @return MockObject
      */
-    protected function setupShippingAssignmentMock($addressMock, $itemMock)
+    protected function setupShippingAssignmentMock($addressMock, $itemMock): MockObject
     {
         $shippingMock = $this->getMockForAbstractClass(ShippingInterface::class);
         $shippingMock->expects($this->any())->method('getAddress')->willReturn($addressMock);
@@ -241,12 +254,14 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Verify that correct fields of item has been set
+     * Verify that correct fields of item has been set.
      *
      * @param MockObject|Item $item
      * @param $itemData
+     *
+     * @return void
      */
-    public function verifyItem(Item $item, $itemData)
+    public function verifyItem(Item $item, $itemData): void
     {
         foreach ($itemData as $key => $value) {
             $this->assertEquals($value, $item->getData($key), 'item ' . $key . ' is incorrect');
@@ -258,8 +273,10 @@ class WeeeTest extends TestCase
      *
      * @param MockObject|Address $address
      * @param $addressData
+     *
+     * @return void
      */
-    public function verifyAddress($address, $addressData)
+    public function verifyAddress($address, $addressData): void
     {
         foreach ($addressData as $key => $value) {
             $this->assertEquals($value, $address->getData($key), 'address ' . $key . ' is incorrect');
@@ -267,7 +284,7 @@ class WeeeTest extends TestCase
     }
 
     /**
-     * Test the collect function of the weee collector
+     * Test the collect function of the weee collector.
      *
      * @param array $taxConfig
      * @param array $weeeConfig
@@ -277,6 +294,8 @@ class WeeeTest extends TestCase
      * @param float $parentQty
      * @param array $addressData
      * @param bool $assertSetApplied
+     *
+     * @return void
      * @dataProvider collectDataProvider
      */
     public function testCollect(
@@ -288,8 +307,9 @@ class WeeeTest extends TestCase
         $parentQty,
         $addressData,
         $assertSetApplied = false
-    ) {
+    ): void {
         $items = [];
+
         if ($parentQty > 0) {
             $items = $this->setupParentItemWithChildrenMock($parentQty, $itemQty);
         } else {
@@ -313,42 +333,37 @@ class WeeeTest extends TestCase
 
         if ($assertSetApplied) {
             $weeeHelper
-                ->expects($this->at(1))
                 ->method('setApplied')
-                ->with(reset($items), []);
-
-            $weeeHelper
-                ->expects($this->at(2))
-                ->method('setApplied')
-                ->with(end($items), []);
-
-            $weeeHelper
-                ->expects($this->at(8))
-                ->method('setApplied')
-                ->with(end($items), [
-                    [
-                        'title' => 'Recycling Fee',
-                        'base_amount' => '10',
-                        'amount' => '10',
-                        'row_amount' => '20',
-                        'base_row_amount' => '20',
-                        'base_amount_incl_tax' => '10',
-                        'amount_incl_tax' => '10',
-                        'row_amount_incl_tax' => '20',
-                        'base_row_amount_incl_tax' => '20',
-                    ],
-                    [
-                        'title' => 'FPT Fee',
-                        'base_amount' => '5',
-                        'amount' => '5',
-                        'row_amount' => '10',
-                        'base_row_amount' => '10',
-                        'base_amount_incl_tax' => '5',
-                        'amount_incl_tax' => '5',
-                        'row_amount_incl_tax' => '10',
-                        'base_row_amount_incl_tax' => '10',
+                ->withConsecutive(
+                    [reset($items), []],
+                    [end($items), []],
+                    [end($items),
+                        [
+                            [
+                                'title' => 'Recycling Fee',
+                                'base_amount' => '10',
+                                'amount' => '10',
+                                'row_amount' => '20',
+                                'base_row_amount' => '20',
+                                'base_amount_incl_tax' => '10',
+                                'amount_incl_tax' => '10',
+                                'row_amount_incl_tax' => '20',
+                                'base_row_amount_incl_tax' => '20'
+                            ],
+                            [
+                                'title' => 'FPT Fee',
+                                'base_amount' => '5',
+                                'amount' => '5',
+                                'row_amount' => '10',
+                                'base_row_amount' => '10',
+                                'base_amount_incl_tax' => '5',
+                                'amount_incl_tax' => '5',
+                                'row_amount_incl_tax' => '10',
+                                'base_row_amount_incl_tax' => '10'
+                            ]
+                        ]
                     ]
-                ]);
+                );
         }
 
         $arguments = [
@@ -375,7 +390,7 @@ class WeeeTest extends TestCase
      *
      * @return array
      */
-    public function collectDataProvider()
+    public function collectDataProvider(): array
     {
         $data = [];
 
@@ -386,7 +401,7 @@ class WeeeTest extends TestCase
         $data['price_incl_tax_weee_taxable_unit_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => true,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -397,14 +412,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -414,20 +429,20 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
             'address_data' => [
                 'subtotal_incl_tax' => 20,
-                'base_subtotal_incl_tax' => 20,
-            ],
+                'base_subtotal_incl_tax' => 20
+            ]
         ];
 
         $data['price_incl_tax_weee_taxable_unit_not_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => true,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -440,12 +455,12 @@ class WeeeTest extends TestCase
                             'name' => 'Recycling Fee',
                             'amount' => 10,
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -455,20 +470,20 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
             'address_data' => [
                 'subtotal_incl_tax' => 20,
-                'base_subtotal_incl_tax' => 20,
-            ],
+                'base_subtotal_incl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_taxable_unit_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -479,14 +494,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -496,20 +511,20 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
             'address_data' => [
                 'subtotal_incl_tax' => 20,
-                'base_subtotal_incl_tax' => 20,
-            ],
+                'base_subtotal_incl_tax' => 20
+            ]
         ];
 
         $data['price_incl_tax_weee_non_taxable_unit_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => true,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -520,14 +535,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -537,7 +552,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
@@ -545,14 +560,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 20,
                 'base_subtotal_incl_tax' => 20,
                 'weee_total_excl_tax' => 20,
-                'weee_base_total_excl_tax' => 20,
-            ],
+                'weee_base_total_excl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_non_taxable_unit_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -563,14 +578,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -580,7 +595,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
@@ -588,14 +603,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 20,
                 'base_subtotal_incl_tax' => 20,
                 'weee_total_excl_tax' => 20,
-                'weee_base_total_excl_tax' => 20,
-            ],
+                'weee_base_total_excl_tax' => 20
+            ]
         ];
 
         $data['price_incl_tax_weee_taxable_row_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => true,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -606,14 +621,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -623,20 +638,20 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
             'address_data' => [
                 'subtotal_incl_tax' => 20,
-                'base_subtotal_incl_tax' => 20,
-            ],
+                'base_subtotal_incl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_taxable_row_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -647,14 +662,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -664,20 +679,20 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
             'address_data' => [
                 'subtotal_incl_tax' => 20,
-                'base_subtotal_incl_tax' => 20,
+                'base_subtotal_incl_tax' => 20
             ],
         ];
 
         $data['price_incl_tax_weee_non_taxable_row_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => true,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -688,14 +703,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -705,7 +720,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
@@ -713,14 +728,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 20,
                 'base_subtotal_incl_tax' => 20,
                 'weee_total_excl_tax' => 20,
-                'weee_base_total_excl_tax' => 20,
-            ],
+                'weee_base_total_excl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_non_taxable_row_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -731,14 +746,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -748,7 +763,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
@@ -756,14 +771,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 20,
                 'base_subtotal_incl_tax' => 20,
                 'weee_total_excl_tax' => 20,
-                'weee_base_total_excl_tax' => 20,
-            ],
+                'weee_base_total_excl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_non_taxable_row_not_included_in_subtotal'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -774,14 +789,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -791,7 +806,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 20,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 20,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 20
             ],
             'item_qty' => 2,
             'parent_qty' => 0,
@@ -799,14 +814,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 20,
                 'base_subtotal_incl_tax' => 20,
                 'weee_total_excl_tax' => 20,
-                'weee_base_total_excl_tax' => 20,
-            ],
+                'weee_base_total_excl_tax' => 20
+            ]
         ];
 
         $data['price_excl_tax_weee_taxable_unit_not_included_in_subtotal_PARENT_ITEM'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_UNIT_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -817,14 +832,14 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 10,
@@ -834,7 +849,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 10,
                 'base_weee_tax_applied_amount_incl_tax' => 10,
                 'weee_tax_applied_row_amount_incl_tax' => 60,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 60,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 60
             ],
             'item_qty' => 2,
             'parent_qty' => 3,
@@ -842,14 +857,14 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 60,
                 'base_subtotal_incl_tax' => 60,
                 'weee_total_excl_tax' => 0,
-                'weee_base_total_excl_tax' => 0,
-            ],
+                'weee_base_total_excl_tax' => 0
+            ]
         ];
 
         $data['price_excl_tax_weee_non_taxable_row_not_included_in_subtotal_dynamic_multiple_weee'] = [
             'tax_config' => [
                 'priceIncludesTax' => false,
-                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE,
+                'getCalculationAlgorithm' => Calculation::CALC_ROW_BASE
             ],
             'weee_config' => [
                 'isEnabled' => true,
@@ -860,20 +875,20 @@ class WeeeTest extends TestCase
                     new DataObject(
                         [
                             'name' => 'Recycling Fee',
-                            'amount' => 10,
+                            'amount' => 10
                         ]
                     ),
                     new DataObject(
                         [
                             'name' => 'FPT Fee',
-                            'amount' => 5,
+                            'amount' => 5
                         ]
-                    ),
-                ],
+                    )
+                ]
             ],
             'tax_rates' => [
                 'store_tax_rate' => 8.25,
-                'customer_tax_rate' => 8.25,
+                'customer_tax_rate' => 8.25
             ],
             'item' => [
                 'weee_tax_applied_amount' => 15,
@@ -883,7 +898,7 @@ class WeeeTest extends TestCase
                 'weee_tax_applied_amount_incl_tax' => 15,
                 'base_weee_tax_applied_amount_incl_tax' => 15,
                 'weee_tax_applied_row_amount_incl_tax' => 30,
-                'base_weee_tax_applied_row_amnt_incl_tax' => 30,
+                'base_weee_tax_applied_row_amnt_incl_tax' => 30
             ],
             'item_qty' => 2,
             'item_is_parent' => true,
@@ -891,9 +906,9 @@ class WeeeTest extends TestCase
                 'subtotal_incl_tax' => 30,
                 'base_subtotal_incl_tax' => 30,
                 'weee_total_excl_tax' => 30,
-                'weee_base_total_excl_tax' => 30,
+                'weee_base_total_excl_tax' => 30
             ],
-            'assertSetApplied' => true,
+            'assertSetApplied' => true
         ];
 
         return $data;

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -159,7 +159,7 @@ class CartTest extends TestCase
     private $cookieMetadataFactoryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/CartTest.php
@@ -159,14 +159,15 @@ class CartTest extends TestCase
     private $cookieMetadataFactoryMock;
 
     /**
+     * @inheirtDoc
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
     {
-        $this->wishlistProviderMock = $this->getMockBuilder(
-            WishlistProviderInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(['getWishlist'])
+        $this->wishlistProviderMock = $this->getMockBuilder(WishlistProviderInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getWishlist'])
             ->getMockForAbstractClass();
 
         $this->quantityProcessorMock = $this->getMockBuilder(LocaleQuantityProcessor::class)
@@ -175,17 +176,18 @@ class CartTest extends TestCase
 
         $this->itemFactoryMock = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->checkoutCartMock = $this->getMockBuilder(CheckoutCart::class)
             ->disableOriginalConstructor()
-            ->setMethods(['save', 'getQuote', 'getShouldRedirectToCart', 'getCartUrl'])
+            ->onlyMethods(['save', 'getQuote'])
+            ->addMethods(['getShouldRedirectToCart', 'getCartUrl'])
             ->getMock();
 
         $this->optionFactoryMock = $this->getMockBuilder(OptionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->productHelperMock = $this->getMockBuilder(ProductHelper::class)
@@ -202,7 +204,8 @@ class CartTest extends TestCase
 
         $this->requestMock = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParams', 'getParam', 'isAjax', 'getPostValue'])
+            ->onlyMethods(['getParams', 'getParam'])
+            ->addMethods(['isAjax', 'getPostValue'])
             ->getMockForAbstractClass();
 
         $this->redirectMock = $this->getMockBuilder(RedirectInterface::class)
@@ -215,12 +218,12 @@ class CartTest extends TestCase
 
         $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccessMessage'])
+            ->onlyMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
         $this->urlMock = $this->getMockBuilder(UrlInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getUrl'])
+            ->onlyMethods(['getUrl'])
             ->getMockForAbstractClass();
         $this->cartHelperMock = $this->getMockBuilder(CartHelper::class)
             ->disableOriginalConstructor()
@@ -277,7 +280,7 @@ class CartTest extends TestCase
 
         $this->cookieMetadataFactoryMock = $this->getMockBuilder(CookieMetadataFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['createPublicCookieMetadata'])
+            ->onlyMethods(['createPublicCookieMetadata'])
             ->getMock();
         $this->cookieMetadataFactoryMock->expects($this->any())
             ->method('createPublicCookieMetadata')
@@ -312,7 +315,10 @@ class CartTest extends TestCase
         );
     }
 
-    public function testExecuteWithInvalidFormKey()
+    /**
+     * @return void
+     */
+    public function testExecuteWithInvalidFormKey(): void
     {
         $this->formKeyValidator->expects($this->once())
             ->method('validate')
@@ -327,7 +333,10 @@ class CartTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->model->execute());
     }
 
-    public function testExecuteWithNoItem()
+    /**
+     * @return void
+     */
+    public function testExecuteWithNoItem(): void
     {
         $itemId = false;
 
@@ -363,7 +372,10 @@ class CartTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->model->execute());
     }
 
-    public function testExecuteWithNoWishlist()
+    /**
+     * @return void
+     */
+    public function testExecuteWithNoWishlist(): void
     {
         $itemId = 2;
         $wishlistId = 1;
@@ -375,7 +387,8 @@ class CartTest extends TestCase
 
         $itemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'getId', 'getWishlistId'])
+            ->onlyMethods(['load', 'getId'])
+            ->addMethods(['getWishlistId'])
             ->getMock();
 
         $this->requestMock->expects($this->once())
@@ -409,7 +422,10 @@ class CartTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->model->execute());
     }
 
-    public function testExecuteWithQuantityArray()
+    /**
+     * @return void
+     */
+    public function testExecuteWithQuantityArray(): void
     {
         $refererUrl = $this->prepareExecuteWithQuantityArray();
 
@@ -426,7 +442,10 @@ class CartTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->model->execute());
     }
 
-    public function testExecuteWithQuantityArrayAjax()
+    /**
+     * @return void
+     */
+    public function testExecuteWithQuantityArrayAjax(): void
     {
         $refererUrl = $this->prepareExecuteWithQuantityArray(true);
 
@@ -445,10 +464,11 @@ class CartTest extends TestCase
 
     /**
      * @param bool $isAjax
-     * @return array
+     *
+     * @return string
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    protected function prepareExecuteWithQuantityArray($isAjax = false)
+    protected function prepareExecuteWithQuantityArray($isAjax = false): string
     {
         $itemId = 2;
         $wishlistId = 1;
@@ -461,28 +481,22 @@ class CartTest extends TestCase
         $params = ['item' => $itemId, 'qty' => $qty];
         $refererUrl = 'referer_url';
 
-        $itemMock = $this->getMockBuilder(Item::class)
-            ->disableOriginalConstructor()
-            ->setMethods(
+        $itemMock = $this->getMockBuilder(Item::class)->disableOriginalConstructor()
+            ->onlyMethods(
                 [
                     'load',
                     'getId',
-                    'getWishlistId',
                     'setQty',
                     'setOptions',
                     'getBuyRequest',
                     'mergeBuyRequest',
                     'addToCart',
-                    'getProduct',
-                    'getProductId',
+                    'getProduct'
                 ]
             )
+            ->addMethods(['getWishlistId', 'getProductId'])
             ->getMock();
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('item', null)
-            ->willReturn($itemId);
         $this->itemFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($itemMock);
@@ -507,10 +521,10 @@ class CartTest extends TestCase
             ->with($wishlistId)
             ->willReturn($wishlistMock);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getParam')
-            ->with('qty', null)
-            ->willReturn($qty);
+            ->withConsecutive(['item', null], ['qty', null])
+            ->willReturnOnConsecutiveCalls($itemId, $qty);
 
         $this->quantityProcessorMock->expects($this->once())
             ->method('process')
@@ -522,19 +536,17 @@ class CartTest extends TestCase
             ->with($qty[$itemId])
             ->willReturnSelf();
 
-        $this->urlMock->expects($this->at(0))
-            ->method('getUrl')
-            ->with('*/*', null)
-            ->willReturn($indexUrl);
-
         $itemMock->expects($this->once())
             ->method('getProductId')
             ->willReturn($productId);
 
-        $this->urlMock->expects($this->at(1))
+        $this->urlMock
             ->method('getUrl')
-            ->with('*/*/configure/', ['id' => $itemId, 'product_id' => $productId])
-            ->willReturn($configureUrl);
+            ->withConsecutive(
+                ['*/*', null],
+                ['*/*/configure/', ['id' => $itemId, 'product_id' => $productId]]
+            )
+            ->willReturnOnConsecutiveCalls($indexUrl, $configureUrl);
 
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
@@ -600,7 +612,8 @@ class CartTest extends TestCase
 
         $quoteMock = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getHasError', 'collectTotals'])
+            ->onlyMethods(['collectTotals'])
+            ->addMethods(['getHasError'])
             ->getMock();
 
         $this->checkoutCartMock->expects($this->exactly(2))
@@ -651,9 +664,11 @@ class CartTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecuteWithoutQuantityArrayAndOutOfStock()
+    public function testExecuteWithoutQuantityArrayAndOutOfStock(): void
     {
         $itemId = 2;
         $wishlistId = 1;
@@ -671,26 +686,21 @@ class CartTest extends TestCase
 
         $itemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'load',
                     'getId',
-                    'getWishlistId',
                     'setQty',
                     'setOptions',
                     'getBuyRequest',
                     'mergeBuyRequest',
                     'addToCart',
-                    'getProduct',
-                    'getProductId',
+                    'getProduct'
                 ]
             )
+            ->addMethods(['getWishlistId', 'getProductId'])
             ->getMock();
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('item', null)
-            ->willReturn($itemId);
         $this->itemFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($itemMock);
@@ -715,10 +725,10 @@ class CartTest extends TestCase
             ->with($wishlistId)
             ->willReturn($wishlistMock);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getParam')
-            ->with('qty', null)
-            ->willReturn($qty);
+            ->withConsecutive(['item', null], ['qty', null])
+            ->willReturnOnConsecutiveCalls($itemId, $qty);
 
         $this->quantityProcessorMock->expects($this->once())
             ->method('process')
@@ -730,19 +740,17 @@ class CartTest extends TestCase
             ->with(1)
             ->willReturnSelf();
 
-        $this->urlMock->expects($this->at(0))
-            ->method('getUrl')
-            ->with('*/*', null)
-            ->willReturn($indexUrl);
-
         $itemMock->expects($this->once())
             ->method('getProductId')
             ->willReturn($productId);
 
-        $this->urlMock->expects($this->at(1))
+        $this->urlMock
             ->method('getUrl')
-            ->with('*/*/configure/', ['id' => $itemId, 'product_id' => $productId])
-            ->willReturn($configureUrl);
+            ->withConsecutive(
+                ['*/*', null],
+                ['*/*/configure/', ['id' => $itemId, 'product_id' => $productId]]
+            )
+            ->willReturnOnConsecutiveCalls($indexUrl, $configureUrl);
 
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
@@ -817,9 +825,11 @@ class CartTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecuteWithoutQuantityArrayAndConfigurable()
+    public function testExecuteWithoutQuantityArrayAndConfigurable(): void
     {
         $itemId = 2;
         $wishlistId = 1;
@@ -837,26 +847,21 @@ class CartTest extends TestCase
 
         $itemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'load',
                     'getId',
-                    'getWishlistId',
                     'setQty',
                     'setOptions',
                     'getBuyRequest',
                     'mergeBuyRequest',
                     'addToCart',
-                    'getProduct',
-                    'getProductId',
+                    'getProduct'
                 ]
             )
+            ->addMethods(['getWishlistId', 'getProductId'])
             ->getMock();
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('item', null)
-            ->willReturn($itemId);
         $this->itemFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($itemMock);
@@ -881,10 +886,10 @@ class CartTest extends TestCase
             ->with($wishlistId)
             ->willReturn($wishlistMock);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getParam')
-            ->with('qty', null)
-            ->willReturn($qty);
+            ->withConsecutive(['item', null], ['qty', null])
+            ->willReturnOnConsecutiveCalls($itemId, $qty);
 
         $this->quantityProcessorMock->expects($this->once())
             ->method('process')
@@ -896,19 +901,17 @@ class CartTest extends TestCase
             ->with(1)
             ->willReturnSelf();
 
-        $this->urlMock->expects($this->at(0))
-            ->method('getUrl')
-            ->with('*/*', null)
-            ->willReturn($indexUrl);
-
         $itemMock->expects($this->once())
             ->method('getProductId')
             ->willReturn($productId);
 
-        $this->urlMock->expects($this->at(1))
+        $this->urlMock
             ->method('getUrl')
-            ->with('*/*/configure/', ['id' => $itemId, 'product_id' => $productId])
-            ->willReturn($configureUrl);
+            ->withConsecutive(
+                ['*/*', null],
+                ['*/*/configure/', ['id' => $itemId, 'product_id' => $productId]]
+            )
+            ->willReturnOnConsecutiveCalls($indexUrl, $configureUrl);
 
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
@@ -983,9 +986,11 @@ class CartTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecuteWithEditQuantity()
+    public function testExecuteWithEditQuantity(): void
     {
         $itemId = 2;
         $wishlistId = 1;
@@ -1004,26 +1009,21 @@ class CartTest extends TestCase
 
         $itemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'load',
                     'getId',
-                    'getWishlistId',
                     'setQty',
                     'setOptions',
                     'getBuyRequest',
                     'mergeBuyRequest',
                     'addToCart',
-                    'getProduct',
-                    'getProductId',
+                    'getProduct'
                 ]
             )
+            ->addMethods(['getWishlistId', 'getProductId'])
             ->getMock();
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('item', null)
-            ->willReturn($itemId);
         $this->itemFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($itemMock);
@@ -1048,10 +1048,10 @@ class CartTest extends TestCase
             ->with($wishlistId)
             ->willReturn($wishlistMock);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getParam')
-            ->with('qty', null)
-            ->willReturn($qty);
+            ->withConsecutive(['item', null], ['qty', null])
+            ->willReturnOnConsecutiveCalls($itemId, $qty);
 
         $this->requestMock->expects($this->once())
             ->method('getPostValue')
@@ -1068,19 +1068,17 @@ class CartTest extends TestCase
             ->with($postQty)
             ->willReturnSelf();
 
-        $this->urlMock->expects($this->at(0))
-            ->method('getUrl')
-            ->with('*/*', null)
-            ->willReturn($indexUrl);
-
         $itemMock->expects($this->once())
             ->method('getProductId')
             ->willReturn($productId);
 
-        $this->urlMock->expects($this->at(1))
+        $this->urlMock
             ->method('getUrl')
-            ->with('*/*/configure/', ['id' => $itemId, 'product_id' => $productId])
-            ->willReturn($configureUrl);
+            ->withConsecutive(
+                ['*/*', null],
+                ['*/*/configure/', ['id' => $itemId, 'product_id' => $productId]]
+            )
+            ->willReturnOnConsecutiveCalls($indexUrl, $configureUrl);
 
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
@@ -83,7 +83,7 @@ class RemoveTest extends TestCase
     protected $formKeyValidator;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -112,7 +112,7 @@ class RemoveTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc 
      */
     protected function tearDown(): void
     {

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/RemoveTest.php
@@ -24,6 +24,8 @@ use Magento\Wishlist\Model\Item;
 use Magento\Wishlist\Model\Wishlist;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Magento\Framework\Controller\Result\Redirect as ResultRedirect;
+use Magento\Framework\Event\Manager as EventManager;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -71,7 +73,7 @@ class RemoveTest extends TestCase
     protected $resultFactoryMock;
 
     /**
-     * @var \Magento\Framework\Controller\Result\Redirect|MockObject
+     * @var ResultRedirect|MockObject
      */
     protected $resultRedirectMock;
 
@@ -80,6 +82,9 @@ class RemoveTest extends TestCase
      */
     protected $formKeyValidator;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->context = $this->createMock(Context::class);
@@ -92,7 +97,7 @@ class RemoveTest extends TestCase
         $this->resultFactoryMock = $this->getMockBuilder(ResultFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->resultRedirectMock = $this->getMockBuilder(\Magento\Framework\Controller\Result\Redirect::class)
+        $this->resultRedirectMock = $this->getMockBuilder(ResultRedirect::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -106,6 +111,9 @@ class RemoveTest extends TestCase
             ->getMock();
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         unset(
@@ -119,9 +127,12 @@ class RemoveTest extends TestCase
         );
     }
 
-    protected function prepareContext()
+    /**
+     * @return void
+     */
+    protected function prepareContext(): void
     {
-        $eventManager = $this->createMock(\Magento\Framework\Event\Manager::class);
+        $eventManager = $this->createMock(EventManager::class);
         $actionFlag = $this->createMock(ActionFlag::class);
 
         $this->context
@@ -160,7 +171,7 @@ class RemoveTest extends TestCase
     /**
      * @return Remove
      */
-    public function getController()
+    public function getController(): Remove
     {
         $this->prepareContext();
 
@@ -176,7 +187,10 @@ class RemoveTest extends TestCase
         );
     }
 
-    public function testExecuteWithInvalidFormKey()
+    /**
+     * @return void
+     */
+    public function testExecuteWithInvalidFormKey(): void
     {
         $this->prepareContext();
 
@@ -199,7 +213,10 @@ class RemoveTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $controller->execute());
     }
 
-    public function testExecuteWithoutItem()
+    /**
+     * @return void
+     */
+    public function testExecuteWithoutItem(): void
     {
         $this->expectException('Magento\Framework\Exception\NotFoundException');
         $item = $this->createMock(Item::class);
@@ -228,7 +245,10 @@ class RemoveTest extends TestCase
         $this->getController()->execute();
     }
 
-    public function testExecuteWithoutWishlist()
+    /**
+     * @return void
+     */
+    public function testExecuteWithoutWishlist(): void
     {
         $this->expectException('Magento\Framework\Exception\NotFoundException');
         $item = $this->createMock(Item::class);
@@ -248,7 +268,6 @@ class RemoveTest extends TestCase
             ->willReturn(2);
 
         $this->request
-            ->expects($this->at(0))
             ->method('getParam')
             ->with('item')
             ->willReturn(1);
@@ -268,7 +287,10 @@ class RemoveTest extends TestCase
         $this->getController()->execute();
     }
 
-    public function testExecuteCanNotSaveWishlist()
+    /**
+     * @return void
+     */
+    public function testExecuteCanNotSaveWishlist(): void
     {
         $referer = 'http://referer-url.com';
 
@@ -351,7 +373,10 @@ class RemoveTest extends TestCase
         $this->assertSame($this->resultRedirectMock, $this->getController()->execute());
     }
 
-    public function testExecuteCanNotSaveWishlistAndWithRedirect()
+    /**
+     * @return void
+     */
+    public function testExecuteCanNotSaveWishlistAndWithRedirect(): void
     {
         $referer = 'http://referer-url.com';
 

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
@@ -9,6 +9,7 @@ namespace Magento\Wishlist\Test\Unit\Controller\Index;
 
 use Magento\Captcha\Helper\Data as CaptchaHelper;
 use Magento\Captcha\Model\DefaultModel as CaptchaModel;
+use Magento\Customer\Model\Customer;
 use Magento\Customer\Model\Data\Customer as CustomerData;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Action\Context as ActionContext;
@@ -37,67 +38,103 @@ use PHPUnit\Framework\TestCase;
  */
 class SendTest extends TestCase
 {
-    /** @var  Send|MockObject */
+    /**
+     * @var  Send|MockObject
+     */
     protected $model;
 
-    /** @var  ActionContext|MockObject */
+    /**
+     * @var  ActionContext|MockObject
+     */
     protected $context;
 
-    /** @var  FormKeyValidator|MockObject */
+    /**
+     * @var  FormKeyValidator|MockObject
+     */
     protected $formKeyValidator;
 
-    /** @var  WishlistProviderInterface|MockObject */
+    /**
+     * @var  WishlistProviderInterface|MockObject
+     */
     protected $wishlistProvider;
 
-    /** @var  Store|MockObject */
+    /**
+     * @var  Store|MockObject
+     */
     protected $store;
 
-    /** @var  ResultFactory|MockObject */
+    /**
+     * @var  ResultFactory|MockObject
+     */
     protected $resultFactory;
 
-    /** @var  ResultRedirect|MockObject */
+    /**
+     * @var  ResultRedirect|MockObject
+     */
     protected $resultRedirect;
 
-    /** @var  ResultLayout|MockObject */
+    /**
+     * @var  ResultLayout|MockObject
+     */
     protected $resultLayout;
 
-    /** @var  RequestInterface|MockObject */
+    /**
+     * @var  RequestInterface|MockObject
+     */
     protected $request;
 
-    /** @var  ManagerInterface|MockObject */
+    /**
+     * @var  ManagerInterface|MockObject
+     */
     protected $messageManager;
 
-    /** @var  CustomerData|MockObject */
+    /**
+     * @var  CustomerData|MockObject
+     */
     protected $customerData;
 
-    /** @var  UrlInterface|MockObject */
+    /**
+     * @var  UrlInterface|MockObject
+     */
     protected $url;
 
-    /** @var  TransportInterface|MockObject */
+    /**
+     * @var  TransportInterface|MockObject
+     */
     protected $transport;
 
-    /** @var  EventManagerInterface|MockObject */
+    /**
+     * @var  EventManagerInterface|MockObject
+     */
     protected $eventManager;
 
-    /** @var  CaptchaHelper|MockObject */
+    /**
+     * @var  CaptchaHelper|MockObject
+     */
     protected $captchaHelper;
 
-    /** @var CaptchaModel|MockObject */
+    /**
+     * @var CaptchaModel|MockObject
+     */
     protected $captchaModel;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $customerSession;
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
     {
-        $this->resultRedirect = $this->getMockBuilder(\Magento\Framework\Controller\Result\Redirect::class)
+        $this->resultRedirect = $this->getMockBuilder(ResultRedirect::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->resultLayout = $this->getMockBuilder(\Magento\Framework\View\Result\Layout::class)
+        $this->resultLayout = $this->getMockBuilder(ResultLayout::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -112,22 +149,19 @@ class SendTest extends TestCase
             ]);
 
         $this->request = $this->getMockBuilder(RequestInterface::class)
-            ->setMethods([
-                'getPost',
-                'getPostValue'
-            ])
+            ->addMethods(['getPost', 'getPostValue'])
             ->getMockForAbstractClass();
 
-        $this->messageManager = $this->getMockBuilder(\Magento\Framework\Message\ManagerInterface::class)
+        $this->messageManager = $this->getMockBuilder(ManagerInterface::class)
             ->getMockForAbstractClass();
 
         $this->url = $this->getMockBuilder(UrlInterface::class)
             ->getMockForAbstractClass();
 
-        $this->eventManager = $this->getMockBuilder(\Magento\Framework\Event\ManagerInterface::class)
+        $this->eventManager = $this->getMockBuilder(EventManagerInterface::class)
             ->getMockForAbstractClass();
 
-        $this->context = $this->getMockBuilder(\Magento\Framework\App\Action\Context::class)
+        $this->context = $this->getMockBuilder(ActionContext::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->context->expects($this->any())
@@ -146,16 +180,14 @@ class SendTest extends TestCase
             ->method('getEventManager')
             ->willReturn($this->eventManager);
 
-        $this->formKeyValidator = $this->getMockBuilder(\Magento\Framework\Data\Form\FormKey\Validator::class)
+        $this->formKeyValidator = $this->getMockBuilder(FormKeyValidator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $customerMock = $this->getMockBuilder(\Magento\Customer\Model\Customer::class)
+        $customerMock = $this->getMockBuilder(Customer::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'getEmail',
-                'getId'
-            ])
+            ->onlyMethods(['getId'])
+            ->addMethods(['getEmail'])
             ->getMock();
 
         $customerMock->expects($this->any())
@@ -168,10 +200,7 @@ class SendTest extends TestCase
 
         $this->customerSession = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'getCustomer',
-                'getData'
-            ])
+            ->onlyMethods(['getCustomer', 'getData'])
             ->getMock();
 
         $this->customerSession->expects($this->any())
@@ -187,17 +216,12 @@ class SendTest extends TestCase
 
         $this->captchaHelper = $this->getMockBuilder(CaptchaHelper::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'getCaptcha'
-            ])
+            ->onlyMethods(['getCaptcha'])
             ->getMock();
 
         $this->captchaModel = $this->getMockBuilder(CaptchaModel::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'isRequired',
-                'logAttempt'
-            ])
+            ->onlyMethods(['isRequired', 'logAttempt'])
             ->getMock();
 
         $objectHelper = new ObjectManager($this);
@@ -253,13 +277,11 @@ class SendTest extends TestCase
             ->with($this->request)
             ->willReturn(true);
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getPost')
-            ->with('emails')
-            ->willReturn('some.Email@gmail.com', 'some.email2@gmail.com');
-        $this->request->expects($this->at(1))
-            ->method('getPost')
-            ->with('message');
+            ->withConsecutive(['emails'], ['message'])
+            ->willReturnOnConsecutiveCalls('some.email2@gmail.com');
+
         $wishlist = $this->createMock(Wishlist::class);
         $this->wishlistProvider->expects($this->once())
             ->method('getWishlist')
@@ -276,9 +298,11 @@ class SendTest extends TestCase
     }
 
     /**
-     * Execute method with no wishlist available
+     * Execute method with no wishlist available.
+     *
+     * @return void
      */
-    public function testExecuteNoWishlistAvailable()
+    public function testExecuteNoWishlistAvailable(): void
     {
         $this->formKeyValidator->expects($this->once())
             ->method('validate')

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/SendTest.php
@@ -124,7 +124,7 @@ class SendTest extends TestCase
     protected $customerSession;
 
     /**
-     * @return void
+     * @inheritdoc
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */

--- a/app/code/Magento/Wishlist/Test/Unit/Helper/RssTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Helper/RssTest.php
@@ -74,7 +74,7 @@ class RssTest extends TestCase
     protected $scopeConfigMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Wishlist/Test/Unit/Helper/RssTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Helper/RssTest.php
@@ -73,11 +73,14 @@ class RssTest extends TestCase
      */
     protected $scopeConfigMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->wishlistFactoryMock = $this->getMockBuilder(WishlistFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->requestMock = $this->getMockBuilder(RequestInterface::class)
@@ -88,7 +91,7 @@ class RssTest extends TestCase
 
         $this->customerFactoryMock = $this->getMockBuilder(CustomerInterfaceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->customerSessionMock = $this->getMockBuilder(Session::class)
@@ -117,12 +120,15 @@ class RssTest extends TestCase
                 'customerSession' => $this->customerSessionMock,
                 'customerRepository' => $this->customerRepositoryMock,
                 'moduleManager' => $this->moduleManagerMock,
-                'scopeConfig' => $this->scopeConfigMock,
+                'scopeConfig' => $this->scopeConfigMock
             ]
         );
     }
 
-    public function testGetWishlistWithWishlistId()
+    /**
+     * @return void
+     */
+    public function testGetWishlistWithWishlistId(): void
     {
         $wishlistId = 1;
 
@@ -148,7 +154,10 @@ class RssTest extends TestCase
         $this->assertSame($wishlist, $this->model->getWishlist());
     }
 
-    public function testGetWishlistWithCustomerId()
+    /**
+     * @return void
+     */
+    public function testGetWishlistWithCustomerId(): void
     {
         $customerId = 1;
         $data = $customerId . ',2';
@@ -160,19 +169,14 @@ class RssTest extends TestCase
             ->method('create')
             ->willReturn($wishlist);
 
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with('wishlist_id', null)
-            ->willReturn('');
-
         $this->urlDecoderMock->expects($this->any())
             ->method('decode')
             ->willReturnArgument(0);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getParam')
-            ->with('data', null)
-            ->willReturn($data);
+            ->withConsecutive(['wishlist_id', null], ['data', null])
+            ->willReturnOnConsecutiveCalls('', $data);
 
         $this->customerSessionMock->expects($this->once())
             ->method('getCustomerId')
@@ -200,7 +204,10 @@ class RssTest extends TestCase
         $this->assertEquals($wishlist, $this->model->getWishlist());
     }
 
-    public function testGetCustomerWithSession()
+    /**
+     * @return void
+     */
+    public function testGetCustomerWithSession(): void
     {
         $customerId = 1;
         $data = $customerId . ',2';
@@ -239,10 +246,15 @@ class RssTest extends TestCase
      * @param bool $isModuleEnabled
      * @param bool $isWishlistActive
      * @param bool $result
+     *
+     * @return void
      * @dataProvider dataProviderIsRssAllow
      */
-    public function testIsRssAllow($isModuleEnabled, $isWishlistActive, $result)
-    {
+    public function testIsRssAllow(
+        bool $isModuleEnabled,
+        bool $isWishlistActive,
+        bool $result
+    ): void {
         $this->moduleManagerMock->expects($this->once())
             ->method('isEnabled')
             ->with('Magento_Rss')
@@ -259,13 +271,13 @@ class RssTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderIsRssAllow()
+    public function dataProviderIsRssAllow(): array
     {
         return [
             [false, false, false],
             [true, false, false],
             [false, true, false],
-            [true, true, true],
+            [true, true, true]
         ];
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -84,7 +84,7 @@ class ItemCarrierTest extends TestCase
     protected $redirectMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/ItemCarrierTest.php
@@ -7,7 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\Wishlist\Test\Unit\Model;
 
+use Exception;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Exception as ProductException;
+use Magento\Checkout\Helper\Cart as HelperCart;
 use Magento\Checkout\Model\Cart;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\Response\RedirectInterface;
@@ -30,36 +33,59 @@ use Psr\Log\LoggerInterface;
  */
 class ItemCarrierTest extends TestCase
 {
-    /** @var ItemCarrier */
+    /**
+     * @var ItemCarrier
+     */
     protected $model;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $sessionMock;
 
-    /** @var LocaleQuantityProcessor|MockObject */
+    /**
+     * @var LocaleQuantityProcessor|MockObject
+     */
     protected $quantityProcessorMock;
 
-    /** @var Cart|MockObject */
+    /**
+     * @var Cart|MockObject
+     */
     protected $cartMock;
 
-    /** @var LoggerInterface|MockObject */
+    /**
+     * @var LoggerInterface|MockObject
+     */
     protected $loggerMock;
 
-    /** @var Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $wishlistHelperMock;
 
-    /** @var \Magento\Checkout\Helper\Cart|MockObject */
+    /**
+     * @var HelperCart|MockObject
+     */
     protected $cartHelperMock;
 
-    /** @var UrlInterface|MockObject */
+    /**
+     * @var UrlInterface|MockObject
+     */
     protected $urlBuilderMock;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     protected $managerMock;
 
-    /** @var RedirectInterface|MockObject */
+    /**
+     * @var RedirectInterface|MockObject
+     */
     protected $redirectMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->sessionMock = $this->getMockBuilder(Session::class)
@@ -76,7 +102,7 @@ class ItemCarrierTest extends TestCase
         $this->wishlistHelperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->cartHelperMock = $this->getMockBuilder(\Magento\Checkout\Helper\Cart::class)
+        $this->cartHelperMock = $this->getMockBuilder(HelperCart::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->urlBuilderMock = $this->getMockBuilder(UrlInterface::class)
@@ -100,9 +126,11 @@ class ItemCarrierTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testMoveAllToCart()
+    public function testMoveAllToCart(): void
     {
         $wishlistId = 7;
         $sessionCustomerId = 23;
@@ -117,23 +145,45 @@ class ItemCarrierTest extends TestCase
 
         /** @var Item|MockObject $itemOneMock */
         $itemOneMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Item|MockObject $itemTwoMock */
         $itemTwoMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var Product|MockObject $productOneMock */
         $productOneMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Product|MockObject $productTwoMock */
         $productTwoMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -275,9 +325,11 @@ class ItemCarrierTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testMoveAllToCartWithNotSalableAndOptions()
+    public function testMoveAllToCartWithNotSalableAndOptions(): void
     {
         $sessionCustomerId = 23;
         $itemOneId = 14;
@@ -292,23 +344,45 @@ class ItemCarrierTest extends TestCase
 
         /** @var Item|MockObject $itemOneMock */
         $itemOneMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Item|MockObject $itemTwoMock */
         $itemTwoMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var Product|MockObject $productOneMock */
         $productOneMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Product|MockObject $productTwoMock */
         $productTwoMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -323,7 +397,8 @@ class ItemCarrierTest extends TestCase
 
         /** @var Wishlist|MockObject $wishlistMock */
         $wishlistMock = $this->getMockBuilder(Wishlist::class)
-            ->setMethods(['isOwner', 'getItemCollection', 'getId', 'getSharingCode', 'save'])
+            ->onlyMethods(['isOwner', 'getItemCollection', 'getId', 'save'])
+            ->addMethods(['getSharingCode'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -379,7 +454,7 @@ class ItemCarrierTest extends TestCase
             ->willReturnMap(
                 [
                     [$qtys[$itemOneId], $qtys[$itemOneId]],
-                    [$qtys[$itemTwoId], $qtys[$itemTwoId]],
+                    [$qtys[$itemTwoId], $qtys[$itemTwoId]]
                 ]
             );
         $itemOneMock->expects($this->once())
@@ -394,7 +469,7 @@ class ItemCarrierTest extends TestCase
         $itemOneMock->expects($this->once())
             ->method('addToCart')
             ->with($this->cartMock, $isOwner)
-            ->willThrowException(new \Magento\Catalog\Model\Product\Exception(__('Product Exception.')));
+            ->willThrowException(new ProductException(__('Product Exception.')));
         $itemTwoMock->expects($this->once())
             ->method('addToCart')
             ->with($this->cartMock, $isOwner)
@@ -409,8 +484,8 @@ class ItemCarrierTest extends TestCase
             ->method('getQuote')
             ->willReturn($quoteMock);
 
-        /** @var \Magento\Quote\Model\Quote\Item|MockObject $collectionMock */
-        $itemMock = $this->getMockBuilder(\Magento\Quote\Model\Quote\Item::class)
+        /** @var Quote\Item|MockObject $collectionMock */
+        $itemMock = $this->getMockBuilder(Quote\Item::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -448,20 +523,13 @@ class ItemCarrierTest extends TestCase
             ->method('getName')
             ->willReturn($productTwoName);
 
-        $this->managerMock->expects($this->at(0))
+        $this->managerMock
             ->method('addErrorMessage')
-            ->with(__('%1 for "%2".', 'Localized Exception', $productTwoName), null)
-            ->willReturnSelf();
-
-        $this->managerMock->expects($this->at(1))
-            ->method('addErrorMessage')
-            ->with(
-                __(
-                    'We couldn\'t add the following product(s) to the shopping cart: %1.',
-                    '"' . $productOneName . '"'
-                ),
-                null
-            )->willReturnSelf();
+            ->withConsecutive([__('%1 for "%2".', 'Localized Exception', $productTwoName), null], [__(
+                'We couldn\'t add the following product(s) to the shopping cart: %1.',
+                '"' . $productOneName . '"'
+            ), null])
+            ->willReturnOnConsecutiveCalls($this->managerMock, $this->managerMock);
 
         $this->wishlistHelperMock->expects($this->once())
             ->method('calculate')
@@ -471,9 +539,11 @@ class ItemCarrierTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testMoveAllToCartWithException()
+    public function testMoveAllToCartWithException(): void
     {
         $wishlistId = 7;
         $sessionCustomerId = 23;
@@ -487,23 +557,45 @@ class ItemCarrierTest extends TestCase
 
         /** @var Item|MockObject $itemOneMock */
         $itemOneMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Item|MockObject $itemTwoMock */
         $itemTwoMock = $this->getMockBuilder(Item::class)
-            ->setMethods(['getProduct', 'unsProduct', 'getId', 'setQty', 'addToCart', 'delete', 'getProductUrl'])
+            ->onlyMethods(
+                [
+                    'getProduct',
+                    'getId',
+                    'setQty',
+                    'addToCart',
+                    'delete',
+                    'getProductUrl'
+                ]
+            )
+            ->addMethods(['unsProduct'])
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var Product|MockObject $productOneMock */
         $productOneMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var Product|MockObject $productTwoMock */
         $productTwoMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['getDisableAddToCart', 'setDisableAddToCart', 'getName'])
+            ->onlyMethods(['getName'])
+            ->addMethods(['getDisableAddToCart', 'setDisableAddToCart'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -587,7 +679,7 @@ class ItemCarrierTest extends TestCase
             ->with($this->cartMock, $isOwner)
             ->willReturn(true);
 
-        $exception = new \Exception('Exception.');
+        $exception = new Exception('Exception.');
         $itemTwoMock->expects($this->once())
             ->method('addToCart')
             ->with($this->cartMock, $isOwner)
@@ -596,11 +688,6 @@ class ItemCarrierTest extends TestCase
         $this->loggerMock->expects($this->once())
             ->method('critical')
             ->with($exception, []);
-
-        $this->managerMock->expects($this->at(0))
-            ->method('addErrorMessage')
-            ->with(__('We can\'t add this item to your shopping cart right now.'), null)
-            ->willReturnSelf();
 
         $this->wishlistHelperMock->expects($this->once())
             ->method('getListUrl')
@@ -618,12 +705,15 @@ class ItemCarrierTest extends TestCase
 
         $wishlistMock->expects($this->once())
             ->method('save')
-            ->willThrowException(new \Exception());
+            ->willThrowException(new Exception());
 
-        $this->managerMock->expects($this->at(1))
+        $this->managerMock
             ->method('addErrorMessage')
-            ->with(__('We can\'t update the Wish List right now.'), null)
-            ->willReturnSelf();
+            ->withConsecutive(
+                [__('We can\'t add this item to your shopping cart right now.'), null],
+                [__('We can\'t update the Wish List right now.'), null]
+            )
+            ->willReturnOnConsecutiveCalls($this->managerMock, $this->managerMock);
 
         $productOneMock->expects($this->any())
             ->method('getName')

--- a/lib/internal/Magento/Framework/Acl/Test/Unit/Loader/ResourceLoaderTest.php
+++ b/lib/internal/Magento/Framework/Acl/Test/Unit/Loader/ResourceLoaderTest.php
@@ -17,23 +17,27 @@ use PHPUnit\Framework\TestCase;
 class ResourceLoaderTest extends TestCase
 {
     /**
-     * Test for \Magento\Framework\Acl\Loader\ResourceLoader::populateAcl
+     * Test for ResourceLoader::populateAcl
+     *
+     * @return void
      */
-    public function testPopulateAclOnValidObjects()
+    public function testPopulateAclOnValidObjects(): void
     {
-        /** @var $aclResource \Magento\Framework\Acl\AclResource */
+        /** @var $aclResource AclResource */
         $aclResource = $this->createMock(AclResource::class);
 
         /** @var Acl $acl */
         $acl = $this->createPartialMock(Acl::class, ['addResource']);
         $acl->expects($this->exactly(2))->method('addResource');
-        $acl->expects($this->at(0))->method('addResource')->with($aclResource, null)->willReturnSelf();
-        $acl->expects($this->at(1))->method('addResource')->with($aclResource, $aclResource)->willReturnSelf();
+        $acl
+            ->method('addResource')
+            ->withConsecutive([$aclResource, null], [$aclResource, $aclResource])
+            ->willReturnOnConsecutiveCalls($acl, $acl);
 
         $factoryObject = $this->createPartialMock(AclResourceFactory::class, ['createResource']);
         $factoryObject->expects($this->any())->method('createResource')->willReturn($aclResource);
 
-        /** @var $resourceProvider \Magento\Framework\Acl\AclResource\ProviderInterface */
+        /** @var $resourceProvider ProviderInterface */
         $resourceProvider = $this->getMockForAbstractClass(ProviderInterface::class);
         $resourceProvider->expects($this->once())
             ->method('getAclResources')
@@ -48,37 +52,38 @@ class ResourceLoaderTest extends TestCase
                                 'id' => 'child_resource::id',
                                 'title' => 'Child Resource Title',
                                 'sortOrder' => 10,
-                                'children' => [],
-                            ],
-                        ],
-                    ],
+                                'children' => []
+                            ]
+                        ]
+                    ]
                 ]
             );
 
-        /** @var $loaderResource \Magento\Framework\Acl\Loader\ResourceLoader */
         $loaderResource = new ResourceLoader($resourceProvider, $factoryObject);
 
         $loaderResource->populateAcl($acl);
     }
 
     /**
-     * Test for \Magento\Framework\Acl\Loader\ResourceLoader::populateAcl
+     * Test for ResourceLoader::populateAcl
+     *
+     * @return void
      */
-    public function testPopulateAclWithException()
+    public function testPopulateAclWithException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Missing ACL resource identifier');
-        /** @var $aclResource \Magento\Framework\Acl\AclResource */
+        /** @var $aclResource AclResource */
         $aclResource = $this->createMock(AclResource::class);
 
         $factoryObject = $this->getMockBuilder(AclResourceFactory::class)
-            ->setMethods(['createResource'])
+            ->onlyMethods(['createResource'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $factoryObject->expects($this->any())->method('createResource')->willReturn($aclResource);
 
-        /** @var $resourceProvider \Magento\Framework\Acl\AclResource\ProviderInterface */
+        /** @var $resourceProvider ProviderInterface */
         $resourceProvider = $this->getMockForAbstractClass(ProviderInterface::class);
         $resourceProvider->expects($this->once())
             ->method('getAclResources')
@@ -92,17 +97,16 @@ class ResourceLoaderTest extends TestCase
                                 'id' => 'child_resource::id',
                                 'title' => 'Child Resource Title',
                                 'sortOrder' => 10,
-                                'children' => [],
-                            ],
-                        ],
-                    ],
+                                'children' => []
+                            ]
+                        ]
+                    ]
                 ]
             );
 
         /** @var Acl $acl */
         $acl = $this->createPartialMock(Acl::class, ['addResource']);
 
-        /** @var $loaderResource \Magento\Framework\Acl\Loader\ResourceLoader */
         $loaderResource = new ResourceLoader($resourceProvider, $factoryObject);
 
         $loaderResource->populateAcl($acl);

--- a/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
@@ -73,7 +73,7 @@ class DataObjectHelperTest extends TestCase
     protected $joinProcessorMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
@@ -72,6 +72,9 @@ class DataObjectHelperTest extends TestCase
      */
     protected $joinProcessorMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -89,7 +92,7 @@ class DataObjectHelperTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->joinProcessorMock = $this->getMockBuilder(JoinProcessor::class)
-            ->setMethods(['extractExtensionAttributes'])
+            ->onlyMethods(['extractExtensionAttributes'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->joinProcessorMock->expects($this->any())
@@ -109,7 +112,10 @@ class DataObjectHelperTest extends TestCase
         );
     }
 
-    public function testPopulateWithArrayWithSimpleAttributes()
+    /**
+     * @return void
+     */
+    public function testPopulateWithArrayWithSimpleAttributes(): void
     {
         $id = 5;
         $countryId = 15;
@@ -122,17 +128,13 @@ class DataObjectHelperTest extends TestCase
         /** @var Address $addressDataObject */
         $addressDataObject = $this->objectManager->getObject(
             Address::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
 
         /** @var Region $regionDataObject */
         $regionDataObject = $this->objectManager->getObject(
             Region::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
         $data = [
             'id' => $id,
@@ -141,18 +143,14 @@ class DataObjectHelperTest extends TestCase
             'default_shipping' => $isDefaultShipping,
             'region' => [
                 'region_id' => $regionId,
-                'region' => $region,
+                'region' => $region
             ],
         ];
 
-        $this->methodsMapProcessor->expects($this->at(0))
+        $this->methodsMapProcessor
             ->method('getMethodReturnType')
-            ->with(AddressInterface::class, 'getStreet')
-            ->willReturn('string[]');
-        $this->methodsMapProcessor->expects($this->at(1))
-            ->method('getMethodReturnType')
-            ->with(AddressInterface::class, 'getRegion')
-            ->willReturn(RegionInterface::class);
+            ->withConsecutive([AddressInterface::class, 'getStreet'], [AddressInterface::class, 'getRegion'])
+            ->willReturnOnConsecutiveCalls('string[]', RegionInterface::class);
         $this->objectFactoryMock->expects($this->once())
             ->method('create')
             ->with(RegionInterface::class, [])
@@ -172,7 +170,10 @@ class DataObjectHelperTest extends TestCase
         $this->assertEquals($regionId, $addressDataObject->getRegion()->getRegionId());
     }
 
-    public function testPopulateWithArrayWithCustomAttribute()
+    /**
+     * @return void
+     */
+    public function testPopulateWithArrayWithCustomAttribute(): void
     {
         $id = 5;
 
@@ -200,7 +201,7 @@ class DataObjectHelperTest extends TestCase
             [
                 'dataObjectHelper' => $this->dataObjectHelper,
                 'metadataService' => $metadataServiceMock,
-                'attributeValueFactory' => $this->attributeValueFactoryMock,
+                'attributeValueFactory' => $this->attributeValueFactoryMock
             ]
         );
 
@@ -230,7 +231,10 @@ class DataObjectHelperTest extends TestCase
         );
     }
 
-    public function testPopulateWithArrayWithCustomAttributes()
+    /**
+     * @return void
+     */
+    public function testPopulateWithArrayWithCustomAttributes(): void
     {
         $id = 5;
 
@@ -258,7 +262,7 @@ class DataObjectHelperTest extends TestCase
             [
                 'dataObjectHelper' => $this->dataObjectHelper,
                 'metadataService' => $metadataServiceMock,
-                'attributeValueFactory' => $this->attributeValueFactoryMock,
+                'attributeValueFactory' => $this->attributeValueFactoryMock
             ]
         );
 
@@ -267,7 +271,7 @@ class DataObjectHelperTest extends TestCase
             CustomAttributesDataInterface::CUSTOM_ATTRIBUTES => [
                 [
                     AttributeInterface::ATTRIBUTE_CODE => $customAttributeCode,
-                    AttributeInterface::VALUE => $customAttributeValue,
+                    AttributeInterface::VALUE => $customAttributeValue
                 ],
             ],
         ];
@@ -296,24 +300,22 @@ class DataObjectHelperTest extends TestCase
     /**
      * @param array $data1
      * @param array $data2
+     *
+     * @return void
      * @dataProvider dataProviderForTestMergeDataObjects
      */
-    public function testMergeDataObjects($data1, $data2)
+    public function testMergeDataObjects($data1, $data2): void
     {
         /** @var Address $addressDataObject */
         $firstAddressDataObject = $this->objectManager->getObject(
             Address::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
 
         /** @var Region $regionDataObject */
         $firstRegionDataObject = $this->objectManager->getObject(
             Region::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
 
         $firstRegionDataObject->setRegionId($data1['region']['region_id']);
@@ -330,17 +332,13 @@ class DataObjectHelperTest extends TestCase
 
         $secondAddressDataObject = $this->objectManager->getObject(
             Address::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
 
         /** @var Region $regionDataObject */
         $secondRegionDataObject = $this->objectManager->getObject(
             Region::class,
-            [
-                'dataObjectHelper' => $this->dataObjectHelper,
-            ]
+            ['dataObjectHelper' => $this->dataObjectHelper]
         );
 
         $secondRegionDataObject->setRegionId($data2['region']['region_id']);
@@ -359,14 +357,10 @@ class DataObjectHelperTest extends TestCase
             ->method('buildOutputDataArray')
             ->with($secondAddressDataObject, get_class($firstAddressDataObject))
             ->willReturn($data2);
-        $this->methodsMapProcessor->expects($this->at(0))
+        $this->methodsMapProcessor
             ->method('getMethodReturnType')
-            ->with(Address::class, 'getStreet')
-            ->willReturn('string[]');
-        $this->methodsMapProcessor->expects($this->at(1))
-            ->method('getMethodReturnType')
-            ->with(Address::class, 'getRegion')
-            ->willReturn(RegionInterface::class);
+            ->withConsecutive([Address::class, 'getStreet'], [Address::class, 'getRegion'])
+            ->willReturnOnConsecutiveCalls('string[]', RegionInterface::class);
         $this->objectFactoryMock->expects($this->once())
             ->method('create')
             ->with(RegionInterface::class, [])
@@ -388,7 +382,7 @@ class DataObjectHelperTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestMergeDataObjects()
+    public function dataProviderForTestMergeDataObjects(): array
     {
         return [
             [
@@ -399,7 +393,7 @@ class DataObjectHelperTest extends TestCase
                     'default_shipping' => true,
                     'region' => [
                         'region_id' => '1',
-                        'region' => 'TX',
+                        'region' => 'TX'
                     ]
                 ],
                 [
@@ -409,7 +403,7 @@ class DataObjectHelperTest extends TestCase
                     'default_shipping' => false,
                     'region' => [
                         'region_id' => '2',
-                        'region' => 'TX',
+                        'region' => 'TX'
                     ]
                 ]
             ],
@@ -419,7 +413,7 @@ class DataObjectHelperTest extends TestCase
                     'default_shipping' => true,
                     'region' => [
                         'region_id' => '1',
-                        'region' => 'TX',
+                        'region' => 'TX'
                     ]
                 ],
                 [
@@ -429,7 +423,7 @@ class DataObjectHelperTest extends TestCase
                     'default_shipping' => false,
                     'region' => [
                         'region_id' => '2',
-                        'region' => 'TX',
+                        'region' => 'TX'
                     ]
                 ]
             ]

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
@@ -33,7 +33,7 @@ class PoolTest extends TestCase
     protected $_frontendInstances = [];
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/PoolTest.php
@@ -32,12 +32,15 @@ class PoolTest extends TestCase
      */
     protected $_frontendInstances = [];
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_frontendInstances = [
             Pool::DEFAULT_FRONTEND_ID => $this->getMockForAbstractClass(FrontendInterface::class),
             'resource1' => $this->getMockForAbstractClass(FrontendInterface::class),
-            'resource2' => $this->getMockForAbstractClass(FrontendInterface::class),
+            'resource2' => $this->getMockForAbstractClass(FrontendInterface::class)
         ];
 
         $frontendFactoryMap = [
@@ -46,25 +49,20 @@ class PoolTest extends TestCase
                 $this->_frontendInstances[Pool::DEFAULT_FRONTEND_ID],
             ],
             [['r1d1' => 'value1', 'r1d2' => 'value2'], $this->_frontendInstances['resource1']],
-            [['r2d1' => 'value1', 'r2d2' => 'value2'], $this->_frontendInstances['resource2']],
+            [['r2d1' => 'value1', 'r2d2' => 'value2'], $this->_frontendInstances['resource2']]
         ];
         $frontendFactory = $this->createMock(Factory::class);
         $frontendFactory->expects($this->any())->method('create')->willReturnMap($frontendFactoryMap);
 
         $deploymentConfig = $this->createMock(DeploymentConfig::class);
-        $deploymentConfig->expects(
-            $this->any()
-        )->method(
-            'getConfigData'
-        )->with(
-            FrontendPool::KEY_CACHE
-        )->willReturn(
-            ['frontend' => ['resource2' => ['r2d1' => 'value1', 'r2d2' => 'value2']]]
-        );
+        $deploymentConfig->expects($this->any())
+            ->method('getConfigData')
+            ->with(FrontendPool::KEY_CACHE)
+            ->willReturn(['frontend' => ['resource2' => ['r2d1' => 'value1', 'r2d2' => 'value2']]]);
 
         $frontendSettings = [
             Pool::DEFAULT_FRONTEND_ID => ['data1' => 'value1', 'data2' => 'value2'],
-            'resource1' => ['r1d1' => 'value1', 'r1d2' => 'value2'],
+            'resource1' => ['r1d1' => 'value1', 'r1d2' => 'value2']
         ];
 
         $this->_model = new Pool(
@@ -75,9 +73,11 @@ class PoolTest extends TestCase
     }
 
     /**
-     * Test that constructor delays object initialization (does not perform any initialization of its own)
+     * Test that constructor delays object initialization (does not perform any initialization of its own).
+     *
+     * @return void
      */
-    public function testConstructorNoInitialization()
+    public function testConstructorNoInitialization(): void
     {
         $deploymentConfig = $this->createMock(DeploymentConfig::class);
         $frontendFactory = $this->createMock(Factory::class);
@@ -96,20 +96,17 @@ class PoolTest extends TestCase
         array $fixtureCacheConfig,
         array $frontendSettings,
         array $expectedFactoryArg
-    ) {
+    ): void {
         $deploymentConfig = $this->createMock(DeploymentConfig::class);
-        $deploymentConfig->expects(
-            $this->once()
-        )->method(
-            'getConfigData'
-        )->with(
-            FrontendPool::KEY_CACHE
-        )->willReturn(
-            $fixtureCacheConfig
-        );
+        $deploymentConfig->expects($this->once())
+            ->method('getConfigData')
+            ->with(FrontendPool::KEY_CACHE)
+            ->willReturn($fixtureCacheConfig);
 
         $frontendFactory = $this->createMock(Factory::class);
-        $frontendFactory->expects($this->at(0))->method('create')->with($expectedFactoryArg);
+        $frontendFactory
+            ->method('create')
+            ->withConsecutive([$expectedFactoryArg]);
 
         $model = new Pool($deploymentConfig, $frontendFactory, $frontendSettings);
         $model->current();
@@ -118,23 +115,23 @@ class PoolTest extends TestCase
     /**
      * @return array
      */
-    public function initializationParamsDataProvider()
+    public function initializationParamsDataProvider(): array
     {
         return [
             'no deployment config, default settings' => [
                 ['frontend' => []],
                 [Pool::DEFAULT_FRONTEND_ID => ['default_option' => 'default_value']],
-                ['default_option' => 'default_value'],
+                ['default_option' => 'default_value']
             ],
             'deployment config, default settings' => [
                 ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
                 [Pool::DEFAULT_FRONTEND_ID => ['default_option' => 'default_value']],
-                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value']
             ],
             'deployment config, overridden settings' => [
                 ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
                 [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'default_value']],
-                ['configured_option' => 'configured_value'],
+                ['configured_option' => 'configured_value']
             ],
             'deployment config, default settings, overridden settings' => [
                 ['frontend' => [Pool::DEFAULT_FRONTEND_ID => ['configured_option' => 'configured_value']]],
@@ -147,27 +144,36 @@ class PoolTest extends TestCase
             'custom deployent config, default settings' => [
                 ['frontend' => ['custom' => ['configured_option' => 'configured_value']]],
                 ['custom' => ['default_option' => 'default_value']],
-                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value']
             ],
             'custom deployent config, default settings, overridden settings' => [
                 ['frontend' => ['custom' => ['configured_option' => 'configured_value']]],
                 ['custom' => ['default_option' => 'default_value', 'configured_option' => 'default_value']],
-                ['configured_option' => 'configured_value', 'default_option' => 'default_value'],
+                ['configured_option' => 'configured_value', 'default_option' => 'default_value']
             ]
         ];
     }
 
-    public function testCurrent()
+    /**
+     * @return void
+     */
+    public function testCurrent(): void
     {
         $this->assertSame($this->_frontendInstances[Pool::DEFAULT_FRONTEND_ID], $this->_model->current());
     }
 
-    public function testKey()
+    /**
+     * @return void
+     */
+    public function testKey(): void
     {
         $this->assertEquals(Pool::DEFAULT_FRONTEND_ID, $this->_model->key());
     }
 
-    public function testNext()
+    /**
+     * @return void
+     */
+    public function testNext(): void
     {
         $this->assertEquals(Pool::DEFAULT_FRONTEND_ID, $this->_model->key());
 
@@ -184,7 +190,10 @@ class PoolTest extends TestCase
         $this->assertFalse($this->_model->current());
     }
 
-    public function testRewind()
+    /**
+     * @return void
+     */
+    public function testRewind(): void
     {
         $this->_model->next();
         $this->assertNotEquals(Pool::DEFAULT_FRONTEND_ID, $this->_model->key());
@@ -193,7 +202,10 @@ class PoolTest extends TestCase
         $this->assertEquals(Pool::DEFAULT_FRONTEND_ID, $this->_model->key());
     }
 
-    public function testValid()
+    /**
+     * @return void
+     */
+    public function testValid(): void
     {
         $this->assertTrue($this->_model->valid());
 
@@ -208,14 +220,20 @@ class PoolTest extends TestCase
         $this->assertTrue($this->_model->valid());
     }
 
-    public function testGet()
+    /**
+     * @return void
+     */
+    public function testGet(): void
     {
         foreach ($this->_frontendInstances as $frontendId => $frontendInstance) {
             $this->assertSame($frontendInstance, $this->_model->get($frontendId));
         }
     }
 
-    public function testFallbackOnDefault()
+    /**
+     * @return void
+     */
+    public function testFallbackOnDefault(): void
     {
         $this->assertSame($this->_frontendInstances[Pool::DEFAULT_FRONTEND_ID], $this->_model->get('unknown'));
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/AccessProxyTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/AccessProxyTest.php
@@ -20,17 +20,21 @@ class AccessProxyTest extends TestCase
      * @param array $params
      * @param bool $disabledResult
      * @param mixed $enabledResult
+     *
+     * @return void
      * @dataProvider proxyMethodDataProvider
      */
-    public function testProxyMethod($method, $params, $disabledResult, $enabledResult)
+    public function testProxyMethod($method, $params, $disabledResult, $enabledResult): void
     {
         $identifier = 'cache_type_identifier';
 
         $frontendMock = $this->getMockForAbstractClass(FrontendInterface::class);
 
         $cacheEnabler = $this->getMockForAbstractClass(StateInterface::class);
-        $cacheEnabler->expects($this->at(0))->method('isEnabled')->with($identifier)->willReturn(false);
-        $cacheEnabler->expects($this->at(1))->method('isEnabled')->with($identifier)->willReturn(true);
+        $cacheEnabler
+            ->method('isEnabled')
+            ->withConsecutive([$identifier], [$identifier])
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $object = new AccessProxy($frontendMock, $cacheEnabler, $identifier);
         $helper = new ProxyTesting();
@@ -47,7 +51,7 @@ class AccessProxyTest extends TestCase
     /**
      * @return array
      */
-    public static function proxyMethodDataProvider()
+    public static function proxyMethodDataProvider(): array
     {
         return [
             ['test', ['record_id'], false, 111],

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/ConfigTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/ConfigTest.php
@@ -27,6 +27,9 @@ class ConfigTest extends TestCase
      */
     protected $frontendMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $cacheFrontendPoolMock = $this->getMockBuilder(FrontendPool::class)
@@ -47,9 +50,11 @@ class ConfigTest extends TestCase
      * @param string $method
      * @param array $params
      * @param mixed $expectedResult
+     *
+     * @return void
      * @dataProvider proxyMethodDataProvider
      */
-    public function testProxyMethod($method, $params, $expectedResult)
+    public function testProxyMethod($method, $params, $expectedResult): void
     {
         $helper = new ProxyTesting();
         $result = $helper->invokeWithExpectations($this->model, $this->frontendMock, $method, $params, $expectedResult);
@@ -59,18 +64,18 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function proxyMethodDataProvider()
+    public function proxyMethodDataProvider(): array
     {
         return [
             ['test', ['record_id'], 111],
             ['load', ['record_id'], '111'],
             ['remove', ['record_id'], true],
             ['getBackend', [], $this->createMock(\Zend_Cache_Backend::class)],
-            ['getLowLevelFrontend', [], $this->createMock(\Zend_Cache_Core::class)],
+            ['getLowLevelFrontend', [], $this->createMock(\Zend_Cache_Core::class)]
         ];
     }
 
-    public function testSave()
+    public function testSave(): void
     {
         $expectedResult = new \stdClass();
         $this->frontendMock->expects(
@@ -89,7 +94,7 @@ class ConfigTest extends TestCase
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    public function testCleanModeAll()
+    public function testCleanModeAll(): void
     {
         $expectedResult = new \stdClass();
         $this->frontendMock->expects(
@@ -109,7 +114,7 @@ class ConfigTest extends TestCase
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    public function testCleanModeMatchingTag()
+    public function testCleanModeMatchingTag(): void
     {
         $expectedResult = new \stdClass();
         $this->frontendMock->expects(
@@ -135,28 +140,12 @@ class ConfigTest extends TestCase
      * @param bool $expectedResult
      * @dataProvider cleanModeMatchingAnyTagDataProvider
      */
-    public function testCleanModeMatchingAnyTag($fixtureResultOne, $fixtureResultTwo, $expectedResult)
+    public function testCleanModeMatchingAnyTag($fixtureResultOne, $fixtureResultTwo, $expectedResult): void
     {
-        $this->frontendMock->expects(
-            $this->at(0)
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['test_tag_one', Config::CACHE_TAG]
-        )->willReturn(
-            $fixtureResultOne
-        );
-        $this->frontendMock->expects(
-            $this->at(1)
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['test_tag_two', Config::CACHE_TAG]
-        )->willReturn(
-            $fixtureResultTwo
-        );
+        $this->frontendMock
+            ->method('clean')
+            ->withConsecutive([\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['test_tag_one', Config::CACHE_TAG]], [\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['test_tag_two', Config::CACHE_TAG]])
+            ->willReturnOnConsecutiveCalls($fixtureResultOne, $fixtureResultTwo);
         $actualResult = $this->model->clean(
             \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
             ['test_tag_one', 'test_tag_two']
@@ -167,7 +156,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function cleanModeMatchingAnyTagDataProvider()
+    public function cleanModeMatchingAnyTagDataProvider(): array
     {
         return [
             'failure, failure' => [false, false, false],

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/ConfigTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Type/ConfigTest.php
@@ -28,7 +28,7 @@ class ConfigTest extends TestCase
     protected $frontendMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
@@ -61,7 +61,7 @@ class ReaderTest extends TestCase
     protected $domFactoryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
@@ -60,6 +60,9 @@ class ReaderTest extends TestCase
      */
     protected $domFactoryMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         if (!function_exists('libxml_set_external_entity_loader')) {
@@ -77,18 +80,22 @@ class ReaderTest extends TestCase
         $this->domFactoryMock = $this->createMock(DomFactory::class);
     }
 
-    public function testConstructor()
+    /**
+     * @return void
+     */
+    public function testConstructor(): void
     {
         $this->createModelAndVerifyConstructor();
     }
 
     /**
-     * @covers \Magento\Framework\App\Config\Initial\Reader::read
+     * @return void
+     * @covers Reader::read
      */
-    public function testReadNoFiles()
+    public function testReadNoFiles(): void
     {
         $this->createModelAndVerifyConstructor();
-        $this->fileResolverMock->expects($this->at(0))
+        $this->fileResolverMock
             ->method('get')
             ->with('config.xml', 'global')
             ->willReturn([]);
@@ -97,9 +104,10 @@ class ReaderTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\App\Config\Initial\Reader::read
+     * @return void
+     * @covers Reader::read
      */
-    public function testReadValidConfig()
+    public function testReadValidConfig(): void
     {
         $this->createModelAndVerifyConstructor();
         $this->prepareDomFactoryMock();
@@ -109,7 +117,7 @@ class ReaderTest extends TestCase
         ];
         $expectedConfig = ['data' => [], 'metadata' => []];
 
-        $this->fileResolverMock->expects($this->at(0))
+        $this->fileResolverMock
             ->method('get')
             ->with('config.xml', 'global')
             ->willReturn($testXmlFilesList);
@@ -121,8 +129,10 @@ class ReaderTest extends TestCase
 
         $this->assertEquals($expectedConfig, $this->model->read());
     }
-
-    private function prepareDomFactoryMock()
+    /**
+     * @return void
+     */
+    private function prepareDomFactoryMock(): void
     {
         $validationStateMock = $this->validationStateMock;
         $this->domFactoryMock->expects($this->once())
@@ -141,9 +151,10 @@ class ReaderTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\App\Config\Initial\Reader::read
+     * @return void
+     * @covers Reader::read
      */
-    public function testReadInvalidConfig()
+    public function testReadInvalidConfig(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Verify the XML and try again.');
@@ -155,7 +166,7 @@ class ReaderTest extends TestCase
         ];
         $expectedConfig = ['data' => [], 'metadata' => []];
 
-        $this->fileResolverMock->expects($this->at(0))
+        $this->fileResolverMock
             ->method('get')
             ->with('config.xml', 'global')
             ->willReturn($testXmlFilesList);
@@ -168,7 +179,10 @@ class ReaderTest extends TestCase
         $this->model->read();
     }
 
-    private function createModelAndVerifyConstructor()
+    /**
+     * @return void
+     */
+    private function createModelAndVerifyConstructor(): void
     {
         $schemaFile = $this->filePath . 'config.xsd';
         $this->schemaLocatorMock->expects($this->once())->method('getSchema')->willReturn($schemaFile);

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/Initial/ReaderTest.php
@@ -90,7 +90,7 @@ class ReaderTest extends TestCase
 
     /**
      * @return void
-     * @covers Reader::read
+     * @covers \Magento\Framework\App\Config\Initial\Reader::read
      */
     public function testReadNoFiles(): void
     {
@@ -105,7 +105,7 @@ class ReaderTest extends TestCase
 
     /**
      * @return void
-     * @covers Reader::read
+     * @covers \Magento\Framework\App\Config\Initial\Reader::read
      */
     public function testReadValidConfig(): void
     {
@@ -152,7 +152,7 @@ class ReaderTest extends TestCase
 
     /**
      * @return void
-     * @covers Reader::read
+     * @covers \Magento\Framework\App\Config\Initial\Reader::read
      */
     public function testReadInvalidConfig(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/ValueTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/ValueTest.php
@@ -38,7 +38,7 @@ class ValueTest extends TestCase
     protected $cacheTypeListMock;
 
     /**
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -62,18 +62,12 @@ class ValueTest extends TestCase
     /**
      * @return void
      */
-    public function testGetOldValue()
+    public function testGetOldValue(): void
     {
-        $this->configMock->expects(
-            $this->once()
-        )->method(
-            'getValue'
-        )->with(
-            null,
-            'default'
-        )->willReturn(
-            'old_value'
-        );
+        $this->configMock->expects($this->once())
+            ->method('getValue')
+            ->with(null, 'default')
+            ->willReturn('old_value');
 
         $this->assertEquals('old_value', $this->model->getOldValue());
     }
@@ -82,20 +76,16 @@ class ValueTest extends TestCase
      * @param string $oldValue
      * @param string $value
      * @param bool $result
+     *
+     * @return void
      * @dataProvider dataIsValueChanged
      */
-    public function testIsValueChanged($oldValue, $value, $result)
+    public function testIsValueChanged($oldValue, $value, $result): void
     {
-        $this->configMock->expects(
-            $this->once()
-        )->method(
-            'getValue'
-        )->with(
-            null,
-            'default'
-        )->willReturn(
-            $oldValue
-        );
+        $this->configMock->expects($this->once())
+            ->method('getValue')
+            ->with(null, 'default')
+            ->willReturn($oldValue);
 
         $this->model->setValue($value);
 
@@ -105,38 +95,34 @@ class ValueTest extends TestCase
     /**
      * @return array
      */
-    public function dataIsValueChanged()
+    public function dataIsValueChanged(): array
     {
         return [
             ['value', 'value', false],
-            ['value', 'new_value', true],
+            ['value', 'new_value', true]
         ];
     }
 
     /**
      * @return void
      */
-    public function testAfterLoad()
+    public function testAfterLoad(): void
     {
-        $this->eventManagerMock->expects(
-            $this->at(0)
-        )->method(
-            'dispatch'
-        )->with(
-            'model_load_after',
-            ['object' => $this->model]
-        );
-        $this->eventManagerMock->expects(
-            $this->at(1)
-        )->method(
-            'dispatch'
-        )->with(
-            'config_data_load_after',
-            [
-                'data_object' => $this->model,
-                'config_data' => $this->model,
-            ]
-        );
+        $this->eventManagerMock
+            ->method('dispatch')
+            ->withConsecutive(
+                [
+                    'model_load_after',
+                    ['object' => $this->model]
+                ],
+                [
+                    'config_data_load_after',
+                    [
+                        'data_object' => $this->model,
+                        'config_data' => $this->model
+                    ]
+                ]
+            );
 
         $this->model->afterLoad();
     }
@@ -145,10 +131,11 @@ class ValueTest extends TestCase
      * @param mixed $fieldsetData
      * @param string $key
      * @param string $result
-     * @dataProvider dataProviderGetFieldsetDataValue
+     *
      * @return void
+     * @dataProvider dataProviderGetFieldsetDataValue
      */
-    public function testGetFieldsetDataValue($fieldsetData, $key, $result)
+    public function testGetFieldsetDataValue($fieldsetData, $key, $result): void
     {
         $this->model->setData('fieldset_data', $fieldsetData);
         $this->assertEquals($result, $this->model->getFieldsetDataValue($key));
@@ -157,33 +144,35 @@ class ValueTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderGetFieldsetDataValue()
+    public function dataProviderGetFieldsetDataValue(): array
     {
         return [
             [
                 ['key' => 'value'],
                 'key',
-                'value',
+                'value'
             ],
             [
                 ['key' => 'value'],
                 'none',
-                null,
+                null
             ],
             [
                 'value',
                 'key',
-                null,
-            ],
+                null
+            ]
         ];
     }
 
     /**
      * @param int $callNumber
      * @param string $oldValue
+     *
+     * @return void
      * @dataProvider afterSaveDataProvider
      */
-    public function testAfterSave($callNumber, $oldValue)
+    public function testAfterSave($callNumber, $oldValue): void
     {
         $this->cacheTypeListMock->expects($this->exactly($callNumber))
             ->method('invalidate');
@@ -197,18 +186,18 @@ class ValueTest extends TestCase
     /**
      * @return array
      */
-    public function afterSaveDataProvider()
+    public function afterSaveDataProvider(): array
     {
         return [
             [0, 'some_value'],
-            [1, 'other_value'],
+            [1, 'other_value']
         ];
     }
 
     /**
-     * @return void;
+     * @return void
      */
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $this->cacheTypeListMock->expects($this->once())->method('invalidate');
         $this->assertInstanceOf(get_class($this->model), $this->model->afterDelete());

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/ValueTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/ValueTest.php
@@ -38,7 +38,7 @@ class ValueTest extends TestCase
     protected $cacheTypeListMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/PageCache/IdentifierTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/PageCache/IdentifierTest.php
@@ -48,7 +48,7 @@ class IdentifierTest extends TestCase
     private $serializerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/PageCache/IdentifierTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/PageCache/IdentifierTest.php
@@ -48,7 +48,7 @@ class IdentifierTest extends TestCase
     private $serializerMock;
 
     /**
-     * @return ObjectManager
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -62,7 +62,7 @@ class IdentifierTest extends TestCase
             ->getMock();
 
         $this->serializerMock = $this->getMockBuilder(Json::class)
-            ->setMethods(['serialize'])
+            ->onlyMethods(['serialize'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->serializerMock->expects($this->any())
@@ -78,20 +78,20 @@ class IdentifierTest extends TestCase
             [
                 'request'    => $this->requestMock,
                 'context'    => $this->contextMock,
-                'serializer' => $this->serializerMock,
+                'serializer' => $this->serializerMock
             ]
         );
         parent::setUp();
     }
 
-    public function testSecureDifferentiator()
+    /**
+     * @return void
+     */
+    public function testSecureDifferentiator(): void
     {
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('isSecure')
-            ->willReturn(true);
-        $this->requestMock->expects($this->at(3))
-            ->method('isSecure')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(true, false);
         $this->requestMock->method('getUriString')
             ->willReturn('http://example.com/path/');
         $this->contextMock->method('getVaryString')->willReturn(self::VARY);
@@ -101,15 +101,15 @@ class IdentifierTest extends TestCase
         $this->assertNotEquals($valueWithSecureRequest, $valueWithInsecureRequest);
     }
 
-    public function testDomainDifferentiator()
+    /**
+     * @return void
+     */
+    public function testDomainDifferentiator(): void
     {
         $this->requestMock->method('isSecure')->willReturn(true);
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getUriString')
-            ->willReturn('http://example.com/path/');
-        $this->requestMock->expects($this->at(4))
-            ->method('getUriString')
-            ->willReturn('http://example.net/path/');
+            ->willReturnOnConsecutiveCalls('http://example.com/path/', 'http://example.net/path/');
         $this->contextMock->method('getVaryString')->willReturn(self::VARY);
 
         $valueDomain1 = $this->model->getValue();
@@ -117,15 +117,15 @@ class IdentifierTest extends TestCase
         $this->assertNotEquals($valueDomain1, $valueDomain2);
     }
 
-    public function testPathDifferentiator()
+    /**
+     * @return void
+     */
+    public function testPathDifferentiator(): void
     {
         $this->requestMock->method('isSecure')->willReturn(true);
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getUriString')
-            ->willReturn('http://example.com/path/');
-        $this->requestMock->expects($this->at(4))
-            ->method('getUriString')
-            ->willReturn('http://example.com/path1/');
+            ->willReturnOnConsecutiveCalls('http://example.com/path/', 'http://example.com/path1/');
         $this->contextMock->method('getVaryString')->willReturn(self::VARY);
 
         $valuePath1 = $this->model->getValue();
@@ -136,9 +136,10 @@ class IdentifierTest extends TestCase
     /**
      * @param $cookieExists
      *
+     * @return void
      * @dataProvider trueFalseDataProvider
      */
-    public function testVaryStringSource($cookieExists)
+    public function testVaryStringSource($cookieExists): void
     {
         $this->requestMock->method('get')->willReturn($cookieExists ? 'vary-string-from-cookie' : null);
         $this->contextMock->expects($cookieExists ? $this->never() : $this->once())->method('getVaryString');
@@ -148,15 +149,17 @@ class IdentifierTest extends TestCase
     /**
      * @return array
      */
-    public function trueFalseDataProvider()
+    public function trueFalseDataProvider(): array
     {
         return [[true], [false]];
     }
 
     /**
-     * Test get identifier value
+     * Test get identifier value.
+     *
+     * @return void
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $this->requestMock->expects($this->any())
             ->method('isSecure')

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
@@ -74,7 +74,7 @@ class HttpTest extends TestCase
     private $cookieLifeTime = 3600;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -117,7 +117,7 @@ class HttpTest extends TestCase
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Test\Unit\Response;
 
 use Magento\Framework\App\Http\Context;
+use Magento\Framework\App\ObjectManager as AppObjectManager;
+use Magento\Framework\App\Request\Http as RequestHttp;
 use Magento\Framework\App\Response\Http;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Session\Config\ConfigInterface;
@@ -19,6 +21,7 @@ use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -51,7 +54,7 @@ class HttpTest extends TestCase
     protected $dateTimeMock;
 
     /**
-     * @var \Magento\Framework\App\Request\Http|MockObject
+     * @var RequestHttp|MockObject
      */
     protected $requestMock;
 
@@ -71,22 +74,23 @@ class HttpTest extends TestCase
     private $cookieLifeTime = 3600;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
-        $this->requestMock = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
+        $this->requestMock = $this->getMockBuilder(RequestHttp::class)
+            ->onlyMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->cookieMetadataFactoryMock = $this->getMockBuilder(
-            CookieMetadataFactory::class
-        )->disableOriginalConstructor()
+        $this->cookieMetadataFactoryMock = $this->getMockBuilder(CookieMetadataFactory::class)
+            ->addMethods(['get'])
+            ->onlyMethods(['createSensitiveCookieMetadata'])
+            ->disableOriginalConstructor()
             ->getMock();
         $this->cookieManagerMock = $this->getMockForAbstractClass(CookieManagerInterface::class);
-        $this->contextMock = $this->getMockBuilder(
-            Context::class
-        )->disableOriginalConstructor()
+        $this->contextMock = $this->getMockBuilder(Context::class)
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->dateTimeMock = $this->getMockBuilder(DateTime::class)
@@ -105,7 +109,7 @@ class HttpTest extends TestCase
                 'cookieMetadataFactory' => $this->cookieMetadataFactoryMock,
                 'context' => $this->contextMock,
                 'dateTime' => $this->dateTimeMock,
-                'sessionConfig' => $this->sessionConfigMock,
+                'sessionConfig' => $this->sessionConfigMock
             ]
         );
         $this->model->headersSentThrowsException = false;
@@ -113,17 +117,20 @@ class HttpTest extends TestCase
     }
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function tearDown(): void
     {
         unset($this->model);
         /** @var ObjectManagerInterface|MockObject $objectManagerMock*/
         $objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
-        \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
+        AppObjectManager::setInstance($objectManagerMock);
     }
 
-    public function testSendVary()
+    /**
+     * @return void
+     */
+    public function testSendVary(): void
     {
         $expectedCookieName = Http::COOKIE_VARY_STRING;
         $expectedCookieValue = 'SHA1 Serialized String';
@@ -160,7 +167,10 @@ class HttpTest extends TestCase
         $this->model->sendVary();
     }
 
-    public function testSendVaryEmptyDataDeleteCookie()
+    /**
+     * @return void
+     */
+    public function testSendVaryEmptyDataDeleteCookie(): void
     {
         $expectedCookieName = Http::COOKIE_VARY_STRING;
         $cookieMetadataMock = $this->createMock(CookieMetadata::class);
@@ -182,7 +192,10 @@ class HttpTest extends TestCase
         $this->model->sendVary();
     }
 
-    public function testSendVaryEmptyData()
+    /**
+     * @return void
+     */
+    public function testSendVaryEmptyData(): void
     {
         $this->contextMock->expects($this->once())
             ->method('getVaryString')
@@ -196,9 +209,11 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test setting public cache headers
+     * Test setting public cache headers.
+     *
+     * @return void
      */
-    public function testSetPublicHeaders()
+    public function testSetPublicHeaders(): void
     {
         $ttl = 120;
         $timestamp = 1000000;
@@ -222,9 +237,11 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test for setting public headers without time to live parameter
+     * Test for setting public headers without time to live parameter.
+     *
+     * @return void
      */
-    public function testSetPublicHeadersWithoutTtl()
+    public function testSetPublicHeadersWithoutTtl(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Time to live is a mandatory parameter for set public headers');
@@ -232,9 +249,11 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test setting public cache headers
+     * Test setting public cache headers.
+     *
+     * @return void
      */
-    public function testSetPrivateHeaders()
+    public function testSetPrivateHeaders(): void
     {
         $ttl = 120;
         $timestamp = 1000000;
@@ -258,9 +277,11 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test for setting public headers without time to live parameter
+     * Test for setting public headers without time to live parameter.
+     *
+     * @return void
      */
-    public function testSetPrivateHeadersWithoutTtl()
+    public function testSetPrivateHeadersWithoutTtl(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Time to live is a mandatory parameter for set private headers');
@@ -268,9 +289,11 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test setting public cache headers
+     * Test setting public cache headers.
+     *
+     * @return void
      */
-    public function testSetNoCacheHeaders()
+    public function testSetNoCacheHeaders(): void
     {
         $timestamp = 1000000;
         $pragma = 'no-cache';
@@ -293,22 +316,27 @@ class HttpTest extends TestCase
     }
 
     /**
-     * Test setting body in JSON format
+     * Test setting body in JSON format.
+     *
+     * @return void
      */
-    public function testRepresentJson()
+    public function testRepresentJson(): void
     {
         $this->model->setHeader('Content-Type', 'text/javascript');
         $this->model->representJson('json_string');
         $this->assertEquals('application/json', $this->model->getHeader('Content-Type')->getFieldValue());
-        $this->assertEquals('json_string', $this->model->getBody('default'));
+        $this->assertEquals('json_string', $this->model->getBody());
     }
 
-    public function testWakeUpWithException()
+    /**
+     * @return void
+     */
+    public function testWakeUpWithException(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('ObjectManager isn\'t initialized');
         /* ensure that the test preconditions are met */
-        $objectManagerClass = new \ReflectionClass(\Magento\Framework\App\ObjectManager::class);
+        $objectManagerClass = new ReflectionClass(AppObjectManager::class);
         $instanceProperty = $objectManagerClass->getProperty('_instance');
         $instanceProperty->setAccessible(true);
         $instanceProperty->setValue(null);
@@ -321,25 +349,29 @@ class HttpTest extends TestCase
     /**
      * Test for the magic method __wakeup
      *
-     * @covers \Magento\Framework\App\Response\Http::__wakeup
+     * @return void
+     * @covers Http::__wakeup
      */
-    public function testWakeUpWith()
+    public function testWakeUpWith(): void
     {
-        $objectManagerMock = $this->createMock(\Magento\Framework\App\ObjectManager::class);
+        $objectManagerMock = $this->createMock(AppObjectManager::class);
         $objectManagerMock->expects($this->once())
             ->method('create')
             ->with(CookieManagerInterface::class)
             ->willReturn($this->cookieManagerMock);
-        $objectManagerMock->expects($this->at(1))
+        $this->cookieMetadataFactoryMock
             ->method('get')
             ->with(CookieMetadataFactory::class)
             ->willReturn($this->cookieMetadataFactoryMock);
 
-        \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
+        AppObjectManager::setInstance($objectManagerMock);
         $this->model->__wakeup();
     }
 
-    public function testSetXFrameOptions()
+    /**
+     * @return void
+     */
+    public function testSetXFrameOptions(): void
     {
         $value = 'DENY';
         $this->model->setXFrameOptions($value);

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/HttpTest.php
@@ -350,7 +350,7 @@ class HttpTest extends TestCase
      * Test for the magic method __wakeup
      *
      * @return void
-     * @covers Http::__wakeup
+     * @covers \Magento\Framework\App\Response\Http::__wakeup
      */
     public function testWakeUpWith(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
@@ -26,7 +26,7 @@ class NoRouteHandlerListTest extends TestCase
     protected $_model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Router/NoRouteHandlerListTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\App\Test\Unit\Router;
 
+use Magento\Backend\App\Router\NoRouteHandler as BackendNoRouteHandler;
 use Magento\Framework\App\Router\NoRouteHandler;
 use Magento\Framework\App\Router\NoRouteHandlerList;
 use Magento\Framework\ObjectManagerInterface;
@@ -24,41 +25,35 @@ class NoRouteHandlerListTest extends TestCase
      */
     protected $_model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $handlersList = [
             'default_handler' => ['class' => NoRouteHandler::class, 'sortOrder' => 100],
-            'backend_handler' => ['class' => \Magento\Backend\App\Router\NoRouteHandler::class, 'sortOrder' => 10],
+            'backend_handler' => ['class' => BackendNoRouteHandler::class, 'sortOrder' => 10],
         ];
 
         $this->_model = new NoRouteHandlerList($this->_objectManagerMock, $handlersList);
     }
 
-    public function testGetHandlers()
+    /**
+     * @return void
+     */
+    public function testGetHandlers(): void
     {
-        $backendHandlerMock = $this->createMock(\Magento\Backend\App\Router\NoRouteHandler::class);
+        $backendHandlerMock = $this->createMock(BackendNoRouteHandler::class);
         $defaultHandlerMock = $this->createMock(NoRouteHandler::class);
 
-        $this->_objectManagerMock->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            \Magento\Backend\App\Router\NoRouteHandler::class
-        )->willReturn(
-            $backendHandlerMock
-        );
-
-        $this->_objectManagerMock->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            NoRouteHandler::class
-        )->willReturn(
-            $defaultHandlerMock
-        );
+        $this->_objectManagerMock
+            ->method('create')
+            ->withConsecutive(
+                [BackendNoRouteHandler::class],
+                [NoRouteHandler::class]
+            )
+            ->willReturnOnConsecutiveCalls($backendHandlerMock, $defaultHandlerMock);
 
         $expectedResult = ['0' => $backendHandlerMock, '1' => $defaultHandlerMock];
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
@@ -31,6 +31,9 @@ class RouterListTest extends TestCase
      */
     protected $routerList;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->routerList = [
@@ -38,17 +41,20 @@ class RouterListTest extends TestCase
             'frontendRouter' => ['class' => 'FrontClass', 'disable' => false, 'sortOrder' => 10],
             'default' => ['class' => 'DefaultClass', 'disable' => false, 'sortOrder' => 5],
             'someRouter' => ['class' => 'SomeClass', 'disable' => false, 'sortOrder' => 10],
-            'anotherRouter' => ['class' => 'AnotherClass', 'disable' => false, 'sortOrder' => 15],
+            'anotherRouter' => ['class' => 'AnotherClass', 'disable' => false, 'sortOrder' => 15]
         ];
 
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->model = new RouterList($this->objectManagerMock, $this->routerList);
     }
 
-    public function testCurrent()
+    /**
+     * @return void
+     */
+    public function testCurrent(): void
     {
         $expectedClass = new DefaultClass();
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with('DefaultClass')
             ->willReturn($expectedClass);
@@ -56,10 +62,13 @@ class RouterListTest extends TestCase
         $this->assertEquals($expectedClass, $this->model->current());
     }
 
-    public function testNext()
+    /**
+     * @return void
+     */
+    public function testNext(): void
     {
         $expectedClass = new FrontClass();
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with('FrontClass')
             ->willReturn($expectedClass);
@@ -68,7 +77,10 @@ class RouterListTest extends TestCase
         $this->assertEquals($expectedClass, $this->model->current());
     }
 
-    public function testValid()
+    /**
+     * @return void
+     */
+    public function testValid(): void
     {
         $this->assertTrue($this->model->valid());
         $this->model->next();
@@ -81,20 +93,18 @@ class RouterListTest extends TestCase
         $this->assertFalse($this->model->valid());
     }
 
-    public function testRewind()
+    /**
+     * @return void
+     */
+    public function testRewind(): void
     {
         $frontClass = new FrontClass();
         $defaultClass = new DefaultClass();
 
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
-            ->with('DefaultClass')
-            ->willReturn($defaultClass);
-
-        $this->objectManagerMock->expects($this->at(1))
-            ->method('create')
-            ->with('FrontClass')
-            ->willReturn($frontClass);
+            ->withConsecutive(['DefaultClass'], ['FrontClass'])
+            ->willReturnOnConsecutiveCalls($defaultClass, $frontClass);
 
         $this->assertEquals($defaultClass, $this->model->current());
         $this->model->next();

--- a/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
@@ -32,7 +32,7 @@ class RouterListTest extends TestCase
     protected $routerList;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
@@ -73,6 +73,9 @@ class ViewTest extends TestCase
      */
     protected $response;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
@@ -84,9 +87,8 @@ class ViewTest extends TestCase
             ->willReturn($this->_layoutProcessor);
         $this->_actionFlagMock = $this->createMock(ActionFlag::class);
         $this->_eventManagerMock = $this->getMockForAbstractClass(ManagerInterface::class);
-        $pageConfigMock = $this->getMockBuilder(
-            Config::class
-        )->disableOriginalConstructor()
+        $pageConfigMock = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
             ->getMock();
         $pageConfigMock->expects($this->any())
             ->method('publicBuild')
@@ -94,25 +96,28 @@ class ViewTest extends TestCase
 
         $pageConfigRendererFactory = $this->getMockBuilder(RendererFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->resultPage = $this->getMockBuilder(Page::class)
             ->setConstructorArgs(
-                $helper->getConstructArguments(Page::class, [
-                    'request' => $this->_requestMock,
-                    'pageConfigRendererFactory' => $pageConfigRendererFactory,
-                    'layout' => $this->_layoutMock
-                ])
+                $helper->getConstructArguments(
+                    Page::class,
+                    [
+                        'request' => $this->_requestMock,
+                        'pageConfigRendererFactory' => $pageConfigRendererFactory,
+                        'layout' => $this->_layoutMock
+                    ]
+                )
             )
-            ->setMethods(['renderResult', 'getConfig'])
+            ->onlyMethods(['renderResult', 'getConfig'])
             ->getMock();
         $this->resultPage->expects($this->any())
             ->method('getConfig')
             ->willReturn($pageConfigMock);
         $pageFactory = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $pageFactory->expects($this->once())
             ->method('create')
@@ -134,12 +139,18 @@ class ViewTest extends TestCase
         );
     }
 
-    public function testGetLayout()
+    /**
+     * @return void
+     */
+    public function testGetLayout(): void
     {
         $this->assertEquals($this->_layoutMock, $this->_view->getLayout());
     }
 
-    public function testLoadLayoutWhenLayoutAlreadyLoaded()
+    /**
+     * @return void
+     */
+    public function testLoadLayoutWhenLayoutAlreadyLoaded(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Layout must be loaded only once.');
@@ -147,30 +158,38 @@ class ViewTest extends TestCase
         $this->_view->loadLayout();
     }
 
-    public function testLoadLayoutWithDefaultSetup()
+    /**
+     * @return void
+     */
+    public function testLoadLayoutWithDefaultSetup(): void
     {
-        $this->_layoutProcessor->expects($this->at(0))->method('addHandle')->with('default');
-        $this->_requestMock->expects(
-            $this->any()
-        )->method(
-            'getFullActionName'
-        )->willReturn(
-            'action_name'
-        );
+        $this->_layoutProcessor
+            ->method('addHandle')
+            ->withConsecutive(['default']);
+        $this->_requestMock->expects($this->any())->method('getFullActionName')->willReturn('action_name');
         $this->_view->loadLayout();
     }
 
-    public function testLoadLayoutWhenBlocksNotGenerated()
+    /**
+     * @return void
+     */
+    public function testLoadLayoutWhenBlocksNotGenerated(): void
     {
         $this->_view->loadLayout('', false, true);
     }
 
-    public function testLoadLayoutWhenXmlNotGenerated()
+    /**
+     * @return void
+     */
+    public function testLoadLayoutWhenXmlNotGenerated(): void
     {
         $this->_view->loadLayout('', true, false);
     }
 
-    public function testGetDefaultLayoutHandle()
+    /**
+     * @return void
+     */
+    public function testGetDefaultLayoutHandle(): void
     {
         $this->_requestMock->expects($this->once())
             ->method('getFullActionName')
@@ -179,7 +198,10 @@ class ViewTest extends TestCase
         $this->assertEquals('expectedvalue', $this->_view->getDefaultLayoutHandle());
     }
 
-    public function testAddActionLayoutHandlesWhenPageLayoutHandlesExist()
+    /**
+     * @return void
+     */
+    public function testAddActionLayoutHandlesWhenPageLayoutHandlesExist(): void
     {
         $this->_requestMock->expects($this->once())
             ->method('getFullActionName')
@@ -192,7 +214,10 @@ class ViewTest extends TestCase
         $this->_view->addActionLayoutHandles();
     }
 
-    public function testAddPageLayoutHandles()
+    /**
+     * @return void
+     */
+    public function testAddPageLayoutHandles(): void
     {
         $pageHandles = ['full_action_name', 'full_action_name_key_value'];
         $this->_requestMock->expects($this->once())
@@ -205,7 +230,10 @@ class ViewTest extends TestCase
         $this->_view->addPageLayoutHandles(['key' => 'value']);
     }
 
-    public function testGenerateLayoutBlocksWhenFlagIsNotSet()
+    /**
+     * @return void
+     */
+    public function testGenerateLayoutBlocksWhenFlagIsNotSet(): void
     {
         $valueMap = [
             ['', ActionInterface::FLAG_NO_DISPATCH_BLOCK_EVENT, false],
@@ -215,11 +243,14 @@ class ViewTest extends TestCase
         $this->_view->generateLayoutBlocks();
     }
 
-    public function testGenerateLayoutBlocksWhenFlagIsSet()
+    /**
+     * @return void
+     */
+    public function testGenerateLayoutBlocksWhenFlagIsSet(): void
     {
         $valueMap = [
             ['', ActionInterface::FLAG_NO_DISPATCH_BLOCK_EVENT, true],
-            ['', ActionInterface::FLAG_NO_DISPATCH_BLOCK_EVENT, true],
+            ['', ActionInterface::FLAG_NO_DISPATCH_BLOCK_EVENT, true]
         ];
         $this->_actionFlagMock->expects($this->any())->method('get')->willReturnMap($valueMap);
 
@@ -227,23 +258,20 @@ class ViewTest extends TestCase
         $this->_view->generateLayoutBlocks();
     }
 
-    public function testRenderLayoutIfActionFlagExist()
+    /**
+     * @return void
+     */
+    public function testRenderLayoutIfActionFlagExist(): void
     {
-        $this->_actionFlagMock->expects(
-            $this->once()
-        )->method(
-            'get'
-        )->with(
-            '',
-            'no-renderLayout'
-        )->willReturn(
-            true
-        );
+        $this->_actionFlagMock->expects($this->once())->method('get')->with('', 'no-renderLayout')->willReturn(true);
         $this->_eventManagerMock->expects($this->never())->method('dispatch');
         $this->_view->renderLayout();
     }
 
-    public function testRenderLayoutWhenOutputNotEmpty()
+    /**
+     * @return void
+     */
+    public function testRenderLayoutWhenOutputNotEmpty(): void
     {
         $this->_actionFlagMock->expects($this->once())
             ->method('get')
@@ -254,7 +282,10 @@ class ViewTest extends TestCase
         $this->_view->renderLayout('output');
     }
 
-    public function testRenderLayoutWhenOutputEmpty()
+    /**
+     * @return void
+     */
+    public function testRenderLayoutWhenOutputEmpty(): void
     {
         $this->_actionFlagMock->expects($this->once())
             ->method('get')

--- a/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/ViewTest.php
@@ -74,7 +74,7 @@ class ViewTest extends TestCase
     protected $response;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Authorization/Test/Unit/Policy/AclTest.php
+++ b/lib/internal/Magento/Framework/Authorization/Test/Unit/Policy/AclTest.php
@@ -31,7 +31,7 @@ class AclTest extends TestCase
     protected $_aclBuilderMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Authorization/Test/Unit/Policy/AclTest.php
+++ b/lib/internal/Magento/Framework/Authorization/Test/Unit/Policy/AclTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\Acl\Builder;
 use Magento\Framework\Authorization\Policy\Acl;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Magento\Framework\Acl as FrameworkAcl;
 
 class AclTest extends TestCase
 {
@@ -29,74 +30,59 @@ class AclTest extends TestCase
      */
     protected $_aclBuilderMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->_aclMock = $this->createMock(\Magento\Framework\Acl::class);
+        $this->_aclMock = $this->createMock(FrameworkAcl::class);
         $this->_aclBuilderMock = $this->createMock(Builder::class);
         $this->_aclBuilderMock->expects($this->any())->method('getAcl')->willReturn($this->_aclMock);
         $this->_model = new Acl($this->_aclBuilderMock);
     }
 
-    public function testIsAllowedReturnsTrueIfResourceIsAllowedToRole()
+    /**
+     * @return void
+     */
+    public function testIsAllowedReturnsTrueIfResourceIsAllowedToRole(): void
     {
-        $this->_aclMock->expects(
-            $this->once()
-        )->method(
-            'isAllowed'
-        )->with(
-            'some_role',
-            'some_resource'
-        )->willReturn(
-            true
-        );
+        $this->_aclMock->expects($this->once())
+            ->method('isAllowed')
+            ->with('some_role', 'some_resource')
+            ->willReturn(true);
 
         $this->assertTrue($this->_model->isAllowed('some_role', 'some_resource'));
     }
 
-    public function testIsAllowedReturnsFalseIfRoleDoesntExist()
+    /**
+     * @return void
+     */
+    public function testIsAllowedReturnsFalseIfRoleDoesntExist(): void
     {
-        $this->_aclMock->expects(
-            $this->once()
-        )->method(
-            'isAllowed'
-        )->with(
-            'some_role',
-            'some_resource'
-        )->willThrowException(
-            new \Zend_Acl_Role_Registry_Exception()
-        );
+        $this->_aclMock->expects($this->once())
+        ->method('isAllowed')
+            ->with('some_role', 'some_resource')
+            ->willThrowException(new \Zend_Acl_Role_Registry_Exception());
 
         $this->_aclMock->expects($this->once())->method('has')->with('some_resource')->willReturn(true);
 
         $this->assertFalse($this->_model->isAllowed('some_role', 'some_resource'));
     }
 
-    public function testIsAllowedReturnsTrueIfResourceDoesntExistAndAllResourcesAreNotPermitted()
+    /**
+     * @return void
+     */
+    public function testIsAllowedReturnsTrueIfResourceDoesntExistAndAllResourcesAreNotPermitted(): void
     {
-        $this->_aclMock->expects(
-            $this->at(0)
-        )->method(
-            'isAllowed'
-        )->with(
-            'some_role',
-            'some_resource'
-        )->willThrowException(
-            new \Zend_Acl_Role_Registry_Exception()
-        );
+        $this->_aclMock
+            ->method('isAllowed')
+            ->withConsecutive([ 'some_role', 'some_resource'], ['some_role', null])
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \Zend_Acl_Role_Registry_Exception()),
+                true
+            );
 
         $this->_aclMock->expects($this->once())->method('has')->with('some_resource')->willReturn(false);
-
-        $this->_aclMock->expects(
-            $this->at(2)
-        )->method(
-            'isAllowed'
-        )->with(
-            'some_role',
-            null
-        )->willReturn(
-            true
-        );
-
         $this->assertTrue($this->_model->isAllowed('some_role', 'some_resource'));
     }
 }

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/DatabaseTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/DatabaseTest.php
@@ -22,7 +22,7 @@ class DatabaseTest extends TestCase
     protected $objectManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/DatabaseTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/DatabaseTest.php
@@ -21,6 +21,9 @@ class DatabaseTest extends TestCase
      */
     protected $objectManager;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -29,23 +32,22 @@ class DatabaseTest extends TestCase
     /**
      * @param array $options
      *
+     * @return void
      * @dataProvider initializeWithExceptionDataProvider
      */
-    public function testInitializeWithException($options)
+    public function testInitializeWithException($options): void
     {
         $this->expectException('Zend_Cache_Exception');
         $this->objectManager->getObject(
             Database::class,
-            [
-                'options' => $options,
-            ]
+            ['options' => $options]
         );
     }
 
     /**
      * @return array
      */
-    public function initializeWithExceptionDataProvider()
+    public function initializeWithExceptionDataProvider(): array
     {
         return [
             'empty_adapter' => [
@@ -55,8 +57,8 @@ class DatabaseTest extends TestCase
                     'data_table_callback' => 'data_table_callback',
                     'tags_table' => 'tags_table',
                     'tags_table_callback' => 'tags_table_callback',
-                    'adapter' => '',
-                ],
+                    'adapter' => ''
+                ]
             ],
             'empty_data_table' => [
                 'options' => [
@@ -65,8 +67,8 @@ class DatabaseTest extends TestCase
                     'data_table_callback' => '',
                     'tags_table' => 'tags_table',
                     'tags_table_callback' => 'tags_table_callback',
-                    'adapter' => $this->createMock(Mysql::class),
-                ],
+                    'adapter' => $this->createMock(Mysql::class)
+                ]
             ],
             'empty_tags_table' => [
                 'options' => [
@@ -75,9 +77,9 @@ class DatabaseTest extends TestCase
                     'data_table_callback' => 'data_table_callback',
                     'tags_table' => '',
                     'tags_table_callback' => '',
-                    'adapter' => $this->createMock(Mysql::class),
-                ],
-            ],
+                    'adapter' => $this->createMock(Mysql::class)
+                ]
+            ]
         ];
     }
 
@@ -85,9 +87,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param bool|string $expected
      *
+     * @return void
      * @dataProvider loadDataProvider
      */
-    public function testLoad($options, $expected)
+    public function testLoad($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -102,10 +105,10 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function loadDataProvider()
+    public function loadDataProvider(): array
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchOne'])
+            ->onlyMethods(['select', 'fetchOne'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -128,13 +131,13 @@ class DatabaseTest extends TestCase
         return [
             'with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
-                'expected' => 'loaded_value',
+                'expected' => 'loaded_value'
 
             ],
             'without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData(),
-                'expected' => false,
-            ],
+                'expected' => false
+            ]
         ];
     }
 
@@ -142,7 +145,7 @@ class DatabaseTest extends TestCase
      * @param Mysql|MockObject $connectionMock
      * @return array
      */
-    public function getOptionsWithStoreData($connectionMock)
+    public function getOptionsWithStoreData($connectionMock): array
     {
         return [
             'adapter_callback' => '',
@@ -151,7 +154,7 @@ class DatabaseTest extends TestCase
             'tags_table' => 'tags_table',
             'tags_table_callback' => 'tags_table_callback',
             'store_data' => 'store_data',
-            'adapter' => $connectionMock,
+            'adapter' => $connectionMock
         ];
     }
 
@@ -159,7 +162,7 @@ class DatabaseTest extends TestCase
      * @param null|Mysql|MockObject $connectionMock
      * @return array
      */
-    public function getOptionsWithoutStoreData($connectionMock = null)
+    public function getOptionsWithoutStoreData($connectionMock = null): array
     {
         if (null === $connectionMock) {
             $connectionMock = $this->getMockBuilder(Mysql::class)
@@ -182,9 +185,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param bool|string $expected
      *
+     * @return void
      * @dataProvider loadDataProvider
      */
-    public function testTest($options, $expected)
+    public function testTest($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -200,9 +204,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param bool $expected
      *
+     * @return void
      * @dataProvider saveDataProvider
      */
-    public function testSave($options, $expected)
+    public function testSave($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -216,21 +221,21 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function saveDataProvider()
+    public function saveDataProvider(): array
     {
         return [
             'major_case_with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($this->getSaveAdapterMock(true)),
-                'expected' => true,
+                'expected' => true
             ],
             'minor_case_with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($this->getSaveAdapterMock(false)),
-                'expected' => false,
+                'expected' => false
             ],
             'without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData(),
-                'expected' => true,
-            ],
+                'expected' => true
+            ]
         ];
     }
 
@@ -238,15 +243,15 @@ class DatabaseTest extends TestCase
      * @param bool $result
      * @return Mysql|MockObject
      */
-    protected function getSaveAdapterMock($result)
+    protected function getSaveAdapterMock($result): Mysql
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['quoteIdentifier', 'query'])
+            ->onlyMethods(['quoteIdentifier', 'query'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $dbStatementMock = $this->getMockBuilder(\Zend_Db_Statement_Interface::class)
-            ->setMethods(['rowCount'])
+            ->onlyMethods(['rowCount'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -269,9 +274,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param bool $expected
      *
+     * @return void
      * @dataProvider removeDataProvider
      */
-    public function testRemove($options, $expected)
+    public function testRemove($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -285,10 +291,10 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function removeDataProvider()
+    public function removeDataProvider(): array
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['delete'])
+            ->onlyMethods(['delete'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -299,13 +305,13 @@ class DatabaseTest extends TestCase
         return [
             'with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
-                'expected' => true,
+                'expected' => true
 
             ],
             'without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData(),
-                'expected' => false,
-            ],
+                'expected' => false
+            ]
         ];
     }
 
@@ -314,9 +320,10 @@ class DatabaseTest extends TestCase
      * @param string $mode
      * @param bool $expected
      *
+     * @return void
      * @dataProvider cleanDataProvider
      */
-    public function testClean($options, $mode, $expected)
+    public function testClean($options, $mode, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -330,10 +337,10 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function cleanDataProvider()
+    public function cleanDataProvider(): array
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['query', 'delete'])
+            ->onlyMethods(['query', 'delete'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -349,44 +356,47 @@ class DatabaseTest extends TestCase
             'mode_all_with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_ALL,
-                'expected' => false,
+                'expected' => false
 
             ],
             'mode_all_without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_ALL,
-                'expected' => false,
+                'expected' => false
             ],
             'mode_old_with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_OLD,
-                'expected' => true,
+                'expected' => true
 
             ],
             'mode_old_without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_OLD,
-                'expected' => true,
+                'expected' => true
             ],
             'mode_matching_tag_without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-                'expected' => true,
+                'expected' => true
             ],
             'mode_not_matching_tag_without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_NOT_MATCHING_TAG,
-                'expected' => true,
+                'expected' => true
             ],
             'mode_matching_any_tag_without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData($connectionMock),
                 'mode' => \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
-                'expected' => true,
-            ],
+                'expected' => true
+            ]
         ];
     }
 
-    public function testCleanException()
+    /**
+     * @return void
+     */
+    public function testCleanException(): void
     {
         $this->expectException('Zend_Cache_Exception');
         /** @var Database $database */
@@ -402,9 +412,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param array $expected
      *
+     * @return void
      * @dataProvider getIdsDataProvider
      */
-    public function testGetIds($options, $expected)
+    public function testGetIds($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -418,10 +429,10 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function getIdsDataProvider()
+    public function getIdsDataProvider(): array
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol'])
+            ->onlyMethods(['select', 'fetchCol'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -441,20 +452,22 @@ class DatabaseTest extends TestCase
         return [
             'with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
-                'expected' => ['value_one', 'value_two'],
-
+                'expected' => ['value_one', 'value_two']
             ],
             'without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData(),
-                'expected' => [],
-            ],
+                'expected' => []
+            ]
         ];
     }
 
-    public function testGetTags()
+    /**
+     * @return void
+     */
+    public function testGetTags(): void
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol'])
+            ->onlyMethods(['select', 'fetchCol'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -483,10 +496,13 @@ class DatabaseTest extends TestCase
         $this->assertEquals(['value_one', 'value_two'], $database->getIds());
     }
 
-    public function testGetIdsMatchingTags()
+    /**
+     * @return void
+     */
+    public function testGetIdsMatchingTags(): void
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol'])
+            ->onlyMethods(['select', 'fetchCol'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -527,10 +543,13 @@ class DatabaseTest extends TestCase
         $this->assertEquals(['value_one', 'value_two'], $database->getIdsMatchingTags());
     }
 
-    public function testGetIdsNotMatchingTags()
+    /**
+     * @return void
+     */
+    public function testGetIdsNotMatchingTags(): void
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol'])
+            ->onlyMethods(['select', 'fetchCol'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -558,13 +577,9 @@ class DatabaseTest extends TestCase
             ->method('select')
             ->willReturn($selectMock);
 
-        $connectionMock->expects($this->at(1))
+        $connectionMock
             ->method('fetchCol')
-            ->willReturn(['some_value_one']);
-
-        $connectionMock->expects($this->at(3))
-            ->method('fetchCol')
-            ->willReturn(['some_value_two']);
+            ->willReturnOnConsecutiveCalls(['some_value_one'], ['some_value_two']);
 
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -575,10 +590,13 @@ class DatabaseTest extends TestCase
         $this->assertEquals(['some_value_one'], $database->getIdsNotMatchingTags());
     }
 
-    public function testGetIdsMatchingAnyTags()
+    /**
+     * @return void
+     */
+    public function testGetIdsMatchingAnyTags(): void
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol'])
+            ->onlyMethods(['select', 'fetchCol'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -607,10 +625,13 @@ class DatabaseTest extends TestCase
         $this->assertEquals(['some_value_one', 'some_value_two'], $database->getIds());
     }
 
-    public function testGetMetadatas()
+    /**
+     * @return void
+     */
+    public function testGetMetadatas(): void
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['select', 'fetchCol', 'fetchRow'])
+            ->onlyMethods(['select', 'fetchCol', 'fetchRow'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -644,7 +665,7 @@ class DatabaseTest extends TestCase
             [
                 'expire' => 3,
                 'mtime' => 2,
-                'tags' => ['some_value_one', 'some_value_two'],
+                'tags' => ['some_value_one', 'some_value_two']
             ],
             $database->getMetadatas(5)
         );
@@ -654,9 +675,10 @@ class DatabaseTest extends TestCase
      * @param array $options
      * @param bool $expected
      *
+     * @return void
      * @dataProvider touchDataProvider
      */
-    public function testTouch($options, $expected)
+    public function testTouch($options, $expected): void
     {
         /** @var Database $database */
         $database = $this->objectManager->getObject(
@@ -670,10 +692,10 @@ class DatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function touchDataProvider()
+    public function touchDataProvider(): array
     {
         $connectionMock = $this->getMockBuilder(Mysql::class)
-            ->setMethods(['update'])
+            ->onlyMethods(['update'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -684,13 +706,13 @@ class DatabaseTest extends TestCase
         return [
             'with_store_data' => [
                 'options' => $this->getOptionsWithStoreData($connectionMock),
-                'expected' => false,
+                'expected' => false
 
             ],
             'without_store_data' => [
                 'options' => $this->getOptionsWithoutStoreData(),
-                'expected' => true,
-            ],
+                'expected' => true
+            ]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Decorator/TagScopeTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Decorator/TagScopeTest.php
@@ -24,55 +24,64 @@ class TagScopeTest extends TestCase
      */
     protected $_frontend;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_frontend = $this->getMockForAbstractClass(FrontendInterface::class);
         $this->_object = new TagScope($this->_frontend, 'enforced_tag');
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         $this->_object = null;
         $this->_frontend = null;
     }
 
-    public function testGetTag()
+    /**
+     * @return void
+     */
+    public function testGetTag(): void
     {
         $this->assertEquals('enforced_tag', $this->_object->getTag());
     }
 
-    public function testSave()
+    /**
+     * @return void
+     */
+    public function testSave(): void
     {
         $expectedResult = new \stdClass();
-        $this->_frontend->expects(
-            $this->once()
-        )->method(
-            'save'
-        )->with(
-            'test_value',
-            'test_id',
-            ['test_tag_one', 'test_tag_two', 'enforced_tag'],
-            111
-        )->willReturn(
-            $expectedResult
-        );
+        $this->_frontend->expects($this->once())
+            ->method('save')
+            ->with(
+                'test_value',
+                'test_id',
+                ['test_tag_one', 'test_tag_two', 'enforced_tag'],
+                111
+            )
+            ->willReturn($expectedResult);
         $actualResult = $this->_object->save('test_value', 'test_id', ['test_tag_one', 'test_tag_two'], 111);
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    public function testCleanModeAll()
+    /**
+     * @return void
+     */
+    public function testCleanModeAll(): void
     {
         $expectedResult = new \stdClass();
-        $this->_frontend->expects(
-            $this->once()
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['enforced_tag']
-        )->willReturn(
-            $expectedResult
-        );
+        $this->_frontend->expects($this->once())
+            ->method('clean')
+            ->with(
+                \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
+                ['enforced_tag']
+            )
+            ->willReturn($expectedResult);
         $actualResult = $this->_object->clean(
             \Zend_Cache::CLEANING_MODE_ALL,
             ['ignored_tag_one', 'ignored_tag_two']
@@ -80,19 +89,18 @@ class TagScopeTest extends TestCase
         $this->assertSame($expectedResult, $actualResult);
     }
 
-    public function testCleanModeMatchingTag()
+    /**
+     * @return void
+     */
+    public function testCleanModeMatchingTag(): void
     {
         $expectedResult = new \stdClass();
-        $this->_frontend->expects(
-            $this->once()
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['test_tag_one', 'test_tag_two', 'enforced_tag']
-        )->willReturn(
-            $expectedResult
-        );
+        $this->_frontend->expects($this->once())
+            ->method('clean')
+            ->with(
+                \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
+                ['test_tag_one', 'test_tag_two', 'enforced_tag'])
+            ->willReturn($expectedResult);
         $actualResult = $this->_object->clean(
             \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
             ['test_tag_one', 'test_tag_two']
@@ -104,30 +112,19 @@ class TagScopeTest extends TestCase
      * @param bool $fixtureResultOne
      * @param bool $fixtureResultTwo
      * @param bool $expectedResult
+     *
+     * @return void
      * @dataProvider cleanModeMatchingAnyTagDataProvider
      */
-    public function testCleanModeMatchingAnyTag($fixtureResultOne, $fixtureResultTwo, $expectedResult)
+    public function testCleanModeMatchingAnyTag($fixtureResultOne, $fixtureResultTwo, $expectedResult): void
     {
-        $this->_frontend->expects(
-            $this->at(0)
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['test_tag_one', 'enforced_tag']
-        )->willReturn(
-            $fixtureResultOne
-        );
-        $this->_frontend->expects(
-            $this->at(1)
-        )->method(
-            'clean'
-        )->with(
-            \Zend_Cache::CLEANING_MODE_MATCHING_TAG,
-            ['test_tag_two', 'enforced_tag']
-        )->willReturn(
-            $fixtureResultTwo
-        );
+        $this->_frontend
+            ->method('clean')
+            ->withConsecutive(
+                [\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['test_tag_one', 'enforced_tag']],
+                [\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['test_tag_two', 'enforced_tag']]
+            )
+            ->willReturnOnConsecutiveCalls($fixtureResultOne, $fixtureResultTwo);
         $actualResult = $this->_object->clean(
             \Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG,
             ['test_tag_one', 'test_tag_two']
@@ -138,7 +135,7 @@ class TagScopeTest extends TestCase
     /**
      * @return array
      */
-    public function cleanModeMatchingAnyTagDataProvider()
+    public function cleanModeMatchingAnyTagDataProvider(): array
     {
         return [
             'failure, failure' => [false, false, false],

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Decorator/TagScopeTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Decorator/TagScopeTest.php
@@ -25,7 +25,7 @@ class TagScopeTest extends TestCase
     protected $_frontend;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -34,7 +34,7 @@ class TagScopeTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Dom/ArrayNodeConfigTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Dom/ArrayNodeConfigTest.php
@@ -30,7 +30,7 @@ class ArrayNodeConfigTest extends TestCase
     protected $nodePathMatcher;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Dom/ArrayNodeConfigTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Dom/ArrayNodeConfigTest.php
@@ -29,6 +29,9 @@ class ArrayNodeConfigTest extends TestCase
      */
     protected $nodePathMatcher;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->nodePathMatcher = $this->createMock(NodePathMatcher::class);
@@ -39,127 +42,66 @@ class ArrayNodeConfigTest extends TestCase
         );
     }
 
-    public function testIsNumericArrayMatched()
+    /**
+     * @return void
+     */
+    public function testIsNumericArrayMatched(): void
     {
         $xpath = '/root/numeric[@attr="value"]/two';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/numeric/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/numeric/two',
-            $xpath
-        )->willReturn(
-            true
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(['/root/numeric/one', $xpath], ['/root/numeric/two', $xpath])
+            ->willReturnOnConsecutiveCalls(false, true);
         $this->assertTrue($this->object->isNumericArray($xpath));
     }
 
-    public function testIsNumericArrayNotMatched()
+    /**
+     * @return void
+     */
+    public function testIsNumericArrayNotMatched(): void
     {
         $xpath = '/root/numeric[@attr="value"]/four';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/numeric/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/numeric/two',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(2)
-        )->method(
-            'match'
-        )->with(
-            '/root/numeric/three',
-            $xpath
-        )->willReturn(
-            false
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(
+                ['/root/numeric/one', $xpath],
+                ['/root/numeric/two', $xpath],
+                ['/root/numeric/three', $xpath]
+            )
+            ->willReturnOnConsecutiveCalls(false, false, false);
         $this->assertFalse($this->object->isNumericArray($xpath));
     }
 
-    public function testGetAssocArrayKeyAttributeMatched()
+    /**
+     * @return void
+     */
+    public function testGetAssocArrayKeyAttributeMatched(): void
     {
         $xpath = '/root/assoc[@attr="value"]/two';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/assoc/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/assoc/two',
-            $xpath
-        )->willReturn(
-            true
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(
+                ['/root/assoc/one', $xpath],
+                ['/root/assoc/two', $xpath]
+            )
+            ->willReturnOnConsecutiveCalls(false, true);
         $this->assertEquals('id', $this->object->getAssocArrayKeyAttribute($xpath));
     }
 
-    public function testGetAssocArrayKeyAttributeNotMatched()
+    /**
+     * @return void
+     */
+    public function testGetAssocArrayKeyAttributeNotMatched(): void
     {
         $xpath = '/root/assoc[@attr="value"]/four';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/assoc/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/assoc/two',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(2)
-        )->method(
-            'match'
-        )->with(
-            '/root/assoc/three',
-            $xpath
-        )->willReturn(
-            false
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(
+                ['/root/assoc/one', $xpath],
+                ['/root/assoc/two', $xpath],
+                ['/root/assoc/three', $xpath]
+            )
+            ->willReturnOnConsecutiveCalls(false, false, false);
         $this->assertNull($this->object->getAssocArrayKeyAttribute($xpath));
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Dom/NodeMergingConfigTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Dom/NodeMergingConfigTest.php
@@ -29,6 +29,9 @@ class NodeMergingConfigTest extends TestCase
      */
     protected $nodePathMatcher;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->nodePathMatcher = $this->createMock(NodePathMatcher::class);
@@ -38,65 +41,36 @@ class NodeMergingConfigTest extends TestCase
         );
     }
 
-    public function testGetIdAttributeMatched()
+    /**
+     * @return void
+     */
+    public function testGetIdAttributeMatched(): void
     {
         $xpath = '/root/two[@attr="value"]';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/two',
-            $xpath
-        )->willReturn(
-            true
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(
+                ['/root/one', $xpath],
+                ['/root/two', $xpath]
+            )
+            ->willReturnOnConsecutiveCalls(false, true);
         $this->assertEquals('id', $this->object->getIdAttribute($xpath));
     }
 
-    public function testGetIdAttributeNotMatched()
+    /**
+     * @return void
+     */
+    public function testGetIdAttributeNotMatched(): void
     {
         $xpath = '/root/four[@attr="value"]';
-        $this->nodePathMatcher->expects(
-            $this->at(0)
-        )->method(
-            'match'
-        )->with(
-            '/root/one',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(1)
-        )->method(
-            'match'
-        )->with(
-            '/root/two',
-            $xpath
-        )->willReturn(
-            false
-        );
-        $this->nodePathMatcher->expects(
-            $this->at(2)
-        )->method(
-            'match'
-        )->with(
-            '/root/three',
-            $xpath
-        )->willReturn(
-            false
-        );
+        $this->nodePathMatcher
+            ->method('match')
+            ->withConsecutive(
+                ['/root/one', $xpath],
+                ['/root/two', $xpath],
+                ['/root/three', $xpath]
+            )
+            ->willReturnOnConsecutiveCalls(false, false, false);
         $this->assertNull($this->object->getIdAttribute($xpath));
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Dom/NodeMergingConfigTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Dom/NodeMergingConfigTest.php
@@ -30,7 +30,7 @@ class NodeMergingConfigTest extends TestCase
     protected $nodePathMatcher;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -41,7 +41,7 @@ class CrontabManagerTest extends TestCase
     private $crontabManager;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
+++ b/lib/internal/Magento/Framework/Crontab/Test/Unit/CrontabManagerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Crontab\Test\Unit;
 
+use Exception;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Crontab\CrontabManager;
 use Magento\Framework\Crontab\CrontabManagerInterface;
@@ -61,7 +62,7 @@ class CrontabManagerTest extends TestCase
      */
     public function testGetTasksNoCrontab(): void
     {
-        $exception = new \Exception('crontab: no crontab for user');
+        $exception = new Exception('crontab: no crontab for user');
         $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
 
         $this->shellMock->expects($this->once())
@@ -77,6 +78,7 @@ class CrontabManagerTest extends TestCase
      *
      * @param string $content
      * @param array $tasks
+     *
      * @return void
      * @dataProvider getTasksDataProvider
      */
@@ -103,7 +105,7 @@ class CrontabManagerTest extends TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
-                'tasks' => ['* * * * * /bin/php /var/www/magento/bin/magento cron:run'],
+                'tasks' => ['* * * * * /bin/php /var/www/magento/bin/magento cron:run']
             ],
             [
                 'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
@@ -111,17 +113,17 @@ class CrontabManagerTest extends TestCase
                     . '* * * * * /bin/php /var/www/magento/bin/magento cron:run' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
                 'tasks' => [
-                    '* * * * * /bin/php /var/www/magento/bin/magento cron:run',
-                ],
+                    '* * * * * /bin/php /var/www/magento/bin/magento cron:run'
+                ]
             ],
             [
                 'content' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL,
-                'tasks' => [],
+                'tasks' => []
             ],
             [
                 'content' => '',
-                'tasks' => [],
-            ],
+                'tasks' => []
+            ]
         ];
     }
 
@@ -134,18 +136,13 @@ class CrontabManagerTest extends TestCase
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Shell error');
-        $exception = new \Exception('Shell error');
+        $exception = new Exception('Shell error');
         $localizedException = new LocalizedException(new Phrase('Some error'), $exception);
 
-        $this->shellMock->expects($this->at(0))
+        $this->shellMock
             ->method('execute')
-            ->with('crontab -l 2>/dev/null', [])
-            ->willReturn('');
-
-        $this->shellMock->expects($this->at(1))
-            ->method('execute')
-            ->with('echo "" | crontab -', [])
-            ->willThrowException($localizedException);
+            ->withConsecutive(['crontab -l 2>/dev/null', []], ['echo "" | crontab -', []])
+            ->willReturnOnConsecutiveCalls('', $this->throwException($localizedException));
 
         $this->crontabManager->removeTasks();
     }
@@ -155,19 +152,16 @@ class CrontabManagerTest extends TestCase
      *
      * @param string $contentBefore
      * @param string $contentAfter
+     *
      * @return void
      * @dataProvider removeTasksDataProvider
      */
     public function testRemoveTasks($contentBefore, $contentAfter): void
     {
-        $this->shellMock->expects($this->at(0))
+        $this->shellMock
             ->method('execute')
-            ->with('crontab -l 2>/dev/null', [])
+            ->withConsecutive(['crontab -l 2>/dev/null', []], ['echo "' . $contentAfter . '" | crontab -', []])
             ->willReturn($contentBefore);
-
-        $this->shellMock->expects($this->at(1))
-            ->method('execute')
-            ->with('echo "' . $contentAfter . '" | crontab -', []);
 
         $this->crontabManager->removeTasks();
     }
@@ -201,7 +195,7 @@ class CrontabManagerTest extends TestCase
             [
                 'contentBefore' => '',
                 'contentAfter' => ''
-            ],
+            ]
         ];
     }
 
@@ -272,6 +266,7 @@ class CrontabManagerTest extends TestCase
      * @param array $tasks
      * @param string $content
      * @param string $contentToSave
+     *
      * @return void
      * @dataProvider saveTasksDataProvider
      */
@@ -295,14 +290,10 @@ class CrontabManagerTest extends TestCase
                 [DirectoryList::LOG, DriverPool::FILE, $logDirMock],
             ]);
 
-        $this->shellMock->expects($this->at(0))
+        $this->shellMock
             ->method('execute')
-            ->with('crontab -l 2>/dev/null', [])
+            ->withConsecutive(['crontab -l 2>/dev/null', []], ['echo "' . $contentToSave . '" | crontab -', []])
             ->willReturn($content);
-
-        $this->shellMock->expects($this->at(1))
-            ->method('execute')
-            ->with('echo "' . $contentToSave . '" | crontab -', []);
 
         $this->crontabManager->saveTasks($tasks);
     }
@@ -328,7 +319,7 @@ class CrontabManagerTest extends TestCase
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' run.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
             ],
             [
                 'tasks' => [
@@ -338,7 +329,7 @@ class CrontabManagerTest extends TestCase
                 'contentToSave' => '* * * * * /bin/php /var/www/cron.php' . PHP_EOL
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '1 2 3 4 5 ' . PHP_BINARY . ' run.php' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
             ],
             [
                 'tasks' => [
@@ -349,7 +340,7 @@ class CrontabManagerTest extends TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php >>'
                     . ' /var/www/magento2/var/log/cron.log' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
             ],
             [
                 'tasks' => [
@@ -360,7 +351,7 @@ class CrontabManagerTest extends TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
                     . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
             ],
             [
                 'tasks' => [
@@ -371,7 +362,7 @@ class CrontabManagerTest extends TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
                     . ' %% cron:run | grep -v \"Ran \'jobs\' by schedule\"' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
             ],
             [
                 'tasks' => [
@@ -382,8 +373,8 @@ class CrontabManagerTest extends TestCase
                     . CrontabManagerInterface::TASKS_BLOCK_START . ' ' . hash("sha256", BP) . PHP_EOL
                     . '* * * * * ' . PHP_BINARY . ' /var/www/magento2/run.php'
                     . ' mysqldump --no-tablespaces db > db-\$(date +%%F).sql' . PHP_EOL
-                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL,
-            ],
+                    . CrontabManagerInterface::TASKS_BLOCK_END . ' ' . hash("sha256", BP) . PHP_EOL
+            ]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
@@ -57,7 +57,7 @@ class AggregatedTest extends TestCase
     protected $loggerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setup(): void
     {

--- a/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
+++ b/lib/internal/Magento/Framework/Css/Test/Unit/PreProcessor/File/Collector/AggregatedTest.php
@@ -57,8 +57,7 @@ class AggregatedTest extends TestCase
     protected $loggerMock;
 
     /**
-     * Setup tests
-     * @return void
+     * @inheirtDoc
      */
     protected function setup(): void
     {
@@ -83,7 +82,10 @@ class AggregatedTest extends TestCase
             ->getMock();
     }
 
-    public function testGetFilesEmpty()
+    /**
+     * @return void
+     */
+    public function testGetFilesEmpty(): void
     {
         $this->libraryFilesMock->expects($this->any())->method('getFiles')->willReturn([]);
         $this->baseFilesMock->expects($this->any())->method('getFiles')->willReturn([]);
@@ -117,10 +119,11 @@ class AggregatedTest extends TestCase
      * *
      * @return void
      */
-    public function testGetFiles($libraryFiles, $baseFiles, $themeFiles)
+    public function testGetFiles($libraryFiles, $baseFiles, $themeFiles): void
     {
-        $this->fileListMock->expects($this->at(0))->method('add')->with($libraryFiles);
-        $this->fileListMock->expects($this->at(1))->method('add')->with($baseFiles);
+        $this->fileListMock
+            ->method('add')
+            ->withConsecutive([$libraryFiles], [$baseFiles]);
         $this->fileListMock->expects($this->any())->method('getAll')->willReturn(['returnedFile']);
 
         $subPath = '*';
@@ -159,11 +162,11 @@ class AggregatedTest extends TestCase
      *
      * @return array
      */
-    public function getFilesDataProvider()
+    public function getFilesDataProvider(): array
     {
         return [
             'all files' => [['file1'], ['file2'], ['file3']],
-            'no library' => [[], ['file1', 'file2'], ['file3']],
+            'no library' => [[], ['file1', 'file2'], ['file3']]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Helper/Mysql/FulltextTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Helper/Mysql/FulltextTest.php
@@ -17,7 +17,10 @@ use PHPUnit\Framework\TestCase;
 
 class FulltextTest extends TestCase
 {
-    public function testGetMatchQuery()
+    /**
+     * @return void
+     */
+    public function testGetMatchQuery(): void
     {
         /** @var Fulltext $select */
         $select = (new ObjectManager($this))->getObject(
@@ -37,9 +40,11 @@ class FulltextTest extends TestCase
 
     /**
      * @param $isCondition
+     *
+     * @return void
      * @dataProvider matchProvider
      */
-    public function testMatch($isCondition)
+    public function testMatch($isCondition): void
     {
         $fullCondition = "MATCH (title, description) AGAINST ('some searchable text' IN NATURAL LANGUAGE MODE)";
 
@@ -73,7 +78,7 @@ class FulltextTest extends TestCase
     /**
      * @return array
      */
-    public function matchProvider()
+    public function matchProvider(): array
     {
         return [[true], [false]];
     }
@@ -81,12 +86,12 @@ class FulltextTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getResourceMock()
+    protected function getResourceMock(): MockObject
     {
         $connection = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $connection->expects($this->at(0))
+        $connection
             ->method('quote')
             ->with('some searchable text')
             ->willReturn("'some searchable text'");

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Select/LikeQueryModifierTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Select/LikeQueryModifierTest.php
@@ -17,26 +17,32 @@ class LikeQueryModifierTest extends TestCase
     /** @var ObjectManager */
     private $objectManager;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
     }
 
-    public function testModify()
+    /**
+     * @return void
+     */
+    public function testModify(): void
     {
         $values = [
             'field1' => 'pattern1',
-            'field2' => 'pattern2',
+            'field2' => 'pattern2'
         ];
         $selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $selectMock->expects($this->at(0))
+        $selectMock
             ->method('where')
-            ->with('field1 LIKE (?)', 'pattern1');
-        $selectMock->expects($this->at(1))
-            ->method('where')
-            ->with('field2 LIKE (?)', 'pattern2');
+            ->withConsecutive(
+                ['field1 LIKE (?)', 'pattern1'],
+                ['field2 LIKE (?)', 'pattern2']
+            );
         $likeQueryModifier = $this->objectManager->getObject(
             LikeQueryModifier::class,
             ['values' => $values]

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Select/LikeQueryModifierTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Select/LikeQueryModifierTest.php
@@ -18,7 +18,7 @@ class LikeQueryModifierTest extends TestCase
     private $objectManager;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
@@ -44,7 +44,7 @@ class EncryptorTest extends TestCase
     private $keyValidatorMock;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
+++ b/lib/internal/Magento/Framework/Encryption/Test/Unit/EncryptorTest.php
@@ -17,6 +17,7 @@ use Magento\Framework\Math\Random;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 /**
  * Test case for \Magento\Framework\Encryption\Encryptor
@@ -43,7 +44,7 @@ class EncryptorTest extends TestCase
     private $keyValidatorMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -67,6 +68,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Hashing without a salt.
+     *
+     * @return void
      */
     public function testGetHashNoSalt(): void
     {
@@ -78,6 +81,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Providing salt for hash.
+     *
+     * @return void
      */
     public function testGetHashSpecifiedSalt(): void
     {
@@ -95,6 +100,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Hashing with random salt.
+     *
+     * @return void
      */
     public function testGetHashRandomSaltDefaultLength(): void
     {
@@ -122,6 +129,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Hashing with random salt of certain length.
+     *
+     * @return void
      */
     public function testGetHashRandomSaltSpecifiedLength(): void
     {
@@ -149,6 +158,7 @@ class EncryptorTest extends TestCase
      * @param string $hash
      * @param bool $expected
      *
+     * @return void
      * @dataProvider validateHashDataProvider
      */
     public function testValidateHash($password, $hash, $expected, int $requiresVersion): void
@@ -184,6 +194,7 @@ class EncryptorTest extends TestCase
      *
      * @param mixed $key
      *
+     * @return void
      * @dataProvider emptyKeyDataProvider
      */
     public function testEncryptWithEmptyKey($key): void
@@ -204,6 +215,7 @@ class EncryptorTest extends TestCase
      *
      * @param mixed $key
      *
+     * @return void
      * @dataProvider emptyKeyDataProvider
      */
     public function testDecryptWithEmptyKey($key): void
@@ -230,6 +242,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Seeing that encrypting uses sodium.
+     *
+     * @return void
      */
     public function testEncrypt(): void
     {
@@ -248,6 +262,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Check that decrypting works.
+     *
+     * @return void
      */
     public function testDecrypt(): void
     {
@@ -259,6 +275,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Using an old algo.
+     *
+     * @return void
      */
     public function testLegacyDecrypt(): void
     {
@@ -280,18 +298,16 @@ class EncryptorTest extends TestCase
 
     /**
      * Seeing that changing a key does not stand in a way of decrypting.
+     *
+     * @return void
      */
     public function testEncryptDecryptNewKeyAdded(): void
     {
         $deploymentConfigMock = $this->createMock(DeploymentConfig::class);
-        $deploymentConfigMock->expects($this->at(0))
+        $deploymentConfigMock
             ->method('get')
-            ->with(Encryptor::PARAM_CRYPT_KEY)
-            ->willReturn(self::CRYPT_KEY_1);
-        $deploymentConfigMock->expects($this->at(1))
-            ->method('get')
-            ->with(Encryptor::PARAM_CRYPT_KEY)
-            ->willReturn(self::CRYPT_KEY_1 . "\n" . self::CRYPT_KEY_2);
+            ->withConsecutive([Encryptor::PARAM_CRYPT_KEY], [Encryptor::PARAM_CRYPT_KEY])
+            ->willReturnOnConsecutiveCalls(self::CRYPT_KEY_1, self::CRYPT_KEY_1 . "\n" . self::CRYPT_KEY_2);
         $model1 = new Encryptor($this->randomGeneratorMock, $deploymentConfigMock);
         // simulate an encryption key is being added
         $model2 = new Encryptor($this->randomGeneratorMock, $deploymentConfigMock);
@@ -307,6 +323,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Checking that encryptor relies on key validator.
+     *
+     * @return void
      */
     public function testValidateKey(): void
     {
@@ -316,6 +334,8 @@ class EncryptorTest extends TestCase
 
     /**
      * Checking that encryptor relies on key validator.
+     *
+     * @return void
      */
     public function testValidateKeyInvalid(): void
     {
@@ -374,6 +394,8 @@ class EncryptorTest extends TestCase
      * @param string|bool $salt
      * @param int $hashAlgo
      * @param string $pattern
+     *
+     * @return void
      */
     public function testGetHashMustUseSpecifiedHashingAlgo($password, $salt, $hashAlgo, $pattern): void
     {
@@ -389,8 +411,10 @@ class EncryptorTest extends TestCase
 
     /**
      * Test hashing working as promised.
+     *
+     * @return void
      */
-    public function testHash()
+    public function testHash(): void
     {
         //Checking that the same hash is returned for the same value.
         $hash1 = $this->encryptor->hash($value = 'some value');
@@ -412,7 +436,8 @@ class EncryptorTest extends TestCase
     /**
      * Test that generated hashes can be later validated.
      *
-     * @throws \Throwable
+     * @return void
+     * @throws Throwable
      */
     public function testValidation(): void
     {
@@ -435,7 +460,8 @@ class EncryptorTest extends TestCase
     /**
      * Test that upgraded generated hashes can be later validated.
      *
-     * @throws \Throwable
+     * @return void
+     * @throws Throwable
      */
     public function testUpgradedValidation(): void
     {

--- a/lib/internal/Magento/Framework/File/Test/Unit/Transfer/Adapter/HttpTest.php
+++ b/lib/internal/Magento/Framework/File/Test/Unit/Transfer/Adapter/HttpTest.php
@@ -41,7 +41,7 @@ class HttpTest extends TestCase
     private $mime;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/File/Test/Unit/Transfer/Adapter/HttpTest.php
+++ b/lib/internal/Magento/Framework/File/Test/Unit/Transfer/Adapter/HttpTest.php
@@ -41,7 +41,7 @@ class HttpTest extends TestCase
     private $mime;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -65,12 +65,12 @@ class HttpTest extends TestCase
         $file = __DIR__ . '/../../_files/javascript.js';
         $contentType = 'content/type';
 
-        $this->response->expects($this->at(0))
+        $this->response
             ->method('setHeader')
-            ->with('Content-length', filesize($file));
-        $this->response->expects($this->at(1))
-            ->method('setHeader')
-            ->with('Content-Type', $contentType);
+            ->withConsecutive(
+                ['Content-length', filesize($file)],
+                ['Content-Type', $contentType]
+            );
         $this->response->expects($this->once())
             ->method('sendHeaders');
         $this->mime->expects($this->once())
@@ -142,12 +142,9 @@ class HttpTest extends TestCase
         $file = __DIR__ . '/../../_files/javascript.js';
         $contentType = 'content/type';
 
-        $this->response->expects($this->at(0))
+        $this->response
             ->method('setHeader')
-            ->with('Content-length', filesize($file));
-        $this->response->expects($this->at(1))
-            ->method('setHeader')
-            ->with('Content-Type', $contentType);
+            ->withConsecutive(['Content-length', filesize($file)], ['Content-Type', $contentType]);
         $this->response->expects($this->once())
             ->method('sendHeaders');
         $this->mime->expects($this->once())

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/BatchSizeManagementTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/BatchSizeManagementTest.php
@@ -31,6 +31,9 @@ class BatchSizeManagementTest extends TestCase
      */
     private $loggerMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->rowSizeEstimatorMock = $this->createMock(
@@ -40,7 +43,10 @@ class BatchSizeManagementTest extends TestCase
         $this->model = new BatchSizeManagement($this->rowSizeEstimatorMock, $this->loggerMock);
     }
 
-    public function testEnsureBatchSize()
+    /**
+     * @return void
+     */
+    public function testEnsureBatchSize(): void
     {
         $batchSize = 200;
         $maxHeapTableSize = 16384;
@@ -50,18 +56,6 @@ class BatchSizeManagementTest extends TestCase
 
         $this->rowSizeEstimatorMock->expects($this->once())->method('estimateRowSize')->willReturn(100);
         $adapterMock = $this->getMockForAbstractClass(AdapterInterface::class);
-        $adapterMock->expects($this->at(0))
-            ->method('fetchOne')
-            ->with('SELECT @@max_heap_table_size;', [])
-            ->willReturn($maxHeapTableSize);
-        $adapterMock->expects($this->at(1))
-            ->method('fetchOne')
-            ->with('SELECT @@tmp_table_size;', [])
-            ->willReturn($tmpTableSize);
-        $adapterMock->expects($this->at(2))
-            ->method('fetchOne')
-            ->with('SELECT @@innodb_buffer_pool_size;', [])
-            ->willReturn($innodbPollSize);
 
         $this->loggerMock->expects($this->once())
             ->method('warning')
@@ -73,13 +67,20 @@ class BatchSizeManagementTest extends TestCase
                 [$batchSize, $size, $innodbPollSize]
             ));
 
-        $adapterMock->expects($this->at(3))
+        $adapterMock
+            ->method('fetchOne')
+            ->withConsecutive(
+                ['SELECT @@max_heap_table_size;', []],
+                ['SELECT @@tmp_table_size;', []],
+                ['SELECT @@innodb_buffer_pool_size;', []]
+            )
+            ->willReturnOnConsecutiveCalls($maxHeapTableSize, $tmpTableSize, $innodbPollSize);
+        $adapterMock
             ->method('query')
-            ->with('SET SESSION tmp_table_size = ' . $size . ';', []);
-
-        $adapterMock->expects($this->at(4))
-            ->method('query')
-            ->with('SET SESSION max_heap_table_size = ' . $size . ';', []);
+            ->withConsecutive(
+                ['SET SESSION tmp_table_size = ' . $size . ';', []],
+                ['SET SESSION max_heap_table_size = ' . $size . ';', []]
+            );
 
         $this->model->ensureBatchSize($adapterMock, $batchSize);
     }

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/BatchSizeManagementTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/BatchSizeManagementTest.php
@@ -32,7 +32,7 @@ class BatchSizeManagementTest extends TestCase
     private $loggerMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexerRegistryTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexerRegistryTest.php
@@ -14,7 +14,10 @@ use PHPUnit\Framework\TestCase;
 
 class IndexerRegistryTest extends TestCase
 {
-    public function testGetCreatesIndexerInstancesAndReusesExistingOnes()
+    /**
+     * @return void
+     */
+    public function testGetCreatesIndexerInstancesAndReusesExistingOnes(): void
     {
         $firstIndexer = $this->getMockForAbstractClass(IndexerInterface::class);
         $firstIndexer->expects($this->once())->method('load')->with('first-indexer')->willReturnSelf();
@@ -23,8 +26,9 @@ class IndexerRegistryTest extends TestCase
         $secondIndexer->expects($this->once())->method('load')->with('second-indexer')->willReturnSelf();
 
         $objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
-        $objectManager->expects($this->at(0))->method('create')->willReturn($firstIndexer);
-        $objectManager->expects($this->at(1))->method('create')->willReturn($secondIndexer);
+        $objectManager
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($firstIndexer, $secondIndexer);
 
         $unit = new IndexerRegistry($objectManager);
         $this->assertSame($firstIndexer, $unit->get('first-indexer'));

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
@@ -46,6 +46,9 @@ class CurrencyTest extends TestCase
     const TEST_EXCEPTION_CURRENCY = 'ZZZ';
     const TEST_EXCEPTION_CURRENCY_LOCALE = 'es_ES';
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->mockEventManager = $this
@@ -67,19 +70,25 @@ class CurrencyTest extends TestCase
                 [
                     'eventManager'     => $this->mockEventManager,
                     'localeResolver'   => $this->mockLocaleResolver,
-                    'currencyFactory'  => $this->mockCurrencyFactory,
+                    'currencyFactory'  => $this->mockCurrencyFactory
                 ]
             );
     }
 
-    public function testGetDefaultCurrency()
+    /**
+     * @return void
+     */
+    public function testGetDefaultCurrency(): void
     {
         $expectedDefaultCurrency = Currency::DEFAULT_CURRENCY;
         $retrievedDefaultCurrency = $this->testCurrencyObject->getDefaultCurrency();
         $this->assertEquals($expectedDefaultCurrency, $retrievedDefaultCurrency);
     }
 
-    public function testGetCurrencyNonCached()
+    /**
+     * @return void
+     */
+    public function testGetCurrencyNonCached(): void
     {
         $options = new \Zend_Currency(null, self::TEST_NONCACHED_CURRENCY_LOCALE);
 
@@ -101,7 +110,10 @@ class CurrencyTest extends TestCase
         $this->assertEquals([self::TEST_NONCACHED_CURRENCY], $retrievedCurrencyObject->getCurrencyList());
     }
 
-    public function testGetCurrencyCached()
+    /**
+     * @return void
+     */
+    public function testGetCurrencyCached(): void
     {
         $options = new \Zend_Currency(null, self::TEST_CACHED_CURRENCY_LOCALE);
 
@@ -146,7 +158,10 @@ class CurrencyTest extends TestCase
         $this->assertEquals([self::TEST_CACHED_CURRENCY], $retrievedCurrencyObject->getCurrencyList());
     }
 
-    public function testGetNonExistentCurrency()
+    /**
+     * @return void
+     */
+    public function testGetNonExistentCurrency(): void
     {
         $options = new \Zend_Currency(null, self::TEST_NONEXISTENT_CURRENCY_LOCALE);
 
@@ -172,19 +187,19 @@ class CurrencyTest extends TestCase
         $this->assertEquals(['EUR'], $retrievedCurrencyObject->getCurrencyList());
     }
 
-    public function testExceptionCase()
+    /**
+     * @return void
+     */
+    public function testExceptionCase(): void
     {
         $options = new \Zend_Currency(null, self::TEST_EXCEPTION_CURRENCY_LOCALE);
 
         $this->mockCurrencyFactory
-            ->expects($this->at(0))
             ->method('create')
-            ->willThrowException(new \Exception());
-
-        $this->mockCurrencyFactory
-            ->expects($this->at(1))
-            ->method('create')
-            ->willReturn($options);
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \Exception()),
+                $options
+            );
 
         $this->mockEventManager
             ->expects($this->once())

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/CurrencyTest.php
@@ -47,7 +47,7 @@ class CurrencyTest extends TestCase
     const TEST_EXCEPTION_CURRENCY_LOCALE = 'es_ES';
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
@@ -82,7 +82,7 @@ class TransportBuilderTest extends TestCase
     private $emailMessageInterfaceFactoryMock;
 
     /**
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -91,14 +91,13 @@ class TransportBuilderTest extends TestCase
         $this->messageMock = $this->createMock(Message::class);
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->senderResolverMock = $this->getMockForAbstractClass(SenderResolverInterface::class);
-        $this->mailTransportFactoryMock = $this->getMockBuilder(
-            TransportInterfaceFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $this->mailTransportFactoryMock = $this->getMockBuilder(TransportInterfaceFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
         $this->messageFactoryMock = $this->getMockBuilder(MessageInterfaceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
 
         $this->emailMessageInterfaceFactoryMock = $this->createMock(EmailMessageInterfaceFactory::class);
@@ -114,19 +113,20 @@ class TransportBuilderTest extends TestCase
                 'mailTransportFactory' => $this->mailTransportFactoryMock,
                 'messageFactory' => $this->messageFactoryMock,
                 'emailMessageInterfaceFactory' => $this->emailMessageInterfaceFactoryMock,
-                'mimePartInterfaceFactory' => $this->mimePartFactoryMock,
+                'mimePartInterfaceFactory' => $this->mimePartFactoryMock
             ]
         );
     }
 
     /**
-     * @dataProvider getTransportDataProvider
      * @param int $templateType
      * @param string $bodyText
      * @param string $templateNamespace
+     *
      * @return void
+     * @dataProvider getTransportDataProvider
      */
-    public function testGetTransport($templateType, $bodyText, $templateNamespace)
+    public function testGetTransport($templateType, $bodyText, $templateNamespace): void
     {
         $this->builder->setTemplateModel($templateNamespace);
 
@@ -161,7 +161,7 @@ class TransportBuilderTest extends TestCase
 
         $transport = $this->getMockForAbstractClass(TransportInterface::class);
 
-        $this->mailTransportFactoryMock->expects($this->at(0))
+        $this->mailTransportFactoryMock
             ->method('create')
             ->willReturn($transport);
 
@@ -172,9 +172,11 @@ class TransportBuilderTest extends TestCase
     }
 
     /**
-     * Test get transport with exception
+     * Test get transport with exception.
+     *
+     * @return void
      */
-    public function testGetTransportWithException()
+    public function testGetTransportWithException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Unknown template type');
@@ -200,7 +202,7 @@ class TransportBuilderTest extends TestCase
     /**
      * @return array
      */
-    public function getTransportDataProvider()
+    public function getTransportDataProvider(): array
     {
         return [
             [
@@ -219,7 +221,7 @@ class TransportBuilderTest extends TestCase
     /**
      * @return void
      */
-    public function testSetFromByScope()
+    public function testSetFromByScope(): void
     {
         $sender = ['email' => 'from@example.com', 'name' => 'name'];
         $scopeId = 1;

--- a/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
+++ b/lib/internal/Magento/Framework/Mail/Test/Unit/Template/TransportBuilderTest.php
@@ -82,7 +82,7 @@ class TransportBuilderTest extends TestCase
     private $emailMessageInterfaceFactoryMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Message/Test/Unit/ManagerTest.php
+++ b/lib/internal/Magento/Framework/Message/Test/Unit/ManagerTest.php
@@ -75,7 +75,7 @@ class ManagerTest extends TestCase
     private $exceptionMessageFactory;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Message/Test/Unit/ManagerTest.php
+++ b/lib/internal/Magento/Framework/Message/Test/Unit/ManagerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Message\Test\Unit;
 
+use Exception;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Message\Collection;
 use Magento\Framework\Message\CollectionFactory;
@@ -73,11 +74,12 @@ class ManagerTest extends TestCase
      */
     private $exceptionMessageFactory;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->messagesFactory = $this->getMockBuilder(
-            CollectionFactory::class
-        )
+        $this->messagesFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->messageFactory = $this->getMockBuilder(
@@ -85,13 +87,10 @@ class ManagerTest extends TestCase
         )
             ->disableOriginalConstructor()
             ->getMock();
-        $this->session = $this->getMockBuilder(
-            Session::class
-        )
+        $this->session = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                ['getData', 'setData']
-            )
+            ->onlyMethods(['getData'])
+            ->addMethods(['setData'])
             ->getMock();
         $this->eventManager = $this->getMockForAbstractClass(ManagerInterface::class);
         $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
@@ -115,184 +114,121 @@ class ManagerTest extends TestCase
         );
     }
 
-    public function testGetDefaultGroup()
+    /**
+     * @return void
+     */
+    public function testGetDefaultGroup(): void
     {
         $this->assertEquals(Manager::DEFAULT_GROUP, $this->model->getDefaultGroup());
     }
 
-    public function testGetMessages()
+    /**
+     * @return void
+     */
+    public function testGetMessages(): void
     {
-        $messageCollection = $this->getMockBuilder(
-            Collection::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-            ['addMessage']
-        )->getMock();
+        $messageCollection = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['addMessage'])->getMock();
 
-        $this->messagesFactory->expects(
-            $this->atLeastOnce()
-        )->method(
-            'create'
-        )->willReturn(
-            $messageCollection
-        );
+        $this->messagesFactory->expects($this->atLeastOnce())
+            ->method('create')
+            ->willReturn($messageCollection);
 
-        $this->session->expects(
-            $this->at(0)
-        )->method(
-            'getData'
-        )->with(
-            Manager::DEFAULT_GROUP
-        )->willReturn(
-            null
-        );
-        $this->session->expects(
-            $this->at(1)
-        )->method(
-            'setData'
-        )->with(
-            Manager::DEFAULT_GROUP,
-            $messageCollection
-        )->willReturn(
-            $this->session
-        );
-        $this->session->expects(
-            $this->at(2)
-        )->method(
-            'getData'
-        )->with(
-            Manager::DEFAULT_GROUP
-        )->willReturn(
-            $messageCollection
-        );
+        $this->session
+            ->method('getData')
+            ->withConsecutive([Manager::DEFAULT_GROUP], [Manager::DEFAULT_GROUP])
+            ->willReturnOnConsecutiveCalls(null, $messageCollection);
+        $this->session
+            ->method('setData')
+            ->with(Manager::DEFAULT_GROUP, $messageCollection)
+            ->willReturn($this->session);
 
         $this->eventManager->expects($this->never())->method('dispatch');
 
         $this->assertEquals($messageCollection, $this->model->getMessages());
     }
 
-    public function testGetMessagesWithClear()
+    /**
+     * @return void
+     */
+    public function testGetMessagesWithClear(): void
     {
-        $messageCollection = $this->getMockBuilder(
-            Collection::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-            ['addMessage', 'clear']
-        )->getMock();
+        $messageCollection = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['addMessage', 'clear'])->getMock();
 
         $messageCollection->expects($this->once())->method('clear');
 
-        $this->session->expects(
-            $this->any()
-        )->method(
-            'getData'
-        )->with(
-            Manager::DEFAULT_GROUP
-        )->willReturn(
-            $messageCollection
-        );
+        $this->session->expects($this->any())
+            ->method('getData')
+            ->with(Manager::DEFAULT_GROUP)
+            ->willReturn($messageCollection);
 
         $this->eventManager->expects($this->once())->method('dispatch')->with('session_abstract_clear_messages');
 
         $this->assertEquals($messageCollection, $this->model->getMessages(true));
     }
 
-    public function testAddExceptionWithAlternativeText()
+    /**
+     * @return void
+     */
+    public function testAddExceptionWithAlternativeText(): void
     {
         $exceptionMessage = 'exception message';
         $alternativeText = 'alternative text';
 
-        $this->logger->expects(
-            $this->once()
-        )->method(
-            'critical'
-        );
+        $this->logger->expects($this->once())
+            ->method('critical');
 
-        $messageError = $this->getMockBuilder(
-            Error::class
-        )->setConstructorArgs(
-            ['text' => $alternativeText]
-        )->getMock();
+        $messageError = $this->getMockBuilder(Error::class)
+            ->setConstructorArgs(['text' => $alternativeText])
+            ->getMock();
 
-        $this->messageFactory->expects(
-            $this->atLeastOnce()
-        )->method(
-            'create'
-        )->with(
-            MessageInterface::TYPE_ERROR,
-            $alternativeText
-        )->willReturn(
-            $messageError
-        );
+        $this->messageFactory->expects($this->atLeastOnce())
+            ->method('create')
+            ->with(
+                MessageInterface::TYPE_ERROR,
+                $alternativeText)
+            ->willReturn($messageError);
 
-        $messageCollection = $this->getMockBuilder(
-            Collection::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-            ['addMessage']
-        )->getMock();
+        $messageCollection = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()
+            ->onlyMethods(['addMessage'])->getMock();
         $messageCollection->expects($this->atLeastOnce())->method('addMessage')->with($messageError);
 
-        $this->session->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getData'
-        )->with(
-            Manager::DEFAULT_GROUP
-        )->willReturn(
-            $messageCollection
-        );
+        $this->session->expects($this->atLeastOnce())
+            ->method('getData')
+            ->with(Manager::DEFAULT_GROUP)
+            ->willReturn($messageCollection);
 
-        $exception = new \Exception($exceptionMessage);
+        $exception = new Exception($exceptionMessage);
         $this->assertEquals($this->model, $this->model->addException($exception, $alternativeText));
     }
 
-    public function testAddExceptionRenderable()
+    /**
+     * @return void
+     */
+    public function testAddExceptionRenderable(): void
     {
         $exceptionMessage = 'exception message';
-        $exception = new \Exception($exceptionMessage);
-
-        $this->logger->expects(
-            $this->once()
-        )->method(
-            'critical'
-        );
-
+        $exception = new Exception($exceptionMessage);
+        $this->logger->expects($this->once())->method('critical');
         $message = $this->getMockForAbstractClass(MessageInterface::class);
+        $this->messageFactory->expects($this->never())->method('create');
 
-        $this->messageFactory->expects(
-            $this->never()
-        )->method(
-            'create'
-        );
+        $this->exceptionMessageFactory->expects($this->once())
+            ->method('createMessage')
+            ->with($exception)
+            ->willReturn($message);
 
-        $this->exceptionMessageFactory->expects(
-            $this->once()
-        )->method(
-            'createMessage'
-        )->with(
-            $exception
-        )->willReturn(
-            $message
-        );
-
-        $messageCollection = $this->getMockBuilder(
-            Collection::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-            ['addMessage']
-        )->getMock();
+        $messageCollection = $this->getMockBuilder(Collection::class)->disableOriginalConstructor()
+            ->onlyMethods(['addMessage'])->getMock();
         $messageCollection->expects($this->atLeastOnce())->method('addMessage')->with($message);
 
-        $this->session->expects(
-            $this->atLeastOnce()
-        )->method(
-            'getData'
-        )->with(
-            Manager::DEFAULT_GROUP
-        )->willReturn(
-            $messageCollection
-        );
+        $this->session->expects($this->atLeastOnce())
+            ->method('getData')
+            ->with(Manager::DEFAULT_GROUP)
+            ->willReturn($messageCollection);
 
         $this->assertEquals($this->model, $this->model->addExceptionMessage($exception));
     }
@@ -300,9 +236,11 @@ class ManagerTest extends TestCase
     /**
      * @param string $type
      * @param string $methodName
+     *
+     * @return void
      * @dataProvider addMessageDataProvider
      */
-    public function testAddMessage($type, $methodName)
+    public function testAddMessage($type, $methodName): void
     {
         $this->assertFalse($this->model->hasMessages());
         $message = 'Message';
@@ -322,7 +260,7 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function addMessageDataProvider()
+    public function addMessageDataProvider(): array
     {
         return [
             'error' => [MessageInterface::TYPE_ERROR, 'addError'],
@@ -335,9 +273,11 @@ class ManagerTest extends TestCase
     /**
      * @param MockObject $messages
      * @param string $expectation
+     *
+     * @return void
      * @dataProvider addUniqueMessagesWhenMessagesImplementMessageInterfaceDataProvider
      */
-    public function testAddUniqueMessagesWhenMessagesImplementMessageInterface($messages, $expectation)
+    public function testAddUniqueMessagesWhenMessagesImplementMessageInterface($messages, $expectation): void
     {
         $messageCollection =
             $this->createPartialMock(Collection::class, ['getItems', 'addMessage']);
@@ -355,7 +295,7 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function addUniqueMessagesWhenMessagesImplementMessageInterfaceDataProvider()
+    public function addUniqueMessagesWhenMessagesImplementMessageInterfaceDataProvider(): array
     {
         return [
             'message_text_is_unique' => [
@@ -364,16 +304,18 @@ class ManagerTest extends TestCase
             ],
             'message_text_already_exists' => [
                 new TestingMessage('text'),
-                'never',
+                'never'
             ]
         ];
     }
 
     /**
      * @param string|array $messages
+     *
+     * @return void
      * @dataProvider addUniqueMessagesDataProvider
      */
-    public function testAddUniqueMessages($messages)
+    public function testAddUniqueMessages($messages): void
     {
         $messageCollection =
             $this->createPartialMock(Collection::class, ['getItems', 'addMessage']);
@@ -391,7 +333,7 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function addUniqueMessagesDataProvider()
+    public function addUniqueMessagesDataProvider(): array
     {
         return [
             'messages_are_text' => [['message']],
@@ -399,7 +341,10 @@ class ManagerTest extends TestCase
         ];
     }
 
-    public function testAddMessages()
+    /**
+     * @return void
+     */
+    public function testAddMessages(): void
     {
         $messageCollection =
             $this->createPartialMock(Collection::class, ['getItems', 'addMessage']);

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
@@ -20,6 +20,7 @@ use Magento\Framework\Registry;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -46,6 +47,9 @@ class AbstractDbTest extends TestCase
      */
     protected $relationProcessorMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_resourcesMock = $this->createMock(ResourceConnection::class);
@@ -78,9 +82,11 @@ class AbstractDbTest extends TestCase
     /**
      * @param $fieldNameType
      * @param $expectedResult
+     *
+     * @return void
      * @dataProvider addUniqueFieldDataProvider
      */
-    public function testAddUniqueField($fieldNameType, $expectedResult)
+    public function testAddUniqueField($fieldNameType, $expectedResult): void
     {
         $this->_model->addUniqueField($fieldNameType);
         $this->assertEquals($expectedResult, $this->_model->getUniqueFields());
@@ -89,22 +95,22 @@ class AbstractDbTest extends TestCase
     /**
      * @return array
      */
-    public function addUniqueFieldDataProvider()
+    public function addUniqueFieldDataProvider(): array
     {
         return [
             [
                 'fieldNameString',
-                ['fieldNameString'],
+                ['fieldNameString']
             ],
             [
                 [
                     'fieldNameArray',
-                    'FieldNameArraySecond',
+                    'FieldNameArraySecond'
                 ],
                 [
                     [
                         'fieldNameArray',
-                        'FieldNameArraySecond',
+                        'FieldNameArraySecond'
                     ]
                 ]
             ],
@@ -115,7 +121,10 @@ class AbstractDbTest extends TestCase
         ];
     }
 
-    public function testAddUniqueFieldArray()
+    /**
+     * @return void
+     */
+    public function testAddUniqueFieldArray(): void
     {
         $this->assertInstanceOf(
             AbstractDb::class,
@@ -123,17 +132,23 @@ class AbstractDbTest extends TestCase
         );
     }
 
-    public function testGetIdFieldNameException()
+    /**
+     * @return void
+     */
+    public function testGetIdFieldNameException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Empty identifier field name');
         $this->_model->getIdFieldName();
     }
 
-    public function testGetIdFieldname()
+    /**
+     * @return void
+     */
+    public function testGetIdFieldname(): void
     {
         $data = 'MainTableName';
-        $idFieldNameProperty = new \ReflectionProperty(
+        $idFieldNameProperty = new ReflectionProperty(
             AbstractDb::class,
             '_idFieldName'
         );
@@ -142,7 +157,10 @@ class AbstractDbTest extends TestCase
         $this->assertEquals($data, $this->_model->getIdFieldName());
     }
 
-    public function testGetMainTableException()
+    /**
+     * @return void
+     */
+    public function testGetMainTableException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Empty main table name');
@@ -150,13 +168,15 @@ class AbstractDbTest extends TestCase
     }
 
     /**
-     * @dataProvider getTableDataProvider
      * @param $tableName
      * @param $expectedResult
+     *
+     * @return void
+     * @dataProvider getTableDataProvider
      */
-    public function testGetMainTable($tableName, $expectedResult)
+    public function testGetMainTable($tableName, $expectedResult): void
     {
-        $mainTableProperty = new \ReflectionProperty(
+        $mainTableProperty = new ReflectionProperty(
             AbstractDb::class,
             '_mainTable'
         );
@@ -172,30 +192,33 @@ class AbstractDbTest extends TestCase
     /**
      * @return array
      */
-    public function getTableDataProvider()
+    public function getTableDataProvider(): array
     {
         return [
             [
                 'tableName',
-                'tableName',
+                'tableName'
             ],
             [
                 [
                     'tableName',
-                    'entity_suffix',
+                    'entity_suffix'
                 ],
                 'tableName_entity_suffix'
             ]
         ];
     }
 
-    public function testGetTable()
+    /**
+     * @return void
+     */
+    public function testGetTable(): void
     {
         $data = 'tableName';
         $this->_resourcesMock->expects($this->once())->method('getTableName')->with($data)->willReturn(
             'tableName'
         );
-        $tablesProperty = new \ReflectionProperty(
+        $tablesProperty = new ReflectionProperty(
             AbstractDb::class,
             '_tables'
         );
@@ -204,17 +227,22 @@ class AbstractDbTest extends TestCase
         $this->assertEquals($data, $this->_model->getTable($data));
     }
 
-    public function testGetChecksumNegative()
+    /**
+     * @return void
+     */
+    public function testGetChecksumNegative(): void
     {
         $this->assertFalse($this->_model->getChecksum(null));
     }
 
     /**
-     * @dataProvider getChecksumProvider
      * @param $checksum
      * @param $expected
+     *
+     * @return void
+     * @dataProvider getChecksumProvider
      */
-    public function testGetChecksum($checksum, $expected)
+    public function testGetChecksum($checksum, $expected): void
     {
         $connectionMock = $this->getMockForAbstractClass(AdapterInterface::class);
         $connectionMock->expects($this->once())->method('getTablesChecksum')->with($checksum)->willReturn(
@@ -229,7 +257,7 @@ class AbstractDbTest extends TestCase
     /**
      * @return array
      */
-    public function getChecksumProvider()
+    public function getChecksumProvider(): array
     {
         return [
             [
@@ -243,9 +271,12 @@ class AbstractDbTest extends TestCase
         ];
     }
 
-    public function testResetUniqueField()
+    /**
+     * @return void
+     */
+    public function testResetUniqueField(): void
     {
-        $uniqueFields = new \ReflectionProperty(
+        $uniqueFields = new ReflectionProperty(
             AbstractDb::class,
             '_uniqueFields'
         );
@@ -255,9 +286,12 @@ class AbstractDbTest extends TestCase
         $this->assertEquals([], $this->_model->getUniqueFields());
     }
 
-    public function testGetUniqueFields()
+    /**
+     * @return void
+     */
+    public function testGetUniqueFields(): void
     {
-        $uniqueFieldsReflection = new \ReflectionProperty(
+        $uniqueFieldsReflection = new ReflectionProperty(
             AbstractDb::class,
             '_uniqueFields'
         );
@@ -266,14 +300,20 @@ class AbstractDbTest extends TestCase
         $this->assertEquals([], $this->_model->getUniqueFields());
     }
 
-    public function testGetValidationRulesBeforeSave()
+    /**
+     * @return void
+     */
+    public function testGetValidationRulesBeforeSave(): void
     {
         $this->assertNull($this->_model->getValidationRulesBeforeSave());
     }
 
-    public function testLoad()
+    /**
+     * @return void
+     */
+    public function testLoad(): void
     {
-        /** @var \Magento\Framework\Model\AbstractModel|MockObject $object */
+        /** @var AbstractModel|MockObject $object */
         $object = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -289,7 +329,10 @@ class AbstractDbTest extends TestCase
         );
     }
 
-    public function testDelete()
+    /**
+     * @return void
+     */
+    public function testDelete(): void
     {
         $connectionInterfaceMock = $this->getMockForAbstractClass(AdapterInterface::class);
         $contextMock = $this->createMock(\Magento\Framework\Model\Context::class);
@@ -331,13 +374,13 @@ class AbstractDbTest extends TestCase
         $this->_resourcesMock->expects($this->any())->method('getTableName')->with($data)->willReturn(
             'tableName'
         );
-        $mainTableReflection = new \ReflectionProperty(
+        $mainTableReflection = new ReflectionProperty(
             AbstractDb::class,
             '_mainTable'
         );
         $mainTableReflection->setAccessible(true);
         $mainTableReflection->setValue($this->_model, 'tableName');
-        $idFieldNameReflection = new \ReflectionProperty(
+        $idFieldNameReflection = new ReflectionProperty(
             AbstractDb::class,
             '_idFieldName'
         );
@@ -354,7 +397,10 @@ class AbstractDbTest extends TestCase
         );
     }
 
-    public function testHasDataChangedNegative()
+    /**
+     * @return void
+     */
+    public function testHasDataChangedNegative(): void
     {
         $contextMock = $this->createMock(\Magento\Framework\Model\Context::class);
         $registryMock = $this->createMock(Registry::class);
@@ -372,11 +418,13 @@ class AbstractDbTest extends TestCase
     }
 
     /**
-     * @dataProvider hasDataChangedDataProvider
      * @param string $getOriginData
      * @param bool $expected
+     *
+     * @return void
+     * @dataProvider hasDataChangedDataProvider
      */
-    public function testGetDataChanged($getOriginData, $expected)
+    public function testGetDataChanged($getOriginData, $expected): void
     {
         $connectionInterfaceMock = $this->getMockForAbstractClass(AdapterInterface::class);
         $this->_resourcesMock->expects($this->any())->method('getConnection')->willReturn(
@@ -393,7 +441,7 @@ class AbstractDbTest extends TestCase
             true,
             ['__wakeup', 'getOrigData', 'getData']
         );
-        $mainTableProperty = new \ReflectionProperty(
+        $mainTableProperty = new ReflectionProperty(
             AbstractDb::class,
             '_mainTable'
         );
@@ -404,8 +452,9 @@ class AbstractDbTest extends TestCase
             ->method('getTableName')
             ->with('table')
             ->willReturn('tableName');
-        $abstractModelMock->expects($this->at(0))->method('getOrigData')->willReturn(true);
-        $abstractModelMock->expects($this->at(1))->method('getOrigData')->willReturn($getOriginData);
+        $abstractModelMock
+            ->method('getOrigData')
+            ->willReturnOnConsecutiveCalls(true, $getOriginData);
         $connectionInterfaceMock->expects($this->any())->method('describeTable')->with('tableName')->willReturn(
             ['tableName']
         );
@@ -415,7 +464,7 @@ class AbstractDbTest extends TestCase
     /**
      * @return array
      */
-    public function hasDataChangedDataProvider()
+    public function hasDataChangedDataProvider(): array
     {
         return [
             [true, true],
@@ -424,12 +473,14 @@ class AbstractDbTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareDataForUpdate()
+    public function testPrepareDataForUpdate(): void
     {
         $connectionMock = $this->getMockBuilder(AdapterInterface::class)
-            ->setMethods(['save'])
+            ->addMethods(['save'])
             ->getMockForAbstractClass();
 
         $context = (new ObjectManager($this))->getObject(
@@ -459,13 +510,13 @@ class AbstractDbTest extends TestCase
             'tableName'
         );
 
-        $mainTableReflection = new \ReflectionProperty(
+        $mainTableReflection = new ReflectionProperty(
             AbstractDb::class,
             '_mainTable'
         );
         $mainTableReflection->setAccessible(true);
         $mainTableReflection->setValue($this->_model, 'tableName');
-        $idFieldNameReflection = new \ReflectionProperty(
+        $idFieldNameReflection = new ReflectionProperty(
             AbstractDb::class,
             '_idFieldName'
         );
@@ -525,19 +576,21 @@ class AbstractDbTest extends TestCase
     }
 
     /**
-     * Test that we only set/override id on object if PK autoincrement is enabled
+     * Test that we only set/override id on object if PK autoincrement is enabled.
+     *
      * @param bool $pkIncrement
+     *
+     * @return void
      * @dataProvider saveNewObjectDataProvider
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function testSaveNewObject($pkIncrement)
+    public function testSaveNewObject($pkIncrement): void
     {
         /**
          * Mock SUT so as not to test extraneous logic
          */
-        $model = $this->getMockBuilder(AbstractDb::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['_prepareDataForSave', 'getIdFieldName', 'getConnection', 'getMainTable'])
+        $model = $this->getMockBuilder(AbstractDb::class)->disableOriginalConstructor()
+            ->onlyMethods(['_prepareDataForSave', 'getIdFieldName', 'getConnection', 'getMainTable'])
             ->getMockForAbstractClass();
         /**
          * Only testing the logic in a protected method and property, must use reflection to avoid dealing with large
@@ -547,14 +600,13 @@ class AbstractDbTest extends TestCase
          */
         $reflectionMethod = new \ReflectionMethod($model, 'saveNewObject');
         $reflectionMethod->setAccessible(true);
-        $reflectionProperty = new \ReflectionProperty($model, '_isPkAutoIncrement');
+        $reflectionProperty = new ReflectionProperty($model, '_isPkAutoIncrement');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($model, $pkIncrement);
 
         // Mocked behavior
-        $connectionMock = $this->getMockBuilder(AdapterInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['lastInsertId'])
+        $connectionMock = $this->getMockBuilder(AdapterInterface::class)->disableOriginalConstructor()
+            ->addMethods(['lastInsertId'])
             ->getMockForAbstractClass();
         $getConnectionInvokedCount = $pkIncrement ? 2 : 1;
         $model->expects($this->exactly($getConnectionInvokedCount))
@@ -588,21 +640,23 @@ class AbstractDbTest extends TestCase
     /**
      * @return array
      */
-    public function saveNewObjectDataProvider()
+    public function saveNewObjectDataProvider(): array
     {
         return [[true], [false]];
     }
 
-    public function testDuplicateExceptionProcessingOnSave()
+    /**
+     * @return void
+     */
+    public function testDuplicateExceptionProcessingOnSave(): void
     {
         $this->expectException('Magento\Framework\Exception\AlreadyExistsException');
         $connection = $this->getMockForAbstractClass(AdapterInterface::class);
         $connection->expects($this->once())->method('rollback');
 
         /** @var AbstractDb|MockObject $model */
-        $model = $this->getMockBuilder(AbstractDb::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getConnection'])
+        $model = $this->getMockBuilder(AbstractDb::class)->disableOriginalConstructor()
+            ->onlyMethods(['getConnection'])
             ->getMockForAbstractClass();
         $model->expects($this->any())->method('getConnection')->willReturn($connection);
 

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/AbstractDbTest.php
@@ -48,7 +48,7 @@ class AbstractDbTest extends TestCase
     protected $relationProcessorMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/ReadEntityRowTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/ReadEntityRowTest.php
@@ -43,7 +43,7 @@ class ReadEntityRowTest extends TestCase
     protected $metadataPool;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/ReadEntityRowTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/ResourceModel/Db/ReadEntityRowTest.php
@@ -42,6 +42,9 @@ class ReadEntityRowTest extends TestCase
      */
     protected $metadataPool;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->select = $this->createMock(Select::class);
@@ -90,7 +93,10 @@ class ReadEntityRowTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $identifier = '100000001';
 
@@ -102,15 +108,10 @@ class ReadEntityRowTest extends TestCase
             ->with(['t' => 'entity_table'])
             ->willReturnSelf();
 
-        $this->select->expects($this->at(1))
+        $this->select
             ->method('where')
-            ->with('identifier = ?', $identifier)
-            ->willReturnSelf();
-
-        $this->select->expects($this->at(2))
-            ->method('where')
-            ->with('store_id = ?', 1)
-            ->willReturnSelf();
+            ->withConsecutive(['identifier = ?', $identifier], ['store_id = ?', 1])
+            ->willReturnOnConsecutiveCalls($this->select, $this->select);
 
         $this->connection->expects($this->once())
             ->method('fetchRow')

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
@@ -36,7 +36,7 @@ class ManagerTest extends TestCase
     private $_outputConfig;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -47,32 +47,36 @@ class ManagerTest extends TestCase
                 [
                     ['Module_One', ['name' => 'One_Module', 'setup_version' => '1']],
                     ['Module_Two', ['name' => 'Two_Module', 'setup_version' => '2']],
-                    ['Module_Three', ['name' => 'Two_Three']],
+                    ['Module_Three', ['name' => 'Two_Three']]
                 ]
             );
         $this->_outputConfig = $this->getMockForAbstractClass(ConfigInterface::class);
         $this->_model = new Manager(
             $this->_outputConfig,
             $this->_moduleList,
-            [
-                'Module_Two' => self::XML_PATH_OUTPUT_ENABLED,
-            ]
+            ['Module_Two' => self::XML_PATH_OUTPUT_ENABLED]
         );
     }
 
-    public function testIsEnabled()
+    /**
+     * @return void
+     */
+    public function testIsEnabled(): void
     {
         $this->_moduleList->expects($this->exactly(2))->method('has')->willReturnMap(
             [
                 ['Module_Exists', true],
-                ['Module_NotExists', false],
+                ['Module_NotExists', false]
             ]
         );
         $this->assertTrue($this->_model->isEnabled('Module_Exists'));
         $this->assertFalse($this->_model->isEnabled('Module_NotExists'));
     }
 
-    public function testIsOutputEnabledReturnsFalseForDisabledModule()
+    /**
+     * @return void
+     */
+    public function testIsOutputEnabledReturnsFalseForDisabledModule(): void
     {
         $this->_outputConfig->expects($this->any())->method('isSetFlag')->willReturn(true);
         $this->assertFalse($this->_model->isOutputEnabled('Disabled_Module'));
@@ -81,9 +85,11 @@ class ManagerTest extends TestCase
     /**
      * @param bool $configValue
      * @param bool $expectedResult
+     *
+     * @return void
      * @dataProvider isOutputEnabledGenericConfigPathDataProvider
      */
-    public function testIsOutputEnabledGenericConfigPath($configValue, $expectedResult)
+    public function testIsOutputEnabledGenericConfigPath($configValue, $expectedResult): void
     {
         $this->_moduleList->expects($this->once())->method('has')->willReturn(true);
         $this->_outputConfig->expects($this->once())
@@ -96,7 +102,7 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function isOutputEnabledGenericConfigPathDataProvider()
+    public function isOutputEnabledGenericConfigPathDataProvider(): array
     {
         return ['output disabled' => [true, false], 'output enabled' => [false, true]];
     }
@@ -104,12 +110,14 @@ class ManagerTest extends TestCase
     /**
      * @param bool $configValue
      * @param bool $expectedResult
+     *
+     * @return void
      * @dataProvider isOutputEnabledCustomConfigPathDataProvider
      */
-    public function testIsOutputEnabledCustomConfigPath($configValue, $expectedResult)
+    public function testIsOutputEnabledCustomConfigPath($configValue, $expectedResult): void
     {
         $this->_moduleList->expects($this->once())->method('has')->willReturn(true);
-        $this->_outputConfig->expects($this->at(0))
+        $this->_outputConfig
             ->method('isSetFlag')
             ->with(self::XML_PATH_OUTPUT_ENABLED)
             ->willReturn($configValue);
@@ -119,11 +127,11 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function isOutputEnabledCustomConfigPathDataProvider()
+    public function isOutputEnabledCustomConfigPathDataProvider(): array
     {
         return [
             'path literal, output disabled' => [false, false],
-            'path literal, output enabled'  => [true, true],
+            'path literal, output enabled'  => [true, true]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ManagerTest.php
@@ -36,7 +36,7 @@ class ManagerTest extends TestCase
     private $_outputConfig;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
@@ -48,7 +48,7 @@ class ModuleListTest extends TestCase
     private $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleListTest.php
@@ -47,6 +47,9 @@ class ModuleListTest extends TestCase
      */
     private $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->config = $this->createMock(DeploymentConfig::class);
@@ -54,7 +57,10 @@ class ModuleListTest extends TestCase
         $this->model = new ModuleList($this->config, $this->loader);
     }
 
-    public function testGetAll()
+    /**
+     * @return void
+     */
+    public function testGetAll(): void
     {
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
@@ -63,7 +69,10 @@ class ModuleListTest extends TestCase
         $this->assertSame($expected, $this->model->getAll()); // second time to ensure loadAll is called once
     }
 
-    public function testGetAllNoData()
+    /**
+     * @return void
+     */
+    public function testGetAllNoData(): void
     {
         $this->loader->expects($this->exactly(2))->method('load')->willReturn([]);
         $this->setLoadConfigExpectation(false);
@@ -71,7 +80,10 @@ class ModuleListTest extends TestCase
         $this->assertEquals([], $this->model->getAll());
     }
 
-    public function testGetOne()
+    /**
+     * @return void
+     */
+    public function testGetOne(): void
     {
         $this->setLoadAllExpectation();
         $this->setLoadConfigExpectation();
@@ -79,7 +91,10 @@ class ModuleListTest extends TestCase
         $this->assertNull($this->model->getOne('bar'));
     }
 
-    public function testGetNames()
+    /**
+     * @return void
+     */
+    public function testGetNames(): void
     {
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
@@ -87,7 +102,10 @@ class ModuleListTest extends TestCase
         $this->assertSame(['foo'], $this->model->getNames()); // second time to ensure config loader is called once
     }
 
-    public function testHas()
+    /**
+     * @return void
+     */
+    public function testHas(): void
     {
         $this->setLoadAllExpectation(false);
         $this->setLoadConfigExpectation();
@@ -95,26 +113,35 @@ class ModuleListTest extends TestCase
         $this->assertFalse($this->model->has('bar'));
     }
 
-    public function testIsModuleInfoAvailable()
+    /**
+     * @return void
+     */
+    public function testIsModuleInfoAvailable(): void
     {
         $this->setLoadConfigExpectation(true);
         $this->assertTrue($this->model->isModuleInfoAvailable());
     }
 
-    public function testIsModuleInfoAvailableNoConfig()
+    /**
+     * @return void
+     */
+    public function testIsModuleInfoAvailableNoConfig(): void
     {
-        $this->config->expects($this->at(0))->method('get')->willReturn(['modules' => 'testModule']);
-        $this->config->expects($this->at(1))->method('get')->willReturn(null);
+        $this->config
+            ->method('get')
+            ->willReturnOnConsecutiveCalls(['modules' => 'testModule'], null);
         $this->assertFalse($this->model->isModuleInfoAvailable());
     }
 
     /**
-     * Prepares expectation for loading deployment configuration
+     * Prepares expectation for loading deployment configuration.
      *
      * @param bool $isExpected
      * @return void
+     *
+     * @return void
      */
-    private function setLoadConfigExpectation($isExpected = true)
+    private function setLoadConfigExpectation($isExpected = true): void
     {
         if ($isExpected) {
             $this->config->expects($this->exactly(2))->method('get')->willReturn(self::$enabledFixture);
@@ -124,12 +151,14 @@ class ModuleListTest extends TestCase
     }
 
     /**
-     * Prepares expectation for loading full list of modules
+     * Prepares expectation for loading full list of modules.
      *
      * @param bool $isExpected
      * @return void
+     *
+     * @return void
      */
-    private function setLoadAllExpectation($isExpected = true)
+    private function setLoadAllExpectation($isExpected = true): void
     {
         if ($isExpected) {
             $this->loader->expects($this->once())->method('load')->willReturn(self::$allFixture);

--- a/lib/internal/Magento/Framework/Module/Test/Unit/StatusTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/StatusTest.php
@@ -49,6 +49,9 @@ class StatusTest extends TestCase
      */
     private $object;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->loader = $this->createMock(Loader::class);
@@ -65,7 +68,10 @@ class StatusTest extends TestCase
         );
     }
 
-    public function testCheckConstraintsEnableAllowed()
+    /**
+     * @return void
+     */
+    public function testCheckConstraintsEnableAllowed(): void
     {
         $this->conflictChecker->expects($this->once())
             ->method('checkConflictsWhenEnableModules')
@@ -81,7 +87,10 @@ class StatusTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testCheckConstraintsEnableNotAllowed()
+    /**
+     * @return void
+     */
+    public function testCheckConstraintsEnableNotAllowed(): void
     {
         $this->conflictChecker->expects($this->once())
             ->method('checkConflictsWhenEnableModules')
@@ -90,7 +99,7 @@ class StatusTest extends TestCase
             ->method('checkDependenciesWhenEnableModules')
             ->willReturn([
                 'Module_Foo' => ['Module_Baz' => ['Module_Foo', 'Module_Baz']],
-                'Module_Bar' => ['Module_Baz' => ['Module_Bar', 'Module_Baz']],
+                'Module_Bar' => ['Module_Baz' => ['Module_Bar', 'Module_Baz']]
             ]);
         $result = $this->object->checkConstraints(true, ['Module_Foo' => '', 'Module_Bar' => ''], [], false);
         $expect = [
@@ -101,12 +110,15 @@ class StatusTest extends TestCase
             'Cannot enable Module_Foo because it conflicts with other modules:',
             "Module_Bar",
             'Cannot enable Module_Bar because it conflicts with other modules:',
-            "Module_Foo",
+            "Module_Foo"
         ];
         $this->assertEquals($expect, $result);
     }
 
-    public function testCheckConstraintsEnableNotAllowedWithPrettyMsg()
+    /**
+     * @return void
+     */
+    public function testCheckConstraintsEnableNotAllowedWithPrettyMsg(): void
     {
         $this->conflictChecker->expects($this->once())
             ->method('checkConflictsWhenEnableModules')
@@ -115,7 +127,7 @@ class StatusTest extends TestCase
             ->method('checkDependenciesWhenEnableModules')
             ->willReturn([
                 'Module_Foo' => ['Module_Baz' => ['Module_Foo', 'Module_Baz']],
-                'Module_Bar' => ['Module_Baz' => ['Module_Bar', 'Module_Baz']],
+                'Module_Bar' => ['Module_Baz' => ['Module_Bar', 'Module_Baz']]
             ]);
         $result = $this->object->checkConstraints(true, ['Module_Foo' => '', 'Module_Bar' => ''], [], true);
         $expect = [
@@ -124,12 +136,15 @@ class StatusTest extends TestCase
             'Cannot enable Module_Foo because it conflicts with other modules:',
             "Module_Bar",
             'Cannot enable Module_Bar because it conflicts with other modules:',
-            "Module_Foo",
+            "Module_Foo"
         ];
         $this->assertEquals($expect, $result);
     }
 
-    public function testCheckConstraintsDisableAllowed()
+    /**
+     * @return void
+     */
+    public function testCheckConstraintsDisableAllowed(): void
     {
         $this->dependencyChecker->expects($this->once())
             ->method('checkDependenciesWhenDisableModules')
@@ -138,38 +153,42 @@ class StatusTest extends TestCase
         $this->assertEquals([], $result);
     }
 
-    public function testCheckConstraintsDisableNotAllowed()
+    public function testCheckConstraintsDisableNotAllowed(): void
     {
         $this->dependencyChecker->expects($this->once())
             ->method('checkDependenciesWhenDisableModules')
             ->willReturn([
                 'Module_Foo' => ['Module_Baz' => ['Module_Baz', 'Module_Foo']],
-                'Module_Bar' => ['Module_Baz' => ['Module_Baz', 'Module_Bar']],
+                'Module_Bar' => ['Module_Baz' => ['Module_Baz', 'Module_Bar']]
             ]);
         $result = $this->object->checkConstraints(false, ['Module_Foo' => '', 'Module_Bar' => '']);
         $expect = [
             'Cannot disable Module_Foo because modules depend on it:',
             "Module_Baz: Module_Baz->Module_Foo",
             'Cannot disable Module_Bar because modules depend on it:',
-            "Module_Baz: Module_Baz->Module_Bar",
+            "Module_Baz: Module_Baz->Module_Bar"
         ];
         $this->assertEquals($expect, $result);
     }
 
-    public function testSetIsEnabled()
+    /**
+     * @return void
+     */
+    public function testSetIsEnabled(): void
     {
         $modules = ['Module_Foo' => '', 'Module_Bar' => '', 'Module_Baz' => ''];
         $this->loader->expects($this->once())->method('load')->willReturn($modules);
-        $this->moduleList->expects($this->at(0))->method('has')->with('Module_Foo')->willReturn(false);
-        $this->moduleList->expects($this->at(1))->method('has')->with('Module_Bar')->willReturn(false);
-        $this->moduleList->expects($this->at(2))->method('has')->with('Module_Baz')->willReturn(false);
+        $this->moduleList
+            ->method('has')
+            ->withConsecutive(['Module_Foo'], ['Module_Bar'], ['Module_Baz'])
+            ->willReturnOnConsecutiveCalls(false, false, false);
         $expectedModules = ['Module_Foo' => 1, 'Module_Bar' => 1, 'Module_Baz' => 0];
         $this->writer->expects($this->once())->method('saveConfig')
             ->with([ConfigFilePool::APP_CONFIG => ['modules' => $expectedModules]]);
         $this->object->setIsEnabled(true, ['Module_Foo', 'Module_Bar']);
     }
 
-    public function testSetIsEnabledUnknown()
+    public function testSetIsEnabledUnknown(): void
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Unknown module(s): \'Module_Baz\'');
@@ -185,14 +204,22 @@ class StatusTest extends TestCase
      * @param bool $thirdEnabled
      * @param bool $isEnabled
      * @param string[] $expected
+     *
+     * @return void
      */
-    public function testGetModulesToChange($firstEnabled, $secondEnabled, $thirdEnabled, $isEnabled, $expected)
-    {
+    public function testGetModulesToChange(
+        $firstEnabled,
+        $secondEnabled,
+        $thirdEnabled,
+        $isEnabled,
+        $expected
+    ): void {
         $modules = ['Module_Foo' => '', 'Module_Bar' => '', 'Module_Baz' => ''];
         $this->loader->expects($this->once())->method('load')->willReturn($modules);
-        $this->moduleList->expects($this->at(0))->method('has')->with('Module_Foo')->willReturn($firstEnabled);
-        $this->moduleList->expects($this->at(1))->method('has')->with('Module_Bar')->willReturn($secondEnabled);
-        $this->moduleList->expects($this->at(2))->method('has')->with('Module_Baz')->willReturn($thirdEnabled);
+        $this->moduleList
+            ->method('has')
+            ->withConsecutive(['Module_Foo'], ['Module_Bar'], ['Module_Baz'])
+            ->willReturnOnConsecutiveCalls($firstEnabled, $secondEnabled, $thirdEnabled);
         $result = $this->object->getModulesToChange($isEnabled, ['Module_Foo', 'Module_Bar', 'Module_Baz']);
         $this->assertEquals($expected, $result);
     }
@@ -200,7 +227,7 @@ class StatusTest extends TestCase
     /**
      * @return array
      */
-    public function getModulesToChangeDataProvider()
+    public function getModulesToChangeDataProvider(): array
     {
         return [
             [true, true, true, true, []],
@@ -211,7 +238,7 @@ class StatusTest extends TestCase
             [true, false, false, false, ['Module_Foo']],
             [false, true, false, false, ['Module_Bar']],
             [false, true, true, false, ['Module_Bar', 'Module_Baz']],
-            [true, true, true, false, ['Module_Foo', 'Module_Bar', 'Module_Baz']],
+            [true, true, true, false, ['Module_Foo', 'Module_Bar', 'Module_Baz']]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Module/Test/Unit/StatusTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/StatusTest.php
@@ -50,7 +50,7 @@ class StatusTest extends TestCase
     private $object;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
@@ -21,6 +21,8 @@ use Magento\Framework\Mview\View\Subscription;
 use Magento\Framework\Mview\ViewInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
+use ReflectionMethod;
 
 class SubscriptionTest extends TestCase
 {
@@ -31,34 +33,44 @@ class SubscriptionTest extends TestCase
      */
     protected $connectionMock;
 
-    /** @var Subscription */
+    /**
+     * @var Subscription
+     */
     protected $model;
 
-    /** @var MockObject|ResourceConnection */
+    /**
+     * @var MockObject|ResourceConnection
+     */
     protected $resourceMock;
 
-    /** @var MockObject|TriggerFactory */
+    /**
+     * @var MockObject|TriggerFactory
+     */
     protected $triggerFactoryMock;
 
-    /** @var MockObject|CollectionInterface */
+    /**
+     * @var MockObject|CollectionInterface
+     */
     protected $viewCollectionMock;
 
-    /** @var MockObject|ViewInterface */
+    /**
+     * @var MockObject|ViewInterface
+     */
     protected $viewMock;
 
-    /** @var  string */
-    private $tableName;
-
     /**
-     * @var Config|MockObject
+     * @var  string
      */
-    private $mviewConfig;
+    private $tableName;
 
     /**
      * @var DefaultProcessor|MockObject
      */
     private $defaultProcessor;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->tableName = 'test_table';
@@ -126,30 +138,41 @@ class SubscriptionTest extends TestCase
         );
     }
 
-    public function testGetView()
+    /**
+     * @return void
+     */
+    public function testGetView(): void
     {
         $this->assertEquals($this->viewMock, $this->model->getView());
     }
 
-    public function testGetTableName()
+    /**
+     * @return void
+     */
+    public function testGetTableName(): void
     {
         $this->assertEquals($this->tableName, $this->model->getTableName());
     }
 
-    public function testGetColumnName()
+    /**
+     * @return void
+     */
+    public function testGetColumnName(): void
     {
         $this->assertEquals('columnName', $this->model->getColumnName());
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $triggerName = 'trigger_name';
         $this->resourceMock->expects($this->atLeastOnce())->method('getTriggerName')->willReturn($triggerName);
         $triggerMock = $this->getMockBuilder(Trigger::class)
-            ->setMethods(['setName', 'getName', 'setTime', 'setEvent', 'setTable', 'addStatement'])
+            ->onlyMethods(['setName', 'getName', 'setTime', 'setEvent', 'setTable', 'addStatement'])
             ->disableOriginalConstructor()
             ->getMock();
         $triggerMock->expects($this->exactly(3))
@@ -167,29 +190,17 @@ class SubscriptionTest extends TestCase
             ->method('setTable')
             ->with($this->tableName)->willReturnSelf();
 
-        $triggerMock->expects($this->at(4))
+        $triggerMock
             ->method('addStatement')
-            ->with("INSERT IGNORE INTO test_view_cl (entity_id) VALUES (NEW.columnName);")->willReturnSelf();
-
-        $triggerMock->expects($this->at(5))
-            ->method('addStatement')
-            ->with("INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (NEW.columnName);")->willReturnSelf();
-
-        $triggerMock->expects($this->at(11))
-            ->method('addStatement')
-            ->with("INSERT IGNORE INTO test_view_cl (entity_id) VALUES (NEW.columnName);")->willReturnSelf();
-
-        $triggerMock->expects($this->at(12))
-            ->method('addStatement')
-            ->with("INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (NEW.columnName);")->willReturnSelf();
-
-        $triggerMock->expects($this->at(18))
-            ->method('addStatement')
-            ->with("INSERT IGNORE INTO test_view_cl (entity_id) VALUES (OLD.columnName);")->willReturnSelf();
-
-        $triggerMock->expects($this->at(19))
-            ->method('addStatement')
-            ->with("INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (OLD.columnName);")->willReturnSelf();
+            ->withConsecutive(
+                ["INSERT IGNORE INTO test_view_cl (entity_id) VALUES (NEW.columnName);"],
+                ["INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (NEW.columnName);"],
+                ["INSERT IGNORE INTO test_view_cl (entity_id) VALUES (NEW.columnName);"],
+                ["INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (NEW.columnName);"],
+                ["INSERT IGNORE INTO test_view_cl (entity_id) VALUES (OLD.columnName);"],
+                ["INSERT IGNORE INTO other_test_view_cl (entity_id) VALUES (OLD.columnName);"]
+            )
+            ->willReturnOnConsecutiveCalls($triggerMock, $triggerMock, $triggerMock, $triggerMock, $triggerMock, $triggerMock);
 
         $changelogMock = $this->getMockForAbstractClass(
             ChangelogInterface::class,
@@ -284,7 +295,10 @@ class SubscriptionTest extends TestCase
         $this->model->create();
     }
 
-    public function testRemove()
+    /**
+     * @return void
+     */
+    public function testRemove(): void
     {
         $triggerMock = $this->createMock(Trigger::class);
         $triggerMock->expects($this->exactly(3))
@@ -373,9 +387,10 @@ class SubscriptionTest extends TestCase
     }
 
     /**
-     * Test ignored columns for mview specified at the subscription level
+     * Test ignored columns for mview specified at the subscription level.
      *
      * @return void
+     * @throws ReflectionException
      */
     public function testBuildStatementIgnoredColumnSubscriptionLevel(): void
     {
@@ -451,7 +466,7 @@ class SubscriptionTest extends TestCase
             $mviewConfigMock
         );
 
-        $method = new \ReflectionMethod($model, 'buildStatement');
+        $method = new ReflectionMethod($model, 'buildStatement');
         $method->setAccessible(true);
         $statement = $method->invoke($model, Trigger::EVENT_UPDATE, $this->viewMock);
 

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
@@ -69,7 +69,7 @@ class SubscriptionTest extends TestCase
     private $defaultProcessor;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ConverterTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ConverterTest.php
@@ -51,7 +51,7 @@ class ConverterTest extends TestCase
     private $definedClassesMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ConverterTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/ConverterTest.php
@@ -12,6 +12,8 @@ use Magento\Framework\Code\Generator\DefinedClasses;
 use Magento\Framework\Code\Generator\EntityAbstract;
 use Magento\Framework\Code\Generator\Io;
 use Magento\Framework\ObjectManager\Code\Generator\Converter;
+use Magento\Framework\ObjectManager\Code\Generator\Sample;
+use Magento\Framework\ObjectManager\Code\Generator\SampleConverter;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,10 +50,13 @@ class ConverterTest extends TestCase
      */
     private $definedClassesMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->sourceClassName = '\\' . \Magento\Framework\ObjectManager\Code\Generator\Sample::class;
-        $this->resultClassName = '\\' . \Magento\Framework\ObjectManager\Code\Generator\SampleConverter::class;
+        $this->sourceClassName = '\\' . Sample::class;
+        $this->resultClassName = '\\' . SampleConverter::class;
 
         $this->ioObjectMock = $this->createMock(Io::class);
         $this->classGenerator = $this->createMock(ClassGenerator::class);
@@ -73,13 +78,16 @@ class ConverterTest extends TestCase
         );
     }
 
-    public function testGenerate()
+    /**
+     * @return void
+     */
+    public function testGenerate(): void
     {
         $generatedCode = 'Generated code';
         $resultFileName = 'SampleConverter.php';
 
         //Mocking _validateData call
-        $this->definedClassesMock->expects($this->at(0))
+        $this->definedClassesMock
             ->method('isClassLoadable')
             ->willReturn(true);
 

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/AbstractAdjustmentTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/AbstractAdjustmentTest.php
@@ -38,6 +38,9 @@ class AbstractAdjustmentTest extends TestCase
      */
     protected $data;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->priceCurrency = $this->getMockForAbstractClass(PriceCurrencyInterface::class);
@@ -51,13 +54,15 @@ class AbstractAdjustmentTest extends TestCase
                 'data' => $this->data
             ]
         );
-        $this->model = $this->getMockBuilder(AbstractAdjustment::class)
-            ->setConstructorArgs($constructorArgs)
-            ->setMethods(['getData', 'setData', 'apply'])
+        $this->model = $this->getMockBuilder(AbstractAdjustment::class)->setConstructorArgs($constructorArgs)
+            ->onlyMethods(['getData', 'setData', 'apply'])
             ->getMockForAbstractClass();
     }
 
-    public function testConvertAndFormatCurrency()
+    /**
+     * @return void
+     */
+    public function testConvertAndFormatCurrency(): void
     {
         $amount = '100';
         $includeContainer = true;
@@ -73,41 +78,47 @@ class AbstractAdjustmentTest extends TestCase
         $this->assertEquals($result, $this->model->convertAndFormatCurrency($amount, $includeContainer, $precision));
     }
 
-    public function testRender()
+    /**
+     * @return void
+     */
+    public function testRender(): void
     {
         $amountRender = $this->createMock(Amount::class);
         $arguments = ['argument_two' => 2];
         $mergedArguments = ['argument_one' => 1, 'argument_two' => 2];
         $renderText = 'amount data';
 
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
-        $this->model->expects($this->at(1))
-            ->method('setData')
-            ->with($mergedArguments);
-        $this->model->expects($this->at(2))
+        $this->model
             ->method('apply')
             ->willReturn($renderText);
-        $this->model->expects($this->at(3))
+        $this->model
             ->method('setData')
-            ->with($this->data);
+            ->withConsecutive([$mergedArguments], [$this->data]);
 
         $result = $this->model->render($amountRender, $arguments);
         $this->assertEquals($renderText, $result);
     }
 
-    public function testGetAmountRender()
+    /**
+     * @return void
+     */
+    public function testGetAmountRender(): void
     {
         $amountRender = $this->createMock(Amount::class);
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
         $this->model->render($amountRender);
         $this->assertEquals($amountRender, $this->model->getAmountRender());
     }
 
-    public function testGetPriceType()
+    /**
+     * @return void
+     */
+    public function testGetPriceType(): void
     {
         $amountRender = $this->createMock(Amount::class);
         $price = $this->getMockForAbstractClass(PriceInterface::class);
@@ -126,14 +137,17 @@ class AbstractAdjustmentTest extends TestCase
             ->with($priceCode)
             ->willReturn($price);
 
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
         $this->model->render($amountRender);
         $this->assertEquals($price, $this->model->getPriceType($priceCode));
     }
 
-    public function testGetPrice()
+    /**
+     * @return void
+     */
+    public function testGetPrice(): void
     {
         $price = 100;
         $amountRender = $this->createMock(Amount::class);
@@ -142,14 +156,17 @@ class AbstractAdjustmentTest extends TestCase
             ->with()
             ->willReturn($price);
 
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
         $this->model->render($amountRender);
         $this->assertEquals($price, $this->model->getPrice());
     }
 
-    public function testGetSealableItem()
+    /**
+     * @return void
+     */
+    public function testGetSealableItem(): void
     {
         $sealableItem = $this->getMockForAbstractClass(SaleableInterface::class);
         $amountRender = $this->createMock(Amount::class);
@@ -158,14 +175,17 @@ class AbstractAdjustmentTest extends TestCase
             ->with()
             ->willReturn($sealableItem);
 
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
         $this->model->render($amountRender);
         $this->assertEquals($sealableItem, $this->model->getSaleableItem());
     }
 
-    public function testGetAdjustment()
+    /**
+     * @return void
+     */
+    public function testGetAdjustment(): void
     {
         $amountRender = $this->createMock(Amount::class);
         $adjustment = $this->getMockForAbstractClass(AdjustmentInterface::class);
@@ -184,7 +204,7 @@ class AbstractAdjustmentTest extends TestCase
             ->with($adjustmentCode)
             ->willReturn($adjustment);
 
-        $this->model->expects($this->at(0))
+        $this->model
             ->method('getData')
             ->willReturn($this->data);
         $this->model->expects($this->once())
@@ -194,7 +214,10 @@ class AbstractAdjustmentTest extends TestCase
         $this->assertEquals($adjustment, $this->model->getAdjustment());
     }
 
-    public function testFormatCurrency()
+    /**
+     * @return void
+     */
+    public function testFormatCurrency(): void
     {
         $amount = 5.3456;
         $includeContainer = false;

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/AbstractAdjustmentTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/AbstractAdjustmentTest.php
@@ -39,7 +39,7 @@ class AbstractAdjustmentTest extends TestCase
     protected $data;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Request/BuilderTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Request/BuilderTest.php
@@ -56,7 +56,7 @@ class BuilderTest extends TestCase
     private $cleaner;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Request/BuilderTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Request/BuilderTest.php
@@ -55,19 +55,22 @@ class BuilderTest extends TestCase
      */
     private $cleaner;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
 
         $this->config = $this->getMockBuilder(Config::class)
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
         $this->requestMapper = $this->getMockBuilder(Mapper::class)
-            ->setMethods(['getRootQuery', 'getBuckets'])
+            ->onlyMethods(['getRootQuery', 'getBuckets'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -76,12 +79,12 @@ class BuilderTest extends TestCase
             ->getMock();
 
         $this->binder = $this->getMockBuilder(Binder::class)
-            ->setMethods(['bind'])
+            ->onlyMethods(['bind'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->cleaner = $this->getMockBuilder(Cleaner::class)
-            ->setMethods(['clean'])
+            ->onlyMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -96,13 +99,19 @@ class BuilderTest extends TestCase
         );
     }
 
-    public function testCreateInvalidArgumentExceptionNotDefined()
+    /**
+     * @return void
+     */
+    public function testCreateInvalidArgumentExceptionNotDefined(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->requestBuilder->create();
     }
 
-    public function testCreateInvalidArgumentException()
+    /**
+     * @return void
+     */
+    public function testCreateInvalidArgumentException(): void
     {
         $this->expectException('Magento\Framework\Search\Request\NonExistingRequestNameException');
         $this->expectExceptionMessage('Request name \'rn\' doesn\'t exist.');
@@ -115,15 +124,17 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $data = [
             'dimensions' => [
                 'scope' => [
                     'name' => 'scope',
-                    'value' => 'default',
+                    'value' => 'default'
                 ],
             ],
             'queries' => [
@@ -133,14 +144,14 @@ class BuilderTest extends TestCase
                     'queryReference' => [
                         [
                             'clause' => 'must',
-                            'ref' => 'fulltext_search_query',
+                            'ref' => 'fulltext_search_query'
                         ],
                         [
                             'clause' => 'must',
-                            'ref' => 'fulltext_search_query2',
+                            'ref' => 'fulltext_search_query2'
                         ],
                     ],
-                    'type' => 'boolQuery',
+                    'type' => 'boolQuery'
                 ],
                 'fulltext_search_query' => [
                     'name' => 'fulltext_search_query',
@@ -149,20 +160,20 @@ class BuilderTest extends TestCase
                     'match' => [
                         [
                             'field' => 'data_index',
-                            'boost' => '2',
+                            'boost' => '2'
                         ],
                     ],
-                    'type' => 'matchQuery',
+                    'type' => 'matchQuery'
                 ],
                 'fulltext_search_query2' => [
                     'name' => 'fulltext_search_query2',
                     'filterReference' => [
                         [
-                            'ref' => 'pid',
-                        ],
+                            'ref' => 'pid'
+                        ]
                     ],
-                    'type' => 'filteredQuery',
-                ],
+                    'type' => 'filteredQuery'
+                ]
             ],
             'filters' => [
                 'pid' => [
@@ -170,34 +181,34 @@ class BuilderTest extends TestCase
                     'filterReference' => [
                         [
                             'clause' => 'should',
-                            'ref' => 'pidm',
+                            'ref' => 'pidm'
                         ],
                         [
                             'clause' => 'should',
-                            'ref' => 'pidsh',
+                            'ref' => 'pidsh'
                         ],
                     ],
-                    'type' => 'boolFilter',
+                    'type' => 'boolFilter'
                 ],
                 'pidm' => [
                     'name' => 'pidm',
                     'field' => 'product_id',
                     'type' => 'rangeFilter',
                     'from' => '$pidm_from$',
-                    'to' => '$pidm_to$',
+                    'to' => '$pidm_to$'
                 ],
                 'pidsh' => [
                     'name' => 'pidsh',
                     'field' => 'product_id',
                     'type' => 'termFilter',
-                    'value' => '$pidsh$',
+                    'value' => '$pidsh$'
                 ],
             ],
             'from' => '10',
             'size' => '10',
             'query' => 'one_match_filters',
             'index' => 'catalogsearch_fulltext',
-            'aggregations' => [],
+            'aggregations' => []
         ];
         $requestName = 'rn';
         $this->requestBuilder->bind('fulltext_search_query', 'socks');
@@ -211,8 +222,9 @@ class BuilderTest extends TestCase
         $this->binder->expects($this->once())->method('bind')->willReturn($data);
         $this->cleaner->expects($this->once())->method('clean')->willReturn($data);
         $this->requestMapper->expects($this->once())->method('getRootQuery')->willReturn([]);
-        $this->objectManager->expects($this->at(0))->method('create')->willReturn($this->requestMapper);
-        $this->objectManager->expects($this->at(2))->method('create')->willReturn($this->request);
+        $this->objectManager
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($this->requestMapper, null, $this->request);
         $this->config->expects($this->once())->method('get')->with($requestName)->willReturn($data);
         $result = $this->requestBuilder->create();
         $this->assertInstanceOf(Request::class, $result);

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Search\Test\Unit\Request;
 
+use InvalidArgumentException;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\Framework\Search\Request\Aggregation\Metric;
 use Magento\Framework\Search\Request\Aggregation\RangeBucket;
@@ -76,6 +77,9 @@ class MapperTest extends TestCase
      */
     private $filterBool;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->helper = new ObjectManager($this);
@@ -113,9 +117,11 @@ class MapperTest extends TestCase
 
     /**
      * @param $queries
+     *
+     * @return void
      * @dataProvider getQueryMatchProvider
      */
-    public function testGetQueryMatch($queries)
+    public function testGetQueryMatch($queries): void
     {
         $query = $queries[self::ROOT_QUERY];
         $this->objectManager->expects($this->once())->method('create')
@@ -145,7 +151,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryMatch, $mapper->getRootQuery());
     }
 
-    public function testGetQueryNotUsedStateException()
+    /**
+     * @return void
+     */
+    public function testGetQueryNotUsedStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $queries = [
@@ -154,15 +163,15 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'value' => 'someValue',
                 'boost' => 3,
-                'match' => 'someMatches',
+                'match' => 'someMatches'
             ],
             'notUsedQuery' => [
                 'type' => QueryInterface::TYPE_MATCH,
                 'name' => 'someName',
                 'value' => 'someValue',
                 'boost' => 3,
-                'match' => 'someMatches',
-            ],
+                'match' => 'someMatches'
+            ]
         ];
         $query = $queries['someQuery'];
         $this->objectManager->expects($this->once())->method('create')
@@ -172,7 +181,7 @@ class MapperTest extends TestCase
                     'name' => $query['name'],
                     'value' => $query['value'],
                     'boost' => isset($query['boost']) ? $query['boost'] : 1,
-                    'matches' => $query['match'],
+                    'matches' => $query['match']
                 ]
             )
             ->willReturn($this->queryMatch);
@@ -192,7 +201,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryMatch, $mapper->getRootQuery());
     }
 
-    public function testGetQueryUsedStateException()
+    /**
+     * @return void
+     */
+    public function testGetQueryUsedStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         /** @var Mapper $mapper */
@@ -207,7 +219,7 @@ class MapperTest extends TestCase
                         'queryReference' => [
                             [
                                 'clause' => 'someClause',
-                                'ref' => 'someQuery',
+                                'ref' => 'someQuery'
                             ],
                         ],
                     ],
@@ -223,34 +235,37 @@ class MapperTest extends TestCase
 
     /**
      * @param $queries
+     *
+     * @return void
      * @dataProvider getQueryFilterQueryReferenceProvider
      */
-    public function testGetQueryFilterQueryReference($queries)
+    public function testGetQueryFilterQueryReference($queries): void
     {
         $query = $queries['someQueryMatch'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Match::class,
+        $queryRoot = $queries[self::ROOT_QUERY];
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'value' => $query['value'],
-                    'boost' => 1,
-                    'matches' => 'someMatches',
+                    Match::class,
+                    [
+                        'name' => $query['name'],
+                        'value' => $query['value'],
+                        'boost' => 1,
+                        'matches' => 'someMatches'
+                    ]
+                ],
+                [
+                    Filter::class,
+                    [
+                        'name' => $queryRoot['name'],
+                        'boost' => isset($queryRoot['boost']) ? $queryRoot['boost'] : 1,
+                        'reference' => $this->queryMatch,
+                        'referenceType' => Filter::REFERENCE_QUERY
+                    ]
                 ]
             )
-            ->willReturn($this->queryMatch);
-        $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                Filter::class,
-                [
-                    'name' => $query['name'],
-                    'boost' => isset($query['boost']) ? $query['boost'] : 1,
-                    'reference' => $this->queryMatch,
-                    'referenceType' => Filter::REFERENCE_QUERY,
-                ]
-            )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->queryMatch, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -267,7 +282,7 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetQueryFilterReferenceException()
+    public function testGetQueryFilterReferenceException(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Reference is not provided');
@@ -279,7 +294,7 @@ class MapperTest extends TestCase
                 'queries' => [
                     'someQuery' => [
                         'type' => QueryInterface::TYPE_FILTER,
-                    ],
+                    ]
                 ],
                 'rootQueryName' => self::ROOT_QUERY,
                 'aggregation' => [],
@@ -294,31 +309,33 @@ class MapperTest extends TestCase
      * @param $queries
      * @dataProvider getQueryBoolProvider
      */
-    public function testGetQueryBool($queries)
+    public function testGetQueryBool($queries): void
     {
         $query = $queries['someQueryMatch'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Match::class,
+        $rootQueries = $queries[self::ROOT_QUERY];
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'value' => $query['value'],
-                    'boost' => 1,
-                    'matches' => 'someMatches',
+                    Match::class,
+                    [
+                        'name' => $query['name'],
+                        'value' => $query['value'],
+                        'boost' => 1,
+                        'matches' => 'someMatches'
+                    ]
+                ],
+                [
+                    BoolExpression::class,
+                    [
+                        'name' => $rootQueries['name'],
+                        'boost' => isset($rootQueries['boost']) ? $rootQueries['boost'] : 1,
+                        'someClause' => ['someQueryMatch' => $this->queryMatch]
+                    ]
                 ]
             )
-            ->willReturn($this->queryMatch);
-        $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                BoolExpression::class,
-                [
-                    'name' => $query['name'],
-                    'boost' => isset($query['boost']) ? $query['boost'] : 1,
-                    'someClause' => ['someQueryMatch' => $this->queryMatch],
-                ]
-            )
-            ->willReturn($this->queryBool);
+            ->willReturnOnConsecutiveCalls($this->queryMatch, $this->queryBool);
+
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -335,9 +352,12 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryBool, $mapper->getRootQuery());
     }
 
-    public function testGetQueryInvalidArgumentException()
+    /**
+     * @return void
+     */
+    public function testGetQueryInvalidArgumentException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
             Mapper::class,
@@ -345,8 +365,8 @@ class MapperTest extends TestCase
                 'objectManager' => $this->objectManager,
                 'queries' => [
                     self::ROOT_QUERY => [
-                        'type' => 'invalid_type',
-                    ],
+                        'type' => 'invalid_type'
+                    ]
                 ],
                 'rootQueryName' => self::ROOT_QUERY,
                 'aggregation' => [],
@@ -357,7 +377,10 @@ class MapperTest extends TestCase
         $mapper->getRootQuery();
     }
 
-    public function testGetQueryException()
+    /**
+     * @return void
+     */
+    public function testGetQueryException(): void
     {
         $this->expectException('Exception');
         /** @var Mapper $mapper */
@@ -374,7 +397,10 @@ class MapperTest extends TestCase
         $mapper->getRootQuery();
     }
 
-    public function testGetFilterTerm()
+    /**
+     * @return void
+     */
+    public function testGetFilterTerm(): void
     {
         $queries = [
             self::ROOT_QUERY => [
@@ -382,43 +408,44 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
                 'type' => FilterInterface::TYPE_TERM,
                 'name' => 'someName',
                 'field' => 'someField',
-                'value' => 'someValue',
-            ],
+                'value' => 'someValue'
+            ]
         ];
 
         $filter = $filters['someFilter'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Term::class,
-                [
-                    'name' => $filter['name'],
-                    'field' => $filter['field'],
-                    'value' => $filter['value'],
-                ]
-            )
-            ->willReturn($this->filterTerm);
         $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                Filter::class,
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'boost' => 1,
-                    'reference' => $this->filterTerm,
-                    'referenceType' => Filter::REFERENCE_FILTER,
+                    Term::class,
+                    [
+                        'name' => $filter['name'],
+                        'field' => $filter['field'],
+                        'value' => $filter['value']
+                    ]
+                ],
+                [
+                    Filter::class,
+                    [
+                        'name' => $query['name'],
+                        'boost' => 1,
+                        'reference' => $this->filterTerm,
+                        'referenceType' => Filter::REFERENCE_FILTER
+                    ]
                 ]
             )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->filterTerm, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -435,7 +462,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterWildcard()
+    /**
+     * @return void
+     */
+    public function testGetFilterWildcard(): void
     {
         $queries = [
             self::ROOT_QUERY => [
@@ -443,43 +473,44 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
                 'type' => FilterInterface::TYPE_WILDCARD,
                 'name' => 'someName',
                 'field' => 'someField',
-                'value' => 'someValue',
-            ],
+                'value' => 'someValue'
+            ]
         ];
 
         $filter = $filters['someFilter'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Wildcard::class,
-                [
-                    'name' => $filter['name'],
-                    'field' => $filter['field'],
-                    'value' => $filter['value'],
-                ]
-            )
-            ->willReturn($this->filterTerm);
         $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                Filter::class,
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'boost' => 1,
-                    'reference' => $this->filterTerm,
-                    'referenceType' => Filter::REFERENCE_FILTER,
+                    Wildcard::class,
+                    [
+                        'name' => $filter['name'],
+                        'field' => $filter['field'],
+                        'value' => $filter['value']
+                    ]
+                ],
+                [
+                    Filter::class,
+                    [
+                        'name' => $query['name'],
+                        'boost' => 1,
+                        'reference' => $this->filterTerm,
+                        'referenceType' => Filter::REFERENCE_FILTER
+                    ]
                 ]
             )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->filterTerm, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -496,7 +527,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterRange()
+    /**
+     * @return void
+     */
+    public function testGetFilterRange(): void
     {
         $queries = [
             self::ROOT_QUERY => [
@@ -504,10 +538,10 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
@@ -515,34 +549,35 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'field' => 'someField',
                 'from' => 'from',
-                'to' => 'to',
-            ],
+                'to' => 'to'
+            ]
         ];
 
         $filter = $filters['someFilter'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Range::class,
-                [
-                    'name' => $filter['name'],
-                    'field' => $filter['field'],
-                    'from' => $filter['from'],
-                    'to' => $filter['to'],
-                ]
-            )
-            ->willReturn($this->filterRange);
         $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                Filter::class,
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'boost' => 1,
-                    'reference' => $this->filterRange,
-                    'referenceType' => Filter::REFERENCE_FILTER,
+                    Range::class,
+                    [
+                        'name' => $filter['name'],
+                        'field' => $filter['field'],
+                        'from' => $filter['from'],
+                        'to' => $filter['to']
+                    ]
+                ],
+                [
+                    Filter::class,
+                    [
+                        'name' => $query['name'],
+                        'boost' => 1,
+                        'reference' => $this->filterRange,
+                        'referenceType' => Filter::REFERENCE_FILTER
+                    ]
                 ]
             )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->filterRange, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -559,7 +594,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterBool()
+    /**
+     * @return void
+     */
+    public function testGetFilterBool(): void
     {
         $queries = [
             self::ROOT_QUERY => [
@@ -567,10 +605,10 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
@@ -579,51 +617,51 @@ class MapperTest extends TestCase
                 'filterReference' => [
                     [
                         'ref' => 'someFilterTerm',
-                        'clause' => 'someClause',
-                    ],
-                ],
+                        'clause' => 'someClause'
+                    ]
+                ]
             ],
             'someFilterTerm' => [
                 'type' => FilterInterface::TYPE_TERM,
                 'name' => 'someName',
                 'field' => 'someField',
-                'value' => 'someValue',
-            ],
+                'value' => 'someValue'
+            ]
         ];
 
-        $filter = $filters['someFilterTerm'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
+        $someFilterTerm = $filters['someFilterTerm'];
+        $someFilter = $filters['someFilter'];
+        $query = $queries[self::ROOT_QUERY];
+
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
+            [
                 Term::class,
                 [
-                    'name' => $filter['name'],
-                    'field' => $filter['field'],
-                    'value' => $filter['value'],
+                    'name' => $someFilterTerm['name'],
+                    'field' => $someFilterTerm['field'],
+                    'value' => $someFilterTerm['value']
                 ]
-            )
-            ->willReturn($this->filterTerm);
-        $filter = $filters['someFilter'];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
+            ],
+            [
                 \Magento\Framework\Search\Request\Filter\BoolExpression::class,
                 [
-                    'name' => $filter['name'],
-                    'someClause' => ['someFilterTerm' => $this->filterTerm],
+                    'name' => $someFilter['name'],
+                    'someClause' => ['someFilterTerm' => $this->filterTerm]
                 ]
-            )
-            ->willReturn($this->filterBool);
-        $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(2))->method('create')
-            ->with(
-                Filter::class,
+            ],
                 [
-                    'name' => $query['name'],
-                    'boost' => 1,
-                    'reference' => $this->filterBool,
-                    'referenceType' => Filter::REFERENCE_FILTER,
+                    Filter::class,
+                    [
+                        'name' => $query['name'],
+                        'boost' => 1,
+                        'reference' => $this->filterBool,
+                        'referenceType' => Filter::REFERENCE_FILTER
+                    ]
                 ]
             )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->filterTerm, $this->filterBool, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -640,7 +678,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterNotUsedStateException()
+    /**
+     * @return void
+     */
+    public function testGetFilterNotUsedStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $queries = [
@@ -649,49 +690,50 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
                 'type' => FilterInterface::TYPE_TERM,
                 'name' => 'someName',
                 'field' => 'someField',
-                'value' => 'someValue',
+                'value' => 'someValue'
             ],
             'notUsedFilter' => [
                 'type' => FilterInterface::TYPE_TERM,
                 'name' => 'someName',
                 'field' => 'someField',
-                'value' => 'someValue',
-            ],
+                'value' => 'someValue'
+            ]
         ];
 
         $filter = $filters['someFilter'];
-        $this->objectManager->expects($this->at(0))->method('create')
-            ->with(
-                Term::class,
-                [
-                    'name' => $filter['name'],
-                    'field' => $filter['field'],
-                    'value' => $filter['value'],
-                ]
-            )
-            ->willReturn($this->filterTerm);
         $query = $queries[self::ROOT_QUERY];
-        $this->objectManager->expects($this->at(1))->method('create')
-            ->with(
-                Filter::class,
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive(
                 [
-                    'name' => $query['name'],
-                    'boost' => 1,
-                    'reference' => $this->filterTerm,
-                    'referenceType' => Filter::REFERENCE_FILTER,
+                    Term::class,
+                    [
+                        'name' => $filter['name'],
+                        'field' => $filter['field'],
+                        'value' => $filter['value']
+                    ]
+                ],
+                [
+                    Filter::class,
+                    [
+                        'name' => $query['name'],
+                        'boost' => 1,
+                        'reference' => $this->filterTerm,
+                        'referenceType' => Filter::REFERENCE_FILTER
+                    ]
                 ]
             )
-            ->willReturn($this->queryFilter);
+            ->willReturnOnConsecutiveCalls($this->filterTerm, $this->queryFilter);
 
         /** @var Mapper $mapper */
         $mapper = $this->helper->getObject(
@@ -708,7 +750,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterUsedStateException()
+    /**
+     * @return void
+     */
+    public function testGetFilterUsedStateException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         /** @var Mapper $mapper */
@@ -722,10 +767,10 @@ class MapperTest extends TestCase
                         'name' => 'someName',
                         'filterReference' => [
                             [
-                                'ref' => 'someFilter',
-                            ],
-                        ],
-                    ],
+                                'ref' => 'someFilter'
+                            ]
+                        ]
+                    ]
                 ],
                 'rootQueryName' => self::ROOT_QUERY,
                 'filters' => [
@@ -735,19 +780,22 @@ class MapperTest extends TestCase
                         'filterReference' => [
                             [
                                 'ref' => 'someFilter',
-                                'clause' => 'someClause',
-                            ],
-                        ],
-                    ],
+                                'clause' => 'someClause'
+                            ]
+                        ]
+                    ]
                 ],
-                'aggregation' => [],
+                'aggregation' => []
             ]
         );
 
         $this->assertEquals($this->queryMatch, $mapper->getRootQuery());
     }
 
-    public function testGetFilterInvalidArgumentException()
+    /**
+     * @return void
+     */
+    public function testGetFilterInvalidArgumentException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Invalid filter type');
@@ -757,15 +805,15 @@ class MapperTest extends TestCase
                 'name' => 'someName',
                 'filterReference' => [
                     [
-                        'ref' => 'someFilter',
-                    ],
-                ],
-            ],
+                        'ref' => 'someFilter'
+                    ]
+                ]
+            ]
         ];
         $filters = [
             'someFilter' => [
-                'type' => 'invalid_type',
-            ],
+                'type' => 'invalid_type'
+            ]
         ];
 
         /** @var Mapper $mapper */
@@ -783,7 +831,10 @@ class MapperTest extends TestCase
         $this->assertEquals($this->queryFilter, $mapper->getRootQuery());
     }
 
-    public function testGetFilterException()
+    /**
+     * @return void
+     */
+    public function testGetFilterException(): void
     {
         $this->expectException('Exception');
         $queries = [
@@ -794,10 +845,10 @@ class MapperTest extends TestCase
                 'filterReference' => [
                     [
                         'ref' => 'someQueryMatch',
-                        'clause' => 'someClause',
-                    ],
-                ],
-            ],
+                        'clause' => 'someClause'
+                    ]
+                ]
+            ]
         ];
 
         /** @var Mapper $mapper */
@@ -817,7 +868,7 @@ class MapperTest extends TestCase
     /**
      * @return array
      */
-    public function getQueryMatchProvider()
+    public function getQueryMatchProvider(): array
     {
         return [
             [
@@ -827,9 +878,9 @@ class MapperTest extends TestCase
                         'name' => 'someName',
                         'value' => 'someValue',
                         'boost' => 3,
-                        'match' => 'someMatches',
-                    ],
-                ],
+                        'match' => 'someMatches'
+                    ]
+                ]
             ],
             [
                 [
@@ -837,8 +888,8 @@ class MapperTest extends TestCase
                         'type' => QueryInterface::TYPE_MATCH,
                         'name' => 'someName',
                         'value' => 'someValue',
-                        'match' => 'someMatches',
-                    ],
+                        'match' => 'someMatches'
+                    ]
                 ]
             ]
         ];
@@ -847,7 +898,7 @@ class MapperTest extends TestCase
     /**
      * @return array
      */
-    public function getQueryFilterQueryReferenceProvider()
+    public function getQueryFilterQueryReferenceProvider(): array
     {
         return [
             [
@@ -859,17 +910,17 @@ class MapperTest extends TestCase
                         'queryReference' => [
                             [
                                 'ref' => 'someQueryMatch',
-                                'clause' => 'someClause',
-                            ],
-                        ],
+                                'clause' => 'someClause'
+                            ]
+                        ]
                     ],
                     'someQueryMatch' => [
                         'type' => QueryInterface::TYPE_MATCH,
                         'value' => 'someValue',
                         'name' => 'someName',
-                        'match' => 'someMatches',
-                    ],
-                ],
+                        'match' => 'someMatches'
+                    ]
+                ]
             ],
             [
                 [
@@ -879,16 +930,16 @@ class MapperTest extends TestCase
                         'queryReference' => [
                             [
                                 'ref' => 'someQueryMatch',
-                                'clause' => 'someClause',
-                            ],
-                        ],
+                                'clause' => 'someClause'
+                            ]
+                        ]
                     ],
                     'someQueryMatch' => [
                         'type' => QueryInterface::TYPE_MATCH,
                         'value' => 'someValue',
                         'name' => 'someName',
-                        'match' => 'someMatches',
-                    ],
+                        'match' => 'someMatches'
+                    ]
                 ]
             ]
         ];
@@ -897,7 +948,7 @@ class MapperTest extends TestCase
     /**
      * @return array
      */
-    public function getQueryBoolProvider()
+    public function getQueryBoolProvider(): array
     {
         return [
             [
@@ -909,17 +960,17 @@ class MapperTest extends TestCase
                         'queryReference' => [
                             [
                                 'ref' => 'someQueryMatch',
-                                'clause' => 'someClause',
-                            ],
-                        ],
+                                'clause' => 'someClause'
+                            ]
+                        ]
                     ],
                     'someQueryMatch' => [
                         'type' => QueryInterface::TYPE_MATCH,
                         'value' => 'someValue',
                         'name' => 'someName',
-                        'match' => 'someMatches',
-                    ],
-                ],
+                        'match' => 'someMatches'
+                    ]
+                ]
             ],
             [
                 [
@@ -929,30 +980,33 @@ class MapperTest extends TestCase
                         'queryReference' => [
                             [
                                 'ref' => 'someQueryMatch',
-                                'clause' => 'someClause',
-                            ],
-                        ],
+                                'clause' => 'someClause'
+                            ]
+                        ]
                     ],
                     'someQueryMatch' => [
                         'type' => QueryInterface::TYPE_MATCH,
                         'value' => 'someValue',
                         'name' => 'someName',
-                        'match' => 'someMatches',
-                    ],
+                        'match' => 'someMatches'
+                    ]
                 ]
             ]
         ];
     }
 
-    public function testGetBucketsTermBucket()
+    /**
+     * @return void
+     */
+    public function testGetBucketsTermBucket(): void
     {
         $queries = [
             self::ROOT_QUERY => [
                 'type' => QueryInterface::TYPE_MATCH,
                 'value' => 'someValue',
                 'name' => 'someName',
-                'match' => 'someMatches',
-            ],
+                'match' => 'someMatches'
+            ]
         ];
 
         $bucket = [
@@ -964,7 +1018,7 @@ class MapperTest extends TestCase
                 ["type" => "min"],
                 ["type" => "max"],
             ],
-            "type" => "termBucket",
+            "type" => "termBucket"
         ];
         $metricClass = Metric::class;
         $bucketClass = TermBucket::class;
@@ -978,7 +1032,7 @@ class MapperTest extends TestCase
         $arguments = [
             'name' => $bucket['name'],
             'field' => $bucket['field'],
-            'metrics' => [null, null, null, null],
+            'metrics' => [null, null, null, null]
         ];
         $this->objectManager->expects($this->any())->method('create')
             ->withConsecutive(
@@ -1004,15 +1058,18 @@ class MapperTest extends TestCase
         $mapper->getBuckets();
     }
 
-    public function testGetBucketsRangeBucket()
+    /**
+     * @return void
+     */
+    public function testGetBucketsRangeBucket(): void
     {
         $queries = [
             self::ROOT_QUERY => [
                 'type' => QueryInterface::TYPE_MATCH,
                 'value' => 'someValue',
                 'name' => 'someName',
-                'match' => 'someMatches',
-            ],
+                'match' => 'someMatches'
+            ]
         ];
 
         $bucket = [
@@ -1022,14 +1079,14 @@ class MapperTest extends TestCase
                 ["type" => "sum"],
                 ["type" => "count"],
                 ["type" => "min"],
-                ["type" => "max"],
+                ["type" => "max"]
             ],
             "range" => [
                 ["from" => "", "to" => "50"],
                 ["from" => "50", "to" => "100"],
-                ["from" => "100", "to" => ""],
+                ["from" => "100", "to" => ""]
             ],
-            "type" => "rangeBucket",
+            "type" => "rangeBucket"
         ];
         $metricClass = Metric::class;
         $bucketClass = RangeBucket::class;
@@ -1039,13 +1096,13 @@ class MapperTest extends TestCase
             'name' => $queries[self::ROOT_QUERY]['name'],
             'value' => $queries[self::ROOT_QUERY]['value'],
             'boost' => 1,
-            'matches' => $queries[self::ROOT_QUERY]['match'],
+            'matches' => $queries[self::ROOT_QUERY]['match']
         ];
         $arguments = [
             'name' => $bucket['name'],
             'field' => $bucket['field'],
             'metrics' => [null, null, null, null],
-            'ranges' => [null, null, null],
+            'ranges' => [null, null, null]
         ];
         $this->objectManager->expects($this->any())->method('create')
             ->withConsecutive(

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Request/MapperTest.php
@@ -78,7 +78,7 @@ class MapperTest extends TestCase
     private $filterBool;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
@@ -79,7 +79,7 @@ class OperationsExecutorTest extends TestCase
     private $dropElement;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/OperationsExecutorTest.php
@@ -78,6 +78,9 @@ class OperationsExecutorTest extends TestCase
      */
     private $dropElement;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->shardingMock = $this->getMockBuilder(Sharding::class)
@@ -124,7 +127,7 @@ class OperationsExecutorTest extends TestCase
     /**
      * @return Table
      */
-    private function prepareTable()
+    private function prepareTable(): Table
     {
         $table = new Table(
             'table',
@@ -149,7 +152,10 @@ class OperationsExecutorTest extends TestCase
         return $table;
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         /** @var DiffInterface|MockObject $diff */
         $diff = $this->getMockBuilder(DiffInterface::class)
@@ -189,7 +195,7 @@ class OperationsExecutorTest extends TestCase
         $diff->expects(self::once())
             ->method('getAll')
             ->willReturn($tablesHistories);
-        $this->dropElement->expects(self::at(0))
+        $this->dropElement
             ->method('doOperation');
         $this->model->execute($diff, []);
     }

--- a/lib/internal/Magento/Framework/Test/Unit/App/ResourceConnectionTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/App/ResourceConnectionTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\App\ResourceConnection\ConfigInterface;
 use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Model\ResourceModel\Type\Db\ConnectionFactoryInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,6 +44,9 @@ class ResourceConnectionTest extends TestCase
      */
     private $configMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->deploymentConfigMock = $this->getMockBuilder(DeploymentConfig::class)
@@ -61,11 +65,14 @@ class ResourceConnectionTest extends TestCase
             [
                 'deploymentConfig' => $this->deploymentConfigMock,
                 'connectionFactory' => $this->connectionFactoryMock,
-                'config' => $this->configMock,
+                'config' => $this->configMock
             ]
         );
     }
 
+    /**
+     * @return void
+     */
     public function testGetTablePrefixWithInjectedPrefix()
     {
         /** @var ResourceConnection $resourceConnection */
@@ -82,6 +89,9 @@ class ResourceConnectionTest extends TestCase
         self::assertEquals($resourceConnection->getTablePrefix(), 'some_prefix');
     }
 
+    /**
+     * @return void
+     */
     public function testGetTablePrefix()
     {
         $this->deploymentConfigMock->expects($this->once())
@@ -91,6 +101,9 @@ class ResourceConnectionTest extends TestCase
         self::assertEquals('pref_', $this->unit->getTablePrefix());
     }
 
+    /**
+     * @return void
+     */
     public function testGetConnectionByName()
     {
         $this->deploymentConfigMock->expects($this->once())->method('get')
@@ -103,6 +116,9 @@ class ResourceConnectionTest extends TestCase
         self::assertEquals('connection', $this->unit->getConnectionByName('default'));
     }
 
+    /**
+     * @return void
+     */
     public function testGetExistingConnectionByName()
     {
         $unit = $this->objectManager->getObject(
@@ -117,28 +133,33 @@ class ResourceConnectionTest extends TestCase
         self::assertEquals('existing_connection', $unit->getConnectionByName('default'));
     }
 
+    /**
+     * @return void
+     */
     public function testCloseConnection()
     {
         $this->configMock->expects($this->once())->method('getConnectionName')->with('default');
-
         $this->unit->closeConnection('default');
     }
 
+    /**
+     * @return void
+     */
     public function testGetTableNameWithBoolParam()
     {
-        $this->deploymentConfigMock->expects($this->at(0))
+        $this->deploymentConfigMock
             ->method('get')
-            ->with(ConfigOptionsListConstants::CONFIG_PATH_DB_PREFIX)
-            ->willReturn('pref_');
-        $this->deploymentConfigMock->expects($this->at(1))->method('get')
-            ->with('db/connection/default')
-            ->willReturn(['config']);
+            ->withConsecutive(
+                [ConfigOptionsListConstants::CONFIG_PATH_DB_PREFIX],
+                ['db/connection/default']
+            )
+            ->willReturnOnConsecutiveCalls('pref_', ['config']);
         $this->configMock->expects($this->atLeastOnce())
             ->method('getConnectionName')
             ->with('default')
             ->willReturn('default');
 
-        $connection = $this->getMockBuilder(\Magento\Framework\DB\Adapter\AdapterInterface::class)->getMock();
+        $connection = $this->getMockBuilder(AdapterInterface::class)->getMock();
         $connection->expects($this->once())->method('getTableName')->with('pref_1');
         $this->connectionFactoryMock->expects($this->once())->method('create')
             ->with(['config'])

--- a/lib/internal/Magento/Framework/Test/Unit/App/ResourceConnectionTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/App/ResourceConnectionTest.php
@@ -45,7 +45,7 @@ class ResourceConnectionTest extends TestCase
     private $configMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Test/Unit/ProfilerTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ProfilerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class ProfilerTest extends TestCase
 {
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/lib/internal/Magento/Framework/Test/Unit/ProfilerTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ProfilerTest.php
@@ -15,24 +15,36 @@ use PHPUnit\Framework\TestCase;
 
 class ProfilerTest extends TestCase
 {
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         Profiler::reset();
     }
 
-    public function testEnable()
+    /**
+     * @return void
+     */
+    public function testEnable(): void
     {
         Profiler::enable();
         $this->assertTrue(Profiler::isEnabled());
     }
 
-    public function testDisable()
+    /**
+     * @return void
+     */
+    public function testDisable(): void
     {
         Profiler::disable();
         $this->assertFalse(Profiler::isEnabled());
     }
 
-    public function testSetDefaultTags()
+    /**
+     * @return void
+     */
+    public function testSetDefaultTags(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -41,7 +53,10 @@ class ProfilerTest extends TestCase
         $this->assertAttributeEquals($expected, '_defaultTags', Profiler::class);
     }
 
-    public function testAddTagFilter()
+    /**
+     * @return void
+     */
+    public function testAddTagFilter(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -54,7 +69,10 @@ class ProfilerTest extends TestCase
         $this->assertAttributeEquals(true, '_hasTagFilters', Profiler::class);
     }
 
-    public function testAdd()
+    /**
+     * @return void
+     */
+    public function testAdd(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -70,16 +88,16 @@ class ProfilerTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function _getDriverMock()
+    protected function _getDriverMock(): MockObject
     {
-        return $this->getMockBuilder(
-            DriverInterface::class
-        )->setMethods(
-            ['start', 'stop', 'clear']
-        )->getMockForAbstractClass();
+        return $this->getMockBuilder(DriverInterface::class)
+            ->onlyMethods(['start', 'stop', 'clear'])->getMockForAbstractClass();
     }
 
-    public function testStartException()
+    /**
+     * @return void
+     */
+    public function testStartException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Timer name must not contain a nesting separator.');
@@ -87,7 +105,10 @@ class ProfilerTest extends TestCase
         Profiler::start('timer ' . Profiler::NESTING_SEPARATOR . ' name');
     }
 
-    public function testDisabledProfiler()
+    /**
+     * @return void
+     */
+    public function testDisabledProfiler(): void
     {
         $driver = $this->_getDriverMock();
         $driver->expects($this->never())->method('start');
@@ -99,7 +120,10 @@ class ProfilerTest extends TestCase
         Profiler::stop('test');
     }
 
-    public function testStartStopSimple()
+    /**
+     * @return void
+     */
+    public function testStartStopSimple(): void
     {
         $driver = $this->_getDriverMock();
         $driver->expects($this->once())->method('start')->with('root_level_timer', null);
@@ -110,14 +134,19 @@ class ProfilerTest extends TestCase
         Profiler::stop('root_level_timer');
     }
 
-    public function testStartNested()
+    /**
+     * @return void
+     */
+    public function testStartNested(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('start')->with('root_level_timer', null);
-        $driver->expects($this->at(1))->method('start')->with('root_level_timer->some_other_timer', null);
 
-        $driver->expects($this->at(2))->method('stop')->with('root_level_timer->some_other_timer');
-        $driver->expects($this->at(3))->method('stop')->with('root_level_timer');
+        $driver
+            ->method('start')
+            ->withConsecutive(['root_level_timer', null], ['root_level_timer->some_other_timer', null]);
+        $driver
+            ->method('stop')
+            ->withConsecutive(['root_level_timer->some_other_timer'], ['root_level_timer']);
 
         Profiler::add($driver);
         Profiler::start('root_level_timer');
@@ -126,7 +155,10 @@ class ProfilerTest extends TestCase
         Profiler::stop('root_level_timer');
     }
 
-    public function testStopExceptionUnknown()
+    /**
+     * @return void
+     */
+    public function testStopExceptionUnknown(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Timer "unknown" has not been started.');
@@ -135,16 +167,24 @@ class ProfilerTest extends TestCase
         Profiler::stop('unknown');
     }
 
-    public function testStopOrder()
+    /**
+     * @return void
+     */
+    public function testStopOrder(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('start')->with('timer1', null);
-        $driver->expects($this->at(1))->method('start')->with('timer1->timer2', null);
-        $driver->expects($this->at(2))->method('start')->with('timer1->timer2->timer1', null);
-        $driver->expects($this->at(3))->method('start')->with('timer1->timer2->timer1->timer3', null);
 
-        $driver->expects($this->at(4))->method('stop')->with('timer1->timer2->timer1->timer3');
-        $driver->expects($this->at(5))->method('stop')->with('timer1->timer2->timer1');
+        $driver
+            ->method('start')
+            ->withConsecutive(
+                ['timer1', null],
+                ['timer1->timer2', null],
+                ['timer1->timer2->timer1', null],
+                ['timer1->timer2->timer1->timer3', null]
+            );
+        $driver
+            ->method('stop')
+            ->withConsecutive(['timer1->timer2->timer1->timer3'], ['timer1->timer2->timer1']);
 
         $driver->expects($this->exactly(4))->method('start');
         $driver->expects($this->exactly(2))->method('stop');
@@ -157,14 +197,19 @@ class ProfilerTest extends TestCase
         Profiler::stop('timer1');
     }
 
-    public function testStopSameName()
+    /**
+     * @return void
+     */
+    public function testStopSameName(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('start')->with('timer1', null);
-        $driver->expects($this->at(1))->method('start')->with('timer1->timer1', null);
 
-        $driver->expects($this->at(2))->method('stop')->with('timer1->timer1');
-        $driver->expects($this->at(3))->method('stop')->with('timer1');
+        $driver
+            ->method('start')
+            ->withConsecutive(['timer1', null], ['timer1->timer1', null]);
+        $driver
+            ->method('stop')
+            ->withConsecutive(['timer1->timer1'], ['timer1']);
 
         Profiler::add($driver);
         Profiler::start('timer1');
@@ -173,30 +218,37 @@ class ProfilerTest extends TestCase
         Profiler::stop('timer1');
     }
 
-    public function testStopLatest()
+    /**
+     * @return void
+     */
+    public function testStopLatest(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('start')->with('root_level_timer', null);
 
-        $driver->expects($this->at(1))->method('stop')->with('root_level_timer');
+        $driver
+            ->method('start')
+            ->with('root_level_timer', null);
+        $driver
+            ->method('stop')
+            ->with('root_level_timer');
 
         Profiler::add($driver);
         Profiler::start('root_level_timer');
         Profiler::stop();
     }
 
-    public function testTags()
+    /**
+     * @return void
+     */
+    public function testTags(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('start')->with('root_level_timer', ['default_tag' => 'default']);
-        $driver->expects(
-            $this->at(1)
-        )->method(
-            'start'
-        )->with(
-            'root_level_timer->some_other_timer',
-            ['default_tag' => 'default', 'type' => 'test']
-        );
+        $driver
+            ->method('start')
+            ->withConsecutive(
+                ['root_level_timer', ['default_tag' => 'default']],
+                ['root_level_timer->some_other_timer', ['default_tag' => 'default', 'type' => 'test']]
+            );
 
         Profiler::add($driver);
         Profiler::setDefaultTags(['default_tag' => 'default']);
@@ -204,16 +256,24 @@ class ProfilerTest extends TestCase
         Profiler::start('some_other_timer', ['type' => 'test']);
     }
 
-    public function testClearTimer()
+    /**
+     * @return void
+     */
+    public function testClearTimer(): void
     {
         $driver = $this->_getDriverMock();
-        $driver->expects($this->at(0))->method('clear')->with('timer');
+        $driver
+            ->method('clear')
+            ->with('timer');
 
         Profiler::add($driver);
         Profiler::clear('timer');
     }
 
-    public function testClearException()
+    /**
+     * @return void
+     */
+    public function testClearException(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Timer name must not contain a nesting separator.');
@@ -221,7 +281,10 @@ class ProfilerTest extends TestCase
         Profiler::clear('timer ' . Profiler::NESTING_SEPARATOR . ' name');
     }
 
-    public function testResetProfiler()
+    /**
+     * @return void
+     */
+    public function testResetProfiler(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -243,9 +306,11 @@ class ProfilerTest extends TestCase
     /**
      * @param string $timerName
      * @param array $tags
+     *
+     * @return void
      * @dataProvider skippedFilterDataProvider
      */
-    public function testTagFilterSkip($timerName, array $tags = null)
+    public function testTagFilterSkip($timerName, array $tags = null): void
     {
         $driver = $this->_getDriverMock();
         $driver->expects($this->never())->method('start');
@@ -258,7 +323,7 @@ class ProfilerTest extends TestCase
     /**
      * @return array
      */
-    public function skippedFilterDataProvider()
+    public function skippedFilterDataProvider(): array
     {
         return [
             'no tags' => ['timer', null],
@@ -270,9 +335,11 @@ class ProfilerTest extends TestCase
     /**
      * @param string $timerName
      * @param array $tags
+     *
+     * @return void
      * @dataProvider passedFilterDataProvider
      */
-    public function testTagFilterPass($timerName, array $tags = null)
+    public function testTagFilterPass($timerName, array $tags = null): void
     {
         $driver = $this->_getDriverMock();
         $driver->expects($this->once())->method('start')->with($timerName, $tags);
@@ -285,7 +352,7 @@ class ProfilerTest extends TestCase
     /**
      * @return array
      */
-    public function passedFilterDataProvider()
+    public function passedFilterDataProvider(): array
     {
         return [
             'one expected tag' => ['timer', ['type' => 'test']],
@@ -293,7 +360,10 @@ class ProfilerTest extends TestCase
         ];
     }
 
-    public function testApplyConfig()
+    /**
+     * @return void
+     */
+    public function testApplyConfig(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -330,12 +400,14 @@ class ProfilerTest extends TestCase
     }
 
     /**
-     * @dataProvider parseConfigDataProvider
      * @param array $data
      * @param boolean $isAjax
      * @param array $expected
+     *
+     * @return void
+     * @dataProvider parseConfigDataProvider
      */
-    public function testParseConfig($data, $isAjax, $expected)
+    public function testParseConfig($data, $isAjax, $expected): void
     {
         $method = new \ReflectionMethod(Profiler::class, '_parseConfig');
         $method->setAccessible(true);
@@ -346,7 +418,7 @@ class ProfilerTest extends TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function parseConfigDataProvider()
+    public function parseConfigDataProvider(): array
     {
         $driverFactory = new Factory();
         $otherDriverFactory = $this->createMock(Factory::class);
@@ -359,14 +431,14 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $driverFactory,
                     'tagFilters' => [],
                     'baseDir' => null
-                ],
+                ]
             ],
             'Full configuration' => [
                 [
                     'drivers' => [['type' => 'foo']],
                     'driverFactory' => $otherDriverFactory,
                     'tagFilters' => ['key' => 'value'],
-                    'baseDir' => '/custom/base/dir',
+                    'baseDir' => '/custom/base/dir'
                 ],
                 false,
                 [
@@ -374,7 +446,7 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $otherDriverFactory,
                     'tagFilters' => ['key' => 'value'],
                     'baseDir' => '/custom/base/dir'
-                ],
+                ]
             ],
             'Driver configuration with type in index' => [
                 ['drivers' => ['foo' => 1]],
@@ -384,7 +456,7 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $driverFactory,
                     'tagFilters' => [],
                     'baseDir' => null
-                ],
+                ]
             ],
             'Driver configuration with type in value' => [
                 ['drivers' => ['foo']],
@@ -394,7 +466,7 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $driverFactory,
                     'tagFilters' => [],
                     'baseDir' => null
-                ],
+                ]
             ],
             'Driver ignored configuration' => [
                 ['drivers' => ['foo' => 0]],
@@ -404,7 +476,7 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $driverFactory,
                     'tagFilters' => [],
                     'baseDir' => null
-                ],
+                ]
             ],
             'Non ajax call' => [
                 1,
@@ -414,7 +486,7 @@ class ProfilerTest extends TestCase
                     'driverFactory' => $driverFactory,
                     'tagFilters' => [],
                     'baseDir' => ''
-                ],
+                ]
             ]
         ];
     }

--- a/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
@@ -117,7 +117,7 @@ class TranslateTest extends TestCase
     protected $fileDriver;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/TranslateTest.php
@@ -36,54 +36,89 @@ use PHPUnit\Framework\TestCase;
  */
 class TranslateTest extends TestCase
 {
-    /** @var Translate */
+    /**
+     * @var Translate
+     */
     protected $translate;
 
-    /** @var DesignInterface|MockObject */
+    /**
+     * @var DesignInterface|MockObject
+     */
     protected $viewDesign;
 
-    /** @var FrontendInterface|MockObject */
+    /**
+     * @var FrontendInterface|MockObject
+     */
     protected $cache;
 
-    /** @var FilesystemView|MockObject */
+    /**
+     * @var FilesystemView|MockObject
+     */
     protected $viewFileSystem;
 
-    /** @var ModuleList|MockObject */
+    /**
+     * @var ModuleList|MockObject
+     */
     protected $moduleList;
 
-    /** @var Reader|MockObject */
+    /**
+     * @var Reader|MockObject
+     */
     protected $modulesReader;
 
-    /** @var ScopeResolverInterface|MockObject */
+    /**
+     * @var ScopeResolverInterface|MockObject
+     */
     protected $scopeResolver;
 
-    /** @var ResourceInterface|MockObject */
+    /**
+     * @var ResourceInterface|MockObject
+     */
     protected $resource;
 
-    /** @var ResolverInterface|MockObject */
+    /**
+     * @var ResolverInterface|MockObject
+     */
     protected $locale;
 
-    /** @var State|MockObject */
+    /**
+     * @var State|MockObject
+     */
     protected $appState;
 
-    /** @var Filesystem|MockObject */
+    /**
+     * @var Filesystem|MockObject
+     */
     protected $filesystem;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $request;
 
-    /** @var Csv|MockObject */
+    /**
+     * @var Csv|MockObject
+     */
     protected $csvParser;
 
-    /** @var  Dictionary|MockObject */
+    /**
+     * @var  Dictionary|MockObject
+     */
     protected $packDictionary;
 
-    /** @var ReadInterface|MockObject */
+    /**
+     * @var ReadInterface|MockObject
+     */
     protected $directory;
 
-    /** @var DriverInterface|MockObject */
+    /**
+     * @var DriverInterface|MockObject
+     */
     protected $fileDriver;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -149,6 +184,8 @@ class TranslateTest extends TestCase
      * @param string $area
      * @param bool $forceReload
      * @param array $cachedData
+     *
+     * @return void
      * @dataProvider dataProviderLoadDataCachedTranslation
      */
     public function testLoadDataCachedTranslation($area, $forceReload, $cachedData): void
@@ -176,13 +213,15 @@ class TranslateTest extends TestCase
         return [
             ['adminhtml', false, $cachedData],
             ['frontend', false, $cachedData],
-            [null, false, $cachedData],
+            [null, false, $cachedData]
         ];
     }
 
     /**
      * @param string $area
      * @param bool $forceReload
+     *
+     * @return void
      * @dataProvider dataProviderForTestLoadData
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
@@ -210,14 +249,14 @@ class TranslateTest extends TestCase
             'module original' => 'module translated',
             'module theme' => 'module-theme original translated',
             'module pack' => 'module-pack original translated',
-            'module db' => 'module-db original translated',
+            'module db' => 'module-db original translated'
         ];
         $this->modulesReader->expects($this->any())->method('getModuleDir')->willReturn('/app/module');
         $themeData = [
             'theme original' => 'theme translated',
             'module theme' => 'theme translated overwrite',
             'module pack' => 'theme-pack translated overwrite',
-            'module db' => 'theme-db translated overwrite',
+            'module db' => 'theme-db translated overwrite'
         ];
         $this->csvParser->expects($this->any())
             ->method('getDataPairs')
@@ -225,7 +264,7 @@ class TranslateTest extends TestCase
                 [
                     ['/app/module/en_US.csv', 0, 1, $moduleData],
                     ['/app/module/en_GB.csv', 0, 1, $moduleData],
-                    ['/theme.csv', 0, 1, $themeData],
+                    ['/theme.csv', 0, 1, $themeData]
                 ]
             );
         $this->fileDriver->expects($this->any())
@@ -234,7 +273,7 @@ class TranslateTest extends TestCase
                 [
                     ['/app/module/en_US.csv', true],
                     ['/app/module/en_GB.csv', true],
-                    ['/theme.csv', true],
+                    ['/theme.csv', true]
                 ]
             );
 
@@ -269,7 +308,7 @@ class TranslateTest extends TestCase
             'module db' => 'db translated overwrite',
             'theme original' => 'theme translated',
             'pack original' => 'pack translated',
-            'db original' => 'db translated',
+            'db original' => 'db translated'
         ];
         $this->assertEquals($expected, $this->translate->getData());
     }
@@ -292,6 +331,8 @@ class TranslateTest extends TestCase
     /**
      * @param $data
      * @param $result
+     *
+     * @return void
      * @dataProvider dataProviderForTestGetData
      */
     public function testGetData($data, $result): void
@@ -316,6 +357,9 @@ class TranslateTest extends TestCase
         ];
     }
 
+    /**
+     * @return void
+     */
     public function testGetLocale(): void
     {
         $this->locale->expects($this->once())->method('getLocale')->willReturn('en_US');
@@ -329,6 +373,9 @@ class TranslateTest extends TestCase
         $this->assertEquals('en_GB', $this->translate->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testSetLocale(): void
     {
         $this->translate->setLocale('en_GB');
@@ -336,18 +383,25 @@ class TranslateTest extends TestCase
         $this->assertEquals('en_GB', $this->translate->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTheme(): void
     {
-        $this->request->expects($this->at(0))->method('getParam')->with('theme')->willReturn('');
 
         $requestTheme = ['theme_title' => 'Theme Title'];
-        $this->request->expects($this->at(1))->method('getParam')->with('theme')
-            ->willReturn($requestTheme);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['theme'], ['theme'])
+            ->willReturnOnConsecutiveCalls('', $requestTheme);
 
         $this->assertEquals('theme', $this->translate->getTheme());
         $this->assertEquals('themeTheme Title', $this->translate->getTheme());
     }
 
+    /**
+     * @return void
+     */
     public function testLoadDataNoTheme(): void
     {
         $forceReload = true;
@@ -360,7 +414,9 @@ class TranslateTest extends TestCase
     }
 
     /**
-     * Declare calls expectation for setConfig() method
+     * Declare calls expectation for setConfig() method.
+     *
+     * @return void
      */
     protected function expectsSetConfig($themeId, $localeCode = 'en_US'): void
     {
@@ -372,7 +428,7 @@ class TranslateTest extends TestCase
             ->willReturnMap(
                 [
                     [null, $scope],
-                    ['admin', $scopeAdmin],
+                    ['admin', $scopeAdmin]
                 ]
             );
         $designTheme = $this->getMockBuilder(Theme::class)

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -89,7 +89,7 @@ class UrlTest extends TestCase
     private $hostChecker;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/UrlTest.php
@@ -27,8 +27,10 @@ use Magento\Framework\Url\SecurityInfoInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\ZendEscaper;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\ScopeInterface as StoreScopeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 /**
  * Test class for Magento\Framework\Url
@@ -86,6 +88,9 @@ class UrlTest extends TestCase
      */
     private $hostChecker;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->routeParamsResolverMock = $this->getMockBuilder(RouteParamsResolver::class)
@@ -127,21 +132,21 @@ class UrlTest extends TestCase
      * @param bool $resolve
      * @return RouteParamsResolverFactory|MockObject
      */
-    protected function getRouteParamsResolverFactory($resolve = true)
+    protected function getRouteParamsResolverFactory($resolve = true): RouteParamsResolverFactory
     {
         $routeParamsResolverFactoryMock = $this->createMock(RouteParamsResolverFactory::class);
         if ($resolve) {
             $routeParamsResolverFactoryMock->expects($this->any())->method('create')
                 ->willReturn($this->routeParamsResolverMock);
         }
+
         return $routeParamsResolverFactoryMock;
     }
 
     /**
-     * @param array $mockMethods
      * @return Http|MockObject
      */
-    protected function getRequestMock()
+    protected function getRequestMock(): Http
     {
         return $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
@@ -150,15 +155,15 @@ class UrlTest extends TestCase
 
     /**
      * @param array $arguments
-     * @return Url
+     * @return object
      */
     protected function getUrlModel($arguments = [])
     {
-        $arguments = array_merge($arguments, ['scopeType' => \Magento\Store\Model\ScopeInterface::SCOPE_STORE]);
+        $arguments = array_merge($arguments, ['scopeType' => StoreScopeInterface::SCOPE_STORE]);
         $objectManager = new ObjectManager($this);
         $model = $objectManager->getObject(Url::class, $arguments);
 
-        $modelProperty = (new \ReflectionClass(get_class($model)))
+        $modelProperty = (new ReflectionClass(get_class($model)))
             ->getProperty('urlModifier');
 
         $modelProperty->setAccessible(true);
@@ -175,9 +180,11 @@ class UrlTest extends TestCase
     /**
      * @param string $httpHost
      * @param string $url
+     *
+     * @return void
      * @dataProvider getCurrentUrlProvider
      */
-    public function testGetCurrentUrl($httpHost, $url)
+    public function testGetCurrentUrl($httpHost, $url): void
     {
         $requestMock = $this->getRequestMock();
         $requestMock->expects($this->once())->method('getRequestUri')->willReturn('/fancy_uri');
@@ -190,7 +197,7 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function getCurrentUrlProvider()
+    public function getCurrentUrlProvider(): array
     {
         return [
             'without_port' => ['example.com', 'http://example.com/fancy_uri'],
@@ -199,7 +206,10 @@ class UrlTest extends TestCase
         ];
     }
 
-    public function testGetBaseUrlNotLinkType()
+    /**
+     * @return void
+     */
+    public function testGetBaseUrlNotLinkType(): void
     {
         $model = $this->getUrlModel(
             [
@@ -220,7 +230,10 @@ class UrlTest extends TestCase
         $this->assertEquals($baseUrl, $model->getBaseUrl($baseUrlParams));
     }
 
-    public function testGetUrlValidateFilter()
+    /**
+     * @return void
+     */
+    public function testGetUrlValidateFilter(): void
     {
         $model = $this->getUrlModel();
         $this->assertEquals('http://test.com', $model->getUrl('http://test.com'));
@@ -230,9 +243,11 @@ class UrlTest extends TestCase
      * @param string|array|bool $query
      * @param string $queryResult
      * @param string $returnUri
+     *
+     * @return void
      * @dataProvider getUrlDataProvider
      */
-    public function testGetUrl($query, $queryResult, $returnUri)
+    public function testGetUrl($query, $queryResult, $returnUri): void
     {
         $requestMock = $this->getRequestMock();
         $routeConfigMock = $this->getMockForAbstractClass(ConfigInterface::class);
@@ -278,7 +293,10 @@ class UrlTest extends TestCase
         $this->assertEquals($returnUri, $url);
     }
 
-    public function testGetUrlIdempotentSetRoutePath()
+    /**
+     * @return void
+     */
+    public function testGetUrlIdempotentSetRoutePath(): void
     {
         $model = $this->getUrlModel([
             'scopeResolver' => $this->scopeResolverMock,
@@ -295,7 +313,10 @@ class UrlTest extends TestCase
         $this->assertEquals('catalog/product/view', $model->getUrl('catalog/product/view'));
     }
 
-    public function testGetUrlIdempotentSetRouteName()
+    /**
+     * @return void
+     */
+    public function testGetUrlIdempotentSetRouteName(): void
     {
         $model = $this->getUrlModel([
             'scopeResolver' => $this->scopeResolverMock,
@@ -311,7 +332,10 @@ class UrlTest extends TestCase
         $this->assertEquals('/product/view/', $model->getUrl('catalog/product/view'));
     }
 
-    public function testGetUrlRouteHasParams()
+    /**
+     * @return void
+     */
+    public function testGetUrlRouteHasParams(): void
     {
         $this->routeParamsResolverMock->expects($this->any())->method('getRouteParams')
             ->willReturn(['foo' => 'bar', 'true' => false]);
@@ -328,7 +352,10 @@ class UrlTest extends TestCase
         $this->assertEquals('/index/index/foo/bar/', $model->getUrl('catalog'));
     }
 
-    public function testGetUrlRouteUseRewrite()
+    /**
+     * @return void
+     */
+    public function testGetUrlRouteUseRewrite(): void
     {
         $this->routeParamsResolverMock->expects($this->any())->method('getRouteParams')
             ->willReturn(['foo' => 'bar']);
@@ -356,28 +383,31 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function getUrlDataProvider()
+    public function getUrlDataProvider(): array
     {
         return [
             'string query' => [
                 'foo=bar',
                 'foo=bar',
-                'http://localhost/index.php/catalog/product/view/id/100/?foo=bar#anchor',
+                'http://localhost/index.php/catalog/product/view/id/100/?foo=bar#anchor'
             ],
             'array query' => [
                 ['foo' => 'bar'],
                 'foo=bar',
-                'http://localhost/index.php/catalog/product/view/id/100/?foo=bar#anchor',
+                'http://localhost/index.php/catalog/product/view/id/100/?foo=bar#anchor'
             ],
             'without query' => [
                 false,
                 '',
                 'http://localhost/index.php/catalog/product/view/id/100/#anchor'
-            ],
+            ]
         ];
     }
 
-    public function testGetUrlWithAsterisksPath()
+    /**
+     * @return void
+     */
+    public function testGetUrlWithAsterisksPath(): void
     {
         $requestMock = $this->getRequestMock();
         $routeConfigMock = $this->getMockForAbstractClass(ConfigInterface::class);
@@ -386,7 +416,7 @@ class UrlTest extends TestCase
                 'scopeResolver' => $this->scopeResolverMock,
                 'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
                 'queryParamsResolver' => $this->queryParamsResolverMock,
-                'request' => $requestMock, 'routeConfig' => $routeConfigMock,
+                'request' => $requestMock, 'routeConfig' => $routeConfigMock
             ]
         );
 
@@ -413,7 +443,10 @@ class UrlTest extends TestCase
         $this->assertEquals('http://localhost/index.php/catalog/product/view/key/value/', $url);
     }
 
-    public function testGetDirectUrl()
+    /**
+     * @return void
+     */
+    public function testGetDirectUrl(): void
     {
         $requestMock = $this->getRequestMock();
         $routeConfigMock = $this->getMockForAbstractClass(ConfigInterface::class);
@@ -448,10 +481,13 @@ class UrlTest extends TestCase
     }
 
     /**
-     * @param string $inputUrl
+     * @param $inputUrl
+     * @param $outputUrl
+     *
+     * @return void
      * @dataProvider getRebuiltUrlDataProvider
      */
-    public function testGetRebuiltUrl($inputUrl, $outputUrl)
+    public function testGetRebuiltUrl($inputUrl, $outputUrl): void
     {
         $requestMock = $this->getRequestMock();
         $model = $this->getUrlModel([
@@ -460,7 +496,7 @@ class UrlTest extends TestCase
             'sidResolver' => $this->sidResolverMock,
             'scopeResolver' => $this->scopeResolverMock,
             'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(false),
-            'queryParamsResolver' => $this->queryParamsResolverMock,
+            'queryParamsResolver' => $this->queryParamsResolverMock
         ]);
 
         $this->queryParamsResolverMock->expects($this->once())->method('getQuery')
@@ -469,7 +505,10 @@ class UrlTest extends TestCase
         $this->assertEquals($outputUrl, $model->getRebuiltUrl($inputUrl));
     }
 
-    public function testGetRedirectUrl()
+    /**
+     * @return void
+     */
+    public function testGetRedirectUrl(): void
     {
         $model = $this->getUrlModel(
             [
@@ -493,14 +532,17 @@ class UrlTest extends TestCase
         $this->assertEquals('http://example.com/?foo=bar', $model->getRedirectUrl('http://example.com/'));
     }
 
-    public function testGetRedirectUrlWithSessionId()
+    /**
+     * @return void
+     */
+    public function testGetRedirectUrlWithSessionId(): void
     {
         $model = $this->getUrlModel(
             [
                 'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(false),
                 'session' => $this->sessionMock,
                 'sidResolver' => $this->sidResolverMock,
-                'queryParamsResolver' => $this->queryParamsResolverMock,
+                'queryParamsResolver' => $this->queryParamsResolverMock
             ]
         );
 
@@ -519,7 +561,7 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function getRebuiltUrlDataProvider()
+    public function getRebuiltUrlDataProvider(): array
     {
         return [
             'with port' => [
@@ -537,7 +579,10 @@ class UrlTest extends TestCase
         ];
     }
 
-    public function testGetRouteUrlWithValidUrl()
+    /**
+     * @return void
+     */
+    public function testGetRouteUrlWithValidUrl(): void
     {
         $model = $this->getUrlModel(['routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(false)]);
 
@@ -548,9 +593,11 @@ class UrlTest extends TestCase
     /**
      * @param bool $result
      * @param string $referrer
+     *
+     * @return void
      * @dataProvider isOwnOriginUrlDataProvider
      */
-    public function testIsOwnOriginUrl($result, $referrer)
+    public function testIsOwnOriginUrl($result, $referrer): void
     {
         $requestMock = $this->getRequestMock();
         $this->hostChecker = $this->getMockBuilder(HostChecker::class)
@@ -568,11 +615,11 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function isOwnOriginUrlDataProvider()
+    public function isOwnOriginUrlDataProvider(): array
     {
         return [
             'is origin url' => [true, 'http://localhost/'],
-            'is not origin url' => [false, 'http://example.com/'],
+            'is not origin url' => [false, 'http://example.com/']
         ];
     }
 
@@ -582,30 +629,32 @@ class UrlTest extends TestCase
      * @param bool $isSecure
      * @param int $isSecureCallCount
      * @param string $key
+     *
+     * @return void
      * @dataProvider getConfigDataDataProvider
      */
-    public function testGetConfigData($urlType, $configPath, $isSecure, $isSecureCallCount, $key)
+    public function testGetConfigData($urlType, $configPath, $isSecure, $isSecureCallCount, $key): void
     {
         $urlSecurityInfoMock = $this->getMockForAbstractClass(SecurityInfoInterface::class);
         $model = $this->getUrlModel([
             'urlSecurityInfo' => $urlSecurityInfoMock,
             'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
             'scopeResolver' => $this->scopeResolverMock,
-            'scopeConfig' => $this->scopeConfig,
+            'scopeConfig' => $this->scopeConfig
         ]);
 
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
-            ->with($configPath, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $this->scopeMock)
+            ->with($configPath, StoreScopeInterface::SCOPE_STORE, $this->scopeMock)
             ->willReturn('http://localhost/');
-        $this->routeParamsResolverMock->expects($this->at(0))->method('hasData')->with('secure_is_forced')
-            ->willReturn(false);
         $this->scopeResolverMock->expects($this->any())
             ->method('getScope')
             ->willReturn($this->scopeMock);
         $this->scopeMock->expects($this->once())->method('isUrlSecure')->willReturn(true);
-        $this->routeParamsResolverMock->expects($this->at(1))->method('hasData')->with('secure')
-            ->willReturn(false);
+        $this->routeParamsResolverMock
+            ->method('hasData')
+            ->withConsecutive(['secure_is_forced'], ['secure'])
+            ->willReturnOnConsecutiveCalls(false, false);
         $this->routeParamsResolverMock->expects($this->any())->method('getType')
             ->willReturn($urlType);
         $this->routeParamsResolverMock->expects($this->once())
@@ -620,7 +669,7 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function getConfigDataDataProvider()
+    public function getConfigDataDataProvider(): array
     {
         return [
             'secure url' => ['some-type', 'web/secure/base_url_secure', true, 0, 'base_url_secure'],
@@ -629,24 +678,27 @@ class UrlTest extends TestCase
                 'web/unsecure/base_url_unsecure',
                 false,
                 1,
-                'base_url_unsecure',
-            ],
+                'base_url_unsecure'
+            ]
         ];
     }
 
-    public function testGetConfigDataWithSecureIsForcedParam()
+    /**
+     * @return void
+     */
+    public function testGetConfigDataWithSecureIsForcedParam(): void
     {
         $model = $this->getUrlModel([
             'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
             'scopeResolver' => $this->scopeResolverMock,
-            'scopeConfig' => $this->scopeConfig,
+            'scopeConfig' => $this->scopeConfig
         ]);
 
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
             ->with(
                 'web/secure/base_url_secure_forced',
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                StoreScopeInterface::SCOPE_STORE,
                 $this->scopeMock
             )
             ->willReturn('http://localhost/');
@@ -664,9 +716,11 @@ class UrlTest extends TestCase
     /**
      * @param string $html
      * @param string $result
+     *
+     * @return void
      * @dataProvider sessionUrlVarWithMatchedHostsAndBaseUrlDataProvider
      */
-    public function testSessionUrlVarWithMatchedHostsAndBaseUrl($html, $result)
+    public function testSessionUrlVarWithMatchedHostsAndBaseUrl($html, $result): void
     {
         $requestMock = $this->getRequestMock();
         $model = $this->getUrlModel(
@@ -675,7 +729,7 @@ class UrlTest extends TestCase
                 'request' => $requestMock,
                 'sidResolver' => $this->sidResolverMock,
                 'scopeResolver' => $this->scopeResolverMock,
-                'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
+                'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory()
             ]
         );
 
@@ -694,7 +748,10 @@ class UrlTest extends TestCase
         $this->assertEquals($result, $model->sessionUrlVar($html));
     }
 
-    public function testSessionUrlVarWithoutMatchedHostsAndBaseUrl()
+    /**
+     * @return void
+     */
+    public function testSessionUrlVarWithoutMatchedHostsAndBaseUrl(): void
     {
         $requestMock = $this->getRequestMock();
         $model = $this->getUrlModel(
@@ -703,7 +760,7 @@ class UrlTest extends TestCase
                 'request' => $requestMock,
                 'sidResolver' => $this->sidResolverMock,
                 'scopeResolver' => $this->scopeResolverMock,
-                'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory(),
+                'routeParamsResolverFactory' => $this->getRouteParamsResolverFactory()
             ]
         );
 
@@ -728,29 +785,32 @@ class UrlTest extends TestCase
     /**
      * @return array
      */
-    public function sessionUrlVarWithMatchedHostsAndBaseUrlDataProvider()
+    public function sessionUrlVarWithMatchedHostsAndBaseUrlDataProvider(): array
     {
         return [
             [
                 '<a href="http://example.com/?___SID=U?SID=session-id">www.example.com</a>',
-                '<a href="http://example.com/?SID=session-id">www.example.com</a>',
+                '<a href="http://example.com/?SID=session-id">www.example.com</a>'
             ],
             [
                 '<a href="http://example.com/?___SID=U&SID=session-id">www.example.com</a>',
-                '<a href="http://example.com/?SID=session-id">www.example.com</a>',
+                '<a href="http://example.com/?SID=session-id">www.example.com</a>'
             ],
             [
                 '<a href="http://example.com/?foo=bar&___SID=U?SID=session-id">www.example.com</a>',
-                '<a href="http://example.com/?foo=bar?SID=session-id">www.example.com</a>',
+                '<a href="http://example.com/?foo=bar?SID=session-id">www.example.com</a>'
             ],
             [
                 '<a href="http://example.com/?foo=bar&___SID=U&SID=session-id">www.example.com</a>',
-                '<a href="http://example.com/?foo=bar&SID=session-id">www.example.com</a>',
-            ],
+                '<a href="http://example.com/?foo=bar&SID=session-id">www.example.com</a>'
+            ]
         ];
     }
 
-    public function testSetRequest()
+    /**
+     * @return void
+     */
+    public function testSetRequest(): void
     {
         $initRequestMock = $this->getRequestMock();
         $requestMock = $this->getRequestMock();

--- a/lib/internal/Magento/Framework/Url/Test/Unit/ScopeResolverTest.php
+++ b/lib/internal/Magento/Framework/Url/Test/Unit/ScopeResolverTest.php
@@ -27,7 +27,7 @@ class ScopeResolverTest extends TestCase
     protected $_object;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/Url/Test/Unit/ScopeResolverTest.php
+++ b/lib/internal/Magento/Framework/Url/Test/Unit/ScopeResolverTest.php
@@ -26,6 +26,9 @@ class ScopeResolverTest extends TestCase
      */
     protected $_object;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -39,26 +42,26 @@ class ScopeResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider getScopeDataProvider
      * @param int|null$scopeId
+     *
+     * @return void
+     * @dataProvider getScopeDataProvider
      */
-    public function testGetScope($scopeId)
+    public function testGetScope($scopeId): void
     {
         $scopeMock = $this->getMockBuilder(ScopeInterface::class)
             ->getMock();
-        $this->scopeResolverMock->expects(
-            $this->at(0)
-        )->method(
-            'getScope'
-        )->with(
-            $scopeId
-        )->willReturn(
-            $scopeMock
-        );
+        $this->scopeResolverMock
+            ->method('getScope')
+            ->with($scopeId)
+            ->willReturn($scopeMock);
         $this->_object->getScope($scopeId);
     }
 
-    public function testGetScopeException()
+    /**
+     * @return void
+     */
+    public function testGetScopeException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('The scope object is invalid. Verify the scope object and try again.');
@@ -68,12 +71,15 @@ class ScopeResolverTest extends TestCase
     /**
      * @return array
      */
-    public function getScopeDataProvider()
+    public function getScopeDataProvider(): array
     {
         return [[null], [1]];
     }
 
-    public function testGetScopes()
+    /**
+     * @return void
+     */
+    public function testGetScopes(): void
     {
         $this->scopeResolverMock->expects($this->once())->method('getScopes');
         $this->_object->getScopes();

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Validator\Test\Unit;
 
-use Magento\Framework\Cache\FrontendInterface;
 use Magento\Framework\Config\FileIterator;
 use Magento\Framework\Module\Dir\Reader;
 use Magento\Framework\ObjectManagerInterface;
@@ -62,6 +61,9 @@ class FactoryTest extends TestCase
      */
     private $data = ['/tmp/moduleOne/etc/validation.xml'];
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->defaultTranslator = AbstractValidator::getDefaultTranslator();
@@ -72,18 +74,11 @@ class FactoryTest extends TestCase
             ['createValidatorBuilder', 'createValidator']
         );
         $translateAdapterMock = $this->createMock(Adapter::class);
-        $this->objectManagerMock->expects($this->at(0))
-            ->method('create')
-            ->with(Adapter::class)
-            ->willReturn($translateAdapterMock);
         $this->fileIteratorMock = $this->createMock(FileIterator::class);
-        $this->objectManagerMock->expects($this->at(1))
+        $this->objectManagerMock
             ->method('create')
-            ->with(
-                Config::class,
-                ['configFiles' => $this->fileIteratorMock]
-            )
-            ->willReturn($this->validatorConfigMock);
+            ->withConsecutive([Adapter::class], [Config::class, ['configFiles' => $this->fileIteratorMock]])
+            ->willReturnOnConsecutiveCalls($translateAdapterMock, $this->validatorConfigMock);
         $this->readerMock = $this->createPartialMock(
             Reader::class,
             ['getConfigurationFiles']
@@ -101,7 +96,9 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * Restore default translator
+     * Restore default translator.
+     *
+     * @return void
      */
     protected function tearDown(): void
     {
@@ -109,7 +106,10 @@ class FactoryTest extends TestCase
         unset($this->defaultTranslator);
     }
 
-    public function testGetValidatorConfig()
+    /**
+     * @return void
+     */
+    public function testGetValidatorConfig(): void
     {
         $this->readerMock->method('getConfigurationFiles')
             ->with('validation.xml')
@@ -129,7 +129,10 @@ class FactoryTest extends TestCase
         );
     }
 
-    public function testCreateValidatorBuilder()
+    /**
+     * @return void
+     */
+    public function testCreateValidatorBuilder(): void
     {
         $this->readerMock->method('getConfigurationFiles')
             ->with('validation.xml')
@@ -147,7 +150,10 @@ class FactoryTest extends TestCase
         );
     }
 
-    public function testCreateValidator()
+    /**
+     * @return void
+     */
+    public function testCreateValidator(): void
     {
         $this->readerMock->method('getConfigurationFiles')
             ->with('validation.xml')

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/FactoryTest.php
@@ -62,7 +62,7 @@ class FactoryTest extends TestCase
     private $data = ['/tmp/moduleOne/etc/validation.xml'];
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -98,7 +98,7 @@ class FactoryTest extends TestCase
     /**
      * Restore default translator.
      *
-     * @return void
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/SourceTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/SourceTest.php
@@ -90,7 +90,7 @@ class SourceTest extends TestCase
     private $readFactory;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc 
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/SourceTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/SourceTest.php
@@ -89,6 +89,9 @@ class SourceTest extends TestCase
      */
     private $readFactory;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->preProcessorPool = $this->createMock(Pool::class);
@@ -97,12 +100,11 @@ class SourceTest extends TestCase
         );
         $this->theme = $this->getMockForAbstractClass(ThemeInterface::class);
         /** @var ScopeConfigInterface $config */
-        $this->chainFactory = $this->getMockBuilder(
-            ChainFactoryInterface::class
-        )->getMock();
+        $this->chainFactory = $this->getMockBuilder(ChainFactoryInterface::class)
+            ->getMock();
         $this->chain = $this->getMockBuilder(Chain::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['isChanged', 'getContent', 'getTargetAssetPath'])
             ->getMock();
         $this->chainFactory->expects($this->any())
             ->method('create')
@@ -135,13 +137,13 @@ class SourceTest extends TestCase
      * @param bool $isMaterialization
      * @param bool $isExist
      *
+     * @return void
      * @dataProvider getFileDataProvider
      */
-    public function testGetFile($origFile, $origPath, $origContent, $isMaterialization, $isExist)
+    public function testGetFile($origFile, $origPath, $origContent, $isMaterialization, $isExist): void
     {
         $filePath = 'some/file.ext';
         $read = $this->createMock(Read::class);
-        $read->expects($this->at(0))->method('readFile')->with($origPath)->willReturn($origContent);
         $this->readFactory->expects($this->atLeastOnce())->method('create')->willReturn($read);
         $this->viewFileResolution->expects($this->once())
             ->method('getFile')
@@ -178,7 +180,11 @@ class SourceTest extends TestCase
                 ->willReturn('result');
         } else {
             $this->tmpDir->expects($this->never())->method('writeFile');
-            $read->expects($this->at(1))
+            $read
+                ->method('readFile')
+                ->with($origPath)
+                ->willReturn($origContent);
+            $read
                 ->method('getAbsolutePath')
                 ->with('file.ext')
                 ->willReturn('result');
@@ -189,9 +195,11 @@ class SourceTest extends TestCase
     /**
      * @param string $path
      * @param string $expected
+     *
+     * @return void
      * @dataProvider getContentTypeDataProvider
      */
-    public function testGetContentType($path, $expected)
+    public function testGetContentType($path, $expected): void
     {
         $this->assertEquals($expected, $this->object->getContentType($path));
     }
@@ -199,21 +207,23 @@ class SourceTest extends TestCase
     /**
      * @return array
      */
-    public function getContentTypeDataProvider()
+    public function getContentTypeDataProvider(): array
     {
         return [
             ['', ''],
             ['path/file', ''],
-            ['path/file.ext', 'ext'],
+            ['path/file.ext', 'ext']
         ];
     }
 
     /**
-     * A callback for affecting preprocessor chain in the test
+     * A callback for affecting preprocessor chain in the test.
      *
      * @param Chain $chain
+     *
+     * @return void
      */
-    public function chainTestCallback(Chain $chain)
+    public function chainTestCallback(Chain $chain): void
     {
         $chain->setContentType('ext');
         $chain->setContent('processed');
@@ -222,17 +232,20 @@ class SourceTest extends TestCase
     /**
      * @return array
      */
-    public function getFileDataProvider()
+    public function getFileDataProvider(): array
     {
         return [
             ['/root/some/file.ext', 'file.ext', 'processed', false, true],
             ['/root/some/file.ext', 'file.ext', 'not_processed', true, false],
             ['/root/some/file.ext2', 'file.ext2', 'processed', true, true],
-            ['/root/some/file.ext2', 'file.ext2', 'not_processed', true, false],
+            ['/root/some/file.ext2', 'file.ext2', 'not_processed', true, false]
         ];
     }
 
-    protected function initFilesystem()
+    /**
+     * @return void
+     */
+    protected function initFilesystem(): void
     {
         $this->filesystem = $this->createMock(Filesystem::class);
         $this->rootDirRead = $this->getMockForAbstractClass(
@@ -246,7 +259,7 @@ class SourceTest extends TestCase
         $readDirMap = [
             [DirectoryList::ROOT, DriverPool::FILE, $this->rootDirRead],
             [DirectoryList::STATIC_VIEW, DriverPool::FILE, $this->staticDirRead],
-            [DirectoryList::TMP_MATERIALIZATION_DIR, DriverPool::FILE, $this->tmpDir],
+            [DirectoryList::TMP_MATERIALIZATION_DIR, DriverPool::FILE, $this->tmpDir]
         ];
 
         $this->filesystem->expects($this->any())
@@ -259,12 +272,13 @@ class SourceTest extends TestCase
     }
 
     /**
-     * Create an asset mock
+     * Create an asset mock.
      *
      * @param bool $isFallback
+     *
      * @return File|MockObject
      */
-    protected function getAsset($isFallback = true)
+    protected function getAsset($isFallback = true): File
     {
         if ($isFallback) {
             $context = new FallbackContext(

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
@@ -74,7 +74,7 @@ class ImageTest extends TestCase
     protected $imagePathMock;
 
     /**
-     * @inheirtDoc
+     * @return void
      */
     private function setupObjectManagerForCheckImageExist($return): void
     {
@@ -87,6 +87,9 @@ class ImageTest extends TestCase
         AppObjectManager::setInstance($objectManagerMock);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         $this->setupObjectManagerForCheckImageExist(false);
@@ -135,7 +138,7 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function tearDown(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
@@ -150,11 +150,9 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @return void
-     *
      * @return MockObject|Path
      */
-    protected function _getImagePathMock(): \Magento\Theme\Model\Theme\Image\Path
+    protected function _getImagePathMock(): Path
     {
         $imagePathMock = $this->createMock(Path::class);
         $testBaseUrl = 'http://localhost/media_path/';
@@ -193,7 +191,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::__construct
+     * @covers \Magento\Framework\View\Design\Theme\Image::__construct
      */
     public function testConstructor(): void
     {
@@ -203,7 +201,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::createPreviewImage
+     * @covers \Magento\Framework\View\Design\Theme\Image::createPreviewImage
      */
     public function testCreatePreviewImage(): void
     {
@@ -223,7 +221,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::createPreviewImageCopy
+     * @covers \Magento\Framework\View\Design\Theme\Image::createPreviewImageCopy
      */
     public function testCreatePreviewImageCopy(): void
     {
@@ -270,7 +268,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::removePreviewImage
+     * @covers \Magento\Framework\View\Design\Theme\Image::removePreviewImage
      */
     public function testRemovePreviewImage(): void
     {
@@ -283,7 +281,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::removePreviewImage
+     * @covers \Magento\Framework\View\Design\Theme\Image::removePreviewImage
      */
     public function testRemoveEmptyPreviewImage(): void
     {
@@ -296,7 +294,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::uploadPreviewImage
+     * @covers \Magento\Framework\View\Design\Theme\Image::uploadPreviewImage
      */
     public function testUploadPreviewImage(): void
     {
@@ -325,7 +323,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::getPreviewImageUrl
+     * @covers \Magento\Framework\View\Design\Theme\Image::getPreviewImageUrl
      */
     public function testGetPreviewImageUrl(): void
     {
@@ -342,7 +340,7 @@ class ImageTest extends TestCase
     /**
      * @return void
      *
-     * @covers Image::getPreviewImageUrl
+     * @covers \Magento\Framework\View\Design\Theme\Image::getPreviewImageUrl
      */
     public function testGetDefaultPreviewImageUrl(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Theme/ImageTest.php
@@ -12,6 +12,7 @@ namespace Magento\Framework\View\Test\Unit\Design\Theme;
 
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager as AppObjectManager;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\ReadInterface;
 use Magento\Framework\Filesystem\Directory\Write;
@@ -72,7 +73,10 @@ class ImageTest extends TestCase
      */
     protected $imagePathMock;
 
-    private function setupObjectManagerForCheckImageExist($return)
+    /**
+     * @inheirtDoc
+     */
+    private function setupObjectManagerForCheckImageExist($return): void
     {
         $objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $mockFileSystem = $this->createMock(Filesystem::class);
@@ -80,7 +84,7 @@ class ImageTest extends TestCase
         $objectManagerMock->method($this->logicalOr('get', 'create'))->willReturn($mockFileSystem);
         $mockFileSystem->method('getDirectoryRead')->willReturn($mockRead);
         $mockRead->method('isExist')->willReturn($return);
-        \Magento\Framework\App\ObjectManager::setInstance($objectManagerMock);
+        AppObjectManager::setInstance($objectManagerMock);
     }
 
     protected function setUp(): void
@@ -99,14 +103,10 @@ class ImageTest extends TestCase
             ->onlyMethods(['getDirectoryWrite'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->_filesystemMock->expects($this->at(0))
+        $this->_filesystemMock
             ->method('getDirectoryWrite')
-            ->with(DirectoryList::MEDIA)
-            ->willReturn($this->_mediaDirectoryMock);
-        $this->_filesystemMock->expects($this->at(1))
-            ->method('getDirectoryWrite')
-            ->with(DirectoryList::ROOT)
-            ->willReturn($this->_rootDirectoryMock);
+            ->withConsecutive([DirectoryList::MEDIA], [DirectoryList::ROOT])
+            ->willReturnOnConsecutiveCalls($this->_mediaDirectoryMock, $this->_rootDirectoryMock);
         $imageFactory = $this->createMock(Factory::class);
         $this->_imageMock = $this->createMock(\Magento\Framework\Image::class);
         $imageFactory->expects($this->any())->method('create')->willReturn($this->_imageMock);
@@ -134,6 +134,9 @@ class ImageTest extends TestCase
         );
     }
 
+    /**
+     * @inheirtDoc
+     */
     protected function tearDown(): void
     {
         $this->_model = null;
@@ -144,40 +147,36 @@ class ImageTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @return MockObject|Path
      */
-    protected function _getImagePathMock()
+    protected function _getImagePathMock(): \Magento\Theme\Model\Theme\Image\Path
     {
         $imagePathMock = $this->createMock(Path::class);
         $testBaseUrl = 'http://localhost/media_path/';
 
-        $imagePathMock->expects($this->any())->method('getPreviewImageDefaultUrl')
+        $imagePathMock->expects($this->any())
+            ->method('getPreviewImageDefaultUrl')
             ->willReturn($testBaseUrl . 'test_default_preview.png');
 
         $testBaseDir = '/media_path/';
-        $imagePathMock->expects(
-            $this->any()
-        )->method(
-            'getImagePreviewDirectory'
-        )->willReturn(
-            $testBaseDir . 'theme/preview'
-        );
-        $imagePathMock->expects(
-            $this->any()
-        )->method(
-            'getTemporaryDirectory'
-        )->willReturn(
-            $testBaseDir . 'tmp'
-        );
+        $imagePathMock->expects($this->any())
+            ->method('getImagePreviewDirectory')
+            ->willReturn($testBaseDir . 'theme/preview');
+        $imagePathMock->expects($this->any())
+            ->method('getTemporaryDirectory')
+            ->willReturn($testBaseDir . 'tmp');
+
         return $imagePathMock;
     }
 
     /**
-     * Sample theme data
+     * Sample theme data.
      *
      * @return array
      */
-    protected function _getThemeSampleData()
+    protected function _getThemeSampleData(): array
     {
         return [
             'theme_id' => 1,
@@ -189,17 +188,21 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::__construct
+     * @return void
+     *
+     * @covers Image::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $this->assertNotEmpty($this->_model);
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::createPreviewImage
+     * @return void
+     *
+     * @covers Image::createPreviewImage
      */
-    public function testCreatePreviewImage()
+    public function testCreatePreviewImage(): void
     {
         $this->_themeMock->method('getPreviewImage')->willReturn(null);
         $this->_imageMock->expects(
@@ -215,9 +218,11 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::createPreviewImageCopy
+     * @return void
+     *
+     * @covers Image::createPreviewImageCopy
      */
-    public function testCreatePreviewImageCopy()
+    public function testCreatePreviewImageCopy(): void
     {
         $previewImage = 'test_preview.png';
         $relativePath = '/media_path/theme/preview/test_preview.png';
@@ -237,17 +242,16 @@ class ImageTest extends TestCase
             ->with($relativePath, $this->anything())
             ->willReturn(true);
 
-        $themeImageMock = $this->getMockBuilder(Image::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getPreviewImagePath'])
+        $themeImageMock = $this->getMockBuilder(Image::class)->disableOriginalConstructor()
+            ->onlyMethods(['getPreviewImagePath'])
             ->getMock();
         $themeImageMock->expects($this->atLeastOnce())
             ->method('getPreviewImagePath')
             ->willReturn($previewImage);
 
-        $themeMock = $this->getMockBuilder(Theme::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getThemeImage', 'getPreviewImage'])
+        $themeMock = $this->getMockBuilder(Theme::class)->disableOriginalConstructor()
+            ->onlyMethods(['getThemeImage'])
+            ->addMethods(['getPreviewImage'])
             ->getMock();
         $themeMock->expects($this->atLeastOnce())
             ->method('getPreviewImage')
@@ -261,9 +265,11 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::removePreviewImage
+     * @return void
+     *
+     * @covers Image::removePreviewImage
      */
-    public function testRemovePreviewImage()
+    public function testRemovePreviewImage(): void
     {
         $this->_themeMock->method('getPreviewImage')->willReturn('test.png');
         $this->_mediaDirectoryMock->expects($this->once())->method('delete');
@@ -272,9 +278,11 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::removePreviewImage
+     * @return void
+     *
+     * @covers Image::removePreviewImage
      */
-    public function testRemoveEmptyPreviewImage()
+    public function testRemoveEmptyPreviewImage(): void
     {
         $this->_themeMock->method('getPreviewImage')->willReturn(null);
         $this->_filesystemMock->expects($this->never())->method('delete');
@@ -283,36 +291,40 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::uploadPreviewImage
+     * @return void
+     *
+     * @covers Image::uploadPreviewImage
      */
-    public function testUploadPreviewImage()
+    public function testUploadPreviewImage(): void
     {
         $scope = 'test_scope';
         $tmpFilePath = '/media_path/tmp/temporary.png';
         $this->_themeMock->method('getPreviewImage')->willReturn('test.png');
-        $this->_uploaderMock->expects(
-            $this->once()
-        )->method(
-            'uploadPreviewImage'
-        )->with(
-            $scope,
-            '/media_path/tmp'
-        )->willReturn(
-            $tmpFilePath
-        );
+        $this->_uploaderMock->expects($this->once())
+            ->method('uploadPreviewImage')
+            ->with($scope, '/media_path/tmp')
+            ->willReturn($tmpFilePath);
 
-        $this->_mediaDirectoryMock->expects($this->at(0))->method('getRelativePath')->willReturnArgument(0);
-        $this->_mediaDirectoryMock->expects($this->at(1))->method('delete')->with($this->stringContains('test.png'));
+        $this->_mediaDirectoryMock
+            ->method('getRelativePath')
+            ->willReturnArgument(0);
 
-        $this->_mediaDirectoryMock->expects($this->at(2))->method('delete')->with($tmpFilePath);
+        $this->_mediaDirectoryMock
+            ->method('delete')
+            ->withConsecutive(
+                [$this->stringContains('test.png')],
+                [$tmpFilePath]
+            );
 
         $this->_model->uploadPreviewImage($scope);
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::getPreviewImageUrl
+     * @return void
+     *
+     * @covers Image::getPreviewImageUrl
      */
-    public function testGetPreviewImageUrl()
+    public function testGetPreviewImageUrl(): void
     {
         $this->_themeMock->method('getPreviewImage')
             ->willReturn('...');
@@ -325,9 +337,11 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Framework\View\Design\Theme\Image::getPreviewImageUrl
+     * @return void
+     *
+     * @covers Image::getPreviewImageUrl
      */
-    public function testGetDefaultPreviewImageUrl()
+    public function testGetDefaultPreviewImageUrl(): void
     {
         $this->_themeMock->method('getPreviewImage')->willReturn(null);
         $this->assertEquals(

--- a/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
@@ -38,7 +38,7 @@ class DesignLoaderTest extends TestCase
     protected $appState;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
@@ -37,6 +37,9 @@ class DesignLoaderTest extends TestCase
      */
     protected $appState;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_areaListMock = $this->createMock(AreaList::class);
@@ -49,15 +52,18 @@ class DesignLoaderTest extends TestCase
         );
     }
 
-    public function testLoad()
+    /**
+     * @return void
+     */
+    public function testLoad(): void
     {
         $area = $this->createMock(Area::class);
         $this->appState->expects($this->once())->method('getAreaCode')->willReturn('area');
         $this->_areaListMock->expects($this->once())->method('getArea')->with('area')->willReturn($area);
-        $area->expects($this->at(0))->method('load')
-            ->with(Area::PART_DESIGN)->willReturn($area);
-        $area->expects($this->at(1))->method('load')
-            ->with(Area::PART_TRANSLATE)->willReturn($area);
+        $area
+            ->method('load')
+            ->withConsecutive([Area::PART_DESIGN], [Area::PART_TRANSLATE])
+            ->willReturnOnConsecutiveCalls($area, $area);
         $this->_model->load($this->_requestMock);
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/LinksTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/LinksTest.php
@@ -33,7 +33,7 @@ class LinksTest extends TestCase
     protected $context;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/LinksTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/LinksTest.php
@@ -22,12 +22,19 @@ class LinksTest extends TestCase
      */
     protected $objectManagerHelper;
 
-    /** @var Links|MockObject */
+    /**
+     * @var Links|MockObject
+     */
     protected $block;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     protected $context;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManager($this);
@@ -37,7 +44,10 @@ class LinksTest extends TestCase
         $this->block = new Links($this->context);
     }
 
-    public function testGetLinks()
+    /**
+     * @return void
+     */
+    public function testGetLinks(): void
     {
         $blocks = [0 => 'blocks'];
         $name = 'test_name';
@@ -50,18 +60,17 @@ class LinksTest extends TestCase
         $this->assertEquals($blocks, $this->block->getLinks());
     }
 
-    public function testSetActive()
+    /**
+     * @return void
+     */
+    public function testSetActive(): void
     {
         $link = $this->createMock(Link::class);
+
         $link
-            ->expects($this->at(1))
             ->method('__call')
-            ->with('setIsHighlighted', [true]);
-        $link
-            ->expects($this->at(0))
-            ->method('__call')
-            ->with('getPath', [])
-            ->willReturn('test/path');
+            ->withConsecutive(['getPath', []], ['setIsHighlighted', [true]])
+            ->willReturnOnConsecutiveCalls('test/path');
 
         $name = 'test_name';
         $this->context->getLayout()
@@ -74,7 +83,10 @@ class LinksTest extends TestCase
         $this->block->setActive('test/path');
     }
 
-    public function testRenderLink()
+    /**
+     * @return void
+     */
+    public function testRenderLink(): void
     {
         $blockHtml = 'test';
         $name = 'test_name';

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/MessagesTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/MessagesTest.php
@@ -53,7 +53,7 @@ class MessagesTest extends TestCase
     private $escaperMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/MessagesTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/MessagesTest.php
@@ -52,6 +52,9 @@ class MessagesTest extends TestCase
      */
     private $escaperMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->collectionFactory = $this->getMockBuilder(CollectionFactory::class)
@@ -77,7 +80,7 @@ class MessagesTest extends TestCase
                 'collectionFactory' => $this->collectionFactory,
                 'messageFactory' => $this->messageFactory,
                 'interpretationStrategy' => $this->messageInterpretationStrategy,
-                'escaper' => $this->escaperMock,
+                'escaper' => $this->escaperMock
             ]
         );
     }
@@ -85,7 +88,7 @@ class MessagesTest extends TestCase
     /**
      * @return MockObject|Collection
      */
-    protected function initMessageCollection()
+    protected function initMessageCollection(): Collection
     {
         $collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -97,7 +100,10 @@ class MessagesTest extends TestCase
         return $collection;
     }
 
-    public function testSetMessages()
+    /**
+     * @return void
+     */
+    public function testSetMessages(): void
     {
         $collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -109,14 +115,20 @@ class MessagesTest extends TestCase
         $this->assertSame($collection, $this->messages->getMessageCollection());
     }
 
-    public function testGetMessageCollection()
+    /**
+     * @return void
+     */
+    public function testGetMessageCollection(): void
     {
         $collection = $this->initMessageCollection();
 
         $this->assertSame($collection, $this->messages->getMessageCollection());
     }
 
-    public function testAddMessages()
+    /**
+     * @return void
+     */
+    public function testAddMessages(): void
     {
         $messageOne = $this->getMockForAbstractClass(MessageInterface::class);
         $messageTwo = $this->getMockForAbstractClass(MessageInterface::class);
@@ -125,12 +137,9 @@ class MessagesTest extends TestCase
 
         $collection = $this->initMessageCollection();
 
-        $collection->expects($this->at(0))
+        $collection
             ->method('addMessage')
-            ->with($messageOne);
-        $collection->expects($this->at(1))
-            ->method('addMessage')
-            ->with($messageTwo);
+            ->withConsecutive([$messageOne], [$messageTwo]);
 
         $collectionForAdd = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -143,7 +152,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addMessages($collectionForAdd));
     }
 
-    public function testAddMessage()
+    /**
+     * @return void
+     */
+    public function testAddMessage(): void
     {
         $message = $this->getMockForAbstractClass(MessageInterface::class);
 
@@ -156,7 +168,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addMessage($message));
     }
 
-    public function testAddError()
+    /**
+     * @return void
+     */
+    public function testAddError(): void
     {
         $messageText = 'Some message error text';
 
@@ -175,7 +190,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addError($messageText));
     }
 
-    public function testAddWarning()
+    /**
+     * @return void
+     */
+    public function testAddWarning(): void
     {
         $messageText = 'Some message warning text';
 
@@ -194,7 +212,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addWarning($messageText));
     }
 
-    public function testAddNotice()
+    /**
+     * @return void
+     */
+    public function testAddNotice(): void
     {
         $messageText = 'Some message notice text';
 
@@ -213,7 +234,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addNotice($messageText));
     }
 
-    public function testAddSuccess()
+    /**
+     * @return void
+     */
+    public function testAddSuccess(): void
     {
         $messageText = 'Some message success text';
 
@@ -232,7 +256,10 @@ class MessagesTest extends TestCase
         $this->assertSame($this->messages, $this->messages->addSuccess($messageText));
     }
 
-    public function testGetMessagesByType()
+    /**
+     * @return void
+     */
+    public function testGetMessagesByType(): void
     {
         $messageType = MessageInterface::TYPE_SUCCESS;
         $resultMessages = [$this->getMockForAbstractClass(MessageInterface::class)];
@@ -246,18 +273,24 @@ class MessagesTest extends TestCase
         $this->assertSame($resultMessages, $this->messages->getMessagesByType($messageType));
     }
 
-    public function testGetMessageTypes()
+    /**
+     * @return void
+     */
+    public function testGetMessageTypes(): void
     {
         $types = [
             MessageInterface::TYPE_ERROR,
             MessageInterface::TYPE_WARNING,
             MessageInterface::TYPE_NOTICE,
-            MessageInterface::TYPE_SUCCESS,
+            MessageInterface::TYPE_SUCCESS
         ];
         $this->assertEquals($types, $this->messages->getMessageTypes());
     }
 
-    public function testGetCacheKeyInfo()
+    /**
+     * @return void
+     */
+    public function testGetCacheKeyInfo(): void
     {
         $emptyMessagesCacheKey = ['storage_types' => ''];
         $this->assertEquals($emptyMessagesCacheKey, $this->messages->getCacheKeyInfo());
@@ -267,7 +300,10 @@ class MessagesTest extends TestCase
         $this->assertEquals($messagesCacheKey, $this->messages->getCacheKeyInfo());
     }
 
-    public function testGetGroupedHtml()
+    /**
+     * @return void
+     */
+    public function testGetGroupedHtml(): void
     {
         $this->messages->setNameInLayout('nameInLayout');
 
@@ -332,7 +368,7 @@ class MessagesTest extends TestCase
                     [MessageInterface::TYPE_ERROR, [$errorMock]],
                     [MessageInterface::TYPE_WARNING, [$warningMock, $warningMock]],
                     [MessageInterface::TYPE_NOTICE, [$noticeMock, $noticeMock, $noticeMock]],
-                    [MessageInterface::TYPE_SUCCESS, [$successMock, $successMock, $successMock, $successMock]],
+                    [MessageInterface::TYPE_SUCCESS, [$successMock, $successMock, $successMock, $successMock]]
                 ]
             );
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Argument/Interpreter/NamedParamsTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Argument/Interpreter/NamedParamsTest.php
@@ -25,7 +25,7 @@ class NamedParamsTest extends TestCase
     protected $_model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Argument/Interpreter/NamedParamsTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Argument/Interpreter/NamedParamsTest.php
@@ -24,6 +24,9 @@ class NamedParamsTest extends TestCase
      */
     protected $_model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_interpreter = $this->getMockForAbstractClass(
@@ -32,30 +35,19 @@ class NamedParamsTest extends TestCase
         $this->_model = new NamedParams($this->_interpreter);
     }
 
-    public function testEvaluate()
+    /**
+     * @return void
+     */
+    public function testEvaluate(): void
     {
         $input = [
             'param' => ['param1' => ['value' => 'value 1'], 'param2' => ['value' => 'value 2']],
         ];
 
-        $this->_interpreter->expects(
-            $this->at(0)
-        )->method(
-            'evaluate'
-        )->with(
-            ['value' => 'value 1']
-        )->willReturn(
-            'value 1 (evaluated)'
-        );
-        $this->_interpreter->expects(
-            $this->at(1)
-        )->method(
-            'evaluate'
-        )->with(
-            ['value' => 'value 2']
-        )->willReturn(
-            'value 2 (evaluated)'
-        );
+        $this->_interpreter
+            ->method('evaluate')
+            ->withConsecutive([['value' => 'value 1']], [['value' => 'value 2']])
+            ->willReturnOnConsecutiveCalls('value 1 (evaluated)', 'value 2 (evaluated)');
         $expected = ['param1' => 'value 1 (evaluated)', 'param2' => 'value 2 (evaluated)'];
 
         $actual = $this->_model->evaluate($input);
@@ -63,9 +55,11 @@ class NamedParamsTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @dataProvider evaluateWrongParamDataProvider
      */
-    public function testEvaluateWrongParam($input, $expectedExceptionMessage)
+    public function testEvaluateWrongParam($input, $expectedExceptionMessage): void
     {
         $this->expectException('\InvalidArgumentException');
         $this->expectExceptionMessage($expectedExceptionMessage);
@@ -75,16 +69,16 @@ class NamedParamsTest extends TestCase
     /**
      * @return array
      */
-    public function evaluateWrongParamDataProvider()
+    public function evaluateWrongParamDataProvider(): array
     {
         return [
             'root param is non-array' => [
                 ['param' => 'non-array'],
-                'Layout argument parameters are expected to be an array',
+                'Layout argument parameters are expected to be an array'
             ],
             'individual param is non-array' => [
                 ['param' => ['sub-param' => 'non-array']],
-                'Parameter data of layout argument is expected to be an array',
+                'Parameter data of layout argument is expected to be an array'
             ]
         ];
     }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/BuilderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/BuilderTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Builder
+ * @covers \Magento\Framework\View\Layout\Builder
  */
 class BuilderTest extends TestCase
 {
@@ -26,7 +26,7 @@ class BuilderTest extends TestCase
     /**
      * @return void
      *
-     * @covers Builder::build()
+     * @covers \Magento\Framework\View\Layout\Builder::build()
      */
     public function testBuild(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/BuilderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/BuilderTest.php
@@ -17,16 +17,18 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Magento\Framework\View\Layout\Builder
+ * @covers Builder
  */
 class BuilderTest extends TestCase
 {
     const CLASS_NAME = Builder::class;
 
     /**
-     * @covers \Magento\Framework\View\Layout\Builder::build()
+     * @return void
+     *
+     * @covers Builder::build()
      */
-    public function testBuild()
+    public function testBuild(): void
     {
         $fullActionName = 'route_controller_action';
 
@@ -50,9 +52,13 @@ class BuilderTest extends TestCase
         $data = ['full_action_name' => $fullActionName, 'layout' => $layout];
         /** @var ManagerInterface|MockObject $eventManager */
         $eventManager = $this->getMockForAbstractClass(ManagerInterface::class);
-        $eventManager->expects($this->at(0))->method('dispatch')->with('layout_load_before', $data);
-        $eventManager->expects($this->at(1))->method('dispatch')->with('layout_generate_blocks_before', $data);
-        $eventManager->expects($this->at(2))->method('dispatch')->with('layout_generate_blocks_after', $data);
+        $eventManager
+            ->method('dispatch')
+            ->withConsecutive(
+                ['layout_load_before', $data],
+                ['layout_generate_blocks_before', $data],
+                ['layout_generate_blocks_after', $data]
+            );
         $builder = $this->getBuilder(['eventManager' => $eventManager, 'request' => $request, 'layout' => $layout]);
         $builder->build();
     }
@@ -60,14 +66,14 @@ class BuilderTest extends TestCase
     /**
      * @return array
      */
-    protected function getLayoutMockMethods()
+    protected function getLayoutMockMethods(): array
     {
         return ['setBuilder', 'getUpdate', 'generateXml', 'generateElements'];
     }
 
     /**
      * @param array $arguments
-     * @return \Magento\Framework\View\Layout\Builder
+     * @return object
      */
     protected function getBuilder($arguments)
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/File/Collector/AggregateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/File/Collector/AggregateTest.php
@@ -49,7 +49,7 @@ class AggregateTest extends TestCase
     private $_overridingThemeFiles;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/File/Collector/AggregateTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/File/Collector/AggregateTest.php
@@ -48,6 +48,9 @@ class AggregateTest extends TestCase
      */
     private $_overridingThemeFiles;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_fileList = $this->createMock(FileList::class);
@@ -74,7 +77,7 @@ class AggregateTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetFiles()
+    public function testGetFiles(): void
     {
         $parentTheme = $this->getMockForAbstractClass(ThemeInterface::class);
         $theme = $this->getMockForAbstractClass(ThemeInterface::class);
@@ -93,82 +96,33 @@ class AggregateTest extends TestCase
             new File('3.xml', 'Module_One', $parentTheme),
             new File('4.xml', 'Module_One', $theme),
             new File('5.xml', 'Module_One', $theme),
-            new File('6.xml', 'Module_One', $theme),
+            new File('6.xml', 'Module_One', $theme)
         ];
 
-        $this->_baseFiles->expects(
-            $this->once()
-        )->method(
-            'getFiles'
-        )->with(
-            $theme
-        )->willReturn(
-            [$files[0]]
-        );
+        $this->_baseFiles->expects($this->once())
+            ->method('getFiles')
+            ->with($theme)
+            ->willReturn([$files[0]]);
 
-        $this->_themeFiles->expects(
-            $this->at(0)
-        )->method(
-            'getFiles'
-        )->with(
-            $parentTheme
-        )->willReturn(
-            [$files[1]]
-        );
-        $this->_overridingBaseFiles->expects(
-            $this->at(0)
-        )->method(
-            'getFiles'
-        )->with(
-            $parentTheme
-        )->willReturn(
-            [$files[2]]
-        );
-        $this->_overridingThemeFiles->expects(
-            $this->at(0)
-        )->method(
-            'getFiles'
-        )->with(
-            $parentTheme
-        )->willReturn(
-            [$files[3]]
-        );
+        $this->_themeFiles
+            ->method('getFiles')
+            ->withConsecutive([$parentTheme], [$theme])
+            ->willReturnOnConsecutiveCalls([$files[1]], [$files[4]]);
+        $this->_overridingBaseFiles
+            ->method('getFiles')
+            ->withConsecutive([$parentTheme], [$theme])
+            ->willReturnOnConsecutiveCalls([$files[2]], [$files[5]]);
+        $this->_overridingThemeFiles
+            ->method('getFiles')
+            ->withConsecutive([$parentTheme], [$theme])
+            ->willReturnOnConsecutiveCalls([$files[3]], [$files[6]]);
 
-        $this->_themeFiles->expects(
-            $this->at(1)
-        )->method(
-            'getFiles'
-        )->with(
-            $theme
-        )->willReturn(
-            [$files[4]]
-        );
-        $this->_overridingBaseFiles->expects(
-            $this->at(1)
-        )->method(
-            'getFiles'
-        )->with(
-            $theme
-        )->willReturn(
-            [$files[5]]
-        );
-        $this->_overridingThemeFiles->expects(
-            $this->at(1)
-        )->method(
-            'getFiles'
-        )->with(
-            $theme
-        )->willReturn(
-            [$files[6]]
-        );
-
-        $this->_fileList->expects($this->at(0))->method('add')->with([$files[0]]);
-        $this->_fileList->expects($this->at(1))->method('add')->with([$files[1]]);
-        $this->_fileList->expects($this->at(2))->method('replace')->with([$files[2]]);
-        $this->_fileList->expects($this->at(3))->method('replace')->with([$files[3]]);
-        $this->_fileList->expects($this->at(4))->method('add')->with([$files[4]]);
-        $this->_fileList->expects($this->at(5))->method('replace')->with([$files[5]]);
-        $this->_fileList->expects($this->at(6))->method('replace')->with([$files[6]]);
+        $this->_fileList
+            ->method('add')
+            ->withConsecutive([[$files[0]]], [[$files[1]]], [[$files[4]]]);
+        $this->_fileList
+            ->method('replace')
+            ->withConsecutive([[$files[2]]], [[$files[3]]], [[$files[5]]], [[$files[6]]]);
 
         $this->_fileList->expects($this->atLeastOnce())->method('getAll')->willReturn($files);
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
@@ -148,7 +148,7 @@ class LayoutTest extends TestCase
     private $serializer;
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void

--- a/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/LayoutTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\View\Test\Unit;
 
+use Exception;
 use Magento\Framework\App\State;
 use Magento\Framework\Cache\FrontendInterface;
 use Magento\Framework\DataObject;
@@ -147,7 +148,7 @@ class LayoutTest extends TestCase
     private $serializer;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -185,13 +186,13 @@ class LayoutTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->pageConfigStructure = $this->getMockBuilder(Structure::class)
-            ->setMethods(['__toArray', 'populateWithArray'])
+            ->onlyMethods(['__toArray', 'populateWithArray'])
             ->getMock();
         $this->layoutScheduledSructure = $this->getMockBuilder(ScheduledStructure::class)
-            ->setMethods(['__toArray', 'populateWithArray'])
+            ->onlyMethods(['__toArray', 'populateWithArray'])
             ->getMock();
         $this->readerContextMock = $this->getMockBuilder(LayoutReaderContext::class)
-            ->setMethods(['getPageConfigStructure', 'getScheduledStructure'])
+            ->onlyMethods(['getPageConfigStructure', 'getScheduledStructure'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->readerContextMock->expects($this->any())->method('getPageConfigStructure')
@@ -235,7 +236,7 @@ class LayoutTest extends TestCase
                 'appState' => $this->appStateMock,
                 'logger' => $this->loggerMock,
                 'cacheable' => true,
-                'serializer' => $this->serializer,
+                'serializer' => $this->serializer
             ]
         );
     }
@@ -515,6 +516,7 @@ class LayoutTest extends TestCase
      * @param bool $hasElement
      * @param string $attribute
      * @param bool $result
+     *
      * @return void
      * @dataProvider isContainerDataProvider
      */
@@ -543,7 +545,7 @@ class LayoutTest extends TestCase
             [false, '', false],
             [true, 'container', true],
             [true, 'block', false],
-            [true, 'something', false],
+            [true, 'something', false]
         ];
     }
 
@@ -551,6 +553,7 @@ class LayoutTest extends TestCase
      * @param bool $parentName
      * @param array $containerConfig
      * @param bool $result
+     *
      * @return void
      * @dataProvider isManipulationAllowedDataProvider
      */
@@ -585,7 +588,7 @@ class LayoutTest extends TestCase
         return [
             ['parent', ['has_element' => true, 'attribute' => 'container'], true],
             ['parent', ['has_element' => true, 'attribute' => 'block'], false],
-            [false, [], false],
+            [false, [], false]
         ];
     }
 
@@ -593,6 +596,7 @@ class LayoutTest extends TestCase
      * @covers \Magento\Framework\View\Layout::setBlock
      * @covers \Magento\Framework\View\Layout::getAllBlocks
      * @covers \Magento\Framework\View\Layout::unsetElement
+     *
      * @return void
      */
     public function testSetGetBlock(): void
@@ -685,7 +689,8 @@ class LayoutTest extends TestCase
 
     /**
      * @param array $type
-     * @param array $blockInstance
+     * @param string $blockInstance
+     *
      * @return void
      * @dataProvider getBlockSingletonDataProvider
      */
@@ -714,8 +719,8 @@ class LayoutTest extends TestCase
             [
                 'some_type',
                 Template::class,
-                true,
-            ],
+                true
+            ]
         ];
     }
 
@@ -723,6 +728,7 @@ class LayoutTest extends TestCase
      * @param array $rendererData
      * @param array $getData
      * @param bool $result
+     *
      * @return void
      * @dataProvider getRendererOptionsDataProvider
      */
@@ -756,7 +762,7 @@ class LayoutTest extends TestCase
             'dynamic_type' => 'dynamic_type_value',
             'type' => 'type_value',
             'template' => 'template.phtml',
-            'data' => ['some' => 'data'],
+            'data' => ['some' => 'data']
         ];
         return [
             'wrong namespace' => [
@@ -764,7 +770,7 @@ class LayoutTest extends TestCase
                 [
                     'namespace' => 'wrong namespace',
                     'static_type' => 'static_type_value',
-                    'dynamic_type' => 'dynamic_type_value',
+                    'dynamic_type' => 'dynamic_type_value'
                 ],
                 null,
             ],
@@ -773,7 +779,7 @@ class LayoutTest extends TestCase
                 [
                     'namespace' => 'namespace_value',
                     'static_type' => 'wrong static type',
-                    'dynamic_type' => 'dynamic_type_value',
+                    'dynamic_type' => 'dynamic_type_value'
                 ],
                 null,
             ],
@@ -782,7 +788,7 @@ class LayoutTest extends TestCase
                 [
                     'namespace' => 'namespace_value',
                     'static_type' => 'static_type_value',
-                    'dynamic_type' => 'wrong dynamic type',
+                    'dynamic_type' => 'wrong dynamic type'
                 ],
                 null,
             ],
@@ -791,14 +797,14 @@ class LayoutTest extends TestCase
                 [
                     'namespace' => 'namespace_value',
                     'static_type' => 'static_type_value',
-                    'dynamic_type' => 'dynamic_type_value',
+                    'dynamic_type' => 'dynamic_type_value'
                 ],
                 [
                     'type' => 'type_value',
                     'template' => 'template.phtml',
-                    'data' => ['some' => 'data'],
-                ],
-            ],
+                    'data' => ['some' => 'data']
+                ]
+            ]
         ];
     }
 
@@ -807,6 +813,7 @@ class LayoutTest extends TestCase
      * @param string $blockName
      * @param bool $hasElement
      * @param bool $cacheable
+     *
      * @return void
      * @dataProvider isCacheableDataProvider
      */
@@ -829,14 +836,14 @@ class LayoutTest extends TestCase
                     . '<block></block></layout>',
                 'blockName' => '',
                 'hasElement' => true,
-                'cacheable' => true,
+                'cacheable' => true
             ],
             'notCacheableBlockWithoutName' => [
                 'xml' => '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
                     . '<block cacheable="false"></block></layout>',
                 'blockName' => '',
                 'hasElement' => true,
-                'cacheable' => true,
+                'cacheable' => true
             ],
             'notCacheableBlockWithMissingBlockReference' => [
                 'xml' => '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -845,7 +852,7 @@ class LayoutTest extends TestCase
                     . '</referenceBlock></layout>',
                 'blockName' => 'non_cacheable_block',
                 'hasElement' => false,
-                'cacheable' => true,
+                'cacheable' => true
             ],
             'notCacheableBlockWithMissingContainerReference' => [
                 'xml' => '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -854,7 +861,7 @@ class LayoutTest extends TestCase
                     . '</referenceContainer></layout>',
                 'blockName' => 'non_cacheable_block',
                 'hasElement' => false,
-                'cacheable' => true,
+                'cacheable' => true
             ],
             'notCacheableBlockWithExistingBlockReference' => [
                 'xml' => '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -863,7 +870,7 @@ class LayoutTest extends TestCase
                     . '</referenceBlock></layout>',
                 'blockName' => 'non_cacheable_block',
                 'hasElement' => true,
-                'cacheable' => false,
+                'cacheable' => false
             ],
             'notCacheableBlockWithExistingContainerReference' => [
                 'xml' => '<?xml version="1.0"?><layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -872,8 +879,8 @@ class LayoutTest extends TestCase
                     . '</referenceContainer></layout>',
                 'blockName' => 'non_cacheable_block',
                 'hasElement' => true,
-                'cacheable' => false,
-            ],
+                'cacheable' => false
+            ]
         ];
     }
 
@@ -923,8 +930,8 @@ class LayoutTest extends TestCase
             'field_3' => [
                 'field_3_1' => '1244',
                 'field_3_2' => null,
-                'field_3_3' => false,
-            ],
+                'field_3_3' => false
+            ]
         ];
         $this->pageConfigStructure->expects($this->any())
             ->method('__toArray')
@@ -932,7 +939,7 @@ class LayoutTest extends TestCase
 
         $layoutScheduledStructureData = [
             'field_1' => 1283,
-            'field_2' => 'text_qwertyuiop[]asdfghjkl;',
+            'field_2' => 'text_qwertyuiop[]asdfghjkl;'
         ];
         $this->layoutScheduledSructure->expects($this->any())
             ->method('__toArray')
@@ -964,7 +971,7 @@ class LayoutTest extends TestCase
             'name_1' => ['type' => '', 'parent' => null],
             'name_2' => ['type' => Element::TYPE_CONTAINER, 'parent' => null],
             'name_3' => ['type' => '', 'parent' => 'parent'],
-            'name_4' => ['type' => Element::TYPE_CONTAINER, 'parent' => 'parent'],
+            'name_4' => ['type' => Element::TYPE_CONTAINER, 'parent' => 'parent']
         ];
 
         $this->structureMock->expects($this->once())
@@ -1006,7 +1013,7 @@ class LayoutTest extends TestCase
             'field_3' => [
                 'field_3_1' => '1244',
                 'field_3_2' => null,
-                'field_3_3' => false,
+                'field_3_3' => false
             ]
         ];
         $this->pageConfigStructure->expects($this->once())
@@ -1052,7 +1059,7 @@ class LayoutTest extends TestCase
             'name_1' => ['type' => '', 'parent' => null],
             'name_2' => ['type' => Element::TYPE_CONTAINER, 'parent' => null],
             'name_3' => ['type' => '', 'parent' => 'parent'],
-            'name_4' => ['type' => Element::TYPE_CONTAINER, 'parent' => 'parent'],
+            'name_4' => ['type' => Element::TYPE_CONTAINER, 'parent' => 'parent']
         ];
 
         $this->structureMock->expects($this->once())
@@ -1073,6 +1080,7 @@ class LayoutTest extends TestCase
 
     /**
      * @param mixed $displayValue
+     *
      * @return void
      * @dataProvider renderElementDisplayDataProvider
      */
@@ -1089,16 +1097,12 @@ class LayoutTest extends TestCase
                 [
                     [$name, 'display', $displayValue],
                     [$child, 'display', $displayValue],
-                    [$child, 'type', Element::TYPE_BLOCK],
+                    [$child, 'type', Element::TYPE_BLOCK]
                 ]
             );
 
         $this->structureMock->expects($this->atLeastOnce())->method('hasElement')
-            ->willReturnMap(
-                [
-                    [$child, true],
-                ]
-            );
+            ->willReturnMap([[$child, true]]);
 
         $this->structureMock->expects($this->once())
             ->method('getChildren')
@@ -1111,17 +1115,25 @@ class LayoutTest extends TestCase
         $renderingOutput = new DataObject();
         $renderingOutput->setData('output', $blockHtml);
 
-        $this->eventManagerMock->expects($this->at(0))
+        $this->eventManagerMock
             ->method('dispatch')
-            ->with(
-                'core_layout_render_element',
-                ['element_name' => $child, 'layout' => $this->model, 'transport' => $renderingOutput]
-            );
-        $this->eventManagerMock->expects($this->at(1))
-            ->method('dispatch')
-            ->with(
-                'core_layout_render_element',
-                ['element_name' => $name, 'layout' => $this->model, 'transport' => $renderingOutput]
+            ->withConsecutive(
+                [
+                    'core_layout_render_element',
+                    [
+                        'element_name' => $child,
+                        'layout' => $this->model,
+                        'transport' => $renderingOutput
+                    ]
+                ],
+                [
+                    'core_layout_render_element',
+                    [
+                        'element_name' => $name,
+                        'layout' => $this->model,
+                        'transport' => $renderingOutput
+                    ]
+                ]
             );
 
         $this->model->setBlock($child, $block);
@@ -1130,9 +1142,11 @@ class LayoutTest extends TestCase
 
     /**
      * @param mixed $displayValue
+     *
+     * @return void
      * @dataProvider renderElementDoNotDisplayDataProvider
      */
-    public function testRenderElementDoNotDisplay($displayValue)
+    public function testRenderElementDoNotDisplay($displayValue): void
     {
         $name = 'test_container';
         $blockHtml = '';
@@ -1152,7 +1166,7 @@ class LayoutTest extends TestCase
         return [
             ['false'],
             ['0'],
-            [0],
+            [0]
         ];
     }
 
@@ -1167,18 +1181,18 @@ class LayoutTest extends TestCase
             [1],
             ['true'],
             [false],
-            [null],
+            [null]
         ];
     }
 
     /**
-     * Test render element with exception
+     * Test render element with exception.
      *
      * @return void
      */
     public function testRenderNonCachedElementWithException(): void
     {
-        $exception = new \Exception('Error message');
+        $exception = new Exception('Error message');
 
         $builderMock = $this->createMock(BuilderInterface::class);
         $builderMock->expects($this->once())

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/BuilderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/BuilderTest.php
@@ -24,7 +24,7 @@ class BuilderTest extends \Magento\Framework\View\Test\Unit\Layout\BuilderTest
 
     /**
      * @param array $arguments
-     * @return \Magento\Framework\View\Layout\Builder
+     * @return object
      */
     protected function getBuilder($arguments)
     {
@@ -57,10 +57,11 @@ class BuilderTest extends \Magento\Framework\View\Test\Unit\Layout\BuilderTest
     /**
      * @return array
      */
-    protected function getLayoutMockMethods()
+    protected function getLayoutMockMethods(): array
     {
         $result = parent::getLayoutMockMethods();
         $result[] = 'getReaderContext';
+
         return $result;
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -44,7 +44,7 @@ class HeadTest extends TestCase
     protected $title;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Generator/HeadTest.php
@@ -29,7 +29,7 @@ class HeadTest extends TestCase
     protected $headGenerator;
 
     /**
-     * @var \Magento\Framework\View\Page\Config|MockObject
+     * @var PageConfig|MockObject
      */
     protected $pageConfigMock;
 
@@ -43,9 +43,12 @@ class HeadTest extends TestCase
      */
     protected $title;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
-        $this->pageConfigMock = $this->getMockBuilder(\Magento\Framework\View\Page\Config::class)
+        $this->pageConfigMock = $this->getMockBuilder(PageConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->title = $this->getMockBuilder(Title::class)
@@ -66,9 +69,11 @@ class HeadTest extends TestCase
     }
 
     /**
+     * @return void
+     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testProcess()
+    public function testProcess(): void
     {
         $generatorContextMock = $this->createMock(Context::class);
         $this->title->expects($this->any())->method('set')->with()->willReturnSelf();
@@ -88,56 +93,50 @@ class HeadTest extends TestCase
                 'src' => 'file-url-css',
                 'src_type' => 'url',
                 'content_type' => 'css',
-                'media' => 'all',
+                'media' => 'all'
             ],
             'remoteCssOrderedLast' => [
                 'src' => 'file-url-css-last',
                 'src_type' => 'url',
                 'content_type' => 'css',
                 'media' => 'all',
-                'order' => 30,
+                'order' => 30
             ],
             'remoteCssOrderedFirst' => [
                 'src' => 'file-url-css-first',
                 'src_type' => 'url',
                 'content_type' => 'css',
                 'media' => 'all',
-                'order' => 10,
+                'order' => 10
             ],
             'remoteLink' => [
                 'src' => 'file-url-link',
                 'src_type' => 'url',
-                'media' => 'all',
+                'media' => 'all'
             ],
             'controllerCss' => [
                 'src' => 'customcss/render/css',
                 'src_type' => 'controller',
                 'content_type' => 'css',
-                'media' => 'all',
+                'media' => 'all'
             ],
             'name' => [
                 'src' => 'file-path',
                 'ie_condition' => 'lt IE 7',
                 'content_type' => 'css',
-                'media' => 'print',
-            ],
+                'media' => 'print'
+            ]
         ];
 
-        $this->pageConfigMock->expects($this->at(0))
+        $this->pageConfigMock
             ->method('addRemotePageAsset')
-            ->with('file-url-css', 'css', ['attributes' => ['media' => 'all']]);
-        $this->pageConfigMock->expects($this->at(1))
-            ->method('addRemotePageAsset')
-            ->with('file-url-css-last', 'css', ['attributes' => ['media' => 'all' ] , 'order' => 30]);
-        $this->pageConfigMock->expects($this->at(2))
-            ->method('addRemotePageAsset')
-            ->with('file-url-css-first', 'css', ['attributes' => ['media' => 'all'] , 'order' => 10]);
-        $this->pageConfigMock->expects($this->at(3))
-            ->method('addRemotePageAsset')
-            ->with('file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]);
-        $this->pageConfigMock->expects($this->at(4))
-            ->method('addRemotePageAsset')
-            ->with('http://magento.dev/customcss/render/css', 'css', ['attributes' => ['media' => 'all']]);
+            ->withConsecutive(
+                ['file-url-css', 'css', ['attributes' => ['media' => 'all']]],
+                ['file-url-css-last', 'css', ['attributes' => ['media' => 'all'], 'order' => 30]],
+                ['file-url-css-first', 'css', ['attributes' => ['media' => 'all'], 'order' => 10]],
+                ['file-url-link', Head::VIRTUAL_CONTENT_TYPE_LINK, ['attributes' => ['media' => 'all']]],
+                ['http://magento.dev/customcss/render/css', 'css', ['attributes' => ['media' => 'all']]]
+            );
         $this->pageConfigMock->expects($this->once())
             ->method('addPageAsset')
             ->with('name', ['attributes' => ['media' => 'print'], 'ie_condition' => 'lt IE 7']);
@@ -162,10 +161,10 @@ class HeadTest extends TestCase
         $elementAttributes = [
             PageConfig::ELEMENT_TYPE_BODY => [
                 'body_attr_1' => 'body_value_1',
-                'body_attr_2' => 'body_value_2',
+                'body_attr_2' => 'body_value_2'
             ],
             PageConfig::ELEMENT_TYPE_HTML => [
-                'html_attr_1' => 'html_attr_1',
+                'html_attr_1' => 'html_attr_1'
             ],
         ];
         $structureMock->expects($this->once())

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
@@ -22,7 +22,7 @@ class HeadTest extends TestCase
     protected $model;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/Reader/HeadTest.php
@@ -21,12 +21,18 @@ class HeadTest extends TestCase
      */
     protected $model;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->model = new Head();
     }
 
-    public function testInterpret()
+    /**
+     * @return void
+     */
+    public function testInterpret(): void
     {
         $readerContextMock = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
@@ -41,66 +47,56 @@ class HeadTest extends TestCase
         $xml = file_get_contents(__DIR__ . '/../_files/template_head.xml');
         $element = new Element($xml);
 
-        $structureMock->expects($this->at(0))
+        $structureMock
             ->method('setTitle')
             ->with('Test title')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(1))
-            ->method('setMetaData')
-            ->with('meta_name', 'meta_content')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(2))
-            ->method('setMetaData')
-            ->with('og:video:secure_url', 'https://secure.example.com/movie.swf')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(3))
-            ->method('setMetaData')
-            ->with('og:locale:alternate', 'uk_UA')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(4))
-            ->method('addAssets')
-            ->with('path/file-3.css', ['src' => 'path/file-3.css', 'media' => 'all', 'content_type' => 'css'])
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(5))
-            ->method('addAssets')
-            ->with('path/file.js', ['src' => 'path/file.js', 'defer' => 'defer', 'content_type' => 'js'])
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(6))
-            ->method('addAssets')
-            ->with('http://url.com', ['src' => 'http://url.com', 'src_type' => 'url'])
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(7))
-            ->method('removeAssets')
-            ->with('path/remove/file.css')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(8))
+            ->willReturn($structureMock);
+        $structureMock
             ->method('setElementAttribute')
             ->with(Config::ELEMENT_TYPE_HEAD, 'head_attribute_name', 'head_attribute_value')
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(9))
+            ->willReturn($structureMock);
+        $structureMock
+            ->method('removeAssets')
+            ->with('path/remove/file.css')
+            ->willReturn($structureMock);
+        $structureMock
             ->method('addAssets')
-            ->with(
-                'path/file-1.css',
-                ['src' => 'path/file-1.css', 'media' => 'all', 'content_type' => 'css', 'order' => 10]
+            ->withConsecutive(
+                [
+                    'path/file-3.css',
+                    ['src' => 'path/file-3.css', 'media' => 'all', 'content_type' => 'css']
+                ],
+                [
+                    'path/file.js',
+                    ['src' => 'path/file.js', 'defer' => 'defer', 'content_type' => 'js']
+                ],
+                [
+                    'http://url.com',
+                    ['src' => 'http://url.com', 'src_type' => 'url']
+                ],
+                [
+                    'path/file-1.css',
+                    ['src' => 'path/file-1.css', 'media' => 'all', 'content_type' => 'css', 'order' => 10]
+                ],
+                [
+                    'path/file-2.css',
+                    ['src' => 'path/file-2.css', 'media' => 'all', 'content_type' => 'css', 'order' => 30]
+                ]
             )
-            ->willReturnSelf();
-
-        $structureMock->expects($this->at(10))
-            ->method('addAssets')
-            ->with(
-                'path/file-2.css',
-                ['src' => 'path/file-2.css', 'media' => 'all', 'content_type' => 'css', 'order' => 30]
-            )
-            ->willReturnSelf();
+            ->willReturnOnConsecutiveCalls(
+                $structureMock,
+                $structureMock,
+                $structureMock,
+                $structureMock,
+                $structureMock
+            );
+        $structureMock
+            ->method('setMetaData')
+            ->withConsecutive(
+                ['meta_name', 'meta_content'],
+                ['og:video:secure_url', 'https://secure.example.com/movie.swf'],
+                ['og:locale:alternate', 'uk_UA'])
+            ->willReturnOnConsecutiveCalls($structureMock, $structureMock, $structureMock);
 
         $this->assertEquals($this->model, $this->model->interpret($readerContextMock, $element->children()[0]));
     }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
@@ -94,7 +94,7 @@ class RendererTest extends TestCase
     protected $objectManagerHelper;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/Config/RendererTest.php
@@ -93,6 +93,9 @@ class RendererTest extends TestCase
      */
     protected $objectManagerHelper;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->pageConfigMock = $this->getMockBuilder(Config::class)
@@ -124,14 +127,14 @@ class RendererTest extends TestCase
             ->getMock();
 
         $this->assetsCollection = $this->getMockBuilder(GroupedCollection::class)
-            ->setMethods(['getGroups'])
+            ->onlyMethods(['getGroups'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->assetInterfaceMock = $this->getMockForAbstractClass(AssetInterface::class);
 
         $this->titleMock = $this->getMockBuilder(Title::class)
-            ->setMethods(['set', 'get'])
+            ->onlyMethods(['set', 'get'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -150,7 +153,10 @@ class RendererTest extends TestCase
         );
     }
 
-    public function testRenderElementAttributes()
+    /**
+     * @return void
+     */
+    public function testRenderElementAttributes(): void
     {
         $elementType = 'elementType';
         $attributes = ['attr1' => 'value1', 'attr2' => 'value2'];
@@ -164,7 +170,10 @@ class RendererTest extends TestCase
         $this->assertEquals($expected, $this->renderer->renderElementAttributes($elementType));
     }
 
-    public function testRenderMetadata()
+    /**
+     * @return void
+     */
+    public function testRenderMetadata(): void
     {
         $metadata = [
             'charset' => 'charsetValue',
@@ -184,10 +193,10 @@ class RendererTest extends TestCase
             . '<meta property="og:video:secure_url" content="secure_url"/>' . "\n"
             . '<meta name="msapplication-TileImage" content="https://site.domain/ms-tile.jpg"/>' . "\n";
 
-        $this->stringMock->expects($this->at(0))
+        $this->stringMock
             ->method('upperCaseWords')
-            ->with('charset', '_', '')
-            ->willReturn('Charset');
+            ->withConsecutive(['charset', '_', ''])
+            ->willReturnOnConsecutiveCalls('Charset');
 
         $this->pageConfigMock->expects($this->once())
             ->method('getCharset')
@@ -208,9 +217,11 @@ class RendererTest extends TestCase
     }
 
     /**
-     * Test renderMetadata when it has 'msapplication-TileImage' meta passed
+     * Test renderMetadata when it has 'msapplication-TileImage' meta passed.
+     *
+     * @return void
      */
-    public function testRenderMetadataWithMsApplicationTileImageAsset()
+    public function testRenderMetadataWithMsApplicationTileImageAsset(): void
     {
         $metadata = [
             'msapplication-TileImage' => 'images/ms-tile.jpg'
@@ -232,7 +243,10 @@ class RendererTest extends TestCase
         $this->assertEquals($expected, $this->renderer->renderMetadata());
     }
 
-    public function testRenderTitle()
+    /**
+     * @return void
+     */
+    public function testRenderTitle(): void
     {
         $title = 'some_title';
         $expected = "<title>some_title</title>" . "\n";
@@ -252,7 +266,10 @@ class RendererTest extends TestCase
         $this->assertEquals($expected, $this->renderer->renderTitle());
     }
 
-    public function testPrepareFavicon()
+    /**
+     * @return void
+     */
+    public function testPrepareFavicon(): void
     {
         $filePath = 'file';
         $this->pageConfigMock->expects($this->exactly(3))
@@ -266,7 +283,7 @@ class RendererTest extends TestCase
                     $filePath,
                     Head::VIRTUAL_CONTENT_TYPE_LINK,
                     ['attributes' => ['rel' => 'icon', 'type' => 'image/x-icon']],
-                    'icon',
+                    'icon'
                 ],
                 [
                     $filePath,
@@ -279,7 +296,10 @@ class RendererTest extends TestCase
         $this->renderer->prepareFavicon();
     }
 
-    public function testPrepareFaviconDefault()
+    /**
+     * @return void
+     */
+    public function testPrepareFaviconDefault(): void
     {
         $defaultFilePath = 'default_file';
         $this->pageConfigMock->expects($this->once())
@@ -310,9 +330,11 @@ class RendererTest extends TestCase
      * @param $groupOne
      * @param $groupTwo
      * @param $expectedResult
+     *
+     * @return void
      * @dataProvider dataProviderRenderAssets
      */
-    public function testRenderAssets($groupOne, $groupTwo, $expectedResult)
+    public function testRenderAssets($groupOne, $groupTwo, $expectedResult): void
     {
         $assetUrl = 'url';
         $assetNoRoutUrl = 'no_route_url';
@@ -340,7 +362,7 @@ class RendererTest extends TestCase
                     [GroupedCollection::PROPERTY_CAN_MERGE, true],
                     [GroupedCollection::PROPERTY_CONTENT_TYPE, $groupOne['type']],
                     ['attributes', $groupOne['attributes']],
-                    ['ie_condition', $groupOne['condition']],
+                    ['ie_condition', $groupOne['condition']]
                 ]
             );
 
@@ -365,7 +387,7 @@ class RendererTest extends TestCase
                     [GroupedCollection::PROPERTY_CAN_MERGE, true],
                     [GroupedCollection::PROPERTY_CONTENT_TYPE, $groupTwo['type']],
                     ['attributes', $groupTwo['attributes']],
-                    ['ie_condition', $groupTwo['condition']],
+                    ['ie_condition', $groupTwo['condition']]
                 ]
             );
 
@@ -399,7 +421,7 @@ class RendererTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderRenderAssets()
+    public function dataProviderRenderAssets(): array
     {
         return [
             [
@@ -438,10 +460,13 @@ class RendererTest extends TestCase
                 '<link  href="no_route_url" />' . "\n"
                     . '<link  attr="value" href="url" />' . "\n"
                     . '<link  attr="value" href="url" />' . "\n"
-            ],
+            ]
         ];
     }
 
+    /**
+     * @return void
+     */
     public function testRenderAssetWithNoContentType() : void
     {
         $type = '';
@@ -468,7 +493,7 @@ class RendererTest extends TestCase
                     [GroupedCollection::PROPERTY_CAN_MERGE, true],
                     [GroupedCollection::PROPERTY_CONTENT_TYPE, $type],
                     ['attributes', 'rel="some-rel"'],
-                    ['ie_condition', null],
+                    ['ie_condition', null]
                 ]
             );
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
@@ -36,7 +36,9 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigTest extends TestCase
 {
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     */
     private $objectManager;
 
     /**
@@ -94,6 +96,9 @@ class ConfigTest extends TestCase
      */
     protected $localeMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->assetRepo = $this->createMock(Repository::class);
@@ -133,7 +138,10 @@ class ConfigTest extends TestCase
         $areaResolverReflection->setValue($this->model, $this->areaResolverMock);
     }
 
-    public function testSetBuilder()
+    /**
+     * @return void
+     */
+    public function testSetBuilder(): void
     {
         $this->assertInstanceOf(
             Config::class,
@@ -141,7 +149,10 @@ class ConfigTest extends TestCase
         );
     }
 
-    public function testBuild()
+    /**
+     * @return void
+     */
+    public function testBuild(): void
     {
         $this->model->setBuilder($this->builder);
         $this->builder->expects($this->once())->method('build')->willReturn(
@@ -150,12 +161,18 @@ class ConfigTest extends TestCase
         $this->model->publicBuild();
     }
 
-    public function testGetTitle()
+    /**
+     * @return void
+     */
+    public function testGetTitle(): void
     {
         $this->assertInstanceOf(Title::class, $this->model->getTitle());
     }
 
-    public function testMetadata()
+    /**
+     * @return void
+     */
+    public function testMetadata(): void
     {
         $expectedMetadata = [
             'charset' => null,
@@ -166,60 +183,86 @@ class ConfigTest extends TestCase
             'robots' => null,
             'title' => null,
             'name' => 'test_value',
-            'html_encoded' => '&lt;title&gt;&lt;span class=&quot;test&quot;&gt;Test&lt;/span&gt;&lt;/title&gt;',
+            'html_encoded' => '&lt;title&gt;&lt;span class=&quot;test&quot;&gt;Test&lt;/span&gt;&lt;/title&gt;'
         ];
         $this->model->setMetadata('name', 'test_value');
         $this->model->setMetadata('html_encoded', '<title><span class="test">Test</span></title>');
         $this->assertEquals($expectedMetadata, $this->model->getMetadata());
     }
 
-    public function testContentType()
+    /**
+     * @return void
+     */
+    public function testContentType(): void
     {
         $contentType = 'test_content_type';
         $this->model->setContentType($contentType);
         $this->assertEquals($contentType, $this->model->getContentType());
     }
 
-    public function testContentTypeEmpty()
+    /**
+     * @return void
+     */
+    public function testContentTypeEmpty(): void
     {
         $expectedData = null;
         $this->assertEquals($expectedData, $this->model->getContentType());
     }
 
-    public function testContentTypeAuto()
+    /**
+     * @return void
+     */
+    public function testContentTypeAuto(): void
     {
         $expectedData = 'default_media_type; charset=default_charset';
         $this->model->setContentType('auto');
-        $this->scopeConfig->expects($this->at(0))->method('getValue')->with('design/head/default_media_type', 'store')
-            ->willReturn('default_media_type');
-        $this->scopeConfig->expects($this->at(1))->method('getValue')->with('design/head/default_charset', 'store')
-            ->willReturn('default_charset');
+        $this->scopeConfig
+            ->method('getValue')
+            ->withConsecutive(
+                ['design/head/default_media_type', 'store'],
+                ['design/head/default_charset', 'store']
+            )
+            ->willReturnOnConsecutiveCalls('default_media_type', 'default_charset');
         $this->assertEquals($expectedData, $this->model->getContentType());
     }
 
-    public function testMediaType()
+    /**
+     * @return void
+     */
+    public function testMediaType(): void
     {
         $mediaType = 'test_media_type';
         $this->model->setMediaType($mediaType);
         $this->assertEquals($mediaType, $this->model->getMediaType());
     }
 
-    public function testMediaTypeEmpty()
+    /**
+     * @return void
+     */
+    public function testMediaTypeEmpty(): void
     {
         $expectedData = 'default_media_type';
-        $this->scopeConfig->expects($this->once())->method('getValue')->with('design/head/default_media_type', 'store')
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with('design/head/default_media_type', 'store')
             ->willReturn('default_media_type');
         $this->assertEquals($expectedData, $this->model->getMediaType());
     }
 
-    public function testCharset()
+    /**
+     * @return void
+     */
+    public function testCharset(): void
     {
         $charset = 'test_charset';
         $this->model->setCharset($charset);
         $this->assertEquals($charset, $this->model->getCharset());
     }
 
-    public function testCharsetEmpty()
+    /**
+     * @return void
+     */
+    public function testCharsetEmpty(): void
     {
         $expectedData = 'default_charset';
         $this->scopeConfig->expects($this->once())->method('getValue')->with('design/head/default_charset', 'store')
@@ -227,29 +270,43 @@ class ConfigTest extends TestCase
         $this->assertEquals($expectedData, $this->model->getCharset());
     }
 
-    public function testDescription()
+    /**
+     * @return void
+     */
+    public function testDescription(): void
     {
         $description = 'test_description';
         $this->model->setDescription($description);
         $this->assertEquals($description, $this->model->getDescription());
     }
 
-    public function testDescriptionEmpty()
+    /**
+     * @return void
+     */
+    public function testDescriptionEmpty(): void
     {
         $expectedData = 'default_description';
-        $this->scopeConfig->expects($this->once())->method('getValue')->with('design/head/default_description', 'store')
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with('design/head/default_description', 'store')
             ->willReturn('default_description');
         $this->assertEquals($expectedData, $this->model->getDescription());
     }
 
-    public function testKeywords()
+    /**
+     * @return void
+     */
+    public function testKeywords(): void
     {
         $keywords = 'test_keywords';
         $this->model->setKeywords($keywords);
         $this->assertEquals($keywords, $this->model->getKeywords());
     }
 
-    public function testKeywordsEmpty()
+    /**
+     * @return void
+     */
+    public function testKeywordsEmpty(): void
     {
         $expectedData = 'default_keywords';
         $this->scopeConfig->expects($this->once())->method('getValue')->with('design/head/default_keywords', 'store')
@@ -257,7 +314,10 @@ class ConfigTest extends TestCase
         $this->assertEquals($expectedData, $this->model->getKeywords());
     }
 
-    public function testRobots()
+    /**
+     * @return void
+     */
+    public function testRobots(): void
     {
         $this->areaResolverMock->expects($this->once())->method('getAreaCode')->willReturn('frontend');
         $robots = 'test_robots';
@@ -265,7 +325,10 @@ class ConfigTest extends TestCase
         $this->assertEquals($robots, $this->model->getRobots());
     }
 
-    public function testRobotsEmpty()
+    /**
+     * @return void
+     */
+    public function testRobotsEmpty(): void
     {
         $this->areaResolverMock->expects($this->once())->method('getAreaCode')->willReturn('frontend');
         $expectedData = 'default_robots';
@@ -277,7 +340,10 @@ class ConfigTest extends TestCase
         $this->assertEquals($expectedData, $this->model->getRobots());
     }
 
-    public function testRobotsAdminhtml()
+    /**
+     * @return void
+     */
+    public function testRobotsAdminhtml(): void
     {
         $this->areaResolverMock->expects($this->once())->method('getAreaCode')->willReturn('adminhtml');
         $robots = 'test_robots';
@@ -285,7 +351,10 @@ class ConfigTest extends TestCase
         $this->assertEquals('NOINDEX,NOFOLLOW', $this->model->getRobots());
     }
 
-    public function testGetAssetCollection()
+    /**
+     * @return void
+     */
+    public function testGetAssetCollection(): void
     {
         $this->assertInstanceOf(
             GroupedCollection::class,
@@ -299,9 +368,10 @@ class ConfigTest extends TestCase
      * @param string|null $name
      * @param string $expectedName
      *
+     * @return void
      * @dataProvider pageAssetDataProvider
      */
-    public function testAddPageAsset($file, $properties, $name, $expectedName)
+    public function testAddPageAsset($file, $properties, $name, $expectedName): void
     {
         $this->assetRepo->expects($this->once())->method('createAsset')->with($file)->willReturn(
             $this->asset
@@ -316,14 +386,14 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function pageAssetDataProvider()
+    public function pageAssetDataProvider(): array
     {
         return [
             [
                 'test.php',
                 ['one', 'two', 3],
                 'test_name',
-                'test_name',
+                'test_name'
             ],
             [
                 'filename',
@@ -341,9 +411,10 @@ class ConfigTest extends TestCase
      * @param string|null $name
      * @param string $expectedName
      *
+     * @return void
      * @dataProvider remotePageAssetDataProvider
      */
-    public function testAddRemotePageAsset($url, $contentType, $properties, $name, $expectedName)
+    public function testAddRemotePageAsset($url, $contentType, $properties, $name, $expectedName): void
     {
         $this->assetRepo->expects($this->once())->method('createRemoteAsset')->with($url, $contentType)->willReturn(
             $this->remoteAsset
@@ -358,7 +429,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function remotePageAssetDataProvider()
+    public function remotePageAssetDataProvider(): array
     {
         return [
             [
@@ -366,7 +437,7 @@ class ConfigTest extends TestCase
                 '<body><context>some content</context></body>',
                 ['one', 'two', 3],
                 'test_name',
-                'test_name',
+                'test_name'
             ],
             [
                 'http://test.com',
@@ -378,7 +449,10 @@ class ConfigTest extends TestCase
         ];
     }
 
-    public function testAddRss()
+    /**
+     * @return void
+     */
+    public function testAddRss(): void
     {
         $title = 'test title';
         $href = 'http://test.com';
@@ -394,7 +468,10 @@ class ConfigTest extends TestCase
         $this->assertInstanceOf(Config::class, $this->model->addRss($title, $href));
     }
 
-    public function testAddBodyClass()
+    /**
+     * @return void
+     */
+    public function testAddBodyClass(): void
     {
         $className = 'test class';
         $this->assertInstanceOf(Config::class, $this->model->addBodyClass($className));
@@ -406,9 +483,10 @@ class ConfigTest extends TestCase
      * @param string $attribute
      * @param string $value
      *
+     * @return void
      * @dataProvider elementAttributeDataProvider
      */
-    public function testElementAttribute($elementType, $attribute, $value)
+    public function testElementAttribute($elementType, $attribute, $value): void
     {
         $this->model->setElementAttribute($elementType, $attribute, $value);
         $this->assertEquals($value, $this->model->getElementAttribute($elementType, $attribute));
@@ -417,13 +495,13 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function elementAttributeDataProvider()
+    public function elementAttributeDataProvider(): array
     {
         return [
             [
                 'head',
                 'class',
-                'test',
+                'test'
             ],
             [
                 'body',
@@ -434,7 +512,7 @@ class ConfigTest extends TestCase
                 Config::ELEMENT_TYPE_HTML,
                 Config::HTML_ATTRIBUTE_LANG,
                 str_replace('_', '-', Resolver::DEFAULT_LOCALE)
-            ],
+            ]
         ];
     }
 
@@ -443,9 +521,10 @@ class ConfigTest extends TestCase
      * @param string $attribute
      * @param string $value
      *
+     * @return void
      * @dataProvider elementAttributeExceptionDataProvider
      */
-    public function testElementAttributeException($elementType, $attribute, $value)
+    public function testElementAttributeException($elementType, $attribute, $value): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage($elementType . " isn't allowed");
@@ -455,13 +534,13 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function elementAttributeExceptionDataProvider()
+    public function elementAttributeExceptionDataProvider(): array
     {
         return [
             [
                 'test',
                 'class',
-                'test',
+                'test'
             ],
             [
                 '',
@@ -480,9 +559,10 @@ class ConfigTest extends TestCase
      * @param string $elementType
      * @param string $attributes
      *
+     * @return void
      * @dataProvider elementAttributesDataProvider
      */
-    public function testElementAttributes($elementType, $attributes)
+    public function testElementAttributes($elementType, $attributes): void
     {
         foreach ($attributes as $attribute => $value) {
             $this->model->setElementAttribute($elementType, $attribute, $value);
@@ -493,7 +573,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function elementAttributesDataProvider()
+    public function elementAttributesDataProvider(): array
     {
         return [
             [
@@ -501,17 +581,18 @@ class ConfigTest extends TestCase
                 [
                     'context' => 'value',
                     Config::HTML_ATTRIBUTE_LANG => str_replace('_', '-', Resolver::DEFAULT_LOCALE)
-                ],
-            ],
+                ]
+            ]
         ];
     }
 
     /**
      * @param string $handle
      *
+     * @return void
      * @dataProvider pageLayoutDataProvider
      */
-    public function testPageLayout($handle)
+    public function testPageLayout($handle): void
     {
         $this->model->setPageLayout($handle);
         $this->assertEquals($handle, $this->model->getPageLayout());
@@ -520,11 +601,11 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function pageLayoutDataProvider()
+    public function pageLayoutDataProvider(): array
     {
         return [
             [
-                'test',
+                'test'
             ],
             [
                 ''
@@ -534,20 +615,26 @@ class ConfigTest extends TestCase
             ],
             [
                 [
-                    'test',
+                    'test'
                 ]
             ]
         ];
     }
 
-    public function testGetFaviconFile()
+    /**
+     * @return void
+     */
+    public function testGetFaviconFile(): void
     {
         $expected = 'test';
         $this->favicon->expects($this->once())->method('getFaviconFile')->willReturn($expected);
         $this->assertEquals($expected, $this->model->getFaviconFile());
     }
 
-    public function testGetDefaultFavicon()
+    /**
+     * @return void
+     */
+    public function testGetDefaultFavicon(): void
     {
         $this->favicon->expects($this->once())->method('getDefaultFavicon');
         $this->model->getDefaultFavicon();
@@ -556,9 +643,11 @@ class ConfigTest extends TestCase
     /**
      * @param bool $isAvailable
      * @param string $result
+     *
+     * @return void
      * @dataProvider getIncludesDataProvider
      */
-    public function testGetIncludes($isAvailable, $result)
+    public function testGetIncludes($isAvailable, $result): void
     {
         $model = (new ObjectManager($this))
             ->getObject(
@@ -583,7 +672,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function getIncludesDataProvider()
+    public function getIncludesDataProvider(): array
     {
         return [
             [

--- a/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Page/ConfigTest.php
@@ -97,7 +97,7 @@ class ConfigTest extends TestCase
     protected $localeMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Result/PageTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Result/PageTest.php
@@ -80,13 +80,19 @@ class PageTest extends TestCase
      */
     private $layoutFactory;
 
-    /** @var MockObject|EntitySpecificHandlesList */
+    /**
+     * @var MockObject|EntitySpecificHandlesList
+     */
     private $entitySpecificHandlesListMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->layout = $this->getMockBuilder(Layout::class)
-            ->setMethods(['addHandle', 'getUpdate', 'isLayoutDefined'])
+            ->onlyMethods(['getUpdate'])
+            ->addMethods(['addHandle', 'isLayoutDefined'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -131,9 +137,8 @@ class PageTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $pageConfigRendererFactory = $this->getMockBuilder(RendererFactory::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['create'])
+        $pageConfigRendererFactory = $this->getMockBuilder(RendererFactory::class)->disableOriginalConstructor()
+            ->onlyMethods(['create'])
             ->getMock();
         $pageConfigRendererFactory->expects($this->once())
             ->method('create')
@@ -156,7 +161,10 @@ class PageTest extends TestCase
         );
     }
 
-    public function testInitLayout()
+    /**
+     * @return void
+     */
+    public function testInitLayout(): void
     {
         $handleDefault = 'default';
         $fullActionName = 'full_action_name';
@@ -164,22 +172,21 @@ class PageTest extends TestCase
             ->method('getFullActionName')
             ->willReturn($fullActionName);
 
-        $this->layoutMerge->expects($this->at(0))
+        $this->layoutMerge
             ->method('addHandle')
-            ->with($handleDefault)
-            ->willReturnSelf();
-        $this->layoutMerge->expects($this->at(1))
-            ->method('addHandle')
-            ->with($fullActionName)
-            ->willReturnSelf();
-        $this->layoutMerge->expects($this->at(2))
+            ->withConsecutive([$handleDefault], [$fullActionName])
+            ->willReturnOnConsecutiveCalls($this->layoutMerge, $this->layoutMerge);
+        $this->layoutMerge
             ->method('isLayoutDefined')
             ->willReturn(false);
 
         $this->assertEquals($this->page, $this->page->initLayout());
     }
 
-    public function testInitLayoutLayoutDefined()
+    /**
+     * @return void
+     */
+    public function testInitLayoutLayoutDefined(): void
     {
         $handleDefault = 'default';
         $fullActionName = 'full_action_name';
@@ -187,31 +194,33 @@ class PageTest extends TestCase
             ->method('getFullActionName')
             ->willReturn($fullActionName);
 
-        $this->layoutMerge->expects($this->at(0))
+        $this->layoutMerge
             ->method('addHandle')
-            ->with($handleDefault)
-            ->willReturnSelf();
-        $this->layoutMerge->expects($this->at(1))
-            ->method('addHandle')
-            ->with($fullActionName)
-            ->willReturnSelf();
-        $this->layoutMerge->expects($this->at(2))
-            ->method('isLayoutDefined')
-            ->willReturn(true);
-        $this->layoutMerge->expects($this->at(3))
+            ->withConsecutive([$handleDefault], [$fullActionName])
+            ->willReturnOnConsecutiveCalls($this->layoutMerge, $this->layoutMerge);
+        $this->layoutMerge
             ->method('removeHandle')
             ->with($handleDefault)
-            ->willReturnSelf();
+            ->willReturn($this->layoutMerge);
+        $this->layoutMerge
+            ->method('isLayoutDefined')
+            ->willReturn(true);
 
         $this->assertEquals($this->page, $this->page->initLayout());
     }
 
-    public function testGetConfig()
+    /**
+     * @return void
+     */
+    public function testGetConfig(): void
     {
         $this->assertEquals($this->pageConfig, $this->page->getConfig());
     }
 
-    public function testGetDefaultLayoutHandle()
+    /**
+     * @return void
+     */
+    public function testGetDefaultLayoutHandle(): void
     {
         $fullActionName = 'Full_Action_Name';
         $expectedFullActionName = 'full_action_name';
@@ -223,18 +232,21 @@ class PageTest extends TestCase
         $this->assertEquals($expectedFullActionName, $this->page->getDefaultLayoutHandle());
     }
 
-    public function testAddPageLayoutHandles()
+    /**
+     * @return void
+     */
+    public function testAddPageLayoutHandles(): void
     {
         $fullActionName = 'Full_Action_Name';
         $defaultHandle = null;
         $parameters = [
             'key_one' => 'val_one',
-            'key_two' => 'val_two',
+            'key_two' => 'val_two'
         ];
         $expected = [
             'full_action_name',
             'full_action_name_key_one_val_one',
-            'full_action_name_key_two_val_two',
+            'full_action_name_key_two_val_two'
         ];
         $this->request->expects($this->any())
             ->method('getFullActionName')
@@ -245,26 +257,28 @@ class PageTest extends TestCase
             ->with($expected)
             ->willReturnSelf();
 
-        $this->entitySpecificHandlesListMock->expects($this->at(0))
-            ->method('addHandle')->with('full_action_name_key_one_val_one');
-        $this->entitySpecificHandlesListMock->expects($this->at(1))
-            ->method('addHandle')->with('full_action_name_key_two_val_two');
+        $this->entitySpecificHandlesListMock
+            ->method('addHandle')
+            ->withConsecutive(['full_action_name_key_one_val_one'], ['full_action_name_key_two_val_two']);
 
         $this->page->addPageLayoutHandles($parameters, $defaultHandle);
     }
 
-    public function testAddPageLayoutHandlesNotEntitySpecific()
+    /**
+     * @return void
+     */
+    public function testAddPageLayoutHandlesNotEntitySpecific(): void
     {
         $fullActionName = 'Full_Action_Name';
         $defaultHandle = null;
         $parameters = [
             'key_one' => 'val_one',
-            'key_two' => 'val_two',
+            'key_two' => 'val_two'
         ];
         $expected = [
             'full_action_name',
             'full_action_name_key_one_val_one',
-            'full_action_name_key_two_val_two',
+            'full_action_name_key_two_val_two'
         ];
         $this->request->expects($this->any())
             ->method('getFullActionName')
@@ -280,17 +294,20 @@ class PageTest extends TestCase
         $this->page->addPageLayoutHandles($parameters, $defaultHandle, false);
     }
 
-    public function testAddPageLayoutHandlesWithDefaultHandle()
+    /**
+     * @return void
+     */
+    public function testAddPageLayoutHandlesWithDefaultHandle(): void
     {
         $defaultHandle = 'default_handle';
         $parameters = [
             'key_one' => 'val_one',
-            'key_two' => 'val_two',
+            'key_two' => 'val_two'
         ];
         $expected = [
             'default_handle',
             'default_handle_key_one_val_one',
-            'default_handle_key_two_val_two',
+            'default_handle_key_two_val_two'
         ];
         $this->request->expects($this->never())
             ->method('getFullActionName');

--- a/lib/internal/Magento/Framework/View/Test/Unit/Result/PageTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Result/PageTest.php
@@ -86,7 +86,7 @@ class PageTest extends TestCase
     private $entitySpecificHandlesListMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
@@ -56,7 +56,7 @@ class UpgradeCommandTest extends TestCase
     private $commandTester;
 
     /**
-     * @return void
+     * @inheirtDoc
      */
     protected function setUp(): void
     {
@@ -94,22 +94,24 @@ class UpgradeCommandTest extends TestCase
     }
 
     /**
-     * @dataProvider executeDataProvider
      * @param array $options
      * @param string $deployMode
      * @param string $expectedString
      * @param array $expectedOptions
+     *
+     * @return void
+     * @dataProvider executeDataProvider
      */
-    public function testExecute($options, $deployMode, $expectedString, $expectedOptions)
+    public function testExecute($options, $deployMode, $expectedString, $expectedOptions): void
     {
         $this->appStateMock->method('getMode')->willReturn($deployMode);
-        $this->installerMock->expects($this->at(0))
-            ->method('updateModulesSequence');
         $this->installerMock->expects($this->once())
             ->method('installSchema')
             ->with($expectedOptions);
-        $this->installerMock->expects($this->at(2))
-            ->method('installDataFixtures');
+        $this->installerMock
+            ->method('updateModulesSequence');
+        $this->installerMock
+        ->method('installDataFixtures');
 
         $this->assertSame(Cli::RETURN_SUCCESS, $this->commandTester->execute($options));
         $this->assertEquals($expectedString, $this->commandTester->getDisplay());
@@ -118,15 +120,15 @@ class UpgradeCommandTest extends TestCase
     /**
      * @return array
      */
-    public function executeDataProvider()
+    public function executeDataProvider(): array
     {
         return [
             [
                 'options' => [
                     '--magento-init-params' => '',
-                    '--convert-old-scripts' => false,
+                    '--convert-old-scripts' => false
                 ],
-                'deployMode' => \Magento\Framework\App\State::MODE_PRODUCTION,
+                'deployMode' => AppState::MODE_PRODUCTION,
                 'expectedString' => 'Please re-run Magento compile command. Use the command "setup:di:compile"'
                     . PHP_EOL,
                 'expectedOptions' => [
@@ -135,16 +137,16 @@ class UpgradeCommandTest extends TestCase
                     'safe-mode' => false,
                     'data-restore' => false,
                     'dry-run' => false,
-                    'magento-init-params' => '',
+                    'magento-init-params' => ''
                 ]
             ],
             [
                 'options' => [
                     '--magento-init-params' => '',
                     '--convert-old-scripts' => false,
-                    '--keep-generated' => true,
+                    '--keep-generated' => true
                 ],
-                'deployMode' => \Magento\Framework\App\State::MODE_PRODUCTION,
+                'deployMode' => AppState::MODE_PRODUCTION,
                 'expectedString' => '',
                 'expectedOptions' => [
                     'keep-generated' => true,
@@ -152,12 +154,12 @@ class UpgradeCommandTest extends TestCase
                     'safe-mode' => false,
                     'data-restore' => false,
                     'dry-run' => false,
-                    'magento-init-params' => '',
+                    'magento-init-params' => ''
                 ]
             ],
             [
                 'options' => ['--magento-init-params' => '', '--convert-old-scripts' => false],
-                'deployMode' => \Magento\Framework\App\State::MODE_DEVELOPER,
+                'deployMode' => AppState::MODE_DEVELOPER,
                 'expectedString' => '',
                 'expectedOptions' => [
                     'keep-generated' => false,
@@ -165,12 +167,12 @@ class UpgradeCommandTest extends TestCase
                     'safe-mode' => false,
                     'data-restore' => false,
                     'dry-run' => false,
-                    'magento-init-params' => '',
+                    'magento-init-params' => ''
                 ]
             ],
             [
                 'options' => ['--magento-init-params' => '', '--convert-old-scripts' => false],
-                'deployMode' => \Magento\Framework\App\State::MODE_DEFAULT,
+                'deployMode' => AppState::MODE_DEFAULT,
                 'expectedString' => '',
                 'expectedOptions' => [
                     'keep-generated' => false,
@@ -178,9 +180,9 @@ class UpgradeCommandTest extends TestCase
                     'safe-mode' => false,
                     'data-restore' => false,
                     'dry-run' => false,
-                    'magento-init-params' => '',
+                    'magento-init-params' => ''
                 ]
-            ],
+            ]
         ];
     }
 }

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
@@ -56,7 +56,7 @@ class UpgradeCommandTest extends TestCase
     private $commandTester;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
@@ -56,6 +56,9 @@ class ConfigModelTest extends TestCase
      */
     private $configOptionsList;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->collector = $this->createMock(ConfigOptionsListCollector::class);
@@ -75,7 +78,10 @@ class ConfigModelTest extends TestCase
         );
     }
 
-    public function testValidate()
+    /**
+     * @return void
+     */
+    public function testValidate(): void
     {
         $option = $this->createMock(TextConfigOption::class);
         $option->expects($this->exactly(3))->method('getName')->willReturn('Fake');
@@ -96,7 +102,10 @@ class ConfigModelTest extends TestCase
         $this->configModel->validate(['Fake' => null]);
     }
 
-    public function testProcess()
+    /**
+     * @return void
+     */
+    public function testProcess(): void
     {
         $testSet1 = [
             ConfigFilePool::APP_CONFIG => [
@@ -159,13 +168,17 @@ class ConfigModelTest extends TestCase
             ->method('collectOptionsLists')
             ->willReturn($configOptionsList);
 
-        $this->writer->expects($this->at(0))->method('saveConfig')->with($testSetExpected1);
-        $this->writer->expects($this->at(1))->method('saveConfig')->with($testSetExpected2);
+        $this->writer
+            ->method('saveConfig')
+            ->withConsecutive([$testSetExpected1], [$testSetExpected2]);
 
         $this->configModel->process([]);
     }
 
-    public function testProcessException()
+    /**
+     * @return void
+     */
+    public function testProcessException(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('In module : Fake_ModuleConfigOption::createConfig');
@@ -183,7 +196,10 @@ class ConfigModelTest extends TestCase
         $this->configModel->process([]);
     }
 
-    public function testWritePermissionErrors()
+    /**
+     * @return void
+     */
+    public function testWritePermissionErrors(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Missing write permissions to the following paths:');

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
@@ -57,7 +57,7 @@ class ConfigModelTest extends TestCase
     private $configOptionsList;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
@@ -47,7 +47,7 @@ class PhpReadinessCheckTest extends TestCase
     private $phpReadinessCheck;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/PhpReadinessCheckTest.php
@@ -46,6 +46,9 @@ class PhpReadinessCheckTest extends TestCase
      */
     private $phpReadinessCheck;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->composerInfo = $this->createMock(ComposerInformation::class);
@@ -60,7 +63,10 @@ class PhpReadinessCheckTest extends TestCase
         );
     }
 
-    public function testCheckPhpVersionNoRequiredVersion()
+    /**
+     * @return void
+     */
+    public function testCheckPhpVersionNoRequiredVersion(): void
     {
         $this->composerInfo->expects($this->once())
             ->method('getRequiredPhpVersion')
@@ -75,7 +81,10 @@ class PhpReadinessCheckTest extends TestCase
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpVersion());
     }
 
-    public function testCheckPhpVersionPrettyVersion()
+    /**
+     * @return void
+     */
+    public function testCheckPhpVersionPrettyVersion(): void
     {
         $this->composerInfo->expects($this->once())->method('getRequiredPhpVersion')->willReturn('1.0');
         $multipleConstraints = $this->getMockForAbstractClass(
@@ -84,30 +93,33 @@ class PhpReadinessCheckTest extends TestCase
             '',
             false
         );
-        $this->versionParser->expects($this->at(0))->method('parseConstraints')->willReturn($multipleConstraints);
-        $this->versionParser->expects($this->at(1))
-            ->method('normalize')
-            ->willThrowException(new \UnexpectedValueException());
-        $this->versionParser->expects($this->at(2))->method('normalize')->willReturn('1.0');
         $currentPhpVersion = $this->getMockForAbstractClass(
             ConstraintInterface::class,
             [],
             '',
             false
         );
-        $this->versionParser->expects($this->at(3))->method('parseConstraints')->willReturn($currentPhpVersion);
+        $this->versionParser
+            ->method('parseConstraints')
+            ->willReturnOnConsecutiveCalls($multipleConstraints, $currentPhpVersion);
+        $this->versionParser
+            ->method('normalize')
+            ->willReturn('1.0');
         $multipleConstraints->expects($this->once())->method('matches')->willReturn(true);
         $expected = [
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_SUCCESS,
             'data' => [
                 'required' => 1.0,
-                'current' => PHP_VERSION,
-            ],
+                'current' => PHP_VERSION
+            ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpVersion());
     }
 
-    public function testCheckPhpVersionPrettyVersionFailed()
+    /**
+     * @return void
+     */
+    public function testCheckPhpVersionPrettyVersionFailed(): void
     {
         $this->composerInfo->expects($this->once())->method('getRequiredPhpVersion')->willReturn('1.0');
         $multipleConstraints = $this->getMockForAbstractClass(
@@ -116,30 +128,33 @@ class PhpReadinessCheckTest extends TestCase
             '',
             false
         );
-        $this->versionParser->expects($this->at(0))->method('parseConstraints')->willReturn($multipleConstraints);
-        $this->versionParser->expects($this->at(1))
-            ->method('normalize')
-            ->willThrowException(new \UnexpectedValueException());
-        $this->versionParser->expects($this->at(2))->method('normalize')->willReturn('1.0');
         $currentPhpVersion = $this->getMockForAbstractClass(
             ConstraintInterface::class,
             [],
             '',
             false
         );
-        $this->versionParser->expects($this->at(3))->method('parseConstraints')->willReturn($currentPhpVersion);
+        $this->versionParser
+            ->method('parseConstraints')
+            ->willReturnOnConsecutiveCalls($multipleConstraints, $currentPhpVersion);
+        $this->versionParser
+            ->method('normalize')
+            ->willReturn('1.0');
         $multipleConstraints->expects($this->once())->method('matches')->willReturn(false);
         $expected = [
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_ERROR,
             'data' => [
                 'required' => 1.0,
-                'current' => PHP_VERSION,
-            ],
+                'current' => PHP_VERSION
+            ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpVersion());
     }
 
-    private function setUpNoPrettyVersionParser()
+    /**
+     * @return void
+     */
+    private function setUpNoPrettyVersionParser(): void
     {
         $multipleConstraints = $this->getMockForAbstractClass(
             ConstraintInterface::class,
@@ -147,19 +162,25 @@ class PhpReadinessCheckTest extends TestCase
             '',
             false
         );
-        $this->versionParser->expects($this->at(0))->method('parseConstraints')->willReturn($multipleConstraints);
-        $this->versionParser->expects($this->at(1))->method('normalize')->willReturn('1.0');
         $currentPhpVersion = $this->getMockForAbstractClass(
             ConstraintInterface::class,
             [],
             '',
             false
         );
-        $this->versionParser->expects($this->at(2))->method('parseConstraints')->willReturn($currentPhpVersion);
+        $this->versionParser
+            ->method('parseConstraints')
+            ->willReturnOnConsecutiveCalls($multipleConstraints, $currentPhpVersion);
+        $this->versionParser
+            ->method('normalize')
+            ->willReturn('1.0');
         $multipleConstraints->expects($this->once())->method('matches')->willReturn(true);
     }
 
-    public function testCheckPhpVersion()
+    /**
+     * @return void
+     */
+    public function testCheckPhpVersion(): void
     {
         $this->composerInfo->expects($this->once())->method('getRequiredPhpVersion')->willReturn('1.0');
 
@@ -168,13 +189,16 @@ class PhpReadinessCheckTest extends TestCase
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_SUCCESS,
             'data' => [
                 'required' => 1.0,
-                'current' => PHP_VERSION,
-            ],
+                'current' => PHP_VERSION
+            ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpVersion());
     }
 
-    public function testCheckPhpVersionFailed()
+    /**
+     * @return void
+     */
+    public function testCheckPhpVersionFailed(): void
     {
         $this->composerInfo->expects($this->once())->method('getRequiredPhpVersion')->willReturn('1.0');
         $multipleConstraints = $this->getMockForAbstractClass(
@@ -183,27 +207,33 @@ class PhpReadinessCheckTest extends TestCase
             '',
             false
         );
-        $this->versionParser->expects($this->at(0))->method('parseConstraints')->willReturn($multipleConstraints);
-        $this->versionParser->expects($this->at(1))->method('normalize')->willReturn('1.0');
         $currentPhpVersion = $this->getMockForAbstractClass(
             ConstraintInterface::class,
             [],
             '',
             false
         );
-        $this->versionParser->expects($this->at(2))->method('parseConstraints')->willReturn($currentPhpVersion);
+        $this->versionParser
+            ->method('parseConstraints')
+            ->willReturnOnConsecutiveCalls($multipleConstraints, $currentPhpVersion);
+        $this->versionParser
+            ->method('normalize')
+            ->willReturn('1.0');
         $multipleConstraints->expects($this->once())->method('matches')->willReturn(false);
         $expected = [
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_ERROR,
             'data' => [
                 'required' => 1.0,
-                'current' => PHP_VERSION,
-            ],
+                'current' => PHP_VERSION
+            ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpVersion());
     }
 
-    public function testCheckPhpSettings()
+    /**
+     * @return void
+     */
+    public function testCheckPhpSettings(): void
     {
         $this->phpInfo->expects($this->once())->method('getCurrent')->willReturn(['xdebug']);
         $this->phpInfo->expects($this->once())->method('getRequiredMinimumXDebugNestedLevel')->willReturn(50);
@@ -228,14 +258,14 @@ class PhpReadinessCheckTest extends TestCase
             'data' => [
                 'xdebug_max_nesting_level' => [
                     'message' => $xdebugMessage,
-                    'error' => false,
+                    'error' => false
                 ],
                 'missed_function_imagecreatefromjpeg' => [
                     'message' => 'You must have installed GD library with --with-jpeg-dir=DIR option.',
                     'helpUrl' => 'http://php.net/manual/en/image.installation.php',
-                    'error' => false,
-                ],
-            ],
+                    'error' => false
+                ]
+            ]
         ];
         if (!$this->isPhp7OrHhvm()) {
             $this->setUpNoPrettyVersionParser();
@@ -248,7 +278,10 @@ class PhpReadinessCheckTest extends TestCase
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
-    public function testCheckPhpSettingsFailed()
+    /**
+     * @return void
+     */
+    public function testCheckPhpSettingsFailed(): void
     {
         $this->phpInfo->expects($this->once())->method('getCurrent')->willReturn(['xdebug']);
         $this->phpInfo->expects($this->once())->method('getRequiredMinimumXDebugNestedLevel')->willReturn(200);
@@ -273,14 +306,14 @@ class PhpReadinessCheckTest extends TestCase
             'data' => [
                 'xdebug_max_nesting_level' => [
                     'message' => $xdebugMessage,
-                    'error' => true,
+                    'error' => true
                 ],
                 'missed_function_imagecreatefromjpeg' => [
                     'message' => 'You must have installed GD library with --with-jpeg-dir=DIR option.',
                     'helpUrl' => 'http://php.net/manual/en/image.installation.php',
-                    'error' => false,
-                ],
-            ],
+                    'error' => false
+                ]
+            ]
         ];
         if (!$this->isPhp7OrHhvm()) {
             $this->setUpNoPrettyVersionParser();
@@ -293,7 +326,10 @@ class PhpReadinessCheckTest extends TestCase
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
-    public function testCheckPhpSettingsNoXDebug()
+    /**
+     * @return void
+     */
+    public function testCheckPhpSettingsNoXDebug(): void
     {
         $this->phpInfo->expects($this->once())->method('getCurrent')->willReturn([]);
 
@@ -323,20 +359,22 @@ class PhpReadinessCheckTest extends TestCase
         $expected['data']['missed_function_imagecreatefromjpeg'] = [
             'message' => 'You must have installed GD library with --with-jpeg-dir=DIR option.',
             'helpUrl' => 'http://php.net/manual/en/image.installation.php',
-            'error' => false,
+            'error' => false
         ];
 
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpSettings());
     }
 
-    public function testCheckPhpSettingsMemoryLimitError()
+    /**
+     * @return void
+     */
+    public function testCheckPhpSettingsMemoryLimitError(): void
     {
         $this->dataSize->expects($this->any())->method('convertSizeToBytes')->willReturnMap(
             [
                 ['512M', 512],
                 ['756M', 756],
-                ['2G', 2048],
-
+                ['2G', 2048]
             ]
         );
 
@@ -350,13 +388,16 @@ class PhpReadinessCheckTest extends TestCase
         $expected['memory_limit'] = [
             'message' => $rawPostMessage,
             'error' => true,
-            'warning' => false,
+            'warning' => false
         ];
 
         $this->assertEquals($expected, $this->phpReadinessCheck->checkMemoryLimit());
     }
 
-    public function testCheckPhpExtensionsNoRequired()
+    /**
+     * @return void
+     */
+    public function testCheckPhpExtensionsNoRequired(): void
     {
         $this->composerInfo->expects($this->once())
             ->method('getRequiredExtensions')
@@ -366,12 +407,15 @@ class PhpReadinessCheckTest extends TestCase
             'data' => [
                 'error' => 'phpExtensionError',
                 'message' => 'Cannot determine required PHP extensions: '
-            ],
+            ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpExtensions());
     }
 
-    public function testCheckPhpExtensions()
+    /**
+     * @return void
+     */
+    public function testCheckPhpExtensions(): void
     {
         $this->composerInfo->expects($this->once())
             ->method('getRequiredExtensions')
@@ -383,13 +427,16 @@ class PhpReadinessCheckTest extends TestCase
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_SUCCESS,
             'data' => [
                 'required' => ['a', 'b', 'c'],
-                'missing' => [],
+                'missing' => []
             ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpExtensions());
     }
 
-    public function testCheckPhpExtensionsFailed()
+    /**
+     * @return void
+     */
+    public function testCheckPhpExtensionsFailed(): void
     {
         $this->composerInfo->expects($this->once())
             ->method('getRequiredExtensions')
@@ -401,7 +448,7 @@ class PhpReadinessCheckTest extends TestCase
             'responseType' => ResponseTypeInterface::RESPONSE_TYPE_ERROR,
             'data' => [
                 'required' => ['a', 'b', 'c'],
-                'missing' => ['c'],
+                'missing' => ['c']
             ]
         ];
         $this->assertEquals($expected, $this->phpReadinessCheck->checkPhpExtensions());
@@ -410,7 +457,7 @@ class PhpReadinessCheckTest extends TestCase
     /**
      * @return bool
      */
-    protected function isPhp7OrHhvm()
+    protected function isPhp7OrHhvm(): bool
     {
         return version_compare(PHP_VERSION, '7.0.0-beta') >= 0 || defined('HHVM_VERSION');
     }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
@@ -37,6 +37,9 @@ class PhpScannerTest extends TestCase
      */
     private $log;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->log = $this->createMock(Log::class);
@@ -44,28 +47,31 @@ class PhpScannerTest extends TestCase
         $this->testDir = str_replace('\\', '/', realpath(__DIR__ . '/../../') . '/_files');
     }
 
-    public function testCollectEntities()
+    /**
+     * @return void
+     */
+    public function testCollectEntities(): void
     {
         $testFiles = [
             $this->testDir . '/app/code/Magento/SomeModule/Helper/Test.php',
             $this->testDir . '/app/code/Magento/SomeModule/Model/DoubleColon.php',
             $this->testDir . '/app/code/Magento/SomeModule/Api/Data/SomeInterface.php',
-            $this->testDir . '/app/code/Magento/SomeModule/Model/StubWithAnonymousClass.php',
+            $this->testDir . '/app/code/Magento/SomeModule/Model/StubWithAnonymousClass.php'
         ];
 
-        $this->log->expects(self::at(0))
+        $this->log
             ->method('add')
-            ->with(
-                4,
-                'Magento\SomeModule\Module\Factory',
-                'Invalid Factory for nonexistent class Magento\SomeModule\Module in file ' . $testFiles[0]
-            );
-        $this->log->expects(self::at(1))
-            ->method('add')
-            ->with(
-                4,
-                'Magento\SomeModule\Element\Factory',
-                'Invalid Factory declaration for class Magento\SomeModule\Element in file ' . $testFiles[0]
+            ->withConsecutive(
+                [
+                    4,
+                    'Magento\SomeModule\Module\Factory',
+                    'Invalid Factory for nonexistent class Magento\SomeModule\Module in file ' . $testFiles[0]
+                ],
+                [
+                    4,
+                    'Magento\SomeModule\Element\Factory',
+                    'Invalid Factory declaration for class Magento\SomeModule\Element in file ' . $testFiles[0]
+                ]
             );
 
         $result = $this->scanner->collectEntities($testFiles);

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/PhpScannerTest.php
@@ -38,7 +38,7 @@ class PhpScannerTest extends TestCase
     private $log;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/XmlScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/XmlScannerTest.php
@@ -29,6 +29,9 @@ class XmlScannerTest extends TestCase
      */
     protected $_testFiles = [];
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_model = new XmlScanner(
@@ -42,36 +45,31 @@ class XmlScannerTest extends TestCase
         ];
     }
 
-    public function testCollectEntities()
+    /**
+     * @return void
+     */
+    public function testCollectEntities(): void
     {
         $className = 'Magento\Store\Model\Config\Invalidator\Proxy';
-        $this->_logMock->expects(
-            $this->at(0)
-        )->method(
-            'add'
-        )->with(
-            4,
-            $className,
-            'Invalid proxy class for ' . substr($className, 0, -5)
-        );
-        $this->_logMock->expects(
-            $this->at(1)
-        )->method(
-            'add'
-        )->with(
-            4,
-            '\Magento\SomeModule\Model\Element\Proxy',
-            'Invalid proxy class for ' . substr('\Magento\SomeModule\Model\Element\Proxy', 0, -5)
-        );
-        $this->_logMock->expects(
-            $this->at(2)
-        )->method(
-            'add'
-        )->with(
-            4,
-            '\Magento\SomeModule\Model\Nested\Element\Proxy',
-            'Invalid proxy class for ' . substr('\Magento\SomeModule\Model\Nested\Element\Proxy', 0, -5)
-        );
+        $this->_logMock
+            ->method('add')
+            ->withConsecutive(
+                [
+                    4,
+                    $className,
+                    'Invalid proxy class for ' . substr($className, 0, -5)
+                ],
+                [
+                    4,
+                    '\Magento\SomeModule\Model\Element\Proxy',
+                    'Invalid proxy class for ' . substr('\Magento\SomeModule\Model\Element\Proxy', 0, -5)
+                ],
+                [
+                    4,
+                    '\Magento\SomeModule\Model\Nested\Element\Proxy',
+                    'Invalid proxy class for ' . substr('\Magento\SomeModule\Model\Nested\Element\Proxy', 0, -5)
+                ]
+            );
         $actual = $this->_model->collectEntities($this->_testFiles);
         $expected = [];
         $this->assertEquals($expected, $actual);

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/XmlScannerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Scanner/XmlScannerTest.php
@@ -30,7 +30,7 @@ class XmlScannerTest extends TestCase
     protected $_testFiles = [];
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/GeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/GeneratorTest.php
@@ -52,7 +52,7 @@ class GeneratorTest extends TestCase
     protected $optionsResolverFactory;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/GeneratorTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/GeneratorTest.php
@@ -51,6 +51,9 @@ class GeneratorTest extends TestCase
      */
     protected $optionsResolverFactory;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->parserMock = $this->createMock(Parser::class);
@@ -76,7 +79,10 @@ class GeneratorTest extends TestCase
         );
     }
 
-    public function testCreatingDictionaryWriter()
+    /**
+     * @return void
+     */
+    public function testCreatingDictionaryWriter(): void
     {
         $outputFilename = 'test';
 
@@ -100,7 +106,10 @@ class GeneratorTest extends TestCase
         $this->assertNull($property->getValue($this->generator));
     }
 
-    public function testUsingRightParserWhileWithoutContextParsing()
+    /**
+     * @return void
+     */
+    public function testUsingRightParserWhileWithoutContextParsing(): void
     {
         $baseDir = 'right_parser';
         $outputFilename = 'file.csv';
@@ -125,7 +134,10 @@ class GeneratorTest extends TestCase
         $this->generator->generate($baseDir, $outputFilename);
     }
 
-    public function testUsingRightParserWhileWithContextParsing()
+    /**
+     * @return void
+     */
+    public function testUsingRightParserWhileWithContextParsing(): void
     {
         $baseDir = 'right_parser2';
         $outputFilename = 'file.csv';
@@ -151,7 +163,10 @@ class GeneratorTest extends TestCase
         $this->generator->generate($baseDir, $outputFilename, true);
     }
 
-    public function testWritingPhrases()
+    /**
+     * @return void
+     */
+    public function testWritingPhrases(): void
     {
         $baseDir = 'WritingPhrases';
         $filesOptions = ['file1', 'file2'];
@@ -171,13 +186,17 @@ class GeneratorTest extends TestCase
         ];
 
         $this->parserMock->expects($this->once())->method('getPhrases')->willReturn($phrases);
-        $this->writerMock->expects($this->at(0))->method('write')->with($phrases[0]);
-        $this->writerMock->expects($this->at(1))->method('write')->with($phrases[1]);
+        $this->writerMock
+            ->method('write')
+            ->withConsecutive([$phrases[0]], [$phrases[1]]);
 
         $this->generator->generate($baseDir, 'file.csv');
     }
 
-    public function testGenerateWithNoPhrases()
+    /**
+     * @return void
+     */
+    public function testGenerateWithNoPhrases(): void
     {
         $this->expectException('UnexpectedValueException');
         $this->expectExceptionMessage('No phrases found in the specified dictionary file.');

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Loader/File/AbstractFileTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Loader/File/AbstractFileTest.php
@@ -31,13 +31,19 @@ class AbstractFileTest extends TestCase
      */
     protected $_abstractLoaderMock;
 
+    /**
+     * @inheirtDoc
+     */
     protected function setUp(): void
     {
         $this->_dictionaryMock = $this->createMock(Dictionary::class);
         $this->_factoryMock = $this->createMock(Factory::class);
     }
 
-    public function testLoadWrongFile()
+    /**
+     * @return void
+     */
+    public function testLoadWrongFile(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Cannot open dictionary file: "wrong_file.csv".');
@@ -52,7 +58,10 @@ class AbstractFileTest extends TestCase
         $abstractLoaderMock->load('wrong_file.csv');
     }
 
-    public function testLoad()
+    /**
+     * @return void
+     */
+    public function testLoad(): void
     {
         $abstractLoaderMock = $this->getMockForAbstractClass(
             AbstractFile::class,
@@ -63,63 +72,55 @@ class AbstractFileTest extends TestCase
             true,
             ['_openFile', '_readFile', '_closeFile']
         );
-        $abstractLoaderMock->expects(
-            $this->at(1)
-        )->method(
-            '_readFile'
-        )->willReturn(
-            ['phrase1', 'translation1']
-        );
-        $abstractLoaderMock->expects(
-            $this->at(2)
-        )->method(
-            '_readFile'
-        )->willReturn(
-            ['phrase2', 'translation2', 'context_type2', 'context_value2']
-        );
+        $abstractLoaderMock
+            ->method('_readFile')
+            ->willReturnOnConsecutiveCalls(
+                ['phrase1', 'translation1'],
+                ['phrase2', 'translation2', 'context_type2', 'context_value2']
+            );
 
         $phraseFirstMock = $this->createMock(Phrase::class);
         $phraseSecondMock = $this->createMock(Phrase::class);
 
-        $this->_factoryMock->expects(
-            $this->once()
-        )->method(
-            'createDictionary'
-        )->willReturn(
+        $this->_factoryMock->expects($this->once())
+            ->method('createDictionary')
+            ->willReturn(
             $this->_dictionaryMock
         );
-        $this->_factoryMock->expects(
-            $this->at(1)
-        )->method(
-            'createPhrase'
-        )->with(
-            ['phrase' => 'phrase1', 'translation' => 'translation1', 'context_type' => '', 'context_value' => '']
-        )->willReturn(
-            $phraseFirstMock
-        );
-        $this->_factoryMock->expects(
-            $this->at(2)
-        )->method(
-            'createPhrase'
-        )->with(
-            [
-                'phrase' => 'phrase2',
-                'translation' => 'translation2',
-                'context_type' => 'context_type2',
-                'context_value' => 'context_value2',
-            ]
-        )->willReturn(
-            $phraseSecondMock
-        );
+        $this->_factoryMock
+            ->method('createPhrase')
+            ->withConsecutive(
+                [
+                    [
+                        'phrase' => 'phrase1',
+                        'translation' => 'translation1',
+                        'context_type' => '',
+                        'context_value' => ''
+                    ]
+                ],
+                [
+                    [
+                        'phrase' => 'phrase2',
+                        'translation' => 'translation2',
+                        'context_type' => 'context_type2',
+                        'context_value' => 'context_value2'
+                    ]
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($phraseFirstMock, $phraseSecondMock);
 
-        $this->_dictionaryMock->expects($this->at(0))->method('addPhrase')->with($phraseFirstMock);
-        $this->_dictionaryMock->expects($this->at(1))->method('addPhrase')->with($phraseSecondMock);
+        $this->_dictionaryMock
+            ->method('addPhrase')
+            ->withConsecutive([$phraseFirstMock], [$phraseSecondMock]);
 
         /** @var AbstractFile $abstractLoaderMock */
         $this->assertEquals($this->_dictionaryMock, $abstractLoaderMock->load('test.csv'));
     }
 
-    public function testErrorsInPhraseCreating()
+    /**
+     * @return void
+     */
+    public function testErrorsInPhraseCreating(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Invalid row #1: "exception_message".');
@@ -132,28 +133,17 @@ class AbstractFileTest extends TestCase
             true,
             ['_openFile', '_readFile']
         );
-        $abstractLoaderMock->expects(
-            $this->at(1)
-        )->method(
-            '_readFile'
-        )->willReturn(
-            ['phrase1', 'translation1']
-        );
+        $abstractLoaderMock
+            ->method('_readFile')
+            ->withConsecutive()
+            ->willReturn(['phrase1', 'translation1']);
 
-        $this->_factoryMock->expects(
-            $this->once()
-        )->method(
-            'createDictionary'
-        )->willReturn(
-            $this->_dictionaryMock
-        );
-        $this->_factoryMock->expects(
-            $this->at(1)
-        )->method(
-            'createPhrase'
-        )->willThrowException(
-            new \DomainException('exception_message')
-        );
+        $this->_factoryMock->expects($this->once())
+            ->method('createDictionary')
+            ->willReturn($this->_dictionaryMock);
+        $this->_factoryMock
+            ->method('createPhrase')
+            ->willThrowException(new \DomainException('exception_message'));
 
         /** @var AbstractFile $abstractLoaderMock */
         $this->assertEquals($this->_dictionaryMock, $abstractLoaderMock->load('test.csv'));

--- a/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Loader/File/AbstractFileTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/I18n/Dictionary/Loader/File/AbstractFileTest.php
@@ -32,7 +32,7 @@ class AbstractFileTest extends TestCase
     protected $_abstractLoaderMock;
 
     /**
-     * @inheirtDoc
+     * @inheritdoc
      */
     protected function setUp(): void
     {


### PR DESCRIPTION
### Description (*)
This PR fixes CE project codebase compatibility problems with the PHPUnit v.9.3.0.
See changes here: [PHPUnit 9.3.0 ChangeLog](https://github.com/sebastianbergmann/phpunit/blob/9.3.0/ChangeLog-9.3.md#configuration-of-code-coverage-and-logging-in-phpunitxml)

In this PR was changed 183 files where the main problem was using at() matcher that has been deprecated.

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/576
https://github.com/magento/partners-magento2b2b/pull/579
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#33707

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)