### PR TITLE
CE-33707: Upgraded CE codebase to be compatible with the PHPUnit v 9.3.0

### DIFF
--- a/app/code/Magento/AdminNotification/Test/Unit/Model/FeedTest.php
+++ b/app/code/Magento/AdminNotification/Test/Unit/Model/FeedTest.php
@@ -28,42 +28,69 @@ use PHPUnit\Framework\TestCase;
  */
 class FeedTest extends TestCase
 {
-    /** @var Feed */
+    /**
+     * @var Feed
+     */
     protected $feed;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var InboxFactory|MockObject */
+    /**
+     * @var InboxFactory|MockObject
+     */
     protected $inboxFactory;
 
-    /** @var Inbox|MockObject */
+    /**
+     * @var Inbox|MockObject
+     */
     protected $inboxModel;
 
-    /** @var CurlFactory|MockObject */
+    /**
+     * @var CurlFactory|MockObject
+     */
     protected $curlFactory;
 
-    /** @var Curl|MockObject */
+    /**
+     * @var Curl|MockObject
+     */
     protected $curl;
 
-    /** @var ConfigInterface|MockObject */
+    /**
+     * @var ConfigInterface|MockObject
+     */
     protected $backendConfig;
 
-    /** @var CacheInterface|MockObject */
+    /**
+     * @var CacheInterface|MockObject
+     */
     protected $cacheManager;
 
-    /** @var State|MockObject */
+    /**
+     * @var State|MockObject
+     */
     protected $appState;
 
-    /** @var DeploymentConfig|MockObject */
+    /**
+     * @var DeploymentConfig|MockObject
+     */
     protected $deploymentConfig;
 
-    /** @var ProductMetadata|MockObject */
+    /**
+     * @var ProductMetadata|MockObject
+     */
     protected $productMetadata;
 
-    /** @var UrlInterface|MockObject */
+    /**
+     * @var UrlInterface|MockObject
+     */
     protected $urlBuilder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->inboxFactory = $this->createPartialMock(
@@ -97,11 +124,8 @@ class FeedTest extends TestCase
         );
 
         $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
-
         $this->objectManagerHelper = new ObjectManagerHelper($this);
-
         $this->productMetadata = $this->createMock(ProductMetadata::class);
-
         $this->urlBuilder = $this->getMockForAbstractClass(UrlInterface::class);
 
         $this->feed = $this->objectManagerHelper->getObject(
@@ -120,11 +144,13 @@ class FeedTest extends TestCase
     }
 
     /**
-     * @dataProvider checkUpdateDataProvider
      * @param bool $callInbox
      * @param string $curlRequest
+     *
+     * @return void
+     * @dataProvider checkUpdateDataProvider
      */
-    public function testCheckUpdate($callInbox, $curlRequest)
+    public function testCheckUpdate(bool $callInbox, string $curlRequest): void
     {
         $mockName    = 'Test Product Name';
         $mockVersion = '0.0.0';
@@ -144,16 +170,19 @@ class FeedTest extends TestCase
 
         $lastUpdate = 0;
         $this->cacheManager->expects($this->once())->method('load')->willReturn($lastUpdate);
-        $this->curlFactory->expects($this->at(0))->method('create')->willReturn($this->curl);
+        $this->curlFactory
+            ->method('create')
+            ->willReturn($this->curl);
         $this->curl->expects($this->once())->method('setConfig')->with($configValues)->willReturnSelf();
         $this->curl->expects($this->once())->method('read')->willReturn($curlRequest);
-        $this->backendConfig->expects($this->at(0))->method('getValue')->willReturn('1');
         $this->backendConfig->expects($this->once())->method('isSetFlag')->willReturn(false);
-        $this->backendConfig->expects($this->at(1))->method('getValue')
-            ->willReturn('http://feed.magento.com');
+        $this->backendConfig
+            ->method('getValue')
+            ->willReturnOnConsecutiveCalls('1', 'http://feed.magento.com');
         $this->deploymentConfig->expects($this->once())->method('get')
             ->with(ConfigOptionsListConstants::CONFIG_PATH_INSTALL_DATE)
             ->willReturn('Sat, 6 Sep 2014 16:46:11 UTC');
+
         if ($callInbox) {
             $this->inboxFactory->expects($this->once())->method('create')
                 ->willReturn($this->inboxModel);
@@ -188,7 +217,7 @@ class FeedTest extends TestCase
     /**
      * @return array
      */
-    public function checkUpdateDataProvider()
+    public function checkUpdateDataProvider(): array
     {
         return [
             [
@@ -246,7 +275,7 @@ class FeedTest extends TestCase
                             </channel>
                         </rss>'
                 // @codingStandardsIgnoreEnd
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricingTest.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Test/Unit/Model/Import/AdvancedPricingTest.php
@@ -137,6 +137,9 @@ class AdvancedPricingTest extends AbstractImportTestCase
      */
     protected $errorAggregator;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -158,7 +161,8 @@ class AdvancedPricingTest extends AbstractImportTestCase
         $this->resourceFactory = $this->getMockBuilder(
             \Magento\CatalogImportExport\Model\Import\Proxy\Product\ResourceModelFactory::class
         )
-            ->setMethods(['create', 'getTable'])
+            ->onlyMethods(['create'])
+            ->addMethods(['getTable'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->resourceFactory->method('create')->willReturnSelf();
@@ -208,8 +212,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test getter for entity type code.
+     *
+     * @return void
      */
-    public function testGetEntityTypeCode()
+    public function testGetEntityTypeCode(): void
     {
         $result = $this->advancedPricing->getEntityTypeCode();
         $expectedResult = 'advanced_pricing';
@@ -220,13 +226,15 @@ class AdvancedPricingTest extends AbstractImportTestCase
     /**
      * Test method validateRow against its result.
      *
-     * @dataProvider validateRowResultDataProvider
      * @param array $rowData
      * @param string|null $behavior
      * @param bool $expectedResult
+     *
+     * @return void
      * @throws \ReflectionException
+     * @dataProvider validateRowResultDataProvider
      */
-    public function testValidateRowResult($rowData, $behavior, $expectedResult)
+    public function testValidateRowResult(array $rowData, ?string $behavior, bool $expectedResult): void
     {
         $rowNum = 0;
         $advancedPricingMock = $this->getAdvancedPricingMock(
@@ -236,7 +244,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 'saveProductPrices',
                 'getCustomerGroupId',
                 'getWebSiteId',
-                'getBehavior',
+                'getBehavior'
             ]
         );
         $this->validator->method('isValid')->willReturn(true);
@@ -249,13 +257,15 @@ class AdvancedPricingTest extends AbstractImportTestCase
     /**
      * Test method validateRow whether AddRowError is called.
      *
-     * @dataProvider validateRowAddRowErrorCallDataProvider
      * @param array $rowData
      * @param string|null $behavior
      * @param string $error
+     *
+     * @return void
      * @throws \ReflectionException
+     * @dataProvider validateRowAddRowErrorCallDataProvider
      */
-    public function testValidateRowAddRowErrorCall($rowData, $behavior, $error)
+    public function testValidateRowAddRowErrorCall(array $rowData, ?string $behavior, string $error): void
     {
         $rowNum = 0;
         $advancedPricingMock = $this->getAdvancedPricingMock(
@@ -265,7 +275,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 'saveProductPrices',
                 'getCustomerGroupId',
                 'getWebSiteId',
-                'getBehavior',
+                'getBehavior'
             ]
         );
         $this->validator->method('isValid')->willReturn(true);
@@ -277,12 +287,14 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method validateRow whether internal validator is called.
+     *
+     * @return void
      */
-    public function testValidateRowValidatorCall()
+    public function testValidateRowValidatorCall(): void
     {
         $rowNum = 0;
         $rowData = [
-            \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing::COL_SKU => 'sku value',
+            \Magento\AdvancedPricingImportExport\Model\Import\AdvancedPricing::COL_SKU => 'sku value'
         ];
         $advancedPricingMock = $this->getAdvancedPricingMock(
             [
@@ -290,7 +302,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 'addRowError',
                 'saveProductPrices',
                 'getCustomerGroupId',
-                'getWebSiteId',
+                'getWebSiteId'
             ]
         );
         $this->setPropertyValue($advancedPricingMock, '_validatedRows', []);
@@ -304,16 +316,20 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method saveAndReplaceAdvancedPrices whether AddRowError is called.
+     *
+     * @return void
      */
-    public function testSaveAndReplaceAdvancedPricesAddRowErrorCall()
+    public function testSaveAndReplaceAdvancedPricesAddRowErrorCall(): void
     {
         $rowNum = 0;
         $testBunch = [
             $rowNum => [
-                'bunch',
+                'bunch'
             ]
         ];
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn($testBunch);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($testBunch);
         $this->advancedPricing->expects($this->once())->method('validateRow')->willReturn(false);
         $this->advancedPricing->method('saveProductPrices')->willReturnSelf();
 
@@ -327,8 +343,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method saveAdvancedPricing.
+     *
+     * @return void
      */
-    public function testSaveAdvancedPricing()
+    public function testSaveAdvancedPricing(): void
     {
         $this->advancedPricing
             ->expects($this->once())
@@ -343,23 +361,25 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * Test method saveAndReplaceAdvancedPrices with append import behaviour.
      * Take into consideration different data and check relative internal calls.
      *
-     * @dataProvider saveAndReplaceAdvancedPricesAppendBehaviourDataProvider
      * @param array $data
      * @param string $tierCustomerGroupId
      * @param string $groupCustomerGroupId
      * @param string $tierWebsiteId
      * @param string $groupWebsiteId
      * @param array $expectedTierPrices
+     *
+     * @return void
      * @throws \ReflectionException
+     * @dataProvider saveAndReplaceAdvancedPricesAppendBehaviourDataProvider
      */
     public function testSaveAndReplaceAdvancedPricesAppendBehaviourDataAndCalls(
-        $data,
-        $tierCustomerGroupId,
-        $groupCustomerGroupId,
-        $tierWebsiteId,
-        $groupWebsiteId,
-        $expectedTierPrices
-    ) {
+        array $data,
+        string $tierCustomerGroupId,
+        string $groupCustomerGroupId,
+        string $tierWebsiteId,
+        string $groupWebsiteId,
+        array $expectedTierPrices
+    ): void {
         $skuProduct = 'product1';
         $sku = $data[0][AdvancedPricing::COL_SKU];
         $advancedPricing = $this->getAdvancedPricingMock(
@@ -379,18 +399,20 @@ class AdvancedPricingTest extends AbstractImportTestCase
         $advancedPricing
             ->method('getBehavior')
             ->willReturn(Import::BEHAVIOR_APPEND);
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn($data);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($data);
         $advancedPricing->method('validateRow')->willReturn(true);
 
         $advancedPricing->method('getCustomerGroupId')->willReturnMap(
             [
-                [$data[0][AdvancedPricing::COL_TIER_PRICE_CUSTOMER_GROUP], $tierCustomerGroupId],
+                [$data[0][AdvancedPricing::COL_TIER_PRICE_CUSTOMER_GROUP], $tierCustomerGroupId]
             ]
         );
 
         $advancedPricing->method('getWebSiteId')->willReturnMap(
             [
-                [$data[0][AdvancedPricing::COL_TIER_PRICE_WEBSITE], $tierWebsiteId],
+                [$data[0][AdvancedPricing::COL_TIER_PRICE_WEBSITE], $tierWebsiteId]
             ]
         );
 
@@ -411,8 +433,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method saveAndReplaceAdvancedPrices with append import behaviour.
+     *
+     * @return void
      */
-    public function testSaveAndReplaceAdvancedPricesAppendBehaviourDataAndCallsWithoutTierPrice()
+    public function testSaveAndReplaceAdvancedPricesAppendBehaviourDataAndCallsWithoutTierPrice(): void
     {
         $data = [
             0 => [
@@ -422,7 +446,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 AdvancedPricing::COL_TIER_PRICE_QTY => 'tier price qty value',
                 AdvancedPricing::COL_TIER_PRICE => 'tier price value',
                 AdvancedPricing::COL_TIER_PRICE_TYPE => AdvancedPricing::TIER_PRICE_TYPE_FIXED
-            ],
+            ]
         ];
         $tierCustomerGroupId = 'tier customer group id value';
         $tierWebsiteId = 'tier website id value';
@@ -447,18 +471,20 @@ class AdvancedPricingTest extends AbstractImportTestCase
         $advancedPricing
             ->method('getBehavior')
             ->willReturn(Import::BEHAVIOR_APPEND);
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn($data);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($data);
         $advancedPricing->method('validateRow')->willReturn(true);
 
         $advancedPricing->method('getCustomerGroupId')->willReturnMap(
             [
-                [$data[0][AdvancedPricing::COL_TIER_PRICE_CUSTOMER_GROUP], $tierCustomerGroupId],
+                [$data[0][AdvancedPricing::COL_TIER_PRICE_CUSTOMER_GROUP], $tierCustomerGroupId]
             ]
         );
 
         $advancedPricing->method('getWebSiteId')->willReturnMap(
             [
-                [$data[0][AdvancedPricing::COL_TIER_PRICE_WEBSITE], $tierWebsiteId],
+                [$data[0][AdvancedPricing::COL_TIER_PRICE_WEBSITE], $tierWebsiteId]
             ]
         );
 
@@ -479,14 +505,16 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method saveAndReplaceAdvancedPrices with replace import behaviour.
+     *
+     * @return void
      */
-    public function testSaveAndReplaceAdvancedPricesReplaceBehaviourInternalCalls()
+    public function testSaveAndReplaceAdvancedPricesReplaceBehaviourInternalCalls(): void
     {
         $skuVal = 'sku value';
         $data = [
             0 => [
-                AdvancedPricing::COL_SKU => $skuVal,
-            ],
+                AdvancedPricing::COL_SKU => $skuVal
+            ]
         ];
         $expectedTierPrices = [];
         $listSku = [
@@ -495,7 +523,9 @@ class AdvancedPricingTest extends AbstractImportTestCase
         $this->advancedPricing->method('getBehavior')->willReturn(
             Import::BEHAVIOR_REPLACE
         );
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn($data);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($data);
         $this->advancedPricing->expects($this->once())->method('validateRow')->willReturn(true);
 
         $this->advancedPricing
@@ -510,7 +540,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
             ->withConsecutive(
                 [
                     $listSku,
-                    AdvancedPricing::TABLE_TIER_PRICE,
+                    AdvancedPricing::TABLE_TIER_PRICE
                 ]
             )
             ->willReturn(true);
@@ -530,8 +560,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method deleteAdvancedPricing() whether correct $listSku is formed.
+     *
+     * @return void
      */
-    public function testDeleteAdvancedPricingFormListSkuToDelete()
+    public function testDeleteAdvancedPricingFormListSkuToDelete(): void
     {
         $skuOne = 'sku value';
         $skuTwo = 'sku value';
@@ -541,10 +573,12 @@ class AdvancedPricingTest extends AbstractImportTestCase
             ],
             1 => [
                 AdvancedPricing::COL_SKU => $skuTwo
-            ],
+            ]
         ];
 
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn($data);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($data);
         $this->advancedPricing->method('validateRow')->willReturn(true);
         $expectedSkuList = ['sku value'];
         $this->advancedPricing
@@ -559,11 +593,15 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method deleteAdvancedPricing() whether _cachedSkuToDelete property is set to null.
+     *
+     * @return void
      */
-    public function testDeleteAdvancedPricingResetCachedSkuToDelete()
+    public function testDeleteAdvancedPricingResetCachedSkuToDelete(): void
     {
         $this->setPropertyValue($this->advancedPricing, '_cachedSkuToDelete', 'some value');
-        $this->dataSourceModel->expects($this->at(0))->method('getNextBunch')->willReturn([]);
+        $this->dataSourceModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls([]);
 
         $this->advancedPricing->deleteAdvancedPricing();
 
@@ -573,8 +611,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
 
     /**
      * Test method replaceAdvancedPricing().
+     *
+     * @return void
      */
-    public function testReplaceAdvancedPricing()
+    public function testReplaceAdvancedPricing(): void
     {
         $this->advancedPricing
             ->expects($this->once())
@@ -590,7 +630,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function saveAndReplaceAdvancedPricesAppendBehaviourDataProvider()
+    public function saveAndReplaceAdvancedPricesAppendBehaviourDataProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -619,9 +659,9 @@ class AdvancedPricingTest extends AbstractImportTestCase
                             'value' => 'tier price value',
                             'website_id' => 'tier website id value',
                             'percentage_value' => null
-                        ],
-                    ],
-                ],
+                        ]
+                    ]
+                ]
             ],
             [
                 '$data' => [
@@ -647,10 +687,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
                             'qty' => 'tier price qty value',
                             'value' => 0,
                             'percentage_value' => 'tier price value',
-                            'website_id' => 'tier website id value',
-                        ],
-                    ],
-                ],
+                            'website_id' => 'tier website id value'
+                        ]
+                    ]
+                ]
             ],
             [// tier customer group is equal to all group
                 '$data' => [
@@ -662,7 +702,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                         AdvancedPricing::COL_TIER_PRICE_QTY => 'tier price qty value',
                         AdvancedPricing::COL_TIER_PRICE => 'tier price value',
                         AdvancedPricing::COL_TIER_PRICE_TYPE => AdvancedPricing::TIER_PRICE_TYPE_FIXED
-                    ],
+                    ]
                 ],
                 '$tierCustomerGroupId' => 'tier customer group id value',
                 '$groupCustomerGroupId' => 'group customer group id value',
@@ -677,9 +717,9 @@ class AdvancedPricingTest extends AbstractImportTestCase
                             'value' => 'tier price value',
                             'website_id' => 'tier website id value',
                             'percentage_value' => null
-                        ],
-                    ],
-                ],
+                        ]
+                    ]
+                ]
             ],
             [
                 '$data' => [
@@ -691,7 +731,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                         AdvancedPricing::COL_TIER_PRICE_QTY => 'tier price qty value',
                         AdvancedPricing::COL_TIER_PRICE => 'tier price value',
                         AdvancedPricing::COL_TIER_PRICE_TYPE => AdvancedPricing::TIER_PRICE_TYPE_FIXED
-                    ],
+                    ]
                 ],
                 '$tierCustomerGroupId' => 'tier customer group id value',
                 '$groupCustomerGroupId' => 'group customer group id value',
@@ -706,10 +746,10 @@ class AdvancedPricingTest extends AbstractImportTestCase
                             'value' => 'tier price value',
                             'website_id' => 'tier website id value',
                             'percentage_value' => null
-                        ],
+                        ]
                     ]
-                ],
-            ],
+                ]
+            ]
         ];
         // @codingStandardsIgnoreEnd
     }
@@ -719,29 +759,29 @@ class AdvancedPricingTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function validateRowResultDataProvider()
+    public function validateRowResultDataProvider(): array
     {
         return [
             [
                 '$rowData' => [
-                    AdvancedPricing::COL_SKU => 'sku value',
+                    AdvancedPricing::COL_SKU => 'sku value'
                 ],
                 '$behavior' => null,
-                '$expectedResult' => true,
+                '$expectedResult' => true
             ],
             [
                 '$rowData' => [
-                    AdvancedPricing::COL_SKU => null,
+                    AdvancedPricing::COL_SKU => null
                 ],
                 '$behavior' => Import::BEHAVIOR_DELETE,
-                '$expectedResult' => false,
+                '$expectedResult' => false
             ],
             [
                 '$rowData' => [
-                    AdvancedPricing::COL_SKU => 'sku value',
+                    AdvancedPricing::COL_SKU => 'sku value'
                 ],
                 '$behavior' => Import::BEHAVIOR_DELETE,
-                '$expectedResult' => true,
+                '$expectedResult' => true
             ]
         ];
     }
@@ -751,7 +791,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function validateRowAddRowErrorCallDataProvider()
+    public function validateRowAddRowErrorCallDataProvider(): array
     {
         return [
             [
@@ -759,15 +799,15 @@ class AdvancedPricingTest extends AbstractImportTestCase
                     AdvancedPricing::COL_SKU => null,
                 ],
                 '$behavior' => Import::BEHAVIOR_DELETE,
-                '$error' => RowValidatorInterface::ERROR_SKU_IS_EMPTY,
+                '$error' => RowValidatorInterface::ERROR_SKU_IS_EMPTY
             ],
             [
                 '$rowData' => [
-                    AdvancedPricing::COL_SKU => false,
+                    AdvancedPricing::COL_SKU => false
                 ],
                 '$behavior' => null,
-                '$error' => RowValidatorInterface::ERROR_ROW_IS_ORPHAN,
-            ],
+                '$error' => RowValidatorInterface::ERROR_ROW_IS_ORPHAN
+            ]
         ];
     }
 
@@ -776,9 +816,11 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @param array $oldSkus
      * @param array $priceIn
      * @param int $callNum
+     *
+     * @return void
      * @dataProvider saveProductPricesDataProvider
      */
-    public function testSaveProductPrices($priceData, $oldSkus, $priceIn, $callNum)
+    public function testSaveProductPrices(array $priceData, array $oldSkus, array $priceIn, int $callNum): void
     {
         $this->advancedPricing = $this->getAdvancedPricingMock(['retrieveOldSkus']);
 
@@ -794,14 +836,14 @@ class AdvancedPricingTest extends AbstractImportTestCase
     /**
      * @return array
      */
-    public function saveProductPricesDataProvider()
+    public function saveProductPricesDataProvider(): array
     {
         return [
             [[], ['oSku1' => 'product1', 'oSku2' => 'product2'], [], 0],
             [
                 [
                     'oSku1' => ['row1' => ['row1-1', 'row1-2'], 'row2' => ['row2-1', 'row2-2']],
-                    'nSku' => ['row3', 'row4'],
+                    'nSku' => ['row3', 'row4']
                 ],
                 ['oSku1' => 'product1', 'oSku2' => 'product2'],
                 [
@@ -809,7 +851,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                     ['row2-1', 'row2-2', self::LINK_FIELD => 'product1']
                 ],
                 1
-            ],
+            ]
         ];
     }
 
@@ -818,18 +860,20 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @param array $cachedSkuToDelete
      * @param int $numCallAddError
      * @param int $numCallDelete
-     * @param boolean $exceptionInDelete
+     * @param int $exceptionInDelete
      * @param boolean $result
+     *
+     * @return void
      * @dataProvider deleteProductTierPricesDataProvider
      */
     public function testDeleteProductTierPrices(
-        $listSku,
-        $cachedSkuToDelete,
-        $numCallAddError,
-        $numCallDelete,
-        $exceptionInDelete,
-        $result
-    ) {
+        array $listSku,
+        array $cachedSkuToDelete,
+        int $numCallAddError,
+        int $numCallDelete,
+        int $exceptionInDelete,
+        bool $result
+    ): void {
         $this->advancedPricing = $this->getAdvancedPricingMock(['addRowError', 'retrieveOldSkus']);
         $dbSelectMock = $this->createMock(Select::class);
         if ($listSku) {
@@ -868,7 +912,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
     /**
      * @return array
      */
-    public function deleteProductTierPricesDataProvider()
+    public function deleteProductTierPricesDataProvider(): array
     {
         return [
             [
@@ -902,7 +946,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 0,
                 0,
                 false
-            ],
+            ]
         ];
     }
 
@@ -912,15 +956,17 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @param array $oldSkus
      * @param int $numCall
      * @param array $args
+     *
+     * @return void
      * @dataProvider processCountExistingPricesDataProvider
      */
     public function testProcessCountExistingPrices(
-        $prices,
-        $existingPrices,
-        $oldSkus,
-        $numCall,
-        $args
-    ) {
+        array $prices,
+        array $existingPrices,
+        array $oldSkus,
+        int $numCall,
+        array $args
+    ): void {
         $this->advancedPricing = $this->getAdvancedPricingMock(
             [
                 'incrementCounterUpdated',
@@ -953,7 +999,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
     /**
      * @return array
      */
-    public function processCountExistingPricesDataProvider()
+    public function processCountExistingPricesDataProvider(): array
     {
         return [
             [
@@ -969,7 +1015,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
                 ['oSku1' => 'product1', 'oSku2' => 'product2'],
                 0,
                 [['price1'], [self::LINK_FIELD => 'product1']]
-            ],
+            ]
         ];
     }
 
@@ -978,6 +1024,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      *
      * @param $object
      * @param $property
+     *
      * @return mixed
      * @throws \ReflectionException
      */
@@ -996,6 +1043,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @param $object
      * @param $property
      * @param $value
+     *
      * @return mixed
      * @throws \ReflectionException
      */
@@ -1015,6 +1063,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @param object $object
      * @param string $method
      * @param array $args
+     *
      * @return mixed
      * @throws \ReflectionException
      */
@@ -1035,7 +1084,7 @@ class AdvancedPricingTest extends AbstractImportTestCase
      * @return MockObject
      * @throws \ReflectionException
      */
-    private function getAdvancedPricingMock($methods = [])
+    private function getAdvancedPricingMock(array $methods = []): MockObject
     {
         $metadataPoolMock = $this->createMock(MetadataPool::class);
         $metadataMock = $this->createMock(EntityMetadata::class);

--- a/app/code/Magento/Analytics/Test/Unit/Model/IntegrationManagerTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/Model/IntegrationManagerTest.php
@@ -43,18 +43,18 @@ class IntegrationManagerTest extends TestCase
      */
     private $integrationManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
         $this->integrationServiceMock = $this->getMockForAbstractClass(IntegrationServiceInterface::class);
         $this->configMock = $this->createMock(Config::class);
         $this->oauthServiceMock = $this->getMockForAbstractClass(OauthServiceInterface::class);
-        $this->integrationMock = $this->getMockBuilder(Integration::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'getId',
-                'getConsumerId'
-            ])
+        $this->integrationMock = $this->getMockBuilder(Integration::class)->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->addMethods(['getConsumerId'])
             ->getMock();
         $this->integrationManager = $objectManagerHelper->getObject(
             IntegrationManager::class,
@@ -67,11 +67,11 @@ class IntegrationManagerTest extends TestCase
     }
 
     /**
-     * @param string $status
+     * @param int $status
      *
      * @return array
      */
-    private function getIntegrationUserData($status)
+    private function getIntegrationUserData(int $status): array
     {
         return [
             'name' => 'ma-integration-user',
@@ -80,14 +80,14 @@ class IntegrationManagerTest extends TestCase
             'resource' => [
                 'Magento_Analytics::analytics',
                 'Magento_Analytics::analytics_api'
-            ],
+            ]
         ];
     }
 
     /**
      * @return void
      */
-    public function testActivateIntegrationSuccess()
+    public function testActivateIntegrationSuccess(): void
     {
         $this->integrationServiceMock->expects($this->once())
             ->method('findByName')
@@ -108,7 +108,10 @@ class IntegrationManagerTest extends TestCase
         $this->assertTrue($this->integrationManager->activateIntegration());
     }
 
-    public function testActivateIntegrationFailureNoSuchEntity()
+    /**
+     * @return void
+     */
+    public function testActivateIntegrationFailureNoSuchEntity(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->integrationServiceMock->expects($this->once())
@@ -128,12 +131,12 @@ class IntegrationManagerTest extends TestCase
     }
 
     /**
-     * @dataProvider integrationIdDataProvider
-     *
      * @param int|null $integrationId If null integration is absent.
+     *
      * @return void
+     * @dataProvider integrationIdDataProvider
      */
-    public function testGetTokenNewIntegration($integrationId)
+    public function testGetTokenNewIntegration(?int $integrationId): void
     {
         $this->configMock->expects($this->atLeastOnce())
             ->method('getConfigDataValue')
@@ -156,14 +159,10 @@ class IntegrationManagerTest extends TestCase
                 ->with($this->getIntegrationUserData(Integration::STATUS_INACTIVE))
                 ->willReturn($this->integrationMock);
         }
-        $this->oauthServiceMock->expects($this->at(0))
+        $this->oauthServiceMock
             ->method('getAccessToken')
-            ->with(100500)
-            ->willReturn(false);
-        $this->oauthServiceMock->expects($this->at(2))
-            ->method('getAccessToken')
-            ->with(100500)
-            ->willReturn('IntegrationToken');
+            ->withConsecutive([100500], [100500])
+            ->willReturnOnConsecutiveCalls(false, 'IntegrationToken');
         $this->oauthServiceMock->expects($this->once())
             ->method('createAccessToken')
             ->with(100500, true)
@@ -172,12 +171,12 @@ class IntegrationManagerTest extends TestCase
     }
 
     /**
-     * @dataProvider integrationIdDataProvider
-     *
      * @param int|null $integrationId If null integration is absent.
+     *
      * @return void
+     * @dataProvider integrationIdDataProvider
      */
-    public function testGetTokenExistingIntegration($integrationId)
+    public function testGetTokenExistingIntegration(?int $integrationId): void
     {
         $this->configMock->expects($this->atLeastOnce())
             ->method('getConfigDataValue')
@@ -212,11 +211,11 @@ class IntegrationManagerTest extends TestCase
     /**
      * @return array
      */
-    public function integrationIdDataProvider()
+    public function integrationIdDataProvider(): array
     {
         return [
             [1],
-            [null],
+            [null]
         ];
     }
 }

--- a/app/code/Magento/Analytics/Test/Unit/ReportXml/DB/Assembler/JoinAssemblerTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/ReportXml/DB/Assembler/JoinAssemblerTest.php
@@ -90,7 +90,7 @@ class JoinAssemblerTest extends TestCase
                 'conditionResolver' => $this->conditionResolverMock,
                 'nameResolver' => $this->nameResolverMock,
                 'columnsResolver' => $this->columnsResolverMock,
-                'resourceConnection' => $this->resourceConnection,
+                'resourceConnection' => $this->resourceConnection
             ]
         );
     }
@@ -98,7 +98,7 @@ class JoinAssemblerTest extends TestCase
     /**
      * @return void
      */
-    public function testAssembleEmpty()
+    public function testAssembleEmpty(): void
     {
         $queryConfigMock = [
             'source' => [
@@ -124,21 +124,24 @@ class JoinAssemblerTest extends TestCase
      * @param array $queryConfigMock
      * @param array $joinsMock
      * @param array $tablesMapping
+     *
      * @return void
      * @dataProvider assembleNotEmptyDataProvider
      */
-    public function testAssembleNotEmpty(array $queryConfigMock, array $joinsMock, array $tablesMapping)
+    public function testAssembleNotEmpty(array $queryConfigMock, array $joinsMock, array $tablesMapping): void
     {
         $filtersMock = [];
 
-        $this->nameResolverMock->expects($this->at(0))
+        $this->nameResolverMock
             ->method('getAlias')
-            ->with($queryConfigMock['source'])
-            ->willReturn($queryConfigMock['source']['alias']);
-        $this->nameResolverMock->expects($this->at(1))
-            ->method('getAlias')
-            ->with($queryConfigMock['source']['link-source'][0])
-            ->willReturn($queryConfigMock['source']['link-source'][0]['alias']);
+            ->withConsecutive(
+                [$queryConfigMock['source']],
+                [$queryConfigMock['source']['link-source'][0]]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $queryConfigMock['source']['alias'],
+                $queryConfigMock['source']['link-source'][0]['alias']
+            );
         $this->nameResolverMock->expects($this->once())
             ->method('getName')
             ->with($queryConfigMock['source']['link-source'][0])
@@ -148,28 +151,25 @@ class JoinAssemblerTest extends TestCase
             ->method('getTableName')
             ->willReturnOnConsecutiveCalls(...array_values($tablesMapping));
 
-        $this->conditionResolverMock->expects($this->at(0))
-            ->method('getFilter')
-            ->with(
-                $this->selectBuilderMock,
-                $queryConfigMock['source']['link-source'][0]['using'],
-                $queryConfigMock['source']['link-source'][0]['alias'],
-                $queryConfigMock['source']['alias']
-            )
-            ->willReturn('(billing.parent_id = `sales`.`entity_id`)');
+        $withArgs = $willReturnArgs = [];
+        $withArgs[] = [
+            $this->selectBuilderMock,
+            $queryConfigMock['source']['link-source'][0]['using'],
+            $queryConfigMock['source']['link-source'][0]['alias'],
+            $queryConfigMock['source']['alias']
+        ];
+        $willReturnArgs[] = '(billing.parent_id = `sales`.`entity_id`)';
 
         if (isset($queryConfigMock['source']['link-source'][0]['filter'])) {
             $filtersMock = ['(sales.entity_id IS NULL)'];
 
-            $this->conditionResolverMock->expects($this->at(1))
-                ->method('getFilter')
-                ->with(
-                    $this->selectBuilderMock,
-                    $queryConfigMock['source']['link-source'][0]['filter'],
-                    $queryConfigMock['source']['link-source'][0]['alias'],
-                    $queryConfigMock['source']['alias']
-                )
-                ->willReturn($filtersMock[0]);
+            $withArgs[] = [
+                $this->selectBuilderMock,
+                $queryConfigMock['source']['link-source'][0]['filter'],
+                $queryConfigMock['source']['link-source'][0]['alias'],
+                $queryConfigMock['source']['alias']
+            ];
+            $willReturnArgs[] = $filtersMock[0];
 
             $this->columnsResolverMock->expects($this->once())
                 ->method('getColumns')
@@ -190,6 +190,10 @@ class JoinAssemblerTest extends TestCase
                     ]
                 );
         }
+        $this->conditionResolverMock
+            ->method('getFilter')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->selectBuilderMock->expects($this->once())
             ->method('setFilters')
@@ -207,7 +211,7 @@ class JoinAssemblerTest extends TestCase
     /**
      * @return array
      */
-    public function assembleNotEmptyDataProvider()
+    public function assembleNotEmptyDataProvider(): array
     {
         return [
             [

--- a/app/code/Magento/Analytics/Test/Unit/ReportXml/SelectHydratorTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/ReportXml/SelectHydratorTest.php
@@ -67,12 +67,15 @@ class SelectHydratorTest extends TestCase
             SelectHydrator::class,
             [
                 'resourceConnection' => $this->resourceConnectionMock,
-                'objectManager' => $this->objectManagerMock,
+                'objectManager' => $this->objectManagerMock
             ]
         );
     }
 
-    public function testExtract()
+    /**
+     * @return void
+     */
+    public function testExtract(): void
     {
         $selectParts =
             [
@@ -100,12 +103,14 @@ class SelectHydratorTest extends TestCase
     }
 
     /**
-     * @dataProvider recreateWithoutExpressionDataProvider
      * @param array $selectParts
      * @param array $parts
      * @param array $partValues
+     *
+     * @return void
+     * @dataProvider recreateWithoutExpressionDataProvider
      */
-    public function testRecreateWithoutExpression($selectParts, $parts, $partValues)
+    public function testRecreateWithoutExpression(array $selectParts, array $parts, array $partValues): void
     {
         $this->resourceConnectionMock->expects($this->once())
             ->method('getConnection')
@@ -113,11 +118,14 @@ class SelectHydratorTest extends TestCase
         $this->connectionMock->expects($this->once())
             ->method('select')
             ->willReturn($this->selectMock);
+        $withArgs = [];
+
         foreach ($parts as $key => $part) {
-            $this->selectMock->expects($this->at($key))
-                ->method('setPart')
-                ->with($part, $partValues[$key]);
+            $withArgs[] = [$part, $partValues[$key]];
         }
+        $this->selectMock
+            ->method('setPart')
+            ->withConsecutive(...$withArgs);
 
         $this->assertSame($this->selectMock, $this->selectHydrator->recreate($selectParts));
     }
@@ -125,7 +133,7 @@ class SelectHydratorTest extends TestCase
     /**
      * @return array
      */
-    public function recreateWithoutExpressionDataProvider()
+    public function recreateWithoutExpressionDataProvider(): array
     {
         return [
             'Select without expressions' => [
@@ -134,12 +142,12 @@ class SelectHydratorTest extends TestCase
                         [
                             'table_name',
                             'field_name',
-                            'alias',
+                            'alias'
                         ],
                         [
                             'table_name',
                             'field_name_2',
-                            'alias_2',
+                            'alias_2'
                         ],
                     ]
                 ],
@@ -148,29 +156,31 @@ class SelectHydratorTest extends TestCase
                     [
                         'table_name',
                         'field_name',
-                        'alias',
+                        'alias'
                     ],
                     [
                         'table_name',
                         'field_name_2',
-                        'alias_2',
-                    ],
-                ]],
-            ],
+                        'alias_2'
+                    ]
+                ]]
+            ]
         ];
     }
 
     /**
-     * @dataProvider recreateWithExpressionDataProvider
      * @param array $selectParts
      * @param array $expectedParts
      * @param MockObject[] $expressionMocks
+     *
+     * @return void
+     * @dataProvider recreateWithExpressionDataProvider
      */
     public function testRecreateWithExpression(
         array $selectParts,
         array $expectedParts,
         array $expressionMocks
-    ) {
+    ): void {
         $this->objectManagerMock
             ->expects($this->exactly(count($expressionMocks)))
             ->method('create')
@@ -186,12 +196,14 @@ class SelectHydratorTest extends TestCase
             ->method('select')
             ->with()
             ->willReturn($this->selectMock);
+        $withArgs = [];
+
         foreach (array_keys($selectParts) as $key => $partName) {
-            $this->selectMock
-                ->expects($this->at($key))
-                ->method('setPart')
-                ->with($partName, $expectedParts[$partName]);
+            $withArgs[] = [$partName, $expectedParts[$partName]];
         }
+        $this->selectMock
+            ->method('setPart')
+            ->withConsecutive(...$withArgs);
 
         $this->assertSame($this->selectMock, $this->selectHydrator->recreate($selectParts));
     }
@@ -199,7 +211,7 @@ class SelectHydratorTest extends TestCase
     /**
      * @return array
      */
-    public function recreateWithExpressionDataProvider()
+    public function recreateWithExpressionDataProvider(): array
     {
         $expressionMock = $this->createMock(\JsonSerializable::class);
 
@@ -210,7 +222,7 @@ class SelectHydratorTest extends TestCase
                         [
                             'table_name',
                             'field_name',
-                            'alias',
+                            'alias'
                         ],
                         [
                             'table_name',
@@ -220,8 +232,8 @@ class SelectHydratorTest extends TestCase
                                     'expression' => ['some(expression)']
                                 ]
                             ],
-                            'alias_2',
-                        ],
+                            'alias_2'
+                        ]
                     ]
                 ],
                 'expectedParts' => [
@@ -229,19 +241,19 @@ class SelectHydratorTest extends TestCase
                         [
                             'table_name',
                             'field_name',
-                            'alias',
+                            'alias'
                         ],
                         [
                             'table_name',
                             $expressionMock,
-                            'alias_2',
-                        ],
+                            'alias_2'
+                        ]
                     ]
                 ],
                 'expectedExpressions' => [
                     $expressionMock
                 ]
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkManagementTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkManagementTest.php
@@ -80,14 +80,12 @@ class BulkManagementTest extends TestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->createMock(EntityManager::class);
-        $this->bulkSummaryFactory = $this
-            ->getMockBuilder(BulkSummaryInterfaceFactory::class)
-            ->setMethods(['create'])
+        $this->bulkSummaryFactory = $this->getMockBuilder(BulkSummaryInterfaceFactory::class)
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->operationCollectionFactory = $this
-            ->getMockBuilder(CollectionFactory::class)
-            ->setMethods(['create'])
+        $this->operationCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->publisher = $this->getMockForAbstractClass(BulkPublisherInterface::class);
@@ -105,7 +103,7 @@ class BulkManagementTest extends TestCase
                 'publisher' => $this->publisher,
                 'metadataPool' => $this->metadataPool,
                 'resourceConnection' => $this->resourceConnection,
-                'logger' => $this->logger,
+                'logger' => $this->logger
             ]
         );
     }
@@ -115,7 +113,7 @@ class BulkManagementTest extends TestCase
      *
      * @return void
      */
-    public function testScheduleBulk()
+    public function testScheduleBulk(): void
     {
         $bulkUuid = 'bulk-001';
         $description = 'Bulk summary description...';
@@ -159,7 +157,7 @@ class BulkManagementTest extends TestCase
      *
      * @return void
      */
-    public function testScheduleBulkWithException()
+    public function testScheduleBulkWithException(): void
     {
         $bulkUuid = 'bulk-001';
         $description = 'Bulk summary description...';
@@ -191,7 +189,7 @@ class BulkManagementTest extends TestCase
      *
      * @return void
      */
-    public function testRetryBulk()
+    public function testRetryBulk(): void
     {
         $bulkUuid = 'bulk-001';
         $errorCodes = ['errorCode'];
@@ -218,14 +216,16 @@ class BulkManagementTest extends TestCase
         $operation->expects($this->once())->method('getId')->willReturn($operationId);
         $this->resourceConnection->expects($this->once())
             ->method('getTableName')->with($operationTable)->willReturn($operationTable);
-        $connection->expects($this->at(1))
+        $connection
             ->method('quoteInto')
-            ->with('operation_key IN (?)', [$operationId])
-            ->willReturn('operation_key IN (' . $operationId . ')');
-        $connection->expects($this->at(2))
-            ->method('quoteInto')
-            ->with('bulk_uuid = ?', $bulkUuid)
-            ->willReturn("bulk_uuid = '$bulkUuid'");
+            ->withConsecutive(
+                ['operation_key IN (?)', [$operationId]],
+                ['bulk_uuid = ?', $bulkUuid]
+            )
+            ->willReturnOnConsecutiveCalls(
+                'operation_key IN (' . $operationId . ')',
+                "bulk_uuid = '$bulkUuid'"
+            );
         $connection->expects($this->once())
             ->method('delete')
             ->with($operationTable, 'operation_key IN (' . $operationId . ') AND bulk_uuid = \'' . $bulkUuid . '\'')
@@ -241,7 +241,7 @@ class BulkManagementTest extends TestCase
      *
      * @return void
      */
-    public function testRetryBulkWithException()
+    public function testRetryBulkWithException(): void
     {
         $bulkUuid = 'bulk-001';
         $errorCodes = ['errorCode'];
@@ -268,14 +268,16 @@ class BulkManagementTest extends TestCase
         $operation->expects($this->once())->method('getId')->willReturn($operationId);
         $this->resourceConnection->expects($this->once())
             ->method('getTableName')->with($operationTable)->willReturn($operationTable);
-        $connection->expects($this->at(1))
+        $connection
             ->method('quoteInto')
-            ->with('operation_key IN (?)', [$operationId])
-            ->willReturn('operation_key IN (' . $operationId . ')');
-        $connection->expects($this->at(2))
-            ->method('quoteInto')
-            ->with('bulk_uuid = ?', $bulkUuid)
-            ->willReturn("bulk_uuid = '$bulkUuid'");
+            ->withConsecutive(
+                ['operation_key IN (?)', [$operationId]],
+                ['bulk_uuid = ?', $bulkUuid]
+            )
+            ->willReturnOnConsecutiveCalls(
+                'operation_key IN (' . $operationId . ')',
+                "bulk_uuid = '$bulkUuid'"
+            );
         $connection->expects($this->once())
             ->method('delete')
             ->with($operationTable, 'operation_key IN (' . $operationId . ') AND bulk_uuid = \'' . $bulkUuid . '\'')
@@ -291,7 +293,7 @@ class BulkManagementTest extends TestCase
      *
      * @return void
      */
-    public function testDeleteBulk()
+    public function testDeleteBulk(): void
     {
         $bulkUuid = 'bulk-001';
         $bulkSummary = $this->getMockForAbstractClass(BulkSummaryInterface::class);

--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkStatusTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkStatusTest.php
@@ -107,24 +107,19 @@ class BulkStatusTest extends TestCase
     /**
      * @param int|null $failureType
      * @param array $failureCodes
+     *
      * @return void
      * @dataProvider getFailedOperationsByBulkIdDataProvider
      */
-    public function testGetFailedOperationsByBulkId($failureType, $failureCodes): void
+    public function testGetFailedOperationsByBulkId(?int $failureType, array $failureCodes): void
     {
         $bulkUuid = 'bulk-1';
         $operationCollection = $this->createMock(OperationCollection::class);
         $this->operationCollectionFactory->expects($this->once())->method('create')->willReturn($operationCollection);
         $operationCollection
-            ->expects($this->at(0))
             ->method('addFieldToFilter')
-            ->with('bulk_uuid', $bulkUuid)
-            ->willReturnSelf();
-        $operationCollection
-            ->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('status', $failureCodes)
-            ->willReturnSelf();
+            ->withConsecutive(['bulk_uuid', $bulkUuid], ['status', $failureCodes])
+            ->willReturnOnConsecutiveCalls($operationCollection, $operationCollection);
         $operationCollection->expects($this->once())->method('getItems')->willReturn([$this->operationMock]);
         $this->assertEquals([$this->operationMock], $this->model->getFailedOperationsByBulkId($bulkUuid, $failureType));
     }
@@ -141,15 +136,9 @@ class BulkStatusTest extends TestCase
         $operationCollection = $this->createMock(OperationCollection::class);
         $this->operationCollectionFactory->expects($this->once())->method('create')->willReturn($operationCollection);
         $operationCollection
-            ->expects($this->at(0))
             ->method('addFieldToFilter')
-            ->with('bulk_uuid', $bulkUuid)
-            ->willReturnSelf();
-        $operationCollection
-            ->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('status', $status)
-            ->willReturnSelf();
+            ->withConsecutive(['bulk_uuid', $bulkUuid], ['status', $status])
+            ->willReturnOnConsecutiveCalls($operationCollection, $operationCollection);
         $operationCollection
             ->expects($this->once())
             ->method('getSize')
@@ -266,9 +255,9 @@ class BulkStatusTest extends TestCase
                 null,
                 [
                     OperationInterface::STATUS_TYPE_RETRIABLY_FAILED,
-                    OperationInterface::STATUS_TYPE_NOT_RETRIABLY_FAILED,
-                ],
-            ],
+                    OperationInterface::STATUS_TYPE_NOT_RETRIABLY_FAILED
+                ]
+            ]
         ];
     }
 
@@ -322,13 +311,8 @@ class BulkStatusTest extends TestCase
         $this->connectionMock->expects($this->once())->method('fetchOne')->with($selectMock)->willReturn(10);
 
         $this->operationCollectionFactory
-            ->expects($this->at(0))
             ->method('create')
-            ->willReturn($allProcessedOperationCollection);
-        $this->operationCollectionFactory
-            ->expects($this->at(1))
-            ->method('create')
-            ->willReturn($completeOperationCollection);
+            ->willReturnOnConsecutiveCalls($allProcessedOperationCollection, $completeOperationCollection);
         $allProcessedOperationCollection
             ->expects($this->once())
             ->method('addFieldToFilter')
@@ -337,15 +321,9 @@ class BulkStatusTest extends TestCase
         $allProcessedOperationCollection->expects($this->once())->method('getSize')->willReturn(5);
 
         $completeOperationCollection
-            ->expects($this->at(0))
             ->method('addFieldToFilter')
-            ->with('bulk_uuid', $bulkUuid)
-            ->willReturnSelf();
-        $completeOperationCollection
-            ->expects($this->at(1))
-            ->method('addFieldToFilter')
-            ->with('status', OperationInterface::STATUS_TYPE_COMPLETE)
-            ->willReturnSelf();
+            ->withConsecutive(['bulk_uuid', $bulkUuid], ['status', OperationInterface::STATUS_TYPE_COMPLETE])
+            ->willReturnOnConsecutiveCalls($completeOperationCollection, $completeOperationCollection);
         $completeOperationCollection->method('getSize')->willReturn(5);
         $this->assertEquals(BulkSummaryInterface::IN_PROGRESS, $this->model->getBulkStatus($bulkUuid));
     }

--- a/app/code/Magento/Authorization/Test/Unit/Model/Acl/Loader/RoleTest.php
+++ b/app/code/Magento/Authorization/Test/Unit/Model/Acl/Loader/RoleTest.php
@@ -71,11 +71,13 @@ class RoleTest extends TestCase
     protected function setUp(): void
     {
         $this->groupFactoryMock = $this->getMockBuilder(GroupFactory::class)
-            ->setMethods(['create', 'getModelInstance'])
+            ->onlyMethods(['create'])
+            ->addMethods(['getModelInstance'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->roleFactoryMock = $this->getMockBuilder(UserFactory::class)
-            ->setMethods(['create', 'getModelInstance'])
+            ->onlyMethods(['create'])
+            ->addMethods(['getModelInstance'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->resourceMock = $this->createMock(ResourceConnection::class);
@@ -119,9 +121,11 @@ class RoleTest extends TestCase
     }
 
     /**
-     * Test populating acl roles with children
+     * Test populating acl roles with children.
+     *
+     * @return void
      */
-    public function testPopulateAclAddsRolesAndTheirChildren()
+    public function testPopulateAclAddsRolesAndTheirChildren(): void
     {
         $this->resourceMock->expects($this->once())
             ->method('getTableName')
@@ -141,7 +145,7 @@ class RoleTest extends TestCase
             ->willReturn(
                 [
                     ['role_id' => 1, 'role_type' => 'G', 'parent_id' => null],
-                    ['role_id' => 2, 'role_type' => 'U', 'parent_id' => 1, 'user_id' => 1],
+                    ['role_id' => 2, 'role_type' => 'U', 'parent_id' => 1, 'user_id' => 1]
                 ]
             );
 
@@ -149,16 +153,22 @@ class RoleTest extends TestCase
         $this->roleFactoryMock->expects($this->once())->method('create')->with(['roleId' => '2']);
 
         $aclMock = $this->createMock(Acl::class);
-        $aclMock->expects($this->at(0))->method('addRole')->with($this->anything(), null);
-        $aclMock->expects($this->at(2))->method('addRole')->with($this->anything(), '1');
+        $aclMock
+            ->method('addRole')
+            ->withConsecutive(
+                [$this->anything(), null],
+                [$this->anything(), '1']
+            );
 
         $this->model->populateAcl($aclMock);
     }
 
     /**
-     * Test populating acl role with multiple parents
+     * Test populating acl role with multiple parents.
+     *
+     * @return void
      */
-    public function testPopulateAclAddsMultipleParents()
+    public function testPopulateAclAddsMultipleParents(): void
     {
         $this->resourceMock->expects($this->once())
             ->method('getTableName')
@@ -181,16 +191,23 @@ class RoleTest extends TestCase
         $this->groupFactoryMock->expects($this->never())->method('getModelInstance');
 
         $aclMock = $this->createMock(Acl::class);
-        $aclMock->expects($this->at(0))->method('hasRole')->with('1')->willReturn(true);
-        $aclMock->expects($this->at(1))->method('addRoleParent')->with('1', '2');
+        $aclMock
+            ->method('hasRole')
+            ->with('1')
+            ->willReturn(true);
+        $aclMock
+            ->method('addRoleParent')
+            ->with('1', '2');
 
         $this->model->populateAcl($aclMock);
     }
 
     /**
-     * Test populating acl role from cache
+     * Test populating acl role from cache.
+     *
+     * @return void
      */
-    public function testPopulateAclFromCache()
+    public function testPopulateAclFromCache(): void
     {
         $this->resourceMock->expects($this->never())->method('getConnection');
         $this->resourceMock->expects($this->never())->method('getTableName');
@@ -215,8 +232,13 @@ class RoleTest extends TestCase
         $this->groupFactoryMock->expects($this->never())->method('getModelInstance');
 
         $aclMock = $this->createMock(Acl::class);
-        $aclMock->expects($this->at(0))->method('hasRole')->with('1')->willReturn(true);
-        $aclMock->expects($this->at(1))->method('addRoleParent')->with('1', '2');
+        $aclMock
+            ->method('hasRole')
+            ->with('1')
+            ->willReturn(true);
+        $aclMock
+            ->method('addRoleParent')
+            ->with('1', '2');
 
         $this->model->populateAcl($aclMock);
     }

--- a/app/code/Magento/Authorization/Test/Unit/Model/Acl/Loader/RuleTest.php
+++ b/app/code/Magento/Authorization/Test/Unit/Model/Acl/Loader/RuleTest.php
@@ -91,9 +91,11 @@ class RuleTest extends TestCase
     }
 
     /**
-     * Test populating acl rule from cache
+     * Test populating acl rule from cache.
+     *
+     * @return void
      */
-    public function testPopulateAclFromCache()
+    public function testPopulateAclFromCache(): void
     {
         $this->resourceMock->expects($this->never())->method('getTable');
         $this->resourceMock->expects($this->never())
@@ -107,17 +109,23 @@ class RuleTest extends TestCase
                     [
                         ['role_id' => 1, 'resource_id' => 'Magento_Backend::all', 'permission' => 'allow'],
                         ['role_id' => 2, 'resource_id' => 1, 'permission' => 'allow'],
-                        ['role_id' => 3, 'resource_id' => 1, 'permission' => 'deny'],
+                        ['role_id' => 3, 'resource_id' => 1, 'permission' => 'deny']
                     ]
                 )
             );
 
         $aclMock = $this->createMock(Acl::class);
         $aclMock->method('has')->willReturn(true);
-        $aclMock->expects($this->at(1))->method('allow')->with('1', null, null);
-        $aclMock->expects($this->at(2))->method('allow')->with('1', 'Magento_Backend::all', null);
-        $aclMock->expects($this->at(4))->method('allow')->with('2', 1, null);
-        $aclMock->expects($this->at(6))->method('deny')->with('3', 1, null);
+        $aclMock
+            ->method('allow')
+            ->withConsecutive(
+                ['1', null, null],
+                ['1', 'Magento_Backend::all', null],
+                ['2', 1, null]
+            );
+        $aclMock
+            ->method('deny')
+            ->with('3', 1, null);
 
         $this->model->populateAcl($aclMock);
     }

--- a/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/AuthenticationTest.php
+++ b/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/AuthenticationTest.php
@@ -29,6 +29,9 @@ class AuthenticationTest extends TestCase
      */
     protected $plugin;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->auth = $this->createPartialMock(
@@ -42,13 +45,19 @@ class AuthenticationTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         $this->auth = null;
         $this->plugin = null;
     }
 
-    public function testAroundDispatchProlongStorage()
+    /**
+     * @return void
+     */
+    public function testAroundDispatchProlongStorage(): void
     {
         $subject = $this->createMock(Index::class);
         $request = $this->createPartialMock(Http::class, ['getActionName']);
@@ -76,9 +85,9 @@ class AuthenticationTest extends TestCase
         $user->expects($this->once())
             ->method('reload');
 
-        $storage->expects($this->at(0))
+        $storage
             ->method('prolong');
-        $storage->expects($this->at(1))
+        $storage
             ->method('refreshAcl');
 
         $proceed = function ($request) use ($expectedResult) {
@@ -89,12 +98,13 @@ class AuthenticationTest extends TestCase
     }
 
     /**
-     * Calls aroundDispatch to access protected method _processNotLoggedInUser
+     * Calls aroundDispatch to access protected method _processNotLoggedInUser.
      *
+     * @return void
      * Data provider supplies different possibilities of request parameters and properties
      * @dataProvider processNotLoggedInUserDataProvider
      */
-    public function testProcessNotLoggedInUser($isIFrameParam, $isAjaxParam, $isForwardedFlag)
+    public function testProcessNotLoggedInUser($isIFrameParam, $isAjaxParam, $isForwardedFlag): void
     {
         $subject = $this->getMockBuilder(Index::class)
             ->disableOriginalConstructor()
@@ -155,7 +165,7 @@ class AuthenticationTest extends TestCase
     /**
      * @return array
      */
-    public function processNotLoggedInUserDataProvider()
+    public function processNotLoggedInUserDataProvider(): array
     {
         return [
             'iFrame' => [true, false, false],

--- a/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/MassactionKeyTest.php
+++ b/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/MassactionKeyTest.php
@@ -31,6 +31,9 @@ class MassactionKeyTest extends TestCase
      */
     protected $subjectMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->subjectMock = $this->createMock(AbstractAction::class);
@@ -49,26 +52,26 @@ class MassactionKeyTest extends TestCase
             MassactionKey::class,
             [
                 'subject' => $this->subjectMock,
-                'request' => $this->requestMock,
+                'request' => $this->requestMock
             ]
         );
     }
 
     /**
-     * @param $postData array|string
+     * @param array|string $postData
      * @param array $convertedData
+     *
+     * @return void
      * @dataProvider beforeDispatchDataProvider
      */
-    public function testBeforeDispatchWhenMassactionPrepareKeyRequestExists($postData, $convertedData)
-    {
-        $this->requestMock->expects($this->at(0))
+    public function testBeforeDispatchWhenMassactionPrepareKeyRequestExists(
+        $postData,
+        array $convertedData
+    ): void {
+        $this->requestMock
             ->method('getPost')
-            ->with('massaction_prepare_key')
-            ->willReturn('key');
-        $this->requestMock->expects($this->at(1))
-            ->method('getPost')
-            ->with('key')
-            ->willReturn($postData);
+            ->withConsecutive(['massaction_prepare_key'], ['key'])
+            ->willReturnOnConsecutiveCalls('key', $postData);
         $this->requestMock->expects($this->once())
             ->method('setPostValue')
             ->with('key', $convertedData);
@@ -79,7 +82,7 @@ class MassactionKeyTest extends TestCase
     /**
      * @return array
      */
-    public function beforeDispatchDataProvider()
+    public function beforeDispatchDataProvider(): array
     {
         return [
             'post_data_is_array' => [['key'], ['key']],
@@ -87,7 +90,10 @@ class MassactionKeyTest extends TestCase
         ];
     }
 
-    public function testBeforeDispatchWhenMassactionPrepareKeyRequestNotExists()
+    /**
+     * @return void
+     */
+    public function testBeforeDispatchWhenMassactionPrepareKeyRequestNotExists(): void
     {
         $this->requestMock->expects($this->once())
             ->method('getPost')

--- a/app/code/Magento/Backend/Test/Unit/App/Area/FrontNameResolverTest.php
+++ b/app/code/Magento/Backend/Test/Unit/App/Area/FrontNameResolverTest.php
@@ -51,6 +51,9 @@ class FrontNameResolverTest extends TestCase
      */
     protected $_defaultFrontName = 'defaultFrontName';
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         /** @var MockObject|DeploymentConfig $deploymentConfigMock */
@@ -74,30 +77,22 @@ class FrontNameResolverTest extends TestCase
         );
     }
 
-    public function testIfCustomPathUsed()
+    /**
+     * @return void
+     */
+    public function testIfCustomPathUsed(): void
     {
-        $this->configMock->expects(
-            $this->at(0)
-        )->method(
-            'getValue'
-        )->with(
-            'admin/url/use_custom_path'
-        )->willReturn(
-            true
-        );
-        $this->configMock->expects(
-            $this->at(1)
-        )->method(
-            'getValue'
-        )->with(
-            'admin/url/custom_path'
-        )->willReturn(
-            'expectedValue'
-        );
+        $this->configMock
+            ->method('getValue')
+            ->withConsecutive(['admin/url/use_custom_path'], ['admin/url/custom_path'])
+            ->willReturnOnConsecutiveCalls(true, 'expectedValue');
         $this->assertEquals('expectedValue', $this->model->getFrontName());
     }
 
-    public function testIfCustomPathNotUsed()
+    /**
+     * @return void
+     */
+    public function testIfCustomPathNotUsed(): void
     {
         $this->configMock->expects(
             $this->once()
@@ -116,11 +111,18 @@ class FrontNameResolverTest extends TestCase
      * @param string $host
      * @param string $useCustomAdminUrl
      * @param string $customAdminUrl
-     * @param string $expectedValue
+     * @param bool $expectedValue
+     *
+     * @return void
      * @dataProvider hostsDataProvider
      */
-    public function testIsHostBackend($url, $host, $useCustomAdminUrl, $customAdminUrl, $expectedValue)
-    {
+    public function testIsHostBackend(
+        string $url,
+        string $host,
+        string $useCustomAdminUrl,
+        string $customAdminUrl,
+        bool $expectedValue
+    ): void {
         $this->scopeConfigMock->expects($this->exactly(2))
             ->method('getValue')
             ->willReturnMap(
@@ -137,7 +139,7 @@ class FrontNameResolverTest extends TestCase
                         ScopeInterface::SCOPE_STORE,
                         null,
                         $customAdminUrl
-                    ],
+                    ]
                 ]
             );
 
@@ -181,7 +183,7 @@ class FrontNameResolverTest extends TestCase
     /**
      * @return array
      */
-    public function hostsDataProvider()
+    public function hostsDataProvider(): array
     {
         return [
             'withoutPort' => [

--- a/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Block/Widget/Grid/Column/Filter/PriceTest.php
@@ -20,27 +20,44 @@ use PHPUnit\Framework\TestCase;
 
 class PriceTest extends TestCase
 {
-    /** @var RequestInterface|MockObject  */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $requestMock;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     private $context;
 
-    /** @var Helper|MockObject */
+    /**
+     * @var Helper|MockObject
+     */
     private $helper;
 
-    /** @var Currency|MockObject */
+    /**
+     * @var Currency|MockObject
+     */
     private $currency;
 
-    /** @var DefaultLocator|MockObject */
+    /**
+     * @var DefaultLocator|MockObject
+     */
     private $currencyLocator;
 
-    /** @var Column|MockObject */
+    /**
+     * @var Column|MockObject
+     */
     private $columnMock;
 
-    /** @var Price  */
+    /**
+     * @var Price
+     */
     private $blockPrice;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->requestMock = $this->getMockForAbstractClass(RequestInterface::class);
@@ -52,14 +69,14 @@ class PriceTest extends TestCase
 
         $this->currency = $this->getMockBuilder(Currency::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAnyRate'])
+            ->onlyMethods(['getAnyRate'])
             ->getMock();
 
         $this->currencyLocator = $this->createMock(DefaultLocator::class);
 
         $this->columnMock = $this->getMockBuilder(Column::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCurrencyCode'])
+            ->addMethods(['getCurrencyCode'])
             ->getMock();
 
         $helper = new ObjectManager($this);
@@ -73,7 +90,10 @@ class PriceTest extends TestCase
         $this->blockPrice->setColumn($this->columnMock);
     }
 
-    public function testGetCondition()
+    /**
+     * @return void
+     */
+    public function testGetCondition(): void
     {
         $this->currencyLocator->expects(
             $this->any()
@@ -85,14 +105,14 @@ class PriceTest extends TestCase
             'defaultCurrency'
         );
 
-        $this->currency->expects($this->at(0))
+        $this->currency
             ->method('getAnyRate')
             ->with('defaultCurrency')
             ->willReturn(1.0);
 
         $testValue = [
             'value' => [
-                'from' => '1234a',
+                'from' => '1234a'
             ]
         ];
 

--- a/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Controller/Adminhtml/System/Account/SaveTest.php
@@ -1,10 +1,10 @@
-<?php declare(strict_types=1);
+<?php
 /**
- * Unit test for \Magento\Backend\Controller\Adminhtml\System\Account controller
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Backend\Test\Unit\Controller\Adminhtml\System\Account;
 
 use Magento\Backend\App\Action\Context;
@@ -29,105 +29,139 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Unit test for \Magento\Backend\Controller\Adminhtml\System\Account controller.
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SaveTest extends TestCase
 {
-    /** @var Account */
-    protected $_controller;
+    /**
+     * @var Account
+     */
+    protected $controller;
 
-    /** @var MockObject|RequestInterface */
-    protected $_requestMock;
+    /**
+     * @var MockObject|RequestInterface
+     */
+    protected $requestMock;
 
-    /** @var MockObject|ResponseInterface */
-    protected $_responseMock;
+    /**
+     * @var MockObject|ResponseInterface
+     */
+    protected $responseMock;
 
-    /** @var MockObject|ObjectManager */
-    protected $_objectManagerMock;
+    /**
+     * @var MockObject|ObjectManager
+     */
+    protected $objectManagerMock;
 
-    /** @var MockObject|\Magento\Framework\Message\ManagerInterface */
-    protected $_messagesMock;
+    /**
+     * @var MockObject|\Magento\Framework\Message\ManagerInterface
+     */
+    protected $messagesMock;
 
-    /** @var MockObject|Data */
-    protected $_helperMock;
+    /**
+     * @var MockObject|Data
+     */
+    protected $helperMock;
 
-    /** @var MockObject|Session */
-    protected $_authSessionMock;
+    /**
+     * @var MockObject|Session
+     */
+    protected $authSessionMock;
 
-    /** @var MockObject|User */
-    protected $_userMock;
+    /**
+     * @var MockObject|User
+     */
+    protected $userMock;
 
-    /** @var MockObject|Locale */
-    protected $_validatorMock;
+    /**
+     * @var MockObject|Locale
+     */
+    protected $validatorMock;
 
-    /** @var MockObject|Manager */
-    protected $_managerMock;
+    /**
+     * @var MockObject|Manager
+     */
+    protected $managerMock;
 
-    /** @var MockObject|TranslateInterface */
-    protected $_translatorMock;
+    /**
+     * @var MockObject|TranslateInterface
+     */
+    protected $translatorMock;
 
-    /** @var MockObject|EventManagerInterface */
+    /**
+     * @var MockObject|EventManagerInterface
+     */
     protected $eventManagerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_requestMock = $this->getMockBuilder(Http::class)
+        $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getOriginalPathInfo'])
+            ->onlyMethods(['getOriginalPathInfo'])
             ->getMock();
-        $this->_responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
+        $this->responseMock = $this->getMockBuilder(\Magento\Framework\App\Response\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMock();
-        $this->_objectManagerMock = $this->getMockBuilder(ObjectManager::class)
+        $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'create'])
+            ->onlyMethods(['get', 'create'])
             ->getMock();
         $frontControllerMock = $this->getMockBuilder(FrontController::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->_helperMock = $this->getMockBuilder(Data::class)
+        $this->helperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getUrl'])
+            ->onlyMethods(['getUrl'])
             ->getMock();
-        $this->_messagesMock = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
+        $this->messagesMock = $this->getMockBuilder(\Magento\Framework\Message\Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccessMessage'])
+            ->onlyMethods(['addSuccessMessage'])
             ->getMockForAbstractClass();
 
-        $this->_authSessionMock = $this->getMockBuilder(Session::class)
+        $this->authSessionMock = $this->getMockBuilder(Session::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getUser'])
+            ->addMethods(['getUser'])
             ->getMock();
 
-        $this->_userMock = $this->getMockBuilder(User::class)
+        $this->userMock = $this->getMockBuilder(User::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
-                    'load', 'save', 'sendNotificationEmailsIfRequired',
-                    'performIdentityCheck', 'validate', '__sleep', '__wakeup'
+                    'load',
+                    'save',
+                    'sendNotificationEmailsIfRequired',
+                    'performIdentityCheck',
+                    'validate',
+                    '__sleep',
+                    '__wakeup'
                 ]
             )
             ->getMock();
 
-        $this->_validatorMock = $this->getMockBuilder(Locale::class)
+        $this->validatorMock = $this->getMockBuilder(Locale::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isValid'])
+            ->onlyMethods(['isValid'])
             ->getMock();
 
-        $this->_managerMock = $this->getMockBuilder(Manager::class)
+        $this->managerMock = $this->getMockBuilder(Manager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['switchBackendInterfaceLocale'])
+            ->onlyMethods(['switchBackendInterfaceLocale'])
             ->getMock();
 
-        $this->_translatorMock = $this->getMockBuilder(TranslateInterface::class)
+        $this->translatorMock = $this->getMockBuilder(TranslateInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
         $resultFactory = $this->getMockBuilder(ResultFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
@@ -149,25 +183,28 @@ class SaveTest extends TestCase
             ])
             ->disableOriginalConstructor()
             ->getMock();
-        $contextMock->expects($this->any())->method('getRequest')->willReturn($this->_requestMock);
-        $contextMock->expects($this->any())->method('getResponse')->willReturn($this->_responseMock);
-        $contextMock->expects($this->any())->method('getObjectManager')->willReturn($this->_objectManagerMock);
+        $contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
+        $contextMock->expects($this->any())->method('getResponse')->willReturn($this->responseMock);
+        $contextMock->expects($this->any())->method('getObjectManager')->willReturn($this->objectManagerMock);
         $contextMock->expects($this->any())->method('getFrontController')->willReturn($frontControllerMock);
-        $contextMock->expects($this->any())->method('getHelper')->willReturn($this->_helperMock);
-        $contextMock->expects($this->any())->method('getMessageManager')->willReturn($this->_messagesMock);
-        $contextMock->expects($this->any())->method('getTranslator')->willReturn($this->_translatorMock);
+        $contextMock->expects($this->any())->method('getHelper')->willReturn($this->helperMock);
+        $contextMock->expects($this->any())->method('getMessageManager')->willReturn($this->messagesMock);
+        $contextMock->expects($this->any())->method('getTranslator')->willReturn($this->translatorMock);
         $contextMock->expects($this->once())->method('getResultFactory')->willReturn($resultFactory);
 
         $args = ['context' => $contextMock];
 
         $testHelper = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
-        $this->_controller = $testHelper->getObject(
+        $this->controller = $testHelper->getObject(
             Save::class,
             $args
         );
     }
 
-    public function testSaveAction()
+    /**
+     * @return void
+     */
+    public function testSaveAction(): void
     {
         $userId = 1;
         $requestParams = [
@@ -178,15 +215,15 @@ class SaveTest extends TestCase
             'firstname' => 'Bar',
             'lastname' => 'Dummy',
             'email' => 'test@example.com',
-            Form::IDENTITY_VERIFICATION_PASSWORD_FIELD => 'current_password',
+            Form::IDENTITY_VERIFICATION_PASSWORD_FIELD => 'current_password'
         ];
 
         $testedMessage = 'You saved the account.';
 
-        $this->_authSessionMock->expects($this->any())->method('getUser')->willReturn($this->_userMock);
+        $this->authSessionMock->expects($this->any())->method('getUser')->willReturn($this->userMock);
 
-        $this->_userMock->expects($this->any())->method('load')->willReturnSelf();
-        $this->_validatorMock->expects(
+        $this->userMock->expects($this->any())->method('load')->willReturnSelf();
+        $this->validatorMock->expects(
             $this->once()
         )->method(
             'isValid'
@@ -195,55 +232,27 @@ class SaveTest extends TestCase
         )->willReturn(
             true
         );
-        $this->_managerMock->expects($this->any())->method('switchBackendInterfaceLocale');
+        $this->managerMock->expects($this->any())->method('switchBackendInterfaceLocale');
 
-        $this->_objectManagerMock->expects(
-            $this->at(0)
-        )->method(
-            'get'
-        )->with(
-            Session::class
-        )->willReturn(
-            $this->_authSessionMock
-        );
-        $this->_objectManagerMock->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            User::class
-        )->willReturn(
-            $this->_userMock
-        );
-        $this->_objectManagerMock->expects(
-            $this->at(2)
-        )->method(
-            'get'
-        )->with(
-            Locale::class
-        )->willReturn(
-            $this->_validatorMock
-        );
-        $this->_objectManagerMock->expects(
-            $this->at(3)
-        )->method(
-            'get'
-        )->with(
-            Manager::class
-        )->willReturn(
-            $this->_managerMock
-        );
+        $this->objectManagerMock
+            ->method('get')
+            ->withConsecutive([Session::class], [Locale::class], [Manager::class])
+            ->willReturnOnConsecutiveCalls($this->authSessionMock, $this->validatorMock, $this->managerMock);
+        $this->objectManagerMock
+            ->method('create')
+            ->with(User::class)
+            ->willReturn($this->userMock);
 
-        $this->_userMock->setUserId($userId);
-        $this->_userMock->expects($this->once())->method('performIdentityCheck')->willReturn(true);
-        $this->_userMock->expects($this->once())->method('save');
-        $this->_userMock->expects($this->once())->method('validate')->willReturn(true);
-        $this->_userMock->expects($this->once())->method('sendNotificationEmailsIfRequired');
+        $this->userMock->setUserId($userId);
+        $this->userMock->expects($this->once())->method('performIdentityCheck')->willReturn(true);
+        $this->userMock->expects($this->once())->method('save');
+        $this->userMock->expects($this->once())->method('validate')->willReturn(true);
+        $this->userMock->expects($this->once())->method('sendNotificationEmailsIfRequired');
 
-        $this->_requestMock->setParams($requestParams);
+        $this->requestMock->setParams($requestParams);
 
-        $this->_messagesMock->expects($this->once())->method('addSuccessMessage')->with($testedMessage);
+        $this->messagesMock->expects($this->once())->method('addSuccessMessage')->with($testedMessage);
 
-        $this->_controller->execute();
+        $this->controller->execute();
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Model/Dashboard/ChartTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Dashboard/ChartTest.php
@@ -44,6 +44,9 @@ class ChartTest extends TestCase
      */
     private $collectionMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManager($this);
@@ -78,22 +81,20 @@ class ChartTest extends TestCase
      * @param string $period
      * @param string $chartParam
      * @param array $result
+     *
+     * @return void
      * @dataProvider getByPeriodDataProvider
      */
-    public function testGetByPeriod($period, $chartParam, $result)
+    public function testGetByPeriod(string $period, string $chartParam, array $result): void
     {
-        $this->orderHelperMock->expects($this->at(0))
+        $this->orderHelperMock
             ->method('setParam')
-            ->with('store', null);
-        $this->orderHelperMock->expects($this->at(1))
-            ->method('setParam')
-            ->with('website', null);
-        $this->orderHelperMock->expects($this->at(2))
-            ->method('setParam')
-            ->with('group', null);
-        $this->orderHelperMock->expects($this->at(3))
-            ->method('setParam')
-            ->with('period', $period);
+            ->withConsecutive(
+                ['store', null],
+                ['website', null],
+                ['group', null],
+                ['period', $period]
+            );
 
         $this->dateRetrieverMock->expects($this->once())
             ->method('getByPeriod')
@@ -129,6 +130,9 @@ class ChartTest extends TestCase
         );
     }
 
+    /**
+     * @return array
+     */
     public function getByPeriodDataProvider(): array
     {
         return [

--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/BuilderTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/BuilderTest.php
@@ -35,6 +35,9 @@ class BuilderTest extends TestCase
      */
     private $factoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->factoryMock = $this->createMock(Factory::class);
@@ -52,7 +55,10 @@ class BuilderTest extends TestCase
         );
     }
 
-    public function testProcessCommand()
+    /**
+     * @return void
+     */
+    public function testProcessCommand(): void
     {
         $command = $this->createMock(Add::class);
         $command->expects($this->any())->method('getId')->willReturn(1);
@@ -63,34 +69,26 @@ class BuilderTest extends TestCase
         $this->model->processCommand($command2);
     }
 
-    public function testGetResultBuildsTreeStructure()
+    /**
+     * @return void
+     */
+    public function testGetResultBuildsTreeStructure(): void
     {
         $item1 = $this->createMock(Item::class);
         $item1->expects($this->once())->method('getChildren')->willReturn($this->menuMock);
         $this->factoryMock->expects($this->any())->method('create')->willReturn($item1);
 
         $item2 = $this->createMock(Item::class);
-        $this->factoryMock->expects($this->at(1))->method('create')->willReturn($item2);
+        $this->factoryMock
+            ->method('create')
+            ->willReturn($item2);
 
-        $this->menuMock->expects(
-            $this->at(0)
-        )->method(
-            'add'
-        )->with(
-            $this->isInstanceOf(Item::class),
-            null,
-            2
-        );
-
-        $this->menuMock->expects(
-            $this->at(1)
-        )->method(
-            'add'
-        )->with(
-            $this->isInstanceOf(Item::class),
-            null,
-            4
-        );
+        $this->menuMock
+            ->method('add')
+            ->withConsecutive(
+                [$this->isInstanceOf(Item::class), null, 2],
+                [$this->isInstanceOf(Item::class), null, 4]
+            );
 
         $this->model->processCommand(
             new Add(
@@ -99,7 +97,7 @@ class BuilderTest extends TestCase
                     'title' => 'Item 1',
                     'module' => 'Magento_Backend',
                     'sortOrder' => 2,
-                    'resource' => 'Magento_Backend::item1',
+                    'resource' => 'Magento_Backend::item1'
                 ]
             )
         );
@@ -111,7 +109,7 @@ class BuilderTest extends TestCase
                     'title' => 'two',
                     'module' => 'Magento_Backend',
                     'sortOrder' => 4,
-                    'resource' => 'Magento_Backend::item2',
+                    'resource' => 'Magento_Backend::item2'
                 ]
             )
         );
@@ -119,7 +117,10 @@ class BuilderTest extends TestCase
         $this->model->getResult($this->menuMock);
     }
 
-    public function testGetResultSkipsRemovedItems()
+    /**
+     * @return void
+     */
+    public function testGetResultSkipsRemovedItems(): void
     {
         $this->model->processCommand(
             new Add(
@@ -127,7 +128,7 @@ class BuilderTest extends TestCase
                     'id' => 1,
                     'title' => 'Item 1',
                     'module' => 'Magento_Backend',
-                    'resource' => 'Magento_Backend::i1',
+                    'resource' => 'Magento_Backend::i1'
                 ]
             )
         );
@@ -138,7 +139,10 @@ class BuilderTest extends TestCase
         $this->model->getResult($this->menuMock);
     }
 
-    public function testGetResultSkipItemsWithInvalidParent()
+    /**
+     * @return void
+     */
+    public function testGetResultSkipItemsWithInvalidParent(): void
     {
         $this->expectException('OutOfRangeException');
         $item1 = $this->createMock(Item::class);
@@ -151,7 +155,7 @@ class BuilderTest extends TestCase
                     'parent' => 'not_exists',
                     'title' => 'Item 1',
                     'module' => 'Magento_Backend',
-                    'resource' => 'Magento_Backend::item1',
+                    'resource' => 'Magento_Backend::item1'
                 ]
             )
         );

--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/ConfigTest.php
@@ -51,6 +51,9 @@ class ConfigTest extends TestCase
      */
     private $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->cacheInstanceMock = $this->createMock(Config::class);
@@ -86,12 +89,15 @@ class ConfigTest extends TestCase
                 'configReader' => $this->configReaderMock,
                 'configCacheType' => $this->cacheInstanceMock,
                 'logger' => $this->logger,
-                'appState' => $appState,
+                'appState' => $appState
             ]
         );
     }
 
-    public function testGetMenuWithCachedObjectReturnsUnserializedObject()
+    /**
+     * @return void
+     */
+    public function testGetMenuWithCachedObjectReturnsUnserializedObject(): void
     {
         $this->cacheInstanceMock->expects(
             $this->once()
@@ -108,17 +114,15 @@ class ConfigTest extends TestCase
         $this->assertEquals($this->menuMock, $this->model->getMenu());
     }
 
-    public function testGetMenuWithNotCachedObjectBuildsObject()
+    /**
+     * @return void
+     */
+    public function testGetMenuWithNotCachedObjectBuildsObject(): void
     {
-        $this->cacheInstanceMock->expects(
-            $this->at(0)
-        )->method(
-            'load'
-        )->with(
-            \Magento\Backend\Model\Menu\Config::CACHE_MENU_OBJECT
-        )->willReturn(
-            false
-        );
+        $this->cacheInstanceMock
+            ->method('load')
+            ->with(\Magento\Backend\Model\Menu\Config::CACHE_MENU_OBJECT)
+            ->willReturn(false);
 
         $this->configReaderMock->expects($this->once())->method('read')->willReturn([]);
 
@@ -136,9 +140,10 @@ class ConfigTest extends TestCase
     /**
      * @param string $expectedException
      *
+     * @return void
      * @dataProvider getMenuExceptionLoggedDataProvider
      */
-    public function testGetMenuExceptionLogged($expectedException)
+    public function testGetMenuExceptionLogged(string $expectedException): void
     {
         $this->expectException($expectedException);
         $this->menuBuilderMock->expects(
@@ -155,7 +160,7 @@ class ConfigTest extends TestCase
     /**
      * @return array
      */
-    public function getMenuExceptionLoggedDataProvider()
+    public function getMenuExceptionLoggedDataProvider(): array
     {
         return [
             'InvalidArgumentException' => ['InvalidArgumentException'],
@@ -164,7 +169,10 @@ class ConfigTest extends TestCase
         ];
     }
 
-    public function testGetMenuGenericExceptionIsNotLogged()
+    /**
+     * @return void
+     */
+    public function testGetMenuGenericExceptionIsNotLogged(): void
     {
         $this->logger->expects($this->never())->method('critical');
 

--- a/app/code/Magento/Backend/Test/Unit/Model/Menu/Director/DirectorTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Menu/Director/DirectorTest.php
@@ -5,9 +5,6 @@
  */
 declare(strict_types=1);
 
-/**
- * Test class for \Magento\Backend\Model\Menu\Director\Director
- */
 namespace Magento\Backend\Test\Unit\Model\Menu\Director;
 
 use Magento\Backend\Model\Menu\Builder;
@@ -18,63 +15,76 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * Test class for \Magento\Backend\Model\Menu\Director\Director
+ */
 class DirectorTest extends TestCase
 {
     /**
      * @var Director
      */
-    protected $_model;
+    protected $model;
 
     /**
      * @var MockObject
      */
-    protected $_commandFactoryMock;
+    protected $commandFactoryMock;
 
     /**
      * @var MockObject
      */
-    protected $_builderMock;
+    protected $builderMock;
 
     /**
      * @var MockObject
      */
-    protected $_logger;
+    protected $logger;
 
     /**
      * @var MockObject
      */
-    protected $_commandMock;
+    protected $commandMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_builderMock = $this->createMock(Builder::class);
-        $this->_logger = $this->getMockForAbstractClass(LoggerInterface::class);
-        $this->_commandMock = $this->createPartialMock(
+        $this->builderMock = $this->createMock(Builder::class);
+        $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
+        $this->commandMock = $this->createPartialMock(
             AbstractCommand::class,
             ['getId', '_execute', 'execute', 'chain']
         );
-        $this->_commandFactoryMock = $this->createPartialMock(
+        $this->commandFactoryMock = $this->createPartialMock(
             CommandFactory::class,
             ['create']
         );
-        $this->_commandFactoryMock->expects(
+        $this->commandFactoryMock->expects(
             $this->any()
         )->method(
             'create'
         )->willReturn(
-            $this->_commandMock
+            $this->commandMock
         );
 
-        $this->_commandMock->expects($this->any())->method('getId')->willReturn(true);
-        $this->_model = new Director($this->_commandFactoryMock);
+        $this->commandMock->expects($this->any())->method('getId')->willReturn(true);
+        $this->model = new Director($this->commandFactoryMock);
     }
 
-    public function testDirectWithExistKey()
+    /**
+     * @return void
+     */
+    public function testDirectWithExistKey(): void
     {
         $config = [['type' => 'update'], ['type' => 'remove'], ['type' => 'added']];
-        $this->_builderMock->expects($this->at(2))->method('processCommand')->with($this->_commandMock);
-        $this->_logger->expects($this->at(1))->method('debug');
-        $this->_commandMock->expects($this->at(1))->method('getId');
-        $this->_model->direct($config, $this->_builderMock, $this->_logger);
+        $this->builderMock
+            ->method('processCommand')
+            ->with($this->commandMock);
+        $this->logger
+            ->method('debug');
+        $this->commandMock
+            ->method('getId');
+        $this->model->direct($config, $this->builderMock, $this->logger);
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Model/UrlTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/UrlTest.php
@@ -35,47 +35,47 @@ class UrlTest extends TestCase
     /**
      * @var Url
      */
-    protected $_model;
+    protected $model;
 
     /**
      * @var string
      */
-    protected $_areaFrontName = 'backendArea';
+    protected $areaFrontName = 'backendArea';
 
     /**
      * @var MockObject
      */
-    protected $_menuMock;
+    protected $menuMock;
 
     /**
      * @var MockObject
      */
-    protected $_formKey;
+    protected $formKey;
 
     /**
      * @var MockObject
      */
-    protected $_scopeConfigMock;
+    protected $scopeConfigMock;
 
     /**
      * @var MockObject
      */
-    protected $_menuConfigMock;
+    protected $menuConfigMock;
 
     /**
      * @var MockObject
      */
-    protected $_backendHelperMock;
+    protected $backendHelperMock;
 
     /**
      * @var MockObject
      */
-    protected $_requestMock;
+    protected $requestMock;
 
     /**
      * @var MockObject
      */
-    protected $_authSessionMock;
+    protected $authSessionMock;
 
     /**
      * @var MockObject
@@ -85,7 +85,7 @@ class UrlTest extends TestCase
     /**
      * @var EncryptorInterface
      */
-    protected $_encryptor;
+    protected $encryptor;
 
     /**
      * @var Json|MockObject
@@ -93,23 +93,23 @@ class UrlTest extends TestCase
     private $serializerMock;
 
     /**
-     * @return void
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
-        $this->_menuMock = $this->getMockBuilder(Menu::class)
+        $this->menuMock = $this->getMockBuilder(Menu::class)
             ->addMethods(['getFirstAvailableChild'])
             ->onlyMethods(['get', 'getFirstAvailable'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->_menuConfigMock = $this->createMock(Config::class);
-        $this->_menuConfigMock->expects($this->any())->method('getMenu')->willReturn($this->_menuMock);
+        $this->menuConfigMock = $this->createMock(Config::class);
+        $this->menuConfigMock->expects($this->any())->method('getMenu')->willReturn($this->menuMock);
 
-        $this->_formKey = $this->createPartialMock(FormKey::class, ['getFormKey']);
-        $this->_formKey->expects($this->any())->method('getFormKey')->willReturn('salt');
+        $this->formKey = $this->createPartialMock(FormKey::class, ['getFormKey']);
+        $this->formKey->expects($this->any())->method('getFormKey')->willReturn('salt');
 
         $mockItem = $this->createMock(Item::class);
         $mockItem->expects($this->any())->method('isDisabled')->willReturn(false);
@@ -123,7 +123,7 @@ class UrlTest extends TestCase
         );
         $mockItem->expects($this->any())->method('getAction')->willReturn('adminhtml/user_role');
 
-        $this->_menuMock->expects(
+        $this->menuMock->expects(
             $this->any()
         )->method(
             'get'
@@ -139,10 +139,10 @@ class UrlTest extends TestCase
         )->method(
             'getAreaFrontName'
         )->willReturn(
-            $this->_areaFrontName
+            $this->areaFrontName
         );
-        $this->_scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
-        $this->_scopeConfigMock->expects(
+        $this->scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
+        $this->scopeConfigMock->expects(
             $this->any()
         )->method(
             'getValue'
@@ -152,9 +152,9 @@ class UrlTest extends TestCase
             'Magento_Backend::system_acl_roles'
         );
 
-        $this->_authSessionMock = $this->createMock(Session::class);
-        $this->_encryptor = $this->createPartialMock(Encryptor::class, ['getHash']);
-        $this->_encryptor->expects($this->any())
+        $this->authSessionMock = $this->createMock(Session::class);
+        $this->encryptor = $this->createPartialMock(Encryptor::class, ['getHash']);
+        $this->encryptor->expects($this->any())
             ->method('getHash')
             ->willReturnArgument(0);
         $routeParamsResolver = $this->createMock(RouteParamsResolver::class);
@@ -167,7 +167,7 @@ class UrlTest extends TestCase
         /** @var HostChecker|MockObject $hostCheckerMock */
         $hostCheckerMock = $this->createMock(HostChecker::class);
         $this->serializerMock = $this->getMockBuilder(Json::class)
-            ->setMethods(['serialize'])
+            ->onlyMethods(['serialize'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -178,25 +178,28 @@ class UrlTest extends TestCase
                     return json_encode($value);
                 }
             );
-        $this->_model = $objectManager->getObject(
+        $this->model = $objectManager->getObject(
             Url::class,
             [
-                'scopeConfig' => $this->_scopeConfigMock,
+                'scopeConfig' => $this->scopeConfigMock,
                 'backendHelper' => $helperMock,
-                'formKey' => $this->_formKey,
-                'menuConfig' => $this->_menuConfigMock,
-                'authSession' => $this->_authSessionMock,
-                'encryptor' => $this->_encryptor,
+                'formKey' => $this->formKey,
+                'menuConfig' => $this->menuConfigMock,
+                'authSession' => $this->authSessionMock,
+                'encryptor' => $this->encryptor,
                 'routeParamsResolverFactory' => $this->routeParamsResolverFactoryMock,
                 'hostChecker' => $hostCheckerMock,
                 'serializer' => $this->serializerMock
             ]
         );
-        $this->_requestMock = $this->createMock(Http::class);
-        $this->_model->setRequest($this->_requestMock);
+        $this->requestMock = $this->createMock(Http::class);
+        $this->model->setRequest($this->requestMock);
     }
 
-    public function testFindFirstAvailableMenuDenied()
+    /**
+     * @return void
+     */
+    public function testFindFirstAvailableMenuDenied(): void
     {
         $user = $this->createMock(User::class);
         $user->expects($this->once())->method('setHasAvailableResources')->with(false);
@@ -208,14 +211,17 @@ class UrlTest extends TestCase
 
         $mockSession->expects($this->any())->method('getUser')->willReturn($user);
 
-        $this->_model->setSession($mockSession);
+        $this->model->setSession($mockSession);
 
-        $this->_menuMock->expects($this->any())->method('getFirstAvailableChild')->willReturn(null);
+        $this->menuMock->expects($this->any())->method('getFirstAvailableChild')->willReturn(null);
 
-        $this->assertEquals('*/denied', $this->_model->findFirstAvailableMenu());
+        $this->assertEquals('*/denied', $this->model->findFirstAvailableMenu());
     }
 
-    public function testFindFirstAvailableMenu()
+    /**
+     * @return void
+     */
+    public function testFindFirstAvailableMenu(): void
     {
         $user = $this->createMock(User::class);
         $mockSession = $this->getMockBuilder(Session::class)
@@ -226,21 +232,27 @@ class UrlTest extends TestCase
 
         $mockSession->expects($this->any())->method('getUser')->willReturn($user);
 
-        $this->_model->setSession($mockSession);
+        $this->model->setSession($mockSession);
 
         $itemMock = $this->createMock(Item::class);
         $itemMock->expects($this->once())->method('getAction')->willReturn('adminhtml/user');
-        $this->_menuMock->expects($this->any())->method('getFirstAvailable')->willReturn($itemMock);
+        $this->menuMock->expects($this->any())->method('getFirstAvailable')->willReturn($itemMock);
 
-        $this->assertEquals('adminhtml/user', $this->_model->findFirstAvailableMenu());
+        $this->assertEquals('adminhtml/user', $this->model->findFirstAvailableMenu());
     }
 
-    public function testGetStartupPageUrl()
+    /**
+     * @return void
+     */
+    public function testGetStartupPageUrl(): void
     {
-        $this->assertEquals('adminhtml/user_role', (string)$this->_model->getStartupPageUrl());
+        $this->assertEquals('adminhtml/user_role', (string)$this->model->getStartupPageUrl());
     }
 
-    public function testGetAreaFrontName()
+    /**
+     * @return void
+     */
+    public function testGetAreaFrontName(): void
     {
         $helperMock = $this->createMock(Data::class);
         $helperMock->expects(
@@ -248,7 +260,7 @@ class UrlTest extends TestCase
         )->method(
             'getAreaFrontName'
         )->willReturn(
-            $this->_areaFrontName
+            $this->areaFrontName
         );
 
         $helper = new ObjectManager($this);
@@ -256,7 +268,7 @@ class UrlTest extends TestCase
             Url::class,
             [
                 'backendHelper' => $helperMock,
-                'authSession' => $this->_authSessionMock,
+                'authSession' => $this->authSessionMock,
                 'routeParamsResolverFactory' => $this->routeParamsResolverFactoryMock
             ]
         );
@@ -265,17 +277,19 @@ class UrlTest extends TestCase
 
     /**
      * Check that secret key generation is based on usage of routeName passed as method param
-     * Params are not equals
+     * Params are not equals.
+     *
+     * @return void
      */
-    public function testGetSecretKeyGenerationWithRouteNameAsParamNotEquals()
+    public function testGetSecretKeyGenerationWithRouteNameAsParamNotEquals(): void
     {
         $routeName = 'adminhtml';
         $controllerName = 'catalog';
         $actionName = 'index';
 
-        $keyWithRouteName = $this->_model->getSecretKey($routeName, $controllerName, $actionName);
-        $keyWithoutRouteName = $this->_model->getSecretKey(null, $controllerName, $actionName);
-        $keyDummyRouteName = $this->_model->getSecretKey('dummy', $controllerName, $actionName);
+        $keyWithRouteName = $this->model->getSecretKey($routeName, $controllerName, $actionName);
+        $keyWithoutRouteName = $this->model->getSecretKey(null, $controllerName, $actionName);
+        $keyDummyRouteName = $this->model->getSecretKey('dummy', $controllerName, $actionName);
 
         $this->assertNotEquals($keyWithRouteName, $keyWithoutRouteName);
         $this->assertNotEquals($keyWithRouteName, $keyDummyRouteName);
@@ -283,132 +297,100 @@ class UrlTest extends TestCase
 
     /**
      * Check that secret key generation is based on usage of routeName passed as method param
-     * Params are equals
+     * Params are equals.
+     *
+     * @return void
      */
-    public function testGetSecretKeyGenerationWithRouteNameAsParamEquals()
+    public function testGetSecretKeyGenerationWithRouteNameAsParamEquals(): void
     {
         $routeName = 'adminhtml';
         $controllerName = 'catalog';
         $actionName = 'index';
 
-        $keyWithRouteName1 = $this->_model->getSecretKey($routeName, $controllerName, $actionName);
-        $keyWithRouteName2 = $this->_model->getSecretKey($routeName, $controllerName, $actionName);
+        $keyWithRouteName1 = $this->model->getSecretKey($routeName, $controllerName, $actionName);
+        $keyWithRouteName2 = $this->model->getSecretKey($routeName, $controllerName, $actionName);
 
         $this->assertEquals($keyWithRouteName1, $keyWithRouteName2);
     }
 
     /**
-     * Check that secret key generation is based on usage of routeName extracted from request
+     * Check that secret key generation is based on usage of routeName extracted from request.
+     *
+     * @return void
      */
-    public function testGetSecretKeyGenerationWithRouteNameInRequest()
+    public function testGetSecretKeyGenerationWithRouteNameInRequest(): void
     {
         $routeName = 'adminhtml';
         $controllerName = 'catalog';
         $actionName = 'index';
 
-        $keyFromParams = $this->_model->getSecretKey($routeName, $controllerName, $actionName);
+        $keyFromParams = $this->model->getSecretKey($routeName, $controllerName, $actionName);
 
-        $this->_requestMock->expects(
+        $this->requestMock->expects(
             $this->exactly(3)
         )->method(
             'getBeforeForwardInfo'
         )->willReturn(
             null
         );
-        $this->_requestMock->expects($this->once())->method('getRouteName')->willReturn($routeName);
-        $this->_requestMock->expects(
+        $this->requestMock->expects($this->once())->method('getRouteName')->willReturn($routeName);
+        $this->requestMock->expects(
             $this->once()
         )->method(
             'getControllerName'
         )->willReturn(
             $controllerName
         );
-        $this->_requestMock->expects($this->once())->method('getActionName')->willReturn($actionName);
-        $this->_model->setRequest($this->_requestMock);
+        $this->requestMock->expects($this->once())->method('getActionName')->willReturn($actionName);
+        $this->model->setRequest($this->requestMock);
 
-        $keyFromRequest = $this->_model->getSecretKey();
+        $keyFromRequest = $this->model->getSecretKey();
         $this->assertEquals($keyFromParams, $keyFromRequest);
     }
 
     /**
-     * Check that secret key generation is based on usage of routeName extracted from request Forward info
+     * Check that secret key generation is based on usage of routeName extracted from request Forward info.
+     *
+     * @return void
      */
-    public function testGetSecretKeyGenerationWithRouteNameInForwardInfo()
+    public function testGetSecretKeyGenerationWithRouteNameInForwardInfo(): void
     {
         $routeName = 'adminhtml';
         $controllerName = 'catalog';
         $actionName = 'index';
 
-        $keyFromParams = $this->_model->getSecretKey($routeName, $controllerName, $actionName);
+        $keyFromParams = $this->model->getSecretKey($routeName, $controllerName, $actionName);
 
-        $this->_requestMock->expects(
-            $this->at(0)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'route_name'
-        )->willReturn(
-            'adminhtml'
-        );
+        $this->requestMock
+            ->method('getBeforeForwardInfo')
+            ->withConsecutive(
+                ['route_name'],
+                ['route_name'],
+                ['controller_name'],
+                ['controller_name'],
+                ['action_name'],
+                ['action_name']
+            )
+            ->willReturnOnConsecutiveCalls(
+                'adminhtml',
+                'adminhtml',
+                'catalog',
+                'catalog',
+                'index',
+                'index'
+            );
 
-        $this->_requestMock->expects(
-            $this->at(1)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'route_name'
-        )->willReturn(
-            'adminhtml'
-        );
-
-        $this->_requestMock->expects(
-            $this->at(2)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'controller_name'
-        )->willReturn(
-            'catalog'
-        );
-
-        $this->_requestMock->expects(
-            $this->at(3)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'controller_name'
-        )->willReturn(
-            'catalog'
-        );
-
-        $this->_requestMock->expects(
-            $this->at(4)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'action_name'
-        )->willReturn(
-            'index'
-        );
-
-        $this->_requestMock->expects(
-            $this->at(5)
-        )->method(
-            'getBeforeForwardInfo'
-        )->with(
-            'action_name'
-        )->willReturn(
-            'index'
-        );
-
-        $this->_model->setRequest($this->_requestMock);
-        $keyFromRequest = $this->_model->getSecretKey();
+        $this->model->setRequest($this->requestMock);
+        $keyFromRequest = $this->model->getSecretKey();
         $this->assertEquals($keyFromParams, $keyFromRequest);
     }
 
-    public function testGetUrlWithUrlInRoutePath()
+    /**
+     * @return void
+     */
+    public function testGetUrlWithUrlInRoutePath(): void
     {
         $routePath = 'https://localhost/index.php/catalog/product/view/id/100/?foo=bar#anchor';
-        static::assertEquals($routePath, $this->_model->getUrl($routePath));
+        static::assertEquals($routePath, $this->model->getUrl($routePath));
     }
 }

--- a/app/code/Magento/Backup/Test/Unit/Model/BackupFactoryTest.php
+++ b/app/code/Magento/Backup/Test/Unit/Model/BackupFactoryTest.php
@@ -19,107 +19,98 @@ class BackupFactoryTest extends TestCase
     /**
      * @var BackupFactory
      */
-    protected $_instance;
+    protected $instance;
 
     /**
      * @var ObjectManagerInterface
      */
-    protected $_objectManager;
+    protected $objectManager;
 
     /**
      * @var Collection
      */
-    protected $_fsCollection;
+    protected $fsCollection;
 
     /**
      * @var Backup
      */
-    protected $_backupModel;
+    protected $backupModel;
 
     /**
      * @var array
      */
-    protected $_data;
+    protected $data;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_data = [
+        $this->data = [
             'id' => '1385661590_snapshot',
             'time' => 1385661590,
             'path' => 'C:\test\test\var\backups',
             'name' => '',
-            'type' => 'snapshot',
+            'type' => 'snapshot'
         ];
-        $this->_fsCollection = $this->createMock(Collection::class);
-        $this->_fsCollection->expects(
-            $this->at(0)
-        )->method(
-            'getIterator'
-        )->willReturn(
-            new \ArrayIterator([new DataObject($this->_data)])
-        );
+        $this->fsCollection = $this->createMock(Collection::class);
+        $this->fsCollection
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([new DataObject($this->data)]));
 
-        $this->_backupModel = $this->createMock(Backup::class);
+        $this->backupModel = $this->createMock(Backup::class);
 
-        $this->_objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
-        $this->_objectManager->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            Collection::class
-        )->willReturn(
-            $this->_fsCollection
-        );
-        $this->_objectManager->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            Backup::class
-        )->willReturn(
-            $this->_backupModel
-        );
+        $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive([Collection::class], [Backup::class])
+            ->willReturnOnConsecutiveCalls($this->fsCollection, $this->backupModel);
 
-        $this->_instance = new BackupFactory($this->_objectManager);
+        $this->instance = new BackupFactory($this->objectManager);
     }
 
-    public function testCreate()
+    /**
+     * @return void
+     */
+    public function testCreate(): void
     {
-        $this->_backupModel->expects($this->once())
+        $this->backupModel->expects($this->once())
             ->method('setType')
-            ->with($this->_data['type'])
+            ->with($this->data['type'])
             ->willReturnSelf();
 
-        $this->_backupModel->expects($this->once())
+        $this->backupModel->expects($this->once())
             ->method('setTime')
-            ->with($this->_data['time'])
+            ->with($this->data['time'])
             ->willReturnSelf();
 
-        $this->_backupModel->expects($this->once())
+        $this->backupModel->expects($this->once())
             ->method('setName')
-            ->with($this->_data['name'])
+            ->with($this->data['name'])
             ->willReturnSelf();
 
-        $this->_backupModel->expects($this->once())
+        $this->backupModel->expects($this->once())
             ->method('setPath')
-            ->with($this->_data['path'])
+            ->with($this->data['path'])
             ->willReturnSelf();
 
-        $this->_backupModel->expects($this->once())
+        $this->backupModel->expects($this->once())
             ->method('setData')
             ->willReturnSelf();
 
-        $this->_instance->create('1385661590', 'snapshot');
+        $this->instance->create('1385661590', 'snapshot');
     }
 
-    public function testCreateInvalid()
+    /**
+     * @return void
+     */
+    public function testCreateInvalid(): void
     {
-        $this->_backupModel->expects($this->never())->method('setType');
-        $this->_backupModel->expects($this->never())->method('setTime');
-        $this->_backupModel->expects($this->never())->method('setName');
-        $this->_backupModel->expects($this->never())->method('setPath');
+        $this->backupModel->expects($this->never())->method('setType');
+        $this->backupModel->expects($this->never())->method('setTime');
+        $this->backupModel->expects($this->never())->method('setName');
+        $this->backupModel->expects($this->never())->method('setPath');
 
-        $this->_instance->create('451094400', 'snapshot');
+        $this->instance->create('451094400', 'snapshot');
     }
 }

--- a/app/code/Magento/Bundle/Test/Unit/Block/Catalog/Product/View/Type/BundleTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Block/Catalog/Product/View/Type/BundleTest.php
@@ -63,7 +63,7 @@ class BundleTest extends TestCase
     private $product;
 
     /**
-     * @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle
+     * @var BundleBlock
      */
     private $bundleBlock;
 
@@ -72,30 +72,39 @@ class BundleTest extends TestCase
      */
     private $escaperMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectHelper = new ObjectManager($this);
 
         $this->bundleProductPriceFactory = $this->getMockBuilder(PriceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->product = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getTypeInstance',
                     'getPriceInfo',
                     'getStoreId',
-                    'getPriceType',
-                    'hasPreconfiguredValues',
                     'getPreconfiguredValues'
                 ]
-            )->getMock();
+            )
+            ->addMethods(
+                [
+                    'getPriceType',
+                    'hasPreconfiguredValues',
+                    'getLowestPrice'
+                ]
+            )
+            ->getMock();
         $registry = $this->getMockBuilder(Registry::class)
             ->disableOriginalConstructor()
-            ->setMethods(['registry'])
+            ->onlyMethods(['registry'])
             ->getMock();
         $registry->expects($this->any())
             ->method('registry')
@@ -114,14 +123,14 @@ class BundleTest extends TestCase
             ->getMock();
         /** @var BundleBlock $bundleBlock */
         $this->bundleBlock = $objectHelper->getObject(
-            \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle::class,
+            BundleBlock::class,
             [
                 'registry' => $registry,
                 'eventManager' => $this->eventManager,
                 'jsonEncoder' => $this->jsonEncoder,
                 'productPrice' => $this->bundleProductPriceFactory,
                 'catalogProduct' => $this->catalogProduct,
-                'escaper' => $this->escaperMock,
+                'escaper' => $this->escaperMock
             ]
         );
 
@@ -136,17 +145,20 @@ class BundleTest extends TestCase
         );
     }
 
-    public function testGetOptionHtmlNoRenderer()
+    /**
+     * @return void
+     */
+    public function testGetOptionHtmlNoRenderer(): void
     {
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['getType'])
+            ->onlyMethods(['getType'])
             ->disableOriginalConstructor()
             ->getMock();
         $option->expects($this->any())->method('getType')->willReturn('checkbox');
         $this->escaperMock->expects($this->once())->method('escapeHtml')->willReturn('checkbox');
         $expected='There is no defined renderer for "checkbox" option type.';
         $layout = $this->getMockBuilder(Layout::class)
-            ->setMethods(['getChildName', 'getBlock'])
+            ->onlyMethods(['getChildName', 'getBlock'])
             ->disableOriginalConstructor()
             ->getMock();
         $layout->expects($this->any())->method('getChildName')->willReturn(false);
@@ -157,22 +169,24 @@ class BundleTest extends TestCase
         );
     }
 
-    public function testGetOptionHtml()
+    /**
+     * @return void
+     */
+    public function testGetOptionHtml(): void
     {
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['getType'])
+            ->onlyMethods(['getType'])
             ->disableOriginalConstructor()
             ->getMock();
         $option->expects($this->once())->method('getType')->willReturn('checkbox');
 
-        $optionBlock = $this->getMockBuilder(
-            Checkbox::class
-        )->setMethods(['setOption', 'toHtml'])->disableOriginalConstructor()
+        $optionBlock = $this->getMockBuilder(Checkbox::class)
+            ->onlyMethods(['setOption', 'toHtml'])->disableOriginalConstructor()
             ->getMock();
         $optionBlock->expects($this->any())->method('setOption')->willReturnSelf();
         $optionBlock->expects($this->any())->method('toHtml')->willReturn('option html');
         $layout = $this->getMockBuilder(Layout::class)
-            ->setMethods(['getChildName', 'getBlock'])
+            ->onlyMethods(['getChildName', 'getBlock'])
             ->disableOriginalConstructor()
             ->getMock();
         $layout->expects($this->any())->method('getChildName')->willReturn('name');
@@ -182,7 +196,10 @@ class BundleTest extends TestCase
         $this->assertEquals('option html', $this->bundleBlock->getOptionHtml($option));
     }
 
-    public function testGetJsonConfigFixedPriceBundleNoOption()
+    /**
+     * @return void
+     */
+    public function testGetJsonConfigFixedPriceBundleNoOption(): void
     {
         $options = [];
         $finalPriceMock = $this->getPriceMock(
@@ -190,9 +207,9 @@ class BundleTest extends TestCase
                 'getPriceWithoutOption' => new DataObject(
                     [
                         'value' => 100,
-                        'base_amount' => 100,
+                        'base_amount' => 100
                     ]
-                ),
+                )
             ]
         );
         $regularPriceMock = $this->getPriceMock(
@@ -200,14 +217,14 @@ class BundleTest extends TestCase
                 'getAmount' => new DataObject(
                     [
                         'value' => 110,
-                        'base_amount' => 110,
+                        'base_amount' => 110
                     ]
-                ),
+                )
             ]
         );
         $prices = [
             FinalPrice::PRICE_CODE => $finalPriceMock,
-            RegularPrice::PRICE_CODE => $regularPriceMock,
+            RegularPrice::PRICE_CODE => $regularPriceMock
         ];
         $priceInfo = $this->getPriceInfoMock($prices);
 
@@ -222,7 +239,10 @@ class BundleTest extends TestCase
         $this->assertEquals(100, $jsonConfig['prices']['finalPrice']['amount']);
     }
 
-    public function testGetJsonConfigFixedPriceBundle()
+    /**
+     * @return void
+     */
+    public function testGetJsonConfigFixedPriceBundle(): void
     {
         $optionId = 1;
         $optionQty = 2;
@@ -236,7 +256,7 @@ class BundleTest extends TestCase
                 [
                     ['price' => new DataObject(
                         ['base_amount' => $baseAmount, 'value' => $basePriceValue]
-                    )],
+                    )]
                 ],
                 true,
                 true
@@ -244,16 +264,15 @@ class BundleTest extends TestCase
         ];
         $bundleProductPrice = $this->getMockBuilder(Price::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getLowestPrice'])
+            ->onlyMethods(['getLowestPrice'])
             ->getMock();
-        $bundleProductPrice->expects($this->at(0))
+        $this->product
             ->method('getLowestPrice')
-            ->with($this->product, $baseAmount)
-            ->willReturn(999);
-        $bundleProductPrice->expects($this->at(1))
-            ->method('getLowestPrice')
-            ->with($this->product, $basePriceValue)
-            ->willReturn(888);
+            ->withConsecutive(
+                [$this->product, $baseAmount],
+                [$this->product, $basePriceValue]
+            )
+            ->willReturnOnConsecutiveCalls(999, 888);
         $this->bundleProductPriceFactory->expects($this->once())
             ->method('create')
             ->willReturn($bundleProductPrice);
@@ -264,9 +283,9 @@ class BundleTest extends TestCase
                 'getPriceWithoutOption' => new DataObject(
                     [
                         'value' => 100,
-                        'base_amount' => 100,
+                        'base_amount' => 100
                     ]
-                ),
+                )
             ]
         );
         $regularPriceMock = $this->getPriceMock(
@@ -274,9 +293,9 @@ class BundleTest extends TestCase
                 'getAmount' => new DataObject(
                     [
                         'value' => 110,
-                        'base_amount' => 110,
+                        'base_amount' => 110
                     ]
-                ),
+                )
             ]
         );
         $bundleOptionPriceMock = $this->getAmountPriceMock(
@@ -288,7 +307,7 @@ class BundleTest extends TestCase
             'bundle_option' => $bundleOptionPriceMock,
             'bundle_option_regular_price' => $bundleOptionPriceMock,
             FinalPrice::PRICE_CODE => $finalPriceMock,
-            RegularPrice::PRICE_CODE => $regularPriceMock,
+            RegularPrice::PRICE_CODE => $regularPriceMock
         ];
         $priceInfo = $this->getPriceInfoMock($prices);
 
@@ -298,11 +317,11 @@ class BundleTest extends TestCase
         $preconfiguredValues = new DataObject(
             [
                 'bundle_option' => [
-                    $optionId => [123123111],
+                    $optionId => [123123111]
                 ],
                 'bundle_option_qty' => [
-                    $optionId => $optionQty,
-                ],
+                    $optionId => $optionQty
+                ]
             ]
         );
         $this->product->expects($this->once())
@@ -325,10 +344,11 @@ class BundleTest extends TestCase
     /**
      * @param array $options
      * @param Base|MockObject $priceInfo
-     * @param string $priceType
+     * @param int $priceType
+     *
      * @return void
      */
-    private function updateBundleBlock($options, $priceInfo, $priceType)
+    private function updateBundleBlock(array $options, Base $priceInfo, int $priceType): void
     {
         $this->eventManager->expects($this->any())->method('dispatch')->willReturn(true);
         $optionCollection = $this->getMockBuilder(Collection::class)
@@ -372,24 +392,27 @@ class BundleTest extends TestCase
 
     /**
      * @param $price
-     * @return MockObject
+     *
+     * @return MockObject|Base
      */
-    private function getPriceInfoMock($price)
+    private function getPriceInfoMock($price): Base
     {
         $priceInfoMock = $this->getMockBuilder(Base::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPrice'])
+            ->onlyMethods(['getPrice'])
             ->getMock();
 
         if (is_array($price)) {
-            $counter = 0;
+            $withArgs = $willReturnArgs = [];
+
             foreach ($price as $priceType => $priceValue) {
-                $priceInfoMock->expects($this->at($counter))
-                    ->method('getPrice')
-                    ->with($priceType)
-                    ->willReturn($priceValue);
-                $counter++;
+                $withArgs[] = [$priceType];
+                $willReturnArgs[] = $priceValue;
             }
+            $priceInfoMock
+                ->method('getPrice')
+                ->withConsecutive(...$withArgs)
+                ->willReturnOnConsecutiveCalls(...$willReturnArgs);
         } else {
             $priceInfoMock->expects($this->any())
                 ->method('getPrice')
@@ -400,18 +423,32 @@ class BundleTest extends TestCase
 
     /**
      * @param $prices
+     *
      * @return MockObject
      */
-    private function getPriceMock($prices)
+    private function getPriceMock($prices): MockObject
     {
-        $methods = [];
+        $onlyMethods = $addMethods = [];
+
         foreach (array_keys($prices) as $methodName) {
-            $methods[] = $methodName;
+            if (method_exists(BasePrice::class, $methodName)) {
+                $onlyMethods[] = $methodName;
+            } else {
+                $addMethods[] = $methodName;
+            }
         }
-        $priceMock = $this->getMockBuilder(BasePrice::class)
-            ->disableOriginalConstructor()
-            ->setMethods($methods)
-            ->getMock();
+        $priceMockBuilder = $this->getMockBuilder(BasePrice::class)
+            ->disableOriginalConstructor();
+
+        if ($onlyMethods) {
+            $priceMockBuilder->onlyMethods($onlyMethods);
+        }
+
+        if ($addMethods) {
+            $priceMockBuilder->addMethods($addMethods);
+        }
+        $priceMock = $priceMockBuilder->getMock();
+
         foreach ($prices as $methodName => $amount) {
             $priceMock->expects($this->any())
                 ->method($methodName)
@@ -425,13 +462,14 @@ class BundleTest extends TestCase
      * @param float $value
      * @param mixed $baseAmount
      * @param array $selectionAmounts
+     *
      * @return AmountInterface|MockObject
      */
-    private function getAmountPriceMock($value, $baseAmount, array $selectionAmounts)
+    private function getAmountPriceMock($value, $baseAmount, array $selectionAmounts): AmountInterface
     {
-        $amountPrice = $this->getMockBuilder(AmountInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getValue', 'getBaseAmount', 'getOptionSelectionAmount'])
+        $amountPrice = $this->getMockBuilder(AmountInterface::class)->disableOriginalConstructor()
+            ->onlyMethods(['getValue', 'getBaseAmount'])
+            ->addMethods(['getOptionSelectionAmount'])
             ->getMockForAbstractClass();
         $amountPrice->expects($this->any())->method('getValue')->willReturn($value);
         $amountPrice->expects($this->any())->method('getBaseAmount')->willReturn($baseAmount);
@@ -443,7 +481,7 @@ class BundleTest extends TestCase
                     new DataObject(
                         [
                             'value' => $selectionAmount['value'],
-                            'base_amount' => $selectionAmount['base_amount'],
+                            'base_amount' => $selectionAmount['base_amount']
                         ]
                     )
                 );
@@ -455,9 +493,10 @@ class BundleTest extends TestCase
     /**
      * @param int $id
      * @param string $title
-     * @param \Magento\Catalog\Model\Product[] $selections
+     * @param Product[]|MockObject[] $selections
      * @param int|string $type
      * @param bool $isRequired
+     *
      * @return MockObject
      * @internal param bool $isDefault
      */
@@ -470,22 +509,15 @@ class BundleTest extends TestCase
     ) {
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getId',
-                    'getTitle',
-                    'getSelections',
-                    'getType',
-                    'getRequired',
-                    'getIsDefault',
-                ]
-            )
+            ->onlyMethods(['getId', 'getTitle', 'getType', 'getRequired'])
+            ->addMethods(['getSelections', 'getIsDefault'])
             ->getMockForAbstractClass();
         $option->expects($this->any())->method('getId')->willReturn($id);
         $option->expects($this->any())->method('getTitle')->willReturn($title);
         $option->expects($this->any())->method('getSelections')->willReturn($selections);
         $option->expects($this->any())->method('getType')->willReturn($type);
         $option->expects($this->any())->method('getRequired')->willReturn($isRequired);
+
         return $option;
     }
 
@@ -497,7 +529,8 @@ class BundleTest extends TestCase
      * @param bool $isCanChangeQty
      * @param bool $isDefault
      * @param bool $isSalable
-     * @return \Magento\Catalog\Model\Product|MockObject
+     *
+     * @return Product|MockObject
      */
     private function createOptionSelection(
         $id,
@@ -509,27 +542,16 @@ class BundleTest extends TestCase
         $isSalable = true
     ) {
         $selection = $this->getMockBuilder(\Magento\Catalog\Model\Product::class)
-            ->setMethods(
-                [
-                    'getSelectionId',
-                    'getName',
-                    'getSelectionQty',
-                    'getPriceInfo',
-                    'getSelectionCanChangeQty',
-                    'getIsDefault',
-                    'isSalable'
-                ]
-            )
+            ->onlyMethods(['getName', 'getPriceInfo', 'isSalable'])
+            ->addMethods(['getSelectionId', 'getSelectionQty', 'getSelectionCanChangeQty', 'getIsDefault'])
             ->disableOriginalConstructor()
             ->getMock();
-        $tierPrice = $this->getMockBuilder(TierPrice::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getTierPriceList'])
+        $tierPrice = $this->getMockBuilder(TierPrice::class)->disableOriginalConstructor()
+            ->onlyMethods(['getTierPriceList'])
             ->getMock();
         $tierPrice->expects($this->any())->method('getTierPriceList')->willReturn($tierPriceList);
-        $priceInfo = $this->getMockBuilder(Base::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getPrice'])
+        $priceInfo = $this->getMockBuilder(Base::class)->disableOriginalConstructor()
+            ->onlyMethods(['getPrice'])
             ->getMock();
         $priceInfo->expects($this->any())->method('getPrice')->willReturn($tierPrice);
         $selection->expects($this->any())->method('getSelectionId')->willReturn($id);
@@ -544,10 +566,12 @@ class BundleTest extends TestCase
     }
 
     /**
-     * @dataProvider getOptionsDataProvider
      * @param bool $stripSelection
+     *
+     * @return void
+     * @dataProvider getOptionsDataProvider
      */
-    public function testGetOptions($stripSelection)
+    public function testGetOptions(bool $stripSelection): void
     {
         $newOptions = ['option_1', 'option_2'];
 
@@ -582,7 +606,7 @@ class BundleTest extends TestCase
     /**
      * @return array
      */
-    public function getOptionsDataProvider()
+    public function getOptionsDataProvider(): array
     {
         return [
             [true],

--- a/app/code/Magento/Bundle/Test/Unit/Helper/Catalog/Product/ConfigurationTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Helper/Catalog/Product/ConfigurationTest.php
@@ -57,6 +57,9 @@ class ConfigurationTest extends TestCase
      */
     private $serializer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->pricingHelper = $this->createPartialMock(Data::class, ['currency']);
@@ -67,7 +70,7 @@ class ConfigurationTest extends TestCase
             ->onlyMethods(['getProduct', 'getOptionByCode', 'getFileDownloadParams'])
             ->getMockForAbstractClass();
         $this->serializer = $this->getMockBuilder(Json::class)
-            ->setMethods(['unserialize'])
+            ->onlyMethods(['unserialize'])
             ->getMockForAbstractClass();
 
         $this->serializer->expects($this->any())
@@ -89,7 +92,10 @@ class ConfigurationTest extends TestCase
         );
     }
 
-    public function testGetSelectionQty()
+    /**
+     * @return void
+     */
+    public function testGetSelectionQty(): void
     {
         $selectionId = 15;
         $selectionQty = 35;
@@ -111,7 +117,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($selectionQty, $this->helper->getSelectionQty($product, $selectionId));
     }
 
-    public function testGetSelectionQtyIfCustomOptionIsNotSet()
+    /**
+     * @return void
+     */
+    public function testGetSelectionQtyIfCustomOptionIsNotSet(): void
     {
         $selectionId = 15;
         $product = $this->createMock(Product::class);
@@ -122,7 +131,10 @@ class ConfigurationTest extends TestCase
         $this->assertEquals(0, $this->helper->getSelectionQty($product, $selectionId));
     }
 
-    public function testGetSelectionFinalPrice()
+    /**
+     * @return void
+     */
+    public function testGetSelectionFinalPrice(): void
     {
         $itemQty = 2;
 
@@ -140,11 +152,13 @@ class ConfigurationTest extends TestCase
         $this->helper->getSelectionFinalPrice($this->item, $selectionProduct);
     }
 
-    public function testGetBundleOptionsEmptyBundleOptionsIds()
+    /**
+     * @return void
+     */
+    public function testGetBundleOptionsEmptyBundleOptionsIds(): void
     {
         $typeInstance = $this->createMock(Type::class);
-        $product = $this->createPartialMock(Product::class, ['getTypeInstance',
-            '__wakeup']);
+        $product = $this->createPartialMock(Product::class, ['getTypeInstance', '__wakeup']);
 
         $product->expects($this->once())->method('getTypeInstance')->willReturn($typeInstance);
         $this->item->expects($this->once())->method('getProduct')->willReturn($product);
@@ -154,12 +168,14 @@ class ConfigurationTest extends TestCase
         $this->assertEquals([], $this->helper->getBundleOptions($this->item));
     }
 
-    public function testGetBundleOptionsEmptyBundleSelectionIds()
+    /**
+     * @return void
+     */
+    public function testGetBundleOptionsEmptyBundleSelectionIds(): void
     {
         $optionIds = '{"0":"1"}';
         $collection = $this->createMock(Collection::class);
-        $product = $this->createPartialMock(Product::class, ['getTypeInstance',
-            '__wakeup']);
+        $product = $this->createPartialMock(Product::class, ['getTypeInstance', '__wakeup']);
         $typeInstance = $this->createPartialMock(Type::class, ['getOptionsByIds']);
         $selectionOption = $this->createPartialMock(
             OptionInterface::class,
@@ -189,22 +205,19 @@ class ConfigurationTest extends TestCase
         $this->item->expects($this->once())
             ->method('getProduct')
             ->willReturn($product);
-        $this->item->expects($this->at(1))
+        $this->item
             ->method('getOptionByCode')
-            ->with('bundle_option_ids')
-            ->willReturn($itemOption);
-        $this->item->expects($this->at(2))
-            ->method('getOptionByCode')
-            ->with('bundle_selection_ids')
-            ->willReturn($selectionOption);
+            ->withConsecutive(['bundle_option_ids'], ['bundle_selection_ids'])
+            ->willReturnOnConsecutiveCalls($itemOption, $selectionOption);
 
         $this->assertEquals([], $this->helper->getBundleOptions($this->item));
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $optionIds = '{"0":"1"}';
         $selectionIds =  '{"0":"2"}';
@@ -276,10 +289,10 @@ class ConfigurationTest extends TestCase
         $product->expects($this->once())->method('getName')->willReturn('name');
         $product->expects($this->once())->method('getPriceModel')->willReturn($priceModel);
         $this->item->expects($this->any())->method('getProduct')->willReturn($product);
-        $this->item->expects($this->at(1))->method('getOptionByCode')->with('bundle_option_ids')
-            ->willReturn($itemOption);
-        $this->item->expects($this->at(2))->method('getOptionByCode')->with('bundle_selection_ids')
-            ->willReturn($selectionOption);
+        $this->item
+            ->method('getOptionByCode')
+            ->withConsecutive(['bundle_option_ids'], ['bundle_selection_ids'])
+            ->willReturnOnConsecutiveCalls($itemOption, $selectionOption);
         $this->productConfiguration->expects($this->once())->method('getCustomOptions')->with($this->item)
             ->willReturn([0 => ['label' => 'title', 'value' => 'value']]);
 
@@ -288,9 +301,9 @@ class ConfigurationTest extends TestCase
                 [
                     'label' => 'title',
                     'value' => ['1 x name <span class="price">$15.00</span>'],
-                    'has_html' => true,
+                    'has_html' => true
                 ],
-                ['label' => 'title', 'value' => 'value'],
+                ['label' => 'title', 'value' => 'value']
             ],
             $this->helper->getOptions($this->item)
         );

--- a/app/code/Magento/Bundle/Test/Unit/Model/LinkManagementTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/LinkManagementTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -31,7 +30,6 @@ use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -141,11 +139,6 @@ class LinkManagementTest extends TestCase
     private $linkField = 'product_id';
 
     /**
-     * @var WebsiteInterface|MockObject
-     */
-    private $websiteMock;
-
-    /**
      * @inheritDoc
      */
     protected function setUp(): void
@@ -153,19 +146,20 @@ class LinkManagementTest extends TestCase
         $helper = new ObjectManager($this);
 
         $this->productRepository = $this->getMockBuilder(ProductRepository::class)
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->productType = $this->getMockBuilder(\Magento\Bundle\Model\Product\Type::class)
-            ->setMethods(['getOptionsCollection', 'setStoreFilter', 'getSelectionsCollection', 'getOptionsIds'])
+            ->onlyMethods(['getOptionsCollection', 'setStoreFilter', 'getSelectionsCollection', 'getOptionsIds'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->option = $this->getMockBuilder(Option::class)
-            ->setMethods(['getSelections', 'getOptionId', '__wakeup'])
+            ->onlyMethods(['getOptionId', '__wakeup'])
+            ->addMethods(['getSelections'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->optionCollection = $this->getMockBuilder(OptionCollection::class)
-            ->setMethods(['appendSelections'])
+            ->onlyMethods(['appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->selectionCollection = $this->getMockBuilder(
@@ -173,14 +167,14 @@ class LinkManagementTest extends TestCase
         )->disableOriginalConstructor()
             ->getMock();
         $this->product = $this->getMockBuilder(Product::class)
-            ->setMethods(['getTypeInstance', 'getStoreId', 'getTypeId', '__wakeup', 'getId', 'getData'])
+            ->onlyMethods(['getTypeInstance', 'getStoreId', 'getTypeId', '__wakeup', 'getId', 'getData'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->link = $this->getMockBuilder(LinkInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->linkFactory = $this->getMockBuilder(LinkInterfaceFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->bundleSelectionMock = $this->createPartialMock(
@@ -210,8 +204,6 @@ class LinkManagementTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->websiteMock = $this->getMockForAbstractClass( WebsiteInterface::class);
-
         $this->model = $helper->getObject(
             LinkManagement::class,
             [
@@ -227,7 +219,10 @@ class LinkManagementTest extends TestCase
         );
     }
 
-    public function testGetChildren()
+    /**
+     * @return void
+     */
+    public function testGetChildren(): void
     {
         $productSku = 'productSku';
 
@@ -284,7 +279,10 @@ class LinkManagementTest extends TestCase
         $this->assertEquals([$this->link], $this->model->getChildren($productSku));
     }
 
-    public function testGetChildrenWithOptionId()
+    /**
+     * @return void
+     */
+    public function testGetChildrenWithOptionId(): void
     {
         $productSku = 'productSku';
 
@@ -332,7 +330,10 @@ class LinkManagementTest extends TestCase
         $this->assertEquals([], $this->model->getChildren($productSku, 1));
     }
 
-    public function testGetChildrenException()
+    /**
+     * @return void
+     */
+    public function testGetChildrenException(): void
     {
         $this->expectException(InputException::class);
 
@@ -350,7 +351,10 @@ class LinkManagementTest extends TestCase
         $this->assertEquals([$this->link], $this->model->getChildren($productSku));
     }
 
-    public function testAddChildToNotBundleProduct()
+    /**
+     * @return void
+     */
+    public function testAddChildToNotBundleProduct(): void
     {
         $this->expectException(InputException::class);
 
@@ -365,7 +369,10 @@ class LinkManagementTest extends TestCase
         $this->model->addChild($productMock, 1, $productLink);
     }
 
-    public function testAddChildNonExistingOption()
+    /**
+     * @return void
+     */
+    public function testAddChildNonExistingOption(): void
     {
         $this->expectException(InputException::class);
 
@@ -381,7 +388,7 @@ class LinkManagementTest extends TestCase
 
         $emptyOption = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->getMock();
         $emptyOption->expects($this->once())
             ->method('getId')
@@ -402,7 +409,10 @@ class LinkManagementTest extends TestCase
         $this->model->addChild($productMock, 1, $productLink);
     }
 
-    public function testAddChildLinkedProductIsComposite()
+    /**
+     * @return void
+     */
+    public function testAddChildLinkedProductIsComposite(): void
     {
         $this->expectException(InputException::class);
         $this->expectExceptionMessage('The bundle product can\'t contain another composite product.');
@@ -439,7 +449,7 @@ class LinkManagementTest extends TestCase
 
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->getMock();
         $option->expects($this->once())->method('getId')->willReturn(1);
 
@@ -460,12 +470,16 @@ class LinkManagementTest extends TestCase
         $this->model->addChild($productMock, 1, $productLink);
     }
 
-    public function testAddChildProductAlreadyExistsInOption()
+    /**
+     * @return void
+     */
+    public function testAddChildProductAlreadyExistsInOption(): void
     {
         $this->expectException(CouldNotSaveException::class);
 
         $productLink = $this->getMockBuilder(LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->onlyMethods(['getSku', 'getOptionId'])
+            ->addMethods(['getSelectionId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->method('getSku')->willReturn('linked_product_sku');
@@ -505,7 +519,7 @@ class LinkManagementTest extends TestCase
 
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->getMock();
         $option->expects($this->once())
             ->method('getId')
@@ -524,7 +538,7 @@ class LinkManagementTest extends TestCase
 
         $selections = [
             ['option_id' => 1, 'product_id' => 12, 'parent_product_id' => 'product_id'],
-            ['option_id' => 1, 'product_id' => 13, 'parent_product_id' => 'product_id'],
+            ['option_id' => 1, 'product_id' => 13, 'parent_product_id' => 'product_id']
         ];
         $bundle = $this->createMock(Bundle::class);
         $bundle->expects($this->once())
@@ -537,12 +551,16 @@ class LinkManagementTest extends TestCase
         $this->model->addChild($productMock, 1, $productLink);
     }
 
-    public function testAddChildCouldNotSave()
+    /**
+     * @return void
+     */
+    public function testAddChildCouldNotSave(): void
     {
         $this->expectException(CouldNotSaveException::class);
 
         $productLink = $this->getMockBuilder(LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->onlyMethods(['getSku', 'getOptionId'])
+            ->addMethods(['getSelectionId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->method('getSku')->willReturn('linked_product_sku');
@@ -576,7 +594,7 @@ class LinkManagementTest extends TestCase
 
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->getMock();
         $option->expects($this->once())->method('getId')->willReturn(1);
 
@@ -616,10 +634,14 @@ class LinkManagementTest extends TestCase
         $this->model->addChild($productMock, 1, $productLink);
     }
 
-    public function testAddChild()
+    /**
+     * @return void
+     */
+    public function testAddChild(): void
     {
         $productLink = $this->getMockBuilder(LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->onlyMethods(['getSku', 'getOptionId'])
+            ->addMethods(['getSelectionId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->method('getSku')->willReturn('linked_product_sku');
@@ -649,7 +671,7 @@ class LinkManagementTest extends TestCase
 
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->getMock();
         $option->expects($this->once())->method('getId')->willReturn(1);
 
@@ -666,7 +688,7 @@ class LinkManagementTest extends TestCase
 
         $selections = [
             ['option_id' => 1, 'product_id' => 11],
-            ['option_id' => 1, 'product_id' => 12],
+            ['option_id' => 1, 'product_id' => 12]
         ];
         $bundle = $this->createMock(Bundle::class);
         $bundle->expects($this->once())->method('getSelectionsData')
@@ -682,7 +704,10 @@ class LinkManagementTest extends TestCase
         $this->assertEquals(42, $result);
     }
 
-    public function testSaveChild()
+    /**
+     * @return void
+     */
+    public function testSaveChild(): void
     {
         $id = 12;
         $optionId = 1;
@@ -697,7 +722,8 @@ class LinkManagementTest extends TestCase
         $bundleProductSku = 'bundleProductSku';
 
         $productLink = $this->getMockBuilder(LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->onlyMethods(['getSku', 'getOptionId'])
+            ->addMethods(['getSelectionId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->method('getSku')->willReturn('linked_product_sku');
@@ -724,15 +750,9 @@ class LinkManagementTest extends TestCase
         $linkedProductMock->method('getId')->willReturn($linkProductId);
         $linkedProductMock->expects($this->once())->method('isComposite')->willReturn(false);
         $this->productRepository
-            ->expects($this->at(0))
             ->method('get')
-            ->with($bundleProductSku)
-            ->willReturn($productMock);
-        $this->productRepository
-            ->expects($this->at(1))
-            ->method('get')
-            ->with('linked_product_sku')
-            ->willReturn($linkedProductMock);
+            ->withConsecutive([$bundleProductSku], ['linked_product_sku'])
+            ->willReturnOnConsecutiveCalls($productMock, $linkedProductMock);
 
         $store = $this->createMock(Store::class);
         $this->storeManagerMock->method('getStore')->willReturn($store);
@@ -749,7 +769,7 @@ class LinkManagementTest extends TestCase
                     'setSelectionPriceType',
                     'setSelectionPriceValue',
                     'setSelectionCanChangeQty',
-                    'setIsDefault',
+                    'setIsDefault'
                 ]
             )
             ->onlyMethods(['save', 'getId', 'load'])
@@ -772,7 +792,10 @@ class LinkManagementTest extends TestCase
         $this->assertTrue($this->model->saveChild($bundleProductSku, $productLink));
     }
 
-    public function testSaveChildFailedToSave()
+    /**
+     * @return void
+     */
+    public function testSaveChildFailedToSave(): void
     {
         $this->expectException(CouldNotSaveException::class);
 
@@ -781,7 +804,8 @@ class LinkManagementTest extends TestCase
         $parentProductId = 32;
 
         $productLink = $this->getMockBuilder(LinkInterface::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId'])
+            ->onlyMethods(['getSku', 'getOptionId'])
+            ->addMethods(['getSelectionId'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $productLink->method('getSku')->willReturn('linked_product_sku');
@@ -806,14 +830,10 @@ class LinkManagementTest extends TestCase
         $linkedProductMock->expects($this->once())
             ->method('isComposite')
             ->willReturn(false);
-        $this->productRepository->expects($this->at(0))
+        $this->productRepository
             ->method('get')
-            ->with($bundleProductSku)
-            ->willReturn($productMock);
-        $this->productRepository->expects($this->at(1))
-            ->method('get')
-            ->with('linked_product_sku')
-            ->willReturn($linkedProductMock);
+            ->withConsecutive([$bundleProductSku], ['linked_product_sku'])
+            ->willReturnOnConsecutiveCalls($productMock, $linkedProductMock);
 
         $store = $this->createMock(Store::class);
         $this->storeManagerMock->method('getStore')
@@ -859,7 +879,10 @@ class LinkManagementTest extends TestCase
         $this->model->saveChild($bundleProductSku, $productLink);
     }
 
-    public function testSaveChildWithoutId()
+    /**
+     * @return void
+     */
+    public function testSaveChildWithoutId(): void
     {
         $this->expectException(InputException::class);
 
@@ -878,19 +901,18 @@ class LinkManagementTest extends TestCase
         $linkedProductMock->expects($this->once())
             ->method('isComposite')
             ->willReturn(false);
-        $this->productRepository->expects($this->at(0))
+        $this->productRepository
             ->method('get')
-            ->with($bundleProductSku)
-            ->willReturn($productMock);
-        $this->productRepository->expects($this->at(1))
-            ->method('get')
-            ->with($linkedProductSku)
-            ->willReturn($linkedProductMock);
+            ->withConsecutive([$bundleProductSku], [$linkedProductSku])
+            ->willReturnOnConsecutiveCalls($productMock, $linkedProductMock);
 
         $this->model->saveChild($bundleProductSku, $productLink);
     }
 
-    public function testSaveChildWithInvalidId()
+    /**
+     * @return void
+     */
+    public function testSaveChildWithInvalidId(): void
     {
         $this->expectException(InputException::class);
         $this->expectExceptionMessage(
@@ -913,20 +935,16 @@ class LinkManagementTest extends TestCase
         $linkedProductMock->expects($this->once())
             ->method('isComposite')
             ->willReturn(false);
-        $this->productRepository->expects($this->at(0))
+        $this->productRepository
             ->method('get')
-            ->with($bundleProductSku)
-            ->willReturn($productMock);
-        $this->productRepository->expects($this->at(1))
-            ->method('get')
-            ->with($linkedProductSku)
-            ->willReturn($linkedProductMock);
+            ->withConsecutive([$bundleProductSku], [$linkedProductSku])
+            ->willReturnOnConsecutiveCalls($productMock, $linkedProductMock);
 
         $selection = $this->createPartialMock(
             Selection::class,
             [
                 'getId',
-                'load',
+                'load'
             ]
         );
         $selection->expects($this->once())
@@ -942,7 +960,10 @@ class LinkManagementTest extends TestCase
         $this->model->saveChild($bundleProductSku, $productLink);
     }
 
-    public function testSaveChildWithCompositeProductLink()
+    /**
+     * @return void
+     */
+    public function testSaveChildWithCompositeProductLink(): void
     {
         $this->expectException(InputException::class);
 
@@ -958,19 +979,18 @@ class LinkManagementTest extends TestCase
 
         $linkedProductMock = $this->createMock(Product::class);
         $linkedProductMock->expects($this->once())->method('isComposite')->willReturn(true);
-        $this->productRepository->expects($this->at(0))
+        $this->productRepository
             ->method('get')
-            ->with($bundleProductSku)
-            ->willReturn($productMock);
-        $this->productRepository->expects($this->at(1))
-            ->method('get')
-            ->with($linkedProductSku)
-            ->willReturn($linkedProductMock);
+            ->withConsecutive([$bundleProductSku], [$linkedProductSku])
+            ->willReturnOnConsecutiveCalls($productMock, $linkedProductMock);
 
         $this->model->saveChild($bundleProductSku, $productLink);
     }
 
-    public function testSaveChildWithSimpleProduct()
+    /**
+     * @return void
+     */
+    public function testSaveChildWithSimpleProduct(): void
     {
         $this->expectException(InputException::class);
 
@@ -993,7 +1013,10 @@ class LinkManagementTest extends TestCase
         $this->model->saveChild($bundleProductSku, $productLink);
     }
 
-    public function testRemoveChild()
+    /**
+     * @return void
+     */
+    public function testRemoveChild(): void
     {
         $this->productRepository->method('get')->willReturn($this->product);
         $bundle = $this->createMock(Bundle::class);
@@ -1011,7 +1034,8 @@ class LinkManagementTest extends TestCase
         $this->getRemoveOptions();
 
         $selection = $this->getMockBuilder(Selection::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId', '__wakeup'])
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId'])
             ->disableOriginalConstructor()
             ->getMock();
         $selection->method('getSku')->willReturn($childSku);
@@ -1031,7 +1055,10 @@ class LinkManagementTest extends TestCase
         $this->assertTrue($this->model->removeChild($productSku, $optionId, $childSku));
     }
 
-    public function testRemoveChildForbidden()
+    /**
+     * @return void
+     */
+    public function testRemoveChildForbidden(): void
     {
         $this->expectException(InputException::class);
 
@@ -1044,7 +1071,10 @@ class LinkManagementTest extends TestCase
         $this->model->removeChild($productSku, $optionId, $childSku);
     }
 
-    public function testRemoveChildInvalidOptionId()
+    /**
+     * @return void
+     */
+    public function testRemoveChildInvalidOptionId(): void
     {
         $this->expectException(NoSuchEntityException::class);
 
@@ -1059,7 +1089,8 @@ class LinkManagementTest extends TestCase
         $this->getRemoveOptions();
 
         $selection = $this->getMockBuilder(Selection::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId', '__wakeup'])
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId'])
             ->disableOriginalConstructor()
             ->getMock();
         $selection->method('getSku')->willReturn($childSku);
@@ -1071,7 +1102,10 @@ class LinkManagementTest extends TestCase
         $this->model->removeChild($productSku, $optionId, $childSku);
     }
 
-    public function testRemoveChildInvalidChildSku()
+    /**
+     * @return void
+     */
+    public function testRemoveChildInvalidChildSku(): void
     {
         $this->expectException(NoSuchEntityException::class);
 
@@ -1086,7 +1120,8 @@ class LinkManagementTest extends TestCase
         $this->getRemoveOptions();
 
         $selection = $this->getMockBuilder(Selection::class)
-            ->setMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId', '__wakeup'])
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getSku', 'getOptionId', 'getSelectionId', 'getProductId'])
             ->disableOriginalConstructor()
             ->getMock();
         $selection->method('getSku')->willReturn($childSku . '_invalid');
@@ -1099,7 +1134,10 @@ class LinkManagementTest extends TestCase
         $this->model->removeChild($productSku, $optionId, $childSku);
     }
 
-    private function getOptions()
+    /**
+     * @return void
+     */
+    private function getOptions(): void
     {
         $this->product->method('getTypeInstance')
             ->willReturn($this->productType);
@@ -1116,7 +1154,10 @@ class LinkManagementTest extends TestCase
             ->willReturn($this->optionCollection);
     }
 
-    public function getRemoveOptions()
+    /**
+     * @return void
+     */
+    public function getRemoveOptions(): void
     {
         $this->product->method('getTypeInstance')
             ->willReturn($this->productType);

--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/CatalogPriceTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/CatalogPriceTest.php
@@ -48,6 +48,9 @@ class CatalogPriceTest extends TestCase
      */
     protected $priceModelMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->storeManagerMock = $this->getMockForAbstractClass(StoreManagerInterface::class);
@@ -69,7 +72,10 @@ class CatalogPriceTest extends TestCase
         );
     }
 
-    public function testGetCatalogPriceWithCurrentStore()
+    /**
+     * @return void
+     */
+    public function testGetCatalogPriceWithCurrentStore(): void
     {
         $this->coreRegistryMock->expects($this->once())->method('unregister')->with('rule_data');
         $this->productMock->expects($this->once())->method('getStoreId')->willReturn('store_id');
@@ -99,7 +105,10 @@ class CatalogPriceTest extends TestCase
         $this->assertEquals(15, $this->catalogPrice->getCatalogPrice($this->productMock));
     }
 
-    public function testGetCatalogPriceWithCustomStore()
+    /**
+     * @return void
+     */
+    public function testGetCatalogPriceWithCustomStore(): void
     {
         $storeMock = $this->getMockForAbstractClass(StoreInterface::class);
         $storeMock->expects($this->once())->method('getId')->willReturn('store_id');
@@ -130,14 +139,20 @@ class CatalogPriceTest extends TestCase
             15
         );
 
-        $this->storeManagerMock->expects($this->at(0))->method('getStore')->willReturn($currentStoreMock);
-        $this->storeManagerMock->expects($this->at(1))->method('setCurrentStore')->with('store_id');
-        $this->storeManagerMock->expects($this->at(2))->method('setCurrentStore')->with('current_store_id');
+        $this->storeManagerMock
+            ->method('getStore')
+            ->willReturn($currentStoreMock);
+        $this->storeManagerMock
+            ->method('setCurrentStore')
+            ->withConsecutive(['store_id'], ['current_store_id']);
 
         $this->assertEquals(15, $this->catalogPrice->getCatalogPrice($this->productMock, $storeMock, true));
     }
 
-    public function testGetCatalogRegularPrice()
+    /**
+     * @return void
+     */
+    public function testGetCatalogRegularPrice(): void
     {
         $this->assertNull($this->catalogPrice->getCatalogRegularPrice($this->productMock));
     }

--- a/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Product/TypeTest.php
@@ -125,23 +125,23 @@ class TypeTest extends TestCase
     private $catalogRuleProcessor;
 
     /**
-     * @return void
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->bundleCollectionFactory =
             $this->getMockBuilder(CollectionFactory::class)
-                ->setMethods(
+                ->onlyMethods(['create'])
+                ->addMethods(
                     [
-                        'create',
+                        'addFilterByRequiredOptions',
                         'addAttributeToSelect',
+                        'getItemById',
+                        'setOptionIdsFilter',
                         'setFlag',
                         'setPositionOrder',
                         'addStoreFilter',
-                        'setStoreId',
-                        'addFilterByRequiredOptions',
-                        'setOptionIdsFilter',
-                        'getItemById'
+                        'setStoreId'
                     ]
                 )
                 ->disableOriginalConstructor()
@@ -153,31 +153,31 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->bundleOptionFactory = $this->getMockBuilder(OptionFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->stockRegistry = $this->getMockBuilder(StockRegistry::class)
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->stockState = $this->getMockBuilder(StockState::class)
-            ->setMethods(['getStockQty'])
+            ->onlyMethods(['getStockQty'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->catalogProduct = $this->getMockBuilder(\Magento\Catalog\Helper\Product::class)
-            ->setMethods(['getSkipSaleableCheck'])
+            ->onlyMethods(['getSkipSaleableCheck'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->priceCurrency = $this->getMockBuilder(PriceCurrencyInterface::class)
-            ->setMethods(['convert'])
+            ->onlyMethods(['convert'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->bundleModelSelection = $this->getMockBuilder(SelectionFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->bundleFactory = $this->getMockBuilder(BundleFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->serializer = $this->getMockBuilder(Json::class)
@@ -188,7 +188,7 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->arrayUtility = $this->getMockBuilder(ArrayUtils::class)
-            ->setMethods(['flatten'])
+            ->onlyMethods(['flatten'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->catalogRuleProcessor = $this->getMockBuilder(CollectionProcessor::class)
@@ -220,68 +220,65 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedWithoutOptions()
+    public function testPrepareForCartAdvancedWithoutOptions(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId', 'getRequired', 'isMultiSelection'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
+            ->addMethods(['getRequired', 'isMultiSelection'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems'])
+            ->onlyMethods(['getItems'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
                     'getData'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter', 'getOptionsCollection', 'getOptionsIds', 'getSelectionsCollection'])
+            ->onlyMethods(['setStoreFilter', 'getOptionsCollection', 'getOptionsIds', 'getSelectionsCollection'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -311,9 +308,9 @@ class TypeTest extends TestCase
         $buyRequest->expects($this->once())
             ->method('getBundleOption')
             ->willReturn('options');
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(333, 3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(true);
@@ -326,61 +323,49 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedWithShoppingCart()
+    public function testPrepareForCartAdvancedWithShoppingCart(): void
     {
         /** @var MockObject|Price $priceModel */
         $priceModel = $this->getMockBuilder(Price::class)
-            ->setMethods(['getSelectionFinalTotalPrice'])
+            ->addMethods(['getSelectionFinalTotalPrice'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
                     'getBundleOptionQty',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(
-                [
-                    'groupFactory',
-                    'getType',
-                    'getId',
-                    'getRequired',
-                    'isMultiSelection',
-                    'getProduct',
-                    'getValue',
-                    'getTitle'
-                ]
-            )
+            ->onlyMethods(['groupFactory', 'getType', 'getId', 'getProduct', 'getTitle'])
+            ->addMethods(['getRequired', 'isMultiSelection', 'getValue'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems', 'getSize'])
+            ->onlyMethods(['getItems', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $selection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->addMethods(
                 [
                     '__wakeup',
                     'isSalable',
@@ -397,15 +382,12 @@ class TypeTest extends TestCase
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
@@ -415,25 +397,18 @@ class TypeTest extends TestCase
                     'getPriceModel'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(
-                [
-                    'setStoreFilter',
-                    'prepareForCart',
-                    'setParentProductId',
-                    'addCustomOption',
-                    'setCartQty',
-                    'getSelectionId'
-                ]
-            )
+            ->onlyMethods(['setStoreFilter', 'prepareForCart'])
+            ->addMethods(['setParentProductId', 'addCustomOption', 'setCartQty', 'getSelectionId'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -517,12 +492,9 @@ class TypeTest extends TestCase
         $selection->expects($this->once())
             ->method('getTypeInstance')
             ->willReturn($productType);
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
-        $option->expects($this->at(9))
-            ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(333, 3, 3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(false);
@@ -571,61 +543,49 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedEmptyShoppingCart()
+    public function testPrepareForCartAdvancedEmptyShoppingCart(): void
     {
         /** @var MockObject|Price $priceModel */
         $priceModel = $this->getMockBuilder(Price::class)
-            ->setMethods(['getSelectionFinalTotalPrice'])
+            ->addMethods(['getSelectionFinalTotalPrice'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
                     'getBundleOptionQty',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(
-                [
-                    'groupFactory',
-                    'getType',
-                    'getId',
-                    'getRequired',
-                    'isMultiSelection',
-                    'getProduct',
-                    'getValue',
-                    'getTitle'
-                ]
-            )
+            ->onlyMethods(['groupFactory', 'getType', 'getId', 'getProduct', 'getTitle'])
+            ->addMethods(['getRequired', 'isMultiSelection', 'getValue'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems', 'getSize'])
+            ->onlyMethods(['getItems', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $selection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->addMethods(
                 [
                     '__wakeup',
                     'isSalable',
@@ -642,15 +602,12 @@ class TypeTest extends TestCase
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
@@ -660,16 +617,17 @@ class TypeTest extends TestCase
                     'getPriceModel'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter', 'prepareForCart'])
+            ->onlyMethods(['setStoreFilter', 'prepareForCart'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -758,12 +716,9 @@ class TypeTest extends TestCase
         $selection->expects($this->once())
             ->method('getTypeInstance')
             ->willReturn($productType);
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
-        $option->expects($this->at(9))
-            ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(333, 3, 3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(false);
@@ -797,61 +752,49 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedStringInResult()
+    public function testPrepareForCartAdvancedStringInResult(): void
     {
         /** @var MockObject|Price $priceModel */
         $priceModel = $this->getMockBuilder(Price::class)
-            ->setMethods(['getSelectionFinalTotalPrice'])
+            ->addMethods(['getSelectionFinalTotalPrice'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
                     'getBundleOptionQty',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(
-                [
-                    'groupFactory',
-                    'getType',
-                    'getId',
-                    'getRequired',
-                    'isMultiSelection',
-                    'getProduct',
-                    'getValue',
-                    'getTitle'
-                ]
-            )
+            ->onlyMethods(['groupFactory', 'getType', 'getId', 'getProduct', 'getTitle'])
+            ->addMethods(['getRequired', 'isMultiSelection', 'getValue'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems', 'getSize'])
+            ->onlyMethods(['getItems', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $selection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->addMethods(
                 [
                     '__wakeup',
                     'isSalable',
@@ -868,15 +811,12 @@ class TypeTest extends TestCase
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
@@ -886,16 +826,17 @@ class TypeTest extends TestCase
                     'getPriceModel'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter', 'prepareForCart'])
+            ->onlyMethods(['setStoreFilter', 'prepareForCart'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -980,12 +921,9 @@ class TypeTest extends TestCase
         $selection->expects($this->once())
             ->method('getTypeInstance')
             ->willReturn($productType);
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
-        $option->expects($this->at(9))
-            ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(333, 3, 3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(false);
@@ -1022,49 +960,45 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedWithoutSelections()
+    public function testPrepareForCartAdvancedWithoutSelections(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
                     'getBundleOptionQty',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId', 'getRequired', 'isMultiSelection'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
+            ->addMethods(['getRequired', 'isMultiSelection'])
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
@@ -1072,16 +1006,17 @@ class TypeTest extends TestCase
                     'getId'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter'])
+            ->onlyMethods(['setStoreFilter'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1115,6 +1050,9 @@ class TypeTest extends TestCase
             ->willReturn(333);
         $productType->expects($this->once())
             ->method('setStoreFilter');
+        $option
+            ->method('getId')
+            ->willReturnOnConsecutiveCalls(333);
 
         $bundleOptions = [];
         $buyRequest->expects($this->once())->method('getBundleOption')->willReturn($bundleOptions);
@@ -1132,73 +1070,70 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedSelectionsSelectionIdsExists()
+    public function testPrepareForCartAdvancedSelectionsSelectionIdsExists(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId', 'getRequired', 'isMultiSelection'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
+            ->addMethods(['getRequired', 'isMultiSelection'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems', 'getSize'])
+            ->onlyMethods(['getItems', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $selection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['__wakeup', 'isSalable', 'getOptionId'])
+            ->addMethods(['__wakeup', 'isSalable', 'getOptionId'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
                     'getData'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter'])
+            ->onlyMethods(['setStoreFilter'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById', 'appendSelections'])
+            ->onlyMethods(['getItems', 'getItemById', 'appendSelections'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1244,18 +1179,12 @@ class TypeTest extends TestCase
 
         $this->arrayUtility->expects($this->once())->method('flatten')->willReturn($bundleOptions);
 
-        $selectionCollection->expects($this->at(0))
+        $selectionCollection
             ->method('getItems')
-            ->willReturn([$selection]);
-        $selectionCollection->expects($this->at(0))
+            ->willReturnOnConsecutiveCalls([$selection], []);
+        $selectionCollection
             ->method('getSize')
-            ->willReturn(1);
-        $selectionCollection->expects($this->at(1))
-            ->method('getItems')
-            ->willReturn([]);
-        $selectionCollection->expects($this->at(1))
-            ->method('getSize')
-            ->willReturn(0);
+            ->willReturnOnConsecutiveCalls(1, 0);
         $option->expects($this->any())
             ->method('getId')
             ->willReturn(3);
@@ -1268,73 +1197,70 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testPrepareForCartAdvancedSelectRequiredOptions()
+    public function testPrepareForCartAdvancedSelectRequiredOptions(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId', 'getRequired', 'isMultiSelection'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
+            ->addMethods(['getRequired', 'isMultiSelection'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|SelectionCollection $selectionCollection */
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(['getItems', 'getSize'])
+            ->onlyMethods(['getItems', 'getSize'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $selection = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['__wakeup', 'isSalable', 'getOptionId'])
+            ->addMethods(['__wakeup', 'isSalable', 'getOptionId'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
                     'getData'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter'])
+            ->onlyMethods(['setStoreFilter'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems', 'getItemById'])
+            ->onlyMethods(['getItems', 'getItemById'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1389,9 +1315,9 @@ class TypeTest extends TestCase
         $selection->expects($this->once())
             ->method('isSalable')
             ->willReturn(false);
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(333, 3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(true);
@@ -1406,24 +1332,20 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testPrepareForCartAdvancedParentClassReturnString()
+    public function testPrepareForCartAdvancedParentClassReturnString(): void
     {
         $exceptedResult = 'String message';
 
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getItems', '__wakeup'])
+            ->addMethods(['getItems', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
-                [
-                    'getOptions',
-                    'getHasOptions'
-                ]
-            )
+            ->onlyMethods(['getOptions'])
+            ->addMethods(['getHasOptions'])
             ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->any())
@@ -1441,63 +1363,60 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testPrepareForCartAdvancedAllRequiredOption()
+    public function testPrepareForCartAdvancedAllRequiredOption(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId', 'getRequired'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
+            ->addMethods(['getRequired'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getOptions',
-                    'getHasOptions',
                     'prepareCustomOptions',
                     'addCustomOption',
-                    'setCartQty',
                     'setQty',
-                    'getSkipCheckRequiredOption',
                     'getTypeInstance',
                     'getStoreId',
                     'hasData',
                     'getData'
                 ]
             )
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Type $productType */
         $productType = $this->getMockBuilder(Type::class)
-            ->setMethods(['setStoreFilter'])
+            ->onlyMethods(['setStoreFilter'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Collection $optionCollection */
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getItems'])
+            ->onlyMethods(['getItems'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1537,9 +1456,9 @@ class TypeTest extends TestCase
         $buyRequest->expects($this->once())
             ->method('getBundleOption')
             ->willReturn([3 => 5]);
-        $option->expects($this->at(3))
+        $option
             ->method('getId')
-            ->willReturn(3);
+            ->willReturnOnConsecutiveCalls(3);
         $option->expects($this->once())
             ->method('getRequired')
             ->willReturn(true);
@@ -1551,49 +1470,38 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testPrepareForCartAdvancedSpecifyProductOptions()
+    public function testPrepareForCartAdvancedSpecifyProductOptions(): void
     {
         /** @var MockObject|DefaultType $group */
         $group = $this->getMockBuilder(DefaultType::class)
-            ->setMethods(
-                ['setOption', 'setProduct', 'setRequest', 'setProcessMode', 'validateUserValue', 'prepareForCart']
-            )
+            ->onlyMethods(['setOption', 'setProduct', 'validateUserValue', 'prepareForCart'])
+            ->addMethods(['setRequest', 'setProcessMode'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|DataObject $buyRequest */
         $buyRequest = $this->getMockBuilder(DataObject::class)
-            ->setMethods(
+            ->onlyMethods(['unsetData', 'getData'])
+            ->addMethods(
                 [
                     '__wakeup',
                     'getOptions',
                     'getSuperProductConfig',
-                    'unsetData',
-                    'getData',
                     'getQty',
                     'getBundleOption',
-                    'getBundleOptionsData',
+                    'getBundleOptionsData'
                 ]
             )
             ->disableOriginalConstructor()
             ->getMock();
         /* @var \PHPUnit\Framework\MockObject\MockObject|\Magento\Catalog\Model\Product\Option $option */
         $option = $this->getMockBuilder(Option::class)
-            ->setMethods(['groupFactory', 'getType', 'getId'])
+            ->onlyMethods(['groupFactory', 'getType', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
         /** @var MockObject|Product $product */
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
-                [
-                    'getOptions',
-                    'getHasOptions',
-                    'prepareCustomOptions',
-                    'addCustomOption',
-                    'setCartQty',
-                    'setQty',
-                    'getSkipCheckRequiredOption'
-                ]
-            )
+            ->onlyMethods(['getOptions', 'prepareCustomOptions', 'addCustomOption', 'setQty'])
+            ->addMethods(['getHasOptions', 'setCartQty', 'getSkipCheckRequiredOption'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1619,7 +1527,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testHasWeightTrue()
+    public function testHasWeightTrue(): void
     {
         $this->assertTrue($this->model->hasWeight(), 'This product has no weight, but it should');
     }
@@ -1627,7 +1535,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetIdentities()
+    public function testGetIdentities(): void
     {
         $identities = ['id1', 'id2'];
         $productMock = $this->createMock(Product::class);
@@ -1662,20 +1570,16 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetSkuWithType()
+    public function testGetSkuWithType(): void
     {
         $sku = 'sku';
         $productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $productMock->expects($this->at(0))
+        $productMock
             ->method('getData')
-            ->with('sku')
-            ->willReturn($sku);
-        $productMock->expects($this->at(2))
-            ->method('getData')
-            ->with('sku_type')
-            ->willReturn('some_data');
+            ->withConsecutive(['sku'], ['sku_type'])
+            ->willReturnOnConsecutiveCalls($sku, 'some_data');
 
         $this->assertEquals($sku, $this->model->getSku($productMock));
     }
@@ -1683,54 +1587,59 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetSkuWithoutType()
+    public function testGetSkuWithoutType(): void
     {
         $sku = 'sku';
         $itemSku = 'item';
         $selectionIds = [1, 2, 3];
         $serializeIds = json_encode($selectionIds);
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
+            ->onlyMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
             ->disableOriginalConstructor()
             ->getMock();
         $customOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Configuration\Item\Option::class)
-            ->setMethods(['getValue', '__wakeup'])
+            ->onlyMethods(['getValue'])
+            ->addMethods(['__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $selectionItemMock = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getSku', 'getEntityId', '__wakeup'])
+            ->addMethods(['getSku', 'getEntityId', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productMock->expects($this->at(0))
-            ->method('getData')
-            ->with('sku')
-            ->willReturn($sku);
-        $productMock->expects($this->at(1))
-            ->method('getCustomOption')
-            ->with('option_ids')
-            ->willReturn(false);
-        $productMock->expects($this->at(2))
-            ->method('getData')
-            ->with('sku_type')
-            ->willReturn(null);
         $productMock->expects($this->once())
             ->method('hasCustomOptions')
             ->willReturn(true);
-        $productMock->expects($this->at(4))
+        $productMock
             ->method('getCustomOption')
-            ->with('bundle_selection_ids')
-            ->willReturn($customOptionMock);
+            ->withConsecutive(['option_ids'], ['bundle_selection_ids'])
+            ->willReturnOnConsecutiveCalls(false, $customOptionMock);
         $customOptionMock->expects($this->any())
             ->method('getValue')
             ->willReturn($serializeIds);
-        $selectionMock = $this->getSelectionsByIdsMock($selectionIds, $productMock, 5, 6);
+        $selectionMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $productMock
+            ->method('getData')
+            ->withConsecutive(
+                ['sku'],
+                ['sku_type'],
+                ['_cache_instance_used_selections'],
+                ['_cache_instance_used_selections_ids']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $sku,
+                null,
+                $selectionMock,
+                $selectionIds
+            );
         $selectionMock->expects(($this->any()))
             ->method('getItemByColumnValue')
             ->willReturn($selectionItemMock);
-        $selectionItemMock->expects($this->at(0))
+        $selectionItemMock
             ->method('getEntityId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(1);
         $selectionItemMock->expects($this->once())
             ->method('getSku')
             ->willReturn($itemSku);
@@ -1741,22 +1650,18 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetWeightWithoutCustomOption()
+    public function testGetWeightWithoutCustomOption(): void
     {
         $weight = 5;
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getData'])
+            ->onlyMethods(['__wakeup', 'getData'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productMock->expects($this->at(0))
+        $productMock
             ->method('getData')
-            ->with('weight_type')
-            ->willReturn(true);
-        $productMock->expects($this->at(1))
-            ->method('getData')
-            ->with('weight')
-            ->willReturn($weight);
+            ->withConsecutive(['weight_type'], ['weight'])
+            ->willReturnOnConsecutiveCalls(true, $weight);
 
         $this->assertEquals($weight, $this->model->getWeight($productMock));
     }
@@ -1764,49 +1669,55 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetWeightWithCustomOption()
+    public function testGetWeightWithCustomOption(): void
     {
         $weight = 5;
         $selectionIds = [1, 2, 3];
         $serializeIds = json_encode($selectionIds);
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
+            ->onlyMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
             ->disableOriginalConstructor()
             ->getMock();
         $customOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Configuration\Item\Option::class)
-            ->setMethods(['getValue', '__wakeup'])
+            ->onlyMethods(['getValue'])
+            ->addMethods(['__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $selectionItemMock = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getSelectionId', 'getWeight', '__wakeup'])
+            ->addMethods(['getSelectionId', 'getWeight', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
-
-        $productMock->expects($this->at(0))
-            ->method('getData')
-            ->with('weight_type')
-            ->willReturn(false);
         $productMock->expects($this->once())
             ->method('hasCustomOptions')
             ->willReturn(true);
-        $productMock->expects($this->at(2))
-            ->method('getCustomOption')
-            ->with('bundle_selection_ids')
-            ->willReturn($customOptionMock);
         $customOptionMock->expects($this->once())
             ->method('getValue')
             ->willReturn($serializeIds);
-        $selectionMock = $this->getSelectionsByIdsMock($selectionIds, $productMock, 3, 4);
+
+        $selectionMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
+        ->disableOriginalConstructor()
+        ->getMock();
+        $productMock
+            ->method('getData')
+            ->withConsecutive(
+                ['weight_type'],
+                ['_cache_instance_used_selections'],
+                ['_cache_instance_used_selections_ids']
+            )
+            ->willReturnOnConsecutiveCalls(false, $selectionMock, $selectionIds);
         $selectionMock->expects($this->once())
             ->method('getItems')
             ->willReturn([$selectionItemMock]);
         $selectionItemMock->expects($this->any())
             ->method('getSelectionId')
             ->willReturn('id');
-        $productMock->expects($this->at(5))
+        $productMock
             ->method('getCustomOption')
-            ->with('selection_qty_' . 'id')
-            ->willReturn(null);
+            ->withConsecutive(
+                ['bundle_selection_ids'],
+                ['selection_qty_' . 'id']
+            )
+            ->willReturnOnConsecutiveCalls($customOptionMock, null);
         $selectionItemMock->expects($this->once())
             ->method('getWeight')
             ->willReturn($weight);
@@ -1817,54 +1728,59 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetWeightWithSeveralCustomOption()
+    public function testGetWeightWithSeveralCustomOption(): void
     {
         $weight = 5;
         $qtyOption = 5;
         $selectionIds = [1, 2, 3];
         $serializeIds = json_encode($selectionIds);
         $productMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
+            ->onlyMethods(['__wakeup', 'getData', 'hasCustomOptions', 'getCustomOption'])
             ->disableOriginalConstructor()
             ->getMock();
         $customOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Configuration\Item\Option::class)
-            ->setMethods(['getValue', '__wakeup'])
+            ->onlyMethods(['getValue'])
+            ->addMethods(['__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $qtyOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Configuration\Item\Option::class)
-            ->setMethods(['getValue', '__wakeup'])
+            ->onlyMethods(['getValue'])
+            ->addMethods(['__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $selectionItemMock = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['getSelectionId', 'getWeight', '__wakeup'])
+            ->addMethods(['getSelectionId', 'getWeight', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productMock->expects($this->at(0))
-            ->method('getData')
-            ->with('weight_type')
-            ->willReturn(false);
         $productMock->expects($this->once())
             ->method('hasCustomOptions')
             ->willReturn(true);
-        $productMock->expects($this->at(2))
-            ->method('getCustomOption')
-            ->with('bundle_selection_ids')
-            ->willReturn($customOptionMock);
         $customOptionMock->expects($this->once())
             ->method('getValue')
             ->willReturn($serializeIds);
-        $selectionMock = $this->getSelectionsByIdsMock($selectionIds, $productMock, 3, 4);
+
+        $selectionMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
+        ->disableOriginalConstructor()
+        ->getMock();
+        $productMock
+            ->method('getData')
+            ->withConsecutive(
+                ['weight_type'],
+                ['_cache_instance_used_selections'],
+                ['_cache_instance_used_selections_ids']
+            )
+            ->willReturnOnConsecutiveCalls(false, $selectionMock, $selectionIds);
         $selectionMock->expects($this->once())
             ->method('getItems')
             ->willReturn([$selectionItemMock]);
         $selectionItemMock->expects($this->any())
             ->method('getSelectionId')
             ->willReturn('id');
-        $productMock->expects($this->at(5))
+        $productMock
             ->method('getCustomOption')
-            ->with('selection_qty_' . 'id')
-            ->willReturn($qtyOptionMock);
+            ->withConsecutive(['bundle_selection_ids'], ['selection_qty_' . 'id'])
+            ->willReturnOnConsecutiveCalls($customOptionMock, $qtyOptionMock);
         $qtyOptionMock->expects($this->once())
             ->method('getValue')
             ->willReturn($qtyOption);
@@ -1878,7 +1794,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsVirtualWithoutCustomOption()
+    public function testIsVirtualWithoutCustomOption(): void
     {
         $productMock = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -1894,7 +1810,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsVirtual()
+    public function testIsVirtual(): void
     {
         $selectionIds = [1, 2, 3];
         $serializeIds = json_encode($selectionIds);
@@ -1903,11 +1819,12 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $customOptionMock = $this->getMockBuilder(\Magento\Catalog\Model\Product\Configuration\Item\Option::class)
-            ->setMethods(['getValue', '__wakeup'])
+            ->onlyMethods(['getValue'])
+            ->addMethods(['__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $selectionItemMock = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['isVirtual', 'getItems', '__wakeup'])
+            ->addMethods(['isVirtual', 'getItems', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -1921,7 +1838,17 @@ class TypeTest extends TestCase
         $customOptionMock->expects($this->once())
             ->method('getValue')
             ->willReturn($serializeIds);
-        $selectionMock = $this->getSelectionsByIdsMock($selectionIds, $productMock, 2, 3);
+
+        $selectionMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $productMock
+            ->method('getData')
+            ->withConsecutive(
+                ['_cache_instance_used_selections'],
+                ['_cache_instance_used_selections_ids']
+            )
+            ->willReturnOnConsecutiveCalls($selectionMock, $selectionIds);
         $selectionMock->expects($this->once())
             ->method('getItems')
             ->willReturn([$selectionItemMock]);
@@ -1939,53 +1866,31 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @param array $selectionIds
-     * @param MockObject $productMock
-     * @param int $getSelectionsIndex
-     * @param int $getSelectionsIdsIndex
-     * @return MockObject
-     */
-    protected function getSelectionsByIdsMock($selectionIds, $productMock, $getSelectionsIndex, $getSelectionsIdsIndex)
-    {
-        $usedSelectionsMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $productMock->expects($this->at($getSelectionsIndex))
-            ->method('getData')
-            ->with('_cache_instance_used_selections')
-            ->willReturn($usedSelectionsMock);
-        $productMock->expects($this->at($getSelectionsIdsIndex))
-            ->method('getData')
-            ->with('_cache_instance_used_selections_ids')
-            ->willReturn($selectionIds);
-
-        return $usedSelectionsMock;
-    }
-
-    /**
      * @param int $expected
      * @param int $firstId
      * @param int $secondId
+     *
      * @return void
      * @dataProvider shakeSelectionsDataProvider
      */
-    public function testShakeSelections($expected, $firstId, $secondId)
+    public function testShakeSelections($expected, $firstId, $secondId): void
     {
         $firstItemMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getOption', 'getOptionId', 'getPosition', 'getSelectionId'])
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getOption', 'getOptionId', 'getPosition', 'getSelectionId'])
             ->disableOriginalConstructor()
             ->getMock();
         $secondItemMock = $this->getMockBuilder(Product::class)
-            ->setMethods(['__wakeup', 'getOption', 'getOptionId', 'getPosition', 'getSelectionId'])
+            ->onlyMethods(['__wakeup'])
+            ->addMethods(['getOption', 'getOptionId', 'getPosition', 'getSelectionId'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionFirstMock = $this->getMockBuilder(\Magento\Bundle\Model\Option::class)
-            ->setMethods(['getPosition', '__wakeup'])
+            ->onlyMethods(['getPosition', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $optionSecondMock = $this->getMockBuilder(\Magento\Bundle\Model\Option::class)
-            ->setMethods(['getPosition', '__wakeup'])
+            ->onlyMethods(['getPosition', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2026,7 +1931,7 @@ class TypeTest extends TestCase
     /**
      * @return array
      */
-    public function shakeSelectionsDataProvider()
+    public function shakeSelectionsDataProvider(): array
     {
         return [
             [0, 0, 0],
@@ -2039,7 +1944,7 @@ class TypeTest extends TestCase
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetSelectionsByIds()
+    public function testGetSelectionsByIds(): void
     {
         $selectionIds = [1, 2, 3];
         $usedSelectionsIds = [4, 5, 6];
@@ -2051,7 +1956,7 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $usedSelectionsMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'addAttributeToSelect',
                     'setFlag',
@@ -2085,7 +1990,7 @@ class TypeTest extends TestCase
             ->willReturn($storeId);
 
         $storeMock = $this->getMockBuilder(Store::class)
-            ->setMethods(['getWebsiteId', '__wakeup'])
+            ->onlyMethods(['getWebsiteId', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->storeManager->expects($this->once())
@@ -2144,7 +2049,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testGetOptionsByIds()
+    public function testGetOptionsByIds(): void
     {
         $optionsIds = [1, 2, 3];
         $usedOptionsIds = [4, 5, 6];
@@ -2154,7 +2059,7 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $usedOptionsMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getResourceCollection'])
+            ->addMethods(['getResourceCollection'])
             ->disableOriginalConstructor()
             ->getMock();
         $resourceClassName = AbstractCollection::class;
@@ -2163,18 +2068,10 @@ class TypeTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $storeMock = $this->getMockBuilder(Store::class)
-            ->setMethods(['getId', '__wakeup'])
+            ->onlyMethods(['getId', '__wakeup'])
             ->disableOriginalConstructor()
             ->getMock();
 
-        $productMock->expects($this->at(0))
-            ->method('getData')
-            ->with('_cache_instance_used_options')
-            ->willReturn(null);
-        $productMock->expects($this->at(1))
-            ->method('getData')
-            ->with('_cache_instance_used_options_ids')
-            ->willReturn($usedOptionsIds);
         $productMock->expects($this->once())
             ->method('getId')
             ->willReturn($productId);
@@ -2204,14 +2101,20 @@ class TypeTest extends TestCase
             ->method('setIdFilter')
             ->with($optionsIds)
             ->willReturnSelf();
-        $productMock->expects($this->at(3))
+        $productMock
+            ->method('getData')
+            ->withConsecutive(
+                ['_cache_instance_used_options'],
+                ['_cache_instance_used_options_ids']
+            )
+            ->willReturnOnConsecutiveCalls(null, $usedOptionsIds);
+        $productMock
             ->method('setData')
-            ->with('_cache_instance_used_options', $dbResourceMock)
-            ->willReturnSelf();
-        $productMock->expects($this->at(4))
-            ->method('setData')
-            ->with('_cache_instance_used_options_ids', $optionsIds)
-            ->willReturnSelf();
+            ->withConsecutive(
+                ['_cache_instance_used_options', $dbResourceMock],
+                ['_cache_instance_used_options_ids', $optionsIds]
+            )
+            ->willReturnOnConsecutiveCalls($productMock, $productMock);
 
         $this->model->getOptionsByIds($optionsIds, $productMock);
     }
@@ -2219,7 +2122,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableFalse()
+    public function testIsSalableFalse(): void
     {
         $product = new DataObject(
             [
@@ -2234,7 +2137,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableWithoutOptions()
+    public function testIsSalableWithoutOptions(): void
     {
         $optionCollectionMock = $this->getOptionCollectionMock([]);
         $product = new DataObject(
@@ -2251,13 +2154,13 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableWithRequiredOptionsTrue()
+    public function testIsSalableWithRequiredOptionsTrue(): void
     {
         $option1 = $this->getRequiredOptionMock(10, 10);
         $option2 = $this->getRequiredOptionMock(20, 10);
 
         $option3 = $this->getMockBuilder(\Magento\Bundle\Model\Option::class)
-            ->setMethods(['getRequired', 'getOptionId', 'getId'])
+            ->onlyMethods(['getRequired', 'getOptionId', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $option3->method('getRequired')
@@ -2279,7 +2182,7 @@ class TypeTest extends TestCase
             [
                 'is_salable' => true,
                 '_cache_instance_options_collection' => $optionCollectionMock,
-                'status' => Status::STATUS_ENABLED,
+                'status' => Status::STATUS_ENABLED
             ]
         );
 
@@ -2289,7 +2192,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableCache()
+    public function testIsSalableCache(): void
     {
         $product = new DataObject(
             [
@@ -2305,7 +2208,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableWithEmptySelectionsCollection()
+    public function testIsSalableWithEmptySelectionsCollection(): void
     {
         $option = $this->getRequiredOptionMock(1, 10);
         $optionCollectionMock = $this->getOptionCollectionMock([$option]);
@@ -2320,7 +2223,7 @@ class TypeTest extends TestCase
             [
                 'is_salable' => true,
                 '_cache_instance_options_collection' => $optionCollectionMock,
-                'status' => Status::STATUS_ENABLED,
+                'status' => Status::STATUS_ENABLED
             ]
         );
 
@@ -2330,7 +2233,7 @@ class TypeTest extends TestCase
     /**
      * @return void
      */
-    public function testIsSalableWithNonSalableRequiredOptions()
+    public function testIsSalableWithNonSalableRequiredOptions(): void
     {
         $option1 = $this->getRequiredOptionMock(10, 10);
         $option2 = $this->getRequiredOptionMock(20, 10);
@@ -2338,7 +2241,7 @@ class TypeTest extends TestCase
         $this->expectProductEntityMetadata();
 
         $selection1 = $this->getMockBuilder(Product::class)
-            ->setMethods(['isSalable'])
+            ->onlyMethods(['isSalable'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2347,7 +2250,7 @@ class TypeTest extends TestCase
             ->willReturn(true);
 
         $selection2 = $this->getMockBuilder(Product::class)
-            ->setMethods(['isSalable'])
+            ->onlyMethods(['isSalable'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2369,7 +2272,7 @@ class TypeTest extends TestCase
             [
                 'is_salable' => true,
                 '_cache_instance_options_collection' => $optionCollectionMock,
-                'status' => Status::STATUS_ENABLED,
+                'status' => Status::STATUS_ENABLED
             ]
         );
 
@@ -2379,19 +2282,24 @@ class TypeTest extends TestCase
     /**
      * @param int $id
      * @param int $selectionQty
+     *
      * @return MockObject
      */
-    private function getRequiredOptionMock($id, $selectionQty)
+    private function getRequiredOptionMock(int $id, int $selectionQty): MockObject
     {
         $option = $this->getMockBuilder(\Magento\Bundle\Model\Option::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getRequired',
+                    'getOptionId',
+                    'getId'
+                ]
+            )
+            ->addMethods(
+                [
                     'isSalable',
                     'hasSelectionQty',
                     'getSelectionQty',
-                    'getOptionId',
-                    'getId',
                     'getSelectionCanChangeQty'
                 ]
             )
@@ -2417,9 +2325,10 @@ class TypeTest extends TestCase
 
     /**
      * @param array $selectedOptions
+     *
      * @return MockObject
      */
-    private function getSelectionCollectionMock(array $selectedOptions)
+    private function getSelectionCollectionMock(array $selectedOptions): MockObject
     {
         $selectionCollectionMock = $this->getMockBuilder(
             \Magento\Bundle\Model\ResourceModel\Selection\Collection::class
@@ -2436,12 +2345,13 @@ class TypeTest extends TestCase
 
     /**
      * @param array $options
+     *
      * @return MockObject
      */
-    private function getOptionCollectionMock(array $options)
+    private function getOptionCollectionMock(array $options): MockObject
     {
         $optionCollectionMock = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
-            ->setMethods(['getIterator'])
+            ->onlyMethods(['getIterator'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -2454,9 +2364,10 @@ class TypeTest extends TestCase
 
     /**
      * @param bool $isManageStock
+     *
      * @return StockItemInterface|MockObject
      */
-    protected function getStockItem($isManageStock)
+    protected function getStockItem(bool $isManageStock): MockObject
     {
         $result = $this->getMockBuilder(StockItemInterface::class)
             ->getMock();
@@ -2471,9 +2382,10 @@ class TypeTest extends TestCase
      * @param MockObject|Option $option
      * @param MockObject|DataObject $buyRequest
      * @param MockObject|Product $product
+     *
      * @return void
      */
-    protected function parentClass($group, $option, $buyRequest, $product)
+    protected function parentClass($group, $option, $buyRequest, $product): void
     {
         $group->expects($this->once())
             ->method('setOption')
@@ -2496,9 +2408,6 @@ class TypeTest extends TestCase
         $option->expects($this->once())
             ->method('groupFactory')
             ->willReturn($group);
-        $option->expects($this->at(0))
-            ->method('getId')
-            ->willReturn(333);
 
         $buyRequest->expects($this->once())
             ->method('getData');
@@ -2535,26 +2444,21 @@ class TypeTest extends TestCase
             ->willReturn(false);
     }
 
-    public function testGetSelectionsCollection()
+    /**
+     * @return void
+     */
+    public function testGetSelectionsCollection(): void
     {
         $optionIds = [1, 2, 3];
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    '_wakeup',
-                    'getStoreId',
-                    'getData',
-                    'hasData',
-                    'setData',
-                    'getId'
-                ]
-            )
+            ->onlyMethods(['getStoreId', 'getData', 'hasData', 'setData', 'getId'])
+            ->addMethods(['_wakeup'])
             ->getMock();
         $this->expectProductEntityMetadata();
         $store = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getWebsiteId'])
+            ->onlyMethods(['getWebsiteId'])
             ->getMock();
 
         $product->expects($this->once())->method('getStoreId')->willReturn('store_id');
@@ -2570,7 +2474,7 @@ class TypeTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getSelectionCollection()
+    private function getSelectionCollection(): MockObject
     {
         $selectionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Selection\Collection::class)
             ->disableOriginalConstructor()
@@ -2588,7 +2492,10 @@ class TypeTest extends TestCase
         return $selectionCollection;
     }
 
-    public function testProcessBuyRequest()
+    /**
+     * @return void
+     */
+    public function testProcessBuyRequest(): void
     {
         $result = ['bundle_option' => [], 'bundle_option_qty' => []];
         $product = $this->getMockBuilder(Product::class)
@@ -2596,7 +2503,7 @@ class TypeTest extends TestCase
             ->getMock();
         $buyRequest = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getBundleOption', 'getBundleOptionQty'])
+            ->addMethods(['getBundleOption', 'getBundleOptionQty'])
             ->getMock();
 
         $buyRequest->expects($this->once())->method('getBundleOption')->willReturn('bundleOption');
@@ -2605,7 +2512,10 @@ class TypeTest extends TestCase
         $this->assertEquals($result, $this->model->processBuyRequest($product, $buyRequest));
     }
 
-    public function testGetProductsToPurchaseByReqGroups()
+    /**
+     * @return void
+     */
+    public function testGetProductsToPurchaseByReqGroups(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
@@ -2618,7 +2528,7 @@ class TypeTest extends TestCase
             ->getMock();
         $item = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getRequired'])
+            ->addMethods(['getId', 'getRequired'])
             ->getMock();
         $selectionCollection = $this->getSelectionCollection();
         $this->bundleCollectionFactory->expects($this->once())->method('create')->willReturn($selectionCollection);
@@ -2628,10 +2538,10 @@ class TypeTest extends TestCase
             ->getMock();
 
         $product->expects($this->any())->method('hasData')->willReturn(true);
-        $product->expects($this->at(1))
+        $product
             ->method('getData')
-            ->with('_cache_instance_options_collection')
-            ->willReturn($dbResourceMock);
+            ->withConsecutive(['_cache_instance_options_collection'])
+            ->willReturnOnConsecutiveCalls($dbResourceMock);
         $dbResourceMock->expects($this->once())->method('getItems')->willReturn([$item]);
         $item->expects($this->once())->method('getId')->willReturn('itemId');
         $item->expects($this->once())->method('getRequired')->willReturn(true);
@@ -2643,15 +2553,19 @@ class TypeTest extends TestCase
         $this->assertEquals([[$selectionItem]], $this->model->getProductsToPurchaseByReqGroups($product));
     }
 
-    public function testGetSearchableData()
+    /**
+     * @return void
+     */
+    public function testGetSearchableData(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['_wakeup', 'getHasOptions', 'getId', 'getStoreId'])
+            ->onlyMethods(['getId', 'getStoreId'])
+            ->addMethods(['_wakeup', 'getHasOptions'])
             ->getMock();
         $option = $this->getMockBuilder(\Magento\Bundle\Model\Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getSearchableData'])
+            ->onlyMethods(['getSearchableData'])
             ->getMock();
 
         $product->expects($this->once())->method('getHasOptions')->willReturn(false);
@@ -2663,16 +2577,20 @@ class TypeTest extends TestCase
         $this->assertEquals(['optionSearchdata'], $this->model->getSearchableData($product));
     }
 
-    public function testHasOptions()
+    /**
+     * @return void
+     */
+    public function testHasOptions(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['_wakeup', 'hasData', 'getData', 'setData', 'getId', 'getStoreId'])
+            ->onlyMethods(['hasData', 'getData', 'setData', 'getId', 'getStoreId'])
+            ->addMethods(['_wakeup'])
             ->getMock();
         $this->expectProductEntityMetadata();
         $optionCollection = $this->getMockBuilder(\Magento\Bundle\Model\ResourceModel\Option\Collection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAllIds'])
+            ->onlyMethods(['getAllIds'])
             ->getMock();
         $selectionCollection = $this->getSelectionCollection();
         $selectionCollection
@@ -2687,10 +2605,10 @@ class TypeTest extends TestCase
             ->with('_cache_instance_store_filter', 0)
             ->willReturnSelf();
         $product->expects($this->any())->method('hasData')->willReturn(true);
-        $product->expects($this->at(3))
+        $product
             ->method('getData')
-            ->with('_cache_instance_options_collection')
-            ->willReturn($optionCollection);
+            ->withConsecutive(['_cache_instance_options_collection'])
+            ->willReturnOnConsecutiveCalls($optionCollection);
         $optionCollection->expects($this->once())->method('getAllIds')->willReturn(['ids']);
 
         $this->assertTrue($this->model->hasOptions($product));
@@ -2699,8 +2617,9 @@ class TypeTest extends TestCase
     /**
      * Bundle product without options should not be possible to buy.
      *
+     * @return void
      */
-    public function testCheckProductBuyStateEmptyOptionsException()
+    public function testCheckProductBuyStateEmptyOptionsException(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Please specify product option');
@@ -2710,7 +2629,7 @@ class TypeTest extends TestCase
         $this->expectProductEntityMetadata();
         $product->method('getCustomOption')->willReturnMap([
             ['bundle_selection_ids', new DataObject(['value' => '[]'])],
-            ['info_buyRequest', new DataObject(['value' => json_encode(['bundle_option' => ''])])],
+            ['info_buyRequest', new DataObject(['value' => json_encode(['bundle_option' => ''])])]
         ]);
         $product->setCustomOption(json_encode([]));
 
@@ -2724,11 +2643,11 @@ class TypeTest extends TestCase
      * @param string $expectedMessage
      * @param bool $check
      *
+     * @return void
      * @throws LocalizedException
-     *
      * @dataProvider notAvailableOptionProvider
      */
-    public function testCheckProductBuyStateMissedOptionException($element, $expectedMessage, $check)
+    public function testCheckProductBuyStateMissedOptionException($element, $expectedMessage, $check): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -2758,8 +2677,9 @@ class TypeTest extends TestCase
     /**
      * In case of missed selection for required options, bundle product should be not able to buy.
      *
+     * @return void
      */
-    public function testCheckProductBuyStateRequiredOptionException()
+    public function testCheckProductBuyStateRequiredOptionException(): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -2772,9 +2692,8 @@ class TypeTest extends TestCase
         ]);
         $product->setCustomOption(json_encode([]));
 
-        $falseSelection = $this->getMockBuilder(Selection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isSalable'])
+        $falseSelection = $this->getMockBuilder(Selection::class)->disableOriginalConstructor()
+            ->addMethods(['isSalable'])
             ->getMock();
         $falseSelection->method('isSalable')->willReturn(false);
 
@@ -2798,19 +2717,12 @@ class TypeTest extends TestCase
      *
      * @return MockObject
      */
-    public function getProductMock()
+    public function getProductMock(): MockObject
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                '_wakeup',
-                'getHasOptions',
-                'getId',
-                'getStoreId',
-                'getCustomOption',
-                'getTypeInstance',
-                'setStoreFilter',
-            ])
+            ->onlyMethods(['getId', 'getStoreId', 'getCustomOption', 'getTypeInstance'])
+            ->addMethods(['_wakeup', 'getHasOptions', 'setStoreFilter'])
             ->getMock();
         $product->method('getTypeInstance')->willReturn($product);
         $product->method('setStoreFilter')->willReturn($product);
@@ -2823,13 +2735,16 @@ class TypeTest extends TestCase
             ]),
         ]);
         $product->setData('_cache_instance_options_collection', $optionCollectionCache);
+
         return $product;
     }
 
     /**
      * Preparation mocks for checkProductsBuyState.
+     *
+     * @return void
      */
-    public function mockBundleCollection()
+    public function mockBundleCollection(): void
     {
         $selectionCollectionMock = $this->getSelectionCollectionMock([]);
         $this->bundleCollectionFactory->expects($this->once())
@@ -2847,33 +2762,33 @@ class TypeTest extends TestCase
 
     /**
      * Data provider for not available option.
+     *
      * @return array
      */
-    public function notAvailableOptionProvider()
+    public function notAvailableOptionProvider(): array
     {
-        $falseSelection = $this->getMockBuilder(Selection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['isSalable'])
+        $falseSelection = $this->getMockBuilder(Selection::class)->disableOriginalConstructor()
+            ->addMethods(['isSalable'])
             ->getMock();
         $falseSelection->method('isSalable')->willReturn(false);
         return [
             [
                 false,
                 'The required options you selected are not available',
-                false,
+                false
             ],
             [
                 $falseSelection,
                 'The required options you selected are not available',
                 false
-            ],
+            ]
         ];
     }
 
     /**
      * @return void
      */
-    private function expectProductEntityMetadata()
+    private function expectProductEntityMetadata(): void
     {
         $entityMetadataMock = $this->getMockBuilder(EntityMetadataInterface::class)
             ->getMockForAbstractClass();

--- a/app/code/Magento/Bundle/Test/Unit/Model/Sales/Order/Pdf/Items/InvoiceTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/Sales/Order/Pdf/Items/InvoiceTest.php
@@ -41,7 +41,7 @@ class InvoiceTest extends TestCase
     private $taxDataMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -71,7 +71,7 @@ class InvoiceTest extends TestCase
                     $serializerMock,
                     $resourceMock,
                     $collectionMock,
-                    [],
+                    []
                 ]
             )
             ->onlyMethods(
@@ -81,16 +81,18 @@ class InvoiceTest extends TestCase
                     'isShipmentSeparately',
                     'isChildCalculated',
                     'getValueHtml',
-                    'getSelectionAttributes',
+                    'getSelectionAttributes'
                 ]
             )
             ->getMock();
     }
 
     /**
-     * @dataProvider \Magento\Bundle\Test\Unit\Model\Sales\Order\Pdf\Items\InvoiceTestProvider::getData
      * @param array $expected
      * @param string $method
+     *
+     * @return void
+     * @dataProvider \Magento\Bundle\Test\Unit\Model\Sales\Order\Pdf\Items\InvoiceTestProvider::getData
      */
     public function testDrawPrice(array $expected, string $method): void
     {
@@ -122,9 +124,9 @@ class InvoiceTest extends TestCase
                 'name' => 'Bundle',
                 'order_item' => new DataObject(
                     [
-                        'product_options' => [],
+                        'product_options' => []
                     ]
-                ),
+                )
             ]
         );
         $items = [
@@ -140,9 +142,9 @@ class InvoiceTest extends TestCase
                     'tax_amount' => '1.66',
                     'order_item' => new DataObject(
                         [
-                            'parent_item' => $parentItem,
+                            'parent_item' => $parentItem
                         ]
-                    ),
+                    )
                 ]
             ),
             new DataObject(
@@ -157,25 +159,29 @@ class InvoiceTest extends TestCase
                     'tax_amount' => '0.83',
                     'order_item' => new DataObject(
                         [
-                            'parent_item' => $parentItem,
+                            'parent_item' => $parentItem
                         ]
-                    ),
+                    )
                 ]
-            ),
+            )
         ];
         $orderMock = $this->createMock(Order::class);
 
         $this->model->expects($this->any())->method('getChildren')->willReturn($items);
         $this->model->expects($this->any())->method('isShipmentSeparately')->willReturn(false);
         $this->model->expects($this->any())->method('isChildCalculated')->willReturn(true);
-        $this->model->expects($this->at(2))->method('getSelectionAttributes')->willReturn(
-            ['option_id' => 1, 'option_label' => 'test option']
-        );
-        $this->model->expects($this->at(3))->method('getValueHtml')->willReturn($items[0]->getName());
-        $this->model->expects($this->at(5))->method('getSelectionAttributes')->willReturn(
-            ['option_id' => 1, 'option_label' => 'second option']
-        );
-        $this->model->expects($this->at(6))->method('getValueHtml')->willReturn($items[1]->getName());
+        $this->model
+            ->method('getSelectionAttributes')
+            ->willReturnOnConsecutiveCalls(
+                ['option_id' => 1, 'option_label' => 'test option'],
+                ['option_id' => 1, 'option_label' => 'second option']
+            );
+        $this->model
+            ->method('getValueHtml')
+            ->willReturnOnConsecutiveCalls(
+                $items[0]->getName(),
+                $items[1]->getName()
+            );
 
         $orderMock->expects($this->any())->method('formatPriceTxt')->willReturnArgument(0);
         $this->model->setOrder($orderMock);

--- a/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/BundlePanelTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Ui/DataProvider/Product/Form/Modifier/BundlePanelTest.php
@@ -93,7 +93,7 @@ class BundlePanelTest extends TestCase
                 'locator' => $this->locatorMock,
                 'urlBuilder' => $this->urlBuilder,
                 'shipmentType' => $this->shipmentType,
-                'arrayManager' => $this->arrayManagerMock,
+                'arrayManager' => $this->arrayManagerMock
             ]
         );
     }
@@ -126,7 +126,7 @@ class BundlePanelTest extends TestCase
                         'children',
                         ArrayManager::DEFAULT_PATH_DELIMITER,
                         $shipmentTypePath
-                    ],
+                    ]
                 ]
             );
         $this->arrayManagerMock->method('merge')
@@ -135,17 +135,21 @@ class BundlePanelTest extends TestCase
             ->willReturn([]);
         $this->arrayManagerMock->method('set')
             ->willReturn([]);
-        $this->arrayManagerMock->expects($this->at(12))
+        $this->arrayManagerMock
             ->method('merge')
-            ->with(
-                $shipmentTypePath . BundlePanel::META_CONFIG_PATH,
-                [],
+            ->withConsecutive(
+                [], [], [], [], [], [], [], [], [], [], [], [],
                 [
-                    'dataScope' => $dataScope,
-                    'validation' => [
-                        'required-entry' => false
+                    $shipmentTypePath . BundlePanel::META_CONFIG_PATH,
+                    [],
+                    [
+                        'dataScope' => $dataScope,
+                        'validation' => [
+                            'required-entry' => false
+                        ]
                     ]
                 ]
+
             );
         $this->bundlePanelModel->modifyMeta($sourceMeta);
     }
@@ -165,7 +169,7 @@ class BundlePanelTest extends TestCase
             [
                 'someAttrGroup/children',
                 'shipment_type'
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/BundleImportExport/Test/Unit/Model/Import/Product/Type/BundleTest.php
+++ b/app/code/Magento/BundleImportExport/Test/Unit/Model/Import/Product/Type/BundleTest.php
@@ -74,24 +74,25 @@ class BundleTest extends AbstractImportTestCase
      */
     protected $setCollection;
 
-    /** @var ScopeResolverInterface|MockObject */
+    /**
+     * @var ScopeResolverInterface|MockObject
+     */
     private $scopeResolver;
 
     /**
-     *
      * @return void
      */
-    protected function initFetchAllCalls()
+    protected function initFetchAllCalls(): void
     {
         $fetchAllForInitAttributes = [
             [
                 'attribute_set_name' => '1',
-                'attribute_id' => '1',
+                'attribute_id' => '1'
             ],
             [
                 'attribute_set_name' => '2',
-                'attribute_id' => '2',
-            ],
+                'attribute_id' => '2'
+            ]
         ];
 
         $fetchAllForOtherCalls = [[
@@ -124,9 +125,7 @@ class BundleTest extends AbstractImportTestCase
     }
 
     /**
-     * Set up
-     *
-     * @return void
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -158,7 +157,7 @@ class BundleTest extends AbstractImportTestCase
                     'insertOnDuplicate',
                     'delete',
                     'quoteInto',
-                'fetchAssoc'
+                    'fetchAssoc'
             ])
             ->disableOriginalConstructor()
             ->getMock();
@@ -206,7 +205,7 @@ class BundleTest extends AbstractImportTestCase
         ];
         $this->scopeResolver = $this->getMockBuilder(ScopeResolverInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getScope'])
+            ->onlyMethods(['getScope'])
             ->getMockForAbstractClass();
         $this->bundle = $this->objectManagerHelper->getObject(
             Bundle::class,
@@ -215,7 +214,7 @@ class BundleTest extends AbstractImportTestCase
                 'prodAttrColFac' => $this->prodAttrColFac,
                 'resource' => $this->resource,
                 'params' => $this->params,
-                'scopeResolver' => $this->scopeResolver,
+                'scopeResolver' => $this->scopeResolver
             ]
         );
 
@@ -239,14 +238,18 @@ class BundleTest extends AbstractImportTestCase
      *
      * @param array $skus
      * @param array $bunch
-     * @param $allowImport
+     * @param bool $allowImport
+     *
+     * @return void
      * @dataProvider saveDataProvider
      */
-    public function testSaveData($skus, $bunch, $allowImport)
+    public function testSaveData(array $skus, array $bunch, bool $allowImport): void
     {
         $this->entityModel->expects($this->any())->method('getBehavior')->willReturn(Import::BEHAVIOR_APPEND);
         $this->entityModel->expects($this->once())->method('getNewSku')->willReturn($skus['newSku']);
-        $this->entityModel->expects($this->at(2))->method('getNextBunch')->willReturn([$bunch]);
+        $this->entityModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls([$bunch]);
         $this->entityModel->expects($this->any())->method('isRowAllowedToImport')->willReturn($allowImport);
         $scope = $this->getMockBuilder(ScopeInterface::class)->getMockForAbstractClass();
         $this->scopeResolver->expects($this->any())->method('getScope')->willReturn($scope);
@@ -317,7 +320,7 @@ class BundleTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function saveDataProvider()
+    public function saveDataProvider(): array
     {
         return [
             [
@@ -343,7 +346,7 @@ class BundleTest extends AbstractImportTestCase
             'Import without bundle values' => [
                 'skus' => ['newSku' => ['sku' => ['sku' => 'sku', 'entity_id' => 3, 'type_id' => 'bundle']]],
                 'bunch' => ['sku' => 'sku', 'name' => 'name'],
-                'allowImport' => true,
+                'allowImport' => true
             ],
             [
                 'skus' => ['newSku' => [
@@ -382,16 +385,22 @@ class BundleTest extends AbstractImportTestCase
 
     /**
      * Test for method saveData()
+     *
+     * @return void
      */
-    public function testSaveDataDelete()
+    public function testSaveDataDelete(): void
     {
         $this->entityModel->expects($this->any())->method('getBehavior')->willReturn(Import::BEHAVIOR_DELETE);
         $this->entityModel->expects($this->once())->method('getNewSku')->willReturn([
             'sku' => ['sku' => 'sku', 'entity_id' => 3, 'attr_set_code' => 'Default', 'type_id' => 'bundle']
         ]);
-        $this->entityModel->expects($this->at(2))->method('getNextBunch')->willReturn([
-            ['bundle_values' => 'value1', 'sku' => 'sku', 'name' => 'name']
-        ]);
+        $this->entityModel
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    ['bundle_values' => 'value1', 'sku' => 'sku', 'name' => 'name']
+                ]
+            );
         $this->entityModel->expects($this->any())->method('isRowAllowedToImport')->willReturn(true);
         $select = $this->createMock(Select::class);
         $this->connection->expects($this->any())->method('select')->willReturn($select);
@@ -405,7 +414,10 @@ class BundleTest extends AbstractImportTestCase
         $this->assertNotNull($bundle);
     }
 
-    public function testPrepareAttributesWithDefaultValueForSaveInsideCall()
+    /**
+     * @return void
+     */
+    public function testPrepareAttributesWithDefaultValueForSaveInsideCall(): void
     {
         $bundleMock = $this->createPartialMock(
             Bundle::class,
@@ -431,8 +443,10 @@ class BundleTest extends AbstractImportTestCase
 
     /**
      * Test for isRowValid()
+     *
+     * @return void
      */
-    public function testIsRowValid()
+    public function testIsRowValid(): void
     {
         $this->entityModel->expects($this->any())->method('getRowScope')->willReturn(-1);
         $rowData = [

--- a/app/code/Magento/CacheInvalidate/Test/Unit/Model/PurgeCacheTest.php
+++ b/app/code/Magento/CacheInvalidate/Test/Unit/Model/PurgeCacheTest.php
@@ -20,18 +20,29 @@ use PHPUnit\Framework\TestCase;
 
 class PurgeCacheTest extends TestCase
 {
-    /** @var PurgeCache */
+    /**
+     * @var PurgeCache
+     */
     protected $model;
 
-    /** @var MockObject|Socket */
+    /**
+     * @var MockObject|Socket
+     */
     protected $socketAdapterMock;
 
-    /** @var MockObject|InvalidateLogger */
+    /**
+     * @var MockObject|InvalidateLogger
+     */
     protected $loggerMock;
 
-    /** @var MockObject|Server */
+    /**
+     * @var MockObject|Server
+     */
     protected $cacheServer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $socketFactoryMock = $this->createMock(SocketFactory::class);
@@ -60,14 +71,16 @@ class PurgeCacheTest extends TestCase
 
     /**
      * @param string[] $hosts
+     *
+     * @return void
      * @dataProvider sendPurgeRequestDataProvider
      */
-    public function testSendPurgeRequest($hosts)
+    public function testSendPurgeRequest(array $hosts): void
     {
         $uris = [];
         /** @var array $host */
         foreach ($hosts as $host) {
-            $port = isset($host['port']) ? $host['port'] : Server::DEFAULT_PORT;
+            $port = $host['port'] ?? Server::DEFAULT_PORT;
             $uris[] = UriFactory::factory('')->setHost($host['host'])
                 ->setPort($port)
                 ->setScheme('http');
@@ -75,19 +88,21 @@ class PurgeCacheTest extends TestCase
         $this->cacheServer->expects($this->once())
             ->method('getUris')
             ->willReturn($uris);
+        $connectWithArgs = $writeWithArgs = [];
 
-        $i = 1;
         foreach ($uris as $uri) {
-            $this->socketAdapterMock->expects($this->at($i++))
-                ->method('connect')
-                ->with($uri->getHost(), $uri->getPort());
-            $this->socketAdapterMock->expects($this->at($i++))
-                ->method('write')
-                ->with('PURGE', $uri, '1.1', ['X-Magento-Tags-Pattern' => 'tags', 'Host' => $uri->getHost()]);
-            $this->socketAdapterMock->expects($this->at($i++))
-                ->method('read');
-            $i++;
+            $withArgs[] = [$uri->getHost(), $uri->getPort()];
+            $writeWithArgs[] = ['PURGE', $uri, '1.1', ['X-Magento-Tags-Pattern' => 'tags', 'Host' => $uri->getHost()]];
         }
+        $this->socketAdapterMock
+            ->method('connect')
+            ->withConsecutive(...$connectWithArgs);
+        $this->socketAdapterMock
+            ->method('write')
+            ->withConsecutive(...$writeWithArgs);
+        $this->socketAdapterMock
+            ->method('read');
+
         $this->socketAdapterMock->expects($this->exactly(count($uris)))
             ->method('close');
 
@@ -97,13 +112,16 @@ class PurgeCacheTest extends TestCase
         $this->assertTrue($this->model->sendPurgeRequest(['tags']));
     }
 
-    public function testSendMultiPurgeRequest()
+    /**
+     * @return void
+     */
+    public function testSendMultiPurgeRequest(): void
     {
         $tags = [
             '(^|,)cat_p_95(,|$)', '(^|,)cat_p_96(,|$)', '(^|,)cat_p_97(,|$)', '(^|,)cat_p_98(,|$)',
             '(^|,)cat_p_99(,|$)', '(^|,)cat_p_100(,|$)', '(^|,)cat_p_10038(,|$)', '(^|,)cat_p_142985(,|$)',
             '(^|,)cat_p_199(,|$)', '(^|,)cat_p_300(,|$)', '(^|,)cat_p_12038(,|$)', '(^|,)cat_p_152985(,|$)',
-            '(^|,)cat_p_299(,|$)', '(^|,)cat_p_400(,|$)', '(^|,)cat_p_13038(,|$)', '(^|,)cat_p_162985(,|$)',
+            '(^|,)cat_p_299(,|$)', '(^|,)cat_p_400(,|$)', '(^|,)cat_p_13038(,|$)', '(^|,)cat_p_162985(,|$)'
         ];
 
         $tagsSplitA = array_slice($tags, 0, 12);
@@ -143,7 +161,7 @@ class PurgeCacheTest extends TestCase
     /**
      * @return array
      */
-    public function sendPurgeRequestDataProvider()
+    public function sendPurgeRequestDataProvider(): array
     {
         return [
             [
@@ -159,7 +177,10 @@ class PurgeCacheTest extends TestCase
         ];
     }
 
-    public function testSendPurgeRequestWithException()
+    /**
+     * @return void
+     */
+    public function testSendPurgeRequestWithException(): void
     {
         $uris[] = UriFactory::factory('')->setHost('127.0.0.1')
             ->setPort(8080)

--- a/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Product/View/GalleryTest.php
@@ -69,9 +69,14 @@ class GalleryTest extends TestCase
      */
     protected $galleryImagesConfigMock;
 
-    /** @var  UrlBuilder|MockObject */
+    /**
+     * @var  UrlBuilder|MockObject
+     */
     private $urlBuilder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->registry = $this->createMock(Registry::class);
@@ -95,7 +100,10 @@ class GalleryTest extends TestCase
         ]);
     }
 
-    public function testGetGalleryImagesJsonWithLabel()
+    /**
+     * @return void
+     */
+    public function testGetGalleryImagesJsonWithLabel(): void
     {
         $this->prepareGetGalleryImagesJsonMocks();
         $json = $this->model->getGalleryImagesJson();
@@ -110,7 +118,10 @@ class GalleryTest extends TestCase
         $this->assertEquals('test_video_url', $decodedJson[0]['videoUrl']);
     }
 
-    public function testGetGalleryImagesJsonWithoutLabel()
+    /**
+     * @return void
+     */
+    public function testGetGalleryImagesJsonWithoutLabel(): void
     {
         $this->prepareGetGalleryImagesJsonMocks(false);
         $json = $this->model->getGalleryImagesJson();
@@ -118,7 +129,10 @@ class GalleryTest extends TestCase
         $this->assertEquals('test_product_name', $decodedJson[0]['caption']);
     }
 
-    private function prepareGetGalleryImagesJsonMocks($hasLabel = true)
+    /**
+     * @return void
+     */
+    private function prepareGetGalleryImagesJsonMocks($hasLabel = true): void
     {
         $storeMock = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
@@ -152,7 +166,7 @@ class GalleryTest extends TestCase
             ->willReturn($productMock);
 
         $this->imageHelper = $this->getMockBuilder(Image::class)
-            ->setMethods(['init', 'setImageFile', 'getUrl'])
+            ->onlyMethods(['init', 'setImageFile', 'getUrl'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -168,22 +182,23 @@ class GalleryTest extends TestCase
             ->method('setImageFile')
             ->with('test_file')
             ->willReturnSelf();
-        $this->urlBuilder->expects($this->at(0))
+        $this->urlBuilder
             ->method('getUrl')
-            ->willReturn('product_page_image_small_url');
-        $this->urlBuilder->expects($this->at(1))
-            ->method('getUrl')
-            ->willReturn('product_page_image_medium_url');
-        $this->urlBuilder->expects($this->at(2))
-            ->method('getUrl')
-            ->willReturn('product_page_image_large_url');
+            ->willReturnOnConsecutiveCalls(
+                'product_page_image_small_url',
+                'product_page_image_medium_url',
+                'product_page_image_large_url'
+            );
 
         $this->galleryImagesConfigMock->expects($this->exactly(2))
             ->method('getItems')
             ->willReturn($this->getGalleryImagesConfigItems());
     }
 
-    public function testGetGalleryImages()
+    /**
+     * @return void
+     */
+    public function testGetGalleryImages(): void
     {
         $productMock = $this->createMock(Product::class);
         $productTypeMock = $this->createMock(AbstractType::class);
@@ -216,7 +231,7 @@ class GalleryTest extends TestCase
      *
      * @return ImagesConfigFactoryInterface
      */
-    private function getImagesConfigFactory()
+    private function getImagesConfigFactory(): ImagesConfigFactoryInterface
     {
         $this->galleryImagesConfigMock = $this->createConfiguredMock(
             Collection::class,
@@ -235,7 +250,7 @@ class GalleryTest extends TestCase
      *
      * @return array
      */
-    private function getGalleryImagesConfigItems()
+    private function getGalleryImagesConfigItems(): array
     {
         return  [
             new DataObject([
@@ -257,9 +272,9 @@ class GalleryTest extends TestCase
     }
 
     /**
-     * @return \Magento\Framework\Data\Collection
+     * @return Collection
      */
-    private function getImagesCollectionWithPopulatedDataObject($hasLabel)
+    private function getImagesCollectionWithPopulatedDataObject($hasLabel): Collection
     {
         $collectionMock = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/Catalog/Test/Unit/Block/Rss/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Rss/CategoryTest.php
@@ -117,21 +117,26 @@ class CategoryTest extends TestCase
         'entries' => [
             [
                 'title' => 'Product Name',
-                'link' => 'http://magento.com/product.html',
-            ],
-        ],
+                'link' => 'http://magento.com/product.html'
+            ]
+        ]
     ];
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockForAbstractClass(RequestInterface::class);
-        $this->request->expects($this->at(0))->method('getParam')->with('cid')->willReturn(1);
-        $this->request->expects($this->at(1))->method('getParam')->with('store_id')->willReturn(null);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['cid'], ['store_id'])
+            ->willReturnOnConsecutiveCalls(1, null);
 
         $this->httpContext = $this->createMock(Context::class);
         $this->catalogHelper = $this->createMock(Data::class);
         $this->categoryFactory = $this->getMockBuilder(CategoryFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->rssModel = $this->createPartialMock(
@@ -144,7 +149,8 @@ class CategoryTest extends TestCase
         $this->customerSession->expects($this->any())->method('getId')->willReturn(1);
         $this->storeManager = $this->getMockForAbstractClass(StoreManagerInterface::class);
         $store = $this->getMockBuilder(Store::class)
-            ->setMethods(['getId'])->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
+            ->disableOriginalConstructor()
             ->getMock();
         $store->expects($this->any())->method('getId')->willReturn(1);
         $this->storeManager->expects($this->any())->method('getStore')->willReturn($store);
@@ -167,15 +173,18 @@ class CategoryTest extends TestCase
                 'customerSession' => $this->customerSession,
                 'storeManager' => $this->storeManager,
                 'categoryRepository' => $this->categoryRepository,
-                'viewConfig' => $this->viewConfig,
+                'viewConfig' => $this->viewConfig
             ]
         );
     }
 
-    public function testGetRssData()
+    /**
+     * @return void
+     */
+    public function testGetRssData(): void
     {
         $category = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
-            ->setMethods(['__sleep', 'load', 'getId', 'getUrl', 'getName'])
+            ->onlyMethods(['__sleep', 'load', 'getId', 'getUrl', 'getName'])
             ->disableOriginalConstructor()
             ->getMock();
         $category->expects($this->once())->method('getName')->willReturn('Category Name');
@@ -193,16 +202,9 @@ class CategoryTest extends TestCase
             ->willReturn($configViewMock);
 
         $product = $this->getMockBuilder(Product::class)
-            ->setMethods(
-                [
-                    '__sleep',
-                    'getName',
-                    'getAllowedInRss',
-                    'getProductUrl',
-                    'getDescription',
-                    'getAllowedPriceInRss'
-                ]
-            )->disableOriginalConstructor()
+            ->onlyMethods(['__sleep', 'getName', 'getProductUrl'])
+            ->addMethods(['getAllowedInRss', 'getDescription', 'getAllowedPriceInRss'])
+            ->disableOriginalConstructor()
             ->getMock();
         $product->expects($this->once())->method('getName')->willReturn('Product Name');
         $product->expects($this->once())->method('getAllowedInRss')->willReturn(true);
@@ -240,12 +242,18 @@ class CategoryTest extends TestCase
         );
     }
 
-    public function testGetCacheLifetime()
+    /**
+     * @return void
+     */
+    public function testGetCacheLifetime(): void
     {
         $this->assertEquals(600, $this->block->getCacheLifetime());
     }
 
-    public function testIsAllowed()
+    /**
+     * @return void
+     */
+    public function testIsAllowed(): void
     {
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/category', ScopeInterface::SCOPE_STORE)
@@ -253,19 +261,22 @@ class CategoryTest extends TestCase
         $this->assertTrue($this->block->isAllowed());
     }
 
-    public function testGetFeeds()
+    /**
+     * @return void
+     */
+    public function testGetFeeds(): void
     {
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/category', ScopeInterface::SCOPE_STORE)
             ->willReturn(true);
 
         $category = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
-            ->setMethods(['__sleep', 'getTreeModel', 'getResourceCollection', 'getId', 'getName'])
+            ->onlyMethods(['__sleep', 'getTreeModel', 'getResourceCollection', 'getId', 'getName'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $collection = $this->getMockBuilder(Collection::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'addIdFilter',
                     'addAttributeToSelect',
@@ -274,7 +285,8 @@ class CategoryTest extends TestCase
                     'addAttributeToFilter',
                     'getIterator'
                 ]
-            )->disableOriginalConstructor()
+            )
+            ->disableOriginalConstructor()
             ->getMock();
         $collection->expects($this->once())->method('addIdFilter')->willReturnSelf();
         $collection->expects($this->exactly(3))->method('addAttributeToSelect')->willReturnSelf();
@@ -290,12 +302,15 @@ class CategoryTest extends TestCase
 
         $node = new DataObject(['id' => 1]);
         $nodes = $this->getMockBuilder(Node::class)
-            ->setMethods(['getChildren'])->disableOriginalConstructor()
+            ->onlyMethods(['getChildren'])
+            ->disableOriginalConstructor()
             ->getMock();
         $nodes->expects($this->once())->method('getChildren')->willReturn([$node]);
 
         $tree = $this->getMockBuilder(Tree::class)
-            ->setMethods(['loadChildren', 'loadNode'])->disableOriginalConstructor()
+            ->onlyMethods(['loadNode'])
+            ->addMethods(['loadChildren'])
+            ->disableOriginalConstructor()
             ->getMock();
         $tree->expects($this->once())->method('loadNode')->willReturnSelf();
         $tree->expects($this->once())->method('loadChildren')->willReturn($nodes);

--- a/app/code/Magento/Catalog/Test/Unit/Block/Rss/Product/SpecialTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Block/Rss/Product/SpecialTest.php
@@ -90,14 +90,19 @@ class SpecialTest extends TestCase
      */
     protected $request;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockForAbstractClass(RequestInterface::class);
-        $this->request->expects($this->at(0))->method('getParam')->with('store_id')->willReturn(null);
-        $this->request->expects($this->at(1))->method('getParam')->with('cid')->willReturn(null);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['store_id'], ['cid'])
+            ->willReturnOnConsecutiveCalls(null, null);
 
         $this->httpContext = $this->getMockBuilder(Context::class)
-            ->setMethods(['getValue'])->disableOriginalConstructor()
+            ->onlyMethods(['getValue'])->disableOriginalConstructor()
             ->getMock();
         $this->httpContext->expects($this->any())->method('getValue')->willReturn(1);
 
@@ -110,7 +115,8 @@ class SpecialTest extends TestCase
 
         $this->storeManager = $this->getMockForAbstractClass(StoreManagerInterface::class);
         $store = $this->getMockBuilder(Store::class)
-            ->setMethods(['getId', 'getFrontendName'])->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'getFrontendName'])
+            ->disableOriginalConstructor()
             ->getMock();
         $store->expects($this->any())->method('getId')->willReturn(1);
         $store->expects($this->any())->method('getFrontendName')->willReturn('Store 1');
@@ -135,12 +141,15 @@ class SpecialTest extends TestCase
                 'rssUrlBuilder' => $this->rssUrlBuilder,
                 'storeManager' => $this->storeManager,
                 'scopeConfig' => $this->scopeConfig,
-                'localeDate' => $this->localeDate,
+                'localeDate' => $this->localeDate
             ]
         );
     }
 
-    public function testGetRssData()
+    /**
+     * @return void
+     */
+    public function testGetRssData(): void
     {
         $this->rssUrlBuilder->expects($this->once())->method('getUrl')
             ->with(['type' => 'special_products', 'store_id' => 1])
@@ -166,9 +175,9 @@ class SpecialTest extends TestCase
             'entries' => [
                 [
                     'title' => 'Product Name',
-                    'link' => 'http://magento.com/product-name.html',
-                ],
-            ],
+                    'link' => 'http://magento.com/product-name.html'
+                ]
+            ]
         ];
         $rssData = $this->block->getRssData();
         $description = $rssData['entries'][0]['description'];
@@ -188,22 +197,29 @@ class SpecialTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getItemMock()
+    protected function getItemMock(): MockObject
     {
         $item = $this->getMockBuilder(Product::class)
-            ->setMethods([
-                '__sleep',
-                'getName',
-                'getProductUrl',
-                'getDescription',
-                'getAllowedInRss',
-                'getAllowedPriceInRss',
-                'getSpecialToDate',
-                'getSpecialPrice',
-                'getFinalPrice',
-                'getPrice',
-                'getUseSpecial',
-            ])->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    '__sleep',
+                    'getName',
+                    'getProductUrl',
+                    'getSpecialToDate',
+                    'getSpecialPrice',
+                    'getFinalPrice',
+                    'getPrice'
+                ]
+            )
+            ->addMethods(
+                [
+                    'getDescription',
+                    'getAllowedInRss',
+                    'getAllowedPriceInRss',
+                    'getUseSpecial'
+                ]
+            )
+            ->disableOriginalConstructor()
             ->getMock();
         $item->expects($this->once())->method('getAllowedInRss')->willReturn(true);
         $item->expects($this->any())->method('getSpecialToDate')->willReturn(date('Y-m-d'));
@@ -219,7 +235,10 @@ class SpecialTest extends TestCase
         return $item;
     }
 
-    public function testIsAllowed()
+    /**
+     * @return void
+     */
+    public function testIsAllowed(): void
     {
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/special', ScopeInterface::SCOPE_STORE)
@@ -227,12 +246,18 @@ class SpecialTest extends TestCase
         $this->assertTrue($this->block->isAllowed());
     }
 
-    public function testGetCacheLifetime()
+    /**
+     * @return void
+     */
+    public function testGetCacheLifetime(): void
     {
         $this->assertEquals(600, $this->block->getCacheLifetime());
     }
 
-    public function testGetFeeds()
+    /**
+     * @return void
+     */
+    public function testGetFeeds(): void
     {
         $this->scopeConfig->expects($this->once())->method('isSetFlag')
             ->with('rss/catalog/special', ScopeInterface::SCOPE_STORE)
@@ -242,7 +267,7 @@ class SpecialTest extends TestCase
             ->willReturn('http://magento.com/rss/feed/index/type/special_products/store_id/1');
         $expected = [
             'label' => 'Special Products',
-            'link' => 'http://magento.com/rss/feed/index/type/special_products/store_id/1',
+            'link' => 'http://magento.com/rss/feed/index/type/special_products/store_id/1'
         ];
         $this->assertEquals($expected, $this->block->getFeeds());
     }

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Category/ViewTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Category/ViewTest.php
@@ -128,7 +128,7 @@ class ViewTest extends TestCase
     protected $pageConfig;
 
     /**
-     * Set up instances and mock objects
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -149,7 +149,15 @@ class ViewTest extends TestCase
         $this->pageConfig->expects($this->any())->method('addBodyClass')->willReturnSelf();
 
         $this->page = $this->getMockBuilder(Page::class)
-            ->setMethods(['getConfig', 'initLayout', 'addPageLayoutHandles', 'getLayout', 'addUpdate'])
+            ->onlyMethods(
+                [
+                    'getConfig',
+                    'initLayout',
+                    'addPageLayoutHandles',
+                    'getLayout',
+                    'addUpdate'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
         $this->page->expects($this->any())->method('getConfig')->willReturn($this->pageConfig);
@@ -184,7 +192,7 @@ class ViewTest extends TestCase
 
         $resultPageFactory = $this->getMockBuilder(PageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $resultPageFactory->expects($this->atLeastOnce())
             ->method('create')
@@ -204,10 +212,12 @@ class ViewTest extends TestCase
     }
 
     /**
-     * Apply custom layout update is correct
+     * Apply custom layout update is correct.
      *
-     * @dataProvider getInvocationData
+     * @param array $expectedData
+     *
      * @return void
+     * @dataProvider getInvocationData
      */
     public function testApplyCustomLayoutUpdate(array $expectedData): void
     {
@@ -230,12 +240,11 @@ class ViewTest extends TestCase
             ->addMethods(['getPageLayout', 'getLayoutUpdates'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->category->expects($this->at(1))
+        $this->category
             ->method('hasChildren')
-            ->willReturn(true);
-        $this->category->expects($this->at(2))
-            ->method('hasChildren')
-            ->willReturn($expectedData[1][0]['type'] === 'default' ? true : false);
+            ->willReturnOnConsecutiveCalls(
+                $expectedData[1][0]['type'] === 'default'
+            );
         $this->category->expects($this->once())
             ->method('getDisplayMode')
             ->willReturn($expectedData[2][0]['displaymode']);
@@ -248,21 +257,22 @@ class ViewTest extends TestCase
     }
 
     /**
-     * Expected invocation for Layout Handles
+     * Expected invocation for Layout Handles.
      *
      * @param array $data
+     *
      * @return void
      */
-    private function expectationForPageLayoutHandles($data): void
+    private function expectationForPageLayoutHandles(array $data): void
     {
-        $index = 1;
+        $withArgs = [];
 
         foreach ($data as $expectedData) {
-            $this->page->expects($this->at($index))
-                ->method('addPageLayoutHandles')
-                ->with($expectedData[0], $expectedData[1], $expectedData[2]);
-            $index++;
+            $withArgs[] = [$expectedData[0], $expectedData[1], $expectedData[2]];
         }
+        $this->page
+            ->method('addPageLayoutHandles')
+            ->withConsecutive(...$withArgs);
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Product/Frontend/Action/SynchronizeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Product/Frontend/Action/SynchronizeTest.php
@@ -45,6 +45,9 @@ class SynchronizeTest extends TestCase
      */
     private $jsonFactoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->getMockBuilder(Context::class)
@@ -72,7 +75,10 @@ class SynchronizeTest extends TestCase
         );
     }
 
-    public function testExecuteAction()
+    /**
+     * @return void
+     */
+    public function testExecuteAction(): void
     {
         $data = [
             'type_id' => null,
@@ -87,15 +93,10 @@ class SynchronizeTest extends TestCase
             ->method('create')
             ->willReturn($jsonObject);
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('ids', [])
-            ->willReturn($data['ids']);
-
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('type_id', null)
-            ->willReturn($data['type_id']);
+            ->withConsecutive(['ids', []], ['type_id', null])
+            ->willReturnOnConsecutiveCalls($data['ids'], $data['type_id']);
 
         $this->synchronizerMock->expects($this->once())
             ->method('syncActions')
@@ -108,7 +109,10 @@ class SynchronizeTest extends TestCase
         $this->synchronize->execute();
     }
 
-    public function testExecuteActionException()
+    /**
+     * @return void
+     */
+    public function testExecuteActionException(): void
     {
         $data = [
             'type_id' => null,
@@ -122,15 +126,10 @@ class SynchronizeTest extends TestCase
             ->method('create')
             ->willReturn($jsonObject);
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('ids', [])
-            ->willReturn($data['ids']);
-
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('type_id', null)
-            ->willReturn($data['type_id']);
+            ->withConsecutive(['ids', []], ['type_id', null])
+            ->willReturnOnConsecutiveCalls($data['ids'], $data['type_id']);
 
         $this->synchronizerMock->expects($this->once())
             ->method('syncActions')

--- a/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/SaveHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Attribute/Backend/TierPrice/SaveHandlerTest.php
@@ -64,30 +64,30 @@ class SaveHandlerTest extends TestCase
     private $tierPriceResource;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStore'])
+            ->onlyMethods(['getStore'])
             ->getMockForAbstractClass();
         $this->attributeRepository = $this->getMockBuilder(ProductAttributeRepositoryInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->getMockForAbstractClass();
         $this->groupManagement = $this->getMockBuilder(GroupManagementInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAllCustomersGroup'])
+            ->onlyMethods(['getAllCustomersGroup'])
             ->getMockForAbstractClass();
         $this->metadataPoll = $this->getMockBuilder(MetadataPool::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getMetadata'])
+            ->onlyMethods(['getMetadata'])
             ->getMock();
         $this->tierPriceResource = $this->getMockBuilder(Tierprice::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['savePriceData', 'loadPriceData'])
             ->getMock();
 
         $this->saveHandler = $this->objectManager->getObject(
@@ -102,6 +102,9 @@ class SaveHandlerTest extends TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testExecute(): void
     {
         $tierPrices = [
@@ -114,7 +117,7 @@ class SaveHandlerTest extends TestCase
         /** @var MockObject $product */
         $product = $this->getMockBuilder(ProductInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getData','setData', 'getStoreId'])
+            ->addMethods(['getData', 'setData', 'getStoreId'])
             ->getMockForAbstractClass();
         $product->expects($this->atLeastOnce())->method('getData')->willReturnMap(
             [
@@ -126,14 +129,14 @@ class SaveHandlerTest extends TestCase
         $product->expects($this->atLeastOnce())->method('setData')->with('tier_price_changed', 1);
         $store = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getWebsiteId'])
+            ->onlyMethods(['getWebsiteId'])
             ->getMockForAbstractClass();
         $store->expects($this->atLeastOnce())->method('getWebsiteId')->willReturn(0);
         $this->storeManager->expects($this->atLeastOnce())->method('getStore')->willReturn($store);
         /** @var MockObject $attribute */
         $attribute = $this->getMockBuilder(ProductAttributeInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getName', 'isScopeGlobal'])
+            ->addMethods(['getName', 'isScopeGlobal'])
             ->getMockForAbstractClass();
         $attribute->expects($this->atLeastOnce())->method('getName')->willReturn('tier_price');
         $attribute->expects($this->atLeastOnce())->method('isScopeGlobal')->willReturn(true);
@@ -141,7 +144,7 @@ class SaveHandlerTest extends TestCase
             ->willReturn($attribute);
         $productMetadata = $this->getMockBuilder(EntityMetadataInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getLinkField'])
+            ->onlyMethods(['getLinkField'])
             ->getMockForAbstractClass();
         $productMetadata->expects($this->atLeastOnce())->method('getLinkField')->willReturn($linkField);
         $this->metadataPoll->expects($this->atLeastOnce())->method('getMetadata')
@@ -149,7 +152,7 @@ class SaveHandlerTest extends TestCase
             ->willReturn($productMetadata);
         $customerGroup = $this->getMockBuilder(GroupInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId'])
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $customerGroup->expects($this->atLeastOnce())->method('getId')->willReturn(3200);
         $this->groupManagement->expects($this->atLeastOnce())->method('getAllCustomersGroup')
@@ -159,6 +162,9 @@ class SaveHandlerTest extends TestCase
         $this->assertEquals($product, $this->saveHandler->execute($product));
     }
 
+    /**
+     * @return void
+     */
     public function testExecuteWithException(): void
     {
         $this->expectException('Magento\Framework\Exception\InputException');
@@ -166,7 +172,7 @@ class SaveHandlerTest extends TestCase
         /** @var MockObject $attribute */
         $attribute = $this->getMockBuilder(ProductAttributeInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getName', 'isScopeGlobal'])
+            ->addMethods(['getName', 'isScopeGlobal'])
             ->getMockForAbstractClass();
         $attribute->expects($this->atLeastOnce())->method('getName')->willReturn('tier_price');
         $this->attributeRepository->expects($this->atLeastOnce())->method('get')->with('tier_price')
@@ -174,7 +180,7 @@ class SaveHandlerTest extends TestCase
         /** @var MockObject $product */
         $product = $this->getMockBuilder(ProductInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getData','setData', 'getStoreId', 'getOrigData'])
+            ->addMethods(['getData', 'setData', 'getStoreId', 'getOrigData'])
             ->getMockForAbstractClass();
         $product->expects($this->atLeastOnce())->method('getData')->with('tier_price')->willReturn(1);
 
@@ -182,20 +188,25 @@ class SaveHandlerTest extends TestCase
     }
 
     /**
-     * @param $tierPrices
-     * @param $tierPricesStored
-     * @param $tierPricesExpected
+     * @param array $tierPrices
+     * @param array $tierPricesStored
+     * @param array $tierPricesExpected
+     *
+     * @return void
      * @dataProvider executeWithWebsitePriceDataProvider
      */
-    public function testExecuteWithWebsitePrice($tierPrices, $tierPricesStored, $tierPricesExpected): void
-    {
+    public function testExecuteWithWebsitePrice(
+        array $tierPrices,
+        array $tierPricesStored,
+        array $tierPricesExpected
+    ): void {
         $productId = 10;
         $linkField = 'entity_id';
 
         /** @var MockObject $product */
         $product = $this->getMockBuilder(ProductInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getData','setData', 'getStoreId'])
+            ->addMethods(['getData', 'setData', 'getStoreId'])
             ->getMockForAbstractClass();
         $product->expects($this->atLeastOnce())->method('getData')->willReturnMap(
             [
@@ -207,14 +218,14 @@ class SaveHandlerTest extends TestCase
         $product->expects($this->atLeastOnce())->method('setData')->with('tier_price_changed', 1);
         $store = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getWebsiteId'])
+            ->onlyMethods(['getWebsiteId'])
             ->getMockForAbstractClass();
         $store->expects($this->atLeastOnce())->method('getWebsiteId')->willReturn(1);
         $this->storeManager->expects($this->atLeastOnce())->method('getStore')->willReturn($store);
         /** @var MockObject $attribute */
         $attribute = $this->getMockBuilder(ProductAttributeInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getName', 'isScopeGlobal'])
+            ->addMethods(['getName', 'isScopeGlobal'])
             ->getMockForAbstractClass();
         $attribute->expects($this->atLeastOnce())->method('getName')->willReturn('tier_price');
         $attribute->expects($this->atLeastOnce())->method('isScopeGlobal')->willReturn(false);
@@ -222,7 +233,7 @@ class SaveHandlerTest extends TestCase
             ->willReturn($attribute);
         $productMetadata = $this->getMockBuilder(EntityMetadataInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getLinkField'])
+            ->onlyMethods(['getLinkField'])
             ->getMockForAbstractClass();
         $productMetadata->expects($this->atLeastOnce())->method('getLinkField')->willReturn($linkField);
         $this->metadataPoll->expects($this->atLeastOnce())->method('getMetadata')
@@ -230,26 +241,23 @@ class SaveHandlerTest extends TestCase
             ->willReturn($productMetadata);
         $customerGroup = $this->getMockBuilder(GroupInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId'])
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $customerGroup->expects($this->atLeastOnce())->method('getId')->willReturn(3200);
         $this->groupManagement->expects($this->atLeastOnce())->method('getAllCustomersGroup')
             ->willReturn($customerGroup);
         $this->tierPriceResource
-            ->expects($this->at(1))
             ->method('savePriceData')
-            ->with(new \Magento\Framework\DataObject($tierPricesExpected[0]))
-            ->willReturnSelf();
-        $this->tierPriceResource
-            ->expects($this->at(2))
-            ->method('savePriceData')
-            ->with(new \Magento\Framework\DataObject($tierPricesExpected[1]))
-            ->willReturnSelf();
-        $this->tierPriceResource
-            ->expects($this->at(3))
-            ->method('savePriceData')
-            ->with(new \Magento\Framework\DataObject($tierPricesExpected[2]))
-            ->willReturnSelf();
+            ->withConsecutive(
+                [new \Magento\Framework\DataObject($tierPricesExpected[0])],
+                [new \Magento\Framework\DataObject($tierPricesExpected[1])],
+                [new \Magento\Framework\DataObject($tierPricesExpected[2])]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->tierPriceResource,
+                $this->tierPriceResource,
+                $this->tierPriceResource
+            );
         $this->tierPriceResource
             ->expects($this->atLeastOnce())
             ->method('loadPriceData')
@@ -258,6 +266,9 @@ class SaveHandlerTest extends TestCase
         $this->assertEquals($product, $this->saveHandler->execute($product));
     }
 
+    /**
+     * @return array
+     */
     public function executeWithWebsitePriceDataProvider(): array
     {
         $productId = 10;
@@ -270,7 +281,8 @@ class SaveHandlerTest extends TestCase
                     'cust_group' => 0,
                     'price' => 10,
                     'product_id' => $productId
-                ],[
+                ],
+                [
                     'price_id' => 2,
                     'website_id' => 1,
                     'price_qty' => 2,
@@ -299,7 +311,8 @@ class SaveHandlerTest extends TestCase
                     'value' => 10,
                     'percentage_value' => null,
                     'entity_id' => $productId
-                ],[
+                ],
+                [
                     'website_id' => 1,
                     'qty' => 2,
                     'customer_group_id' => 0,
@@ -307,7 +320,8 @@ class SaveHandlerTest extends TestCase
                     'value' => null,
                     'percentage_value' => 20,
                     'entity_id' => $productId
-                ],[
+                ],
+                [
                     'website_id' => 1,
                     'qty' => 3,
                     'customer_group_id' => 0,

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/ReadHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/ReadHandlerTest.php
@@ -46,7 +46,7 @@ class ReadHandlerTest extends TestCase
     {
         $this->categoryLinkFactory = $this->getMockBuilder(CategoryLinkInterfaceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->productCategoryLink = $this->getMockBuilder(CategoryLink::class)
             ->disableOriginalConstructor()
@@ -62,7 +62,10 @@ class ReadHandlerTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+     * @return void
+     */
+    public function testExecute(): void
     {
         $categoryLinks = [
             ['category_id' => 3, 'position' => 10],
@@ -70,25 +73,28 @@ class ReadHandlerTest extends TestCase
         ];
 
         $dtoCategoryLinks = [];
+        $dataObjHelperWithArgs = $categoryLinkFactoryWillReturnArgs = [];
+
         foreach ($categoryLinks as $key => $categoryLink) {
-            $dtoCategoryLinks[$key] = $this->getMockBuilder(CategoryLinkInterface::class)
-                ->getMockForAbstractClass();
-            $this->dataObjectHelper->expects(static::at($key))
-                ->method('populateWithArray')
-                ->with($dtoCategoryLinks[$key], $categoryLink, CategoryLinkInterface::class);
-            $this->categoryLinkFactory->expects(static::at($key))
-                ->method('create')
-                ->willReturn($dtoCategoryLinks[$key]);
+            $dtoCategoryLinks[$key] = $this->getMockBuilder(CategoryLinkInterface::class)->getMockForAbstractClass();
+            $dataObjHelperWithArgs[] = [$dtoCategoryLinks[$key], $categoryLink, CategoryLinkInterface::class];
+            $categoryLinkFactoryWillReturnArgs[] = $dtoCategoryLinks[$key];
         }
+        $this->dataObjectHelper
+            ->method('populateWithArray')
+            ->withConsecutive(...$dataObjHelperWithArgs);
+        $this->categoryLinkFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(...$categoryLinkFactoryWillReturnArgs);
 
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getExtensionAttributes', 'setExtensionAttributes'])
+            ->onlyMethods(['getExtensionAttributes', 'setExtensionAttributes'])
             ->getMock();
 
         $extensionAttributes = $this->getMockBuilder(ProductExtensionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCategoryLinks'])
+            ->onlyMethods(['setCategoryLinks'])
             ->getMockForAbstractClass();
         $extensionAttributes->expects(static::once())->method('setCategoryLinks')->with($dtoCategoryLinks);
 
@@ -109,16 +115,19 @@ class ReadHandlerTest extends TestCase
         static::assertSame($product, $entity);
     }
 
-    public function testExecuteNullExtensionAttributes()
+    /**
+     * @return void
+     */
+    public function testExecuteNullExtensionAttributes(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getExtensionAttributes', 'setExtensionAttributes'])
+            ->onlyMethods(['getExtensionAttributes', 'setExtensionAttributes'])
             ->getMock();
 
         $extensionAttributes = $this->getMockBuilder(ProductExtensionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCategoryLinks'])
+            ->onlyMethods(['setCategoryLinks'])
             ->getMockForAbstractClass();
         $extensionAttributes->expects(static::once())->method('setCategoryLinks')->with(null);
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Link/SaveHandlerTest.php
@@ -40,7 +40,7 @@ class SaveHandlerTest extends TestCase
     private $hydratorPool;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -61,15 +61,21 @@ class SaveHandlerTest extends TestCase
 
     /**
      * @param array $categoryIds
-     * @param array $categoryLinks
+     * @param array|null $categoryLinks
      * @param array $existCategoryLinks
      * @param array $expectedCategoryLinks
      * @param array $affectedIds
      *
+     * @return void
      * @dataProvider getCategoryDataProvider
      */
-    public function testExecute($categoryIds, $categoryLinks, $existCategoryLinks, $expectedCategoryLinks, $affectedIds)
-    {
+    public function testExecute(
+        array $categoryIds,
+        ?array $categoryLinks,
+        array $existCategoryLinks,
+        array $expectedCategoryLinks,
+        array $affectedIds
+    ): void {
         if ($categoryLinks) {
             $this->hydrator->expects(static::any())
                 ->method('extract')
@@ -82,7 +88,7 @@ class SaveHandlerTest extends TestCase
 
         $extensionAttributes = $this->getMockBuilder(ProductExtensionInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCategoryLinks', 'getCategoryLinks'])
+            ->onlyMethods(['setCategoryLinks', 'getCategoryLinks'])
             ->getMockForAbstractClass();
         $extensionAttributes->expects(static::any())
             ->method('getCategoryLinks')
@@ -90,16 +96,10 @@ class SaveHandlerTest extends TestCase
 
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getExtensionAttributes',
-                    'setAffectedCategoryIds',
-                    'setIsChangedCategories',
-                    'getCategoryIds'
-                ]
-            )
+            ->onlyMethods(['getExtensionAttributes', 'getCategoryIds'])
+            ->addMethods(['setAffectedCategoryIds', 'setIsChangedCategories'])
             ->getMock();
-        $product->expects(static::at(0))->method('setIsChangedCategories')->with(false);
+        $product->method('setIsChangedCategories')->withConsecutive([false]);
         $product->expects(static::once())
             ->method('getExtensionAttributes')
             ->willReturn($extensionAttributes);
@@ -131,7 +131,7 @@ class SaveHandlerTest extends TestCase
     /**
      * @return array
      */
-    public function getCategoryDataProvider()
+    public function getCategoryDataProvider(): array
     {
         return [
             [
@@ -139,88 +139,92 @@ class SaveHandlerTest extends TestCase
                 null, // dto category links
                 [
                     ['category_id' => 3, 'position' => 10],
-                    ['category_id' => 4, 'position' => 20],
+                    ['category_id' => 4, 'position' => 20]
                 ],
                 [
                     ['category_id' => 3, 'position' => 10],
                     ['category_id' => 4, 'position' => 20],
-                    ['category_id' => 5, 'position' => 0],
+                    ['category_id' => 5, 'position' => 0]
                 ],
-                [3,4,5], //affected category_ids
+                [3,4,5] //affected category_ids
             ],
             [
                 [3, 4], //model category_ids
                 [], // dto category links
                 [
                     ['category_id' => 3, 'position' => 10],
-                    ['category_id' => 4, 'position' => 20],
+                    ['category_id' => 4, 'position' => 20]
                 ],
                 [],
-                [3,4], //affected category_ids
+                [3,4] //affected category_ids
             ],
             [
                 [], //model category_ids
                 [
-                    ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 3, 'position' => 20]
                 ], // dto category links
                 [
                     ['category_id' => 3, 'position' => 10],
-                    ['category_id' => 4, 'position' => 20],
+                    ['category_id' => 4, 'position' => 20]
                 ],
                 [
-                    ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 3, 'position' => 20]
                 ],
-                [3,4], //affected category_ids
+                [3,4] //affected category_ids
+            ],
+            [
+                [3], //model category_ids
+                [
+                    ['category_id' => 3, 'position' => 20]
+                ], // dto category links
+                [
+                    ['category_id' => 3, 'position' => 10]
+                ],
+                [
+                    ['category_id' => 3, 'position' => 20]
+                ],
+                [3] //affected category_ids
+            ],
+            [
+                [], //model category_ids
+                [
+                    ['category_id' => 3, 'position' => 10]
+                ], // dto category links
+                [
+                    ['category_id' => 3, 'position' => 10]
+                ],
+                [
+                    ['category_id' => 3, 'position' => 10]
+                ],
+                [] //affected category_ids
             ],
             [
                 [3], //model category_ids
                 [
                     ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 4, 'position' => 30]
                 ], // dto category links
                 [
-                    ['category_id' => 3, 'position' => 10],
+                    ['category_id' => 3, 'position' => 10]
                 ],
                 [
                     ['category_id' => 3, 'position' => 20],
+                    ['category_id' => 4, 'position' => 30]
                 ],
-                [3], //affected category_ids
-            ],
-            [
-                [], //model category_ids
-                [
-                    ['category_id' => 3, 'position' => 10],
-                ], // dto category links
-                [
-                    ['category_id' => 3, 'position' => 10],
-                ],
-                [
-                    ['category_id' => 3, 'position' => 10],
-                ],
-                [], //affected category_ids
-            ],
-            [
-                [3], //model category_ids
-                [
-                    ['category_id' => 3, 'position' => 20],
-                    ['category_id' => 4, 'position' => 30],
-                ], // dto category links
-                [
-                    ['category_id' => 3, 'position' => 10],
-                ],
-                [
-                    ['category_id' => 3, 'position' => 20],
-                    ['category_id' => 4, 'position' => 30],
-                ],
-                [3, 4], //affected category_ids
-            ],
+                [3, 4] //affected category_ids
+            ]
         ];
     }
 
-    public function testExecuteWithoutProcess()
+    /**
+     * @return void
+     */
+    public function testExecuteWithoutProcess(): void
     {
         $product = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getExtensionAttributes', 'hasCategoryIds'])
+            ->onlyMethods(['getExtensionAttributes'])
+            ->addMethods(['hasCategoryIds'])
             ->getMock();
         $product->expects(static::once())
             ->method('getExtensionAttributes')

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
@@ -145,6 +145,9 @@ class CategoryTest extends TestCase
      */
     private $objectManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -190,7 +193,10 @@ class CategoryTest extends TestCase
         $this->category = $this->getCategoryModel();
     }
 
-    public function testFormatUrlKey()
+    /**
+     * @return void
+     */
+    public function testFormatUrlKey(): void
     {
         $strIn = 'Some string';
         $resultString = 'some';
@@ -202,10 +208,9 @@ class CategoryTest extends TestCase
     }
 
     /**
-     * @codingStandardsIgnoreStart
-     * @codingStandardsIgnoreEnd
+     * @return void
      */
-    public function testMoveWhenCannotFindParentCategory()
+    public function testMoveWhenCannotFindParentCategory(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Sorry, but we can\'t find the new parent category you selected.');
@@ -225,10 +230,9 @@ class CategoryTest extends TestCase
     }
 
     /**
-     * @codingStandardsIgnoreStart
-     * @codingStandardsIgnoreEnd
+     * @return void
      */
-    public function testMoveWhenCannotFindNewCategory()
+    public function testMoveWhenCannotFindNewCategory(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Sorry, but we can\'t find the new category you selected.');
@@ -248,10 +252,9 @@ class CategoryTest extends TestCase
     }
 
     /**
-     * @codingStandardsIgnoreStart
-     * @codingStandardsIgnoreEnd
+     * @return void
      */
-    public function testMoveWhenParentCategoryIsSameAsChildCategory()
+    public function testMoveWhenParentCategoryIsSameAsChildCategory(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage(
@@ -274,7 +277,10 @@ class CategoryTest extends TestCase
         $this->category->move(1, 2);
     }
 
-    public function testMovePrimaryWorkflow()
+    /**
+     * @return void
+     */
+    public function testMovePrimaryWorkflow(): void
     {
         $indexer = $this->getMockBuilder(\stdClass::class)->addMethods(['isScheduled'])
             ->disableOriginalConstructor()
@@ -300,12 +306,18 @@ class CategoryTest extends TestCase
         $this->category->move(5, 7);
     }
 
-    public function testGetUseFlatResourceFalse()
+    /**
+     * @return void
+     */
+    public function testGetUseFlatResourceFalse(): void
     {
         $this->assertFalse($this->category->getUseFlatResource());
     }
 
-    public function testGetUseFlatResourceTrue()
+    /**
+     * @return void
+     */
+    public function testGetUseFlatResourceTrue(): void
     {
         $this->flatState->expects($this->any())
             ->method('isAvailable')
@@ -318,7 +330,7 @@ class CategoryTest extends TestCase
     /**
      * @return object
      */
-    protected function getCategoryModel()
+    protected function getCategoryModel(): object
     {
         return $this->objectManager->getObject(
             Category::class,
@@ -341,7 +353,7 @@ class CategoryTest extends TestCase
                 'resource' => $this->resource,
                 'indexerRegistry' => $this->indexerRegistry,
                 'metadataService' => $this->metadataServiceMock,
-                'customAttributeFactory' => $this->attributeValueFactory,
+                'customAttributeFactory' => $this->attributeValueFactory
             ]
         );
     }
@@ -349,13 +361,13 @@ class CategoryTest extends TestCase
     /**
      * @return array
      */
-    public function reindexFlatEnabledTestDataProvider()
+    public function reindexFlatEnabledTestDataProvider(): array
     {
         return [
             'set 1' => [false, false, 1, 1],
             'set 2' => [true,  false, 0, 1],
             'set 3' => [false, true,  1, 0],
-            'set 4' => [true,  true,  0, 0],
+            'set 4' => [true,  true,  0, 0]
         ];
     }
 
@@ -365,6 +377,7 @@ class CategoryTest extends TestCase
      * @param $expectedFlatReindexCalls
      * @param $expectedProductReindexCall
      *
+     * @return void
      * @dataProvider reindexFlatEnabledTestDataProvider
      */
     public function testReindexFlatEnabled(
@@ -372,7 +385,7 @@ class CategoryTest extends TestCase
         $productScheduled,
         $expectedFlatReindexCalls,
         $expectedProductReindexCall
-    ) {
+    ): void {
         $affectedProductIds = ["1", "2"];
         $this->category->setAffectedProductIds($affectedProductIds);
         $pathIds = ['path/1/2', 'path/2/3'];
@@ -395,15 +408,10 @@ class CategoryTest extends TestCase
             ->method('reindexList')
             ->with($pathIds);
 
-        $this->indexerRegistry->expects($this->at(0))
+        $this->indexerRegistry
             ->method('get')
-            ->with(State::INDEXER_ID)
-            ->willReturn($this->flatIndexer);
-
-        $this->indexerRegistry->expects($this->at(1))
-            ->method('get')
-            ->with(Product::INDEXER_ID)
-            ->willReturn($this->productIndexer);
+            ->withConsecutive([State::INDEXER_ID], [Product::INDEXER_ID])
+            ->willReturnOnConsecutiveCalls($this->flatIndexer, $this->productIndexer);
 
         $this->category->reindex();
     }
@@ -411,7 +419,7 @@ class CategoryTest extends TestCase
     /**
      * @return array
      */
-    public function reindexFlatDisabledTestDataProvider()
+    public function reindexFlatDisabledTestDataProvider(): array
     {
         return [
             [false, null, null, null, null, null, 0],
@@ -422,8 +430,7 @@ class CategoryTest extends TestCase
             [false, ["1", "2"], 0, 1, null, null,  1],
             [false, null, 1, 1, null, null, 0],
             [false, ["1", "2"], null, null, 0, 1,  1],
-            [false, ["1", "2"], null, null, 1, 0,  1],
-
+            [false, ["1", "2"], null, null, 1, 0,  1]
         ];
     }
 
@@ -434,6 +441,7 @@ class CategoryTest extends TestCase
      * @param int|string $isAnchor
      * @param int $expectedProductReindexCall
      *
+     * @return void
      * @dataProvider reindexFlatDisabledTestDataProvider
      */
     public function testReindexFlatDisabled(
@@ -444,7 +452,7 @@ class CategoryTest extends TestCase
         $isActiveOrig,
         $isActive,
         $expectedProductReindexCall
-    ) {
+    ): void {
         $this->category->setAffectedProductIds($affectedIds);
         $this->category->setData('is_anchor', $isAnchor);
         $this->category->setOrigData('is_anchor', $isAnchorOrig);
@@ -468,7 +476,7 @@ class CategoryTest extends TestCase
             ->method('reindexList')
             ->with($pathIds);
 
-        $this->indexerRegistry->expects($this->at(0))
+        $this->indexerRegistry
             ->method('get')
             ->with(Product::INDEXER_ID)
             ->willReturn($this->productIndexer);
@@ -476,7 +484,10 @@ class CategoryTest extends TestCase
         $this->category->reindex();
     }
 
-    public function testGetCustomAttributes()
+    /**
+     * @return void
+     */
+    public function testGetCustomAttributes(): void
     {
         $interfaceAttributeCode = 'name';
         $customAttributeCode = 'description';
@@ -527,7 +538,7 @@ class CategoryTest extends TestCase
     /**
      * @return array
      */
-    public function getImageWithAttributeCodeDataProvider()
+    public function getImageWithAttributeCodeDataProvider(): array
     {
         return [
             ['testimage', 'http://www.example.com/catalog/category/testimage'],
@@ -539,9 +550,10 @@ class CategoryTest extends TestCase
      * @param string|bool $value
      * @param string|bool $url
      *
+     * @return void
      * @dataProvider getImageWithAttributeCodeDataProvider
      */
-    public function testGetImageWithAttributeCode($value, $url)
+    public function testGetImageWithAttributeCode($value, $url): void
     {
         $storeManager = $this->createPartialMock(StoreManager::class, ['getStore']);
         $store = $this->createPartialMock(Store::class, ['getBaseUrl']);
@@ -570,7 +582,10 @@ class CategoryTest extends TestCase
         $this->assertEquals($url, $result);
     }
 
-    public function testGetImageWithoutAttributeCode()
+    /**
+     * return void
+     */
+    public function testGetImageWithoutAttributeCode(): void
     {
         $storeManager = $this->createPartialMock(StoreManager::class, ['getStore']);
         $store = $this->createPartialMock(Store::class, ['getBaseUrl']);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/FlatTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/FlatTest.php
@@ -52,6 +52,9 @@ class FlatTest extends TestCase
      */
     protected $cacheContextMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->fullMock = $this->createPartialMock(
@@ -95,7 +98,10 @@ class FlatTest extends TestCase
         $cacheContextProperty->setValue($this->model, $this->cacheContextMock);
     }
 
-    public function testExecuteWithIndexerInvalid()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerInvalid(): void
     {
         $this->indexerMock->expects($this->once())->method('isInvalid')->willReturn(true);
         $this->prepareIndexer();
@@ -105,7 +111,10 @@ class FlatTest extends TestCase
         $this->model->execute([1, 2, 3]);
     }
 
-    public function testExecuteWithIndexerWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -117,8 +126,10 @@ class FlatTest extends TestCase
             Rows::class,
             ['reindex']
         );
-        $rowMock->expects($this->at(0))->method('reindex')->with($ids, true)->willReturnSelf();
-        $rowMock->expects($this->at(1))->method('reindex')->with($ids, false)->willReturnSelf();
+        $rowMock
+            ->method('reindex')
+            ->withConsecutive([$ids, true], [$ids, false])
+            ->willReturnOnConsecutiveCalls($rowMock, $rowMock);
 
         $this->rowsMock->expects($this->once())->method('create')->willReturn($rowMock);
 
@@ -129,7 +140,10 @@ class FlatTest extends TestCase
         $this->model->execute($ids);
     }
 
-    public function testExecuteWithIndexerNotWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerNotWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -152,7 +166,10 @@ class FlatTest extends TestCase
         $this->model->execute($ids);
     }
 
-    protected function prepareIndexer()
+    /**
+     * @return void
+     */
+    protected function prepareIndexer(): void
     {
         $this->indexerRegistryMock->expects($this->once())
             ->method('get')
@@ -160,7 +177,10 @@ class FlatTest extends TestCase
             ->willReturn($this->indexerMock);
     }
 
-    public function testExecuteFull()
+    /**
+     * @return void
+     */
+    public function testExecuteFull(): void
     {
         /** @var Full $categoryIndexerFlatFull */
         $categoryIndexerFlatFull = $this->createMock(Full::class);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Product/Action/RowsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/Product/Action/RowsTest.php
@@ -107,6 +107,9 @@ class RowsTest extends TestCase
      */
     private $rowsModel;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp() : void
     {
         $this->workingStateProvider = $this->getMockBuilder(WorkingStateProvider::class)
@@ -180,6 +183,9 @@ class RowsTest extends TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testExecuteWithIndexerWorking() : void
     {
         $categoryId = '1';
@@ -220,26 +226,22 @@ class RowsTest extends TestCase
         $this->connection->expects($this->any())
             ->method('fetchOne')
             ->willReturn($categoryId);
-        $this->indexerRegistry->expects($this->at(0))
+        $this->indexerRegistry
             ->method('get')
-            ->with(ProductCategoryIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(1))
-            ->method('get')
-            ->with(ProductCategoryIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(2))
-            ->method('get')
-            ->with(CategoryProductIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(3))
-            ->method('get')
-            ->with(ProductCategoryIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(4))
-            ->method('get')
-            ->with(CategoryProductIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
+            ->withConsecutive(
+                [ProductCategoryIndexer::INDEXER_ID],
+                [ProductCategoryIndexer::INDEXER_ID],
+                [CategoryProductIndexer::INDEXER_ID],
+                [ProductCategoryIndexer::INDEXER_ID],
+                [CategoryProductIndexer::INDEXER_ID]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->indexer,
+                $this->indexer,
+                $this->indexer,
+                $this->indexer,
+                $this->indexer
+            );
         $this->indexer->expects($this->any())
             ->method('getId')
             ->willReturn(ProductCategoryIndexer::INDEXER_ID);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/ProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Category/ProductTest.php
@@ -51,6 +51,9 @@ class ProductTest extends TestCase
      */
     protected $cacheContextMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->fullMock = $this->createPartialMock(
@@ -94,7 +97,10 @@ class ProductTest extends TestCase
         $cacheContextProperty->setValue($this->model, $this->cacheContextMock);
     }
 
-    public function testExecuteWithIndexerWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -104,14 +110,20 @@ class ProductTest extends TestCase
             Rows::class,
             ['execute']
         );
-        $rowMock->expects($this->at(0))->method('execute')->with($ids)->willReturnSelf();
+        $rowMock
+            ->method('execute')
+            ->with($ids)
+            ->willReturn($rowMock);
 
         $this->rowsMock->expects($this->once())->method('create')->willReturn($rowMock);
 
         $this->model->execute($ids);
     }
 
-    public function testExecuteWithIndexerNotWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerNotWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -132,7 +144,10 @@ class ProductTest extends TestCase
         $this->model->execute($ids);
     }
 
-    protected function prepareIndexer()
+    /**
+     * @return void
+     */
+    protected function prepareIndexer(): void
     {
         $this->indexerRegistryMock->expects($this->any())
             ->method('get')
@@ -140,7 +155,10 @@ class ProductTest extends TestCase
             ->willReturn($this->indexerMock);
     }
 
-    public function testExecuteFull()
+    /**
+     * @return void
+     */
+    public function testExecuteFull(): void
     {
         /** @var Full $productIndexerFlatFull */
         $productIndexerFlatFull = $this->createMock(Full::class);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Category/Action/RowsTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Category/Action/RowsTest.php
@@ -107,6 +107,9 @@ class RowsTest extends TestCase
      */
     private $rowsModel;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp() : void
     {
         $this->workingStateProvider = $this->getMockBuilder(WorkingStateProvider::class)
@@ -186,6 +189,9 @@ class RowsTest extends TestCase
         );
     }
 
+    /**
+     * @return void
+     */
     public function testExecuteWithIndexerWorking() : void
     {
         $categoryId = '1';
@@ -229,26 +235,22 @@ class RowsTest extends TestCase
         $this->connection->expects($this->any())
             ->method('fetchOne')
             ->willReturn($categoryId);
-        $this->indexerRegistry->expects($this->at(0))
+        $this->indexerRegistry
             ->method('get')
-            ->with(CategoryProductIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(1))
-            ->method('get')
-            ->with(CategoryProductIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(2))
-            ->method('get')
-            ->with(ProductCategoryIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(3))
-            ->method('get')
-            ->with(CategoryProductIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
-        $this->indexerRegistry->expects($this->at(4))
-            ->method('get')
-            ->with(ProductCategoryIndexer::INDEXER_ID)
-            ->willReturn($this->indexer);
+            ->withConsecutive(
+                [CategoryProductIndexer::INDEXER_ID],
+                [CategoryProductIndexer::INDEXER_ID],
+                [ProductCategoryIndexer::INDEXER_ID],
+                [CategoryProductIndexer::INDEXER_ID],
+                [ProductCategoryIndexer::INDEXER_ID]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->indexer,
+                $this->indexer,
+                $this->indexer,
+                $this->indexer,
+                $this->indexer
+            );
         $this->indexer->expects($this->any())
             ->method('getId')
             ->willReturn(CategoryProductIndexer::INDEXER_ID);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/CategoryTest.php
@@ -54,6 +54,9 @@ class CategoryTest extends TestCase
      */
     protected $cacheContextMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->fullMock = $this->createPartialMock(
@@ -97,7 +100,10 @@ class CategoryTest extends TestCase
         $cacheContextProperty->setValue($this->model, $this->cacheContextMock);
     }
 
-    public function testExecuteWithIndexerWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -107,14 +113,20 @@ class CategoryTest extends TestCase
             Rows::class,
             ['execute']
         );
-        $rowMock->expects($this->at(0))->method('execute')->with($ids)->willReturnSelf();
+        $rowMock
+            ->method('execute')
+            ->with($ids)
+            ->willReturn($rowMock);
 
         $this->rowsMock->expects($this->once())->method('create')->willReturn($rowMock);
 
         $this->model->execute($ids);
     }
 
-    public function testExecuteWithIndexerNotWorking()
+    /**
+     * @return void
+     */
+    public function testExecuteWithIndexerNotWorking(): void
     {
         $ids = [1, 2, 3];
 
@@ -135,7 +147,10 @@ class CategoryTest extends TestCase
         $this->model->execute($ids);
     }
 
-    protected function prepareIndexer()
+    /**
+     * @return void
+     */
+    protected function prepareIndexer(): void
     {
         $this->indexerRegistryMock->expects($this->any())
             ->method('get')
@@ -143,7 +158,10 @@ class CategoryTest extends TestCase
             ->willReturn($this->indexerMock);
     }
 
-    public function testExecuteFull()
+    /**
+     * @return void
+     */
+    public function testExecuteFull(): void
     {
         /** @var Full $productIndexerFlatFull */
         $productIndexerFlatFull = $this->createMock(Full::class);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Eav/Plugin/AttributeSet/IndexableAttributeFilterTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Eav/Plugin/AttributeSet/IndexableAttributeFilterTest.php
@@ -16,27 +16,25 @@ use PHPUnit\Framework\TestCase;
 
 class IndexableAttributeFilterTest extends TestCase
 {
-    public function testFilter()
+    /**
+     * @return void
+     */
+    public function testFilter(): void
     {
         $catalogResourceMock = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'isIndexable'])
+            ->onlyMethods(['load', 'isIndexable'])
             ->getMock();
         $catalogResourceMock->expects($this->any())
             ->method('load')
             ->willReturnSelf();
-        $catalogResourceMock->expects($this->at(1))
+        $catalogResourceMock
             ->method('isIndexable')
-            ->willReturn(true);
-        $catalogResourceMock->expects($this->at(2))
-            ->method('isIndexable')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(true, false);
 
-        $eavAttributeFactoryMock = $this->getMockBuilder(
-            AttributeFactory::class
-        )
+        $eavAttributeFactoryMock = $this->getMockBuilder(AttributeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $eavAttributeFactoryMock->expects($this->once())
             ->method('create')
@@ -44,7 +42,7 @@ class IndexableAttributeFilterTest extends TestCase
 
         $attributeMock1 = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getAttributeId', 'getAttributeCode', 'load'])
+            ->onlyMethods(['getId', 'getAttributeId', 'getAttributeCode', 'load'])
             ->getMock();
         $attributeMock1->expects($this->any())
             ->method('getAttributeCode')
@@ -55,7 +53,7 @@ class IndexableAttributeFilterTest extends TestCase
 
         $attributeMock2 = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getAttributeId', 'getAttributeCode', 'load'])
+            ->onlyMethods(['getId', 'getAttributeId', 'getAttributeCode', 'load'])
             ->getMock();
         $attributeMock2->expects($this->any())
             ->method('getAttributeCode')
@@ -68,7 +66,7 @@ class IndexableAttributeFilterTest extends TestCase
 
         $groupMock = $this->getMockBuilder(Group::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributes'])
+            ->addMethods(['getAttributes'])
             ->getMock();
         $groupMock->expects($this->once())
             ->method('getAttributes')
@@ -76,7 +74,7 @@ class IndexableAttributeFilterTest extends TestCase
 
         $attributeSetMock = $this->getMockBuilder(Set::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getGroups'])
+            ->addMethods(['getGroups'])
             ->getMock();
         $attributeSetMock->expects($this->once())
             ->method('getGroups')

--- a/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/EraserTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Indexer/Product/Flat/Action/EraserTest.php
@@ -40,6 +40,9 @@ class EraserTest extends TestCase
      */
     protected $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $resource = $this->createMock(ResourceConnection::class);
@@ -60,7 +63,10 @@ class EraserTest extends TestCase
         );
     }
 
-    public function testRemoveDeletedProducts()
+    /**
+     * @return void
+     */
+    public function testRemoveDeletedProducts(): void
     {
         $productsToDeleteIds = [1, 2];
         $select = $this->createMock(Select::class);
@@ -83,7 +89,10 @@ class EraserTest extends TestCase
         $this->model->removeDeletedProducts($productsToDeleteIds, 1);
     }
 
-    public function testDeleteProductsFromStoreForAllStores()
+    /**
+     * @return void
+     */
+    public function testDeleteProductsFromStoreForAllStores(): void
     {
         $store1 = $this->createMock(Store::class);
         $store1->expects($this->any())->method('getId')->willReturn(1);
@@ -91,10 +100,12 @@ class EraserTest extends TestCase
         $store2->expects($this->any())->method('getId')->willReturn(2);
         $this->storeManager->expects($this->once())->method('getStores')
             ->willReturn([$store1, $store2]);
-        $this->connection->expects($this->at(0))->method('delete')
-            ->with('store_1_flat', ['entity_id IN(?)' => [1]]);
-        $this->connection->expects($this->at(1))->method('delete')
-            ->with('store_2_flat', ['entity_id IN(?)' => [1]]);
+        $this->connection
+            ->method('delete')
+            ->withConsecutive(
+                ['store_1_flat', ['entity_id IN(?)' => [1]]],
+                ['store_2_flat', ['entity_id IN(?)' => [1]]]
+            );
 
         $this->model->deleteProductsFromStore(1);
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/AttributeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/AttributeTest.php
@@ -28,7 +28,9 @@ use PHPUnit\Framework\TestCase;
  */
 class AttributeTest extends TestCase
 {
-    /** @var  Attribute|MockObject */
+    /**
+     * @var Attribute|MockObject
+     */
     private $filterAttribute;
 
     /**
@@ -36,34 +38,53 @@ class AttributeTest extends TestCase
      */
     private $target;
 
-    /** @var  AbstractFrontend|MockObject */
+    /**
+     * @var AbstractFrontend|MockObject
+     */
     private $frontend;
 
-    /** @var  State|MockObject */
+    /**
+     * @var State|MockObject
+     */
     private $state;
 
-    /** @var  \Magento\Eav\Model\Entity\Attribute|MockObject */
+    /**
+     * @var \Magento\Eav\Model\Entity\Attribute|MockObject
+     */
     private $attribute;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var  AttributeFactory|MockObject */
+    /**
+     * @var AttributeFactory|MockObject
+     */
     private $filterAttributeFactory;
 
-    /** @var  ItemFactory|MockObject */
+    /**
+     * @var ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
-    /** @var  StoreManagerInterface|MockObject */
+    /**
+     * @var StoreManagerInterface|MockObject
+     */
     private $storeManager;
 
-    /** @var  Layer|MockObject */
+    /**
+     * @var Layer|MockObject
+     */
     private $layer;
 
-    /** @var  DataBuilder|MockObject */
+    /**
+     * @var DataBuilder|MockObject
+     */
     private $itemDataBuilder;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -71,39 +92,36 @@ class AttributeTest extends TestCase
         /** @var ItemFactory $filterItemFactory */
         $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         /** @var StoreManagerInterface $storeManager */
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         /** @var Layer $layer */
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState'])
+            ->onlyMethods(['getState'])
             ->getMock();
         /** @var DataBuilder $itemDataBuilder */
         $this->itemDataBuilder = $this->getMockBuilder(DataBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItemData', 'build'])
+            ->onlyMethods(['addItemData', 'build'])
             ->getMock();
 
-        $this->filterAttribute = $this->getMockBuilder(
-            Attribute::class
-        )->disableOriginalConstructor()
-            ->setMethods(['getCount', 'applyFilterToCollection'])
+        $this->filterAttribute = $this->getMockBuilder(Attribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getCount', 'applyFilterToCollection'])
             ->getMock();
 
         $this->filterAttribute->expects($this->any())
             ->method('applyFilterToCollection')->willReturnSelf();
 
-        $this->filterAttributeFactory = $this->getMockBuilder(
-            AttributeFactory::class
-        )
+        $this->filterAttributeFactory = $this->getMockBuilder(AttributeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->filterAttributeFactory->expects($this->once())
@@ -112,7 +130,7 @@ class AttributeTest extends TestCase
 
         $this->state = $this->getMockBuilder(State::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFilter'])
+            ->onlyMethods(['addFilter'])
             ->getMock();
         $this->layer->expects($this->any())
             ->method('getState')
@@ -120,11 +138,12 @@ class AttributeTest extends TestCase
 
         $this->frontend = $this->getMockBuilder(AbstractFrontend::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getOption', 'getSelectOptions'])
+            ->onlyMethods(['getOption', 'getSelectOptions'])
             ->getMock();
         $this->attribute = $this->getMockBuilder(\Magento\Eav\Model\Entity\Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributeCode', 'getFrontend', 'getIsFilterable'])
+            ->onlyMethods(['getAttributeCode', 'getFrontend'])
+            ->addMethods(['getIsFilterable'])
             ->getMock();
         $this->attribute->expects($this->atLeastOnce())
             ->method('getFrontend')
@@ -132,12 +151,12 @@ class AttributeTest extends TestCase
 
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
 
         $stripTagsFilter = $this->getMockBuilder(StripTags::class)
             ->disableOriginalConstructor()
-            ->setMethods(['filter'])
+            ->onlyMethods(['filter'])
             ->getMock();
         $stripTagsFilter->expects($this->any())
             ->method('filter')
@@ -145,7 +164,7 @@ class AttributeTest extends TestCase
 
         $string = $this->getMockBuilder(StringUtils::class)
             ->disableOriginalConstructor()
-            ->setMethods(['strlen'])
+            ->onlyMethods(['strlen'])
             ->getMock();
         $string->expects($this->any())
             ->method('strlen')
@@ -165,12 +184,15 @@ class AttributeTest extends TestCase
                 'itemDataBuilder' => $this->itemDataBuilder,
                 'filterAttributeFactory' => $this->filterAttributeFactory,
                 'tagFilter' => $stripTagsFilter,
-                'string' => $string,
+                'string' => $string
             ]
         );
     }
 
-    public function testApplyFilter()
+    /**
+     * @return void
+     */
+    public function testApplyFilter(): void
     {
         $attributeCode = 'attributeCode';
         $attributeValue = 'attributeValue';
@@ -192,7 +214,7 @@ class AttributeTest extends TestCase
             ->with($attributeValue)
             ->willReturn($attributeLabel);
 
-        $filterItem = $this->createFilterItem(0, $attributeLabel, $attributeValue, 0);
+        $filterItem = $this->createFilterItem($attributeLabel, $attributeValue, 0);
 
         $filterItem->expects($this->once())
             ->method('setFilter')
@@ -219,7 +241,10 @@ class AttributeTest extends TestCase
         $this->assertEquals($this->target, $result);
     }
 
-    public function testGetItems()
+    /**
+     * @return void
+     */
+    public function testGetItems(): void
     {
         $attributeCode = 'attributeCode';
         $attributeValue = 'attributeValue';
@@ -241,7 +266,7 @@ class AttributeTest extends TestCase
             ->with($attributeValue)
             ->willReturn($attributeLabel);
 
-        $filterItem = $this->createFilterItem(0, $attributeLabel, $attributeValue, 0);
+        $filterItem = $this->createFilterItem($attributeLabel, $attributeValue, 0);
 
         $this->state->expects($this->once())
             ->method('addFilter')
@@ -255,17 +280,17 @@ class AttributeTest extends TestCase
     }
 
     /**
-     * @param int $index
      * @param string $label
      * @param string $value
      * @param int $count
+     *
      * @return Item|MockObject
      */
-    private function createFilterItem($index, $label, $value, $count)
+    private function createFilterItem(string $label, string $value, int $count): Item
     {
         $filterItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+            ->addMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
             ->getMock();
 
         $filterItem->expects($this->once())
@@ -284,9 +309,9 @@ class AttributeTest extends TestCase
             ->method('setCount')
             ->with($count)->willReturnSelf();
 
-        $this->filterItemFactory->expects($this->at($index))
+        $this->filterItemFactory
             ->method('create')
-            ->willReturn($filterItem);
+            ->willReturnOnConsecutiveCalls($filterItem);
 
         return $filterItem;
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -59,27 +59,38 @@ class CategoryTest extends TestCase
      */
     private $target;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var  ItemFactory|MockObject */
+    /**
+     * @var  ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
+    /**
+     * @var  State|MockObject
+     */
+    private $state;
+
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->getMockForAbstractClass();
 
-        $dataProviderFactory = $this->getMockBuilder(
-            CategoryFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])->getMock();
+        $dataProviderFactory = $this->getMockBuilder(CategoryFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])->getMock();
 
         $this->dataProvider = $this->getMockBuilder(CategoryDataProvider::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCategoryId', 'getCategory'])
+            ->onlyMethods(['setCategoryId', 'getCategory'])
             ->getMock();
 
         $dataProviderFactory->expects($this->once())
@@ -88,31 +99,36 @@ class CategoryTest extends TestCase
 
         $this->category = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getChildrenCategories', 'getIsActive'])
+            ->onlyMethods(
+                [
+                    'getId',
+                    'getChildrenCategories',
+                    'getIsActive'
+                ]
+            )
             ->getMock();
 
-        $this->dataProvider->expects($this->any())
-            ->method('getCategory', 'isValid')
+        $this->dataProvider
+            ->method('getCategory')
             ->willReturn($this->category);
 
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState', 'getProductCollection'])
+            ->onlyMethods(['getState', 'getProductCollection'])
             ->getMock();
 
         $this->state = $this->getMockBuilder(State::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFilter'])
+            ->onlyMethods(['addFilter'])
             ->getMock();
         $this->layer->expects($this->any())
             ->method('getState')
             ->willReturn($this->state);
 
-        $this->collection = $this->getMockBuilder(
-            ProductCollectionResourceModel::class
-        )
+        $this->collection = $this->getMockBuilder(ProductCollectionResourceModel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addCategoryFilter', 'getFacetedData', 'addCountToCategories'])
+            ->onlyMethods(['addCategoryFilter', 'addCountToCategories'])
+            ->addMethods(['getFacetedData'])
             ->getMock();
 
         $this->layer->expects($this->any())
@@ -121,18 +137,23 @@ class CategoryTest extends TestCase
 
         $this->itemDataBuilder = $this->getMockBuilder(DataBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItemData', 'build'])
+            ->onlyMethods(['addItemData', 'build'])
             ->getMock();
 
-        $this->filterItemFactory = $this->getMockBuilder(
-            ItemFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])->getMock();
+        $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])->getMock();
 
-        $filterItem = $this->getMockBuilder(
-            Item::class
-        )->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+        $filterItem = $this->getMockBuilder(Item::class)
+            ->disableOriginalConstructor()
+            ->addMethods(
+                [
+                    'setFilter',
+                    'setLabel',
+                    'setValue',
+                    'setCount'
+                ]
+            )
             ->getMock();
         $filterItem->expects($this->any())
             ->method($this->anything())->willReturnSelf();
@@ -142,7 +163,7 @@ class CategoryTest extends TestCase
 
         $escaper = $this->getMockBuilder(Escaper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['escapeHtml'])
+            ->onlyMethods(['escapeHtml'])
             ->getMock();
         $escaper->expects($this->any())
             ->method('escapeHtml')
@@ -156,40 +177,27 @@ class CategoryTest extends TestCase
                 'layer' => $this->layer,
                 'itemDataBuilder' => $this->itemDataBuilder,
                 'filterItemFactory' => $this->filterItemFactory,
-                'escaper' => $escaper,
+                'escaper' => $escaper
             ]
         );
     }
 
-    /** @var  State|MockObject */
-    private $state;
-
     /**
      * @param $requestValue
      * @param $idValue
-     * @param $isIdUsed
+     *
+     * @return void
      * @dataProvider applyWithEmptyRequestDataProvider
      */
-    public function testApplyWithEmptyRequest($requestValue, $idValue)
+    public function testApplyWithEmptyRequest($requestValue, $idValue): void
     {
         $requestField = 'test_request_var';
-        $idField = 'id';
 
         $this->target->setRequestVar($requestField);
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with($requestField)
-            ->willReturnCallback(
-                function ($field) use ($requestField, $idField, $requestValue, $idValue) {
-                    switch ($field) {
-                        case $requestField:
-                            return $requestValue;
-                        case $idField:
-                            return $idValue;
-                    }
-                }
-            );
+            ->with($requestField);
 
         $result = $this->target->apply($this->request);
         $this->assertSame($this->target, $result);
@@ -198,25 +206,28 @@ class CategoryTest extends TestCase
     /**
      * @return array
      */
-    public function applyWithEmptyRequestDataProvider()
+    public function applyWithEmptyRequestDataProvider(): array
     {
         return [
             [
                 'requestValue' => null,
-                'id' => 0,
+                'id' => 0
             ],
             [
                 'requestValue' => 0,
-                'id' => false,
+                'id' => false
             ],
             [
                 'requestValue' => 0,
-                'id' => null,
+                'id' => null
             ]
         ];
     }
 
-    public function testApply()
+    /**
+     * @return void
+     */
+    public function testApply(): void
     {
         $categoryId = 123;
         $requestVar = 'test_request_var';
@@ -247,7 +258,10 @@ class CategoryTest extends TestCase
         $this->target->apply($this->request);
     }
 
-    public function testGetItems()
+    /**
+     * @return void
+     */
+    public function testGetItems(): void
     {
         $this->category->expects($this->any())
             ->method('getIsActive')
@@ -255,7 +269,14 @@ class CategoryTest extends TestCase
 
         $category1 = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getName', 'getIsActive', 'getProductCount'])
+            ->onlyMethods(
+                [
+                    'getId',
+                    'getName',
+                    'getIsActive',
+                    'getProductCount'
+                ]
+            )
             ->getMock();
         $category1->expects($this->atLeastOnce())
             ->method('getId')
@@ -272,7 +293,14 @@ class CategoryTest extends TestCase
 
         $category2 = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getName', 'getIsActive', 'getProductCount'])
+            ->onlyMethods(
+                [
+                    'getId',
+                    'getName',
+                    'getIsActive',
+                    'getProductCount'
+                ]
+            )
             ->getMock();
         $category2->expects($this->atLeastOnce())
             ->method('getId')
@@ -298,31 +326,19 @@ class CategoryTest extends TestCase
             [
                 'label' => 'Category 1',
                 'value' => 120,
-                'count' => 10,
+                'count' => 10
             ],
             [
                 'label' => 'Category 2',
                 'value' => 5641,
-                'count' => 45,
-            ],
+                'count' => 45
+            ]
         ];
 
-        $this->itemDataBuilder->expects($this->at(0))
+        $this->itemDataBuilder
             ->method('addItemData')
-            ->with(
-                'Category 1',
-                120,
-                10
-            )
-            ->willReturnSelf();
-        $this->itemDataBuilder->expects($this->at(1))
-            ->method('addItemData')
-            ->with(
-                'Category 2',
-                5641,
-                45
-            )
-            ->willReturnSelf();
+            ->withConsecutive(['Category 1', 120, 10], ['Category 2', 5641, 45])
+            ->willReturnOnConsecutiveCalls($this->itemDataBuilder, $this->itemDataBuilder);
         $this->itemDataBuilder->expects($this->once())
             ->method('build')
             ->willReturn($builtData);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/PriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/Filter/PriceTest.php
@@ -30,17 +30,20 @@ use PHPUnit\Framework\TestCase;
  */
 class PriceTest extends TestCase
 {
+    /**
+     * @var DataBuilder|MockObject
+     */
     private $itemDataBuilder;
 
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Layer\Filter\Price|MockObject
+     */
     private $resource;
 
-    /** @var Auto|MockObject */
-    private $algorithm;
-
     /**
-     * @var \Magento\Catalog\Model\Price|MockObject
+     * @var Auto|MockObject
      */
-    private $price;
+    private $algorithm;
 
     /**
      * @var Layer|MockObject
@@ -57,39 +60,50 @@ class PriceTest extends TestCase
      */
     private $target;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var  ItemFactory|MockObject */
+    /**
+     * @var  ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
-    /** @var  State|MockObject */
+    /**
+     * @var  State|MockObject
+     */
     private $state;
 
     /**
+     * @var  Attribute|MockObject
+     */
+    private $attribute;
+
+    /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->getMockForAbstractClass();
 
-        $dataProviderFactory = $this->getMockBuilder(
-            PriceFactory::class
-        )
+        $dataProviderFactory = $this->getMockBuilder(PriceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->dataProvider = $this->getMockBuilder(Price::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setPriceId', 'getPrice', 'getResource'])
+            ->onlyMethods(['getResource'])
+            ->addMethods(['setPriceId', 'getPrice'])
             ->getMock();
         $this->resource = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Layer\Filter\Price::class)
             ->disableOriginalConstructor()
-            ->setMethods(['applyPriceRange'])
+            ->onlyMethods(['applyPriceRange'])
             ->getMock();
         $this->dataProvider->expects($this->any())
             ->method('getResource')
@@ -101,12 +115,12 @@ class PriceTest extends TestCase
 
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState'])
+            ->onlyMethods(['getState'])
             ->getMock();
 
         $this->state = $this->getMockBuilder(State::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFilter'])
+            ->onlyMethods(['addFilter'])
             ->getMock();
         $this->layer->expects($this->any())
             ->method('getState')
@@ -114,21 +128,17 @@ class PriceTest extends TestCase
 
         $this->itemDataBuilder = $this->getMockBuilder(DataBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItemData', 'build'])
+            ->onlyMethods(['addItemData', 'build'])
             ->getMock();
 
-        $this->filterItemFactory = $this->getMockBuilder(
-            ItemFactory::class
-        )
+        $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $filterItem = $this->getMockBuilder(
-            Item::class
-        )
+        $filterItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+            ->addMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
             ->getMock();
         $filterItem->expects($this->any())
             ->method($this->anything())->willReturnSelf();
@@ -138,7 +148,7 @@ class PriceTest extends TestCase
 
         $escaper = $this->getMockBuilder(Escaper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['escapeHtml'])
+            ->onlyMethods(['escapeHtml'])
             ->getMock();
         $escaper->expects($this->any())
             ->method('escapeHtml')
@@ -146,16 +156,17 @@ class PriceTest extends TestCase
 
         $this->attribute = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributeCode', 'getFrontend', 'getIsFilterable'])
+            ->onlyMethods(['getAttributeCode', 'getFrontend'])
+            ->addMethods(['getIsFilterable'])
             ->getMock();
         $algorithmFactory = $this->getMockBuilder(AlgorithmFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->algorithm = $this->getMockBuilder(Auto::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getItemsData'])
+            ->onlyMethods(['getItemsData'])
             ->getMock();
 
         $algorithmFactory->expects($this->any())
@@ -179,29 +190,20 @@ class PriceTest extends TestCase
     /**
      * @param $requestValue
      * @param $idValue
-     * @param $isIdUsed
+     *
+     * @return void
      * @dataProvider applyWithEmptyRequestDataProvider
      */
-    public function testApplyWithEmptyRequest($requestValue, $idValue)
+    public function testApplyWithEmptyRequest($requestValue, $idValue): void
     {
         $requestField = 'test_request_var';
         $idField = 'id';
 
         $this->target->setRequestVar($requestField);
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with($requestField)
-            ->willReturnCallback(
-                function ($field) use ($requestField, $idField, $requestValue, $idValue) {
-                    switch ($field) {
-                        case $requestField:
-                            return $requestValue;
-                        case $idField:
-                            return $idValue;
-                    }
-                }
-            );
+            ->with($requestField);
 
         $result = $this->target->apply($this->request);
         $this->assertSame($this->target, $result);
@@ -210,28 +212,28 @@ class PriceTest extends TestCase
     /**
      * @return array
      */
-    public function applyWithEmptyRequestDataProvider()
+    public function applyWithEmptyRequestDataProvider(): array
     {
         return [
             [
                 'requestValue' => null,
-                'id' => 0,
+                'id' => 0
             ],
             [
                 'requestValue' => 0,
-                'id' => false,
+                'id' => false
             ],
             [
                 'requestValue' => 0,
-                'id' => null,
+                'id' => null
             ]
         ];
     }
 
-    /** @var  Attribute|MockObject */
-    private $attribute;
-
-    public function testApply()
+    /**
+     * @return void
+     */
+    public function testApply(): void
     {
         $priceId = '15-50';
         $requestVar = 'test_request_var';
@@ -249,7 +251,10 @@ class PriceTest extends TestCase
         $this->target->apply($this->request);
     }
 
-    public function testGetItems()
+    /**
+     * @return void
+     */
+    public function testGetItems(): void
     {
         $this->target->setAttributeModel($this->attribute);
         $attributeCode = 'attributeCode';

--- a/app/code/Magento/Catalog/Test/Unit/Model/Layer/FilterListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Layer/FilterListTest.php
@@ -52,7 +52,7 @@ class FilterListTest extends TestCase
     private $layerCategoryConfigMock;
 
     /**
-     * Set Up
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -65,7 +65,7 @@ class FilterListTest extends TestCase
             FilterList::CATEGORY_FILTER => 'CategoryFilterClass',
             FilterList::PRICE_FILTER => 'PriceFilterClass',
             FilterList::DECIMAL_FILTER => 'DecimalFilterClass',
-            FilterList::ATTRIBUTE_FILTER => 'AttributeFilterClass',
+            FilterList::ATTRIBUTE_FILTER => 'AttributeFilterClass'
 
         ];
         $this->layerMock = $this->createMock(Layer::class);
@@ -81,26 +81,30 @@ class FilterListTest extends TestCase
 
     /**
      * @param string $method
-     * @param string $value
+     * @param string|null $value
      * @param string $expectedClass
-     * @dataProvider getFiltersDataProvider
      *
+     * @return void
+     * @dataProvider getFiltersDataProvider
      * @covers \Magento\Catalog\Model\Layer\FilterList::getFilters
      * @covers \Magento\Catalog\Model\Layer\FilterList::createAttributeFilter
      * @covers \Magento\Catalog\Model\Layer\FilterList::__construct
      */
-    public function testGetFilters($method, $value, $expectedClass)
+    public function testGetFilters(string $method, ?string $value, string $expectedClass): void
     {
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
-            ->willReturn('filter');
-
-        $this->objectManagerMock->expects($this->at(1))
-            ->method('create')
-            ->with($expectedClass, [
-                'data' => ['attribute_model' => $this->attributeMock],
-                'layer' => $this->layerMock])
-            ->willReturn('filter');
+            ->withConsecutive(
+                [],
+                [
+                    $expectedClass,
+                    [
+                        'data' => ['attribute_model' => $this->attributeMock],
+                        'layer' => $this->layerMock
+                    ]
+                ]
+            )
+            ->willReturnOnConsecutiveCalls('filter', 'filter');
 
         $this->attributeMock->expects($this->once())
             ->method($method)
@@ -118,16 +122,15 @@ class FilterListTest extends TestCase
     }
 
     /**
-     * Test filters list result when category should not be included
+     * Test filters list result when category should not be included.
      *
      * @param string $method
      * @param string $value
      * @param string $expectedClass
      * @param array $expectedResult
      *
-     * @dataProvider getFiltersWithoutCategoryDataProvider
-     *
      * @return void
+     * @dataProvider getFiltersWithoutCategoryDataProvider
      */
     public function testGetFiltersWithoutCategoryFilter(
         string $method,
@@ -135,7 +138,7 @@ class FilterListTest extends TestCase
         string $expectedClass,
         array $expectedResult
     ): void {
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('create')
             ->with(
                 $expectedClass,
@@ -164,29 +167,29 @@ class FilterListTest extends TestCase
     /**
      * @return array
      */
-    public function getFiltersDataProvider()
+    public function getFiltersDataProvider(): array
     {
         return [
             [
                 'method' => 'getAttributeCode',
                 'value' => FilterList::PRICE_FILTER,
-                'expectedClass' => 'PriceFilterClass',
+                'expectedClass' => 'PriceFilterClass'
             ],
             [
                 'method' => 'getBackendType',
                 'value' => FilterList::DECIMAL_FILTER,
-                'expectedClass' => 'DecimalFilterClass',
+                'expectedClass' => 'DecimalFilterClass'
             ],
             [
                 'method' => 'getAttributeCode',
                 'value' => null,
-                'expectedClass' => 'AttributeFilterClass',
+                'expectedClass' => 'AttributeFilterClass'
             ]
         ];
     }
 
     /**
-     * Provides attribute filters without category item
+     * Provides attribute filters without category item.
      *
      * @return array
      */

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
@@ -55,7 +55,7 @@ class GalleryManagementTest extends TestCase
     protected $attributeValueMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -71,7 +71,7 @@ class GalleryManagementTest extends TestCase
                 'getCustomAttribute',
                 'getMediaGalleryEntries',
                 'setMediaGalleryEntries',
-                'getMediaAttributes',
+                'getMediaAttributes'
             ]
         );
         $this->mediaGalleryEntryMock =
@@ -85,7 +85,10 @@ class GalleryManagementTest extends TestCase
             ->getMock();
     }
 
-    public function testCreateWithInvalidImageException()
+    /**
+     * @return void
+     */
+    public function testCreateWithInvalidImageException(): void
     {
         $this->expectException('Magento\Framework\Exception\InputException');
         $this->expectExceptionMessage('The image content is invalid. Verify the content and try again.');
@@ -100,7 +103,10 @@ class GalleryManagementTest extends TestCase
         $this->model->create("sku", $this->mediaGalleryEntryMock);
     }
 
-    public function testCreateWithCannotSaveException()
+    /**
+     * @return void
+     */
+    public function testCreateWithCannotSaveException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $this->expectExceptionMessage('The product can\'t be saved.');
@@ -129,7 +135,10 @@ class GalleryManagementTest extends TestCase
         $this->model->create($productSku, $this->mediaGalleryEntryMock);
     }
 
-    public function testCreate()
+    /**
+     * @return void
+     */
+    public function testCreate(): void
     {
         $productSku = 'mediaProduct';
         $entryContentMock = $this->createMock(
@@ -153,15 +162,19 @@ class GalleryManagementTest extends TestCase
 
         $newEntryMock = $this->getMockForAbstractClass(ProductAttributeMediaGalleryEntryInterface::class);
         $newEntryMock->expects($this->exactly(2))->method('getId')->willReturn(42);
-        $this->productMock->expects($this->at(2))->method('getMediaGalleryEntries')
-            ->willReturn([$newEntryMock]);
+        $this->productMock
+            ->method('getMediaGalleryEntries')
+            ->willReturnOnConsecutiveCalls([], [$newEntryMock]);
         $this->productMock->expects($this->once())->method('setMediaGalleryEntries')
             ->with([$this->mediaGalleryEntryMock]);
 
         $this->assertEquals(42, $this->model->create($productSku, $this->mediaGalleryEntryMock));
     }
 
-    public function testUpdateWithNonExistingImage()
+    /**
+     * @return void
+     */
+    public function testUpdateWithNonExistingImage(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage('No image with the provided ID was found. Verify the ID and try again.');
@@ -182,7 +195,10 @@ class GalleryManagementTest extends TestCase
         $this->model->update($productSku, $entryMock);
     }
 
-    public function testUpdateWithCannotSaveException()
+    /**
+     * @return void
+     */
+    public function testUpdateWithCannotSaveException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $this->expectExceptionMessage('The product can\'t be saved.');
@@ -210,7 +226,7 @@ class GalleryManagementTest extends TestCase
      *
      * @return void
      */
-    public function testUpdate()
+    public function testUpdate(): void
     {
         $productSku = 'testProduct';
         $entryMock = $this->getMockForAbstractClass(ProductAttributeMediaGalleryEntryInterface::class);
@@ -245,7 +261,10 @@ class GalleryManagementTest extends TestCase
         $this->assertTrue($this->model->update($productSku, $entryMock));
     }
 
-    public function testRemoveWithNonExistingImage()
+    /**
+     * @return void
+     */
+    public function testRemoveWithNonExistingImage(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage('No image with the provided ID was found. Verify the ID and try again.');
@@ -262,7 +281,10 @@ class GalleryManagementTest extends TestCase
         $this->model->remove($productSku, $entryId);
     }
 
-    public function testRemove()
+    /**
+     * @return void
+     */
+    public function testRemove(): void
     {
         $productSku = 'testProduct';
         $entryId = 42;
@@ -280,7 +302,10 @@ class GalleryManagementTest extends TestCase
         $this->assertTrue($this->model->remove($productSku, $entryId));
     }
 
-    public function testGetWithNonExistingProduct()
+    /**
+     * @return void
+     */
+    public function testGetWithNonExistingProduct(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage('The product doesn\'t exist. Verify and try again.');
@@ -291,7 +316,10 @@ class GalleryManagementTest extends TestCase
         $this->model->get($productSku, $imageId);
     }
 
-    public function testGetWithNonExistingImage()
+    /**
+     * @return void
+     */
+    public function testGetWithNonExistingImage(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage('The image doesn\'t exist. Verify and try again.');
@@ -308,7 +336,10 @@ class GalleryManagementTest extends TestCase
         $this->model->get($productSku, $imageId);
     }
 
-    public function testGet()
+    /**
+     * @return void
+     */
+    public function testGet(): void
     {
         $productSku = 'testProduct';
         $imageId = 42;
@@ -323,7 +354,10 @@ class GalleryManagementTest extends TestCase
         $this->assertEquals($existingEntryMock, $this->model->get($productSku, $imageId));
     }
 
-    public function testGetList()
+    /**
+     * @return void
+     */
+    public function testGetList(): void
     {
         $productSku = 'testProductSku';
         $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
@@ -106,6 +106,9 @@ class ImageTest extends TestCase
      */
     private $paramsBuilder;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -117,25 +120,27 @@ class ImageTest extends TestCase
 
         $this->storeManager = $this->getMockBuilder(StoreManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStore', 'getWebsite'])->getMock();
+            ->onlyMethods(['getStore', 'getWebsite'])->getMock();
         $store = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__sleep', 'getBaseUrl'])->getMock();
+            ->onlyMethods(['getId', '__sleep', 'getBaseUrl'])->getMock();
         $store->expects($this->any())->method('getId')->willReturn(1);
         $store->expects($this->any())->method('getBaseUrl')->willReturn('http://magento.com/media/');
         $this->storeManager->expects($this->any())->method('getStore')->willReturn($store);
 
         $this->config = $this->getMockBuilder(Config::class)
-            ->setMethods(['getBaseMediaPath'])->disableOriginalConstructor()
+            ->onlyMethods(['getBaseMediaPath'])
+            ->disableOriginalConstructor()
             ->getMock();
         $this->config->expects($this->any())->method('getBaseMediaPath')->willReturn('catalog/product');
         $this->coreFileHelper = $this->getMockBuilder(Database::class)
-            ->setMethods(['saveFile', 'deleteFolder'])->disableOriginalConstructor()
+            ->onlyMethods(['saveFile', 'deleteFolder'])
+            ->disableOriginalConstructor()
             ->getMock();
 
         $this->mediaDirectory = $this->getMockBuilder(Write::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create', 'isFile', 'isExist', 'getAbsolutePath'])
+            ->onlyMethods(['create', 'isFile', 'isExist', 'getAbsolutePath'])
             ->getMock();
 
         $this->filesystem = $this->createMock(Filesystem::class);
@@ -146,11 +151,11 @@ class ImageTest extends TestCase
 
         $this->viewAssetImageFactory = $this->getMockBuilder(ImageFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->viewAssetPlaceholderFactory = $this->getMockBuilder(PlaceholderFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->serializer = $this->getMockBuilder(
             SerializerInterface::class
@@ -198,50 +203,74 @@ class ImageTest extends TestCase
         );
     }
 
-    public function testSetGetQuality()
+    /**
+     * @return void
+     */
+    public function testSetGetQuality(): void
     {
         $this->image->setQuality(100);
         $this->assertEquals(100, $this->image->getQuality());
     }
 
-    public function testSetGetKeepAspectRatio()
+    /**
+     * @return void
+     */
+    public function testSetGetKeepAspectRatio(): void
     {
         $result = $this->image->setKeepAspectRatio(true);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetKeepFrame()
+    /**
+     * @return void
+     */
+    public function testSetKeepFrame(): void
     {
         $result = $this->image->setKeepFrame(true);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetKeepTransparency()
+    /**
+     * @return void
+     */
+    public function testSetKeepTransparency(): void
     {
         $result = $this->image->setKeepTransparency(true);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetConstrainOnly()
+    /**
+     * @return void
+     */
+    public function testSetConstrainOnly(): void
     {
         $result = $this->image->setConstrainOnly(true);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetBackgroundColor()
+    /**
+     * @return void
+     */
+    public function testSetBackgroundColor(): void
     {
         $result = $this->image->setBackgroundColor([0, 0, 0]);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetSize()
+    /**
+     * @return void
+     */
+    public function testSetSize(): void
     {
         $this->image->setSize('99xsadf');
         $this->assertEquals(99, $this->image->getWidth());
         $this->assertNull($this->image->getHeight());
     }
 
-    public function testSetGetBaseFile()
+    /**
+     * @return void
+     */
+    public function testSetGetBaseFile(): void
     {
         $miscParams = [
             'image_type' => null,
@@ -253,7 +282,7 @@ class ImageTest extends TestCase
             'constrain_only' => 'doconstrainonly',
             'background' => 'ffffff',
             'angle' => null,
-            'quality' => 80,
+            'quality' => 80
         ];
         $this->paramsBuilder->expects(self::once())
             ->method('build')
@@ -268,7 +297,7 @@ class ImageTest extends TestCase
             ->with(
                 [
                     'miscParams' => $miscParams,
-                    'filePath' => '/somefile.png',
+                    'filePath' => '/somefile.png'
                 ]
             )
             ->willReturn($this->imageAsset);
@@ -282,7 +311,10 @@ class ImageTest extends TestCase
         );
     }
 
-    public function testSetBaseNoSelectionFile()
+    /**
+     * @return void
+     */
+    public function testSetBaseNoSelectionFile(): void
     {
         $this->viewAssetPlaceholderFactory->expects($this->once())->method('create')->willReturn($this->imageAsset);
         $this->imageAsset->expects($this->any())->method('getSourceFile')->willReturn('Default Placeholder Path');
@@ -290,7 +322,10 @@ class ImageTest extends TestCase
         $this->assertEquals('Default Placeholder Path', $this->image->getBaseFile());
     }
 
-    public function testSetGetImageProcessor()
+    /**
+     * @return void
+     */
+    public function testSetGetImageProcessor(): void
     {
         $imageProcessor = $this->getMockBuilder(\Magento\Framework\Image::class)->disableOriginalConstructor()
             ->getMock();
@@ -299,7 +334,10 @@ class ImageTest extends TestCase
         $this->assertSame($imageProcessor, $this->image->getImageProcessor());
     }
 
-    public function testResize()
+    /**
+     * @return void
+     */
+    public function testResize(): void
     {
         $this->image->setWidth(100);
         $this->image->setHeight(100);
@@ -312,9 +350,13 @@ class ImageTest extends TestCase
         $this->assertSame($this->image, $result);
     }
 
-    public function testRotate()
+    /**
+     * @return void
+     */
+    public function testRotate(): void
     {
-        $imageProcessor = $this->getMockBuilder(\Magento\Framework\Image::class)->disableOriginalConstructor()
+        $imageProcessor = $this->getMockBuilder(\Magento\Framework\Image::class)
+            ->disableOriginalConstructor()
             ->getMock();
         $imageProcessor->expects($this->once())->method('rotate')->with(90)->willReturn(true);
         $this->image->setImageProcessor($imageProcessor);
@@ -322,40 +364,51 @@ class ImageTest extends TestCase
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetAngle()
+    /**
+     * @return void
+     */
+    public function testSetAngle(): void
     {
         $result = $this->image->setAngle(90);
         $this->assertSame($this->image, $result);
     }
 
-    public function testSetWatermark()
+    /**
+     * @return void
+     */
+    public function testSetWatermark(): void
     {
         $website = $this->getMockBuilder(Website::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', '__sleep'])->getMock();
+            ->onlyMethods(['getId', '__sleep'])->getMock();
         $website->expects($this->any())->method('getId')->willReturn(1);
         $this->storeManager->expects($this->any())->method('getWebsite')->willReturn($website);
-        $this->mediaDirectory->expects($this->at(3))->method('isExist')->with('catalog/product/watermark//somefile.png')
-            ->willReturn(true);
+        $this->mediaDirectory
+            ->method('isExist')
+            ->withConsecutive([], [], [], ['catalog/product/watermark//somefile.png'])
+            ->willReturnOnConsecutiveCalls(null, null, null, true);
         $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
         $this->mediaDirectory->expects($this->any())->method('getAbsolutePath')
             ->with('catalog/product/watermark//somefile.png')
             ->willReturn($absolutePath);
 
-        $imageProcessor = $this->getMockBuilder(\Magento\Framework\Image::class)->disableOriginalConstructor()
-            ->setMethods([
-                'keepAspectRatio',
-                'keepFrame',
-                'keepTransparency',
-                'constrainOnly',
-                'backgroundColor',
-                'quality',
-                'setWatermarkPosition',
-                'setWatermarkImageOpacity',
-                'setWatermarkWidth',
-                'setWatermarkHeight',
-                'watermark',
-            ])->getMock();
+        $imageProcessor = $this->getMockBuilder(\Magento\Framework\Image::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    'keepAspectRatio',
+                    'keepFrame',
+                    'keepTransparency',
+                    'constrainOnly',
+                    'backgroundColor',
+                    'quality',
+                    'setWatermarkPosition',
+                    'setWatermarkImageOpacity',
+                    'setWatermarkWidth',
+                    'setWatermarkHeight',
+                    'watermark'
+                ]
+            )->getMock();
         $imageProcessor->expects($this->once())->method('setWatermarkPosition')->with('center')
             ->willReturn(true);
         $imageProcessor->expects($this->once())->method('setWatermarkImageOpacity')->with(50)
@@ -377,7 +430,10 @@ class ImageTest extends TestCase
         $this->assertSame($this->image, $result);
     }
 
-    public function testSaveFile()
+    /**
+     * @return void
+     */
+    public function testSaveFile(): void
     {
         $imageProcessor = $this->getMockBuilder(
             \Magento\Framework\Image::class
@@ -389,7 +445,10 @@ class ImageTest extends TestCase
         $this->image->saveFile();
     }
 
-    public function testSaveFileNoSelection()
+    /**
+     * @return void
+     */
+    public function testSaveFileNoSelection(): void
     {
         $imageProcessor = $this->getMockBuilder(
             \Magento\Framework\Image::class
@@ -399,14 +458,20 @@ class ImageTest extends TestCase
         $this->assertSame($this->image, $this->image->saveFile());
     }
 
-    public function testGetUrl()
+    /**
+     * @return void
+     */
+    public function testGetUrl(): void
     {
         $this->testSetGetBaseFile();
         $this->imageAsset->expects($this->any())->method('getUrl')->willReturn('url of exist image');
         $this->assertEquals('url of exist image', $this->image->getUrl());
     }
 
-    public function testGetUrlNoSelection()
+    /**
+     * @return void
+     */
+    public function testGetUrlNoSelection(): void
     {
         $this->viewAssetPlaceholderFactory->expects($this->once())->method('create')->willReturn($this->imageAsset);
         $this->imageAsset->expects($this->any())->method('getUrl')->willReturn('Default Placeholder URL');
@@ -414,13 +479,19 @@ class ImageTest extends TestCase
         $this->assertEquals('Default Placeholder URL', $this->image->getUrl());
     }
 
-    public function testSetGetDestinationSubdir()
+    /**
+     * @return void
+     */
+    public function testSetGetDestinationSubdir(): void
     {
         $this->image->setDestinationSubdir('image_type');
         $this->assertEquals('image_type', $this->image->getDestinationSubdir());
     }
 
-    public function testIsCached()
+    /**
+     * @return void
+     */
+    public function testIsCached(): void
     {
         $this->testSetGetBaseFile();
         $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
@@ -431,21 +502,30 @@ class ImageTest extends TestCase
         $this->assertTrue($this->image->isCached());
     }
 
-    public function testClearCache()
+    /**
+     * @return void
+     */
+    public function testClearCache(): void
     {
         $this->coreFileHelper->expects($this->once())->method('deleteFolder')->willReturn(true);
         $this->cacheManager->expects($this->once())->method('clean');
         $this->image->clearCache();
     }
 
-    public function testResizeWithoutSize()
+    /**
+     * @return void
+     */
+    public function testResizeWithoutSize(): void
     {
         $this->image->setHeight(null);
         $this->image->setWidth(null);
         $this->assertSame($this->image, $this->image->resize());
     }
 
-    public function testGetImageProcessor()
+    /**
+     * @return void
+     */
+    public function testGetImageProcessor(): void
     {
         $imageProcessor = $this->getMockBuilder(
             \Magento\Framework\Image::class
@@ -455,12 +535,18 @@ class ImageTest extends TestCase
         $this->assertSame($imageProcessor, $this->image->getImageProcessor());
     }
 
-    public function testIsBaseFilePlaceholder()
+    /**
+     * @return void
+     */
+    public function testIsBaseFilePlaceholder(): void
     {
         $this->assertFalse($this->image->isBaseFilePlaceholder());
     }
 
-    public function testGetResizedImageInfoWithCache()
+    /**
+     * @return void
+     */
+    public function testGetResizedImageInfoWithCache(): void
     {
         $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
         $this->imageAsset->expects($this->any())->method('getPath')->willReturn($absolutePath);
@@ -471,7 +557,10 @@ class ImageTest extends TestCase
         $this->assertEquals(['image data'], $this->image->getResizedImageInfo());
     }
 
-    public function testGetResizedImageInfoEmptyCache()
+    /**
+     * @return void
+     */
+    public function testGetResizedImageInfoEmptyCache(): void
     {
         $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
         $this->imageAsset->expects($this->any())->method('getPath')->willReturn($absolutePath);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/RepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/RepositoryTest.php
@@ -56,6 +56,9 @@ class RepositoryTest extends TestCase
      */
     protected $productMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->productRepositoryMock = $this->createMock(ProductRepository::class);
@@ -66,7 +69,7 @@ class RepositoryTest extends TestCase
         $optionFactory = $this->createPartialMock(OptionFactory::class, ['create']);
         $this->optionCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $metadataPool = $this->getMockBuilder(MetadataPool::class)
             ->disableOriginalConstructor()
@@ -86,7 +89,10 @@ class RepositoryTest extends TestCase
         );
     }
 
-    public function testGetList()
+    /**
+    * @return void
+    */
+    public function testGetList(): void
     {
         $productSku = 'simple_product';
         $expectedResult = ['Expected_option'];
@@ -99,13 +105,19 @@ class RepositoryTest extends TestCase
         $this->assertEquals($expectedResult, $this->optionRepository->getList($productSku));
     }
 
-    public function testDelete()
+    /**
+    * @return void
+    */
+    public function testDelete(): void
     {
         $this->optionResourceMock->expects($this->once())->method('delete')->with($this->optionMock);
         $this->assertTrue($this->optionRepository->delete($this->optionMock));
     }
 
-    public function testGetNonExistingOption()
+    /**
+    * @return void
+    */
+    public function testGetNonExistingOption(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $optionId = 1;
@@ -123,7 +135,10 @@ class RepositoryTest extends TestCase
         $this->optionRepository->get($productSku, $optionId);
     }
 
-    public function testGet()
+    /**
+    * @return void
+    */
+    public function testGet(): void
     {
         $optionId = 1;
         $productSku = 'simple_product';
@@ -139,7 +154,10 @@ class RepositoryTest extends TestCase
         $this->assertEquals($this->optionMock, $this->optionRepository->get($productSku, $optionId));
     }
 
-    public function testDeleteByIdentifierNonExistingOption()
+    /**
+    * @return void
+    */
+    public function testDeleteByIdentifierNonExistingOption(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $optionId = 1;
@@ -158,7 +176,10 @@ class RepositoryTest extends TestCase
         $this->optionRepository->deleteByIdentifier($productSku, $optionId);
     }
 
-    public function testDeleteByIdentifier()
+    /**
+    * @return void
+    */
+    public function testDeleteByIdentifier(): void
     {
         $optionId = 1;
         $productSku = 'simple_product';
@@ -178,7 +199,10 @@ class RepositoryTest extends TestCase
         $this->assertTrue($this->optionRepository->deleteByIdentifier($productSku, $optionId));
     }
 
-    public function testDeleteByIdentifierWhenCannotRemoveOption()
+    /**
+    * @return void
+    */
+    public function testDeleteByIdentifierWhenCannotRemoveOption(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotSaveException');
         $optionId = 1;
@@ -203,7 +227,10 @@ class RepositoryTest extends TestCase
         $this->assertTrue($this->optionRepository->deleteByIdentifier($productSku, $optionId));
     }
 
-    public function testSaveCouldNotSaveException()
+    /**
+    * @return void
+    */
+    public function testSaveCouldNotSaveException(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotSaveException');
         $this->expectExceptionMessage('The ProductSku is empty. Set the ProductSku and try again.');
@@ -211,7 +238,10 @@ class RepositoryTest extends TestCase
         $this->optionRepository->save($this->optionMock);
     }
 
-    public function testSaveNoSuchEntityException()
+    /**
+    * @return void
+    */
+    public function testSaveNoSuchEntityException(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $productSku = 'simple_product';
@@ -230,7 +260,10 @@ class RepositoryTest extends TestCase
         $this->optionRepository->save($this->optionMock);
     }
 
-    public function testSave()
+    /**
+    * @return void
+    */
+    public function testSave(): void
     {
         $productSku = 'simple_product';
         $optionId = 1;
@@ -240,7 +273,10 @@ class RepositoryTest extends TestCase
         $originalValue2 = clone $originalValue1;
         $originalValue3 = clone $originalValue1;
 
-        $originalValue1->expects($this->at(0))->method('getData')->with('option_type_id')->willReturn(10);
+        $originalValue1
+            ->method('getData')
+            ->withConsecutive(['option_type_id'])
+            ->willReturnOnConsecutiveCalls(10);
         $originalValue1->expects($this->once())->method('setData')->with('is_delete', 1);
         $originalValue2->expects($this->once())->method('getData')->with('option_type_id')->willReturn(4);
         $originalValue3->expects($this->once())->method('getData')->with('option_type_id')->willReturn(5);
@@ -270,7 +306,10 @@ class RepositoryTest extends TestCase
         $this->assertEquals($this->optionMock, $this->optionRepository->save($this->optionMock));
     }
 
-    public function testSaveWhenOptionTypeWasChanged()
+    /**
+    * @return void
+    */
+    public function testSaveWhenOptionTypeWasChanged(): void
     {
         $productSku = 'simple_product';
         $optionId = 1;

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/FileTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/FileTest.php
@@ -34,7 +34,7 @@ class FileTest extends TestCase
     protected $localeFormatMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -50,9 +50,9 @@ class FileTest extends TestCase
                     [
                         'label' => 'label 1.1',
                         'name' => 'name 1.1',
-                        'disabled' => false,
-                    ],
-                ],
+                        'disabled' => false
+                    ]
+                ]
             ],
             [
                 'label' => 'group label 2',
@@ -60,10 +60,10 @@ class FileTest extends TestCase
                     [
                         'label' => 'label 2.2',
                         'name' => 'name 2.2',
-                        'disabled' => true,
-                    ],
+                        'disabled' => true
+                    ]
                 ]
-            ],
+            ]
         ];
         $configMock->expects($this->once())->method('getAll')->willReturn($config);
         $methods = ['getTitle', 'getType', 'getPriceType', 'getPrice', 'getImageSizeX', 'getImageSizeY','__wakeup'];
@@ -78,7 +78,7 @@ class FileTest extends TestCase
     /**
      * @return void
      */
-    public function testIsValidSuccess()
+    public function testIsValidSuccess(): void
     {
         $this->valueMock->expects($this->once())->method('getTitle')->willReturn('option_title');
         $this->valueMock->expects($this->exactly(2))->method('getType')->willReturn('name 1.1');
@@ -88,15 +88,10 @@ class FileTest extends TestCase
             ->willReturn(10);
         $this->valueMock->expects($this->once())->method('getImageSizeX')->willReturn(10);
         $this->valueMock->expects($this->once())->method('getImageSizeY')->willReturn(15);
-        $this->localeFormatMock->expects($this->at(0))
-            ->method('getNumber')
-            ->with(10)
-            ->willReturn(10);
         $this->localeFormatMock
-            ->expects($this->at(2))
             ->method('getNumber')
-            ->with(15)
-            ->willReturn(15);
+            ->withConsecutive([10], [], [15])
+            ->willReturnOnConsecutiveCalls(10, null, 15);
         $this->assertEmpty($this->validator->getMessages());
         $this->assertTrue($this->validator->isValid($this->valueMock));
     }
@@ -104,7 +99,7 @@ class FileTest extends TestCase
     /**
      * @return void
      */
-    public function testIsValidWithNegativeImageSize()
+    public function testIsValidWithNegativeImageSize(): void
     {
         $this->valueMock->expects($this->once())->method('getTitle')->willReturn('option_title');
         $this->valueMock->expects($this->exactly(2))->method('getType')->willReturn('name 1.1');
@@ -114,15 +109,10 @@ class FileTest extends TestCase
             ->willReturn(10);
         $this->valueMock->expects($this->once())->method('getImageSizeX')->willReturn(-10);
         $this->valueMock->expects($this->never())->method('getImageSizeY');
-        $this->localeFormatMock->expects($this->at(0))
-            ->method('getNumber')
-            ->with(10)
-            ->willReturn(10);
         $this->localeFormatMock
-            ->expects($this->at(1))
             ->method('getNumber')
-            ->with(-10)
-            ->willReturn(-10);
+            ->withConsecutive([10], [-10])
+            ->willReturnOnConsecutiveCalls(10, -10);
 
         $messages = [
             'option values' => 'Invalid option value',
@@ -134,7 +124,7 @@ class FileTest extends TestCase
     /**
      * @return void
      */
-    public function testIsValidWithNegativeImageSizeY()
+    public function testIsValidWithNegativeImageSizeY(): void
     {
         $this->valueMock->expects($this->once())->method('getTitle')->willReturn('option_title');
         $this->valueMock->expects($this->exactly(2))->method('getType')->willReturn('name 1.1');
@@ -144,15 +134,10 @@ class FileTest extends TestCase
             ->willReturn(10);
         $this->valueMock->expects($this->once())->method('getImageSizeX')->willReturn(10);
         $this->valueMock->expects($this->once())->method('getImageSizeY')->willReturn(-10);
-        $this->localeFormatMock->expects($this->at(0))
-            ->method('getNumber')
-            ->with(10)
-            ->willReturn(10);
         $this->localeFormatMock
-            ->expects($this->at(2))
             ->method('getNumber')
-            ->with(-10)
-            ->willReturn(-10);
+            ->withConsecutive([10], [], [-10])
+            ->willReturnOnConsecutiveCalls(10, null, -10);
         $messages = [
             'option values' => 'Invalid option value',
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/TextTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/Validator/TextTest.php
@@ -34,7 +34,7 @@ class TextTest extends TestCase
     protected $localeFormatMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -49,9 +49,9 @@ class TextTest extends TestCase
                     [
                         'label' => 'label 1.1',
                         'name' => 'name 1.1',
-                        'disabled' => false,
-                    ],
-                ],
+                        'disabled' => false
+                    ]
+                ]
             ],
             [
                 'label' => 'group label 2',
@@ -59,10 +59,10 @@ class TextTest extends TestCase
                     [
                         'label' => 'label 2.2',
                         'name' => 'name 2.2',
-                        'disabled' => true,
-                    ],
+                        'disabled' => true
+                    ]
                 ]
-            ],
+            ]
         ];
         $configMock->expects($this->once())->method('getAll')->willReturn($config);
         $methods = ['getTitle', 'getType', 'getPriceType', 'getPrice', 'getMaxCharacters'];
@@ -77,7 +77,7 @@ class TextTest extends TestCase
     /**
      * @return void
      */
-    public function testIsValidSuccess()
+    public function testIsValidSuccess(): void
     {
         $this->valueMock->expects($this->once())->method('getTitle')->willReturn('option_title');
         $this->valueMock->expects($this->exactly(2))->method('getType')->willReturn('name 1.1');
@@ -97,7 +97,7 @@ class TextTest extends TestCase
     /**
      * @return void
      */
-    public function testIsValidWithNegativeMaxCharacters()
+    public function testIsValidWithNegativeMaxCharacters(): void
     {
         $this->valueMock->expects($this->once())->method('getTitle')->willReturn('option_title');
         $this->valueMock->expects($this->exactly(2))->method('getType')->willReturn('name 1.1');
@@ -106,15 +106,10 @@ class TextTest extends TestCase
         $this->valueMock->method('getPrice')
             ->willReturn(10);
         $this->valueMock->expects($this->once())->method('getMaxCharacters')->willReturn(-10);
-        $this->localeFormatMock->expects($this->at(0))
-            ->method('getNumber')
-            ->with(10)
-            ->willReturn(10);
         $this->localeFormatMock
-            ->expects($this->at(1))
             ->method('getNumber')
-            ->with(-10)
-            ->willReturn(-10);
+            ->withConsecutive([10], [-10])
+            ->willReturnOnConsecutiveCalls(10, -10);
         $messages = [
             'option values' => 'Invalid option value',
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Price/Validation/ResultTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Price/Validation/ResultTest.php
@@ -3,7 +3,6 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
 declare(strict_types=1);
 
 namespace Magento\Catalog\Test\Unit\Model\Product\Price\Validation;
@@ -33,13 +32,13 @@ class ResultTest extends TestCase
     private $objectManager;
 
     /**
-     * Setup environment for test
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->priceUpdateResultFactory = $this->getMockBuilder(PriceUpdateResultInterfaceFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->objectManager = new ObjectManagerHelper($this);
@@ -55,27 +54,28 @@ class ResultTest extends TestCase
     }
 
     /**
-     * Test getFailedRowIds() function
+     * Test getFailedRowIds() function.
+     *
+     * @return void
      */
-    public function testGetFailedRowIds()
+    public function testGetFailedRowIds(): void
     {
         $this->assertEquals([1, 2], $this->model->getFailedRowIds());
     }
 
     /**
-     * Test getFailedItems() function
+     * Test getFailedItems() function.
+     *
+     * @return void
      */
-    public function testGetFailedItems()
+    public function testGetFailedItems(): void
     {
         $priceUpdateResult1 = $this->getMockForAbstractClass(PriceUpdateResultInterface::class);
         $priceUpdateResult2 = $this->getMockForAbstractClass(PriceUpdateResultInterface::class);
 
-        $this->priceUpdateResultFactory->expects($this->at(0))
+        $this->priceUpdateResultFactory
             ->method('create')
-            ->willReturn($priceUpdateResult1);
-        $this->priceUpdateResultFactory->expects($this->at(1))
-            ->method('create')
-            ->willReturn($priceUpdateResult2);
+            ->willReturnOnConsecutiveCalls($priceUpdateResult1, $priceUpdateResult2);
 
         $priceUpdateResult1->expects($this->once())->method('setMessage')
             ->with('Invalid attribute color = 1');

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ProductFrontendAction/SynchronizerTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ProductFrontendAction/SynchronizerTest.php
@@ -26,30 +26,49 @@ use PHPUnit\Framework\TestCase;
  */
 class SynchronizerTest extends TestCase
 {
-    /** @var Synchronizer */
+    /**
+     * @var Synchronizer
+     */
     protected $model;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $sessionMock;
 
-    /** @var Visitor|MockObject */
+    /**
+     * @var Visitor|MockObject
+     */
     protected $visitorMock;
 
-    /** @var ProductFrontendActionFactory|MockObject */
+    /**
+     * @var ProductFrontendActionFactory|MockObject
+     */
     protected $productFrontendActionFactoryMock;
 
-    /** @var EntityManager|MockObject */
+    /**
+     * @var EntityManager|MockObject
+     */
     protected $entityManagerMock;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $collectionFactoryMock;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $frontendStorageConfigurationPoolMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->sessionMock = $this->getMockBuilder(Session::class)
@@ -58,18 +77,16 @@ class SynchronizerTest extends TestCase
         $this->visitorMock = $this->getMockBuilder(Visitor::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->productFrontendActionFactoryMock = $this
-            ->getMockBuilder(ProductFrontendActionFactory::class)
+        $this->productFrontendActionFactoryMock = $this->getMockBuilder(ProductFrontendActionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->entityManagerMock = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->collectionFactoryMock = $this
-            ->getMockBuilder(CollectionFactory::class)
+        $this->collectionFactoryMock = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->frontendStorageConfigurationPoolMock = $this
             ->getMockBuilder(FrontendStorageConfigurationPool::class)
@@ -90,21 +107,24 @@ class SynchronizerTest extends TestCase
         );
     }
 
-    public function testFilterProductActions()
+    /**
+     * @inheritDoc
+     */
+    public function testFilterProductActions(): void
     {
         $typeId = 'recently_compared_product';
         $productsData = [
             'website-1-1' => [
                 'added_at' => 12,
-                'product_id' => 1,
+                'product_id' => 1
             ],
             'website-1-2' => [
                 'added_at' => 13,
-                'product_id' => '2',
+                'product_id' => '2'
             ],
             'website-2-3' => [
                 'added_at' => 14,
-                'product_id' => 3,
+                'product_id' => 3
             ]
         ];
         $frontendConfiguration = $this->getMockForAbstractClass(FrontendStorageConfigurationInterface::class);
@@ -139,12 +159,9 @@ class SynchronizerTest extends TestCase
         $collection->expects($this->once())
             ->method('addFilterByUserIdentities')
             ->with(1, 34);
-        $collection->expects($this->at(1))
+        $collection
             ->method('addFieldToFilter')
-            ->with('type_id', $typeId);
-        $collection->expects($this->at(2))
-            ->method('addFieldToFilter')
-            ->with('product_id', [1, 2]);
+            ->withConsecutive(['type_id', $typeId], ['product_id', [1, 2]]);
         $iterator = new \IteratorIterator(new \ArrayIterator([$frontendAction]));
         $collection->expects($this->once())
             ->method('getIterator')

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/TypeTest.php
@@ -11,12 +11,14 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\Product\Type\Pool;
 use Magento\Catalog\Model\Product\Type\Price;
+use Magento\Catalog\Model\Product\Type\Price\Factory as PriceFactory;
 use Magento\Catalog\Model\Product\Type\Simple;
 use Magento\Catalog\Model\Product\Type\Virtual;
 use Magento\Catalog\Model\ProductTypes\ConfigInterface;
 use Magento\Framework\Pricing\PriceInfo\Factory;
 use Magento\Framework\Pricing\PriceInfoInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -41,9 +43,9 @@ class TypeTest extends TestCase
             'label' => 'label_3',
             'model' => 'some_model',
             'composite' => 'some_type',
-            'price_model' => 'some_model',
+            'price_model' => 'some_model'
         ],
-        'simple' => ['label' => 'label_4', 'composite' => false],
+        'simple' => ['label' => 'label_4', 'composite' => false]
     ];
 
     /**
@@ -51,7 +53,11 @@ class TypeTest extends TestCase
      */
     protected $_model;
 
-    public function testGetTypes()
+    /**
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testGetTypes(): void
     {
         $property = new \ReflectionProperty($this->_model, '_types');
         $property->setAccessible(true);
@@ -59,12 +65,18 @@ class TypeTest extends TestCase
         $this->assertEquals($this->_productTypes, $this->_model->getTypes());
     }
 
-    public function testGetOptionArray()
+    /**
+     * @return void
+     */
+    public function testGetOptionArray(): void
     {
         $this->assertEquals($this->getOptionArray(), $this->_model->getOptionArray());
     }
 
-    public function testGetAllOptions()
+    /**
+     * @return void
+     */
+    public function testGetAllOptions(): void
     {
         $res[] = ['value' => '', 'label' => ''];
         foreach ($this->getOptionArray() as $index => $value) {
@@ -73,7 +85,10 @@ class TypeTest extends TestCase
         $this->assertEquals($res, $this->_model->getAllOptions());
     }
 
-    public function testGetOptions()
+    /**
+     * @return void
+     */
+    public function testGetOptions(): void
     {
         $res = [];
         foreach ($this->getOptionArray() as $index => $value) {
@@ -82,14 +97,20 @@ class TypeTest extends TestCase
         $this->assertEquals($res, $this->_model->getOptions());
     }
 
-    public function testGetAllOption()
+    /**
+     * @return void
+     */
+    public function testGetAllOption(): void
     {
         $options = $this->getOptionArray();
         array_unshift($options, ['value' => '', 'label' => '']);
         $this->assertEquals($options, $this->_model->getAllOption());
     }
 
-    public function testGetOptionText()
+    /**
+     * @return void
+     */
+    public function testGetOptionText(): void
     {
         $options = $this->getOptionArray();
         $this->assertEquals($options['type_id_3'], $this->_model->getOptionText('type_id_3'));
@@ -98,7 +119,10 @@ class TypeTest extends TestCase
         $this->assertNull($this->_model->getOptionText('not_exist'));
     }
 
-    public function testGetCompositeTypes()
+    /**
+     * @return void
+     */
+    public function testGetCompositeTypes(): void
     {
         $property = new \ReflectionProperty($this->_model, '_compositeTypes');
         $property->setAccessible(true);
@@ -107,7 +131,10 @@ class TypeTest extends TestCase
         $this->assertEquals(['type_id_3'], $this->_model->getCompositeTypes());
     }
 
-    public function testGetTypesByPriority()
+    /**
+     * @return void
+     */
+    public function testGetTypesByPriority(): void
     {
         $expected = [];
         foreach ($this->_productTypes as $typeId => $type) {
@@ -123,23 +150,26 @@ class TypeTest extends TestCase
         $this->assertEquals($expected, $this->_model->getTypesByPriority());
     }
 
-    public function testGetPriceInfo()
+    /**
+     * @return void
+     */
+    public function testGetPriceInfo(): void
     {
         $mockedProduct = $this->getMockedProduct();
         $expectedResult = PriceInfoInterface::class;
         $this->assertInstanceOf($expectedResult, $this->_model->getPriceInfo($mockedProduct));
     }
 
-    public function testFactory()
+    /**
+     * @return void
+     */
+    public function testFactory(): void
     {
         $mockedProduct = $this->getMockedProduct();
 
-        $mockedProduct->expects($this->at(0))
+        $mockedProduct
             ->method('getTypeId')
-            ->willReturn('type_id_1');
-        $mockedProduct->expects($this->at(1))
-            ->method('getTypeId')
-            ->willReturn('type_id_3');
+            ->willReturnOnConsecutiveCalls('type_id_1', 'type_id_3');
 
         $this->assertInstanceOf(
             Simple::class,
@@ -151,7 +181,10 @@ class TypeTest extends TestCase
         );
     }
 
-    public function testPriceFactory()
+    /**
+     * @return void
+     */
+    public function testPriceFactory(): void
     {
         $this->assertInstanceOf(
             Price::class,
@@ -159,6 +192,9 @@ class TypeTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->_objectHelper = new ObjectManager($this);
@@ -181,7 +217,7 @@ class TypeTest extends TestCase
     /**
      * @return array
      */
-    protected function getOptionArray()
+    protected function getOptionArray(): array
     {
         $options = [];
         foreach ($this->_productTypes as $typeId => $type) {
@@ -191,9 +227,9 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return \Magento\Catalog\Model\Product
+     * @return Product|MockObject
      */
-    private function getMockedProduct()
+    private function getMockedProduct(): Product
     {
         $mockBuilder = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor();
@@ -203,15 +239,15 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return Factory
+     * @return Factory|MockObject
      */
-    private function getMockedPriceInfoFactory()
+    private function getMockedPriceInfoFactory(): Factory
     {
         $mockedPriceInfoInterface = $this->getMockedPriceInfoInterface();
 
         $mockBuilder = $this->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create']);
+            ->onlyMethods(['create']);
         $mock = $mockBuilder->getMock();
 
         $mock->expects($this->any())
@@ -222,9 +258,9 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return \Magento\Framework\Pricing\PriceInfoInterface
+     * @return PriceInfoInterface|MockObject
      */
-    private function getMockedPriceInfoInterface()
+    private function getMockedPriceInfoInterface(): PriceInfoInterface
     {
         $mockBuilder = $this->getMockBuilder(PriceInfoInterface::class)
             ->disableOriginalConstructor();
@@ -234,13 +270,13 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return Pool
+     * @return Pool|MockObject
      */
-    private function getMockedProductTypePool()
+    private function getMockedProductTypePool(): Pool
     {
         $mockBuild = $this->getMockBuilder(Pool::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get']);
+            ->onlyMethods(['get']);
         $mock = $mockBuild->getMock();
 
         $mock->expects($this->any())
@@ -248,7 +284,7 @@ class TypeTest extends TestCase
             ->willReturnMap(
                 [
                     ['some_model', [], $this->getMockedProductTypeVirtual()],
-                    [Simple::class, [], $this->getMockedProductTypeSimple()],
+                    [Simple::class, [], $this->getMockedProductTypeSimple()]
                 ]
             );
 
@@ -256,13 +292,13 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return Virtual
+     * @return Virtual|MockObject
      */
-    private function getMockedProductTypeVirtual()
+    private function getMockedProductTypeVirtual(): Virtual
     {
         $mockBuilder = $this->getMockBuilder(Virtual::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setConfig']);
+            ->onlyMethods(['setConfig']);
         $mock = $mockBuilder->getMock();
 
         $mock->expects($this->any())
@@ -272,13 +308,13 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return Simple
+     * @return Simple|MockObject
      */
-    private function getMockedProductTypeSimple()
+    private function getMockedProductTypeSimple(): Simple
     {
         $mockBuilder = $this->getMockBuilder(Simple::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setConfig']);
+            ->onlyMethods(['setConfig']);
         $mock = $mockBuilder->getMock();
 
         $mock->expects($this->any())
@@ -288,13 +324,13 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return ConfigInterface
+     * @return ConfigInterface|MockObject
      */
-    private function getMockedConfig()
+    private function getMockedConfig(): ConfigInterface
     {
         $mockBuild = $this->getMockBuilder(ConfigInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAll']);
+            ->onlyMethods(['getAll']);
         $mock = $mockBuild->getMockForAbstractClass();
 
         $mock->expects($this->any())
@@ -305,13 +341,13 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return \Magento\Catalog\Model\Product\Type\Price\Factory
+     * @return PriceFactory|MockObject
      */
-    private function getMockedTypePriceFactory()
+    private function getMockedTypePriceFactory(): PriceFactory
     {
         $mockBuild = $this->getMockBuilder(\Magento\Catalog\Model\Product\Type\Price\Factory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create']);
+            ->onlyMethods(['create']);
         $mock = $mockBuild->getMockForAbstractClass();
 
         $mock->expects($this->any())
@@ -319,7 +355,7 @@ class TypeTest extends TestCase
             ->willReturnMap(
                 [
                     ['some_model', [], $this->getMockedProductTypePrice()],
-                    [Price::class, [], $this->getMockedProductTypePrice()],
+                    [Price::class, [], $this->getMockedProductTypePrice()]
                 ]
             );
 
@@ -327,9 +363,9 @@ class TypeTest extends TestCase
     }
 
     /**
-     * @return Price
+     * @return Price|MockObject
      */
-    private function getMockedProductTypePrice()
+    private function getMockedProductTypePrice(): Price
     {
         $mockBuild = $this->getMockBuilder(Price::class)
             ->disableOriginalConstructor();

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -37,7 +37,6 @@ use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\DB\Adapter\ConnectionException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
@@ -127,7 +126,7 @@ class ProductRepositoryTest extends TestCase
      */
     private $productData = [
         'sku' => 'exisiting',
-        'name' => 'existing product',
+        'name' => 'existing product'
     ];
 
     /**
@@ -198,6 +197,7 @@ class ProductRepositoryTest extends TestCase
     private $cacheLimit = 2;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -264,9 +264,8 @@ class ProductRepositoryTest extends TestCase
         );
         $this->resourceModel = $this->createMock(\Magento\Catalog\Model\ResourceModel\Product::class);
         $this->objectManager = new ObjectManager($this);
-        $this->extensibleDataObjectConverter = $this
-            ->getMockBuilder(ExtensibleDataObjectConverter::class)
-            ->setMethods(['toNestedArray'])
+        $this->extensibleDataObjectConverter = $this->getMockBuilder(ExtensibleDataObjectConverter::class)
+            ->onlyMethods(['toNestedArray'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->fileSystem = $this->getMockBuilder(Filesystem::class)
@@ -283,10 +282,10 @@ class ProductRepositoryTest extends TestCase
 
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getStore', 'getWebsites'])
             ->getMockForAbstractClass();
         $this->productExtension = $this->getMockBuilder(ProductExtensionInterface::class)
-            ->setMethods(['__toArray'])
+            ->addMethods(['__toArray'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->productExtension
@@ -306,7 +305,7 @@ class ProductRepositoryTest extends TestCase
             ->willReturn([1, 2, 3, 4]);
         $storeMock = $this->getMockBuilder(StoreInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getId', 'getWebsiteId', 'getCode'])
             ->getMockForAbstractClass();
         $storeMock->method('getId')->willReturn(self::STUB_STORE_ID);
         $storeMock->expects($this->any())->method('getWebsiteId')->willReturn('1');
@@ -333,7 +332,7 @@ class ProductRepositoryTest extends TestCase
             [
                 'processor' => $this->processor,
                 'contentFactory' => $this->contentFactory,
-                'imageProcessor' => $this->imageProcessor,
+                'imageProcessor' => $this->imageProcessor
             ]
         );
         $this->model = $this->objectManager->getObject(
@@ -363,9 +362,10 @@ class ProductRepositoryTest extends TestCase
     }
 
     /**
-     * Test save product with global store id
+     * Test save product with global store id.
      *
      * @param array $productData
+     *
      * @return void
      * @dataProvider getProductData
      */
@@ -379,14 +379,17 @@ class ProductRepositoryTest extends TestCase
             ->willReturn($productData);
         $this->resourceModel->method('getIdBySku')->willReturn(self::STUB_PRODUCT_ID);
         $this->resourceModel->expects($this->once())->method('validate')->willReturn(true);
-        $this->product->expects($this->at(14))->method('setData')
-            ->with('store_id', $productData['store_id']);
+        $this->product
+            ->method('setData')
+            ->withConsecutive(
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                ['store_id', $productData['store_id']]);
 
         $this->model->save($this->product);
     }
 
     /**
-     * Product data provider
+     * Product data provider.
      *
      * @return array
      */
@@ -397,14 +400,14 @@ class ProductRepositoryTest extends TestCase
                 [
                     'sku' => self::STUB_PRODUCT_SKU,
                     'name' => self::STUB_PRODUCT_NAME,
-                    'store_id' => self::STUB_STORE_ID_GLOBAL,
-                ],
-            ],
+                    'store_id' => self::STUB_STORE_ID_GLOBAL
+                ]
+            ]
         ];
     }
 
     /**
-     * Test save product without store
+     * Test save product without store.
      *
      * @return void
      */
@@ -418,17 +421,20 @@ class ProductRepositoryTest extends TestCase
             ->willReturn($this->productData);
         $this->resourceModel->method('getIdBySku')->willReturn(self::STUB_PRODUCT_ID);
         $this->resourceModel->expects($this->once())->method('validate')->willReturn(true);
-        $this->product->expects($this->at(15))->method('setData')
-            ->with('store_id', self::STUB_STORE_ID);
+        $this->product
+            ->method('setData')
+            ->withConsecutive(
+                [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                ['store_id', self::STUB_STORE_ID]
+            );
 
         $this->model->save($this->product);
     }
 
     /**
-     * @expectedException \Magento\Framework\Exception\NoSuchEntityException
-     * @expectedExceptionMessage The product that was requested doesn't exist. Verify the product and try again.
+     * @return void
      */
-    public function testGetAbsentProduct()
+    public function testGetAbsentProduct(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage(
@@ -442,7 +448,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->get('test_sku');
     }
 
-    public function testCreateCreatesProduct()
+    /**
+    * @return void
+    */
+    public function testCreateCreatesProduct(): void
     {
         $sku = 'test_sku';
         $this->productFactory->expects($this->once())->method('create')
@@ -454,7 +463,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->get($sku));
     }
 
-    public function testGetProductInEditMode()
+    /**
+    * @return void
+    */
+    public function testGetProductInEditMode(): void
     {
         $sku = 'test_sku';
         $this->productFactory->expects($this->once())->method('create')
@@ -467,7 +479,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->get($sku, true));
     }
 
-    public function testGetBySkuWithSpace()
+    /**
+    * @return void
+    */
+    public function testGetBySkuWithSpace(): void
     {
         $trimmedSku = 'test_sku';
         $sku = 'test_sku ';
@@ -480,7 +495,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->get($sku));
     }
 
-    public function testGetWithSetStoreId()
+    /**
+    * @return void
+    */
+    public function testGetWithSetStoreId(): void
     {
         $productId = 123;
         $sku = 'test-sku';
@@ -494,7 +512,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertSame($this->product, $this->model->get($sku, false, $storeId));
     }
 
-    public function testGetByIdAbsentProduct()
+    /**
+    * @return void
+    */
+    public function testGetByIdAbsentProduct(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage(
@@ -507,7 +528,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->getById('product_id');
     }
 
-    public function testGetByIdProductInEditMode()
+    /**
+    * @return void
+    */
+    public function testGetByIdProductInEditMode(): void
     {
         $productId = 123;
         $this->productFactory->method('create')->willReturn($this->product);
@@ -522,22 +546,30 @@ class ProductRepositoryTest extends TestCase
      * @param mixed $identifier
      * @param bool $editMode
      * @param mixed $storeId
-     * @return void
      *
+     * @return void
      * @dataProvider cacheKeyDataProvider
      */
-    public function testGetByIdForCacheKeyGenerate($identifier, $editMode, $storeId)
+    public function testGetByIdForCacheKeyGenerate($identifier, $editMode, $storeId): void
     {
         $callIndex = 0;
-        $this->productFactory->expects($this->once())->method('create')
+        $this->productFactory
+            ->expects($this->once())
+            ->method('create')
             ->willReturn($this->product);
+
+        $withArgs = [];
+
         if ($editMode) {
-            $this->product->expects($this->at($callIndex))->method('setData')->with('_edit_mode', $editMode);
-            ++$callIndex;
+            $withArgs[] = ['_edit_mode', $editMode];
         }
+
         if ($storeId !== null) {
-            $this->product->expects($this->at($callIndex))->method('setData')->with('store_id', $storeId);
+            $withArgs[] = ['store_id', $storeId];
         }
+        $this->product
+            ->method('setData')->withConsecutive(...$withArgs);
+
         $this->product->expects($this->once())->method('load')->with($identifier);
         $this->product->expects($this->atLeastOnce())->method('getId')->willReturn($identifier);
         $this->product->method('getSku')->willReturn('simple');
@@ -547,11 +579,11 @@ class ProductRepositoryTest extends TestCase
     }
 
     /**
-     * Test the forceReload parameter
+     * Test the forceReload parameter.
      *
-     * @throws NoSuchEntityException
+     * @return void
      */
-    public function testGetByIdForcedReload()
+    public function testGetByIdForcedReload(): void
     {
         $identifier = "23";
         $editMode = false;
@@ -576,7 +608,7 @@ class ProductRepositoryTest extends TestCase
      *
      * @return void
      */
-    public function testGetByIdWhenCacheReduced()
+    public function testGetByIdWhenCacheReduced(): void
     {
         $result = [];
         $expectedResult = [];
@@ -601,23 +633,16 @@ class ProductRepositoryTest extends TestCase
      * Get product mocks for testGetByIdWhenCacheReduced() method.
      *
      * @param int $productsCount
+     *
      * @return array
      */
-    private function getProductMocksForReducedCache($productsCount)
+    private function getProductMocksForReducedCache(int $productsCount): array
     {
         $productMocks = [];
 
         for ($i = 1; $i <= $productsCount; $i++) {
-            $productMock = $this->getMockBuilder(Product::class)
-                ->disableOriginalConstructor()
-                ->setMethods(
-                    [
-                        'getId',
-                        'getSku',
-                        'load',
-                        'setData',
-                    ]
-                )
+            $productMock = $this->getMockBuilder(Product::class)->disableOriginalConstructor()
+                ->onlyMethods(['getId', 'getSku', 'load', 'setData'])
                 ->getMock();
             $productMock->expects($this->once())->method('load');
             $productMock->expects($this->atLeastOnce())->method('getId')->willReturn($i);
@@ -629,11 +654,11 @@ class ProductRepositoryTest extends TestCase
     }
 
     /**
-     * Test forceReload parameter
+     * Test forceReload parameter.
      *
-     * @throws NoSuchEntityException
+     * @return void
      */
-    public function testGetForcedReload()
+    public function testGetForcedReload(): void
     {
         $sku = "sku";
         $id = "23";
@@ -656,7 +681,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->get($sku, $editMode, $storeId, true));
     }
 
-    public function testGetByIdWithSetStoreId()
+    /**
+    * @return void
+    */
+    public function testGetByIdWithSetStoreId(): void
     {
         $productId = 123;
         $storeId = 1;
@@ -669,7 +697,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->getById($productId, false, $storeId));
     }
 
-    public function testGetBySkuFromCacheInitializedInGetById()
+    /**
+    * @return void
+    */
+    public function testGetBySkuFromCacheInitializedInGetById(): void
     {
         $productId = 123;
         $productSku = 'product_123';
@@ -682,7 +713,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->get($productSku));
     }
 
-    public function testSaveExisting()
+    /**
+    * @return void
+    */
+    public function testSaveExisting(): void
     {
         $this->resourceModel->expects($this->any())->method('getIdBySku')->willReturn(100);
         $this->productFactory->expects($this->any())
@@ -701,11 +735,15 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->save($this->product));
     }
 
-    public function testSaveNew()
+    /**
+    * @return void
+    */
+    public function testSaveNew(): void
     {
         $this->storeManager->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);
-        $this->resourceModel->expects($this->at(0))->method('getIdBySku')->willReturn(null);
-        $this->resourceModel->expects($this->at(3))->method('getIdBySku')->willReturn(100);
+        $this->resourceModel
+            ->method('getIdBySku')
+            ->willReturnOnConsecutiveCalls(null, 100);
         $this->productFactory->expects($this->any())
             ->method('create')
             ->willReturn($this->product);
@@ -722,7 +760,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->save($this->product));
     }
 
-    public function testSaveUnableToSaveException()
+    /**
+    * @return void
+    */
+    public function testSaveUnableToSaveException(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotSaveException');
         $this->expectExceptionMessage('The product was unable to be saved. Please try again.');
@@ -746,7 +787,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->save($this->product);
     }
 
-    public function testSaveException()
+    /**
+    * @return void
+    */
+    public function testSaveException(): void
     {
         $this->expectException('Magento\Framework\Exception\InputException');
         $this->expectExceptionMessage('Invalid value of "" provided for the  field.');
@@ -770,7 +814,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->save($this->product);
     }
 
-    public function testSaveInvalidProductException()
+    /**
+    * @return void
+    */
+    public function testSaveInvalidProductException(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotSaveException');
         $this->expectExceptionMessage('Invalid product data: error1,error2');
@@ -792,7 +839,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->save($this->product);
     }
 
-    public function testSaveThrowsTemporaryStateExceptionIfDatabaseConnectionErrorOccurred()
+    /**
+    * @return void
+    */
+    public function testSaveThrowsTemporaryStateExceptionIfDatabaseConnectionErrorOccurred(): void
     {
         $this->expectException('Magento\Framework\Exception\TemporaryState\CouldNotSaveException');
         $this->expectExceptionMessage('Database connection error');
@@ -819,7 +869,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->save($this->product);
     }
 
-    public function testDelete()
+    /**
+    * @return void
+    */
+    public function testDelete(): void
     {
         $this->product->expects($this->exactly(2))->method('getSku')->willReturn('product-42');
         $this->product->expects($this->exactly(2))->method('getId')->willReturn(42);
@@ -828,7 +881,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertTrue($this->model->delete($this->product));
     }
 
-    public function testDeleteException()
+    /**
+    * @return void
+    */
+    public function testDeleteException(): void
     {
         $this->expectException('Magento\Framework\Exception\StateException');
         $this->expectExceptionMessage('The "product-42" product couldn\'t be removed.');
@@ -839,7 +895,10 @@ class ProductRepositoryTest extends TestCase
         $this->model->delete($this->product);
     }
 
-    public function testDeleteById()
+    /**
+    * @return void
+    */
+    public function testDeleteById(): void
     {
         $sku = 'product-42';
         $this->productFactory->expects($this->once())->method('create')
@@ -851,7 +910,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertTrue($this->model->deleteById($sku));
     }
 
-    public function testGetList()
+    /**
+    * @return void
+    */
+    public function testGetList(): void
     {
         $searchCriteriaMock = $this->getMockForAbstractClass(SearchCriteriaInterface::class);
         $searchCriteriaMock->expects($this->once())
@@ -880,11 +942,11 @@ class ProductRepositoryTest extends TestCase
     }
 
     /**
-     * Data provider for the key cache generator
+     * Data provider for the key cache generator.
      *
      * @return array
      */
-    public function cacheKeyDataProvider()
+    public function cacheKeyDataProvider(): array
     {
         $anyObject = $this->getMockBuilder(\stdClass::class)->addMethods(['getId'])
             ->disableOriginalConstructor()
@@ -897,55 +959,55 @@ class ProductRepositoryTest extends TestCase
             [
                 'identifier' => 'test-sku',
                 'editMode' => false,
-                'storeId' => null,
+                'storeId' => null
             ],
             [
                 'identifier' => 25,
                 'editMode' => false,
-                'storeId' => null,
+                'storeId' => null
             ],
             [
                 'identifier' => 25,
                 'editMode' => true,
-                'storeId' => null,
+                'storeId' => null
             ],
             [
                 'identifier' => 'test-sku',
                 'editMode' => true,
-                'storeId' => null,
+                'storeId' => null
             ],
             [
                 'identifier' => 25,
                 'editMode' => true,
-                'storeId' => $anyObject,
+                'storeId' => $anyObject
             ],
             [
                 'identifier' => 'test-sku',
                 'editMode' => true,
-                'storeId' => $anyObject,
+                'storeId' => $anyObject
             ],
             [
                 'identifier' => 25,
                 'editMode' => false,
-                'storeId' => $anyObject,
+                'storeId' => $anyObject
             ],
             [
 
                 'identifier' => 'test-sku',
                 'editMode' => false,
-                'storeId' => $anyObject,
-            ],
+                'storeId' => $anyObject
+            ]
         ];
     }
 
     /**
      * @param array $newOptions
-     * @param array $existingOptions
-     * @param array $expectedData
+     *
+     * @return void
      * @dataProvider saveExistingWithOptionsDataProvider
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function testSaveExistingWithOptions(array $newOptions, array $existingOptions, array $expectedData)
+    public function testSaveExistingWithOptions(array $newOptions): void
     {
         $this->storeManager->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);
         $this->resourceModel->expects($this->any())->method('getIdBySku')->willReturn(100);
@@ -975,7 +1037,7 @@ class ProductRepositoryTest extends TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function saveExistingWithOptionsDataProvider()
+    public function saveExistingWithOptionsDataProvider(): array
     {
         $data = [];
 
@@ -983,79 +1045,75 @@ class ProductRepositoryTest extends TestCase
         //there are two existing options, one will be updated and one will be deleted
         $newOptionsData = [
             [
-                "option_id" => 10,
-                "type" => "drop_down",
-                "values" => [
+                'option_id' => 10,
+                'type' => 'drop_down',
+                'values' => [
                     [
-                        "title" => "DropdownOptions_1",
+                        'title' => 'DropdownOptions_1',
                         "option_type_id" => 8, //existing
-                        "price" => 3,
+                        'price' => 3
                     ],
                     [ //new option value
-                        "title" => "DropdownOptions_3",
-                        "price" => 4,
-                    ],
-                ],
+                        'title' => 'DropdownOptions_3',
+                        'price' => 4
+                    ]
+                ]
             ],
             [//new option
-                "type" => "checkbox",
-                "values" => [
+                'type' => 'checkbox',
+                'values' => [
                     [
-                        "title" => "CheckBoxValue2",
-                        "price" => 5,
-                    ],
-                ],
-            ],
+                        'title' => 'CheckBoxValue2',
+                        'price' => 5
+                    ]
+                ]
+            ]
         ];
 
         /** @var Option|MockObject $existingOption1 */
         $existingOption1 = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
         $existingOption1->setData(
             [
-                "option_id" => 10,
-                "type" => "drop_down",
+                'option_id' => 10,
+                'type' => 'drop_down'
             ]
         );
         /** @var Value $existingOptionValue1 */
         $existingOptionValue1 = $this->getMockBuilder(Value::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
         $existingOptionValue1->setData(
             [
-                "option_type_id" => "8",
-                "title" => "DropdownOptions_1",
-                "price" => 5,
+                'option_type_id' => '8',
+                'title' => 'DropdownOptions_1',
+                'price' => 5
             ]
         );
         $existingOptionValue2 = $this->getMockBuilder(Value::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
         $existingOptionValue2->setData(
             [
-                "option_type_id" => "9",
-                "title" => "DropdownOptions_2",
-                "price" => 6,
+                'option_type_id' => '9',
+                'title' => 'DropdownOptions_2',
+                'price' => 6
             ]
         );
         $existingOption1->setValues(
             [
-                "8" => $existingOptionValue1,
-                "9" => $existingOptionValue2,
+                '8' => $existingOptionValue1,
+                '9' => $existingOptionValue2
             ]
         );
         $existingOption2 = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(null)
             ->getMock();
         $existingOption2->setData(
             [
-                "option_id" => 11,
-                "type" => "drop_down",
+                'option_id' => 11,
+                'type' => 'drop_down'
             ]
         );
         $data['scenario_1'] = [
@@ -1066,43 +1124,42 @@ class ProductRepositoryTest extends TestCase
             ],
             'expected_data' => [
                 [
-                    "option_id" => 10,
-                    "type" => "drop_down",
-                    "values" => [
+                    'option_id' => 10,
+                    'type' => 'drop_down',
+                    'values' => [
                         [
-                            "title" => "DropdownOptions_1",
-                            "option_type_id" => 8,
-                            "price" => 3,
+                            'title' => 'DropdownOptions_1',
+                            'option_type_id' => 8,
+                            'price' => 3
                         ],
                         [
-                            "title" => "DropdownOptions_3",
-                            "price" => 4,
+                            'title' => 'DropdownOptions_3',
+                            "price" => 4
                         ],
                         [
-                            "option_type_id" => 9,
-                            "title" => "DropdownOptions_2",
-                            "price" => 6,
-                            "is_delete" => 1,
-                        ],
-                    ],
+                            'option_type_id' => 9,
+                            'title' => 'DropdownOptions_2',
+                            'price' => 6,
+                            'is_delete' => 1
+                        ]
+                    ]
                 ],
                 [
-                    "type" => "checkbox",
-                    "values" => [
+                    'type' => 'checkbox',
+                    'values' => [
                         [
-                            "title" => "CheckBoxValue2",
-                            "price" => 5,
-                        ],
-                    ],
+                            'title' => 'CheckBoxValue2',
+                            'price' => 5
+                        ]
+                    ]
                 ],
                 [
-                    "option_id" => 11,
-                    "type" => "drop_down",
-                    "values" => [],
-                    "is_delete" => 1,
-
-                ],
-            ],
+                    'option_id' => 11,
+                    'type' => 'drop_down',
+                    'values' => [],
+                    'is_delete' => 1
+                ]
+            ]
         ];
 
         return $data;
@@ -1112,11 +1169,11 @@ class ProductRepositoryTest extends TestCase
      * @param array $newLinks
      * @param array $existingLinks
      * @param array $expectedData
+     *
+     * @return void
      * @dataProvider saveWithLinksDataProvider
-     * @throws CouldNotSaveException
-     * @throws InputException
      */
-    public function testSaveWithLinks(array $newLinks, array $existingLinks, array $expectedData)
+    public function testSaveWithLinks(array $newLinks, array $existingLinks, array $expectedData): void
     {
         $this->storeManager->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);
         $this->resourceModel->expects($this->any())->method('getIdBySku')->willReturn(100);
@@ -1171,17 +1228,14 @@ class ProductRepositoryTest extends TestCase
                 ->willReturn([]);
         }
 
-        $this->extensibleDataObjectConverter
-            ->expects($this->at(0))
-            ->method('toNestedArray')
-            ->willReturn($this->productData);
+        $willReturnArgs = [$this->productData];
 
         if (!empty($newLinks)) {
-            $this->extensibleDataObjectConverter
-                ->expects($this->at(1))
-                ->method('toNestedArray')
-                ->willReturn($newLinks);
+            $willReturnArgs[] = $newLinks;
         }
+        $this->extensibleDataObjectConverter
+            ->method('toNestedArray')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $outputLinks = [];
         if (!empty($expectedData)) {
@@ -1218,7 +1272,7 @@ class ProductRepositoryTest extends TestCase
     /**
      * @return mixed
      */
-    public function saveWithLinksDataProvider()
+    public function saveWithLinksDataProvider(): array
     {
         // Scenario 1
         // No existing, new links
@@ -1229,7 +1283,7 @@ class ProductRepositoryTest extends TestCase
                 "linked_product_sku" => "Simple Product 2",
                 "linked_product_type" => "simple",
                 "position" => 0,
-                "qty" => 1,
+                "qty" => 1
             ],
             'existingLinks' => [],
             'expectedData' => [[
@@ -1238,8 +1292,8 @@ class ProductRepositoryTest extends TestCase
                 "linked_product_sku" => "Simple Product 2",
                 "linked_product_type" => "simple",
                 "position" => 0,
-                "qty" => 1,
-            ]],
+                "qty" => 1
+            ]]
         ];
 
         // Scenario 2
@@ -1251,9 +1305,9 @@ class ProductRepositoryTest extends TestCase
                 "link_type" => "related",
                 "linked_product_sku" => "Simple Product 2",
                 "linked_product_type" => "simple",
-                "position" => 0,
+                "position" => 0
             ],
-            'expectedData' => [],
+            'expectedData' => []
         ];
 
         // Scenario 3
@@ -1264,14 +1318,14 @@ class ProductRepositoryTest extends TestCase
                 "link_type" => "related",
                 "linked_product_sku" => "Simple Product 2",
                 "linked_product_type" => "simple",
-                "position" => 0,
+                "position" => 0
             ],
             'existingLinks' => [
                 "product_sku" => "Simple Product 1",
                 "link_type" => "related",
                 "linked_product_sku" => "Simple Product 3",
                 "linked_product_type" => "simple",
-                "position" => 0,
+                "position" => 0
             ],
             'expectedData' => [
                 [
@@ -1279,15 +1333,18 @@ class ProductRepositoryTest extends TestCase
                     "link_type" => "related",
                     "linked_product_sku" => "Simple Product 2",
                     "linked_product_type" => "simple",
-                    "position" => 0,
-                ],
-            ],
+                    "position" => 0
+                ]
+            ]
         ];
 
         return $data;
     }
 
-    protected function setupProductMocksForSave()
+    /**
+    * @return void
+    */
+    protected function setupProductMocksForSave(): void
     {
         $this->resourceModel->expects($this->any())->method('getIdBySku')->willReturn(100);
         $this->productFactory->expects($this->any())
@@ -1300,7 +1357,10 @@ class ProductRepositoryTest extends TestCase
             ->with($this->initializedProduct)->willReturn(true);
     }
 
-    public function testSaveExistingWithNewMediaGalleryEntries()
+    /**
+    * @return void
+    */
+    public function testSaveExistingWithNewMediaGalleryEntries(): void
     {
         $this->storeManager->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);
         $newEntriesData = [
@@ -1315,10 +1375,10 @@ class ProductRepositoryTest extends TestCase
                         'data' => [
                             ImageContentInterface::NAME => 'filename',
                             ImageContentInterface::TYPE => 'image/jpeg',
-                            ImageContentInterface::BASE64_ENCODED_DATA => 'encoded_content',
-                        ],
+                            ImageContentInterface::BASE64_ENCODED_DATA => 'encoded_content'
+                        ]
                     ],
-                    'media_type' => 'media_type',
+                    'media_type' => 'media_type'
                 ]
             ]
         ];
@@ -1392,18 +1452,22 @@ class ProductRepositoryTest extends TestCase
     /**
      * @return array
      */
-    public function websitesProvider()
+    public function websitesProvider(): array
     {
         return [
             [[1,2,3]]
         ];
     }
 
-    public function testSaveWithDifferentWebsites()
+    /**
+    * @return void
+    */
+    public function testSaveWithDifferentWebsites(): void
     {
         $storeMock = $this->getMockForAbstractClass(StoreInterface::class);
-        $this->resourceModel->expects($this->at(0))->method('getIdBySku')->willReturn(null);
-        $this->resourceModel->expects($this->at(3))->method('getIdBySku')->willReturn(100);
+        $this->resourceModel
+            ->method('getIdBySku')
+            ->willReturnOnConsecutiveCalls(null, 100);
         $this->productFactory->expects($this->any())
             ->method('create')
             ->willReturn($this->product);
@@ -1433,7 +1497,10 @@ class ProductRepositoryTest extends TestCase
         $this->assertEquals($this->product, $this->model->save($this->product));
     }
 
-    public function testSaveExistingWithMediaGalleryEntries()
+    /**
+    * @return void
+    */
+    public function testSaveExistingWithMediaGalleryEntries(): void
     {
         $this->storeManager->expects($this->any())->method('getWebsites')->willReturn([1 => 'default']);
         //update one entry, delete one entry
@@ -1444,7 +1511,7 @@ class ProductRepositoryTest extends TestCase
                 'file' => 'filename1',
                 'position' => 10,
                 'disabled' => false,
-                'types' => ['image', 'small_image'],
+                'types' => ['image', 'small_image']
             ],
         ];
 
@@ -1455,13 +1522,13 @@ class ProductRepositoryTest extends TestCase
                     "label" => "label_text",
                     'file' => 'filename1',
                     'position' => 10,
-                    'disabled' => true,
+                    'disabled' => true
                 ],
                 [
                     'value_id' => 6, //will be deleted
-                    'file' => 'filename2',
-                ],
-            ],
+                    'file' => 'filename2'
+                ]
+            ]
         ];
 
         $expectedResult = [
@@ -1471,13 +1538,13 @@ class ProductRepositoryTest extends TestCase
                 'file' => 'filename1',
                 'position' => 10,
                 'disabled' => false,
-                'types' => ['image', 'small_image'],
+                'types' => ['image', 'small_image']
             ],
             [
                 'value_id' => 6, //will be deleted
                 'file' => 'filename2',
-                'removed' => true,
-            ],
+                'removed' => true
+            ]
         ];
 
         $this->setupProductMocksForSave();

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
@@ -265,6 +265,7 @@ class ProductTest extends TestCase
 
     /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -275,7 +276,7 @@ class ProductTest extends TestCase
             ['isEnabled']
         );
         $this->extensionAttributes = $this->getMockBuilder(ExtensionAttributesInterface::class)
-            ->setMethods(['getWebsiteIds', 'setWebsiteIds'])
+            ->addMethods(['getWebsiteIds', 'setWebsiteIds'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -327,7 +328,8 @@ class ProductTest extends TestCase
             ->willReturn($actionValidatorMock);
 
         $this->optionInstanceMock = $this->getMockBuilder(Option::class)
-            ->setMethods(['setProduct', 'saveOptions', '__sleep'])
+            ->onlyMethods(['setProduct', '__sleep'])
+            ->addMethods(['saveOptions'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -382,12 +384,12 @@ class ProductTest extends TestCase
             ->getMock();
         $this->imageCacheFactory = $this->getMockBuilder(CacheFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->mediaGalleryEntryFactoryMock =
             $this->getMockBuilder(ProductAttributeMediaGalleryEntryInterfaceFactory::class)
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->disableOriginalConstructor()
                 ->getMock();
 
@@ -422,13 +424,13 @@ class ProductTest extends TestCase
             ->getMock();
         $this->collectionFactoryMock = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->mediaConfig = $this->createMock(\Magento\Catalog\Model\Product\Media\Config::class);
         $this->eavConfig = $this->createMock(Config::class);
 
         $this->productExtAttributes = $this->getMockBuilder(ProductExtensionInterface::class)
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->getMockForAbstractClass();
         $this->extensionAttributesFactory
             ->expects($this->any())
@@ -474,17 +476,20 @@ class ProductTest extends TestCase
         );
     }
 
-    public function testGetAttributes()
+    /**
+    * @return void
+    */
+    public function testGetAttributes(): void
     {
         $productType = $this->getMockBuilder(AbstractType::class)
-            ->setMethods(['getSetAttributes'])
+            ->onlyMethods(['getSetAttributes'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->productTypeInstanceMock->expects($this->any())->method('factory')->willReturn(
             $productType
         );
         $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(['isInGroup'])
+            ->onlyMethods(['isInGroup'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $attribute->expects($this->any())->method('isInGroup')->willReturn(true);
@@ -496,7 +501,10 @@ class ProductTest extends TestCase
         $this->assertEquals($expect, $this->model->getAttributes());
     }
 
-    public function testGetStoreIds()
+    /**
+    * @return void
+    */
+    public function testGetStoreIds(): void
     {
         $expectedStoreIds = [1, 2, 3];
         $websiteIds = ['test'];
@@ -506,9 +514,10 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @dataProvider getSingleStoreIds
      * @param bool $isObjectNew
+     *
      * @return void
+     * @dataProvider getSingleStoreIds
      */
     public function testGetStoreSingleSiteModelIds(bool $isObjectNew): void
     {
@@ -539,7 +548,10 @@ class ProductTest extends TestCase
         ];
     }
 
-    public function testGetStoreId()
+    /**
+    * @return void
+    */
+    public function testGetStoreId(): void
     {
         $this->model->setStoreId(3);
         $this->assertEquals(3, $this->model->getStoreId());
@@ -548,7 +560,10 @@ class ProductTest extends TestCase
         $this->assertEquals(5, $this->model->getStoreId());
     }
 
-    public function testGetCategoryCollection()
+    /**
+     * @return void
+     */
+    public function testGetCategoryCollection(): void
     {
         $collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -558,26 +573,26 @@ class ProductTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider getCategoryCollectionCollectionNullDataProvider
      */
-    public function testGetCategoryCollectionCollectionNull($initCategoryCollection, $getIdResult, $productIdCached)
-    {
+    public function testGetCategoryCollectionCollectionNull(
+        $initCategoryCollection,
+        $getIdResult,
+        $productIdCached
+    ): void {
         $product = $this->createPartialMock(
             \Magento\Catalog\Model\Product::class,
             [
                 '_getResource',
                 'setCategoryCollection',
-                'getId',
+                'getId'
             ]
         );
 
         $abstractDbMock = $this->getMockBuilder(AbstractDb::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'getCategoryCollection',
-                ]
-            )
+            ->addMethods(['getCategoryCollection'])
             ->getMockForAbstractClass();
         $getCategoryCollectionMock = $this->createMock(
             Collection::class
@@ -619,17 +634,20 @@ class ProductTest extends TestCase
             [
                 '$initCategoryCollection' => null,
                 '$getIdResult' => 'getIdResult value',
-                '$productIdCached' => 'productIdCached value',
+                '$productIdCached' => 'productIdCached value'
             ],
             [
                 '$initCategoryCollection' => 'value',
                 '$getIdResult' => 'getIdResult value',
-                '$productIdCached' => 'not getIdResult value',
-            ],
+                '$productIdCached' => 'not getIdResult value'
+            ]
         ];
     }
 
-    public function testSetCategoryCollection()
+    /**
+    * @return void
+    */
+    public function testSetCategoryCollection(): void
     {
         $collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
@@ -638,7 +656,10 @@ class ProductTest extends TestCase
         $this->assertSame($this->model->getCategoryCollection(), $this->model->getCategoryCollection());
     }
 
-    public function testGetCategory()
+    /**
+    * @return void
+    */
+    public function testGetCategory(): void
     {
         $this->model->setData('category_ids', [10]);
         $this->category->expects($this->any())->method('getId')->willReturn(10);
@@ -647,47 +668,69 @@ class ProductTest extends TestCase
         $this->assertInstanceOf(Category::class, $this->model->getCategory());
     }
 
-    public function testGetCategoryId()
+    /**
+     * @return void
+     */
+    public function testGetCategoryId(): void
     {
         $this->model->setData('category_ids', [10]);
         $this->category->expects($this->any())->method('getId')->willReturn(10);
 
-        $this->registry->expects($this->at(0))->method('registry');
-        $this->registry->expects($this->at(1))->method('registry')->willReturn($this->category);
+        $this->registry
+            ->method('registry')
+            ->willReturnOnConsecutiveCalls(null, $this->category);
         $this->assertFalse($this->model->getCategoryId());
         $this->assertEquals(10, $this->model->getCategoryId());
     }
 
-    public function testGetIdBySku()
+    /**
+    * @return void
+    */
+    public function testGetIdBySku(): void
     {
         $this->resource->expects($this->once())->method('getIdBySku')->willReturn(5);
         $this->assertEquals(5, $this->model->getIdBySku('someSku'));
     }
 
-    public function testGetCategoryIds()
+    /**
+    * @return void
+    */
+    public function testGetCategoryIds(): void
     {
         $this->model->lockAttribute('category_ids');
         $this->assertEquals([], $this->model->getCategoryIds());
     }
 
-    public function testGetStatusInitial()
+    /**
+     * @return void
+     */
+    public function testGetStatusInitial(): void
     {
         $this->assertEquals(Status::STATUS_ENABLED, $this->model->getStatus());
     }
 
-    public function testGetStatus()
+    /**
+     * @return void
+     */
+    public function testGetStatus(): void
     {
         $this->model->setStatus(null);
         $this->assertEquals(Status::STATUS_ENABLED, $this->model->getStatus());
     }
 
-    public function testIsInStock()
+    /**
+     * @return void
+     */
+    public function testIsInStock(): void
     {
         $this->model->setStatus(Status::STATUS_ENABLED);
         $this->assertTrue($this->model->isInStock());
     }
 
-    public function testIndexerAfterDeleteCommitProduct()
+    /**
+     * @return void
+     */
+    public function testIndexerAfterDeleteCommitProduct(): void
     {
         $this->model->isDeleted(true);
         $this->categoryIndexerMock->expects($this->once())->method('reindexRow');
@@ -703,9 +746,10 @@ class ProductTest extends TestCase
      * @param $productFlatCount
      * @param $categoryIndexerCount
      *
+     * @return void
      * @dataProvider getProductReindexProvider
      */
-    public function testReindex($productChanged, $isScheduled, $productFlatCount, $categoryIndexerCount)
+    public function testReindex($productChanged, $isScheduled, $productFlatCount, $categoryIndexerCount): void
     {
         $this->model->setData('entity_id', 1);
         $this->_catalogProduct->expects($this->once())
@@ -737,7 +781,10 @@ class ProductTest extends TestCase
         ];
     }
 
-    public function testPriceReindexCallback()
+    /**
+    * @return void
+    */
+    public function testPriceReindexCallback(): void
     {
         $this->model = $this->objectManagerHelper->getObject(
             \Magento\Catalog\Model\Product::class,
@@ -758,12 +805,14 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @dataProvider getIdentitiesProvider
      * @param array $expected
      * @param array|null $origData
      * @param array $data
      * @param bool $isDeleted
      * @param bool $isNew
+     *
+     * @return void
+     * @dataProvider getIdentitiesProvider
      */
     public function testGetIdentities(
         array $expected,
@@ -771,7 +820,7 @@ class ProductTest extends TestCase
         array $data,
         bool $isDeleted = false,
         bool $isNew = false
-    ) {
+    ): void {
         $this->model->setIdFieldName('id');
         if (is_array($origData)) {
             foreach ($origData as $key => $value) {
@@ -793,7 +842,7 @@ class ProductTest extends TestCase
     {
         $extensionAttributesMock = $this->getMockBuilder(ExtensionAttributesInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStockItem'])->getMockForAbstractClass();
+            ->addMethods(['getStockItem'])->getMockForAbstractClass();
         $stockItemMock = $this->getMockBuilder(StockItemInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
@@ -804,7 +853,7 @@ class ProductTest extends TestCase
             'no changes' => [
                 ['cat_p_1'],
                 ['id' => 1, 'name' => 'value', 'category_ids' => [1]],
-                ['id' => 1, 'name' => 'value', 'category_ids' => [1]],
+                ['id' => 1, 'name' => 'value', 'category_ids' => [1]]
             ],
             'new product' => $this->getNewProductProviderData(),
             'new disabled product' => $this->getNewDisabledProductProviderData(),
@@ -818,7 +867,7 @@ class ProductTest extends TestCase
                     'status' => Status::STATUS_ENABLED,
                     'affected_category_ids' => [1, 2],
                     'is_changed_categories' => true
-                ],
+                ]
             ],
             'category change for disabled product' => [
                 [0 => 'cat_p_1'],
@@ -830,23 +879,23 @@ class ProductTest extends TestCase
                     'status' => Status::STATUS_DISABLED,
                     'affected_category_ids' => [1, 2],
                     'is_changed_categories' => true
-                ],
+                ]
             ],
             'status change to disabled' => [
                 [0 => 'cat_p_1', 1 => 'cat_c_p_7'],
                 ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_ENABLED],
-                ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_DISABLED],
+                ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_DISABLED]
             ],
             'status change to enabled' => [
                 [0 => 'cat_p_1', 1 => 'cat_c_p_7'],
                 ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_DISABLED],
-                ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_ENABLED],
+                ['id' => 1, 'name' => 'value', 'category_ids' => [7], 'status' => Status::STATUS_ENABLED]
             ],
             'status changed, category unassigned' => $this->getStatusAndCategoryChangesData(),
             'no status changes' => [
                 [0 => 'cat_p_1'],
                 ['id' => 1, 'name' => 'value', 'category_ids' => [1], 'status' => Status::STATUS_ENABLED],
-                ['id' => 1, 'name' => 'value', 'category_ids' => [1], 'status' => Status::STATUS_ENABLED],
+                ['id' => 1, 'name' => 'value', 'category_ids' => [1], 'status' => Status::STATUS_ENABLED]
             ],
             'no stock status changes' => $this->getNoStockStatusChangesData($extensionAttributesMock),
             'no stock status data 1' => [
@@ -857,8 +906,8 @@ class ProductTest extends TestCase
                     'name' => 'value',
                     'category_ids' => [1],
                     'status' => Status::STATUS_ENABLED,
-                    ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock,
-                ],
+                    ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock
+                ]
             ],
             'no stock status data 2' => [
                 [0 => 'cat_p_1'],
@@ -868,8 +917,8 @@ class ProductTest extends TestCase
                     'name' => 'value',
                     'category_ids' => [1],
                     'status' => Status::STATUS_ENABLED,
-                    'stock_data' => ['is_in_stock' => true],
-                ],
+                    'stock_data' => ['is_in_stock' => true]
+                ]
             ],
             'stock status changes for enabled product' => $this->getStatusStockProviderData($extensionAttributesMock),
             'stock status changes for disabled product' => [
@@ -881,9 +930,9 @@ class ProductTest extends TestCase
                     'category_ids' => [1],
                     'status' => Status::STATUS_DISABLED,
                     'stock_data' => ['is_in_stock' => false],
-                    ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock,
-                ],
-            ],
+                    ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock
+                ]
+            ]
         ];
     }
 
@@ -902,15 +951,16 @@ class ProductTest extends TestCase
                 'status' => Status::STATUS_ENABLED,
                 'is_changed_categories' => true,
                 'affected_category_ids' => [5]
-            ],
+            ]
         ];
     }
 
     /**
      * @param MockObject $extensionAttributesMock
+     *
      * @return array
      */
-    private function getNoStockStatusChangesData($extensionAttributesMock): array
+    private function getNoStockStatusChangesData(MockObject $extensionAttributesMock): array
     {
         return [
             [0 => 'cat_p_1'],
@@ -921,8 +971,8 @@ class ProductTest extends TestCase
                 'category_ids' => [1],
                 'status' => Status::STATUS_ENABLED,
                 'stock_data' => ['is_in_stock' => true],
-                ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock,
-            ],
+                ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock
+            ]
         ];
     }
 
@@ -942,7 +992,7 @@ class ProductTest extends TestCase
                 'is_changed_categories' => true
             ],
             false,
-            true,
+            true
         ];
     }
 
@@ -963,15 +1013,16 @@ class ProductTest extends TestCase
                 'is_changed_categories' => true
             ],
             false,
-            true,
+            true
         ];
     }
 
     /**
      * @param MockObject $extensionAttributesMock
+     *
      * @return array
      */
-    private function getStatusStockProviderData($extensionAttributesMock): array
+    private function getStatusStockProviderData(MockObject $extensionAttributesMock): array
     {
         return [
             [0 => 'cat_p_1', 1 => 'cat_c_p_1'],
@@ -982,15 +1033,17 @@ class ProductTest extends TestCase
                 'category_ids' => [1],
                 'status' => Status::STATUS_ENABLED,
                 'stock_data' => ['is_in_stock' => false],
-                ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock,
-            ],
+                ExtensibleDataInterface::EXTENSION_ATTRIBUTES_KEY => $extensionAttributesMock
+            ]
         ];
     }
 
     /**
-     * Test retrieving price Info
+     * Test retrieving price Info.
+     *
+     * @return void
      */
-    public function testGetPriceInfo()
+    public function testGetPriceInfo(): void
     {
         $this->productTypeInstanceMock->expects($this->once())
             ->method('getPriceInfo')
@@ -1000,9 +1053,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Test for set qty
+     * Test for set qty.
+     *
+     * @return void
      */
-    public function testSetQty()
+    public function testSetQty(): void
     {
         $this->productTypeInstanceMock->expects($this->exactly(2))
             ->method('getPriceInfo')
@@ -1019,9 +1074,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Test reload PriceInfo
+     * Test reload PriceInfo.
+     *
+     * @return void
      */
-    public function testReloadPriceInfo()
+    public function testReloadPriceInfo(): void
     {
         $this->productTypeInstanceMock->expects($this->exactly(2))
             ->method('getPriceInfo')
@@ -1032,18 +1089,22 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Test for get qty
+     * Test for get qty.
+     *
+     * @return void
      */
-    public function testGetQty()
+    public function testGetQty(): void
     {
         $this->model->setQty(1);
         $this->assertEquals(1, $this->model->getQty());
     }
 
     /**
-     *  Test for `save` method
+     *  Test for `save` method.
+     *
+     * @return void
      */
-    public function testSave()
+    public function testSave(): void
     {
         $collection = $this->createMock(Collection::class);
         $collection->method('count')->willReturn(1);
@@ -1056,9 +1117,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Image cache generation would not be performed if area was emulated
+     * Image cache generation would not be performed if area was emulated.
+     *
+     * @return void
      */
-    public function testSaveIfAreaEmulated()
+    public function testSaveIfAreaEmulated(): void
     {
         $this->appStateMock->expects($this->any())->method('isAreaCodeEmulated')->willReturn(true);
         $this->imageCache->expects($this->never())
@@ -1070,9 +1133,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     *  Test for `save` method for duplicated product
+     *  Test for `save` method for duplicated product.
+     *
+     * @return void
      */
-    public function testSaveAndDuplicate()
+    public function testSaveAndDuplicate(): void
     {
         $collection = $this->createMock(Collection::class);
         $collection->method('count')->willReturn(1);
@@ -1085,9 +1150,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Test for save method behavior with type options
+     * Test for save method behavior with type options.
+     *
+     * @return void
      */
-    public function testSaveWithoutTypeOptions()
+    public function testSaveWithoutTypeOptions(): void
     {
         $this->model->setCanSaveCustomOptions(false);
         $this->model->setTypeHasOptions(true);
@@ -1100,9 +1167,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Test for save method with provided options data
+     * Test for save method with provided options data.
+     *
+     * @return void
      */
-    public function testSaveWithProvidedRequiredOptions()
+    public function testSaveWithProvidedRequiredOptions(): void
     {
         $this->model->setData("has_options", "1");
         $this->model->setData("required_options", "1");
@@ -1113,7 +1182,10 @@ class ProductTest extends TestCase
         $this->assertTrue($this->model->getRequiredOptions());
     }
 
-    public function testGetIsSalableSimple()
+    /**
+    * @return void
+    */
+    public function testGetIsSalableSimple(): void
     {
         $typeInstanceMock =
             $this->createPartialMock(Simple::class, ['isSalable']);
@@ -1127,7 +1199,10 @@ class ProductTest extends TestCase
         self::assertTrue($this->model->getIsSalable());
     }
 
-    public function testGetIsSalableHasDataIsSaleable()
+    /**
+    * @return void
+    */
+    public function testGetIsSalableHasDataIsSaleable(): void
     {
         $typeInstanceMock = $this->createMock(Simple::class);
 
@@ -1139,13 +1214,15 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Configure environment for `testSave` and `testSaveAndDuplicate` methods
+     * Configure environment for `testSave` and `testSaveAndDuplicate` methods.
+     *
+     * @return void
      */
-    protected function configureSaveTest()
+    protected function configureSaveTest(): void
     {
         $productTypeMock = $this->getMockBuilder(Simple::class)
             ->disableOriginalConstructor()
-            ->setMethods(['beforeSave', 'save'])->getMock();
+            ->onlyMethods(['beforeSave', 'save'])->getMock();
         $productTypeMock->expects($this->once())->method('beforeSave')->willReturnSelf();
         $productTypeMock->expects($this->once())->method('save')->willReturnSelf();
 
@@ -1161,10 +1238,10 @@ class ProductTest extends TestCase
      *
      * @return void
      */
-    public function testFromArray()
+    public function testFromArray(): void
     {
         $data = [
-            'stock_item' => ['stock-item-data'],
+            'stock_item' => ['stock-item-data']
         ];
 
         $stockItemMock = $this->getMockForAbstractClass(
@@ -1192,7 +1269,10 @@ class ProductTest extends TestCase
         $this->assertEquals($this->model, $this->model->fromArray($data));
     }
 
-    protected function prepareCategoryIndexer()
+    /**
+    * @return void
+    */
+    protected function prepareCategoryIndexer(): void
     {
         $this->indexerRegistryMock->expects($this->once())
             ->method('get')
@@ -1201,9 +1281,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     *  Test for getProductLinks()
+     *  Test for getProductLinks().
+     *
+     * @return void
      */
-    public function testGetProductLinks()
+    public function testGetProductLinks(): void
     {
         $outputRelatedLink = $this->objectManagerHelper->getObject(Link::class);
         $outputRelatedLink->setSku("Simple Product 1");
@@ -1214,7 +1296,7 @@ class ProductTest extends TestCase
         $expectedOutput = [$outputRelatedLink];
         $this->productLinkRepositoryMock->expects($this->once())->method('getList')->willReturn($expectedOutput);
         $typeInstance = $this->getMockBuilder(AbstractType::class)
-            ->setMethods(['getSku'])
+            ->onlyMethods(['getSku'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $typeInstance->method('getSku')->willReturn('model');
@@ -1224,9 +1306,11 @@ class ProductTest extends TestCase
     }
 
     /**
-     *  Test for setProductLinks()
+     *  Test for setProductLinks().
+     *
+     * @return void
      */
-    public function testSetProductLinks()
+    public function testSetProductLinks(): void
     {
         $link = $this->objectManagerHelper->getObject(Link::class);
         $link->setSku("Simple Product 1");
@@ -1240,12 +1324,14 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Set up two media attributes: image and small_image
+     * Set up two media attributes: image and small_image.
+     *
+     * @return void
      */
-    protected function setupMediaAttributes()
+    protected function setupMediaAttributes(): array
     {
         $productType = $this->getMockBuilder(AbstractType::class)
-            ->setMethods(['getSetAttributes'])
+            ->onlyMethods(['getSetAttributes'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->productTypeInstanceMock->expects($this->any())->method('factory')->willReturn(
@@ -1254,11 +1340,11 @@ class ProductTest extends TestCase
 
         $frontendMock = $this->getMockBuilder(AbstractFrontend::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getInputType'])
+            ->onlyMethods(['getInputType'])
             ->getMockForAbstractClass();
         $frontendMock->expects($this->any())->method('getInputType')->willReturn('media_image');
         $attributeImage = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(['getFrontend', 'getAttributeCode'])
+            ->onlyMethods(['getFrontend', 'getAttributeCode'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $attributeImage->expects($this->any())
@@ -1266,7 +1352,7 @@ class ProductTest extends TestCase
             ->willReturn($frontendMock);
         $attributeImage->expects($this->any())->method('getAttributeCode')->willReturn('image');
         $attributeSmallImage = $this->getMockBuilder(AbstractAttribute::class)
-            ->setMethods(['getFrontend', 'getAttributeCode'])
+            ->onlyMethods(['getFrontend', 'getAttributeCode'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $attributeSmallImage->expects($this->any())
@@ -1281,7 +1367,10 @@ class ProductTest extends TestCase
         return [$attributeImage, $attributeSmallImage];
     }
 
-    public function getMediaAttributes()
+    /**
+    * @return void
+    */
+    public function getMediaAttributes(): void
     {
         $expected = [];
         $mediaAttributes = $this->setupMediaAttributes();
@@ -1291,7 +1380,10 @@ class ProductTest extends TestCase
         $this->assertEquals($expected, $this->model->getMediaAttributes());
     }
 
-    public function testGetMediaAttributeValues()
+    /**
+    * @return void
+    */
+    public function testGetMediaAttributeValues(): void
     {
         $this->mediaConfig->expects($this->once())->method('getMediaAttributeCodes')
             ->willReturn(['image', 'small_image']);
@@ -1305,12 +1397,18 @@ class ProductTest extends TestCase
         $this->assertEquals($expectedMediaAttributeValues, $this->model->getMediaAttributeValues());
     }
 
-    public function testGetMediaGalleryEntriesNone()
+    /**
+    * @return void
+    */
+    public function testGetMediaGalleryEntriesNone(): void
     {
         $this->assertNull($this->model->getMediaGalleryEntries());
     }
 
-    public function testGetMediaGalleryEntries()
+    /**
+    * @return void
+    */
+    public function testGetMediaGalleryEntries(): void
     {
         $this->setupMediaAttributes();
         $this->model->setData('image', 'imageFile.jpg');
@@ -1321,13 +1419,13 @@ class ProductTest extends TestCase
                 [
                     'value_id' => 1,
                     'file' => 'imageFile.jpg',
-                    'media_type' => 'image',
+                    'media_type' => 'image'
                 ],
                 [
                     'value_id' => 2,
                     'file' => 'smallImageFile.jpg',
-                    'media_type' => 'image',
-                ],
+                    'media_type' => 'image'
+                ]
             ]
         ];
         $this->model->setData('media_gallery', $mediaEntries);
@@ -1349,7 +1447,10 @@ class ProductTest extends TestCase
         $this->assertEquals([$entry1, $entry2], $this->model->getMediaGalleryEntries());
     }
 
-    public function testSetMediaGalleryEntries()
+    /**
+    * @return void
+    */
+    public function testSetMediaGalleryEntries(): void
     {
         $expectedResult = [
             'images' => [
@@ -1369,22 +1470,22 @@ class ProductTest extends TestCase
                     ],
                     'media_type' => 'image'
                 ]
-            ],
+            ]
         ];
 
         $entryMock = $this->getMockBuilder(ProductAttributeMediaGalleryEntryInterface::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getId',
                     'getFile',
                     'getLabel',
                     'getPosition',
                     'isDisabled',
-                    'types',
                     'getContent',
                     'getMediaType'
                 ]
             )
+            ->addMethods(['types'])
             ->getMockForAbstractClass();
 
         $result = [
@@ -1410,7 +1511,10 @@ class ProductTest extends TestCase
         $this->assertEquals($expectedResult, $this->model->getMediaGallery());
     }
 
-    public function testGetMediaGalleryImagesMerging()
+    /**
+    * @return void
+    */
+    public function testGetMediaGalleryImagesMerging(): void
     {
         $mediaEntries =
             [
@@ -1418,17 +1522,17 @@ class ProductTest extends TestCase
                     [
                         'value_id' => 1,
                         'file' => 'imageFile.jpg',
-                        'media_type' => 'image',
+                        'media_type' => 'image'
                     ],
                     [
                         'value_id' => 3,
-                        'file' => 'imageFile.jpg',
+                        'file' => 'imageFile.jpg'
                     ],
                     [
                         'value_id' => 2,
                         'file' => 'smallImageFile.jpg',
-                        'media_type' => 'image',
-                    ],
+                        'media_type' => 'image'
+                    ]
                 ]
             ];
         $expectedImageDataObject = new DataObject(
@@ -1438,7 +1542,7 @@ class ProductTest extends TestCase
                 'media_type' => 'image',
                 'url' => 'http://magento.dev/pub/imageFile.jpg',
                 'id' => 1,
-                'path' => '/var/www/html/pub/imageFile.jpg',
+                'path' => '/var/www/html/pub/imageFile.jpg'
             ]
         );
         $expectedSmallImageDataObject = new DataObject(
@@ -1448,7 +1552,7 @@ class ProductTest extends TestCase
                 'media_type' => 'image',
                 'url' => 'http://magento.dev/pub/smallImageFile.jpg',
                 'id' => 2,
-                'path' => '/var/www/html/pub/smallImageFile.jpg',
+                'path' => '/var/www/html/pub/smallImageFile.jpg'
             ]
         );
 
@@ -1469,7 +1573,7 @@ class ProductTest extends TestCase
             [
                 [1, null],
                 [2, null],
-                [3, 'not_null_skeep_foreache'],
+                [3, 'not_null_skeep_foreache']
             ]
         );
         $imagesCollectionMock->expects(self::exactly(2))->method('addItem')
@@ -1482,7 +1586,10 @@ class ProductTest extends TestCase
         $this->model->getMediaGalleryImages();
     }
 
-    public function testGetCustomAttributes()
+    /**
+    * @return void
+    */
+    public function testGetCustomAttributes(): void
     {
         $priceCode = 'price';
         $customAttributeCode = 'color';
@@ -1533,17 +1640,20 @@ class ProductTest extends TestCase
         ];
     }
 
-    public function testGetOptions()
+    /**
+    * @return void
+    */
+    public function testGetOptions(): void
     {
         $option1Id = 2;
         $optionMock1 = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'setProduct'])
+            ->onlyMethods(['getId', 'setProduct'])
             ->getMock();
         $option2Id = 3;
         $optionMock2 = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'setProduct'])
+            ->onlyMethods(['getId', 'setProduct'])
             ->getMock();
         $expectedOptions = [
             $option1Id => $optionMock1,
@@ -1584,7 +1694,10 @@ class ProductTest extends TestCase
         return $reflectionProperty->getValue($object);
     }
 
-    public function testGetFinalPrice()
+    /**
+    * @return void
+    */
+    public function testGetFinalPrice(): void
     {
         $finalPrice = 11;
         $qty = 1;
@@ -1608,7 +1721,10 @@ class ProductTest extends TestCase
         $this->model->setFinalPrice(9.99);
     }
 
-    public function testGetFinalPricePreset()
+    /**
+    * @return void
+    */
+    public function testGetFinalPricePreset(): void
     {
         $finalPrice = 9.99;
         $qty = 1;
@@ -1631,7 +1747,10 @@ class ProductTest extends TestCase
         $this->assertEquals($finalPrice, $this->model->getFinalPrice($qty));
     }
 
-    public function testGetTypeId()
+    /**
+    * @return void
+    */
+    public function testGetTypeId(): void
     {
         $productType = $this->getMockBuilder(Virtual::class)
             ->disableOriginalConstructor()
@@ -1646,7 +1765,10 @@ class ProductTest extends TestCase
         $this->model->getTypeInstance();
     }
 
-    public function testGetOptionById()
+    /**
+    * @return void
+    */
+    public function testGetOptionById(): void
     {
         $optionId = 100;
         $optionMock = $this->createMock(Option::class);
@@ -1655,7 +1777,10 @@ class ProductTest extends TestCase
         $this->assertEquals($optionMock, $this->model->getOptionById($optionId));
     }
 
-    public function testGetOptionByIdWithWrongOptionId()
+    /**
+    * @return void
+    */
+    public function testGetOptionByIdWithWrongOptionId(): void
     {
         $optionId = 100;
         $optionMock = $this->createMock(Option::class);
@@ -1664,7 +1789,10 @@ class ProductTest extends TestCase
         $this->assertNull($this->model->getOptionById($optionId));
     }
 
-    public function testGetOptionByIdForProductWithoutOptions()
+    /**
+    * @return void
+    */
+    public function testGetOptionByIdForProductWithoutOptions(): void
     {
         $this->assertNull($this->model->getOptionById(100));
     }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/CategoryTest.php
@@ -104,14 +104,16 @@ class CategoryTest extends TestCase
     private $indexerProcessorMock;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->selectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->selectMock->expects($this->at(2))->method('where')->willReturnSelf();
+        $this->selectMock
+            ->method('where')
+            ->willReturn($this->selectMock);
         $this->selectMock->expects($this->once())->method('from')->willReturnSelf();
         $this->selectMock->expects($this->once())->method('joinLeft')->willReturnSelf();
         $this->connectionMock = $this->getMockBuilder(Adapter::class)->getMockForAbstractClass();
@@ -170,7 +172,7 @@ class CategoryTest extends TestCase
     /**
      * @return void
      */
-    public function testFindWhereAttributeIs()
+    public function testFindWhereAttributeIs(): void
     {
         $entityIdsFilter = [1, 2];
         $expectedValue = 123;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
@@ -61,9 +61,12 @@ class GalleryTest extends TestCase
         'url' => ['DATA_TYPE' => 'text', 'NULLABLE' => true],
         'title' => ['DATA_TYPE' => 'varchar', 'NULLABLE' => true],
         'description' => ['DATA_TYPE' => 'text', 'NULLABLE' => true],
-        'metadata' => ['DATA_TYPE' => 'text', 'NULLABLE' => true],
+        'metadata' => ['DATA_TYPE' => 'text', 'NULLABLE' => true]
     ];
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -100,7 +103,10 @@ class GalleryTest extends TestCase
         $this->attribute = $this->createMock(AbstractAttribute::class);
     }
 
-    public function testLoadDataFromTableByValueId()
+    /**
+    * @return void
+    */
+    public function testLoadDataFromTableByValueId(): void
     {
         $tableNameAlias = 'catalog_product_entity_media_gallery_value_video';
         $ids = [5, 8];
@@ -111,12 +117,12 @@ class GalleryTest extends TestCase
             'video_url_default' => 'url',
             'video_title_default' => 'title',
             'video_description_default' => 'description',
-            'video_metadata_default' => 'metadata',
+            'video_metadata_default' => 'metadata'
         ];
         $leftJoinTables = [
             0 => [
                 0 => [
-                    'store_value' => 'catalog_product_entity_media_gallery_value_video',
+                    'store_value' => 'catalog_product_entity_media_gallery_value_video'
                 ],
                 1 => 'main.value_id = store_value.value_id AND store_value.store_id = 0',
                 2 => [
@@ -124,34 +130,33 @@ class GalleryTest extends TestCase
                     'video_url' => 'url',
                     'video_title' => 'title',
                     'video_description' => 'description',
-                    'video_metadata' => 'metadata',
-                ],
-            ],
+                    'video_metadata' => 'metadata'
+                ]
+            ]
         ];
         $whereCondition = null;
         $getTableReturnValue = 'table';
         $this->connection->expects($this->once())->method('select')->willReturn($this->select);
-        $this->select->expects($this->at(0))->method('from')->with(
-            [
-                'main' => $getTableReturnValue,
-            ],
-            [
-                'value_id' => 'value_id',
-                'video_provider_default' => 'provider',
-                'video_url_default' => 'url',
-                'video_title_default' => 'title',
-                'video_description_default' => 'description',
-                'video_metadata_default' => 'metadata',
-            ]
-        )->willReturnSelf();
-        $this->select->expects($this->at(1))->method('where')->with(
-            'main.value_id IN(?)',
-            $ids
-        )->willReturnSelf();
-        $this->select->expects($this->at(2))->method('where')->with(
-            'main.store_id = ?',
-            $storeId
-        )->willReturnSelf();
+        $this->select
+            ->method('from')
+            ->with(
+                [
+                    'main' => $getTableReturnValue,
+                ],
+                [
+                    'value_id' => 'value_id',
+                    'video_provider_default' => 'provider',
+                    'video_url_default' => 'url',
+                    'video_title_default' => 'title',
+                    'video_description_default' => 'description',
+                    'video_metadata_default' => 'metadata'
+                ]
+            )
+            ->willReturn($this->select);
+        $this->select
+            ->method('where')
+            ->withConsecutive(['main.value_id IN(?)', $ids], ['main.store_id = ?', $storeId])
+            ->willReturnOnConsecutiveCalls($this->select, $this->select);
         $resultRow = [
             [
                 'value_id' => '4',
@@ -165,7 +170,7 @@ class GalleryTest extends TestCase
                 'video_url' => 'https://www.youtube.com/watch?v=abcdefghij',
                 'video_title' => 'Some first title',
                 'video_description' => 'Description first',
-                'video_metadata' => 'meta one',
+                'video_metadata' => 'meta one'
             ],
             [
                 'value_id' => '5',
@@ -179,7 +184,7 @@ class GalleryTest extends TestCase
                 'video_url' => 'https://www.youtube.com/watch?v=ab123456',
                 'video_title' => 'Some second title',
                 'video_description' => 'Description second',
-                'video_metadata' => '',
+                'video_metadata' => ''
             ]
         ];
         $this->connection->expects($this->once())->method('fetchAll')
@@ -197,7 +202,10 @@ class GalleryTest extends TestCase
         $this->assertEquals($resultRow, $methodResult);
     }
 
-    public function testLoadDataFromTableByValueIdNoColsWithWhere()
+    /**
+    * @return void
+    */
+    public function testLoadDataFromTableByValueIdNoColsWithWhere(): void
     {
         $tableNameAlias = 'catalog_product_entity_media_gallery_value_video';
         $ids = [5, 8];
@@ -206,7 +214,7 @@ class GalleryTest extends TestCase
         $leftJoinTables = [
             0 => [
                 0 => [
-                    'store_value' => 'catalog_product_entity_media_gallery_value_video',
+                    'store_value' => 'catalog_product_entity_media_gallery_value_video'
                 ],
                 1 => 'main.value_id = store_value.value_id AND store_value.store_id = 0',
                 2 => [
@@ -214,34 +222,28 @@ class GalleryTest extends TestCase
                     'video_url' => 'url',
                     'video_title' => 'title',
                     'video_description' => 'description',
-                    'video_metadata' => 'metadata',
-                ],
-            ],
+                    'video_metadata' => 'metadata'
+                ]
+            ]
         ];
         $whereCondition = 'main.store_id = ' . $storeId;
         $getTableReturnValue = 'table';
 
         $this->connection->expects($this->once())->method('select')->willReturn($this->select);
-        $this->select->expects($this->at(0))->method('from')->with(
-            [
-                'main' => $getTableReturnValue,
-            ],
-            '*'
-        )->willReturnSelf();
 
-        $this->select->expects($this->at(1))->method('where')->with(
-            'main.value_id IN(?)',
-            $ids
-        )->willReturnSelf();
-
-        $this->select->expects($this->at(2))->method('where')->with(
-            'main.store_id = ?',
-            $storeId
-        )->willReturnSelf();
-
-        $this->select->expects($this->at(3))->method('where')->with(
-            $whereCondition
-        )->willReturnSelf();
+        $this->select
+            ->method('from')
+            ->with(
+                [
+                    'main' => $getTableReturnValue
+                ],
+                '*'
+            )
+            ->willReturn($this->select);
+        $this->select
+            ->method('where')
+            ->withConsecutive(['main.value_id IN(?)', $ids], ['main.store_id = ?', $storeId], [$whereCondition])
+            ->willReturnOnConsecutiveCalls($this->select, $this->select, $this->select);
 
         $resultRow = [
             [
@@ -256,7 +258,7 @@ class GalleryTest extends TestCase
                 'video_url' => 'https://www.youtube.com/watch?v=abcdefghij',
                 'video_title' => 'Some first title',
                 'video_description' => 'Description first',
-                'video_metadata' => 'meta one',
+                'video_metadata' => 'meta one'
             ],
             [
                 'value_id' => '5',
@@ -270,7 +272,7 @@ class GalleryTest extends TestCase
                 'video_url' => 'https://www.youtube.com/watch?v=ab123456',
                 'video_title' => 'Some second title',
                 'video_description' => 'Description second',
-                'video_metadata' => '',
+                'video_metadata' => ''
             ]
         ];
 
@@ -290,7 +292,10 @@ class GalleryTest extends TestCase
         $this->assertEquals($resultRow, $methodResult);
     }
 
-    public function testBindValueToEntityRecordExists()
+    /**
+    * @return void
+    */
+    public function testBindValueToEntityRecordExists(): void
     {
         $valueId = 14;
         $entityId = 1;
@@ -298,9 +303,10 @@ class GalleryTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testLoadGallery()
+    public function testLoadGallery(): void
     {
         $productId = 5;
         $storeId = 1;
@@ -323,8 +329,8 @@ class GalleryTest extends TestCase
                 'disabled' => '0',
                 'label_default' => null,
                 'position_default' => '1',
-                'disabled_default' => '0',
-            ],
+                'disabled_default' => '0'
+            ]
         ];
 
         $this->connection->expects($this->once())->method('getCheckSql')->with(
@@ -333,24 +339,13 @@ class GalleryTest extends TestCase
             'value.position'
         )->willReturn($positionCheckSql);
         $this->connection->expects($this->once())->method('select')->willReturn($this->select);
-        $this->select->expects($this->at(0))->method('from')->with(
-            [
-                'main' => $getTableReturnValue,
-            ],
-            [
-                'value_id',
-                'file' => 'value',
-                'media_type'
-            ]
-        )->willReturnSelf();
-        $this->select->expects($this->at(1))->method('joinInner')->with(
-            ['entity' => $getTableReturnValue],
-            'main.value_id = entity.value_id',
-            ['entity_id']
-        )->willReturnSelf();
-        $this->product->expects($this->at(0))->method('getData')
-            ->with('entity_id')->willReturn($productId);
-        $this->product->expects($this->at(1))->method('getStoreId')->willReturn($storeId);
+        $this->product
+            ->method('getData')
+            ->with('entity_id')
+            ->willReturn($productId);
+        $this->product
+            ->method('getStoreId')
+            ->willReturn($storeId);
         $this->connection->expects($this->exactly(2))->method('quoteInto')->withConsecutive(
             ['value.store_id = ?'],
             ['default_value.store_id = ?']
@@ -377,33 +372,51 @@ class GalleryTest extends TestCase
                 ]
             ]
         );
-        $this->select->expects($this->at(2))->method('joinLeft')->with(
-            ['value' => $getTableReturnValue],
-            $quoteInfoReturnValue,
-            []
-        )->willReturnSelf();
-        $this->select->expects($this->at(3))->method('joinLeft')->with(
-            ['default_value' => $getTableReturnValue],
-            $quoteDefaultInfoReturnValue,
-            []
-        )->willReturnSelf();
-        $this->select->expects($this->at(4))->method('columns')->with([
-            'label' => 'IFNULL(`value`.`label`, `default_value`.`label`)',
-            'position' => 'IFNULL(`value`.`position`, `default_value`.`position`)',
-            'disabled' => 'IFNULL(`value`.`disabled`, `default_value`.`disabled`)',
-            'label_default' => 'default_value.label',
-            'position_default' => 'default_value.position',
-            'disabled_default' => 'default_value.disabled'
-        ])->willReturnSelf();
-        $this->select->expects($this->at(5))->method('where')->with(
-            'main.attribute_id = ?',
-            $attributeId
-        )->willReturnSelf();
-        $this->select->expects($this->at(6))->method('where')
-            ->with('main.disabled = 0')->willReturnSelf();
-        $this->select->expects($this->at(8))->method('where')
-            ->with('entity.entity_id = ?', $productId)
-            ->willReturnSelf();
+        $this->select
+            ->method('from')
+            ->with(
+                [
+                    'main' => $getTableReturnValue,
+                ], [
+                    'value_id',
+                    'file' => 'value',
+                    'media_type'
+                ]
+            )
+            ->willReturn($this->select);
+        $this->select
+            ->method('where')
+            ->withConsecutive(
+                ['main.attribute_id = ?', $attributeId], ['main.disabled = 0'], [
+                'entity.entity_id = ?',
+                $productId
+            ]
+            )
+            ->willReturnOnConsecutiveCalls($this->select, $this->select, $this->select);
+        $this->select
+            ->method('columns')
+            ->with(
+                [
+                    'label' => 'IFNULL(`value`.`label`, `default_value`.`label`)',
+                    'position' => 'IFNULL(`value`.`position`, `default_value`.`position`)',
+                    'disabled' => 'IFNULL(`value`.`disabled`, `default_value`.`disabled`)',
+                    'label_default' => 'default_value.label',
+                    'position_default' => 'default_value.position',
+                    'disabled_default' => 'default_value.disabled'
+                ]
+            )
+            ->willReturn($this->select);
+        $this->select
+            ->method('joinLeft')
+            ->withConsecutive(
+                [['value' => $getTableReturnValue], $quoteInfoReturnValue, []],
+                [['default_value' => $getTableReturnValue], $quoteDefaultInfoReturnValue, []]
+            )
+            ->willReturnOnConsecutiveCalls($this->select, $this->select);
+        $this->select
+            ->method('joinInner')
+            ->with(['entity' => $getTableReturnValue], 'main.value_id = entity.value_id', ['entity_id'])
+            ->willReturn($this->select);
         $this->select->expects($this->once())->method('order')
             ->with($positionCheckSql . ' ' . Select::SQL_ASC)
             ->willReturnSelf();
@@ -414,7 +427,10 @@ class GalleryTest extends TestCase
         $this->assertEquals($resultRow, $this->resource->loadProductGalleryByAttributeId($this->product, $attributeId));
     }
 
-    public function testInsertGalleryValueInStore()
+    /**
+    * @return void
+    */
+    public function testInsertGalleryValueInStore(): void
     {
         $data = [
             'value_id' => '8',
@@ -423,7 +439,7 @@ class GalleryTest extends TestCase
             'url' => 'https://www.youtube.com/watch?v=abcdfghijk',
             'title' => 'New Title',
             'description' => 'New Description',
-            'metadata' => 'New metadata',
+            'metadata' => 'New metadata'
         ];
 
         $this->connection->expects($this->once())->method('describeTable')->willReturn($this->fields);
@@ -440,7 +456,10 @@ class GalleryTest extends TestCase
         $this->resource->insertGalleryValueInStore($data);
     }
 
-    public function testDeleteGalleryValueInStore()
+    /**
+    * @return void
+    */
+    public function testDeleteGalleryValueInStore(): void
     {
         $valueId = 4;
         $entityId = 6;
@@ -464,7 +483,10 @@ class GalleryTest extends TestCase
         $this->resource->deleteGalleryValueInStore($valueId, $entityId, $storeId);
     }
 
-    public function testCountImageUses()
+    /**
+    * @return void
+    */
+    public function testCountImageUses(): void
     {
         $results = [
             [
@@ -472,21 +494,24 @@ class GalleryTest extends TestCase
                 'attribute_id' => 90,
                 'value' => '/d/o/download_7.jpg',
                 'media_type' => 'image',
-                'disabled' => '0',
-            ],
+                'disabled' => '0'
+            ]
         ];
 
         $this->connection->expects($this->once())->method('select')->willReturn($this->select);
-        $this->select->expects($this->at(0))->method('from')->with(
-            [
-                'main' => 'table',
-            ],
-            '*'
-        )->willReturnSelf();
-        $this->select->expects($this->at(1))->method('where')->with(
-            'value = ?',
-            1
-        )->willReturnSelf();
+        $this->select
+            ->method('from')
+            ->with(
+                [
+                    'main' => 'table',
+                ],
+                '*'
+            )
+            ->willReturn($this->select);
+        $this->select
+            ->method('where')
+            ->with('value = ?', 1)
+            ->willReturn($this->select);
         $this->connection->expects($this->once())->method('fetchAll')
             ->with($this->select)
             ->willReturn($results);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/Indexer/Price/CompositeProductRelationsCalculatorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/Indexer/Price/CompositeProductRelationsCalculatorTest.php
@@ -26,6 +26,9 @@ class CompositeProductRelationsCalculatorTest extends TestCase
      */
     private $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->defaultPriceMock = $this->getMockBuilder(DefaultPrice::class)
@@ -34,7 +37,10 @@ class CompositeProductRelationsCalculatorTest extends TestCase
         $this->model = new CompositeProductRelationsCalculator($this->defaultPriceMock);
     }
 
-    public function testGetMaxRelationsCount()
+    /**
+    * @return void
+    */
+    public function testGetMaxRelationsCount(): void
     {
         $tableName = 'catalog_product_relation';
         $maxRelatedProductCount = 200;
@@ -55,7 +61,6 @@ class CompositeProductRelationsCalculatorTest extends TestCase
             )
             ->willReturnSelf();
         $relationSelectMock->expects($this->once())->method('group')->with('parent_id')->willReturnSelf();
-        $connectionMock->expects($this->at(0))->method('select')->willReturn($relationSelectMock);
 
         $maxSelectMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
@@ -67,9 +72,11 @@ class CompositeProductRelationsCalculatorTest extends TestCase
                 ['count' => 'MAX(count)']
             )
             ->willReturnSelf();
-        $connectionMock->expects($this->at(1))->method('select')->willReturn($maxSelectMock);
 
-        $connectionMock->expects($this->at(2))
+        $connectionMock
+            ->method('select')
+            ->willReturnOnConsecutiveCalls($relationSelectMock, $maxSelectMock);
+        $connectionMock
             ->method('fetchOne')
             ->with($maxSelectMock)
             ->willReturn($maxRelatedProductCount);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/Indexer/TemporaryTableStrategyTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/Indexer/TemporaryTableStrategyTest.php
@@ -32,6 +32,9 @@ class TemporaryTableStrategyTest extends TestCase
      */
     private $resourceMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->tableStrategyMock = $this->createMock(Strategy::class);
@@ -43,19 +46,28 @@ class TemporaryTableStrategyTest extends TestCase
         );
     }
 
-    public function testGetUseIdxTable()
+    /**
+    * @return void
+    */
+    public function testGetUseIdxTable(): void
     {
         $this->tableStrategyMock->expects($this->once())->method('getUseIdxTable')->willReturn(true);
         $this->assertTrue($this->model->getUseIdxTable());
     }
 
-    public function testSetUseIdxTable()
+    /**
+    * @return void
+    */
+    public function testSetUseIdxTable(): void
     {
         $this->tableStrategyMock->expects($this->once())->method('setUseIdxTable')->with(true)->willReturnSelf();
         $this->assertEquals($this->tableStrategyMock, $this->model->setUseIdxTable(true));
     }
 
-    public function testGetTableName()
+    /**
+    * @return void
+    */
+    public function testGetTableName(): void
     {
         $tablePrefix = 'prefix';
         $expectedResult = $tablePrefix . StrategyInterface::IDX_SUFFIX;
@@ -67,7 +79,10 @@ class TemporaryTableStrategyTest extends TestCase
         $this->assertEquals($expectedResult, $this->model->getTableName($tablePrefix));
     }
 
-    public function testPrepareTableName()
+    /**
+    * @return void
+    */
+    public function testPrepareTableName(): void
     {
         $tablePrefix = 'prefix';
         $expectedResult = $tablePrefix . TemporaryTableStrategy::TEMP_SUFFIX;
@@ -80,14 +95,10 @@ class TemporaryTableStrategyTest extends TestCase
             ->method('getConnection')
             ->with('indexer')
             ->willReturn($connectionMock);
-        $this->resourceMock->expects($this->at(1))
+        $this->resourceMock
             ->method('getTableName')
-            ->with($expectedResult)
-            ->willReturn($expectedResult);
-        $this->resourceMock->expects($this->at(2))
-            ->method('getTableName')
-            ->with($tempTableName)
-            ->willReturn($tempTableName);
+            ->withConsecutive([$expectedResult], [$tempTableName])
+            ->willReturnOnConsecutiveCalls($expectedResult, $tempTableName);
         $connectionMock->expects($this->once())
             ->method('createTemporaryTableLike')
             ->with($expectedResult, $tempTableName, true);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/LinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/LinkTest.php
@@ -37,6 +37,9 @@ class LinkTest extends TestCase
      */
     protected $dbSelect;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -50,23 +53,25 @@ class LinkTest extends TestCase
         );
     }
 
-    protected function prepareAdapter()
+    /**
+    * @return void
+    */
+    protected function prepareAdapter(): void
     {
         $this->dbSelect = $this->createMock(Select::class);
 
         // method flow
-        $this->resource->expects(
-            $this->at(0)
-        )->method(
-            'getConnection'
-        )->willReturn(
-            $this->connection
-        );
+        $this->resource
+            ->method('getConnection')
+            ->willReturn($this->connection);
 
         $this->connection->expects($this->once())->method('select')->willReturn($this->dbSelect);
     }
 
-    public function testGetAttributesByType()
+    /**
+    * @return void
+    */
+    public function testGetAttributesByType(): void
     {
         $typeId = 4;
         $result = [100, 200, 300, 400];
@@ -87,7 +92,10 @@ class LinkTest extends TestCase
         $this->assertEquals($result, $this->model->getAttributesByType($typeId));
     }
 
-    public function testGetAttributeTypeTable()
+    /**
+    * @return void
+    */
+    public function testGetAttributeTypeTable(): void
     {
         $inputTable = 'megatable';
         $resultTable = 'advancedTable';
@@ -104,7 +112,10 @@ class LinkTest extends TestCase
         $this->assertEquals($resultTable, $this->model->getAttributeTypeTable($inputTable));
     }
 
-    public function testGetChildrenIds()
+    /**
+    * @return void
+    */
+    public function testGetChildrenIds(): void
     {
         //prepare mocks and data
         $parentId = 100;
@@ -133,7 +144,10 @@ class LinkTest extends TestCase
         $this->assertEquals($result, $this->model->getChildrenIds($parentId, $typeId));
     }
 
-    public function testGetParentIdsByChild()
+    /**
+    * @return void
+    */
+    public function testGetParentIdsByChild(): void
     {
         $childId = 234;
         $typeId = 4;

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/StatusBaseSelectProcessorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/StatusBaseSelectProcessorTest.php
@@ -54,6 +54,9 @@ class StatusBaseSelectProcessorTest extends TestCase
      */
     private $statusBaseSelectProcessor;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->eavConfig = $this->getMockBuilder(Config::class)
@@ -71,11 +74,14 @@ class StatusBaseSelectProcessorTest extends TestCase
         $this->statusBaseSelectProcessor =  (new ObjectManager($this))->getObject(StatusBaseSelectProcessor::class, [
             'eavConfig' => $this->eavConfig,
             'metadataPool' => $this->metadataPool,
-            'storeManager' => $this->storeManager,
+            'storeManager' => $this->storeManager
         ]);
     }
 
-    public function testProcess()
+    /**
+    * @return void
+    */
+    public function testProcess(): void
     {
         $linkField = 'link_field';
         $backendTable = 'backend_table';
@@ -93,7 +99,7 @@ class StatusBaseSelectProcessorTest extends TestCase
 
         /** @var AttributeInterface|MockObject $statusAttribute */
         $statusAttribute = $this->getMockBuilder(AttributeInterface::class)
-            ->setMethods(['getBackendTable', 'getAttributeId'])
+            ->addMethods(['getBackendTable', 'getAttributeId'])
             ->getMockForAbstractClass();
         $statusAttribute->expects($this->atLeastOnce())
             ->method('getBackendTable')
@@ -117,28 +123,27 @@ class StatusBaseSelectProcessorTest extends TestCase
             ->method('getId')
             ->willReturn($currentStoreId);
 
-        $this->select->expects($this->at(0))
+        $this->select
             ->method('joinLeft')
-            ->with(
-                ['status_global_attr' => $backendTable],
-                "status_global_attr.{$linkField} = "
-                . BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS . ".{$linkField}"
-                . " AND status_global_attr.attribute_id = {$attributeId}"
-                . ' AND status_global_attr.store_id = ' . Store::DEFAULT_STORE_ID,
-                []
+            ->withConsecutive(
+                [
+                    ['status_global_attr' => $backendTable],
+                    "status_global_attr.{$linkField} = "
+                    . BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS . ".{$linkField}"
+                    . " AND status_global_attr.attribute_id = {$attributeId}"
+                    . ' AND status_global_attr.store_id = ' . Store::DEFAULT_STORE_ID,
+                    []
+                ],
+                [
+                    ['status_attr' => $backendTable],
+                    "status_attr.{$linkField} = " . BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS . ".{$linkField}"
+                    . " AND status_attr.attribute_id = {$attributeId}"
+                    . " AND status_attr.store_id = {$currentStoreId}",
+                    []
+                ]
             )
-            ->willReturnSelf();
-        $this->select->expects($this->at(1))
-            ->method('joinLeft')
-            ->with(
-                ['status_attr' => $backendTable],
-                "status_attr.{$linkField} = " . BaseSelectProcessorInterface::PRODUCT_TABLE_ALIAS . ".{$linkField}"
-                . " AND status_attr.attribute_id = {$attributeId}"
-                . " AND status_attr.store_id = {$currentStoreId}",
-                []
-            )
-            ->willReturnSelf();
-        $this->select->expects($this->at(2))
+            ->willReturnOnConsecutiveCalls($this->select, $this->select);
+        $this->select
             ->method('where')
             ->with('IFNULL(status_attr.value, status_global_attr.value) = ?', Status::STATUS_ENABLED)
             ->willReturnSelf();

--- a/app/code/Magento/Catalog/Test/Unit/Pricing/Price/CustomOptionPriceTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Pricing/Price/CustomOptionPriceTest.php
@@ -20,7 +20,6 @@ use Magento\Framework\Pricing\Price\PriceInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\Pricing\PriceInfo\Base;
 use Magento\Framework\Pricing\PriceInfoInterface;
-
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +59,7 @@ class CustomOptionPriceTest extends TestCase
     protected $priceCurrencyMock;
 
     /**
-     * SetUp
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -91,9 +90,10 @@ class CustomOptionPriceTest extends TestCase
 
     /**
      * @param array $optionsData
+     *
      * @return array
      */
-    protected function setupOptions(array $optionsData)
+    protected function setupOptions(array $optionsData): array
     {
         $options = [];
         foreach ($optionsData as $optionData) {
@@ -102,7 +102,7 @@ class CustomOptionPriceTest extends TestCase
 
             $optionItemMock = $this->getMockBuilder(Option::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['getValues', 'getIsRequire', 'getId', 'getType'])
+                ->onlyMethods(['getValues', 'getIsRequire', 'getId', 'getType'])
                 ->getMock();
             $optionItemMock->expects($this->any())
                 ->method('getId')
@@ -118,27 +118,32 @@ class CustomOptionPriceTest extends TestCase
                 ->willReturn([$optionValueMax, $optionValueMin]);
             $options[] = $optionItemMock;
         }
+
         return $options;
     }
 
     /**
-     * @param $optionsData
+     * @param array $optionsData
+     *
      * @return array
      */
-    protected function setupSingleValueOptions($optionsData)
+    protected function setupSingleValueOptions(array $optionsData): array
     {
         $options = [];
+
         foreach ($optionsData as $optionData) {
             $optionItemMock = $this->getMockBuilder(Option::class)
                 ->disableOriginalConstructor()
-                ->setMethods([
-                    'getValues',
-                    'getIsRequire',
-                    'getId',
-                    'getType',
-                    'getPriceType',
-                    'getPrice',
-                ])
+                ->onlyMethods(
+                    [
+                        'getValues',
+                        'getIsRequire',
+                        'getId',
+                        'getType',
+                        'getPriceType',
+                        'getPrice'
+                    ]
+                )
                 ->getMock();
             $optionItemMock->expects($this->any())
                 ->method('getId')
@@ -161,13 +166,16 @@ class CustomOptionPriceTest extends TestCase
                 ->willReturn($optionData['price']);
             $options[] = $optionItemMock;
         }
+
         return $options;
     }
 
     /**
-     * Test getValue()
+     * Test getValue().
+     *
+     * @return void
      */
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $option1Id = 1;
         $option1MaxPrice = 100;
@@ -185,14 +193,14 @@ class CustomOptionPriceTest extends TestCase
                 'type' => $option1Type,
                 'max_option_price' => $option1MaxPrice,
                 'min_option_price' => $option1MinPrice,
-                'is_require' => true,
+                'is_require' => true
             ],
             [
                 'id' => $option2Id,
                 'type' => $option2Type,
                 'max_option_price' => $option2MaxPrice,
                 'min_option_price' => $option2MinPrice,
-                'is_require' => false,
+                'is_require' => false
             ]
         ];
 
@@ -207,8 +215,8 @@ class CustomOptionPriceTest extends TestCase
                     'type' => $singleValueOptionType,
                     'price' => $singleValueOptionPrice,
                     'price_type' => 'fixed',
-                    'is_require' => true,
-                ],
+                    'is_require' => true
+                ]
             ]
         );
 
@@ -223,26 +231,29 @@ class CustomOptionPriceTest extends TestCase
                 'option_id' => $option1Id,
                 'type' => $option1Type,
                 'min' => $option1MinPrice,
-                'max' => $option1MaxPrice,
+                'max' => $option1MaxPrice
             ],
             [
                 'option_id' => $option2Id,
                 'type' => $option2Type,
                 'min' => 0.,
-                'max' => $option2MaxPrice + $option2MinPrice,
+                'max' => $option2MaxPrice + $option2MinPrice
             ],
             [
                 'option_id' => $singleValueOptionId,
                 'type' => $singleValueOptionType,
                 'min' => $singleValueOptionPrice,
-                'max' => $singleValueOptionPrice,
+                'max' => $singleValueOptionPrice
             ]
         ];
         $result = $this->object->getValue();
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testGetCustomOptionRange()
+    /**
+    * @return void
+    */
+    public function testGetCustomOptionRange(): void
     {
         $option1Id = 1;
         $option1MaxPrice = 100;
@@ -260,14 +271,14 @@ class CustomOptionPriceTest extends TestCase
                 'type' => $option1Type,
                 'max_option_price' => $option1MaxPrice,
                 'min_option_price' => $option1MinPrice,
-                'is_require' => true,
+                'is_require' => true
             ],
             [
                 'id' => $option2Id,
                 'type' => $option2Type,
                 'max_option_price' => $option2MaxPrice,
                 'min_option_price' => $option2MinPrice,
-                'is_require' => false,
+                'is_require' => false
             ]
         ];
         $options = $this->setupOptions($optionsData);
@@ -278,27 +289,24 @@ class CustomOptionPriceTest extends TestCase
 
         $convertMinValue = $option1MinPrice / 2;
         $convertedMaxValue = ($option2MaxPrice + $option1MaxPrice) / 2;
-        $this->priceCurrencyMock->expects($this->at(0))
+        $this->priceCurrencyMock
             ->method('convertAndRound')
-            ->with($option1MinPrice)
-            ->willReturn($convertMinValue);
-        $this->priceCurrencyMock->expects($this->at(1))
-            ->method('convertAndRound')
-            ->with($option2MaxPrice + $option1MaxPrice)
-            ->willReturn($convertedMaxValue);
+            ->withConsecutive([$option1MinPrice], [$option2MaxPrice + $option1MaxPrice])
+            ->willReturnOnConsecutiveCalls($convertMinValue, $convertedMaxValue);
         $this->assertEquals($option1MinPrice / 2, $this->object->getCustomOptionRange(true));
         $this->assertEquals($convertedMaxValue, $this->object->getCustomOptionRange(false));
     }
 
     /**
      * @param int $price
+     *
      * @return MockObject
      */
-    protected function getOptionValueMock($price)
+    protected function getOptionValueMock($price): MockObject
     {
         $optionValueMock = $this->getMockBuilder(Value::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPriceType', 'getPrice', 'getId', 'getOption', 'getData'])
+            ->onlyMethods(['getPriceType', 'getPrice', 'getId', 'getOption', 'getData'])
             ->getMock();
         $optionValueMock->expects($this->any())
             ->method('getPriceType')
@@ -315,7 +323,7 @@ class CustomOptionPriceTest extends TestCase
 
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getProduct'])
+            ->onlyMethods(['getProduct'])
             ->getMock();
 
         $optionValueMock->expects($this->any())->method('getOption')->willReturn($optionMock);
@@ -324,7 +332,7 @@ class CustomOptionPriceTest extends TestCase
 
         $priceMock = $this->getMockBuilder(PriceInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getValue'])
+            ->onlyMethods(['getValue'])
             ->getMockForAbstractClass();
         $priceMock->method('getValue')->willReturn($price);
 
@@ -334,9 +342,11 @@ class CustomOptionPriceTest extends TestCase
     }
 
     /**
-     * Test getSelectedOptions()
+     * Test getSelectedOptions().
+     *
+     * @return void
      */
-    public function testGetSelectedOptions()
+    public function testGetSelectedOptions(): void
     {
         $optionId1 = 1;
         $optionId2 = 2;
@@ -344,15 +354,16 @@ class CustomOptionPriceTest extends TestCase
         $optionType = 'select';
         $optionValueMock = $this->getMockBuilder(DefaultType::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getValue'])
+            ->addMethods(['getValue'])
             ->getMock();
         $optionMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getType', 'groupFactory'])
+            ->onlyMethods(['getId', 'getType', 'groupFactory'])
             ->getMock();
         $groupMock = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setOption', 'setConfigurationItemOption', 'getOptionPrice'])
+            ->onlyMethods(['setOption', 'getOptionPrice'])
+            ->addMethods(['setConfigurationItemOption'])
             ->getMock();
 
         $groupMock->expects($this->once())
@@ -365,7 +376,7 @@ class CustomOptionPriceTest extends TestCase
             ->method('getOptionPrice')
             ->with($optionValue, 0.)
             ->willReturn($optionValue);
-        $optionMock->expects($this->at(0))
+        $optionMock
             ->method('getId')
             ->willReturn($optionId1);
         $optionMock->expects($this->once())
@@ -382,14 +393,10 @@ class CustomOptionPriceTest extends TestCase
 
         $customOptions = ['option_ids' => $optionIds, 'option_1' => $optionValueMock, 'option_2' => null];
         $this->product->setCustomOptions($customOptions);
-        $this->product->expects($this->at(0))
+        $this->product
             ->method('getOptionById')
-            ->with($optionId1)
-            ->willReturn($optionMock);
-        $this->product->expects($this->at(1))
-            ->method('getOptionById')
-            ->with($optionId2)
-            ->willReturn(null);
+            ->withConsecutive([$optionId1], [$optionId2])
+            ->willReturnOnConsecutiveCalls($optionMock, null);
 
         // Return from cache
         $result = $this->object->getSelectedOptions();
@@ -397,9 +404,11 @@ class CustomOptionPriceTest extends TestCase
     }
 
     /**
-     * Test getOptions()
+     * Test getOptions().
+     *
+     * @return void
      */
-    public function testGetOptions()
+    public function testGetOptions(): void
     {
         $price = 100;
         $displayValue = 120;
@@ -420,7 +429,7 @@ class CustomOptionPriceTest extends TestCase
             ->willReturn($id);
         $optionItemMock = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getValues'])
+            ->onlyMethods(['getValues'])
             ->getMock();
         $optionItemMock->expects($this->any())
             ->method('getValues')

--- a/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
@@ -96,6 +96,9 @@ class FinalPriceBoxTest extends TestCase
      */
     private $minimalPriceCalculator;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->product = $this->getMockBuilder(Product::class)
@@ -133,7 +136,8 @@ class FinalPriceBoxTest extends TestCase
         $store = $this->getMockBuilder(StoreInterface::class)
             ->getMockForAbstractClass();
         $storeManager = $this->getMockBuilder(StoreManagerInterface::class)
-            ->setMethods(['getStore', 'getCode'])
+            ->onlyMethods(['getStore'])
+            ->addMethods(['getCode'])
             ->getMockForAbstractClass();
         $storeManager->expects($this->any())->method('getStore')->willReturn($store);
 
@@ -196,7 +200,10 @@ class FinalPriceBoxTest extends TestCase
         );
     }
 
-    public function testRenderMsrpDisabled()
+    /**
+    * @return void
+    */
+    public function testRenderMsrpDisabled(): void
     {
         $priceType = $this->createMock(MsrpPrice::class);
         $this->priceInfo->expects($this->once())
@@ -219,7 +226,10 @@ class FinalPriceBoxTest extends TestCase
         $this->assertMatchesRegularExpression('/[final_price]/', $result);
     }
 
-    public function testNotSalableItem()
+    /**
+    * @return void
+    */
+    public function testNotSalableItem(): void
     {
         $this->salableResolverMock
             ->expects($this->once())
@@ -231,7 +241,10 @@ class FinalPriceBoxTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    public function testRenderMsrpEnabled()
+    /**
+    * @return void
+    */
+    public function testRenderMsrpEnabled(): void
     {
         $priceType = $this->createMock(MsrpPrice::class);
         $this->priceInfo->expects($this->once())
@@ -265,7 +278,11 @@ class FinalPriceBoxTest extends TestCase
             ->with('msrp_price', $this->product, $arguments)
             ->willReturn($priceBoxRender);
 
-        $this->salableResolverMock->expects($this->once())->method('isSalable')->with($this->product)->willReturn(true);
+        $this->salableResolverMock
+            ->expects($this->once())
+            ->method('isSalable')
+            ->with($this->product)
+            ->willReturn(true);
 
         $result = $this->object->toHtml();
 
@@ -277,7 +294,10 @@ class FinalPriceBoxTest extends TestCase
         );
     }
 
-    public function testRenderMsrpNotRegisteredException()
+    /**
+    * @return void
+    */
+    public function testRenderMsrpNotRegisteredException(): void
     {
         $this->logger->expects($this->once())
             ->method('critical');
@@ -287,7 +307,11 @@ class FinalPriceBoxTest extends TestCase
             ->with('msrp_price')
             ->willThrowException(new \InvalidArgumentException());
 
-        $this->salableResolverMock->expects($this->once())->method('isSalable')->with($this->product)->willReturn(true);
+        $this->salableResolverMock
+            ->expects($this->once())
+            ->method('isSalable')
+            ->with($this->product)
+            ->willReturn(true);
 
         $result = $this->object->toHtml();
 
@@ -297,7 +321,10 @@ class FinalPriceBoxTest extends TestCase
         $this->assertMatchesRegularExpression('/[final_price]/', $result);
     }
 
-    public function testRenderAmountMinimal()
+    /**
+    * @return void
+    */
+    public function testRenderAmountMinimal(): void
     {
         $priceId = 'price_id';
         $html = 'html';
@@ -317,7 +344,7 @@ class FinalPriceBoxTest extends TestCase
             'display_label' => 'As low as',
             'price_id' => $priceId,
             'include_container' => false,
-            'skip_adjustments' => true,
+            'skip_adjustments' => true
         ];
 
         $amountRender = $this->createPartialMock(Amount::class, ['toHtml']);
@@ -334,12 +361,14 @@ class FinalPriceBoxTest extends TestCase
     }
 
     /**
-     * @dataProvider hasSpecialPriceProvider
      * @param float $regularPrice
      * @param float $finalPrice
      * @param bool $expectedResult
+     *
+     * @return void
+     * @dataProvider hasSpecialPriceProvider
      */
-    public function testHasSpecialPrice($regularPrice, $finalPrice, $expectedResult)
+    public function testHasSpecialPrice(float $regularPrice, float $finalPrice, bool $expectedResult): void
     {
         $regularPriceType = $this->createMock(RegularPrice::class);
         $finalPriceType = $this->createMock(FinalPrice::class);
@@ -360,14 +389,10 @@ class FinalPriceBoxTest extends TestCase
             ->method('getAmount')
             ->willReturn($finalPriceAmount);
 
-        $this->priceInfo->expects($this->at(0))
+        $this->priceInfo
             ->method('getPrice')
-            ->with(RegularPrice::PRICE_CODE)
-            ->willReturn($regularPriceType);
-        $this->priceInfo->expects($this->at(1))
-            ->method('getPrice')
-            ->with(FinalPrice::PRICE_CODE)
-            ->willReturn($finalPriceType);
+            ->withConsecutive([RegularPrice::PRICE_CODE], [FinalPrice::PRICE_CODE])
+            ->willReturnOnConsecutiveCalls($regularPriceType, $finalPriceType);
 
         $this->assertEquals($expectedResult, $this->object->hasSpecialPrice());
     }
@@ -375,7 +400,7 @@ class FinalPriceBoxTest extends TestCase
     /**
      * @return array
      */
-    public function hasSpecialPriceProvider()
+    public function hasSpecialPriceProvider(): array
     {
         return [
             [10.0, 20.0, false],
@@ -384,7 +409,10 @@ class FinalPriceBoxTest extends TestCase
         ];
     }
 
-    public function testShowMinimalPrice()
+    /**
+    * @return void
+    */
+    public function testShowMinimalPrice(): void
     {
         $minimalPrice = 5.0;
         $finalPrice = 10.0;
@@ -412,7 +440,10 @@ class FinalPriceBoxTest extends TestCase
         $this->assertTrue($this->object->showMinimalPrice());
     }
 
-    public function testHidePrice()
+    /**
+    * @return void
+    */
+    public function testHidePrice(): void
     {
         $this->product->expects($this->any())
             ->method('getCanShowPrice')
@@ -421,21 +452,29 @@ class FinalPriceBoxTest extends TestCase
         $this->assertEmpty($this->object->toHtml());
     }
 
-    public function testGetCacheKey()
+    /**
+    * @return void
+    */
+    public function testGetCacheKey(): void
     {
         $result = $this->object->getCacheKey();
         $this->assertStringEndsWith('list-category-page', $result);
     }
 
-    public function testGetCacheKeyInfoContainsDisplayMinimalPrice()
+    /**
+    * @return void
+    */
+    public function testGetCacheKeyInfoContainsDisplayMinimalPrice(): void
     {
         $this->assertArrayHasKey('display_minimal_price', $this->object->getCacheKeyInfo());
     }
 
     /**
-     * Test when is_product_list flag is not specified
+     * Test when is_product_list flag is not specified.
+     *
+     * @return void
      */
-    public function testGetCacheKeyInfoContainsIsProductListFlagByDefault()
+    public function testGetCacheKeyInfoContainsIsProductListFlagByDefault(): void
     {
         $cacheInfo = $this->object->getCacheKeyInfo();
         self::assertArrayHasKey('is_product_list', $cacheInfo);
@@ -443,12 +482,14 @@ class FinalPriceBoxTest extends TestCase
     }
 
     /**
-     * Test when is_product_list flag is specified
+     * Test when is_product_list flag is specified.
      *
      * @param bool $flag
+     *
+     * @return void
      * @dataProvider isProductListDataProvider
      */
-    public function testGetCacheKeyInfoContainsIsProductListFlag($flag)
+    public function testGetCacheKeyInfoContainsIsProductListFlag($flag): void
     {
         $this->object->setData('is_product_list', $flag);
         $cacheInfo = $this->object->getCacheKeyInfo();
@@ -457,20 +498,24 @@ class FinalPriceBoxTest extends TestCase
     }
 
     /**
-     * Test when is_product_list flag is not specified
+     * Test when is_product_list flag is not specified.
+     *
+     * @return void
      */
-    public function testIsProductListByDefault()
+    public function testIsProductListByDefault(): void
     {
         self::assertFalse($this->object->isProductList());
     }
 
     /**
-     * Test when is_product_list flag is specified
+     * Test when is_product_list flag is specified.
      *
      * @param bool $flag
+     *
+     * @return void
      * @dataProvider isProductListDataProvider
      */
-    public function testIsProductList($flag)
+    public function testIsProductList($flag): void
     {
         $this->object->setData('is_product_list', $flag);
         self::assertEquals($flag, $this->object->isProductList());
@@ -479,11 +524,11 @@ class FinalPriceBoxTest extends TestCase
     /**
      * @return array
      */
-    public function isProductListDataProvider()
+    public function isProductListDataProvider(): array
     {
         return [
             'is_not_product_list' => [false],
-            'is_product_list' => [true],
+            'is_product_list' => [true]
         ];
     }
 }

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Type/OptionTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/Product/Type/OptionTest.php
@@ -94,7 +94,7 @@ class OptionTest extends AbstractImportTestCase
         ['option_id' => 2, 'store_id' => 0, 'title' => 'Test Field Title'],
         ['option_id' => 3, 'store_id' => 0, 'title' => 'Test Date and Time Title'],
         ['option_id' => 4, 'store_id' => 0, 'title' => 'Test Select'],
-        ['option_id' => 5, 'store_id' => 0, 'title' => 'Test Radio'],
+        ['option_id' => 5, 'store_id' => 0, 'title' => 'Test Radio']
     ];
 
     /**
@@ -128,7 +128,7 @@ class OptionTest extends AbstractImportTestCase
         ['option_type_id' => 2, 'store_id' => 0, 'title' => 'Option 1'],
         ['option_type_id' => 3, 'store_id' => 0, 'title' => 'Option 2'],
         ['option_type_id' => 4, 'store_id' => 0, 'title' => 'Option 1'],
-        ['option_type_id' => 5, 'store_id' => 0, 'title' => 'Option 2'],
+        ['option_type_id' => 5, 'store_id' => 0, 'title' => 'Option 2']
     ];
 
     /**
@@ -318,7 +318,8 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Unset entity adapter model
+     * Unset entity adapter model.
+     * @inheritDoc
      */
     protected function tearDown(): void
     {
@@ -327,15 +328,19 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Create mocks for all $this->model dependencies
+     * Create mocks for all $this->model dependencies.
      *
      * @param bool $addExpectations
      * @param bool $deleteBehavior
      * @param bool $doubleOptions
+     *
      * @return array
      */
-    protected function _getModelDependencies($addExpectations = false, $deleteBehavior = false, $doubleOptions = false)
-    {
+    protected function _getModelDependencies(
+        bool $addExpectations = false,
+        bool $deleteBehavior = false,
+        bool $doubleOptions = false
+    ): array {
         $connection = $this->getMockBuilder(\stdClass::class)->addMethods(
             ['delete', 'quoteInto', 'insertMultiple', 'insertOnDuplicate']
         )
@@ -396,14 +401,15 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Get source data mocks
+     * Get source data mocks.
      *
      * @param bool $addExpectations
      * @param bool $doubleOptions
+     *
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    protected function _getSourceDataMocks($addExpectations, $doubleOptions)
+    protected function _getSourceDataMocks(bool $addExpectations, bool $doubleOptions): array
     {
         $csvData = $this->_loadCsvFile();
 
@@ -411,14 +417,9 @@ class OptionTest extends AbstractImportTestCase
             ->disableOriginalConstructor()
             ->getMock();
         if ($addExpectations) {
-            $dataSourceModel->expects(
-                $this->at(0)
-            )->method(
-                'getNextBunch'
-            )->willReturn(
-                $csvData['data']
-            );
-            $dataSourceModel->expects($this->at(1))->method('getNextBunch')->willReturn(null);
+            $dataSourceModel
+                ->method('getNextBunch')
+                ->willReturnOnConsecutiveCalls($csvData['data'], null);
         }
 
         $products = [];
@@ -464,9 +465,15 @@ class OptionTest extends AbstractImportTestCase
         $logger = $this->getMockForAbstractClass(LoggerInterface::class);
         $entityFactory = $this->createMock(EntityFactory::class);
 
-        $optionCollection = $this->getMockBuilder(AbstractDb::class)
-            ->setConstructorArgs([$entityFactory, $logger, $fetchStrategy])
-            ->setMethods(['reset', 'addProductToFilter', 'getSelect', 'getNewEmptyItem'])
+        $optionCollection = $this->getMockBuilder(AbstractDb::class)->setConstructorArgs(
+            [
+                $entityFactory,
+                $logger,
+                $fetchStrategy
+            ]
+        )
+            ->onlyMethods(['getSelect', 'getNewEmptyItem'])
+            ->addMethods(['reset', 'addProductToFilter'])
             ->getMockForAbstractClass();
 
         $select = $this->createPartialMock(Select::class, ['join', 'where']);
@@ -518,15 +525,16 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Iterate stub
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * Iterate stub.
      *
      * @param AbstractDb $collection
      * @param int $pageSize
      * @param array $callbacks
+     *
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function iterate(AbstractDb $collection, $pageSize, array $callbacks)
+    public function iterate(AbstractDb $collection, int $pageSize, array $callbacks): void
     {
         foreach ($collection as $option) {
             foreach ($callbacks as $callback) {
@@ -540,19 +548,20 @@ class OptionTest extends AbstractImportTestCase
      *
      * @return \Magento\Catalog\Model\Product\Option|MockObject
      */
-    public function getNewOptionMock()
+    public function getNewOptionMock(): MockObject
     {
         return $this->createPartialMock(\Magento\Catalog\Model\Product\Option::class, ['__wakeup']);
     }
 
     /**
-     * Stub method to emulate adapter quoteInfo() method and get data in needed for test format
+     * Stub method to emulate adapter quoteInfo() method and get data in needed for test format.
      *
      * @param string $text
      * @param array|int|float|string $value
-     * @return mixed
+     *
+     * @return string
      */
-    public function stubQuoteInto($text, $value)
+    public function stubQuoteInto($text, $value): string
     {
         if (is_array($value)) {
             $value = implode(', ', $value);
@@ -561,12 +570,14 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Verify data, sent to $this->_connection->delete() method
+     * Verify data, sent to $this->_connection->delete() method.
      *
      * @param string $table
      * @param string $where
+     *
+     * @return void
      */
-    public function verifyDelete($table, $where)
+    public function verifyDelete(string $table, string $where): void
     {
         if ($table == 'catalog_product_option') {
             $this->assertEquals($this->_tables['catalog_product_option'], $table);
@@ -578,12 +589,14 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Verify data, sent to $this->_connection->insertMultiple() method
+     * Verify data, sent to $this->_connection->insertMultiple() method.
      *
      * @param string $table
      * @param array $data
+     *
+     * @return void
      */
-    public function verifyInsertMultiple($table, array $data)
+    public function verifyInsertMultiple(string $table, array $data): void
     {
         switch ($table) {
             case $this->_tables['catalog_product_option']:
@@ -598,13 +611,15 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Verify data, sent to $this->_connection->insertOnDuplicate() method
+     * Verify data, sent to $this->_connection->insertOnDuplicate() method.
      *
      * @param string $table
      * @param array $data
      * @param array $fields
+     *
+     * @return void
      */
-    public function verifyInsertOnDuplicate($table, array $data, array $fields = [])
+    public function verifyInsertOnDuplicate(string $table, array $data, array $fields = []): void
     {
         switch ($table) {
             case $this->_tables['catalog_product_option_title']:
@@ -638,14 +653,18 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
+     *
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::getEntityTypeCode
      */
-    public function testGetEntityTypeCode()
+    public function testGetEntityTypeCode(): void
     {
         $this->assertEquals('product_options', $this->model->getEntityTypeCode());
     }
 
     /**
+     * @return void
+     *
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::importData
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_importData
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_saveOptions
@@ -656,40 +675,44 @@ class OptionTest extends AbstractImportTestCase
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_saveSpecificTypeTitles
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_updateProducts
      */
-    public function testImportDataAppendBehavior()
+    public function testImportDataAppendBehavior(): void
     {
         $this->model->importData();
     }
 
     /**
+     * @return void
+     *
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_importData
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_deleteEntities
      */
-    public function testImportDataDeleteBehavior()
+    public function testImportDataDeleteBehavior(): void
     {
         $this->model->setParameters(['behavior' => Import::BEHAVIOR_DELETE]);
         $this->model->importData();
     }
 
     /**
-     * Load and return CSV source data
+     * Load and return CSV source data.
      *
      * @return array
      */
-    protected function _loadCsvFile()
+    protected function _loadCsvFile(): array
     {
         $data = $this->_csvToArray(file_get_contents(__DIR__ . self::PATH_TO_CSV_FILE));
+
         return $data;
     }
 
     /**
-     * Export CSV string to array
+     * Export CSV string to array.
      *
      * @param string $content
      * @param mixed $entityId
+     *
      * @return array
      */
-    protected function _csvToArray($content, $entityId = null)
+    protected function _csvToArray($content, $entityId = null): array
     {
         $data = ['header' => [], 'data' => []];
 
@@ -714,11 +737,11 @@ class OptionTest extends AbstractImportTestCase
      * Make model bypass format converting, used to pass tests' with old data.
      * @todo should be refactored/removed when all old options are converted into the new format.
      *
-     * @param array $rowData
-     *  old format data
+     * @param array $rowData old format data
+     *
      * @return void
      */
-    private function _bypassModelMethodGetMultiRowFormat($rowData)
+    private function _bypassModelMethodGetMultiRowFormat(array $rowData): void
     {
         $this->modelMock->expects($this->any())
             ->method('_getMultiRowFormat')
@@ -726,11 +749,12 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Test for validation of row without custom option
+     * Test for validation of row without custom option.
      *
+     * @return void
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_isRowWithCustomOption
      */
-    public function testValidateRowNoCustomOption()
+    public function testValidateRowNoCustomOption(): void
     {
         $rowData = include __DIR__ . '/_files/row_data_no_custom_option.php';
         $this->_bypassModelMethodGetMultiRowFormat($rowData);
@@ -738,11 +762,12 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Test for simple cases of row validation (without existing related data)
+     * Test for simple cases of row validation (without existing related data).
      *
      * @param array $rowData
      * @param array $errors
      *
+     * @return void
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::validateRow
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_isRowWithCustomOption
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_isMainOptionRow
@@ -754,7 +779,7 @@ class OptionTest extends AbstractImportTestCase
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_validateSpecificParameterData
      * @dataProvider validateRowDataProvider
      */
-    public function testValidateRow(array $rowData, array $errors)
+    public function testValidateRow(array $rowData, array $errors): void
     {
         $this->_bypassModelMethodGetMultiRowFormat($rowData);
         if (empty($errors)) {
@@ -767,13 +792,14 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Test for validation of ambiguous data
+     * Test for validation of ambiguous data.
      *
      * @param array $rowData
      * @param array $errors
      * @param string|null $behavior
      * @param int $numberOfValidations
      *
+     * @return void
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::validateAmbiguousData
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_findNewOptionsWithTheSameTitles
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_findOldOptionsWithTheSameTitles
@@ -786,7 +812,7 @@ class OptionTest extends AbstractImportTestCase
         array $errors,
         $behavior = null,
         $numberOfValidations = 1
-    ) {
+    ): void {
         $this->_testStores = ['admin' => 0];
         $this->setUp();
         if ($behavior) {
@@ -809,14 +835,16 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Test for row without store view code field
+     * Test for row without store view code field.
+     *
      * @param array $rowData
      * @param array $responseData
      *
+     * @return void
      * @covers \Magento\CatalogImportExport\Model\Import\Product\Option::_parseCustomOptions
      * @dataProvider validateRowStoreViewCodeFieldDataProvider
      */
-    public function testValidateRowDataForStoreViewCodeField($rowData, $responseData)
+    public function testValidateRowDataForStoreViewCodeField(array $rowData, array $responseData): void
     {
         $reflection = new \ReflectionClass(Option::class);
         $reflectionMethod = $reflection->getMethod('_parseCustomOptions');
@@ -826,11 +854,11 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Data provider for test of method _parseCustomOptions
+     * Data provider for test of method _parseCustomOptions.
      *
      * @return array
      */
-    public function validateRowStoreViewCodeFieldDataProvider()
+    public function validateRowStoreViewCodeFieldDataProvider(): array
     {
         return [
             'with_store_view_code' => [
@@ -854,7 +882,7 @@ class OptionTest extends AbstractImportTestCase
                             ]
                         ]
                     ]
-                ],
+                ]
             ],
             'without_store_view_code' => [
                 '$rowData' => [
@@ -874,18 +902,18 @@ class OptionTest extends AbstractImportTestCase
                             ]
                         ]
                     ]
-                ],
+                ]
             ]
         ];
     }
 
     /**
-     * Data provider of row data and errors
+     * Data provider of row data and errors.
      *
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function validateRowDataProvider()
+    public function validateRowDataProvider(): array
     {
         return [
             'main_valid' => [
@@ -978,11 +1006,11 @@ class OptionTest extends AbstractImportTestCase
     }
 
     /**
-     * Data provider for test of method validateAmbiguousData
+     * Data provider for test of method validateAmbiguousData.
      *
      * @return array
      */
-    public function validateAmbiguousDataDataProvider()
+    public function validateAmbiguousDataDataProvider(): array
     {
         return [
             'ambiguity_several_input_rows' => [
@@ -1010,19 +1038,25 @@ class OptionTest extends AbstractImportTestCase
         ];
     }
 
-    public function testParseRequiredData()
+    /**
+    * @return void
+    */
+    public function testParseRequiredData(): void
     {
         $modelData = $this->getMockBuilder(\stdClass::class)->addMethods(['getNextBunch'])
             ->disableOriginalConstructor()
             ->getMock();
-        $modelData->expects(
-            $this->at(0)
-        )->method(
-            'getNextBunch'
-        )->willReturn(
-            [['sku' => 'simple3', '_custom_option_type' => 'field', '_custom_option_title' => 'Title']]
-        );
-        $modelData->expects($this->at(1))->method('getNextBunch')->willReturn(null);
+        $modelData
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    [
+                        'sku' => 'simple3',
+                        '_custom_option_type' => 'field',
+                        '_custom_option_title' => 'Title'
+                    ]
+                ], null
+            );
 
         $productModel = $this->getMockBuilder(\stdClass::class)->addMethods(['getProductEntitiesInfo'])
             ->disableOriginalConstructor()
@@ -1060,7 +1094,10 @@ class OptionTest extends AbstractImportTestCase
         $this->assertTrue($model->importData());
     }
 
-    public function testClearProductsSkuToId()
+    /**
+    * @return void
+    */
+    public function testClearProductsSkuToId(): void
     {
         $this->setPropertyValue($this->modelMock, '_productsSkuToId', 'value');
 
@@ -1077,6 +1114,7 @@ class OptionTest extends AbstractImportTestCase
      * @param object $object
      * @param string $property
      * @param mixed $value
+     *
      * @return object
      */
     protected function setPropertyValue(&$object, $property, $value)

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -72,126 +72,206 @@ class ProductTest extends AbstractImportTestCase
 
     const ENTITY_ID = 13;
 
-    /** @var AdapterInterface|MockObject */
+    /**
+     * @var AdapterInterface|MockObject
+     */
     protected $_connection;
 
-    /** @var \Magento\Framework\Json\Helper\Data| MockObject */
+    /**
+     * @var \Magento\Framework\Json\Helper\Data|MockObject
+     */
     protected $jsonHelper;
 
-    /** @var \Magento\ImportExport\Model\ResourceModel\Import\Data| MockObject */
+    /**
+     * @var \Magento\ImportExport\Model\ResourceModel\Import\Data|MockObject
+     */
     protected $_dataSourceModel;
 
-    /** @var ResourceConnection|MockObject */
+    /**
+     * @var ResourceConnection|MockObject
+     */
     protected $resource;
 
-    /** @var Helper|MockObject */
+    /**
+     * @var Helper|MockObject
+     */
     protected $_resourceHelper;
 
-    /** @var StringUtils|MockObject */
+    /**
+     * @var StringUtils|MockObject
+     */
     protected $string;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     protected $_eventManager;
 
-    /** @var StockRegistryInterface|MockObject */
+    /**
+     * @var StockRegistryInterface|MockObject
+     */
     protected $stockRegistry;
 
-    /** @var \Magento\CatalogImportExport\Model\Import\Product\OptionFactory|MockObject */
+    /**
+     * @var \Magento\CatalogImportExport\Model\Import\Product\OptionFactory|MockObject
+     */
     protected $optionFactory;
 
-    /** @var StockConfigurationInterface|MockObject */
+    /**
+     * @var StockConfigurationInterface|MockObject
+     */
     protected $stockConfiguration;
 
-    /** @var StockStateProviderInterface|MockObject */
+    /**
+     * @var StockStateProviderInterface|MockObject
+     */
     protected $stockStateProvider;
 
-    /** @var Option|MockObject */
+    /**
+     * @var Option|MockObject
+     */
     protected $optionEntity;
 
-    /** @var DateTime|MockObject */
+    /**
+     * @var DateTime|MockObject
+     */
     protected $dateTime;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $data;
 
-    /** @var \Magento\ImportExport\Helper\Data|MockObject */
+    /**
+     * @var \Magento\ImportExport\Helper\Data|MockObject
+     */
     protected $importExportData;
 
-    /** @var \Magento\ImportExport\Model\ResourceModel\Import\Data|MockObject */
+    /**
+     * @var \Magento\ImportExport\Model\ResourceModel\Import\Data|MockObject
+     */
     protected $importData;
 
-    /** @var Config|MockObject */
+    /**
+     * @var Config|MockObject
+     */
     protected $config;
 
-    /** @var Helper|MockObject */
+    /**
+     * @var Helper|MockObject
+     */
     protected $resourceHelper;
 
-    /** @var \Magento\Catalog\Helper\Data|MockObject */
+    /**
+     * @var \Magento\Catalog\Helper\Data|MockObject
+     */
     protected $_catalogData;
 
-    /** @var \Magento\ImportExport\Model\Import\Config|MockObject */
+    /**
+     * @var \Magento\ImportExport\Model\Import\Config|MockObject
+     */
     protected $_importConfig;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $_resourceFactory;
 
     // @codingStandardsIgnoreStart
-    /** @var  \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory|MockObject */
+    /**
+     * @var \Magento\Eav\Model\ResourceModel\Entity\Attribute\Set\CollectionFactory|MockObject
+     */
     protected $_setColFactory;
 
-    /** @var  Factory|MockObject */
+    /**
+     * @var Factory|MockObject
+     */
     protected $_productTypeFactory;
 
-    /** @var  \Magento\Catalog\Model\ResourceModel\Product\LinkFactory|MockObject */
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product\LinkFactory|MockObject
+     */
     protected $_linkFactory;
 
-    /** @var  \Magento\CatalogImportExport\Model\Import\Proxy\ProductFactory|MockObject */
+    /**
+     * @var \Magento\CatalogImportExport\Model\Import\Proxy\ProductFactory|MockObject
+     */
     protected $_proxyProdFactory;
 
-    /** @var  \Magento\CatalogImportExport\Model\Import\UploaderFactory|MockObject */
+    /**
+     * @var \Magento\CatalogImportExport\Model\Import\UploaderFactory|MockObject
+     */
     protected $_uploaderFactory;
 
-    /** @var  Filesystem|MockObject */
+    /**
+     * @var Filesystem|MockObject
+     */
     protected $_filesystem;
 
-    /** @var  WriteInterface|MockObject */
+    /**
+     * @var WriteInterface|MockObject
+     */
     protected $_mediaDirectory;
 
-    /** @var  \Magento\CatalogInventory\Model\ResourceModel\Stock\ItemFactory|MockObject */
+    /**
+     * @var \Magento\CatalogInventory\Model\ResourceModel\Stock\ItemFactory|MockObject
+     */
     protected $_stockResItemFac;
 
-    /** @var  TimezoneInterface|MockObject */
+    /**
+     * @var TimezoneInterface|MockObject
+     */
     protected $_localeDate;
 
-    /** @var IndexerRegistry|MockObject */
+    /**
+     * @var IndexerRegistry|MockObject
+     */
     protected $indexerRegistry;
 
-    /** @var LoggerInterface|MockObject */
+    /**
+     * @var LoggerInterface|MockObject
+     */
     protected $_logger;
 
-    /** @var  StoreResolver|MockObject */
+    /**
+     * @var StoreResolver|MockObject
+     */
     protected $storeResolver;
 
-    /** @var  SkuProcessor|MockObject */
+    /**
+     * @var SkuProcessor|MockObject
+     */
     protected $skuProcessor;
 
-    /** @var  CategoryProcessor|MockObject */
+    /**
+     * @var CategoryProcessor|MockObject
+     */
     protected $categoryProcessor;
 
-    /** @var  Validator|MockObject */
+    /**
+     * @var Validator|MockObject
+     */
     protected $validator;
 
-    /** @var  ObjectRelationProcessor|MockObject */
+    /**
+     * @var ObjectRelationProcessor|MockObject
+     */
     protected $objectRelationProcessor;
 
-    /** @var  TransactionManagerInterface|MockObject */
+    /**
+     * @var TransactionManagerInterface|MockObject
+     */
     protected $transactionManager;
 
-    /** @var  \Magento\CatalogImportExport\Model\Import\Product\TaxClassProcessor|MockObject */
+    /**
+     * @var \Magento\CatalogImportExport\Model\Import\Product\TaxClassProcessor|MockObject
+     */
     // @codingStandardsIgnoreEnd
     protected $taxClassProcessor;
 
-    /** @var  Product */
+    /**
+     * @var Product
+     */
     protected $importProduct;
 
     /**
@@ -199,19 +279,28 @@ class ProductTest extends AbstractImportTestCase
      */
     protected $errorAggregator;
 
-    /** @var ScopeConfigInterface|MockObject */
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
     protected $scopeConfig;
 
-    /** @var Url|MockObject */
+    /**
+     * @var Url|MockObject
+     */
     protected $productUrl;
 
-    /** @var  ImageTypeProcessor|MockObject */
+    /**
+     * @var ImageTypeProcessor|MockObject
+     */
     protected $imageTypeProcessor;
 
-    /** @var DriverFile|MockObject */
+    /**
+     * @var DriverFile|MockObject
+     */
     private $driverFile;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -330,11 +419,7 @@ class ProductTest extends AbstractImportTestCase
                 ->getMock();
         $this->storeResolver =
             $this->getMockBuilder(StoreResolver::class)
-                ->setMethods(
-                    [
-                        'getStoreCodeToId',
-                    ]
-                )
+                ->onlyMethods(['getStoreCodeToId'])
                 ->disableOriginalConstructor()
                 ->getMock();
         $this->skuProcessor =
@@ -352,7 +437,7 @@ class ProductTest extends AbstractImportTestCase
                 ->getMock();
         $this->validator =
             $this->getMockBuilder(Validator::class)
-                ->setMethods(['isAttributeValid', 'getMessages', 'isValid', 'init'])
+                ->onlyMethods(['isAttributeValid', 'getMessages', 'isValid', 'init'])
                 ->disableOriginalConstructor()
                 ->getMock();
         $this->objectRelationProcessor =
@@ -530,7 +615,7 @@ class ProductTest extends AbstractImportTestCase
         $entityTypes = [
             'simple' => [
                 'model' => 'simple_product',
-                'params' => [],
+                'params' => []
             ]];
         $productTypeInstance =
             $this->getMockBuilder(AbstractType::class)
@@ -575,7 +660,10 @@ class ProductTest extends AbstractImportTestCase
         return $this;
     }
 
-    public function testSaveProductAttributes()
+    /**
+    * @return void
+    */
+    public function testSaveProductAttributes(): void
     {
         $testTable = 'test_table';
         $attributeId = 'test_attribute_id';
@@ -603,12 +691,12 @@ class ProductTest extends AbstractImportTestCase
             ->with($testTable, $tableData, ['value']);
         $attribute = $this->getMockBuilder(AbstractAttribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId'])
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $attribute->expects($this->once())->method('getId')->willReturn(1);
         $resource = $this->getMockBuilder(ResourceModel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttribute'])
+            ->onlyMethods(['getAttribute'])
             ->getMock();
         $resource->expects($this->once())->method('getAttribute')->willReturn($attribute);
         $this->_resourceFactory->expects($this->once())->method('create')->willReturn($resource);
@@ -618,9 +706,10 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider isAttributeValidAssertAttrValidDataProvider
      */
-    public function testIsAttributeValidAssertAttrValid($attrParams, $rowData)
+    public function testIsAttributeValidAssertAttrValid($attrParams, $rowData): void
     {
         $attrCode = 'code';
         $rowNum = 0;
@@ -635,9 +724,10 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider isAttributeValidAssertAttrInvalidDataProvider
      */
-    public function testIsAttributeValidAssertAttrInvalid($attrParams, $rowData)
+    public function testIsAttributeValidAssertAttrInvalid($attrParams, $rowData): void
     {
         $attrCode = 'code';
         $rowNum = 0;
@@ -653,7 +743,10 @@ class ProductTest extends AbstractImportTestCase
         $this->assertFalse($result);
     }
 
-    public function testGetMultipleValueSeparatorDefault()
+    /**
+    * @return void
+    */
+    public function testGetMultipleValueSeparatorDefault(): void
     {
         $this->setPropertyValue($this->importProduct, '_parameters', null);
         $this->assertEquals(
@@ -662,7 +755,10 @@ class ProductTest extends AbstractImportTestCase
         );
     }
 
-    public function testGetMultipleValueSeparatorFromParameters()
+    /**
+    * @return void
+    */
+    public function testGetMultipleValueSeparatorFromParameters(): void
     {
         $expectedSeparator = 'value';
         $this->setPropertyValue(
@@ -679,7 +775,10 @@ class ProductTest extends AbstractImportTestCase
         );
     }
 
-    public function testGetEmptyAttributeValueConstantDefault()
+    /**
+    * @return void
+    */
+    public function testGetEmptyAttributeValueConstantDefault(): void
     {
         $this->setPropertyValue($this->importProduct, '_parameters', null);
         $this->assertEquals(
@@ -688,14 +787,17 @@ class ProductTest extends AbstractImportTestCase
         );
     }
 
-    public function testGetEmptyAttributeValueConstantFromParameters()
+    /**
+    * @return void
+    */
+    public function testGetEmptyAttributeValueConstantFromParameters(): void
     {
         $expectedSeparator = '__EMPTY__VALUE__TEST__';
         $this->setPropertyValue(
             $this->importProduct,
             '_parameters',
             [
-                Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT => $expectedSeparator,
+                Import::FIELD_EMPTY_ATTRIBUTE_VALUE_CONSTANT => $expectedSeparator
             ]
         );
 
@@ -705,16 +807,14 @@ class ProductTest extends AbstractImportTestCase
         );
     }
 
-    public function testDeleteProductsForReplacement()
+    /**
+    * @return void
+    */
+    public function testDeleteProductsForReplacement(): void
     {
         $importProduct = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(
-                [
-                    'setParameters',
-                    '_deleteProducts'
-                ]
-            )
+            ->onlyMethods(['setParameters', '_deleteProducts'])
             ->getMock();
 
         $importProduct->expects($this->once())->method('setParameters')->with(
@@ -729,20 +829,22 @@ class ProductTest extends AbstractImportTestCase
         $this->assertEquals($importProduct, $result);
     }
 
-    public function testGetMediaGalleryAttributeIdIfNotSetYet()
+    /**
+    * @return void
+    */
+    public function testGetMediaGalleryAttributeIdIfNotSetYet(): void
     {
         // reset possible existing id
         $this->setPropertyValue($this->importProduct, '_mediaGalleryAttributeId', null);
 
         $expectedId = '100';
-        $attribute = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getId'])
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
             ->getMockForAbstractClass();
         $attribute->expects($this->once())->method('getId')->willReturn($expectedId);
         $resource = $this->getMockBuilder(ResourceModel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttribute'])
+            ->onlyMethods(['getAttribute'])
             ->getMock();
         $resource->expects($this->once())->method('getAttribute')->willReturn($attribute);
         $this->_resourceFactory->expects($this->once())->method('create')->willReturn($resource);
@@ -752,18 +854,20 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider getRowScopeDataProvider
      */
-    public function testGetRowScope($rowData, $expectedResult)
+    public function testGetRowScope($rowData, $expectedResult): void
     {
         $result = $this->importProduct->getRowScope($rowData);
         $this->assertEquals($expectedResult, $result);
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function testValidateRowIsAlreadyValidated()
+    public function testValidateRowIsAlreadyValidated(): void
     {
         $rowNum = 0;
         $this->setPropertyValue($this->importProduct, '_validatedRows', [$rowNum => true]);
@@ -772,13 +876,13 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider validateRowDataProvider
      */
-    public function testValidateRow($rowScope, $oldSku, $expectedResult, $behaviour = Import::BEHAVIOR_DELETE)
+    public function testValidateRow($rowScope, $oldSku, $expectedResult, $behaviour = Import::BEHAVIOR_DELETE): void
     {
-        $importProduct = $this->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getBehavior', 'getRowScope', 'getErrorAggregator'])
+        $importProduct = $this->getMockBuilder(Product::class)->disableOriginalConstructor()
+            ->onlyMethods(['getBehavior', 'getRowScope', 'getErrorAggregator'])
             ->getMock();
         $importProduct
             ->expects($this->any())
@@ -798,11 +902,14 @@ class ProductTest extends AbstractImportTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testValidateRowDeleteBehaviourAddRowErrorCall()
+    /**
+    * @return void
+    */
+    public function testValidateRowDeleteBehaviourAddRowErrorCall(): void
     {
         $importProduct = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getBehavior', 'getRowScope', 'addRowError', 'getErrorAggregator'])
+            ->onlyMethods(['getBehavior', 'getRowScope', 'addRowError', 'getErrorAggregator'])
             ->getMock();
 
         $importProduct->expects($this->exactly(2))->method('getBehavior')
@@ -821,7 +928,10 @@ class ProductTest extends AbstractImportTestCase
         $importProduct->validateRow($rowData, 0);
     }
 
-    public function testValidateRowValidatorCheck()
+    /**
+    * @return void
+    */
+    public function testValidateRowValidatorCheck(): void
     {
         $messages = ['validator message'];
         $this->validator->expects($this->once())->method('getMessages')->willReturn($messages);
@@ -834,8 +944,10 @@ class ProductTest extends AbstractImportTestCase
 
     /**
      * Cover getProductWebsites().
+     *
+     * @return void
      */
-    public function testGetProductWebsites()
+    public function testGetProductWebsites(): void
     {
         $productSku = 'productSku';
         $productValue = [
@@ -859,8 +971,10 @@ class ProductTest extends AbstractImportTestCase
 
     /**
      * Cover getProductCategories().
+     *
+     * @return void
      */
-    public function testGetProductCategories()
+    public function testGetProductCategories(): void
     {
         $productSku = 'productSku';
         $productValue = [
@@ -885,9 +999,10 @@ class ProductTest extends AbstractImportTestCase
     /**
      * Cover getStoreIdByCode().
      *
+     * @return void
      * @dataProvider getStoreIdByCodeDataProvider
      */
-    public function testGetStoreIdByCode($storeCode, $expectedResult)
+    public function testGetStoreIdByCode($storeCode, $expectedResult): void
     {
         $this->storeResolver
             ->expects($this->any())
@@ -900,8 +1015,10 @@ class ProductTest extends AbstractImportTestCase
 
     /**
      * Cover getNewSku().
+     *
+     * @return void
      */
-    public function testGetNewSku()
+    public function testGetNewSku(): void
     {
         $expectedSku = 'value';
         $expectedResult = 'result value';
@@ -918,8 +1035,10 @@ class ProductTest extends AbstractImportTestCase
 
     /**
      * Cover getCategoryProcessor().
+     *
+     * @return void
      */
-    public function testGetCategoryProcessor()
+    public function testGetCategoryProcessor(): void
     {
         $expectedResult = 'value';
         $this->setPropertyValue($this->importProduct, 'categoryProcessor', $expectedResult);
@@ -931,24 +1050,25 @@ class ProductTest extends AbstractImportTestCase
     /**
      * @return array
      */
-    public function getStoreIdByCodeDataProvider()
+    public function getStoreIdByCodeDataProvider(): array
     {
         return [
             [
                 '$storeCode' => null,
-                '$expectedResult' => Product::SCOPE_DEFAULT,
+                '$expectedResult' => Product::SCOPE_DEFAULT
             ],
             [
                 '$storeCode' => 'value',
-                '$expectedResult' => 'getStoreCodeToId value',
-            ],
+                '$expectedResult' => 'getStoreCodeToId value'
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider validateRowCheckSpecifiedSkuDataProvider
      */
-    public function testValidateRowCheckSpecifiedSku($sku, $expectedError)
+    public function testValidateRowCheckSpecifiedSku($sku, $expectedError): void
     {
         $importProduct = $this->createModelMockWithErrorAggregator(
             ['addRowError', 'getOptionEntity', 'getRowScope'],
@@ -958,7 +1078,7 @@ class ProductTest extends AbstractImportTestCase
         $rowNum = 0;
         $rowData = [
             Product::COL_SKU => $sku,
-            Product::COL_STORE => '',
+            Product::COL_STORE => ''
         ];
 
         $this->storeResolver->method('getStoreCodeToId')->willReturn(null);
@@ -971,12 +1091,18 @@ class ProductTest extends AbstractImportTestCase
             ->expects($this->once())
             ->method('getRowScope')
             ->willReturn(Product::SCOPE_STORE);
-        $importProduct->expects($this->at(1))->method('addRowError')->with($expectedError, $rowNum)->willReturn(null);
+        $importProduct
+            ->method('addRowError')
+            ->withConsecutive([$expectedError, $rowNum])
+            ->willReturnOnConsecutiveCalls(null);
 
         $importProduct->validateRow($rowData, $rowNum);
     }
 
-    public function testValidateRowProcessEntityIncrement()
+    /**
+    * @return void
+    */
+    public function testValidateRowProcessEntityIncrement(): void
     {
         $count = 0;
         $rowNum = 0;
@@ -991,7 +1117,10 @@ class ProductTest extends AbstractImportTestCase
         $this->assertEquals(++$count, $this->importProduct->getProcessedEntitiesCount());
     }
 
-    public function testValidateRowValidateExistingProductTypeAddNewSku()
+    /**
+    * @return void
+    */
+    public function testValidateRowValidateExistingProductTypeAddNewSku(): void
     {
         $importProduct = $this->createModelMockWithErrorAggregator(
             ['addRowError', 'getOptionEntity'],
@@ -1007,12 +1136,12 @@ class ProductTest extends AbstractImportTestCase
             $sku => [
                 'entity_id' => 'entity_id_val',
                 'type_id' => 'type_id_val',
-                'attr_set_id' => 'attr_set_id_val',
-            ],
+                'attr_set_id' => 'attr_set_id_val'
+            ]
         ];
 
         $_productTypeModels = [
-            $oldSku[$sku]['type_id'] => 'type_id_val_val',
+            $oldSku[$sku]['type_id'] => 'type_id_val_val'
         ];
         $this->setPropertyValue($importProduct, '_productTypeModels', $_productTypeModels);
 
@@ -1037,7 +1166,10 @@ class ProductTest extends AbstractImportTestCase
         $importProduct->validateRow($rowData, $rowNum);
     }
 
-    public function testValidateRowValidateExistingProductTypeAddErrorRowCall()
+    /**
+    * @return void
+    */
+    public function testValidateRowValidateExistingProductTypeAddErrorRowCall(): void
     {
         $sku = 'sku';
         $rowNum = 0;
@@ -1046,7 +1178,7 @@ class ProductTest extends AbstractImportTestCase
         ];
         $oldSku = [
             $sku => [
-                'type_id' => 'type_id_val',
+                'type_id' => 'type_id_val'
             ],
         ];
         $importProduct = $this->createModelMockWithErrorAggregator(
@@ -1066,12 +1198,14 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
-     * @dataProvider validateRowValidateNewProductTypeAddRowErrorCallDataProvider
      * @param string $colType
      * @param string $productTypeModelsColType
      * @param string $colAttrSet
      * @param string $attrSetNameToIdColAttrSet
      * @param string $error
+     *
+     * @return void
+     * @dataProvider validateRowValidateNewProductTypeAddRowErrorCallDataProvider
      */
     public function testValidateRowValidateNewProductTypeAddRowErrorCall(
         $colType,
@@ -1079,22 +1213,22 @@ class ProductTest extends AbstractImportTestCase
         $colAttrSet,
         $attrSetNameToIdColAttrSet,
         $error
-    ) {
+    ): void {
         $sku = 'sku';
         $rowNum = 0;
         $rowData = [
             Product::COL_SKU => $sku,
             Product::COL_TYPE => $colType,
-            Product::COL_ATTR_SET => $colAttrSet,
+            Product::COL_ATTR_SET => $colAttrSet
         ];
         $_attrSetNameToId = [
-            $rowData[Product::COL_ATTR_SET] => $attrSetNameToIdColAttrSet,
+            $rowData[Product::COL_ATTR_SET] => $attrSetNameToIdColAttrSet
         ];
         $_productTypeModels = [
-            $rowData[Product::COL_TYPE] => $productTypeModelsColType,
+            $rowData[Product::COL_TYPE] => $productTypeModelsColType
         ];
         $oldSku = [
-            $sku => null,
+            $sku => null
         ];
         $importProduct = $this->createModelMockWithErrorAggregator(
             ['addRowError', 'getOptionEntity'],
@@ -1114,20 +1248,23 @@ class ProductTest extends AbstractImportTestCase
         $importProduct->validateRow($rowData, $rowNum);
     }
 
-    public function testValidateRowValidateNewProductTypeGetNewSkuCall()
+    /**
+    * @return void
+    */
+    public function testValidateRowValidateNewProductTypeGetNewSkuCall(): void
     {
         $sku = 'sku';
         $rowNum = 0;
         $rowData = [
             Product::COL_SKU => $sku,
             Product::COL_TYPE => 'value',
-            Product::COL_ATTR_SET => 'value',
+            Product::COL_ATTR_SET => 'value'
         ];
         $_productTypeModels = [
-            $rowData[Product::COL_TYPE] => 'value',
+            $rowData[Product::COL_TYPE] => 'value'
         ];
         $oldSku = [
-            $sku => null,
+            $sku => null
         ];
         $_attrSetNameToId = [
             $rowData[Product::COL_ATTR_SET] => 'attr_set_code_val'
@@ -1158,7 +1295,10 @@ class ProductTest extends AbstractImportTestCase
         $importProduct->validateRow($rowData, $rowNum);
     }
 
-    public function testValidateDefaultScopeNotValidAttributesResetSku()
+    /**
+    * @return void
+    */
+    public function testValidateDefaultScopeNotValidAttributesResetSku(): void
     {
         $this->validator->expects($this->once())->method('isAttributeValid')->willReturn(false);
         $messages = ['validator message'];
@@ -1168,27 +1308,30 @@ class ProductTest extends AbstractImportTestCase
         $this->assertFalse($result);
     }
 
-    public function testValidateRowSetAttributeSetCodeIntoRowData()
+    /**
+    * @return void
+    */
+    public function testValidateRowSetAttributeSetCodeIntoRowData(): void
     {
         $sku = 'sku';
         $rowNum = 0;
         $rowData = [
             Product::COL_SKU => $sku,
-            Product::COL_ATTR_SET => 'col_attr_set_val',
+            Product::COL_ATTR_SET => 'col_attr_set_val'
         ];
         $expectedAttrSetCode = 'new_attr_set_code';
         $newSku = [
             'attr_set_code' => $expectedAttrSetCode,
-            'type_id' => 'new_type_id_val',
+            'type_id' => 'new_type_id_val'
         ];
         $expectedRowData = [
             Product::COL_SKU => $sku,
-            Product::COL_ATTR_SET => $newSku['attr_set_code'],
+            Product::COL_ATTR_SET => $newSku['attr_set_code']
         ];
         $oldSku = [
             $sku => [
-                'type_id' => 'type_id_val',
-            ],
+                'type_id' => 'type_id_val'
+            ]
         ];
         $importProduct = $this->createModelMockWithErrorAggregator(['getOptionEntity']);
 
@@ -1216,18 +1359,21 @@ class ProductTest extends AbstractImportTestCase
         $importProduct->validateRow($rowData, $rowNum);
     }
 
-    public function testValidateValidateOptionEntity()
+    /**
+    * @return void
+    */
+    public function testValidateValidateOptionEntity(): void
     {
         $sku = 'sku';
         $rowNum = 0;
         $rowData = [
             Product::COL_SKU => $sku,
-            Product::COL_ATTR_SET => 'col_attr_set_val',
+            Product::COL_ATTR_SET => 'col_attr_set_val'
         ];
         $oldSku = [
             $sku => [
-                'type_id' => 'type_id_val',
-            ],
+                'type_id' => 'type_id_val'
+            ]
         ];
         $importProduct = $this->createModelMockWithErrorAggregator(
             ['addRowError', 'getOptionEntity'],
@@ -1249,9 +1395,10 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider getImagesFromRowDataProvider
      */
-    public function testGetImagesFromRow($rowData, $expectedResult)
+    public function testGetImagesFromRow($rowData, $expectedResult): void
     {
         $this->assertEquals(
             $this->importProduct->getImagesFromRow($rowData),
@@ -1259,7 +1406,10 @@ class ProductTest extends AbstractImportTestCase
         );
     }
 
-    public function testParseAttributesWithoutWrappedValuesWillReturnsLowercasedAttributeCodes()
+    /**
+    * @return void
+    */
+    public function testParseAttributesWithoutWrappedValuesWillReturnsLowercasedAttributeCodes(): void
     {
         $attributesData = 'PARAM1=value1,param2=value2';
         $preparedAttributes = $this->invokeMethod(
@@ -1277,20 +1427,21 @@ class ProductTest extends AbstractImportTestCase
         $this->assertArrayNotHasKey('PARAM1', $preparedAttributes);
     }
 
-    public function testParseAttributesWithWrappedValuesWillReturnsLowercasedAttributeCodes()
+    /**
+    * @return void
+    */
+    public function testParseAttributesWithWrappedValuesWillReturnsLowercasedAttributeCodes(): void
     {
-        $attribute1 = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getFrontendInput'])
+        $attribute1 = $this->getMockBuilder(AbstractAttribute::class)->disableOriginalConstructor()
+            ->onlyMethods(['getFrontendInput'])
             ->getMockForAbstractClass();
 
         $attribute1->expects($this->once())
             ->method('getFrontendInput')
             ->willReturn('text');
 
-        $attribute2 = $this->getMockBuilder(AbstractAttribute::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getFrontendInput'])
+        $attribute2 = $this->getMockBuilder(AbstractAttribute::class)->disableOriginalConstructor()
+            ->onlyMethods(['getFrontendInput'])
             ->getMockForAbstractClass();
 
         $attribute2->expects($this->once())
@@ -1299,7 +1450,7 @@ class ProductTest extends AbstractImportTestCase
 
         $attributeCache = [
             'param1' => $attribute1,
-            'param2' => $attribute2,
+            'param2' => $attribute2
         ];
 
         $this->setPropertyValue($this->importProduct, '_attributeCache', $attributeCache);
@@ -1325,9 +1476,11 @@ class ProductTest extends AbstractImportTestCase
      * @param bool $isRead
      * @param bool $isWrite
      * @param string $message
+     *
+     * @return void
      * @dataProvider fillUploaderObjectDataProvider
      */
-    public function testFillUploaderObject($isRead, $isWrite, $message)
+    public function testFillUploaderObject($isRead, $isWrite, $message): void
     {
         $fileUploaderMock = $this
             ->getMockBuilder(Uploader::class)
@@ -1353,7 +1506,7 @@ class ProductTest extends AbstractImportTestCase
             ->willReturnMap(
                 [
                     ['import', 'import'],
-                    ['catalog/product', 'catalog/product'],
+                    ['catalog/product', 'catalog/product']
                 ]
             );
 
@@ -1380,9 +1533,11 @@ class ProductTest extends AbstractImportTestCase
      *
      * @param string $fileName
      * @param bool $throwException
+     *
+     * @return void
      * @dataProvider uploadMediaFilesDataProvider
      */
-    public function testUploadMediaFiles(string $fileName, bool $throwException)
+    public function testUploadMediaFiles(string $fileName, bool $throwException): void
     {
         $exception = new \Exception();
         $expectedFileName = $fileName;
@@ -1426,7 +1581,7 @@ class ProductTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function fillUploaderObjectDataProvider()
+    public function fillUploaderObjectDataProvider(): array
     {
         return [
             [false, true, 'File directory \'pub/media/import\' is not readable.'],
@@ -1440,18 +1595,18 @@ class ProductTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function uploadMediaFilesDataProvider()
+    public function uploadMediaFilesDataProvider(): array
     {
         return [
             ['test1.jpg', false],
-            ['test2.jpg', true],
+            ['test2.jpg', true]
         ];
     }
 
     /**
      * @return array
      */
-    public function getImagesFromRowDataProvider()
+    public function getImagesFromRowDataProvider(): array
     {
         return [
             [
@@ -1471,7 +1626,7 @@ class ProductTest extends AbstractImportTestCase
                     ],
                     [
                         '_media_image' => ['label1', 'label2']
-                    ],
+                    ]
                 ]
             ]
         ];
@@ -1480,7 +1635,7 @@ class ProductTest extends AbstractImportTestCase
     /**
      * @return array
      */
-    public function validateRowValidateNewProductTypeAddRowErrorCallDataProvider()
+    public function validateRowValidateNewProductTypeAddRowErrorCallDataProvider(): array
     {
         return [
             [
@@ -1495,85 +1650,85 @@ class ProductTest extends AbstractImportTestCase
                 '$productTypeModelsColType' => null,
                 '$colAttrSet' => null,
                 '$attrSetNameToIdColAttrSet' => null,
-                '$error' => Validator::ERROR_INVALID_TYPE,
+                '$error' => Validator::ERROR_INVALID_TYPE
             ],
             [
                 '$colType' => 'value',
                 '$productTypeModelsColType' => 'value',
                 '$colAttrSet' => null,
                 '$attrSetNameToIdColAttrSet' => 'value',
-                '$error' => Validator::ERROR_INVALID_ATTR_SET,
+                '$error' => Validator::ERROR_INVALID_ATTR_SET
             ],
             [
                 '$colType' => 'value',
                 '$productTypeModelsColType' => 'value',
                 '$colAttrSet' => 'value',
                 '$attrSetNameToIdColAttrSet' => null,
-                '$error' => Validator::ERROR_INVALID_ATTR_SET,
-            ],
+                '$error' => Validator::ERROR_INVALID_ATTR_SET
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function validateRowCheckSpecifiedSkuDataProvider()
+    public function validateRowCheckSpecifiedSkuDataProvider(): array
     {
         return [
             [
                 '$sku' => null,
-                '$expectedError' => Validator::ERROR_SKU_IS_EMPTY,
+                '$expectedError' => Validator::ERROR_SKU_IS_EMPTY
             ],
             [
                 '$sku' => false,
-                '$expectedError' => Validator::ERROR_ROW_IS_ORPHAN,
+                '$expectedError' => Validator::ERROR_ROW_IS_ORPHAN
             ],
             [
                 '$sku' => 'sku',
-                '$expectedError' => Validator::ERROR_INVALID_STORE,
-            ],
+                '$expectedError' => Validator::ERROR_INVALID_STORE
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function validateRowDataProvider()
+    public function validateRowDataProvider(): array
     {
         return [
             [
                 '$rowScope' => Product::SCOPE_DEFAULT,
                 '$oldSku' => null,
-                '$expectedResult' => false,
+                '$expectedResult' => false
             ],
             [
                 '$rowScope' => null,
                 '$oldSku' => null,
-                '$expectedResult' => true,
+                '$expectedResult' => true
             ],
             [
                 '$rowScope' => null,
                 '$oldSku' => true,
-                '$expectedResult' => true,
+                '$expectedResult' => true
             ],
             [
                 '$rowScope' => Product::SCOPE_DEFAULT,
                 '$oldSku' => true,
-                '$expectedResult' => true,
+                '$expectedResult' => true
             ],
             [
                 '$rowScope' => Product::SCOPE_DEFAULT,
                 '$oldSku' => null,
                 '$expectedResult' => false,
                 '$behaviour' => Import::BEHAVIOR_REPLACE
-            ],
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function isAttributeValidAssertAttrValidDataProvider()
+    public function isAttributeValidAssertAttrValidDataProvider(): array
     {
         return [
             [
@@ -1589,11 +1744,11 @@ class ProductTest extends AbstractImportTestCase
             ],
             [
                 '$attrParams' => [
-                    'type' => 'decimal',
+                    'type' => 'decimal'
                 ],
                 '$rowData' => [
-                    'code' => 10,
-                ],
+                    'code' => 10
+                ]
             ],
             [
                 '$attrParams' => [
@@ -1601,8 +1756,8 @@ class ProductTest extends AbstractImportTestCase
                     'options' => ['code' => 1]
                 ],
                 '$rowData' => [
-                    'code' => 'code',
-                ],
+                    'code' => 'code'
+                ]
             ],
             [
                 '$attrParams' => [
@@ -1610,116 +1765,116 @@ class ProductTest extends AbstractImportTestCase
                     'options' => ['code' => 1]
                 ],
                 '$rowData' => [
-                    'code' => 'code',
-                ],
+                    'code' => 'code'
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'int',
+                    'type' => 'int'
                 ],
                 '$rowData' => [
-                    'code' => 1000,
-                ],
+                    'code' => 1000
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'datetime',
+                    'type' => 'datetime'
                 ],
                 '$rowData' => [
-                    'code' => "5 September 2015",
-                ],
+                    'code' => "5 September 2015"
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'text',
+                    'type' => 'text'
                 ],
                 '$rowData' => [
                     'code' => str_repeat(
                         'a',
                         Product::DB_MAX_TEXT_LENGTH - 1
-                    ),
-                ],
-            ],
+                    )
+                ]
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function isAttributeValidAssertAttrInvalidDataProvider()
+    public function isAttributeValidAssertAttrInvalidDataProvider(): array
     {
         return [
             [
                 '$attrParams' => [
-                    'type' => 'varchar',
+                    'type' => 'varchar'
                 ],
                 '$rowData' => [
                     'code' => str_repeat(
                         'a',
                         Product::DB_MAX_VARCHAR_LENGTH + 1
-                    ),
-                ],
+                    )
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'decimal',
+                    'type' => 'decimal'
                 ],
                 '$rowData' => [
-                    'code' => 'incorrect',
-                ],
+                    'code' => 'incorrect'
+                ]
             ],
             [
                 '$attrParams' => [
                     'type' => 'select',
-                    'not options' => null,
+                    'not options' => null
                 ],
                 '$rowData' => [
-                    'code' => 'code',
-                ],
+                    'code' => 'code'
+                ]
             ],
             [
                 '$attrParams' => [
                     'type' => 'multiselect',
-                    'not options' => null,
+                    'not options' => null
                 ],
                 '$rowData' => [
-                    'code' => 'code',
-                ],
+                    'code' => 'code'
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'int',
+                    'type' => 'int'
                 ],
                 '$rowData' => [
-                    'code' => 'not int',
-                ],
+                    'code' => 'not int'
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'datetime',
+                    'type' => 'datetime'
                 ],
                 '$rowData' => [
-                    'code' => "incorrect datetime",
-                ],
+                    'code' => "incorrect datetime"
+                ]
             ],
             [
                 '$attrParams' => [
-                    'type' => 'text',
+                    'type' => 'text'
                 ],
                 '$rowData' => [
                     'code' => str_repeat(
                         'a',
                         Product::DB_MAX_TEXT_LENGTH + 1
-                    ),
-                ],
-            ],
+                    )
+                ]
+            ]
         ];
     }
 
     /**
      * @return array
      */
-    public function getRowScopeDataProvider()
+    public function getRowScopeDataProvider(): array
     {
         $colSku = Product::COL_SKU;
         $colStore = Product::COL_STORE;
@@ -1728,21 +1883,21 @@ class ProductTest extends AbstractImportTestCase
             [
                 '$rowData' => [
                     $colSku => null,
-                    $colStore => 'store',
+                    $colStore => 'store'
                 ],
                 '$expectedResult' => Product::SCOPE_STORE
             ],
             [
                 '$rowData' => [
                     $colSku => 'sku',
-                    $colStore => null,
+                    $colStore => null
                 ],
                 '$expectedResult' => Product::SCOPE_DEFAULT
             ],
             [
                 '$rowData' => [
                     $colSku => 'sku',
-                    $colStore => 'store',
+                    $colStore => 'store'
                 ],
                 '$expectedResult' => Product::SCOPE_STORE
             ],
@@ -1822,9 +1977,10 @@ class ProductTest extends AbstractImportTestCase
      * @see _rewriteGetOptionEntityInImportProduct()
      * @see _setValidatorMockInImportProduct()
      * @param Product  Param should go with rewritten getOptionEntity method.
+     *
      * @return Option|MockObject
      */
-    private function _suppressValidateRowOptionValidatorInvalidRows($importProduct)
+    private function _suppressValidateRowOptionValidatorInvalidRows($importProduct): MockObject
     {
         //suppress option validation
         $this->_rewriteGetOptionEntityInImportProduct($importProduct);
@@ -1839,6 +1995,7 @@ class ProductTest extends AbstractImportTestCase
      * Set validator mock in importProduct, return true for isValid method.
      *
      * @param Product
+     *
      * @return Validator|MockObject
      */
     private function _setValidatorMockInImportProduct($importProduct)
@@ -1854,9 +2011,10 @@ class ProductTest extends AbstractImportTestCase
      * Make getOptionEntity return option mock.
      *
      * @param Product  Param should go with rewritten getOptionEntity method.
+     *
      * @return Option|MockObject
      */
-    private function _rewriteGetOptionEntityInImportProduct($importProduct)
+    private function _rewriteGetOptionEntityInImportProduct($importProduct): MockObject
     {
         $option = $this->getMockBuilder(Option::class)
             ->disableOriginalConstructor()
@@ -1869,10 +2027,13 @@ class ProductTest extends AbstractImportTestCase
     /**
      * @param array $methods
      * @param array $errorAggregatorMethods
+     *
      * @return MockObject
      */
-    protected function createModelMockWithErrorAggregator(array $methods = [], array $errorAggregatorMethods = [])
-    {
+    protected function createModelMockWithErrorAggregator(
+        array $methods = [],
+        array $errorAggregatorMethods = []
+    ): MockObject {
         $methods[] = 'getErrorAggregator';
         $importProduct = $this->getMockBuilder(Product::class)
             ->disableOriginalConstructor()

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Indexer/ProductPriceIndexFilterTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Indexer/ProductPriceIndexFilterTest.php
@@ -23,29 +23,28 @@ use PHPUnit\Framework\TestCase;
  */
 class ProductPriceIndexFilterTest extends TestCase
 {
-
     /**
-     * @var MockObject|StockConfigurationInterface $stockConfiguration
+     * @var MockObject|StockConfigurationInterface
      */
     private $stockConfiguration;
 
     /**
-     * @var MockObject|Item $item
+     * @var MockObject|Item
      */
     private $item;
 
     /**
-     * @var MockObject|ResourceConnection $resourceCnnection
+     * @var MockObject|ResourceConnection
      */
-    private $resourceCnnection;
+    private $resourceConnection;
 
     /**
-     * @var MockObject|Generator $generator
+     * @var MockObject|Generator
      */
     private $generator;
 
     /**
-     * @var ProductPriceIndexFilter $productPriceIndexFilter
+     * @var ProductPriceIndexFilter
      */
     private $productPriceIndexFilter;
 
@@ -56,13 +55,13 @@ class ProductPriceIndexFilterTest extends TestCase
     {
         $this->stockConfiguration = $this->getMockForAbstractClass(StockConfigurationInterface::class);
         $this->item = $this->createMock(Item::class);
-        $this->resourceCnnection = $this->createMock(ResourceConnection::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
         $this->generator = $this->createMock(Generator::class);
 
         $this->productPriceIndexFilter = new ProductPriceIndexFilter(
             $this->stockConfiguration,
             $this->item,
-            $this->resourceCnnection,
+            $this->resourceConnection,
             'indexer',
             $this->generator,
             100
@@ -70,20 +69,22 @@ class ProductPriceIndexFilterTest extends TestCase
     }
 
     /**
-     * Test to ensure that Modify Price method uses entityIds,
+     * Test to ensure that Modify Price method uses entityIds.
+     *
+     * @return void
      */
-    public function testModifyPrice()
+    public function testModifyPrice(): void
     {
         $entityIds = [1, 2, 3];
         $indexTableStructure = $this->createMock(IndexTableStructure::class);
         $connectionMock = $this->getMockForAbstractClass(AdapterInterface::class);
-        $this->resourceCnnection->expects($this->once())->method('getConnection')->willReturn($connectionMock);
+        $this->resourceConnection->expects($this->once())->method('getConnection')->willReturn($connectionMock);
         $selectMock = $this->createMock(Select::class);
         $connectionMock->expects($this->once())->method('select')->willReturn($selectMock);
-        $selectMock->expects($this->at(2))
+        $selectMock
             ->method('where')
-            ->with('stock_item.product_id IN (?)', $entityIds)
-            ->willReturn($selectMock);
+            ->withConsecutive([], [], ['stock_item.product_id IN (?)', $entityIds])
+            ->willReturnOnConsecutiveCalls(null, null, $selectMock);
         $this->generator->expects($this->once())
             ->method('generate')
             ->willReturnCallback(
@@ -103,6 +104,7 @@ class ProductPriceIndexFilterTest extends TestCase
      *
      * @param MockObject $selectMock
      * @param int $batchCount
+     *
      * @return \Closure
      */
     private function getBatchIteratorCallback(MockObject $selectMock, int $batchCount): \Closure

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/QuantityValidatorTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Quote/Item/QuantityValidator/Initializer/QuantityValidatorTest.php
@@ -121,6 +121,9 @@ class QuantityValidatorTest extends TestCase
      */
     private $stockStatusMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManager($this);
@@ -186,20 +189,20 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario when item is not in stock
+     * This tests the scenario when item is not in stock.
      *
      * @return void
      */
-    public function testValidateOutOfStock()
+    public function testValidateOutOfStock(): void
     {
         $this->createInitialStub(0);
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
 
         $this->stockRegistryMock->expects($this->atLeastOnce())
             ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock);
 
         $this->stockStatusMock
             ->method('getStockStatus')
@@ -224,28 +227,24 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario when item is in stock but parent is not in stock
+     * This tests the scenario when item is in stock but parent is not in stock.
      *
      * @return void
      */
-    public function testValidateInStock()
+    public function testValidateInStock(): void
     {
         $this->createInitialStub(1);
-        $this->stockRegistryMock->expects($this->at(0))
-            ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
-
-        $this->stockRegistryMock->expects($this->at(1))
-            ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
 
         $this->quoteItemMock->expects($this->any())
             ->method('getParentItem')
             ->willReturn($this->parentItemMock);
 
-        $this->stockRegistryMock->expects($this->at(2))
+        $this->stockRegistryMock
+            ->method('getStockItem')
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->parentStockItemMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock, $this->parentStockItemMock);
 
         $this->parentStockItemMock->expects($this->once())
             ->method('getStockStatus')
@@ -274,27 +273,28 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario when item is in stock and has options
+     * This tests the scenario when item is in stock and has options.
      *
      * @return void
      */
-    public function testValidateWithOptions()
+    public function testValidateWithOptions(): void
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError', 'getStockStateResult', 'getProduct'])
+            ->onlyMethods(['getProduct'])
+            ->addMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
         $optionMock->expects($this->once())
             ->method('getStockStateResult')
             ->willReturn($this->resultMock);
         $optionMock->method('getProduct')
             ->willReturn($this->productMock);
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
-        $this->stockRegistryMock->expects($this->at(1))
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock);
         $options = [$optionMock];
         $this->createInitialStub(1);
         $this->setUpStubForQuantity(1, true);
@@ -317,22 +317,23 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario with options but has errors
+     * This tests the scenario with options but has errors.
      *
      * @return void
      */
-    public function testValidateWithOptionsAndError()
+    public function testValidateWithOptionsAndError(): void
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError', 'getStockStateResult', 'getProduct'])
+            ->onlyMethods(['getProduct'])
+            ->addMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
-        $this->stockRegistryMock->expects($this->at(1))
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock);
         $optionMock->expects($this->once())
             ->method('getStockStateResult')
             ->willReturn($this->resultMock);
@@ -364,27 +365,28 @@ class QuantityValidatorTest extends TestCase
      *
      * @return void
      */
-    public function testValidateAndRemoveErrorsFromQuote()
+    public function testValidateAndRemoveErrorsFromQuote(): void
     {
         $optionMock = $this->getMockBuilder(OptionItem::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setHasError', 'getStockStateResult', 'getProduct'])
+            ->onlyMethods(['getProduct'])
+            ->addMethods(['setHasError', 'getStockStateResult'])
             ->getMock();
         $quoteItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getItemId', 'getErrorInfos'])
+            ->onlyMethods(['getItemId', 'getErrorInfos'])
             ->getMock();
         $optionMock->expects($this->once())
             ->method('getStockStateResult')
             ->willReturn($this->resultMock);
         $optionMock->method('getProduct')
             ->willReturn($this->productMock);
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
-        $this->stockRegistryMock->expects($this->at(1))
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock);
         $options = [$optionMock];
         $this->createInitialStub(1);
         $this->setUpStubForQuantity(1, true);
@@ -414,23 +416,23 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario when all the items are both parent and item are in stock and any errors are cleared
+     * This tests the scenario when all the items are both parent and item are in stock and any errors are cleared.
      *
      * @return void
      */
-    public function testRemoveError()
+    public function testRemoveError(): void
     {
         $this->createInitialStub(1);
         $this->setUpStubForRemoveError();
         $this->quoteItemMock->expects($this->any())
             ->method('getQtyOptions')
             ->willReturn(null);
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
-            ->willReturn($this->stockItemMock);
-        $this->stockRegistryMock->expects($this->at(1))
+            ->willReturnOnConsecutiveCalls($this->stockItemMock);
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock);
         $this->quoteItemMock->expects($this->any())
             ->method('getParentItem')
             ->willReturn($this->parentItemMock);
@@ -445,15 +447,15 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This test the scenario when stock Item is not of correct type and throws appropriate exception
+     * This test the scenario when stock Item is not of correct type and throws appropriate exception.
      *
-     * @throws LocalizedException
      * @return void
+     * @throws LocalizedException
      */
-    public function testException()
+    public function testException(): void
     {
         $this->createInitialStub(1);
-        $this->stockRegistryMock->expects($this->at(0))
+        $this->stockRegistryMock
             ->method('getStockItem')
             ->willReturn(null);
         $this->expectException(LocalizedException::class);
@@ -461,7 +463,7 @@ class QuantityValidatorTest extends TestCase
     }
 
     /**
-     * This tests the scenario when the error is in the quote item already
+     * This tests the scenario when the error is in the quote item already.
      *
      * @return void
      */
@@ -475,16 +477,13 @@ class QuantityValidatorTest extends TestCase
             ->willReturn(true);
         $this->stockRegistryMock->method('getStockItem')
             ->willReturn($this->stockItemMock);
-        $this->stockRegistryMock->expects($this->at(1))
-            ->method('getStockStatus')
-            ->willReturn($this->stockStatusMock);
         $this->quoteItemMock->method('getParentItem')
             ->willReturn($this->parentItemMock);
         $this->quoteItemMock->method('getStockStateResult')
             ->willReturn($resultMock);
-        $this->stockRegistryMock->expects($this->at(2))
+        $this->stockRegistryMock
             ->method('getStockStatus')
-            ->willReturn($this->parentStockItemMock);
+            ->willReturnOnConsecutiveCalls($this->stockStatusMock, $this->parentStockItemMock);
         $this->parentStockItemMock->method('getStockStatus')
             ->willReturn(0);
         $this->stockStatusMock->expects($this->atLeastOnce())
@@ -510,8 +509,10 @@ class QuantityValidatorTest extends TestCase
     /**
      * @param $qty
      * @param $hasError
+     *
+     * @return void
      */
-    private function setUpStubForQuantity($qty, $hasError)
+    private function setUpStubForQuantity($qty, $hasError): void
     {
         $this->productMock->expects($this->any())
             ->method('getTypeInstance')
@@ -544,7 +545,7 @@ class QuantityValidatorTest extends TestCase
     /**
      * @param $qty
      */
-    private function createInitialStub($qty)
+    private function createInitialStub($qty): void
     {
         $this->storeMock->expects($this->any())
             ->method('getWebsiteId')
@@ -601,7 +602,10 @@ class QuantityValidatorTest extends TestCase
             ->willReturn($this->resultMock);
     }
 
-    private function setUpStubForRemoveError()
+    /**
+    * @return void
+    */
+    private function setUpStubForRemoveError(): void
     {
         $quoteItems = [$this->quoteItemMock];
         $this->quoteItemMock->expects($this->any())

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/StockTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/StockTest.php
@@ -89,7 +89,7 @@ class StockTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->stockConfigurationMock = $this->getMockBuilder(StockConfiguration::class)
-            ->setMethods(['getIsQtyTypeIds', 'getDefaultScopeId'])
+            ->onlyMethods(['getIsQtyTypeIds', 'getDefaultScopeId'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
@@ -100,14 +100,14 @@ class StockTest extends TestCase
             ->getMock();
         $this->statementMock = $this->getMockForAbstractClass(\Zend_Db_Statement_Interface::class);
         $this->stock = $this->getMockBuilder(Stock::class)
-            ->setMethods(['getTable', 'getConnection'])
+            ->onlyMethods(['getTable', 'getConnection'])
             ->setConstructorArgs(
                 [
                     'context' => $this->contextMock,
                     'scopeConfig' => $this->scopeConfigMock,
                     'dateTime' => $this->dateTimeMock,
                     'stockConfiguration' => $this->stockConfigurationMock,
-                    'storeManager' => $this->storeManagerMock,
+                    'storeManager' => $this->storeManagerMock
                 ]
             )->getMock();
     }
@@ -115,7 +115,6 @@ class StockTest extends TestCase
     /**
      * Test Save Product Status per website with product ids.
      *
-     * @dataProvider productsDataProvider
      * @param int $websiteId
      * @param array $productIds
      * @param array $products
@@ -123,6 +122,7 @@ class StockTest extends TestCase
      * @param array $items
      *
      * @return void
+     * @dataProvider productsDataProvider
      */
     public function testLockProductsStock(
         int $websiteId,
@@ -130,7 +130,7 @@ class StockTest extends TestCase
         array $products,
         array $result,
         array $items
-    ) {
+    ): void {
         $itemIds = [];
         foreach ($items as $item) {
             $itemIds[] = $item['item_id'];
@@ -167,12 +167,9 @@ class StockTest extends TestCase
             ->method('query')
             ->with($this->identicalTo($this->selectMock))
             ->willReturn($this->statementMock);
-        $this->statementMock->expects($this->at(0))
+        $this->statementMock
             ->method('fetchAll')
-            ->willReturn($items);
-        $this->statementMock->expects($this->at(1))
-            ->method('fetchAll')
-            ->willReturn($products);
+            ->willReturnOnConsecutiveCalls($items, $products);
         $this->connectionMock->expects($this->once())
             ->method('fetchAll')
             ->with($this->identicalTo($this->selectMock))
@@ -207,24 +204,24 @@ class StockTest extends TestCase
                 [
                     1 => ['product_id' => 1],
                     2 => ['product_id' => 2],
-                    3 => ['product_id' => 3],
+                    3 => ['product_id' => 3]
                 ],
                 [
                     1 => [
                         'product_id' => 1,
-                        'type_id' => 'simple',
+                        'type_id' => 'simple'
                     ],
                     2 => [
                         'product_id' => 2,
-                        'type_id' => 'simple',
+                        'type_id' => 'simple'
                     ],
                     3 => [
                         'product_id' => 3,
-                        'type_id' => 'simple',
+                        'type_id' => 'simple'
                     ],
                 ],
                 [['item_id' => 1], ['item_id' => 2], ['item_id' => 3]]
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/CatalogRuleRepositoryTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/CatalogRuleRepositoryTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\CatalogRule\Test\Unit\Model;
 
 use Magento\CatalogRule\Model\CatalogRuleRepository;
@@ -36,6 +35,9 @@ class CatalogRuleRepositoryTest extends TestCase
      */
     protected $ruleMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->ruleResourceMock = $this->createMock(Rule::class);
@@ -47,7 +49,10 @@ class CatalogRuleRepositoryTest extends TestCase
         );
     }
 
-    public function testSave()
+    /**
+    * @return void
+    */
+    public function testSave(): void
     {
         $this->ruleMock->expects($this->once())->method('getRuleId')->willReturn(null);
         $this->ruleMock->expects($this->once())->method('getId')->willReturn(1);
@@ -55,7 +60,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->assertEquals($this->ruleMock, $this->repository->save($this->ruleMock));
     }
 
-    public function testEditRule()
+    /**
+    * @return void
+    */
+    public function testEditRule(): void
     {
         $ruleId = 1;
         $ruleData = ['id' => $ruleId];
@@ -71,12 +79,16 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->assertEquals($ruleMock, $this->repository->save($this->ruleMock));
     }
 
-    public function testEnableSaveRule()
+    /**
+    * @return void
+    */
+    public function testEnableSaveRule(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotSaveException');
         $this->expectExceptionMessage('The "1" rule was unable to be saved. Please try again.');
-        $this->ruleMock->expects($this->at(0))->method('getRuleId')->willReturn(null);
-        $this->ruleMock->expects($this->at(1))->method('getRuleId')->willReturn(1);
+        $this->ruleMock
+            ->method('getRuleId')
+            ->willReturnOnConsecutiveCalls(null, 1);
         $this->ruleMock->expects($this->never())->method('getId');
         $this->ruleResourceMock
             ->expects($this->once())
@@ -85,7 +97,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->repository->save($this->ruleMock);
     }
 
-    public function testDeleteRule()
+    /**
+    * @return void
+    */
+    public function testDeleteRule(): void
     {
         $this->ruleMock->expects($this->once())->method('getId')->willReturn(1);
         $this->ruleResourceMock
@@ -95,7 +110,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->assertTrue($this->repository->delete($this->ruleMock));
     }
 
-    public function testDeleteRuleById()
+    /**
+    * @return void
+    */
+    public function testDeleteRuleById(): void
     {
         $ruleId = 1;
         $ruleMock = $this->createMock(\Magento\CatalogRule\Model\Rule::class);
@@ -110,7 +128,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->assertTrue($this->repository->deleteById($ruleId));
     }
 
-    public function testUnableDeleteRule()
+    /**
+    * @return void
+    */
+    public function testUnableDeleteRule(): void
     {
         $this->expectException('Magento\Framework\Exception\CouldNotDeleteException');
         $this->expectExceptionMessage('The "1" rule couldn\'t be removed.');
@@ -122,7 +143,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->repository->delete($this->ruleMock);
     }
 
-    public function testGetRule()
+    /**
+    * @return void
+    */
+    public function testGetRule(): void
     {
         $ruleId = 1;
         $ruleMock = $this->createMock(\Magento\CatalogRule\Model\Rule::class);
@@ -134,7 +158,10 @@ class CatalogRuleRepositoryTest extends TestCase
         $this->assertEquals($ruleMock, $this->repository->get($ruleId));
     }
 
-    public function testGetNonExistentRule()
+    /**
+    * @return void
+    */
+    public function testGetNonExistentRule(): void
     {
         $this->expectException('Magento\Framework\Exception\NoSuchEntityException');
         $this->expectExceptionMessage('The rule with the "1" ID wasn\'t found. Verify the ID and try again.');

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Data/Condition/ConverterTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Data/Condition/ConverterTest.php
@@ -25,6 +25,9 @@ class ConverterTest extends TestCase
      */
     protected $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->conditionFactoryMock = $this->createPartialMock(
@@ -34,7 +37,10 @@ class ConverterTest extends TestCase
         $this->model = new Converter($this->conditionFactoryMock);
     }
 
-    public function testDataModelToArray()
+    /**
+    * @return void
+    */
+    public function testDataModelToArray(): void
     {
         $childConditionMock = $this->getMockForAbstractClass(ConditionInterface::class);
         $childConditionMock->expects($this->once())->method('getType')->willReturn('child-type');
@@ -68,14 +74,17 @@ class ConverterTest extends TestCase
                     'operator' => 'child-operator',
                     'value' => 'child-value',
                     'is_value_processed' => 1,
-                    'aggregator' => 'all',
+                    'aggregator' => 'all'
                 ]
             ]
         ];
         $this->assertEquals($expectedResult, $this->model->dataModelToArray($dataModelMock));
     }
 
-    public function testArrayToDataModel()
+    /**
+    * @return void
+    */
+    public function testArrayToDataModel(): void
     {
         $array = [
             'type' => 'type',
@@ -91,7 +100,7 @@ class ConverterTest extends TestCase
                     'operator' => 'child-operator',
                     'value' => 'child-value',
                     'is_value_parsed' => false,
-                    'aggregator' => 'any',
+                    'aggregator' => 'any'
                 ]
             ]
         ];
@@ -99,8 +108,9 @@ class ConverterTest extends TestCase
         $conditionMock = $this->getMockForAbstractClass(ConditionInterface::class);
         $conditionChildMock = $this->getMockForAbstractClass(ConditionInterface::class);
 
-        $this->conditionFactoryMock->expects($this->at(0))->method('create')->willReturn($conditionMock);
-        $this->conditionFactoryMock->expects($this->at(1))->method('create')->willReturn($conditionChildMock);
+        $this->conditionFactoryMock
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($conditionMock, $conditionChildMock);
 
         $conditionMock->expects($this->once())->method('setType')->with('type')->willReturnSelf();
         $conditionMock->expects($this->once())->method('setAggregator')->with('all')->willReturnSelf();

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/IndexerTableSwapperTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/IndexerTableSwapperTest.php
@@ -40,7 +40,7 @@ class IndexerTableSwapperTest extends TestCase
     private $tableMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -89,14 +89,10 @@ class IndexerTableSwapperTest extends TestCase
         $temporaryTableName = 'catalogrule_product__temp9604';
         $this->setObjectProperty($model, 'temporaryTables', []);
 
-        $this->resourceConnectionMock->expects($this->at(0))
+        $this->resourceConnectionMock
             ->method('getTableName')
-            ->with($originalTableName)
-            ->willReturn($originalTableName);
-        $this->resourceConnectionMock->expects($this->at(1))
-            ->method('getTableName')
-            ->with($this->stringStartsWith($originalTableName . '__temp'))
-            ->willReturn($temporaryTableName);
+            ->withConsecutive([$originalTableName], [$this->stringStartsWith($originalTableName . '__temp')])
+            ->willReturnOnConsecutiveCalls($originalTableName, $temporaryTableName);
 
         $this->assertEquals(
             $temporaryTableName,
@@ -127,7 +123,7 @@ class IndexerTableSwapperTest extends TestCase
     public function testSwapIndexTables(): void
     {
         $model = $this->getMockBuilder(IndexerTableSwapper::class)
-            ->setMethods(['getWorkingTableName'])
+            ->onlyMethods(['getWorkingTableName'])
             ->setConstructorArgs([$this->resourceConnectionMock])
             ->getMock();
         $originalTableName = 'catalogrule_product';
@@ -136,22 +132,18 @@ class IndexerTableSwapperTest extends TestCase
         $toRename = [
             [
                 'oldName' => $originalTableName,
-                'newName' => $temporaryOriginalTableName,
+                'newName' => $temporaryOriginalTableName
             ],
             [
                 'oldName' => $temporaryTableName,
-                'newName' => $originalTableName,
-            ],
+                'newName' => $originalTableName
+            ]
         ];
 
-        $this->resourceConnectionMock->expects($this->at(0))
+        $this->resourceConnectionMock
             ->method('getTableName')
-            ->with($originalTableName)
-            ->willReturn($originalTableName);
-        $this->resourceConnectionMock->expects($this->at(1))
-            ->method('getTableName')
-            ->with($this->stringStartsWith($originalTableName))
-            ->willReturn($temporaryOriginalTableName);
+            ->withConsecutive([$originalTableName], [$this->stringStartsWith($originalTableName)])
+            ->willReturnOnConsecutiveCalls($originalTableName, $temporaryOriginalTableName);
         $model->expects($this->once())
             ->method('getWorkingTableName')
             ->with($originalTableName)

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleGroupWebsiteTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleGroupWebsiteTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\CatalogRule\Test\Unit\Model\Indexer;
 
 use Magento\Catalog\Model\ResourceModel\Indexer\ActiveTableSwitcher;
@@ -45,6 +44,9 @@ class ReindexRuleGroupWebsiteTest extends TestCase
      */
     private $tableSwapperMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->dateTimeMock = $this->getMockBuilder(DateTime::class)
@@ -68,13 +70,18 @@ class ReindexRuleGroupWebsiteTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $timeStamp = (int)gmdate('U');
         $insertString = 'insert_string';
         $connectionMock = $this->getMockBuilder(AdapterInterface::class)
             ->getMock();
-        $this->resourceMock->expects($this->at(0))->method('getConnection')->willReturn($connectionMock);
+        $this->resourceMock
+            ->method('getConnection')
+            ->willReturn($connectionMock);
         $this->dateTimeMock->expects($this->once())->method('gmtTimestamp')->willReturn($timeStamp);
 
         $this->tableSwapperMock->expects($this->any())
@@ -82,7 +89,7 @@ class ReindexRuleGroupWebsiteTest extends TestCase
             ->willReturnMap(
                 [
                     ['catalogrule_group_website', 'catalogrule_group_website_replica'],
-                    ['catalogrule_product', 'catalogrule_product_replica'],
+                    ['catalogrule_product', 'catalogrule_product_replica']
                 ]
             );
 
@@ -93,7 +100,7 @@ class ReindexRuleGroupWebsiteTest extends TestCase
                     ['catalogrule_group_website', 'default', 'catalogrule_group_website'],
                     ['catalogrule_product', 'default', 'catalogrule_product'],
                     ['catalogrule_group_website_replica', 'default', 'catalogrule_group_website_replica'],
-                    ['catalogrule_product_replica', 'default', 'catalogrule_product_replica'],
+                    ['catalogrule_product_replica', 'default', 'catalogrule_product_replica']
                 ]
             );
 

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleProductPriceTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleProductPriceTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\CatalogRule\Test\Unit\Model\Indexer;
 
 use Magento\CatalogRule\Model\Indexer\ProductPriceCalculator;
@@ -51,6 +50,9 @@ class ReindexRuleProductPriceTest extends TestCase
      */
     private $pricesPersistorMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->storeManagerMock = $this->getMockForAbstractClass(StoreManagerInterface::class);
@@ -69,7 +71,10 @@ class ReindexRuleProductPriceTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $websiteId = 234;
         $defaultGroupId = 11;
@@ -117,12 +122,9 @@ class ReindexRuleProductPriceTest extends TestCase
             ->with($defaultStoreId, null, true)
             ->willReturn(new \DateTime());
 
-        $statementMock->expects($this->at(0))
+        $statementMock
             ->method('fetch')
-            ->willReturn($ruleData);
-        $statementMock->expects($this->at(1))
-            ->method('fetch')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls($ruleData, false);
 
         $this->productPriceCalculatorMock->expects($this->atLeastOnce())
             ->method('calculate');

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleProductTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/ReindexRuleProductTest.php
@@ -52,6 +52,9 @@ class ReindexRuleProductTest extends TestCase
      */
     private $ruleMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->resourceMock = $this->createMock(ResourceConnection::class);
@@ -70,6 +73,9 @@ class ReindexRuleProductTest extends TestCase
         );
     }
 
+    /**
+    * @return void
+    */
     public function testExecuteIfRuleInactive(): void
     {
         $ruleMock = $this->createMock(Rule::class);
@@ -79,6 +85,9 @@ class ReindexRuleProductTest extends TestCase
         self::assertFalse($this->model->execute($ruleMock, 100, true));
     }
 
+    /**
+     * @return void
+     */
     public function testExecuteIfRuleWithoutWebsiteIds(): void
     {
         $ruleMock = $this->createMock(Rule::class);
@@ -91,6 +100,9 @@ class ReindexRuleProductTest extends TestCase
         self::assertFalse($this->model->execute($ruleMock, 100, true));
     }
 
+    /**
+     * @return void
+     */
     public function testExecute(): void
     {
         $websiteId = 3;
@@ -99,7 +111,7 @@ class ReindexRuleProductTest extends TestCase
         $productIds = [
             4 => [$websiteId => 1],
             5 => [$websiteId => 1],
-            6 => [$websiteId => 1],
+            6 => [$websiteId => 1]
         ];
 
         $this->prepareResourceMock();
@@ -108,7 +120,7 @@ class ReindexRuleProductTest extends TestCase
         $this->localeDateMock->method('getConfigTimezone')
             ->willReturnMap([
                 [ScopeInterface::SCOPE_WEBSITE, self::ADMIN_WEBSITE_ID, $adminTimeZone],
-                [ScopeInterface::SCOPE_WEBSITE, $websiteId, $websiteTz],
+                [ScopeInterface::SCOPE_WEBSITE, $websiteId, $websiteTz]
             ]);
 
         $batchRows = [
@@ -122,7 +134,7 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ],
             [
                 'rule_id' => 100,
@@ -134,7 +146,7 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ]
         ];
 
@@ -149,20 +161,23 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ]
         ];
 
-        $this->connectionMock->expects(self::at(0))
+        $this->connectionMock
             ->method('insertMultiple')
-            ->with('catalogrule_product_replica', $batchRows);
-        $this->connectionMock->expects(self::at(1))
-            ->method('insertMultiple')
-            ->with('catalogrule_product_replica', $rowsNotInBatch);
+            ->withConsecutive(
+                ['catalogrule_product_replica', $batchRows],
+                ['catalogrule_product_replica', $rowsNotInBatch]
+            );
 
         self::assertTrue($this->model->execute($this->ruleMock, 2, true));
     }
 
+    /**
+     * @return void
+     */
     public function testExecuteWithExcludedWebsites(): void
     {
         $websitesIds = [1, 2, 3];
@@ -171,14 +186,14 @@ class ReindexRuleProductTest extends TestCase
         $productIds = [
             1 => [1 => 1],
             2 => [2 => 1],
-            3 => [3 => 1],
+            3 => [3 => 1]
         ];
 
         $this->prepareResourceMock();
         $this->prepareRuleMock($websitesIds, $productIds, [10, 20]);
 
         $extensionAttributes = $this->getMockBuilder(\Magento\Framework\Api\ExtensionAttributesInterface::class)
-            ->setMethods(['getExtensionAttributes', 'getExcludeWebsiteIds'])
+            ->addMethods(['getExtensionAttributes', 'getExcludeWebsiteIds'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->ruleMock->expects(self::once())->method('getExtensionAttributes')
@@ -191,7 +206,7 @@ class ReindexRuleProductTest extends TestCase
                 [ScopeInterface::SCOPE_WEBSITE, self::ADMIN_WEBSITE_ID, $adminTimeZone],
                 [ScopeInterface::SCOPE_WEBSITE, 1, $websiteTz],
                 [ScopeInterface::SCOPE_WEBSITE, 2, $websiteTz],
-                [ScopeInterface::SCOPE_WEBSITE, 3, $websiteTz],
+                [ScopeInterface::SCOPE_WEBSITE, 3, $websiteTz]
             ]);
 
         $batchRows = [
@@ -205,7 +220,7 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ],
             [
                 'rule_id' => 100,
@@ -217,7 +232,7 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ],
             [
                 'rule_id' => 100,
@@ -229,7 +244,7 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ],
             [
                 'rule_id' => 100,
@@ -241,40 +256,41 @@ class ReindexRuleProductTest extends TestCase
                 'action_operator' => 'simple_action',
                 'action_amount' => 43,
                 'action_stop' => true,
-                'sort_order' => 1,
+                'sort_order' => 1
             ]
         ];
 
-        $this->connectionMock->expects(self::at(0))
+        $this->connectionMock
             ->method('insertMultiple')
             ->with('catalogrule_product_replica', $batchRows);
 
         self::assertTrue($this->model->execute($this->ruleMock, 100, true));
     }
 
+    /**
+     * @return void
+     */
     private function prepareResourceMock(): void
     {
         $this->tableSwapperMock->expects(self::once())
             ->method('getWorkingTableName')
             ->with('catalogrule_product')
             ->willReturn('catalogrule_product_replica');
-        $this->resourceMock->expects(self::at(0))
+        $this->resourceMock
             ->method('getConnection')
             ->willReturn($this->connectionMock);
-        $this->resourceMock->expects(self::at(1))
+        $this->resourceMock
             ->method('getTableName')
-            ->with('catalogrule_product')
-            ->willReturn('catalogrule_product');
-        $this->resourceMock->expects(self::at(2))
-            ->method('getTableName')
-            ->with('catalogrule_product_replica')
-            ->willReturn('catalogrule_product_replica');
+            ->withConsecutive(['catalogrule_product'], ['catalogrule_product_replica'])
+            ->willReturnOnConsecutiveCalls('catalogrule_product', 'catalogrule_product_replica');
     }
 
     /**
      * @param array $websiteId
      * @param array $productIds
      * @param array $customerGroupIds
+     *
+     * @return void
      */
     private function prepareRuleMock(array $websiteId, array $productIds, array $customerGroupIds): void
     {

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/RuleProductPricesPersistorTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Indexer/RuleProductPricesPersistorTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\CatalogRule\Test\Unit\Model\Indexer;
 
 use Magento\Catalog\Model\ResourceModel\Indexer\ActiveTableSwitcher;
@@ -44,6 +43,9 @@ class RuleProductPricesPersistorTest extends TestCase
      */
     private $tableSwapperMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->dateTimeMock = $this->getMockBuilder(DateTime::class)
@@ -66,19 +68,25 @@ class RuleProductPricesPersistorTest extends TestCase
         );
     }
 
-    public function testExecuteWithEmptyPriceData()
+    /**
+    * @return void
+    */
+    public function testExecuteWithEmptyPriceData(): void
     {
         $this->assertFalse($this->model->execute([]));
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $priceData = [
             [
                 'product_id' => 1,
                 'rule_date' => '2017-05-01',
                 'latest_start_date' => '2017-05-10',
-                'earliest_end_date' => '2017-05-20',
+                'earliest_end_date' => '2017-05-20'
             ]
         ];
         $tableName = 'catalogrule_product_price_replica';
@@ -92,29 +100,23 @@ class RuleProductPricesPersistorTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($connectionMock);
-        $this->resourceMock->expects($this->at(1))
+        $this->resourceMock
             ->method('getTableName')
-            ->with('catalogrule_product_price')
-            ->willReturn('catalogrule_product_price');
-        $this->resourceMock->expects($this->at(2))
-            ->method('getTableName')
-            ->with($tableName)
-            ->willReturn($tableName);
+            ->withConsecutive(['catalogrule_product_price'], [$tableName])
+            ->willReturnOnConsecutiveCalls('catalogrule_product_price', $tableName);
 
-        $this->dateTimeMock->expects($this->at(0))
+        $this->dateTimeMock
             ->method('formatDate')
-            ->with($priceData[0]['rule_date'], false)
-            ->willReturn($priceData[0]['rule_date']);
-
-        $this->dateTimeMock->expects($this->at(1))
-            ->method('formatDate')
-            ->with($priceData[0]['latest_start_date'], false)
-            ->willReturn($priceData[0]['latest_start_date']);
-
-        $this->dateTimeMock->expects($this->at(2))
-            ->method('formatDate')
-            ->with($priceData[0]['earliest_end_date'], false)
-            ->willReturn($priceData[0]['earliest_end_date']);
+            ->withConsecutive(
+                [$priceData[0]['rule_date'], false],
+                [$priceData[0]['latest_start_date'], false],
+                [$priceData[0]['earliest_end_date'], false]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $priceData[0]['rule_date'],
+                $priceData[0]['latest_start_date'],
+                $priceData[0]['earliest_end_date']
+            );
 
         $connectionMock->expects($this->once())
             ->method('insertOnDuplicate')
@@ -123,7 +125,10 @@ class RuleProductPricesPersistorTest extends TestCase
         $this->assertTrue($this->model->execute($priceData, true));
     }
 
-    public function testExecuteWithException()
+    /**
+    * @return void
+    */
+    public function testExecuteWithException(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Insert error.');
@@ -132,7 +137,7 @@ class RuleProductPricesPersistorTest extends TestCase
                 'product_id' => 1,
                 'rule_date' => '2017-05-5',
                 'latest_start_date' => '2017-05-10',
-                'earliest_end_date' => '2017-05-22',
+                'earliest_end_date' => '2017-05-22'
             ]
         ];
         $tableName = 'catalogrule_product_price_replica';
@@ -142,20 +147,18 @@ class RuleProductPricesPersistorTest extends TestCase
             ->with('catalogrule_product_price')
             ->willReturn($tableName);
 
-        $this->dateTimeMock->expects($this->at(0))
+        $this->dateTimeMock
             ->method('formatDate')
-            ->with($priceData[0]['rule_date'], false)
-            ->willReturn($priceData[0]['rule_date']);
-
-        $this->dateTimeMock->expects($this->at(1))
-            ->method('formatDate')
-            ->with($priceData[0]['latest_start_date'], false)
-            ->willReturn($priceData[0]['latest_start_date']);
-
-        $this->dateTimeMock->expects($this->at(2))
-            ->method('formatDate')
-            ->with($priceData[0]['earliest_end_date'], false)
-            ->willReturn($priceData[0]['earliest_end_date']);
+            ->withConsecutive(
+                [$priceData[0]['rule_date'], false],
+                [$priceData[0]['latest_start_date'], false],
+                [$priceData[0]['earliest_end_date'], false]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $priceData[0]['rule_date'],
+                $priceData[0]['latest_start_date'],
+                $priceData[0]['earliest_end_date']
+            );
 
         $connectionMock = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
@@ -166,14 +169,10 @@ class RuleProductPricesPersistorTest extends TestCase
             ->willThrowException(new \Exception('Insert error.'));
 
         $this->resourceMock->expects($this->once())->method('getConnection')->willReturn($connectionMock);
-        $this->resourceMock->expects($this->at(1))
+        $this->resourceMock
             ->method('getTableName')
-            ->with('catalogrule_product_price')
-            ->willReturn('catalogrule_product_price');
-        $this->resourceMock->expects($this->at(2))
-            ->method('getTableName')
-            ->with($tableName)
-            ->willReturn($tableName);
+            ->withConsecutive(['catalogrule_product_price'], [$tableName])
+            ->willReturnOnConsecutiveCalls('catalogrule_product_price', $tableName);
 
         $this->assertTrue($this->model->execute($priceData, true));
     }

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/ResourceModel/SaveHandlerTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/ResourceModel/SaveHandlerTest.php
@@ -32,6 +32,9 @@ class SaveHandlerTest extends TestCase
      */
     protected $metadataMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->resourceMock = $this->createMock(Rule::class);
@@ -42,7 +45,10 @@ class SaveHandlerTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $linkedField = 'entity_id';
         $entityId = 100;
@@ -66,15 +72,13 @@ class SaveHandlerTest extends TestCase
             ->willReturn($metadataMock);
         $metadataMock->expects($this->once())->method('getLinkField')->willReturn($linkedField);
 
-        $this->resourceMock->expects($this->at(0))
+        $this->resourceMock
             ->method('bindRuleToEntity')
-            ->with($entityId, explode(',', (string)$websiteIds), 'website')
-            ->willReturnSelf();
-
-        $this->resourceMock->expects($this->at(1))
-            ->method('bindRuleToEntity')
-            ->with($entityId, explode(',', (string)$customerGroupIds), 'customer_group')
-            ->willReturnSelf();
+            ->withConsecutive(
+                [$entityId, explode(',', (string) $websiteIds), 'website'],
+                [$entityId, explode(',', (string)$customerGroupIds), 'customer_group']
+            )
+            ->willReturnOnConsecutiveCalls($this->resourceMock, $this->resourceMock);
 
         $this->assertEquals($entityData, $this->subject->execute($entityType, $entityData));
     }

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/Rule/Condition/ProductTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/Rule/Condition/ProductTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\CatalogRule\Test\Unit\Model\Rule\Condition;
 
 use Magento\Catalog\Model\ProductCategoryList;
@@ -18,27 +17,44 @@ use PHPUnit\Framework\TestCase;
 
 class ProductTest extends TestCase
 {
-    /** @var Product */
+    /**
+     * @var Product
+     */
     protected $product;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var Config|MockObject */
+    /**
+     * @var Config|MockObject
+     */
     protected $config;
 
-    /** @var \Magento\Catalog\Model\Product|MockObject */
+    /**
+     * @var \Magento\Catalog\Model\Product|MockObject
+     */
     protected $productModel;
 
-    /** @var \Magento\Catalog\Model\ResourceModel\Product|MockObject */
+    /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product|MockObject
+     */
     protected $productResource;
 
-    /** @var Attribute|MockObject */
+    /**
+     * @var Attribute|MockObject
+     */
     protected $eavAttributeResource;
 
-    /** @var ProductCategoryList|MockObject */
+    /**
+     * @var ProductCategoryList|MockObject
+     */
     private $productCategoryList;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->config = $this->createPartialMock(Config::class, ['getAttribute']);
@@ -53,7 +69,15 @@ class ProductTest extends TestCase
             ->getMock();
 
         $this->productResource = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Product::class)
-            ->setMethods(['loadAllAttributes', 'getAttributesByCode', 'getAttribute', 'getConnection', 'getTable'])
+            ->onlyMethods(
+                [
+                    'loadAllAttributes',
+                    'getAttributesByCode',
+                    'getAttribute',
+                    'getConnection',
+                    'getTable'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -98,7 +122,7 @@ class ProductTest extends TestCase
     /**
      * @return void
      */
-    public function testValidateMeetsCategory()
+    public function testValidateMeetsCategory(): void
     {
         $categoryIdList = [1, 2, 3];
 
@@ -111,16 +135,16 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @dataProvider validateDataProvider
-     *
      * @param string $attributeValue
      * @param string|array $parsedValue
      * @param string $newValue
      * @param string $operator
      * @param array $input
+     *
      * @return void
+     * @dataProvider validateDataProvider
      */
-    public function testValidateWithDatetimeValue($attributeValue, $parsedValue, $newValue, $operator, $input)
+    public function testValidateWithDatetimeValue($attributeValue, $parsedValue, $newValue, $operator, $input): void
     {
         $this->product->setData('attribute', 'attribute_key');
         $this->product->setData('value_parsed', $parsedValue);
@@ -136,10 +160,9 @@ class ProductTest extends TestCase
 
         $this->productModel->expects($this->any())->method('hasData')
             ->willReturn(true);
-        $this->productModel->expects($this->at(0))->method('getData')
-            ->willReturn(['1' => ['1' => $attributeValue]]);
-        $this->productModel->expects($this->any())->method('getData')
-            ->willReturn($newValue);
+        $this->productModel
+            ->method('getData')
+            ->willReturnOnConsecutiveCalls(['1' => ['1' => $attributeValue]], $newValue, $newValue);
         $this->productModel->expects($this->any())->method('getId')
             ->willReturn('1');
         $this->productModel->expects($this->once())->method('getStoreId')
@@ -157,7 +180,7 @@ class ProductTest extends TestCase
     /**
      * @return void
      */
-    public function testValidateWithNoValue()
+    public function testValidateWithNoValue(): void
     {
         $this->product->setData('attribute', 'color');
         $this->product->setData('value_parsed', '1');
@@ -173,7 +196,7 @@ class ProductTest extends TestCase
     /**
      * @return array
      */
-    public function validateDataProvider()
+    public function validateDataProvider(): array
     {
         return [
             [
@@ -181,7 +204,7 @@ class ProductTest extends TestCase
                 'parsed_value' => '12:12',
                 'new_value' => '12:13',
                 'operator' => '>=',
-                'input' => ['method' => 'getBackendType', 'type' => 'input_type'],
+                'input' => ['method' => 'getBackendType', 'type' => 'input_type']
             ],
             [
                 'attribute_value' => '1',

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
@@ -70,17 +70,17 @@ class RuleTest extends TestCase
     /**
      * @var RuleProductProcessor|MockObject
      */
-    private $_ruleProductProcessor;
+    private $ruleProductProcessor;
 
     /**
      * @var CollectionFactory|MockObject
      */
-    private $_productCollectionFactory;
+    private $productCollectionFactory;
 
     /**
      * @var Iterator|MockObject
      */
-    private $_resourceIterator;
+    private $resourceIterator;
 
     /**
      * @var Product|MockObject
@@ -88,9 +88,7 @@ class RuleTest extends TestCase
     private $productModel;
 
     /**
-     * Set up before test
-     *
-     * @return void
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -100,7 +98,7 @@ class RuleTest extends TestCase
         $this->combineFactory = $this->createPartialMock(
             CombineFactory::class,
             [
-                'create',
+                'create'
             ]
         );
         $this->productModel = $this->createPartialMock(
@@ -108,7 +106,7 @@ class RuleTest extends TestCase
             [
                 '__wakeup',
                 'getId',
-                'setData',
+                'setData'
             ]
         );
         $this->condition = $this->getMockBuilder(Combine::class)
@@ -121,19 +119,19 @@ class RuleTest extends TestCase
             [
                 '__wakeup',
                 'getId',
-                'getDefaultStore',
+                'getDefaultStore'
             ]
         );
-        $this->_ruleProductProcessor = $this->createMock(
+        $this->ruleProductProcessor = $this->createMock(
             RuleProductProcessor::class
         );
 
-        $this->_productCollectionFactory = $this->createPartialMock(
+        $this->productCollectionFactory = $this->createPartialMock(
             CollectionFactory::class,
             ['create']
         );
 
-        $this->_resourceIterator = $this->createPartialMock(
+        $this->resourceIterator = $this->createPartialMock(
             Iterator::class,
             ['walk']
         );
@@ -146,26 +144,25 @@ class RuleTest extends TestCase
             [
                 'storeManager' => $this->storeManager,
                 'combineFactory' => $this->combineFactory,
-                'ruleProductProcessor' => $this->_ruleProductProcessor,
-                'productCollectionFactory' => $this->_productCollectionFactory,
-                'resourceIterator' => $this->_resourceIterator,
+                'ruleProductProcessor' => $this->ruleProductProcessor,
+                'productCollectionFactory' => $this->productCollectionFactory,
+                'resourceIterator' => $this->resourceIterator,
                 'extensionFactory' => $extensionFactoryMock,
                 'customAttributeFactory' => $attributeValueFactoryMock,
-                'serializer' => $this->getSerializerMock(),
+                'serializer' => $this->getSerializerMock()
             ]
         );
     }
 
     /**
-     * Get mock for serializer
+     * Get mock for serializer.
      *
      * @return MockObject
      */
-    private function getSerializerMock()
+    private function getSerializerMock(): MockObject
     {
-        $serializerMock = $this->getMockBuilder(Json::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['serialize', 'unserialize'])
+        $serializerMock = $this->getMockBuilder(Json::class)->disableOriginalConstructor()
+            ->onlyMethods(['serialize', 'unserialize'])
             ->getMock();
 
         $serializerMock->expects($this->any())
@@ -188,12 +185,12 @@ class RuleTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderCallbackValidateProduct
      * @param bool $validate
      *
      * @return void
+     * @dataProvider dataProviderCallbackValidateProduct
      */
-    public function testCallbackValidateProduct($validate)
+    public function testCallbackValidateProduct($validate): void
     {
         $args['product'] = $this->productModel;
         $args['attributes'] = [];
@@ -207,20 +204,18 @@ class RuleTest extends TestCase
             'has_options' => '0',
             'required_options' => '0',
             'created_at' => '2014-06-25 13:14:30',
-            'updated_at' => '2014-06-25 14:37:15',
+            'updated_at' => '2014-06-25 14:37:15'
         ];
         $this->storeManager->expects($this->any())->method('getWebsites')->with(false)
             ->willReturn([$this->websiteModel, $this->websiteModel]);
-        $this->websiteModel->expects($this->at(0))->method('getId')
-            ->willReturn('1');
-        $this->websiteModel->expects($this->at(2))->method('getId')
-            ->willReturn('2');
+        $this->websiteModel
+            ->method('getId')
+            ->willReturnOnConsecutiveCalls('1', '2');
         $this->websiteModel->expects($this->any())->method('getDefaultStore')
             ->willReturn($this->storeModel);
-        $this->storeModel->expects($this->at(0))->method('getId')
-            ->willReturn('1');
-        $this->storeModel->expects($this->at(1))->method('getId')
-            ->willReturn('2');
+        $this->storeModel
+            ->method('getId')
+            ->willReturnOnConsecutiveCalls('1', '2');
         $this->combineFactory->expects($this->any())->method('create')
             ->willReturn($this->condition);
         $this->condition->expects($this->any())->method('validate')
@@ -238,122 +233,123 @@ class RuleTest extends TestCase
     }
 
     /**
-     * Data provider for callbackValidateProduct test
+     * Data provider for callbackValidateProduct test.
      *
      * @return array
      */
-    public function dataProviderCallbackValidateProduct()
+    public function dataProviderCallbackValidateProduct(): array
     {
         return [
             [false],
-            [true],
+            [true]
         ];
     }
 
     /**
-     * Test validateData action
+     * Test validateData action.
      *
-     * @dataProvider validateDataDataProvider
      * @param array $data Data for the rule actions
      * @param bool|array $expected True or an array of errors
      *
      * @return void
+     * @dataProvider validateDataDataProvider
      */
-    public function testValidateData($data, $expected)
+    public function testValidateData(array $data, $expected): void
     {
         $result = $this->rule->validateData(new DataObject($data));
         $this->assertEquals($result, $expected);
     }
 
     /**
-     * Data provider for testValidateData test
+     * Data provider for testValidateData test.
      *
      * @return array
      */
-    public function validateDataDataProvider()
+    public function validateDataDataProvider(): array
     {
         return [
             [
                 [
                     'simple_action' => 'by_fixed',
-                    'discount_amount' => '123',
+                    'discount_amount' => '123'
                 ],
-                true,
+                true
             ],
             [
                 [
                     'simple_action' => 'by_percent',
-                    'discount_amount' => '9,99',
+                    'discount_amount' => '9,99'
                 ],
-                true,
+                true
             ],
             [
                 [
                     'simple_action' => 'by_percent',
-                    'discount_amount' => '123.12',
+                    'discount_amount' => '123.12'
                 ],
                 [
-                    'Percentage discount should be between 0 and 100.',
-                ],
+                    'Percentage discount should be between 0 and 100.'
+                ]
             ],
             [
                 [
                     'simple_action' => 'to_percent',
-                    'discount_amount' => '-12',
+                    'discount_amount' => '-12'
                 ],
                 [
-                    'Percentage discount should be between 0 and 100.',
-                ],
+                    'Percentage discount should be between 0 and 100.'
+                ]
             ],
             [
                 [
                     'simple_action' => 'to_fixed',
-                    'discount_amount' => '-1234567890',
+                    'discount_amount' => '-1234567890'
                 ],
                 [
-                    'Discount value should be 0 or greater.',
-                ],
+                    'Discount value should be 0 or greater.'
+                ]
             ],
             [
                 [
                     'simple_action' => 'invalid action',
-                    'discount_amount' => '12',
+                    'discount_amount' => '12'
                 ],
                 [
-                    'Unknown action.',
-                ],
-            ],
+                    'Unknown action.'
+                ]
+            ]
         ];
     }
 
     /**
-     * Test after delete action
+     * Test after delete action.
      *
      * @return void
      */
-    public function testAfterDelete()
+    public function testAfterDelete(): void
     {
         $indexer = $this->getMockForAbstractClass(IndexerInterface::class);
         $indexer->expects($this->once())->method('invalidate');
-        $this->_ruleProductProcessor->expects($this->once())->method('getIndexer')->willReturn($indexer);
+        $this->ruleProductProcessor->expects($this->once())->method('getIndexer')->willReturn($indexer);
         $this->rule->afterDelete();
     }
 
     /**
      * Test after update action for active and deactivated rule.
      *
-     * @dataProvider afterUpdateDataProvider
      * @param int $active
+     *
      * @return void
+     * @dataProvider afterUpdateDataProvider
      */
-    public function testAfterUpdate(int $active)
+    public function testAfterUpdate(int $active): void
     {
         $this->rule->isObjectNew(false);
         $this->rule->setIsActive($active);
         $this->rule->setOrigData(RuleInterface::IS_ACTIVE, 1);
         $indexer = $this->getMockForAbstractClass(IndexerInterface::class);
         $indexer->expects($this->once())->method('invalidate');
-        $this->_ruleProductProcessor->expects($this->once())->method('getIndexer')->willReturn($indexer);
+        $this->ruleProductProcessor->expects($this->once())->method('getIndexer')->willReturn($indexer);
         $this->rule->afterSave();
     }
 
@@ -362,12 +358,12 @@ class RuleTest extends TestCase
      *
      * @return void
      */
-    public function testAfterUpdateInactiveRule()
+    public function testAfterUpdateInactiveRule(): void
     {
         $this->rule->isObjectNew(false);
         $this->rule->setIsActive(0);
         $this->rule->setOrigData(RuleInterface::IS_ACTIVE, 0);
-        $this->_ruleProductProcessor->expects($this->never())->method('getIndexer');
+        $this->ruleProductProcessor->expects($this->never())->method('getIndexer');
         $this->rule->afterSave();
     }
 
@@ -378,14 +374,12 @@ class RuleTest extends TestCase
     {
         return [
             ['active' => 0],
-            ['active' => 1],
+            ['active' => 1]
         ];
     }
 
     /**
      * Test isRuleBehaviorChanged action
-     *
-     * @dataProvider isRuleBehaviorChangedDataProvider
      *
      * @param array $dataArray
      * @param array $originDataArray
@@ -393,14 +387,19 @@ class RuleTest extends TestCase
      * @param bool $result
      *
      * @return void
+     * @dataProvider isRuleBehaviorChangedDataProvider
      */
-    public function testIsRuleBehaviorChanged($dataArray, $originDataArray, $isObjectNew, $result)
-    {
+    public function testIsRuleBehaviorChanged(
+        array $dataArray,
+        array $originDataArray,
+        bool $isObjectNew,
+        bool $result
+    ): void {
         $this->rule->setData('website_ids', []);
         $this->rule->isObjectNew($isObjectNew);
         $indexer = $this->getMockForAbstractClass(IndexerInterface::class);
         $indexer->expects($this->any())->method('invalidate');
-        $this->_ruleProductProcessor->expects($this->any())->method('getIndexer')->willReturn($indexer);
+        $this->ruleProductProcessor->expects($this->any())->method('getIndexer')->willReturn($indexer);
 
         foreach ($dataArray as $data) {
             $this->rule->setData($data);
@@ -414,11 +413,11 @@ class RuleTest extends TestCase
     }
 
     /**
-     * Data provider for testIsRuleBehaviorChanged test
+     * Data provider for testIsRuleBehaviorChanged test.
      *
      * @return array
      */
-    public function isRuleBehaviorChangedDataProvider()
+    public function isRuleBehaviorChangedDataProvider(): array
     {
         return [
             [['new name', 'new description'], ['name', 'description'], false, false],
@@ -426,11 +425,14 @@ class RuleTest extends TestCase
             [['name', 'important_data'], ['name', 'important_data'], false, false],
             [['name', 'new important_data'], ['name', 'important_data'], false, true],
             [['name', 'description'], ['name', 'description'], true, true],
-            [['name', 'description'], ['name', 'important_data'], true, true],
+            [['name', 'description'], ['name', 'important_data'], true, true]
         ];
     }
 
-    public function testGetConditionsFieldSetId()
+    /**
+    * @return void
+    */
+    public function testGetConditionsFieldSetId(): void
     {
         $formName = 'form_name';
         $this->rule->setId(100);
@@ -438,9 +440,12 @@ class RuleTest extends TestCase
         $this->assertEquals($expectedResult, $this->rule->getConditionsFieldSetId($formName));
     }
 
-    public function testReindex()
+    /**
+    * @return void
+    */
+    public function testReindex(): void
     {
-        $this->_ruleProductProcessor->expects($this->once())->method('reindexList');
+        $this->ruleProductProcessor->expects($this->once())->method('reindexList');
         $this->rule->reindex();
     }
 }

--- a/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Observer/AddDirtyRulesNoticeTest.php
@@ -27,6 +27,9 @@ class AddDirtyRulesNoticeTest extends TestCase
      */
     private $messageManagerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
@@ -36,24 +39,29 @@ class AddDirtyRulesNoticeTest extends TestCase
         $this->observer = $objectManagerHelper->getObject(
             AddDirtyRulesNotice::class,
             [
-                'messageManager' => $this->messageManagerMock,
+                'messageManager' => $this->messageManagerMock
             ]
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $message = "test";
         $flagMock = $this->getMockBuilder(Flag::class)
-            ->setMethods(['getState'])
+            ->addMethods(['getState'])
             ->disableOriginalConstructor()
             ->getMock();
         $eventObserverMock = $this->getMockBuilder(Observer::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $eventObserverMock->expects($this->at(0))->method('getData')->with('dirty_rules')->willReturn($flagMock);
         $flagMock->expects($this->once())->method('getState')->willReturn(1);
-        $eventObserverMock->expects($this->at(1))->method('getData')->with('message')->willReturn($message);
+        $eventObserverMock
+            ->method('getData')
+            ->withConsecutive(['dirty_rules'], ['message'])
+            ->willReturnOnConsecutiveCalls($flagMock, $message);
         $this->messageManagerMock->expects($this->once())->method('addNoticeMessage')->with($message);
         $this->observer->execute($eventObserverMock);
     }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/OptionsTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Adapter/OptionsTest.php
@@ -10,7 +10,6 @@ namespace Magento\CatalogSearch\Test\Unit\Model\Adapter;
 use Magento\CatalogSearch\Model\Adapter\Options;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
-use Magento\Store\Model\ScopeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -26,12 +25,15 @@ class OptionsTest extends TestCase
      */
     private $options;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
 
         $this->scopeConfig = $this->getMockBuilder(ScopeConfigInterface::class)
-            ->setMethods(['getValue'])
+            ->onlyMethods(['getValue'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -43,7 +45,10 @@ class OptionsTest extends TestCase
         );
     }
 
-    public function testGet()
+    /**
+    * @return void
+    */
+    public function testGet(): void
     {
         $expectedResult = [
             'interval_division_limit' => 15,
@@ -52,18 +57,13 @@ class OptionsTest extends TestCase
             'max_intervals_number' => 33
         ];
 
-        $this->scopeConfig->expects($this->at(0))
+        $this->scopeConfig
             ->method('getValue')
-            ->withConsecutive([Options::XML_PATH_INTERVAL_DIVISION_LIMIT, ScopeInterface::SCOPE_STORE])
-            ->willReturn($expectedResult['interval_division_limit']);
-        $this->scopeConfig->expects($this->at(1))
-            ->method('getValue')
-            ->withConsecutive([Options::XML_PATH_RANGE_STEP, ScopeInterface::SCOPE_STORE])
-            ->willReturn($expectedResult['range_step']);
-        $this->scopeConfig->expects($this->at(2))
-            ->method('getValue')
-            ->withConsecutive([Options::XML_PATH_RANGE_MAX_INTERVALS, ScopeInterface::SCOPE_STORE])
-            ->willReturn($expectedResult['max_intervals_number']);
+            ->willReturnOnConsecutiveCalls(
+                $expectedResult['interval_division_limit'],
+                $expectedResult['range_step'],
+                $expectedResult['max_intervals_number']
+            );
 
         $this->options->get();
     }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Advanced/Request/BuilderTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Advanced/Request/BuilderTest.php
@@ -55,19 +55,22 @@ class BuilderTest extends TestCase
      */
     private $cleaner;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $helper = new ObjectManager($this);
 
         $this->config = $this->getMockBuilder(Config::class)
-            ->setMethods(['get'])
+            ->onlyMethods(['get'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
         $this->requestMapper = $this->getMockBuilder(Mapper::class)
-            ->setMethods(['getRootQuery', 'getBuckets'])
+            ->onlyMethods(['getRootQuery', 'getBuckets'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -76,12 +79,12 @@ class BuilderTest extends TestCase
             ->getMock();
 
         $this->binder = $this->getMockBuilder(Binder::class)
-            ->setMethods(['bind'])
+            ->onlyMethods(['bind'])
             ->disableOriginalConstructor()
             ->getMock();
 
         $this->cleaner = $this->getMockBuilder(Cleaner::class)
-            ->setMethods(['clean'])
+            ->onlyMethods(['clean'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -99,25 +102,25 @@ class BuilderTest extends TestCase
     /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $data = [
             'dimensions' => [
                 'scope' => [
                     'name' => 'scope',
-                    'value' => 'default',
-                ],
+                    'value' => 'default'
+                ]
             ],
             'queries' => [
                 'filter_search_query' => [
                     'name' => 'filter_search_query',
                     'filterReference' => [
                         [
-                            'ref' => 'boolFilter',
-                        ],
+                            'ref' => 'boolFilter'
+                        ]
                     ],
-                    'type' => 'filteredQuery',
-                ],
+                    'type' => 'filteredQuery'
+                ]
             ],
             'filters' => [
                 'boolFilter' => [
@@ -125,56 +128,56 @@ class BuilderTest extends TestCase
                     'filterReference' => [
                         [
                             'clause' => 'should',
-                            'ref' => 'from_to',
+                            'ref' => 'from_to'
                         ],
                         [
                             'clause' => 'should',
-                            'ref' => 'not_array',
+                            'ref' => 'not_array'
                         ],
                         [
                             'clause' => 'should',
-                            'ref' => 'like',
-                        ],
+                            'ref' => 'like'
+                        ]
                     ],
-                    'type' => 'boolFilter',
+                    'type' => 'boolFilter'
                 ],
                 'from_to' => [
                     'name' => 'from_to',
                     'field' => 'product_id',
                     'type' => 'rangeFilter',
                     'from' => '$from_to.from$',
-                    'to' => '$from_to.to$',
+                    'to' => '$from_to.to$'
                 ],
                 'not_array' => [
                     'name' => 'not_array',
                     'field' => 'product_id',
                     'type' => 'termFilter',
-                    'value' => '$not_array$',
+                    'value' => '$not_array$'
                 ],
                 'like' => [
                     'name' => 'like',
                     'field' => 'product_id',
                     'type' => 'wildcardFilter',
-                    'value' => '$like$',
+                    'value' => '$like$'
                 ],
                 'in' => [
                     'name' => 'in',
                     'field' => 'product_id',
                     'type' => 'termFilter',
-                    'value' => '$in$',
+                    'value' => '$in$'
                 ],
                 'in_set' => [
                     'name' => 'in_set',
                     'field' => 'product_id',
                     'type' => 'termFilter',
-                    'value' => '$in_set$',
-                ],
+                    'value' => '$in_set$'
+                ]
             ],
             'from' => '10',
             'size' => '10',
             'query' => 'one_match_filters',
             'index' => 'catalogsearch_fulltext',
-            'aggregations' => [],
+            'aggregations' => []
         ];
         $requestName = 'rn';
         $bindData = [
@@ -185,7 +188,7 @@ class BuilderTest extends TestCase
                 '$not_array$' => 130,
                 '$like$' => 'search_text',
                 '$in$' => 23,
-                '$in_set$' => [12, 23, 34, 45],
+                '$in_set$' => [12, 23, 34, 45]
             ],
             'requestName' => $requestName,
             'from' => 10,
@@ -210,12 +213,9 @@ class BuilderTest extends TestCase
         $this->requestMapper->expects($this->once())
             ->method('getRootQuery')
             ->willReturn([]);
-        $this->objectManager->expects($this->at(0))
+        $this->objectManager
             ->method('create')
-            ->willReturn($this->requestMapper);
-        $this->objectManager->expects($this->at(2))
-            ->method('create')
-            ->willReturn($this->request);
+            ->willReturnOnConsecutiveCalls($this->requestMapper, null, $this->request);
         $this->config->expects($this->once())
             ->method('get')
             ->with($requestName)

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/AttributeTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/AttributeTest.php
@@ -37,61 +37,81 @@ class AttributeTest extends TestCase
      */
     private $target;
 
-    /** @var AbstractFrontend|MockObject */
+    /**
+     * @var AbstractFrontend|MockObject
+     */
     private $frontend;
 
-    /** @var Collection|MockObject */
+    /**
+     * @var Collection|MockObject
+     */
     private $fulltextCollection;
 
-    /** @var State|MockObject */
+    /**
+     * @var State|MockObject
+     */
     private $state;
 
-    /** @var EavAttribute|MockObject */
+    /**
+     * @var EavAttribute|MockObject
+     */
     private $attribute;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var AttributeFactory|MockObject */
+    /**
+     * @var AttributeFactory|MockObject
+     */
     private $filterAttributeFactory;
 
-    /** @var ItemFactory|MockObject */
+    /**
+     * @var ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
-    /** @var StoreManagerInterface|MockObject */
+    /**
+     * @var StoreManagerInterface|MockObject
+     */
     private $storeManager;
 
-    /** @var Layer|MockObject */
+    /**
+     * @var Layer|MockObject
+     */
     private $layer;
 
-    /** @var  DataBuilder|MockObject */
+    /**
+     * @var  DataBuilder|MockObject
+     */
     private $itemDataBuilder;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         /** @var ItemFactory $filterItemFactory */
         $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         /** @var StoreManagerInterface $storeManager */
         $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         /** @var Layer $layer */
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState', 'getProductCollection'])
+            ->onlyMethods(['getState', 'getProductCollection'])
             ->getMock();
         $this->fulltextCollection =
             $this->getMockBuilder(Collection::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['addFieldToFilter', 'getFacetedData', 'getSize'])
+                ->onlyMethods(['addFieldToFilter', 'getFacetedData', 'getSize'])
                 ->getMock();
         $this->layer->expects($this->atLeastOnce())
             ->method('getProductCollection')
@@ -99,17 +119,17 @@ class AttributeTest extends TestCase
         /** @var DataBuilder $itemDataBuilder */
         $this->itemDataBuilder = $this->getMockBuilder(DataBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItemData', 'build'])
+            ->onlyMethods(['addItemData', 'build'])
             ->getMock();
 
         $this->filterAttributeFactory = $this->getMockBuilder(AttributeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->state = $this->getMockBuilder(State::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFilter'])
+            ->onlyMethods(['addFilter'])
             ->getMock();
         $this->layer->expects($this->any())
             ->method('getState')
@@ -117,7 +137,7 @@ class AttributeTest extends TestCase
 
         $this->frontend = $this->getMockBuilder(AbstractFrontend::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getOption', 'getSelectOptions'])
+            ->onlyMethods(['getOption', 'getSelectOptions'])
             ->getMock();
         $this->attribute = $this->getMockBuilder(EavAttribute::class)
             ->disableOriginalConstructor()
@@ -125,17 +145,17 @@ class AttributeTest extends TestCase
                 'getAttributeCode',
                 'getFrontend',
                 'getIsFilterable',
-                'getBackendType',
+                'getBackendType'
             ])
             ->getMock();
 
         $this->request = $this->getMockBuilder(RequestInterface::class)
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->getMockForAbstractClass();
 
         $stripTagsFilter = $this->getMockBuilder(StripTags::class)
             ->disableOriginalConstructor()
-            ->setMethods(['filter'])
+            ->onlyMethods(['filter'])
             ->getMock();
         $stripTagsFilter->expects($this->any())
             ->method('filter')
@@ -150,17 +170,18 @@ class AttributeTest extends TestCase
                 'layer' => $this->layer,
                 'itemDataBuilder' => $this->itemDataBuilder,
                 'filterAttributeFactory' => $this->filterAttributeFactory,
-                'tagFilter' => $stripTagsFilter,
+                'tagFilter' => $stripTagsFilter
             ]
         );
     }
 
     /**
-     * @dataProvider attributeDataProvider
      * @param array $attributeData
+     *
      * @return void
+     * @dataProvider attributeDataProvider
      */
-    public function testApplyFilter(array $attributeData)
+    public function testApplyFilter(array $attributeData): void
     {
         $this->attribute->expects($this->exactly(2))
             ->method('getAttributeCode')
@@ -194,11 +215,13 @@ class AttributeTest extends TestCase
             ->willReturn($attributeData['attribute_label']);
 
         $filterItem = $this->createFilterItem(
-            0,
             $attributeData['attribute_label'],
             $attributeData['attribute_value'],
             0
         );
+        $this->filterItemFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($filterItem);
 
         $filterItem->expects($this->once())
             ->method('setFilter')
@@ -241,21 +264,24 @@ class AttributeTest extends TestCase
                     'attribute_code' => 'attributeCode',
                     'attribute_value' => 'attributeValue',
                     'attribute_label' => 'attributeLabel',
-                    'backend_type' => 'text',
-                ],
+                    'backend_type' => 'text'
+                ]
             ],
             'Attribute with \'int\' backend type' => [
                 [
                     'attribute_code' => 'attributeCode',
                     'attribute_value' => '0',
                     'attribute_label' => 'attributeLabel',
-                    'backend_type' => 'int',
-                ],
-            ],
+                    'backend_type' => 'int'
+                ]
+            ]
         ];
     }
 
-    public function testGetItemsWithApply()
+    /**
+    * @return void
+    */
+    public function testGetItemsWithApply(): void
     {
         $attributeCode = 'attributeCode';
         $attributeValue = 'attributeValue';
@@ -283,7 +309,11 @@ class AttributeTest extends TestCase
             ->method('getOption')
             ->with($attributeValue)
             ->willReturn($attributeLabel);
-        $filterItem = $this->createFilterItem(0, $attributeLabel, $attributeValue, 0);
+        $filterItem = $this->createFilterItem($attributeLabel, $attributeValue, 0);
+
+        $this->filterItemFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($filterItem);
 
         $this->state->expects($this->once())
             ->method('addFilter')
@@ -297,50 +327,51 @@ class AttributeTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetItemsWithoutApply()
+    public function testGetItemsWithoutApply(): void
     {
         $attributeCode = 'attributeCode';
         $selectedOptions = [
             [
                 'label' => 'selectedOptionLabel1',
                 'value' => 'selectedOptionValue1',
-                'count' => 25,
+                'count' => 25
             ],
             [
                 'label' => 'selectedOptionLabel2',
                 'value' => 'selectedOptionValue2',
-                'count' => 13,
+                'count' => 13
             ],
             [
                 'label' => 'selectedOptionLabel3',
                 'value' => 'selectedOptionValue3',
-                'count' => 10,
-            ],
+                'count' => 10
+            ]
         ];
         $facetedData = [
             'selectedOptionValue1' => ['count' => 10],
             'selectedOptionValue2' => ['count' => 45],
-            'selectedOptionValue3' => ['count' => 50],
+            'selectedOptionValue3' => ['count' => 50]
         ];
 
         $builtData = [
             [
                 'label' => $selectedOptions[0]['label'],
                 'value' => $selectedOptions[0]['value'],
-                'count' => $facetedData[$selectedOptions[0]['value']]['count'],
+                'count' => $facetedData[$selectedOptions[0]['value']]['count']
             ],
             [
                 'label' => $selectedOptions[1]['label'],
                 'value' => $selectedOptions[1]['value'],
-                'count' => $facetedData[$selectedOptions[1]['value']]['count'],
+                'count' => $facetedData[$selectedOptions[1]['value']]['count']
             ],
             [
                 'label' => $selectedOptions[2]['label'],
                 'value' => $selectedOptions[2]['value'],
-                'count' => $facetedData[$selectedOptions[2]['value']]['count'],
-            ],
+                'count' => $facetedData[$selectedOptions[2]['value']]['count']
+            ]
         ];
 
         $this->attribute->expects($this->exactly(2))
@@ -360,29 +391,33 @@ class AttributeTest extends TestCase
             ->method('getFacetedData')
             ->willReturn($facetedData);
 
-        $this->itemDataBuilder->expects($this->at(0))
+        $this->itemDataBuilder
             ->method('addItemData')
-            ->with(
-                $selectedOptions[0]['label'],
-                $selectedOptions[0]['value'],
-                $facetedData[$selectedOptions[0]['value']]['count']
-            )->willReturnSelf();
-        $this->itemDataBuilder->expects($this->at(1))
-            ->method('addItemData')
-            ->with(
-                $selectedOptions[1]['label'],
-                $selectedOptions[1]['value'],
-                $facetedData[$selectedOptions[1]['value']]['count']
-            )->willReturnSelf();
+            ->withConsecutive(
+                [
+                    $selectedOptions[0]['label'],
+                    $selectedOptions[0]['value'],
+                    $facetedData[$selectedOptions[0]['value']]['count']
+                ], [
+                    $selectedOptions[1]['label'],
+                    $selectedOptions[1]['value'],
+                    $facetedData[$selectedOptions[1]['value']]['count']
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($this->itemDataBuilder, $this->itemDataBuilder);
+
         $this->itemDataBuilder->expects($this->once())
             ->method('build')
             ->willReturn($builtData);
 
         $expectedFilterItems = [
-            $this->createFilterItem(0, $builtData[0]['label'], $builtData[0]['value'], $builtData[0]['count']),
-            $this->createFilterItem(1, $builtData[1]['label'], $builtData[1]['value'], $builtData[1]['count']),
-            $this->createFilterItem(2, $builtData[2]['label'], $builtData[2]['value'], $builtData[2]['count']),
+            $this->createFilterItem($builtData[0]['label'], $builtData[0]['value'], $builtData[0]['count']),
+            $this->createFilterItem($builtData[1]['label'], $builtData[1]['value'], $builtData[1]['count']),
+            $this->createFilterItem($builtData[2]['label'], $builtData[2]['value'], $builtData[2]['count'])
         ];
+        $this->filterItemFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(...$expectedFilterItems);
 
         $result = $this->target->getItems();
 
@@ -390,31 +425,32 @@ class AttributeTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetItemsOnlyWithResults()
+    public function testGetItemsOnlyWithResults(): void
     {
         $attributeCode = 'attributeCode';
         $selectedOptions = [
             [
                 'label' => 'selectedOptionLabel1',
-                'value' => 'selectedOptionValue1',
+                'value' => 'selectedOptionValue1'
             ],
             [
                 'label' => 'selectedOptionLabel2',
-                'value' => 'selectedOptionValue2',
-            ],
+                'value' => 'selectedOptionValue2'
+            ]
         ];
         $facetedData = [
             'selectedOptionValue1' => ['count' => 10],
-            'selectedOptionValue2' => ['count' => 0],
+            'selectedOptionValue2' => ['count' => 0]
         ];
         $builtData = [
             [
                 'label' => $selectedOptions[0]['label'],
                 'value' => $selectedOptions[0]['value'],
-                'count' => $facetedData[$selectedOptions[0]['value']]['count'],
-            ],
+                'count' => $facetedData[$selectedOptions[0]['value']]['count']
+            ]
         ];
 
         $this->attribute->expects($this->atLeastOnce())
@@ -450,17 +486,22 @@ class AttributeTest extends TestCase
             ->willReturn($builtData);
 
         $expectedFilterItems = [
-            $this->createFilterItem(0, $builtData[0]['label'], $builtData[0]['value'], $builtData[0]['count']),
+            $this->createFilterItem($builtData[0]['label'], $builtData[0]['value'], $builtData[0]['count'])
         ];
+        $this->filterItemFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($expectedFilterItems[0]);
+
         $result = $this->target->getItems();
 
         $this->assertEquals($expectedFilterItems, $result);
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetItemsIfFacetedDataIsEmpty()
+    public function testGetItemsIfFacetedDataIsEmpty(): void
     {
         $attributeCode = 'attributeCode';
 
@@ -485,17 +526,17 @@ class AttributeTest extends TestCase
     }
 
     /**
-     * @param int $index
      * @param string $label
      * @param string $value
      * @param int $count
+     *
      * @return Item|MockObject
      */
-    private function createFilterItem($index, $label, $value, $count)
+    private function createFilterItem($label, $value, $count): MockObject
     {
         $filterItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+            ->addMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
             ->getMock();
 
         $filterItem->expects($this->once())
@@ -513,10 +554,6 @@ class AttributeTest extends TestCase
         $filterItem->expects($this->once())
             ->method('setCount')
             ->with($count)->willReturnSelf();
-
-        $this->filterItemFactory->expects($this->at($index))
-            ->method('create')
-            ->willReturn($filterItem);
 
         return $filterItem;
     }

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/CategoryTest.php
@@ -26,6 +26,9 @@ use PHPUnit\Framework\TestCase;
  */
 class CategoryTest extends TestCase
 {
+    /**
+     * @var DataBuilder|MockObject
+     */
     private $itemDataBuilder;
 
     /**
@@ -53,27 +56,33 @@ class CategoryTest extends TestCase
      */
     private $target;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var  ItemFactory|MockObject */
+    /**
+     * @var ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->getMockForAbstractClass();
 
-        $dataProviderFactory = $this->getMockBuilder(
-            CategoryFactory::class
-        )->disableOriginalConstructor()
-            ->setMethods(['create'])->getMock();
+        $dataProviderFactory = $this->getMockBuilder(CategoryFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])->getMock();
 
         $this->dataProvider = $this->getMockBuilder(\Magento\Catalog\Model\Layer\Filter\DataProvider\Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setCategoryId', 'getCategory'])
+            ->onlyMethods(['setCategoryId', 'getCategory'])
             ->getMock();
 
         $dataProviderFactory->expects($this->once())
@@ -82,23 +91,21 @@ class CategoryTest extends TestCase
 
         $this->category = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getChildrenCategories', 'getIsActive'])
+            ->onlyMethods(['getId', 'getChildrenCategories', 'getIsActive'])
             ->getMock();
 
         $this->dataProvider->expects($this->any())
-            ->method('getCategory', 'isValid')
+            ->method('getCategory')
             ->willReturn($this->category);
 
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState', 'getProductCollection'])
+            ->onlyMethods(['getState', 'getProductCollection'])
             ->getMock();
 
-        $this->fulltextCollection = $this->getMockBuilder(
-            Collection::class
-        )
+        $this->fulltextCollection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addCategoryFilter', 'getFacetedData', 'getSize'])
+            ->onlyMethods(['addCategoryFilter', 'getFacetedData', 'getSize'])
             ->getMock();
 
         $this->layer->expects($this->any())
@@ -107,21 +114,17 @@ class CategoryTest extends TestCase
 
         $this->itemDataBuilder = $this->getMockBuilder(DataBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItemData', 'build'])
+            ->onlyMethods(['addItemData', 'build'])
             ->getMock();
 
-        $this->filterItemFactory = $this->getMockBuilder(
-            ItemFactory::class
-        )
+        $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $filterItem = $this->getMockBuilder(
-            Item::class
-        )
+        $filterItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+            ->addMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
             ->getMock();
         $filterItem->expects($this->any())
             ->method($this->anything())->willReturnSelf();
@@ -131,7 +134,7 @@ class CategoryTest extends TestCase
 
         $escaper = $this->getMockBuilder(Escaper::class)
             ->disableOriginalConstructor()
-            ->setMethods(['escapeHtml'])
+            ->onlyMethods(['escapeHtml'])
             ->getMock();
         $escaper->expects($this->any())
             ->method('escapeHtml')
@@ -145,7 +148,7 @@ class CategoryTest extends TestCase
                 'layer' => $this->layer,
                 'itemDataBuilder' => $this->itemDataBuilder,
                 'filterItemFactory' => $this->filterItemFactory,
-                'escaper' => $escaper,
+                'escaper' => $escaper
             ]
         );
     }
@@ -154,28 +157,20 @@ class CategoryTest extends TestCase
      * @param $requestValue
      * @param $idValue
      * @param $isIdUsed
+     *
+     * @return void
      * @dataProvider applyWithEmptyRequestDataProvider
      */
-    public function testApplyWithEmptyRequest($requestValue, $idValue)
+    public function testApplyWithEmptyRequest($requestValue, $idValue): void
     {
         $requestField = 'test_request_var';
         $idField = 'id';
 
         $this->target->setRequestVar($requestField);
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with($requestField)
-            ->willReturnCallback(
-                function ($field) use ($requestField, $idField, $requestValue, $idValue) {
-                    switch ($field) {
-                        case $requestField:
-                            return $requestValue;
-                        case $idField:
-                            return $idValue;
-                    }
-                }
-            );
+            ->withConsecutive([$requestField]);
 
         $result = $this->target->apply($this->request);
         $this->assertSame($this->target, $result);
@@ -184,25 +179,28 @@ class CategoryTest extends TestCase
     /**
      * @return array
      */
-    public function applyWithEmptyRequestDataProvider()
+    public function applyWithEmptyRequestDataProvider(): array
     {
         return [
             [
                 'requestValue' => null,
-                'id' => 0,
+                'id' => 0
             ],
             [
                 'requestValue' => 0,
-                'id' => false,
+                'id' => false
             ],
             [
                 'requestValue' => 0,
-                'id' => null,
+                'id' => null
             ]
         ];
     }
 
-    public function testApply()
+    /**
+    * @return void
+    */
+    public function testApply(): void
     {
         $categoryId = 123;
         $requestVar = 'test_request_var';
@@ -233,9 +231,10 @@ class CategoryTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetItems()
+    public function testGetItems(): void
     {
         $this->category->expects($this->any())
             ->method('getIsActive')
@@ -243,7 +242,7 @@ class CategoryTest extends TestCase
 
         $category1 = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getName', 'getIsActive'])
+            ->onlyMethods(['getId', 'getName', 'getIsActive'])
             ->getMock();
         $category1->expects($this->atLeastOnce())
             ->method('getId')
@@ -257,7 +256,7 @@ class CategoryTest extends TestCase
 
         $category2 = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getName', 'getIsActive'])
+            ->onlyMethods(['getId', 'getName', 'getIsActive'])
             ->getMock();
         $category2->expects($this->atLeastOnce())
             ->method('getId')
@@ -271,7 +270,7 @@ class CategoryTest extends TestCase
 
         $category3 = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getId', 'getName', 'getIsActive'])
+            ->onlyMethods(['getId', 'getName', 'getIsActive'])
             ->getMock();
         $category3->expects($this->atLeastOnce())
             ->method('getId')
@@ -285,7 +284,7 @@ class CategoryTest extends TestCase
         $categories = [
             $category1,
             $category2,
-            $category3,
+            $category3
         ];
         $this->category->expects($this->once())
             ->method('getChildrenCategories')
@@ -310,31 +309,19 @@ class CategoryTest extends TestCase
             [
                 'label' => 'Category 1',
                 'value' => 120,
-                'count' => 10,
+                'count' => 10
             ],
             [
                 'label' => 'Category 2',
                 'value' => 5641,
-                'count' => 45,
-            ],
+                'count' => 45
+            ]
         ];
 
-        $this->itemDataBuilder->expects($this->at(0))
+        $this->itemDataBuilder
             ->method('addItemData')
-            ->with(
-                'Category 1',
-                120,
-                10
-            )
-            ->willReturnSelf();
-        $this->itemDataBuilder->expects($this->at(1))
-            ->method('addItemData')
-            ->with(
-                'Category 2',
-                5641,
-                45
-            )
-            ->willReturnSelf();
+            ->withConsecutive(['Category 1', 120, 10], ['Category 2', 5641, 45])
+            ->willReturnOnConsecutiveCalls($this->itemDataBuilder, $this->itemDataBuilder);
         $this->itemDataBuilder->expects($this->once())
             ->method('build')
             ->willReturn($builtData);

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/Layer/Filter/DecimalTest.php
@@ -25,6 +25,9 @@ use PHPUnit\Framework\TestCase;
  */
 class DecimalTest extends TestCase
 {
+    /**
+     * @var Item|MockObject
+     */
     private $filterItem;
 
     /**
@@ -42,41 +45,48 @@ class DecimalTest extends TestCase
      */
     private $target;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var  State|MockObject */
+    /**
+     * @var State|MockObject
+     */
     private $state;
 
-    /** @var  ItemFactory|MockObject */
+    /**
+     * @var ItemFactory|MockObject
+     */
     private $filterItemFactory;
 
-    /** @var  Attribute|MockObject */
+    /**
+     * @var Attribute|MockObject
+     */
     private $attribute;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getParam'])
+            ->onlyMethods(['getParam'])
             ->getMockForAbstractClass();
 
         $this->layer = $this->getMockBuilder(Layer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getState', 'getProductCollection'])
+            ->onlyMethods(['getState', 'getProductCollection'])
             ->getMock();
-        $this->filterItemFactory = $this->getMockBuilder(
-            ItemFactory::class
-        )
+        $this->filterItemFactory = $this->getMockBuilder(ItemFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
-        $this->filterItem = $this->getMockBuilder(
-            Item::class
-        )
+        $this->filterItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
+            ->addMethods(['setFilter', 'setLabel', 'setValue', 'setCount'])
             ->getMock();
         $this->filterItem->expects($this->any())
             ->method($this->anything())->willReturnSelf();
@@ -97,11 +107,11 @@ class DecimalTest extends TestCase
         $filterDecimalFactory =
             $this->getMockBuilder(DecimalFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $resource = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Layer\Filter\Decimal::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMock();
         $filterDecimalFactory->expects($this->once())
             ->method('create')
@@ -109,12 +119,13 @@ class DecimalTest extends TestCase
 
         $this->attribute = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAttributeCode', 'getFrontend', 'getIsFilterable'])
+            ->onlyMethods(['getAttributeCode', 'getFrontend'])
+            ->addMethods(['getIsFilterable'])
             ->getMock();
 
         $this->state = $this->getMockBuilder(State::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addFilter'])
+            ->onlyMethods(['addFilter'])
             ->getMock();
         $this->layer->expects($this->any())
             ->method('getState')
@@ -126,7 +137,7 @@ class DecimalTest extends TestCase
             [
                 'filterItemFactory' => $this->filterItemFactory,
                 'layer' => $this->layer,
-                'filterDecimalFactory' => $filterDecimalFactory,
+                'filterDecimalFactory' => $filterDecimalFactory
             ]
         );
 
@@ -134,31 +145,22 @@ class DecimalTest extends TestCase
     }
 
     /**
-     * @param $requestValue
-     * @param $idValue
-     * @param $isIdUsed
+     * @param int|null $requestValue
+     * @param int|null|bool $idValue
+     *
+     * @return void
      * @dataProvider applyWithEmptyRequestDataProvider
      */
-    public function testApplyWithEmptyRequest($requestValue, $idValue)
+    public function testApplyWithEmptyRequest(?int $requestValue, $idValue): void
     {
         $requestField = 'test_request_var';
         $idField = 'id';
 
         $this->target->setRequestVar($requestField);
 
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with($requestField)
-            ->willReturnCallback(
-                function ($field) use ($requestField, $idField, $requestValue, $idValue) {
-                    switch ($field) {
-                        case $requestField:
-                            return $requestValue;
-                        case $idField:
-                            return $idValue;
-                    }
-                }
-            );
+            ->with($requestField);
 
         $result = $this->target->apply($this->request);
         $this->assertSame($this->target, $result);
@@ -167,25 +169,28 @@ class DecimalTest extends TestCase
     /**
      * @return array
      */
-    public function applyWithEmptyRequestDataProvider()
+    public function applyWithEmptyRequestDataProvider(): array
     {
         return [
             [
                 'requestValue' => null,
-                'id' => 0,
+                'id' => 0
             ],
             [
                 'requestValue' => 0,
-                'id' => false,
+                'id' => false
             ],
             [
                 'requestValue' => 0,
-                'id' => null,
+                'id' => null
             ]
         ];
     }
 
-    public function testApply()
+    /**
+    * @return void
+    */
+    public function testApply(): void
     {
         $filter = '10-150';
         $requestVar = 'test_request_var';
@@ -212,7 +217,10 @@ class DecimalTest extends TestCase
         $this->target->apply($this->request);
     }
 
-    public function testItemData()
+    /**
+    * @return void
+    */
+    public function testItemData(): void
     {
         $this->fulltextCollection->expects($this->any())
             ->method('getSize')

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/ChildrenCategoriesProviderTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Category/ChildrenCategoriesProviderTest.php
@@ -18,35 +18,57 @@ use PHPUnit\Framework\TestCase;
 
 class ChildrenCategoriesProviderTest extends TestCase
 {
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $category;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $select;
 
-    /** @var MockObject */
+    /**
+     * @var MockObject
+     */
     protected $connection;
 
-    /** @var ChildrenCategoriesProvider */
+    /**
+     * @var ChildrenCategoriesProvider
+     */
     protected $childrenCategoriesProvider;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->category = $this->getMockBuilder(Category::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getPath', 'getResourceCollection', 'getResource', 'getLevel', '__wakeup', 'isObjectNew'])
+            ->onlyMethods(
+                [
+                    'getPath',
+                    'getResourceCollection',
+                    'getResource',
+                    'getLevel',
+                    '__wakeup',
+                    'isObjectNew'
+                ]
+            )
             ->getMock();
-        $categoryCollection = $this->getMockBuilder(
-            AbstractCollection::class
-        )->disableOriginalConstructor()
-            ->setMethods(['addAttributeToSelect', 'addIdFilter'])->getMock();
+        $categoryCollection = $this->getMockBuilder(AbstractCollection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['addAttributeToSelect'])
+            ->addMethods(['addIdFilter'])
+            ->getMock();
         $this->category->expects($this->any())->method('getPath')->willReturn('category-path');
         $this->category->expects($this->any())->method('getResourceCollection')->willReturn($categoryCollection);
         $categoryCollection->expects($this->any())->method('addAttributeToSelect')->willReturnSelf();
         $categoryCollection->expects($this->any())->method('addIdFilter')->with(['id'])->willReturnSelf();
         $this->select = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
-            ->setMethods(['from', 'where', 'deleteFromSelect'])->getMock();
+            ->onlyMethods(['where', 'deleteFromSelect', 'from'])
+            ->getMock();
         $this->connection = $this->getMockForAbstractClass(AdapterInterface::class);
         $categoryResource = $this->getMockBuilder(\Magento\Catalog\Model\ResourceModel\Category::class)
             ->disableOriginalConstructor()
@@ -62,7 +84,10 @@ class ChildrenCategoriesProviderTest extends TestCase
         );
     }
 
-    public function testGetChildrenRecursive()
+    /**
+    * @return void
+    */
+    public function testGetChildrenRecursive(): void
     {
         $bind = ['c_path' => 'category-path/%'];
         $this->category->expects($this->once())->method('isObjectNew')->willReturn(false);
@@ -71,17 +96,25 @@ class ChildrenCategoriesProviderTest extends TestCase
         $this->childrenCategoriesProvider->getChildren($this->category, true);
     }
 
-    public function testGetChildrenForNewCategory()
+    /**
+    * @return void
+    */
+    public function testGetChildrenForNewCategory(): void
     {
         $this->category->expects($this->once())->method('isObjectNew')->willReturn(true);
         $this->assertEquals([], $this->childrenCategoriesProvider->getChildren($this->category));
     }
 
-    public function testGetChildren()
+    /**
+    * @return void
+    */
+    public function testGetChildren(): void
     {
         $categoryLevel = 3;
-        $this->select->expects($this->at(1))->method('where')->with('path LIKE :c_path')->willReturnSelf();
-        $this->select->expects($this->at(2))->method('where')->with('level <= :c_level')->willReturnSelf();
+        $this->select
+            ->method('where')
+            ->withConsecutive(['path LIKE :c_path'], ['level <= :c_level'])
+            ->willReturnOnConsecutiveCalls($this->select, $this->select);
         $this->category->expects($this->once())->method('isObjectNew')->willReturn(false);
         $this->category->expects($this->once())->method('getLevel')->willReturn($categoryLevel);
         $bind = ['c_path' => 'category-path/%', 'c_level' => $categoryLevel + 1];

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Map/DataCategoryUsedInProductsHashMapTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Model/Map/DataCategoryUsedInProductsHashMapTest.php
@@ -20,21 +20,34 @@ use PHPUnit\Framework\TestCase;
 
 class DataCategoryUsedInProductsHashMapTest extends TestCase
 {
-    /** @var HashMapPool|MockObject */
+    /**
+     * @var HashMapPool|MockObject
+     */
     private $hashMapPoolMock;
 
-    /** @var DataCategoryHashMap|MockObject */
+    /**
+     * @var DataCategoryHashMap|MockObject
+     */
     private $dataCategoryMapMock;
 
-    /** @var DataProductHashMap|MockObject */
+    /**
+     * @var DataProductHashMap|MockObject
+     */
     private $dataProductMapMock;
 
-    /** @var ResourceConnection|MockObject */
+    /**
+     * @var ResourceConnection|MockObject
+     */
     private $connectionMock;
 
-    /** @var DataCategoryUsedInProductsHashMap|MockObject */
+    /**
+     * @var DataCategoryUsedInProductsHashMap|MockObject
+     */
     private $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->hashMapPoolMock = $this->createMock(HashMapPool::class);
@@ -63,9 +76,11 @@ class DataCategoryUsedInProductsHashMapTest extends TestCase
     }
 
     /**
-     * Tests getAllData, getData and resetData functionality
+     * Tests getAllData, getData and resetData functionality.
+     *
+     * @return void
      */
-    public function testGetAllData()
+    public function testGetAllData(): void
     {
         $categoryIds = ['1' => [1, 2, 3], '2' => [2, 3], '3' => 3];
         $categoryIdsOther = ['2' => [2, 3, 4]];
@@ -91,12 +106,9 @@ class DataCategoryUsedInProductsHashMapTest extends TestCase
         $selectMock->expects($this->any())
             ->method('where')
             ->willReturnSelf();
-        $this->hashMapPoolMock->expects($this->at(4))
+        $this->hashMapPoolMock
             ->method('resetMap')
-            ->with(DataProductHashMap::class, 1);
-        $this->hashMapPoolMock->expects($this->at(5))
-            ->method('resetMap')
-            ->with(DataCategoryHashMap::class, 1);
+            ->withConsecutive([DataProductHashMap::class, 1], [DataCategoryHashMap::class, 1]);
 
         $this->assertEquals($categoryIds, $this->model->getAllData(1));
         $this->assertEquals($categoryIds[2], $this->model->getData(1, 2));

--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteSavingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/CategoryProcessUrlRewriteSavingObserverTest.php
@@ -71,7 +71,7 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
     private $scopeConfigMock;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -105,11 +105,11 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->storeGroupFactory = $this->getMockBuilder(CollectionFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterfaceAlias::class)
-            ->setMethods(['getValue'])
+            ->onlyMethods(['getValue'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->scopeConfigMock->method('getValue')->willReturn(true);
@@ -127,7 +127,10 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
         );
     }
 
-    public function testExecuteForRootDirectory()
+    /**
+    * @return void
+    */
+    public function testExecuteForRootDirectory(): void
     {
         $this->category->expects($this->once())
             ->method('getParentId')
@@ -138,7 +141,10 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
         $this->categoryProcessUrlRewriteSavingObserver->execute($this->observer);
     }
 
-    public function testExecuteHasStoreId()
+    /**
+    * @return void
+    */
+    public function testExecuteHasStoreId(): void
     {
         $this->category->expects($this->once())
             ->method('getParentId')
@@ -154,7 +160,7 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
             ->willReturnMap(
                 [
                     ['url_key', false],
-                    ['is_anchor', false],
+                    ['is_anchor', false]
                 ]
             );
         $this->category->expects($this->once())
@@ -164,7 +170,10 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
         $this->categoryProcessUrlRewriteSavingObserver->execute($this->observer);
     }
 
-    public function testExecuteHasNotChanges()
+    /**
+    * @return void
+    */
+    public function testExecuteHasNotChanges(): void
     {
         $this->category->expects($this->once())
             ->method('getParentId')
@@ -180,7 +189,7 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
             ->willReturnMap(
                 [
                     ['url_key', false],
-                    ['is_anchor', false],
+                    ['is_anchor', false]
                 ]
             );
         $this->category->expects($this->once())
@@ -192,7 +201,10 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
         $this->categoryProcessUrlRewriteSavingObserver->execute($this->observer);
     }
 
-    public function testExecuteHasChanges()
+    /**
+    * @return void
+    */
+    public function testExecuteHasChanges(): void
     {
         $this->category->expects($this->once())
             ->method('getParentId')
@@ -208,7 +220,7 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
             ->willReturnMap(
                 [
                     ['url_key', true],
-                    ['is_anchor', false],
+                    ['is_anchor', false]
                 ]
             );
         $this->category->expects($this->any())
@@ -221,20 +233,16 @@ class CategoryProcessUrlRewriteSavingObserverTest extends TestCase
             ->method('generate')
             ->with($this->category)
             ->willReturn($result1);
-        $this->urlRewriteBunchReplacerMock->expects($this->at(0))
-            ->method('doBunchReplace')
-            ->with($result1)
-            ->willReturn(null);
 
         $result2 = ['test2'];
         $this->urlRewriteHandlerMock->expects($this->once())
             ->method('generateProductUrlRewrites')
             ->with($this->category)
             ->willReturn($result2);
-        $this->urlRewriteBunchReplacerMock->expects($this->at(1))
+        $this->urlRewriteBunchReplacerMock
             ->method('doBunchReplace')
-            ->with($result2)
-            ->willReturn(null);
+            ->withConsecutive([$result1], [$result2])
+            ->willReturnOnConsecutiveCalls(null, null);
 
         $this->databaseMapPoolMock->expects($this->any())
             ->method('resetMap');

--- a/app/code/Magento/CatalogWidget/Test/Unit/Controller/Adminhtml/Product/Widget/ConditionsTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Controller/Adminhtml/Product/Widget/ConditionsTest.php
@@ -44,11 +44,15 @@ class ConditionsTest extends TestCase
      */
     protected $objectManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->rule = $this->createMock(Rule::class);
         $this->response = $this->getMockBuilder(ResponseInterface::class)
-            ->setMethods(['setBody', 'sendResponse'])
+            ->onlyMethods(['sendResponse'])
+            ->addMethods(['setBody'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->response->expects($this->once())->method('setBody')->willReturnSelf();
@@ -70,27 +74,30 @@ class ConditionsTest extends TestCase
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $type = 'Magento\CatalogWidget\Model\Rule\Condition\Product|attribute_set_id';
-        $this->request->expects($this->at(0))
-            ->method('getParam')->with('id')->willReturn('1--1');
-        $this->request->expects($this->at(1))
-            ->method('getParam')->with('type')->willReturn($type);
-        $this->request->expects($this->at(2))
-            ->method('getParam')->with('form')
-            ->willReturn('request_form_param_value');
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(['id'], ['type'], ['form'])
+            ->willReturnOnConsecutiveCalls('1--1', $type, 'request_form_param_value');
 
         $condition = $this->getMockBuilder(Product::class)
-            ->setMethods([
-                'setId',
-                'setType',
-                'setRule',
-                'setPrefix',
-                'setAttribute',
-                'asHtmlRecursive',
-                'setJsFormObject',
-            ])->disableOriginalConstructor()
+            ->onlyMethods(['asHtmlRecursive'])
+            ->addMethods(
+                [
+                    'setId',
+                    'setType',
+                    'setRule',
+                    'setPrefix',
+                    'setAttribute',
+                    'setJsFormObject'
+                ]
+            )
+            ->disableOriginalConstructor()
             ->getMock();
         $condition->expects($this->once())
             ->method('setId')->with('1--1')->willReturnSelf();

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/GridTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/GridTest.php
@@ -74,13 +74,16 @@ class GridTest extends TestCase
      */
     private $pagerBlockMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManagerHelper = new ObjectManagerHelper($this);
         $this->itemCollectionFactoryMock =
             $this->getMockBuilder(CollectionFactory::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['create'])
+                ->onlyMethods(['create'])
                 ->getMock();
         $this->joinAttributeProcessorMock =
             $this->getMockBuilder(JoinProcessorInterface::class)
@@ -93,6 +96,7 @@ class GridTest extends TestCase
         $this->itemCollectionMock = $objectManagerHelper
             ->getCollectionMock(Collection::class, []);
         $this->quoteMock = $this->getMockBuilder(Quote::class)
+            ->onlyMethods(['getAllVisibleItems', 'getItemsCount'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->layoutMock = $this->getMockBuilder(LayoutInterface::class)
@@ -102,13 +106,6 @@ class GridTest extends TestCase
             ->getMock();
         $this->checkoutSessionMock->expects($this->any())->method('getQuote')->willReturn($this->quoteMock);
         $this->quoteMock->expects($this->any())->method('getAllVisibleItems')->willReturn([]);
-        $this->scopeConfigMock->expects($this->at(0))
-            ->method('getValue')
-            ->with(
-                Grid::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER,
-                ScopeInterface::SCOPE_STORE,
-                null
-            )->willReturn(20);
         $this->block = $objectManagerHelper->getObject(
             Grid::class,
             [
@@ -122,33 +119,40 @@ class GridTest extends TestCase
         );
     }
 
-    public function testGetTemplate()
+    /**
+    * @return void
+    */
+    public function testGetTemplate(): void
     {
         $this->assertEquals('cart/form1.phtml', $this->block->getTemplate());
     }
 
-    public function testGetItemsForGrid()
+    /**
+    * @return void
+    */
+    public function testGetItemsForGrid(): void
     {
         $this->getMockItemsForGrid();
         $this->assertEquals($this->itemCollectionMock, $this->block->getItemsForGrid());
     }
 
     /**
+     * @return void
      * @cover \Magento\Checkout\Block\Cart\Grid::_prepareLayout
      */
-    public function testSetLayout()
+    public function testSetLayout(): void
     {
         $itemsCount = 150;
         $availableLimit = 20;
         $this->getMockItemsForGrid();
         $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn($itemsCount);
-        $this->scopeConfigMock->expects($this->at(1))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                Grid::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER,
-                ScopeInterface::SCOPE_STORE,
-                null
-            )->willReturn($availableLimit);
+            ->withConsecutive(
+                [Grid::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER, ScopeInterface::SCOPE_STORE, null],
+                [Grid::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER, ScopeInterface::SCOPE_STORE, null]
+            )
+            ->willReturnOnConsecutiveCalls(20, $availableLimit);
         $this->layoutMock
             ->expects($this->once())
             ->method('createBlock')
@@ -171,7 +175,10 @@ class GridTest extends TestCase
         $this->block->setLayout($this->layoutMock);
     }
 
-    public function testGetItems()
+    /**
+    * @return void
+    */
+    public function testGetItems(): void
     {
         $this->getMockItemsForGrid();
         $this->quoteMock->expects($this->once())->method('getItemsCount')->willReturn(20);
@@ -179,7 +186,10 @@ class GridTest extends TestCase
         $this->assertEquals(['expected'], $this->block->getItems());
     }
 
-    private function getMockItemsForGrid()
+    /**
+    * @return void
+    */
+    private function getMockItemsForGrid(): void
     {
         $this->itemCollectionFactoryMock
             ->expects($this->once())
@@ -196,9 +206,10 @@ class GridTest extends TestCase
     }
 
     /**
+     * @return void
      * @cover \Magento\Checkout\Block\Cart::prepareItemUrls
      */
-    public function testGetItemsIfCustomItemsExists()
+    public function testGetItemsIfCustomItemsExists(): void
     {
         $itemMock = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
@@ -224,7 +235,10 @@ class GridTest extends TestCase
         $this->assertEquals([$itemMock], $this->block->getItems());
     }
 
-    public function testGetItemsWhenPagerNotVisible()
+    /**
+    * @return void
+    */
+    public function testGetItemsWhenPagerNotVisible(): void
     {
         $this->assertEquals([], $this->block->getItems());
     }

--- a/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Block/Cart/SidebarTest.php
@@ -30,7 +30,9 @@ use PHPUnit\Framework\TestCase;
  */
 class SidebarTest extends TestCase
 {
-    /** @var ObjectManager  */
+    /**
+     * @var ObjectManager
+     */
     protected $_objectManager;
 
     /**
@@ -78,6 +80,9 @@ class SidebarTest extends TestCase
      */
     private $serializer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->_objectManager = new ObjectManager($this);
@@ -123,12 +128,15 @@ class SidebarTest extends TestCase
         );
     }
 
-    public function testGetTotalsHtml()
+    /**
+    * @return void
+    */
+    public function testGetTotalsHtml(): void
     {
         $totalsHtml = "$134.36";
         $totalsBlockMock = $this->getMockBuilder(Price::class)
             ->disableOriginalConstructor()
-            ->setMethods(['toHtml'])
+            ->onlyMethods(['toHtml'])
             ->getMock();
 
         $totalsBlockMock->expects($this->once())
@@ -143,7 +151,10 @@ class SidebarTest extends TestCase
         $this->assertEquals($totalsHtml, $this->model->getTotalsHtml());
     }
 
-    public function testGetConfig()
+    /**
+    * @return void
+    */
+    public function testGetConfig(): void
     {
         $websiteId = 100;
         $storeMock = $this->createMock(Store::class);
@@ -186,26 +197,23 @@ class SidebarTest extends TestCase
         $this->storeManagerMock->expects($this->any())->method('getStore')->willReturn($storeMock);
         $storeMock->expects($this->once())->method('getBaseUrl')->willReturn($baseUrl);
 
-        $this->scopeConfigMock->expects($this->at(0))
+        $this->scopeConfigMock
             ->method('getValue')
-            ->with(
-                Sidebar::XML_PATH_CHECKOUT_SIDEBAR_COUNT,
-                ScopeInterface::SCOPE_STORE
-            )->willReturn(3);
-
-        $this->scopeConfigMock->expects($this->at(1))
-            ->method('getValue')
-            ->with(
-                'checkout/sidebar/max_items_display_count',
-                ScopeInterface::SCOPE_STORE
-            )->willReturn(8);
+            ->withConsecutive(
+                [Sidebar::XML_PATH_CHECKOUT_SIDEBAR_COUNT, ScopeInterface::SCOPE_STORE],
+                ['checkout/sidebar/max_items_display_count', ScopeInterface::SCOPE_STORE]
+            )
+            ->willReturnOnConsecutiveCalls(3, 8);
 
         $storeMock->expects($this->once())->method('getWebsiteId')->willReturn($websiteId);
 
         $this->assertEquals($expectedResult, $this->model->getConfig());
     }
 
-    public function testGetIsNeedToDisplaySideBar()
+    /**
+    * @return void
+    */
+    public function testGetIsNeedToDisplaySideBar(): void
     {
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
@@ -217,7 +225,10 @@ class SidebarTest extends TestCase
         $this->assertTrue($this->model->getIsNeedToDisplaySideBar());
     }
 
-    public function testGetTotalsCache()
+    /**
+    * @return void
+    */
+    public function testGetTotalsCache(): void
     {
         $quoteMock = $this->createMock(Quote::class);
         $totalsMock = ['totals'];

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Cart/ConfigureTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Cart/ConfigureTest.php
@@ -78,6 +78,9 @@ class ConfigureTest extends TestCase
      */
     protected $cartMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
@@ -119,11 +122,11 @@ class ConfigureTest extends TestCase
     }
 
     /**
-     * Test checks controller call product view and send parameter to it
+     * Test checks controller call product view and send parameter to it.
      *
      * @return void
      */
-    public function testPrepareAndRenderCall()
+    public function testPrepareAndRenderCall(): void
     {
         $quoteId = 1;
         $actualProductId = 1;
@@ -146,14 +149,10 @@ class ConfigureTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         //expects
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('id')
-            ->willReturn($quoteId);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('product_id')
-            ->willReturn($actualProductId);
+            ->withConsecutive(['id'], ['product_id'])
+            ->willReturnOnConsecutiveCalls($quoteId, $actualProductId);
         $this->cartMock->expects($this->any())->method('getQuote')->willReturn($quoteMock);
 
         $quoteItemMock->expects($this->exactly(1))->method('getBuyRequest')->willReturn($buyRequestMock);
@@ -162,7 +161,7 @@ class ConfigureTest extends TestCase
             ->method('create')
             ->with(ResultFactory::TYPE_PAGE, [])
             ->willReturn($pageMock);
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('get')
             ->with(View::class)
             ->willReturn($viewMock);
@@ -188,11 +187,11 @@ class ConfigureTest extends TestCase
 
     /**
      * Test checks controller redirect user to cart
-     * if user request product id in cart edit page is not same as quota product id
+     * if user request product id in cart edit page is not same as quota product id.
      *
      * @return void
      */
-    public function testRedirectWithWrongProductId()
+    public function testRedirectWithWrongProductId(): void
     {
         $quotaId = 1;
         $productIdInQuota = 1;

--- a/app/code/Magento/Checkout/Test/Unit/Controller/OnepageTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/OnepageTest.php
@@ -55,6 +55,9 @@ class OnepageTest extends TestCase
      */
     protected $eventManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -70,14 +73,10 @@ class OnepageTest extends TestCase
             ->willReturn($this->quote);
 
         $objectManagerMock = $this->createMock(\Magento\Framework\ObjectManager\ObjectManager::class);
-        $objectManagerMock->expects($this->at(0))
+        $objectManagerMock
             ->method('get')
-            ->with(Session::class)
-            ->willReturn($this->checkoutSession);
-        $objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(\Magento\Customer\Model\Session::class)
-            ->willReturn($this->customerSession);
+            ->withConsecutive([Session::class], [\Magento\Customer\Model\Session::class])
+            ->willReturnOnConsecutiveCalls($this->checkoutSession, $this->customerSession);
 
         $context = $this->createMock(Context::class);
         $context->expects($this->once())
@@ -101,7 +100,10 @@ class OnepageTest extends TestCase
         );
     }
 
-    public function testDispatch()
+    /**
+    * @return void
+    */
+    public function testDispatch(): void
     {
         $this->request->expects($this->once())
             ->method('getActionName')

--- a/app/code/Magento/Checkout/Test/Unit/Controller/Sidebar/UpdateItemQtyTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Controller/Sidebar/UpdateItemQtyTest.php
@@ -21,30 +21,49 @@ use Psr\Log\LoggerInterface;
 
 class UpdateItemQtyTest extends TestCase
 {
-    /** @var UpdateItemQty */
+    /**
+     * @var UpdateItemQty
+     */
     protected $updateItemQty;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var Sidebar|MockObject */
+    /**
+     * @var Sidebar|MockObject
+     */
     protected $sidebarMock;
 
-    /** @var LoggerInterface|MockObject */
+    /**
+     * @var LoggerInterface|MockObject
+     */
     protected $loggerMock;
 
-    /** @var Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $jsonHelperMock;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $requestMock;
 
-    /** @var ResponseInterface|MockObject */
+    /**
+     * @var ResponseInterface|MockObject
+     */
     protected $responseMock;
 
-    /** @var RequestQuantityProcessor|MockObject */
+    /**
+     * @var RequestQuantityProcessor|MockObject
+     */
     private $quantityProcessor;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->sidebarMock = $this->createMock(Sidebar::class);
@@ -71,21 +90,20 @@ class UpdateItemQtyTest extends TestCase
                 'jsonHelper' => $this->jsonHelperMock,
                 'quantityProcessor' => $this->quantityProcessor,
                 'request' => $this->requestMock,
-                'response' => $this->responseMock,
+                'response' => $this->responseMock
             ]
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('item_id', null)
-            ->willReturn('1');
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('item_qty', null)
-            ->willReturn('2');
+            ->withConsecutive(['item_id', null], ['item_qty', null])
+            ->willReturnOnConsecutiveCalls('1', '2');
 
         $this->sidebarMock->expects($this->once())
             ->method('checkQuoteItem')
@@ -103,8 +121,8 @@ class UpdateItemQtyTest extends TestCase
                     'data' => [
                         'summary_qty' => 2,
                         'summary_text' => __(' items'),
-                        'subtotal' => 12.34,
-                    ],
+                        'subtotal' => 12.34
+                    ]
                 ]
             );
 
@@ -115,8 +133,8 @@ class UpdateItemQtyTest extends TestCase
                     'data' => [
                         'summary_qty' => 2,
                         'summary_text' => __(' items'),
-                        'subtotal' => 12.34,
-                    ],
+                        'subtotal' => 12.34
+                    ]
                 ]
             )
             ->willReturn('json encoded');
@@ -134,16 +152,15 @@ class UpdateItemQtyTest extends TestCase
         $this->assertEquals('json represented', $this->updateItemQty->execute());
     }
 
-    public function testExecuteWithLocalizedException()
+    /**
+    * @return void
+    */
+    public function testExecuteWithLocalizedException(): void
     {
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('item_id', null)
-            ->willReturn('1');
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('item_qty', null)
-            ->willReturn('2');
+            ->withConsecutive(['item_id', null], ['item_qty', null])
+            ->willReturnOnConsecutiveCalls('1', '2');
 
         $this->sidebarMock->expects($this->once())
             ->method('checkQuoteItem')
@@ -156,7 +173,7 @@ class UpdateItemQtyTest extends TestCase
             ->willReturn(
                 [
                     'success' => false,
-                    'error_message' => 'Error!',
+                    'error_message' => 'Error!'
                 ]
             );
 
@@ -165,7 +182,7 @@ class UpdateItemQtyTest extends TestCase
             ->with(
                 [
                     'success' => false,
-                    'error_message' => 'Error!',
+                    'error_message' => 'Error!'
                 ]
             )
             ->willReturn('json encoded');
@@ -178,16 +195,15 @@ class UpdateItemQtyTest extends TestCase
         $this->assertEquals('json represented', $this->updateItemQty->execute());
     }
 
-    public function testExecuteWithException()
+    /**
+    * @return void
+    */
+    public function testExecuteWithException(): void
     {
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with('item_id', null)
-            ->willReturn('1');
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with('item_qty', null)
-            ->willReturn('2');
+            ->withConsecutive(['item_id', null], ['item_qty', null])
+            ->willReturnOnConsecutiveCalls('1', '2');
 
         $exception = new \Exception('Error!');
 
@@ -207,7 +223,7 @@ class UpdateItemQtyTest extends TestCase
             ->willReturn(
                 [
                     'success' => false,
-                    'error_message' => 'Error!',
+                    'error_message' => 'Error!'
                 ]
             );
 
@@ -216,7 +232,7 @@ class UpdateItemQtyTest extends TestCase
             ->with(
                 [
                     'success' => false,
-                    'error_message' => 'Error!',
+                    'error_message' => 'Error!'
                 ]
             )
             ->willReturn('json encoded');

--- a/app/code/Magento/Checkout/Test/Unit/Helper/ExpressRedirectTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Helper/ExpressRedirectTest.php
@@ -23,78 +23,80 @@ class ExpressRedirectTest extends TestCase
     /**
      * @var MockObject
      */
-    protected $_actionFlag;
+    protected $actionFlag;
 
     /**
      * @var MockObject
      */
-    protected $_objectManager;
+    protected $objectManager;
 
     /**
      * Customer session
      *
      * @var MockObject
      */
-    protected $_customerSession;
+    protected $customerSession;
 
     /**
      * @var MockObject
      */
-    protected $_context;
+    protected $context;
 
     /**
      * @var ExpressRedirect
      */
-    protected $_helper;
+    protected $helper;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_actionFlag = $this->getMockBuilder(
-            ActionFlag::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['set']
-            )->getMock();
+        $this->actionFlag = $this->getMockBuilder(ActionFlag::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['set'])
+            ->getMock();
 
-        $this->_objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
+        $this->objectManager = $this->getMockForAbstractClass(ObjectManagerInterface::class);
 
-        $this->_customerSession = $this->getMockBuilder(
-            Session::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['setBeforeAuthUrl']
-            )->getMock();
+        $this->customerSession = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setBeforeAuthUrl'])->getMock();
 
-        $this->_context = $this->getMockBuilder(Context::class)
+        $this->context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->_helper = new ExpressRedirect(
-            $this->_actionFlag,
-            $this->_objectManager,
-            $this->_customerSession,
-            $this->_context
+        $this->helper = new ExpressRedirect(
+            $this->actionFlag,
+            $this->objectManager,
+            $this->customerSession,
+            $this->context
         );
     }
 
     /**
-     * @dataProvider redirectLoginDataProvider
      * @param array $actionFlagList
      * @param string|null $customerBeforeAuthUrl
      * @param string|null $customerBeforeAuthUrlDefault
+     *
+     * @return void
+     * @dataProvider redirectLoginDataProvider
      */
-    public function testRedirectLogin($actionFlagList, $customerBeforeAuthUrl, $customerBeforeAuthUrlDefault)
-    {
-        $expressRedirectMock = $this->getMockBuilder(
-            RedirectLoginInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(
+    public function testRedirectLogin(
+        array $actionFlagList,
+        ?string $customerBeforeAuthUrl,
+        ?string $customerBeforeAuthUrlDefault
+    ): void {
+        $expressRedirectMock = $this->getMockBuilder(RedirectLoginInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
                 [
                     'getActionFlagList',
                     'getResponse',
                     'getCustomerBeforeAuthUrl',
                     'getLoginUrl',
-                    'getRedirectActionName',
+                    'getRedirectActionName'
                 ]
             )->getMock();
         $expressRedirectMock->expects(
@@ -104,13 +106,15 @@ class ExpressRedirectTest extends TestCase
         )->willReturn(
             $actionFlagList
         );
-
-        $atIndex = 0;
         $actionFlagList = array_merge(['no-dispatch' => true], $actionFlagList);
+        $withArgs = [];
+
         foreach ($actionFlagList as $actionKey => $actionFlag) {
-            $this->_actionFlag->expects($this->at($atIndex))->method('set')->with('', $actionKey, $actionFlag);
-            $atIndex++;
+            $withArgs[] = ['', $actionKey, $actionFlag];
         }
+        $this->actionFlag
+            ->method('set')
+            ->withConsecutive(...$withArgs);
 
         $expectedLoginUrl = 'loginURL';
         $expressRedirectMock->expects(
@@ -121,12 +125,9 @@ class ExpressRedirectTest extends TestCase
             $expectedLoginUrl
         );
 
-        $urlMock = $this->getMockBuilder(
-            Data::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['addRequestParam']
-            )->getMock();
+        $urlMock = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['addRequestParam'])->getMock();
         $urlMock->expects(
             $this->once()
         )->method(
@@ -138,7 +139,7 @@ class ExpressRedirectTest extends TestCase
             $expectedLoginUrl
         );
 
-        $this->_objectManager->expects(
+        $this->objectManager->expects(
             $this->once()
         )->method(
             'get'
@@ -148,12 +149,9 @@ class ExpressRedirectTest extends TestCase
             $urlMock
         );
 
-        $responseMock = $this->getMockBuilder(
-            Http::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['setRedirect']
-            )->getMock();
+        $responseMock = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setRedirect'])->getMock();
         $responseMock->expects($this->once())->method('setRedirect')->with($expectedLoginUrl);
 
         $expressRedirectMock->expects($this->once())->method('getResponse')->willReturn($responseMock);
@@ -167,8 +165,9 @@ class ExpressRedirectTest extends TestCase
         );
         $expectedCustomerBeforeAuthUrl = $customerBeforeAuthUrl !== null
         ? $customerBeforeAuthUrl : $customerBeforeAuthUrlDefault;
+
         if ($expectedCustomerBeforeAuthUrl) {
-            $this->_customerSession->expects(
+            $this->customerSession->expects(
                 $this->once()
             )->method(
                 'setBeforeAuthUrl'
@@ -176,14 +175,15 @@ class ExpressRedirectTest extends TestCase
                 $expectedCustomerBeforeAuthUrl
             );
         }
-        $this->_helper->redirectLogin($expressRedirectMock, $customerBeforeAuthUrlDefault);
+        $this->helper->redirectLogin($expressRedirectMock, $customerBeforeAuthUrlDefault);
     }
 
     /**
-     * Data provider
+     * Data provider.
+     *
      * @return array
      */
-    public function redirectLoginDataProvider()
+    public function redirectLoginDataProvider(): array
     {
         return [
             [[], 'beforeCustomerUrl', 'beforeCustomerUrlDEFAULT'],

--- a/app/code/Magento/Checkout/Test/Unit/Model/CartTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/CartTest.php
@@ -33,13 +33,19 @@ use PHPUnit\Framework\TestCase;
  */
 class CartTest extends TestCase
 {
-    /** @var Cart */
+    /**
+     * @var Cart
+     */
     protected $cart;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var Session|MockObject */
+    /**
+     * @var Session|MockObject
+     */
     protected $checkoutSessionMock;
 
     /**
@@ -47,7 +53,9 @@ class CartTest extends TestCase
      */
     protected $customerSessionMock;
 
-    /** @var StockItemInterface|MockObject */
+    /**
+     * @var StockItemInterface|MockObject
+     */
     protected $stockItemMock;
 
     /**
@@ -95,6 +103,9 @@ class CartTest extends TestCase
      */
     private $requestInfoFilterMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->checkoutSessionMock = $this->createMock(Session::class);
@@ -106,7 +117,7 @@ class CartTest extends TestCase
         $this->productRepository = $this->getMockForAbstractClass(ProductRepositoryInterface::class);
         $this->stockRegistry = $this->getMockBuilder(StockRegistry::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getStockItem'])
+            ->onlyMethods(['getStockItem'])
             ->getMock();
         $this->stockItemMock = $this->createPartialMock(
             Item::class,
@@ -154,7 +165,10 @@ class CartTest extends TestCase
             ->setBackwardCompatibleProperty($this->cart, 'requestInfoFilter', $this->requestInfoFilterMock);
     }
 
-    public function testSuggestItemsQty()
+    /**
+    * @return void
+    */
+    public function testSuggestItemsQty(): void
     {
         $data = [[] , ['qty' => -2], ['qty' => 3], ['qty' => 3.5], ['qty' => 5], ['qty' => 4]];
         $this->quoteMock->expects($this->any())
@@ -163,15 +177,12 @@ class CartTest extends TestCase
                 [2, $this->prepareQuoteItemMock(2)],
                 [3, $this->prepareQuoteItemMock(3)],
                 [4, $this->prepareQuoteItemMock(4)],
-                [5, $this->prepareQuoteItemMock(5)],
+                [5, $this->prepareQuoteItemMock(5)]
             ]);
 
-        $this->stockState->expects($this->at(0))
+        $this->stockState
             ->method('suggestQty')
-            ->willReturn(3.0);
-        $this->stockState->expects($this->at(1))
-            ->method('suggestQty')
-            ->willReturn(3.5);
+            ->willReturnOnConsecutiveCalls(3.0, 3.5);
 
         $this->checkoutSessionMock->expects($this->any())
             ->method('getQuote')
@@ -184,13 +195,16 @@ class CartTest extends TestCase
                 ['qty' => 3., 'before_suggest_qty' => 3.],
                 ['qty' => 3.5, 'before_suggest_qty' => 3.5],
                 ['qty' => 5],
-                ['qty' => 4],
+                ['qty' => 4]
             ],
             $this->cart->suggestItemsQty($data)
         );
     }
 
-    public function testUpdateItems()
+    /**
+    * @return void
+    */
+    public function testUpdateItems(): void
     {
         $data = [['qty' => 5.5, 'before_suggest_qty' => 5.5]];
         $infoDataObject = $this->objectManagerHelper->getObject(
@@ -201,14 +215,17 @@ class CartTest extends TestCase
         $this->checkoutSessionMock->expects($this->once())
             ->method('getQuote')
             ->willReturn($this->quoteMock);
-        $this->eventManagerMock->expects($this->at(0))->method('dispatch')->with(
-            'checkout_cart_update_items_before',
-            ['cart' => $this->cart, 'info' => $infoDataObject]
-        );
-        $this->eventManagerMock->expects($this->at(1))->method('dispatch')->with(
-            'checkout_cart_update_items_after',
-            ['cart' => $this->cart, 'info' => $infoDataObject]
-        );
+        $this->eventManagerMock
+            ->method('dispatch')
+            ->withConsecutive(
+                [
+                    'checkout_cart_update_items_before',
+                    ['cart' => $this->cart, 'info' => $infoDataObject]
+                ], [
+                    'checkout_cart_update_items_after',
+                    ['cart' => $this->cart, 'info' => $infoDataObject]
+                ]
+            );
 
         $result = $this->cart->updateItems($data);
         $this->assertSame($this->cart, $result);
@@ -216,7 +233,8 @@ class CartTest extends TestCase
 
     /**
      * @param int|bool $itemId
-     * @return MockObject
+     *
+     * @return MockObject|bool
      */
     public function prepareQuoteItemMock($itemId)
     {
@@ -272,9 +290,11 @@ class CartTest extends TestCase
 
     /**
      * @param boolean $useQty
+     *
+     * @return void
      * @dataProvider useQtyDataProvider
      */
-    public function testGetSummaryQty($useQty)
+    public function testGetSummaryQty(bool $useQty): void
     {
         $quoteId = 1;
         $itemsCount = 1;
@@ -284,7 +304,9 @@ class CartTest extends TestCase
         );
 
         $this->checkoutSessionMock->expects($this->any())->method('getQuote')->willReturn($quoteMock);
-        $this->checkoutSessionMock->expects($this->at(2))->method('getQuoteId')->willReturn($quoteId);
+        $this->checkoutSessionMock
+            ->method('getQuoteId')
+            ->willReturn($quoteId);
         $this->customerSessionMock->expects($this->any())->method('isLoggedIn')->willReturn(true);
 
         $this->scopeConfigMock->expects($this->once())->method('getValue')
@@ -300,7 +322,7 @@ class CartTest extends TestCase
     /**
      * @return array
      */
-    public function useQtyDataProvider()
+    public function useQtyDataProvider(): array
     {
         return [
             ['useQty' => true],
@@ -309,13 +331,15 @@ class CartTest extends TestCase
     }
 
     /**
-     * Test successful scenarios for AddProduct
+     * Test successful scenarios for AddProduct.
      *
      * @param int|Product $productInfo
      * @param DataObject|int|array $requestInfo
+     *
+     * @return void
      * @dataProvider addProductDataProvider
      */
-    public function testAddProduct($productInfo, $requestInfo)
+    public function testAddProduct($productInfo, $requestInfo): void
     {
         $product = $this->createPartialMock(
             Product::class,
@@ -337,11 +361,6 @@ class CartTest extends TestCase
             ->method('getById')
             ->willReturn($product);
 
-        $this->eventManagerMock->expects($this->at(0))->method('dispatch')->with(
-            'checkout_cart_product_add_before',
-            ['info' => $requestInfo, 'product' => $product]
-        );
-
         $this->quoteMock->expects($this->once())
             ->method('addProduct')
             ->willReturn(1);
@@ -349,10 +368,18 @@ class CartTest extends TestCase
             ->method('getQuote')
             ->willReturn($this->quoteMock);
 
-        $this->eventManagerMock->expects($this->at(1))->method('dispatch')->with(
-            'checkout_cart_product_add_after',
-            ['quote_item' => 1, 'product' => $product]
-        );
+        $this->eventManagerMock
+            ->method('dispatch')
+            ->withConsecutive(
+                [
+                    'checkout_cart_product_add_before',
+                    ['info' => $requestInfo, 'product' => $product]
+                ],
+                [
+                    'checkout_cart_product_add_after',
+                    ['quote_item' => 1, 'product' => $product]
+                ]
+            );
 
         if (!$productInfo) {
             $productInfo = $product;
@@ -362,11 +389,11 @@ class CartTest extends TestCase
     }
 
     /**
-     * Test exception on adding product for AddProduct
+     * Test exception on adding product for AddProduct.
      *
-     * @throws LocalizedException
+     * @return void
      */
-    public function testAddProductException()
+    public function testAddProductException(): void
     {
         $product = $this->createPartialMock(
             Product::class,
@@ -405,11 +432,11 @@ class CartTest extends TestCase
     }
 
     /**
-     * Test bad parameters on adding product for AddProduct
+     * Test bad parameters on adding product for AddProduct.
      *
-     * @throws LocalizedException
+     * @return void
      */
-    public function testAddProductExceptionBadParams()
+    public function testAddProductExceptionBadParams(): void
     {
         $product = $this->createPartialMock(
             Product::class,
@@ -439,11 +466,11 @@ class CartTest extends TestCase
     }
 
     /**
-     * Data provider for testAddProduct
+     * Data provider for testAddProduct.
      *
      * @return array
      */
-    public function addProductDataProvider()
+    public function addProductDataProvider(): array
     {
         $obj = new ObjectManagerHelper($this);
         $data = ['qty' => 5.5, 'sku' => 'prod'];

--- a/app/code/Magento/Checkout/Test/Unit/Model/Session/SuccessValidatorTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/Session/SuccessValidatorTest.php
@@ -15,15 +15,23 @@ use PHPUnit\Framework\TestCase;
 
 class SuccessValidatorTest extends TestCase
 {
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManagerHelper($this);
     }
 
-    public function testIsValid()
+    /**
+    * @return void
+    */
+    public function testIsValid(): void
     {
         $checkoutSession = $this->getMockBuilder(
             Session::class
@@ -32,79 +40,66 @@ class SuccessValidatorTest extends TestCase
         $this->assertFalse($this->createSuccessValidator($checkoutSession)->isValid($checkoutSession));
     }
 
-    public function testIsValidWithNotEmptyGetLastSuccessQuoteId()
+    /**
+    * @return void
+    */
+    public function testIsValidWithNotEmptyGetLastSuccessQuoteId(): void
     {
         $checkoutSession = $this->getMockBuilder(
             Session::class
         )->disableOriginalConstructor()
             ->getMock();
 
-        $checkoutSession->expects(
-            $this->at(0)
-        )->method(
-            '__call'
-        )->with(
-            'getLastSuccessQuoteId'
-        )->willReturn(
-            1
-        );
-
-        $checkoutSession->expects($this->at(1))->method('__call')->with('getLastQuoteId')->willReturn(0);
+        $checkoutSession
+            ->method('__call')
+            ->withConsecutive(['getLastSuccessQuoteId'], ['getLastQuoteId'])
+            ->willReturnOnConsecutiveCalls(1, 0);
 
         $this->assertFalse($this->createSuccessValidator($checkoutSession)->isValid($checkoutSession));
     }
 
-    public function testIsValidWithEmptyQuoteAndOrder()
+    /**
+    * @return void
+    */
+    public function testIsValidWithEmptyQuoteAndOrder(): void
     {
         $checkoutSession = $this->getMockBuilder(
             Session::class
         )->disableOriginalConstructor()
             ->getMock();
-        $checkoutSession->expects(
-            $this->at(0)
-        )->method(
-            '__call'
-        )->with(
-            'getLastSuccessQuoteId'
-        )->willReturn(
-            1
-        );
 
-        $checkoutSession->expects($this->at(1))->method('__call')->with('getLastQuoteId')->willReturn(1);
-
-        $checkoutSession->expects($this->at(2))->method('__call')->with('getLastOrderId')->willReturn(0);
+        $checkoutSession
+            ->method('__call')
+            ->withConsecutive(['getLastSuccessQuoteId'], ['getLastQuoteId'], ['getLastOrderId'])
+            ->willReturnOnConsecutiveCalls(1, 1, 0);
 
         $this->assertFalse($this->createSuccessValidator($checkoutSession)->isValid($checkoutSession));
     }
 
-    public function testIsValidTrue()
+    /**
+    * @return void
+    */
+    public function testIsValidTrue(): void
     {
         $checkoutSession = $this->getMockBuilder(
             Session::class
         )->disableOriginalConstructor()
             ->getMock();
-        $checkoutSession->expects(
-            $this->at(0)
-        )->method(
-            '__call'
-        )->with(
-            'getLastSuccessQuoteId'
-        )->willReturn(
-            1
-        );
 
-        $checkoutSession->expects($this->at(1))->method('__call')->with('getLastQuoteId')->willReturn(1);
-
-        $checkoutSession->expects($this->at(2))->method('__call')->with('getLastOrderId')->willReturn(1);
+        $checkoutSession
+            ->method('__call')
+            ->withConsecutive(['getLastSuccessQuoteId'], ['getLastQuoteId'], ['getLastOrderId'])
+            ->willReturnOnConsecutiveCalls(1, 1, 1);
 
         $this->assertTrue($this->createSuccessValidator($checkoutSession)->isValid($checkoutSession));
     }
 
     /**
      * @param MockObject $checkoutSession
+     *
      * @return object
      */
-    protected function createSuccessValidator(MockObject $checkoutSession)
+    protected function createSuccessValidator(MockObject $checkoutSession): object
     {
         return $this->objectManagerHelper->getObject(
             SuccessValidator::class,

--- a/app/code/Magento/Checkout/Test/Unit/Model/SessionTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/SessionTest.php
@@ -5,9 +5,6 @@
  */
 declare(strict_types=1);
 
-/**
- * Test class for \Magento\Checkout\Model\Session
- */
 namespace Magento\Checkout\Test\Unit\Model;
 
 use Magento\Checkout\Model\Session;
@@ -32,6 +29,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
+ * Test class for \Magento\Checkout\Model\Session
+ *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class SessionTest extends TestCase
@@ -39,35 +38,40 @@ class SessionTest extends TestCase
     /**
      * @var ObjectManager
      */
-    protected $_helper;
+    protected $helper;
 
     /**
      * @var \Magento\Checkout\Model\Session
      */
-    protected $_session;
+    protected $session;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->_helper = new ObjectManager($this);
+        $this->helper = new ObjectManager($this);
     }
 
     /**
      * @param int|null $orderId
      * @param int|null $incrementId
      * @param Order|MockObject $orderMock
+     *
+     * @return void
      * @dataProvider getLastRealOrderDataProvider
      */
-    public function testGetLastRealOrder($orderId, $incrementId, $orderMock)
+    public function testGetLastRealOrder($orderId, $incrementId, $orderMock): void
     {
         $orderFactory = $this->getMockBuilder(OrderFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $orderFactory->expects($this->once())->method('create')->willReturn($orderMock);
 
         $messageCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $quoteRepository = $this->getMockForAbstractClass(CartRepositoryInterface::class);
 
@@ -80,7 +84,7 @@ class SessionTest extends TestCase
         $request = $this->createMock(Http::class);
         $request->expects($this->any())->method('getHttpHost')->willReturn([]);
 
-        $constructArguments = $this->_helper->getConstructArguments(
+        $constructArguments = $this->helper->getConstructArguments(
             Session::class,
             [
                 'request' => $request,
@@ -90,19 +94,19 @@ class SessionTest extends TestCase
                 'storage' => new Storage()
             ]
         );
-        $this->_session = $this->_helper->getObject(Session::class, $constructArguments);
-        $this->_session->setLastRealOrderId($orderId);
+        $this->session = $this->helper->getObject(Session::class, $constructArguments);
+        $this->session->setLastRealOrderId($orderId);
+        $this->assertSame($orderMock, $this->session->getLastRealOrder());
 
-        $this->assertSame($orderMock, $this->_session->getLastRealOrder());
         if ($orderId == $incrementId) {
-            $this->assertSame($orderMock, $this->_session->getLastRealOrder());
+            $this->assertSame($orderMock, $this->session->getLastRealOrder());
         }
     }
 
     /**
      * @return array
      */
-    public function getLastRealOrderDataProvider()
+    public function getLastRealOrderDataProvider(): array
     {
         return [
             [null, 1, $this->_getOrderMock(1, null)],
@@ -114,17 +118,14 @@ class SessionTest extends TestCase
     /**
      * @param int|null $incrementId
      * @param int|null $orderId
+     *
      * @return Order|MockObject
      */
-    protected function _getOrderMock($incrementId, $orderId)
+    protected function _getOrderMock($incrementId, $orderId): MockObject
     {
         /** @var MockObject|\Magento\Sales\Model\Order $order */
-        $order = $this->getMockBuilder(
-            Order::class
-        )->disableOriginalConstructor()
-            ->setMethods(
-                ['getIncrementId', 'loadByIncrementId', '__sleep']
-            )->getMock();
+        $order = $this->getMockBuilder(Order::class)->disableOriginalConstructor()
+            ->onlyMethods(['getIncrementId', 'loadByIncrementId', '__sleep'])->getMock();
 
         if ($orderId && $incrementId) {
             $order->expects($this->once())->method('getIncrementId')->willReturn($incrementId);
@@ -135,22 +136,24 @@ class SessionTest extends TestCase
     }
 
     /**
-     * @param $paramToClear
+     * @param string $paramToClear
+     *
+     * @return void
      * @dataProvider clearHelperDataDataProvider
      */
-    public function testClearHelperData($paramToClear)
+    public function testClearHelperData(string $paramToClear): void
     {
         $storage = new Storage('default', [$paramToClear => 'test_data']);
-        $this->_session = $this->_helper->getObject(Session::class, ['storage' => $storage]);
+        $this->session = $this->helper->getObject(Session::class, ['storage' => $storage]);
 
-        $this->_session->clearHelperData();
-        $this->assertNull($this->_session->getData($paramToClear));
+        $this->session->clearHelperData();
+        $this->assertNull($this->session->getData($paramToClear));
     }
 
     /**
      * @return array
      */
-    public function clearHelperDataDataProvider()
+    public function clearHelperDataDataProvider(): array
     {
         return [
             ['redirect_url'],
@@ -163,10 +166,12 @@ class SessionTest extends TestCase
     /**
      * @param bool $hasOrderId
      * @param bool $hasQuoteId
-     * @dataProvider restoreQuoteDataProvider
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     * @dataProvider restoreQuoteDataProvider
      */
-    public function testRestoreQuote($hasOrderId, $hasQuoteId)
+    public function testRestoreQuote(bool $hasOrderId, bool $hasQuoteId): void
     {
         $order = $this->createPartialMock(
             Order::class,
@@ -176,7 +181,7 @@ class SessionTest extends TestCase
         $orderFactory = $this->createPartialMock(OrderFactory::class, ['create']);
         $orderFactory->expects($this->once())->method('create')->willReturn($order);
         $quoteRepository = $this->getMockBuilder(CartRepositoryInterface::class)
-            ->setMethods(['save'])
+            ->onlyMethods(['save'])
             ->getMockForAbstractClass();
         $storage = new Storage();
         $store = $this->createMock(Store::class);
@@ -185,7 +190,7 @@ class SessionTest extends TestCase
         $eventManager = $this->getMockForAbstractClass(ManagerInterface::class);
 
         /** @var Session $session */
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             [
                 'orderFactory' => $orderFactory,
@@ -265,28 +270,33 @@ class SessionTest extends TestCase
     /**
      * @return array
      */
-    public function restoreQuoteDataProvider()
+    public function restoreQuoteDataProvider(): array
     {
         return [[true, true], [true, false], [false, true], [false, false]];
     }
 
-    public function testHasQuote()
+    /**
+    * @return void
+    */
+    public function testHasQuote(): void
     {
         $quote = $this->getMockBuilder(Quote::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $session = $this->_helper->getObject(Session::class, ['quote' => $quote]);
+        $session = $this->helper->getObject(Session::class, ['quote' => $quote]);
         $this->assertFalse($session->hasQuote());
     }
 
-    public function testReplaceQuote()
+    /**
+    * @return void
+    */
+    public function testReplaceQuote(): void
     {
         $replaceQuoteId = 3;
         $websiteId = 1;
 
-        $store = $this->getMockBuilder(Store::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getWebsiteId'])
+        $store = $this->getMockBuilder(Store::class)->disableOriginalConstructor()
+            ->onlyMethods(['getWebsiteId'])
             ->getMock();
         $store->expects($this->any())
             ->method('getWebsiteId')
@@ -306,7 +316,7 @@ class SessionTest extends TestCase
 
         $storage = $this->getMockBuilder(Storage::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setData', 'getData'])
+            ->onlyMethods(['setData', 'getData'])
             ->getMock();
 
         $storage->expects($this->any())
@@ -328,7 +338,7 @@ class SessionTest extends TestCase
         $quoteIdMaskFactoryMock = $this->createPartialMock(QuoteIdMaskFactory::class, ['create']);
         $quoteIdMaskFactoryMock->expects($this->once())->method('create')->willReturn($quoteIdMaskMock);
 
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             [
                 'storeManager' => $storeManager,
@@ -343,16 +353,19 @@ class SessionTest extends TestCase
         $this->assertEquals($replaceQuoteId, $session->getQuoteId());
     }
 
-    public function testClearStorage()
+    /**
+    * @return void
+    */
+    public function testClearStorage(): void
     {
         $storage = $this->getMockBuilder(Storage::class)
             ->disableOriginalConstructor()
-            ->setMethods(['unsetData'])
+            ->onlyMethods(['unsetData'])
             ->getMock();
         $storage->expects($this->once())
             ->method('unsetData');
 
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             [
                 'storage' => $storage
@@ -363,10 +376,13 @@ class SessionTest extends TestCase
         $this->assertFalse($session->hasQuote());
     }
 
-    public function testResetCheckout()
+    /**
+    * @return void
+    */
+    public function testResetCheckout(): void
     {
         /** @var $session \Magento\Checkout\Model\Session */
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             ['storage' => new Storage()]
         );
@@ -374,16 +390,19 @@ class SessionTest extends TestCase
         $this->assertEquals(Session::CHECKOUT_STATE_BEGIN, $session->getCheckoutState());
     }
 
-    public function testGetStepData()
+    /**
+    * @return void
+    */
+    public function testGetStepData(): void
     {
         $stepData = [
             'simple' => 'data',
             'complex' => [
-                'key' => 'value',
-            ],
+                'key' => 'value'
+            ]
         ];
         /** @var $session \Magento\Checkout\Model\Session */
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             ['storage' => new Storage()]
         );
@@ -396,7 +415,7 @@ class SessionTest extends TestCase
     }
 
     /**
-     * Ensure that if quote not exist for customer quote will be null
+     * Ensure that if quote not exist for customer quote will be null.
      *
      * @return void
      */
@@ -418,18 +437,18 @@ class SessionTest extends TestCase
             ->willReturn(true);
         $store = $this->getMockBuilder(Store::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getWebsiteId'])
+            ->onlyMethods(['getWebsiteId'])
             ->getMock();
         $storeManager->expects($this->any())
             ->method('getStore')
             ->willReturn($store);
         $storage = $this->getMockBuilder(Storage::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setData', 'getData'])
+            ->onlyMethods(['setData', 'getData'])
             ->getMock();
-        $storage->expects($this->at(0))
+        $storage
             ->method('getData')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $quoteRepository->expects($this->once())
             ->method('getActiveForCustomer')
             ->willThrowException(new NoSuchEntityException());
@@ -442,7 +461,7 @@ class SessionTest extends TestCase
             ->method('setCustomer')
             ->with(null);
 
-        $constructArguments = $this->_helper->getConstructArguments(
+        $constructArguments = $this->helper->getConstructArguments(
             Session::class,
             [
                 'storeManager' => $storeManager,
@@ -453,11 +472,14 @@ class SessionTest extends TestCase
                 'logger' => $logger
             ]
         );
-        $this->_session = $this->_helper->getObject(Session::class, $constructArguments);
-        $this->_session->getQuote();
+        $this->session = $this->helper->getObject(Session::class, $constructArguments);
+        $this->session->getQuote();
     }
 
-    public function testSetStepData()
+    /**
+    * @return void
+    */
+    public function testSetStepData(): void
     {
         $stepData = [
             'complex' => [
@@ -465,7 +487,7 @@ class SessionTest extends TestCase
             ],
         ];
         /** @var $session \Magento\Checkout\Model\Session */
-        $session = $this->_helper->getObject(
+        $session = $this->helper->getObject(
             Session::class,
             ['storage' => new Storage()]
         );
@@ -477,12 +499,12 @@ class SessionTest extends TestCase
         $expectedResult = [
             'complex' => [
                 'key' => 'value',
-                'key2' => 'value2',
+                'key2' => 'value2'
             ],
             'simple' => [
                 'key' => 'value',
-                'key2' => 'value2',
-            ],
+                'key2' => 'value2'
+            ]
         ];
         $this->assertEquals($expectedResult, $session->getSteps());
     }

--- a/app/code/Magento/CheckoutAgreements/Test/Unit/Model/AgreementsConfigProviderTest.php
+++ b/app/code/Magento/CheckoutAgreements/Test/Unit/Model/AgreementsConfigProviderTest.php
@@ -53,7 +53,7 @@ class AgreementsConfigProviderTest extends TestCase
     private $agreementsFilterMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -84,7 +84,7 @@ class AgreementsConfigProviderTest extends TestCase
      *
      * @return void
      */
-    public function testGetConfigIfContentIsHtml()
+    public function testGetConfigIfContentIsHtml(): void
     {
         $content = 'content';
         $checkboxText = 'checkbox_text';
@@ -102,9 +102,9 @@ class AgreementsConfigProviderTest extends TestCase
                         'mode' => $mode,
                         'agreementId' => $agreementId,
                         'contentHeight' => $contentHeight
-                    ],
-                ],
-            ],
+                    ]
+                ]
+            ]
         ];
 
         $this->scopeConfigMock->expects($this->once())
@@ -142,7 +142,7 @@ class AgreementsConfigProviderTest extends TestCase
      *
      * @return void
      */
-    public function testGetConfigIfContentIsNotHtml()
+    public function testGetConfigIfContentIsNotHtml(): void
     {
         $content = 'content';
         $escapedContent = 'escaped_content';
@@ -161,9 +161,9 @@ class AgreementsConfigProviderTest extends TestCase
                         'mode' => $mode,
                         'agreementId' => $agreementId,
                         'contentHeight' => $contentHeight
-                    ],
-                ],
-            ],
+                    ]
+                ]
+            ]
         ];
 
         $this->scopeConfigMock->expects($this->once())
@@ -181,11 +181,10 @@ class AgreementsConfigProviderTest extends TestCase
             ->with($searchCriteriaMock)
             ->willReturn([$agreement]);
 
-        $this->escaperMock->expects($this->at(0))->method('escapeHtml')->with($content)->willReturn($escapedContent);
-        $this->escaperMock->expects($this->at(1))
+        $this->escaperMock
             ->method('escapeHtml')
-            ->with($checkboxText)
-            ->willReturn($escapedCheckboxText);
+            ->withConsecutive([$content], [$checkboxText])
+            ->willReturnOnConsecutiveCalls($escapedContent, $escapedCheckboxText);
         $agreement->expects($this->once())->method('getIsHtml')->willReturn(false);
         $agreement->expects($this->once())->method('getContent')->willReturn($content);
         $agreement->expects($this->once())->method('getCheckboxText')->willReturn($checkboxText);

--- a/app/code/Magento/CheckoutAgreements/Test/Unit/Model/AgreementsProviderTest.php
+++ b/app/code/Magento/CheckoutAgreements/Test/Unit/Model/AgreementsProviderTest.php
@@ -41,6 +41,9 @@ class AgreementsProviderTest extends TestCase
      */
     protected $storeManagerMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -62,7 +65,10 @@ class AgreementsProviderTest extends TestCase
         );
     }
 
-    public function testGetRequiredAgreementIdsIfAgreementsEnabled()
+    /**
+    * @return void
+    */
+    public function testGetRequiredAgreementIdsIfAgreementsEnabled(): void
     {
         $storeId = 100;
         $expectedResult = [1, 2, 3, 4, 5];
@@ -81,20 +87,19 @@ class AgreementsProviderTest extends TestCase
         $this->storeManagerMock->expects($this->once())->method('getStore')->willReturn($storeMock);
 
         $agreementCollection->expects($this->once())->method('addStoreFilter')->with($storeId)->willReturnSelf();
-        $agreementCollection->expects($this->at(1))
+        $agreementCollection
             ->method('addFieldToFilter')
-            ->with('is_active', 1)
-            ->willReturnSelf();
-        $agreementCollection->expects($this->at(2))
-            ->method('addFieldToFilter')
-            ->with('mode', AgreementModeOptions::MODE_MANUAL)
-            ->willReturnSelf();
+            ->withConsecutive(['is_active', 1], ['mode', AgreementModeOptions::MODE_MANUAL])
+            ->willReturnOnConsecutiveCalls($agreementCollection, $agreementCollection);
         $agreementCollection->expects($this->once())->method('getAllIds')->willReturn($expectedResult);
 
         $this->assertEquals($expectedResult, $this->model->getRequiredAgreementIds());
     }
 
-    public function testGetRequiredAgreementIdsIfAgreementsDisabled()
+    /**
+    * @return void
+    */
+    public function testGetRequiredAgreementIdsIfAgreementsDisabled(): void
     {
         $expectedResult = [];
         $this->scopeConfigMock->expects($this->once())

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/EditTest.php
@@ -84,6 +84,9 @@ class EditTest extends TestCase
      */
     protected $resultPageFactoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -95,7 +98,7 @@ class EditTest extends TestCase
             ->getMock();
 
         $this->objectManagerMock = $this->getMockBuilder(\Magento\Framework\ObjectManager\ObjectManager::class)
-            ->setMethods(['create', 'get'])
+            ->onlyMethods(['create', 'get'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->objectManagerMock->expects($this->once())
@@ -142,7 +145,10 @@ class EditTest extends TestCase
         );
     }
 
-    public function testEditActionBlockNoExists()
+    /**
+    * @return void
+    */
+    public function testEditActionBlockNoExists(): void
     {
         $blockId = 1;
 
@@ -175,12 +181,14 @@ class EditTest extends TestCase
     }
 
     /**
-     * @param int $blockId
+     * @param int|null $blockId
      * @param string $label
      * @param string $title
+     *
+     * @return void
      * @dataProvider editActionData
      */
-    public function testEditAction($blockId, $label, $title)
+    public function testEditAction(?int $blockId, string $label, string $title): void
     {
         $this->requestMock->expects($this->once())
             ->method('getParam')
@@ -208,8 +216,9 @@ class EditTest extends TestCase
             ->willReturn($resultPageMock);
 
         $titleMock = $this->createMock(Title::class);
-        $titleMock->expects($this->at(0))->method('prepend')->with(__('Blocks'));
-        $titleMock->expects($this->at(1))->method('prepend')->with($this->getTitle());
+        $titleMock
+            ->method('prepend')
+            ->withConsecutive([__('Blocks')], [$this->getTitle()]);
         $pageConfigMock = $this->createMock(Config::class);
         $pageConfigMock->expects($this->exactly(2))->method('getTitle')->willReturn($titleMock);
 
@@ -219,10 +228,10 @@ class EditTest extends TestCase
         $resultPageMock->expects($this->any())
             ->method('addBreadcrumb')
             ->willReturnSelf();
-        $resultPageMock->expects($this->at(3))
+        $resultPageMock
             ->method('addBreadcrumb')
-            ->with(__($label), __($title))
-            ->willReturnSelf();
+            ->withConsecutive([], [], [], [__($label), __($title)])
+            ->willReturnOnConsecutiveCalls(null, null, null, $resultPageMock);
         $resultPageMock->expects($this->exactly(2))
             ->method('getConfig')
             ->willReturn($pageConfigMock);
@@ -241,7 +250,7 @@ class EditTest extends TestCase
     /**
      * @return array
      */
-    public function editActionData()
+    public function editActionData(): array
     {
         return [
             [null, 'New Block', 'New Block'],

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/SaveTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Block/SaveTest.php
@@ -97,6 +97,9 @@ class SaveTest extends TestCase
      */
     protected $blockId = 1;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
@@ -105,7 +108,7 @@ class SaveTest extends TestCase
 
         $this->resultRedirectFactory = $this->getMockBuilder(RedirectFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->resultRedirect = $this->getMockBuilder(Redirect::class)
             ->disableOriginalConstructor()
@@ -146,7 +149,7 @@ class SaveTest extends TestCase
 
         $this->objectManagerMock = $this->getMockBuilder(ObjectManager::class)
             ->disableOriginalConstructor()
-            ->setMethods(['get', 'create'])
+            ->onlyMethods(['get', 'create'])
             ->getMock();
 
         $this->contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
@@ -159,7 +162,7 @@ class SaveTest extends TestCase
 
         $this->blockFactory = $this->getMockBuilder(BlockFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->blockRepository = $this->getMockBuilder(BlockRepositoryInterface::class)
@@ -172,12 +175,15 @@ class SaveTest extends TestCase
                 'context' => $this->contextMock,
                 'dataPersistor' => $this->dataPersistorMock,
                 'blockFactory' => $this->blockFactory,
-                'blockRepository' => $this->blockRepository,
+                'blockRepository' => $this->blockRepository
             ]
         );
     }
 
-    public function testSaveAction()
+    /**
+    * @return void
+    */
+    public function testSaveAction(): void
     {
         $postData = [
             'title' => '"><img src=y onerror=prompt(document.domain)>;',
@@ -194,7 +200,7 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, 'continue'],
+                    ['back', null, 'continue']
                 ]
             );
 
@@ -223,14 +229,20 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveActionWithoutData()
+    /**
+    * @return void
+    */
+    public function testSaveActionWithoutData(): void
     {
         $this->requestMock->expects($this->any())->method('getPostValue')->willReturn(false);
         $this->resultRedirect->expects($this->atLeastOnce())->method('setPath')->with('*/*/')->willReturnSelf();
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveActionNoId()
+    /**
+    * @return void
+    */
+    public function testSaveActionNoId(): void
     {
         $postData = [
             'block_id' => 1,
@@ -243,7 +255,7 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, false],
+                    ['back', null, false]
                 ]
             );
 
@@ -265,7 +277,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveAndDuplicate()
+    /**
+    * @return void
+    */
+    public function testSaveAndDuplicate(): void
     {
         $postData = [
             'title' => 'unique_title_123',
@@ -282,22 +297,18 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, true],
+                    ['back', null, true]
                 ]
             );
-
-        $this->blockFactory->expects($this->at(0))
-            ->method('create')
-            ->willReturn($this->blockMock);
 
         $duplicateBlockMock = $this->getMockBuilder(
             Block::class
         )->disableOriginalConstructor()
             ->getMock();
 
-        $this->blockFactory->expects($this->at(1))
+        $this->blockFactory
             ->method('create')
-            ->willReturn($duplicateBlockMock);
+            ->willReturnOnConsecutiveCalls($this->blockMock, $duplicateBlockMock);
 
         $duplicateBlockMock->expects($this->atLeastOnce())
             ->method('setId')
@@ -323,16 +334,13 @@ class SaveTest extends TestCase
             ->willReturn($this->blockMock);
 
         $this->blockMock->expects($this->any())->method('setData');
-        $this->blockRepository->expects($this->at(1))->method('save')->with($this->blockMock);
-        $this->blockRepository->expects($this->at(2))->method('save')->with($duplicateBlockMock);
+        $this->blockRepository
+            ->method('save')
+            ->withConsecutive([$this->blockMock], [$duplicateBlockMock]);
 
-        $this->messageManagerMock->expects($this->at(0))
+        $this->messageManagerMock
             ->method('addSuccessMessage')
-            ->with(__('You saved the block.'));
-
-        $this->messageManagerMock->expects($this->at(1))
-            ->method('addSuccessMessage')
-            ->with(__('You duplicated the block.'));
+            ->withConsecutive([__('You saved the block.')], [__('You duplicated the block.')]);
 
         $this->dataPersistorMock->expects($this->any())
             ->method('clear')
@@ -346,7 +354,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveAndClose()
+    /**
+    * @return void
+    */
+    public function testSaveAndClose(): void
     {
         $postData = [
             'title' => '"><img src=y onerror=prompt(document.domain)>;',
@@ -363,7 +374,7 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, 'close'],
+                    ['back', null, 'close']
                 ]
             );
 
@@ -392,7 +403,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveActionWithMarginalSpace()
+    /**
+    * @return void
+    */
+    public function testSaveActionWithMarginalSpace(): void
     {
         $postData = [
             'title' => 'unique_title_123',
@@ -409,7 +423,7 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, true],
+                    ['back', null, true]
                 ]
             );
 
@@ -444,7 +458,10 @@ class SaveTest extends TestCase
         $this->assertSame($this->resultRedirect, $this->saveController->execute());
     }
 
-    public function testSaveActionThrowsException()
+    /**
+    * @return void
+    */
+    public function testSaveActionThrowsException(): void
     {
         $postData = [
             'title' => '"><img src=y onerror=prompt(document.domain)>;',
@@ -461,7 +478,7 @@ class SaveTest extends TestCase
             ->willReturnMap(
                 [
                     ['block_id', null, 1],
-                    ['back', null, true],
+                    ['back', null, true]
                 ]
             );
 

--- a/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Controller/Adminhtml/Page/EditTest.php
@@ -83,6 +83,9 @@ class EditTest extends TestCase
      */
     protected $resultPageFactoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -94,7 +97,7 @@ class EditTest extends TestCase
             ->getMock();
 
         $this->objectManagerMock = $this->getMockBuilder(\Magento\Framework\ObjectManager\ObjectManager::class)
-            ->setMethods(['create', 'get'])
+            ->onlyMethods(['create', 'get'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->objectManagerMock->expects($this->once())
@@ -136,12 +139,15 @@ class EditTest extends TestCase
             [
                 'context' => $this->contextMock,
                 'resultPageFactory' => $this->resultPageFactoryMock,
-                'registry' => $this->coreRegistryMock,
+                'registry' => $this->coreRegistryMock
             ]
         );
     }
 
-    public function testEditActionPageNoExists()
+    /**
+    * @return void
+    */
+    public function testEditActionPageNoExists(): void
     {
         $pageId = 1;
 
@@ -174,12 +180,14 @@ class EditTest extends TestCase
     }
 
     /**
-     * @param int $pageId
+     * @param int|null $pageId
      * @param string $label
      * @param string $title
+     *
+     * @return void
      * @dataProvider editActionData
      */
-    public function testEditAction($pageId, $label, $title)
+    public function testEditAction(?int $pageId, string $label, string $title): void
     {
         $this->requestMock->expects($this->once())
             ->method('getParam')
@@ -207,8 +215,9 @@ class EditTest extends TestCase
             ->willReturn($resultPageMock);
 
         $titleMock = $this->createMock(Title::class);
-        $titleMock->expects($this->at(0))->method('prepend')->with(__('Pages'));
-        $titleMock->expects($this->at(1))->method('prepend')->with($this->getTitle());
+        $titleMock
+            ->method('prepend')
+            ->withConsecutive([__('Pages')], [$this->getTitle()]);
         $pageConfigMock = $this->createMock(Config::class);
         $pageConfigMock->expects($this->exactly(2))->method('getTitle')->willReturn($titleMock);
 
@@ -218,10 +227,10 @@ class EditTest extends TestCase
         $resultPageMock->expects($this->any())
             ->method('addBreadcrumb')
             ->willReturnSelf();
-        $resultPageMock->expects($this->at(3))
+        $resultPageMock
             ->method('addBreadcrumb')
-            ->with(__($label), __($title))
-            ->willReturnSelf();
+            ->withConsecutive([], [], [], [__($label), __($title)])
+            ->willReturnOnConsecutiveCalls(null, null, null, $resultPageMock);
         $resultPageMock->expects($this->exactly(2))
             ->method('getConfig')
             ->willReturn($pageConfigMock);
@@ -240,7 +249,7 @@ class EditTest extends TestCase
     /**
      * @return array
      */
-    public function editActionData()
+    public function editActionData(): array
     {
         return [
             [null, 'New Page', 'New Page'],

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Structure/Element/Dependency/MapperTest.php
@@ -53,28 +53,28 @@ class MapperTest extends TestCase
      */
     private $_scopeConfigMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->_testData = [
             'field_x' => ['id' => self::FIELD_ID1],
-            'field_y' => ['id' => self::FIELD_ID2],
+            'field_y' => ['id' => self::FIELD_ID2]
         ];
 
-        $this->_configStructureMock = $this->getMockBuilder(
-            Structure::class
-        )->setMethods(
-            ['getElement']
-        )->disableOriginalConstructor()
+        $this->_configStructureMock = $this->getMockBuilder(Structure::class)
+            ->onlyMethods(['getElement'])
+            ->disableOriginalConstructor()
             ->getMock();
-        $this->_fieldFactoryMock = $this->getMockBuilder(
-            FieldFactory::class
-        )->setMethods(
-            ['create']
-        )->disableOriginalConstructor()
+        $this->_fieldFactoryMock = $this->getMockBuilder(FieldFactory::class)
+            ->onlyMethods(['create'])
+            ->disableOriginalConstructor()
             ->getMock();
         $this->_scopeConfigMock = $this->getMockBuilder(
             ScopeConfigInterface::class
-        )->disableOriginalConstructor()
+        )
+            ->disableOriginalConstructor()
             ->getMock();
         $this->_model = new Mapper(
             $this->_configStructureMock,
@@ -83,6 +83,9 @@ class MapperTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         unset($this->_model);
@@ -93,13 +96,20 @@ class MapperTest extends TestCase
 
     /**
      * @param bool $isValueSatisfy
+     *
+     * @return void
      * @dataProvider getDependenciesDataProvider
      */
-    public function testGetDependenciesWhenDependentIsInvisible($isValueSatisfy)
+    public function testGetDependenciesWhenDependentIsInvisible($isValueSatisfy): void
     {
         $expected = [];
         $rowData = array_values($this->_testData);
         $count = count($this->_testData);
+
+        $configStructureMockWithArgs = $configStructureMockWillReturnArgs = [];
+        $fieldFactoryMockWithArgs = $fieldFactoryMockWillReturnArgs = [];
+        $scopeConfigMockWithArgs = $scopeConfigMockWillReturnArgs = [];
+
         for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $dependentPath = 'some path ' . $i;
@@ -108,45 +118,35 @@ class MapperTest extends TestCase
                 $dependentPath,
                 'Magento_Backend_Model_Config_Structure_Element_Field_' . (string)$isValueSatisfy . $i
             );
-            $this->_configStructureMock->expects(
-                $this->at($i)
-            )->method(
-                'getElement'
-            )->with(
-                $data['id']
-            )->willReturn(
-                $field
-            );
             $dependencyField = $this->_getDependencyField(
                 $isValueSatisfy,
                 false,
                 $data['id'],
                 'Magento_Backend_Model_Config_Structure_Element_Dependency_Field_' . (string)$isValueSatisfy . $i
             );
-            $this->_fieldFactoryMock->expects(
-                $this->at($i)
-            )->method(
-                'create'
-            )->with(
-                ['fieldData' => $data, 'fieldPrefix' => self::FIELD_PREFIX]
-            )->willReturn(
-                $dependencyField
-            );
-            $this->_scopeConfigMock->expects(
-                $this->at($i)
-            )->method(
-                'getValue'
-            )->with(
-                $dependentPath,
-                ScopeInterface::SCOPE_STORE,
-                self::STORE_CODE
-            )->willReturn(
-                self::VALUE_IN_STORE
-            );
+            $configStructureMockWithArgs[] = [$data['id']];
+            $configStructureMockWillReturnArgs[] = $field;
+            $fieldFactoryMockWithArgs[] = [['fieldData' => $data, 'fieldPrefix' => self::FIELD_PREFIX]];
+            $fieldFactoryMockWillReturnArgs[] = $dependencyField;
+            $scopeConfigMockWithArgs[] = [$dependentPath, ScopeInterface::SCOPE_STORE, self::STORE_CODE];
+            $scopeConfigMockWillReturnArgs[] = self::VALUE_IN_STORE;
+
             if (!$isValueSatisfy) {
                 $expected[$data['id']] = $dependencyField;
             }
         }
+        $this->_configStructureMock
+            ->method('getElement')
+            ->withConsecutive(...$configStructureMockWithArgs)
+            ->willReturn(...$configStructureMockWillReturnArgs);
+        $this->_fieldFactoryMock
+            ->method('create')
+            ->withConsecutive(...$fieldFactoryMockWithArgs)
+            ->willReturnOnConsecutiveCalls(...$fieldFactoryMockWillReturnArgs);
+        $this->_scopeConfigMock->method('getValue')
+            ->withConsecutive(...$scopeConfigMockWithArgs)
+            ->willReturnOnConsecutiveCalls(...$scopeConfigMockWillReturnArgs);
+
         $actual = $this->_model->getDependencies($this->_testData, self::STORE_CODE, self::FIELD_PREFIX);
         $this->assertEquals($expected, $actual);
     }
@@ -154,16 +154,22 @@ class MapperTest extends TestCase
     /**
      * @return array
      */
-    public function getDependenciesDataProvider()
+    public function getDependenciesDataProvider(): array
     {
         return [[true], [false]];
     }
 
-    public function testGetDependenciesIsVisible()
+    /**
+    * @return void
+    */
+    public function testGetDependenciesIsVisible(): void
     {
         $expected = [];
         $rowData = array_values($this->_testData);
         $count = count($this->_testData);
+        $configStructureMockWithArgs = $configStructureMockWillReturnArgs = [];
+        $fieldFactoryMockWithArgs = $fieldFactoryMockWillReturnArgs = [];
+
         for ($i = 0; $i < $count; ++$i) {
             $data = $rowData[$i];
             $field = $this->_getField(
@@ -171,32 +177,28 @@ class MapperTest extends TestCase
                 'some path',
                 'Magento_Backend_Model_Config_Structure_Element_Field_visible_' . $i
             );
-            $this->_configStructureMock->expects(
-                $this->at($i)
-            )->method(
-                'getElement'
-            )->with(
-                $data['id']
-            )->willReturn(
-                $field
-            );
             $dependencyField = $this->_getDependencyField(
                 (bool)$i,
                 true,
                 $data['id'],
                 'Magento_Backend_Model_Config_Structure_Element_Dependency_Field_visible_' . $i
             );
-            $this->_fieldFactoryMock->expects(
-                $this->at($i)
-            )->method(
-                'create'
-            )->with(
-                ['fieldData' => $data, 'fieldPrefix' => self::FIELD_PREFIX]
-            )->willReturn(
-                $dependencyField
-            );
+            $configStructureMockWithArgs[] = [$data['id']];
+            $configStructureMockWillReturnArgs[] = $field;
+            $fieldFactoryMockWithArgs[] = [['fieldData' => $data, 'fieldPrefix' => self::FIELD_PREFIX]];
+            $fieldFactoryMockWillReturnArgs[] = $dependencyField;
+
             $expected[$data['id']] = $dependencyField;
         }
+        $this->_configStructureMock
+            ->method('getElement')
+            ->withConsecutive(...$configStructureMockWithArgs)
+            ->willReturn(...$configStructureMockWillReturnArgs);
+        $this->_fieldFactoryMock
+            ->method('create')
+            ->withConsecutive(...$fieldFactoryMockWithArgs)
+            ->willReturnOnConsecutiveCalls(...$fieldFactoryMockWillReturnArgs);
+
         $actual = $this->_model->getDependencies($this->_testData, self::STORE_CODE, self::FIELD_PREFIX);
         $this->assertEquals($expected, $actual);
     }
@@ -208,17 +210,15 @@ class MapperTest extends TestCase
      * @param bool $isFieldVisible
      * @param string $fieldId
      * @param string $mockClassName
+     *
      * @return MockObject
      */
-    protected function _getDependencyField($isValueSatisfy, $isFieldVisible, $fieldId, $mockClassName)
+    protected function _getDependencyField($isValueSatisfy, $isFieldVisible, $fieldId, $mockClassName): MockObject
     {
-        $field = $this->getMockBuilder(
-            Field::class
-        )->setMethods(
-            ['isValueSatisfy', 'getId']
-        )->setMockClassName(
-            $mockClassName
-        )->disableOriginalConstructor()
+        $field = $this->getMockBuilder(Field::class)
+            ->onlyMethods(['isValueSatisfy', 'getId'])
+            ->setMockClassName($mockClassName)
+            ->disableOriginalConstructor()
             ->getMock();
         if ($isFieldVisible) {
             $field->expects($isFieldVisible ? $this->never() : $this->once())->method('isValueSatisfy');
@@ -249,17 +249,15 @@ class MapperTest extends TestCase
      * @param bool $isVisible
      * @param string $path
      * @param string $mockClassName
+     *
      * @return MockObject
      */
-    protected function _getField($isVisible, $path, $mockClassName)
+    protected function _getField($isVisible, $path, $mockClassName): MockObject
     {
-        $field = $this->getMockBuilder(
-            \Magento\Config\Model\Config\Structure\Element\Field::class
-        )->setMethods(
-            ['isVisible', 'getPath']
-        )->setMockClassName(
-            $mockClassName
-        )->disableOriginalConstructor()
+        $field = $this->getMockBuilder(\Magento\Config\Model\Config\Structure\Element\Field::class)
+            ->onlyMethods(['isVisible', 'getPath'])
+            ->setMockClassName($mockClassName)
+            ->disableOriginalConstructor()
             ->getMock();
         $field->expects($this->once())->method('isVisible')->willReturn($isVisible);
         if ($isVisible) {

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/NameTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/NameTest.php
@@ -55,24 +55,36 @@ class NameTest extends TestCase
     const INVALID_ATTRIBUTE_CODE = 'invalid attribute code';
 
     const PREFIX_STORE_LABEL = 'Name Prefix';
-
     /**#@-*/
-    /** @var  MockObject|AttributeMetadataInterface */
+
+    /**
+     * @var MockObject|AttributeMetadataInterface
+     */
     private $attribute;
 
-    /** @var  MockObject|Options */
+    /**
+     * @var MockObject|Options
+     */
     private $_options;
 
-    /** @var  MockObject|Escaper */
+    /**
+     * @var MockObject|Escaper
+     */
     private $_escaper;
 
-    /** @var  Name */
+    /**
+     * @var Name
+     */
     private $_block;
 
-    /** @var  MockObject|CustomerMetadataInterface */
+    /**
+     * @var MockObject|CustomerMetadataInterface
+     */
     private $customerMetadata;
 
-    /** @var MockObject|AddressMetadataInterface */
+    /**
+     * @var MockObject|AddressMetadataInterface
+     */
     private $addressMetadata;
 
     /**
@@ -80,6 +92,14 @@ class NameTest extends TestCase
      */
     protected $_objectManager;
 
+    /**
+     * @var bool
+     */
+    private $isVisibleAttribute = true;
+
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->_objectManager = new ObjectManager($this);
@@ -119,18 +139,23 @@ class NameTest extends TestCase
     }
 
     /**
+     * @return void
      * @see self::_setUpShowAttribute()
      */
-    public function testShowPrefix()
+    public function testShowPrefix(): void
     {
         $this->_setUpShowAttribute([Customer::PREFIX => self::PREFIX]);
         $this->assertTrue($this->_block->showPrefix());
 
-        $this->attribute->expects($this->at(0))->method('isVisible')->willReturn(false);
+        $this->isVisibleAttribute = false;
         $this->assertFalse($this->_block->showPrefix());
+        $this->isVisibleAttribute = true;
     }
 
-    public function testShowPrefixWithException()
+    /**
+    * @return void
+    */
+    public function testShowPrefixWithException(): void
     {
         $this->customerMetadata->expects(
             $this->any()
@@ -149,9 +174,11 @@ class NameTest extends TestCase
 
     /**
      * @param $method
+     *
+     * @return void
      * @dataProvider methodDataProvider
      */
-    public function testMethodWithNoSuchEntityException($method)
+    public function testMethodWithNoSuchEntityException($method): void
     {
         $this->customerMetadata->expects(
             $this->any()
@@ -171,7 +198,7 @@ class NameTest extends TestCase
     /**
      * @return array
      */
-    public function methodDataProvider()
+    public function methodDataProvider(): array
     {
         return [
             'showPrefix' => ['showPrefix'],
@@ -184,39 +211,55 @@ class NameTest extends TestCase
     }
 
     /**
+     * @return void
      * @see self::_setUpIsAttributeRequired()
      */
-    public function testIsPrefixRequired()
+    public function testIsPrefixRequired(): void
     {
         $this->_setUpIsAttributeRequired();
         $this->assertTrue($this->_block->isPrefixRequired());
     }
 
-    public function testShowMiddlename()
+    /**
+    * @return void
+    */
+    public function testShowMiddlename(): void
     {
         $this->_setUpShowAttribute([Customer::MIDDLENAME => self::MIDDLENAME]);
         $this->assertTrue($this->_block->showMiddlename());
     }
 
-    public function testIsMiddlenameRequired()
+    /**
+    * @return void
+    */
+    public function testIsMiddlenameRequired(): void
     {
         $this->_setUpIsAttributeRequired();
         $this->assertTrue($this->_block->isMiddlenameRequired());
     }
 
-    public function testShowSuffix()
+    /**
+    * @return void
+    */
+    public function testShowSuffix(): void
     {
         $this->_setUpShowAttribute([Customer::SUFFIX => self::SUFFIX]);
         $this->assertTrue($this->_block->showSuffix());
     }
 
-    public function testIsSuffixRequired()
+    /**
+    * @return void
+    */
+    public function testIsSuffixRequired(): void
     {
         $this->_setUpIsAttributeRequired();
         $this->assertTrue($this->_block->isSuffixRequired());
     }
 
-    public function testGetPrefixOptionsNotEmpty()
+    /**
+    * @return void
+    */
+    public function testGetPrefixOptionsNotEmpty(): void
     {
         /**
          * Added some padding so that the trim() call on Customer::getPrefix() will remove it. Also added
@@ -247,7 +290,10 @@ class NameTest extends TestCase
         $this->assertSame($expectedOptions, $this->_block->getPrefixOptions());
     }
 
-    public function testGetPrefixOptionsEmpty()
+    /**
+    * @return void
+    */
+    public function testGetPrefixOptionsEmpty(): void
     {
         $customer = $this->getMockBuilder(
             CustomerInterface::class
@@ -265,7 +311,10 @@ class NameTest extends TestCase
         $this->assertEmpty($this->_block->getPrefixOptions());
     }
 
-    public function testGetSuffixOptionsNotEmpty()
+    /**
+    * @return void
+    */
+    public function testGetSuffixOptionsNotEmpty(): void
     {
         /**
          * Added padding and special characters to show that trim() works on Customer::getSuffix() and that
@@ -295,7 +344,10 @@ class NameTest extends TestCase
         $this->assertSame($expectedOptions, $this->_block->getSuffixOptions());
     }
 
-    public function testGetSuffixOptionsEmpty()
+    /**
+    * @return void
+    */
+    public function testGetSuffixOptionsEmpty(): void
     {
         $customer = $this->getMockBuilder(
             CustomerInterface::class
@@ -313,7 +365,10 @@ class NameTest extends TestCase
         $this->assertEmpty($this->_block->getSuffixOptions());
     }
 
-    public function testGetClassName()
+    /**
+    * @return void
+    */
+    public function testGetClassName(): void
     {
         /** Test the default case when the block has no data set for the class name. */
         $this->assertEquals(self::DEFAULT_CLASS_NAME, $this->_block->getClassName());
@@ -329,31 +384,18 @@ class NameTest extends TestCase
      * @param bool $isSuffixVisible Value returned by Name::showSuffix()
      * @param string $expectedValue The expected value of Name::getContainerClassName()
      *
+     * @return void
      * @dataProvider getContainerClassNameProvider
      */
-    public function testGetContainerClassName($isPrefixVisible, $isMiddlenameVisible, $isSuffixVisible, $expectedValue)
-    {
-        $this->attribute->expects(
-            $this->at(0)
-        )->method(
-            'isVisible'
-        )->willReturn(
-            $isPrefixVisible
-        );
-        $this->attribute->expects(
-            $this->at(1)
-        )->method(
-            'isVisible'
-        )->willReturn(
-            $isMiddlenameVisible
-        );
-        $this->attribute->expects(
-            $this->at(2)
-        )->method(
-            'isVisible'
-        )->willReturn(
-            $isSuffixVisible
-        );
+    public function testGetContainerClassName(
+        $isPrefixVisible,
+        $isMiddlenameVisible,
+        $isSuffixVisible,
+        $expectedValue
+    ): void {
+        $this->attribute
+            ->method('isVisible')
+            ->willReturnOnConsecutiveCalls($isPrefixVisible, $isMiddlenameVisible, $isSuffixVisible);
 
         $this->assertEquals($expectedValue, $this->_block->getContainerClassName());
     }
@@ -364,7 +406,7 @@ class NameTest extends TestCase
      *
      * @return array
      */
-    public function getContainerClassNameProvider()
+    public function getContainerClassNameProvider(): array
     {
         return [
             [false, false, false, self::DEFAULT_CLASS_NAME],
@@ -388,9 +430,10 @@ class NameTest extends TestCase
      * @param string $storeLabel The attribute's store label
      * @param string $expectedValue The expected value of Name::getStoreLabel()
      *
+     * @return void
      * @dataProvider getStoreLabelProvider
      */
-    public function testGetStoreLabel($attributeCode, $storeLabel, $expectedValue)
+    public function testGetStoreLabel($attributeCode, $storeLabel, $expectedValue): void
     {
         $this->attribute->expects($this->atLeastOnce())->method('getStoreLabel')->willReturn($storeLabel);
         $this->assertEquals($expectedValue, $this->_block->getStoreLabel($attributeCode));
@@ -403,7 +446,7 @@ class NameTest extends TestCase
      *
      * @return array
      */
-    public function getStoreLabelProvider()
+    public function getStoreLabelProvider(): array
     {
         return [
             [self::INVALID_ATTRIBUTE_CODE, '', ''],
@@ -411,7 +454,10 @@ class NameTest extends TestCase
         ];
     }
 
-    public function testGetStoreLabelWithException()
+    /**
+    * @return void
+    */
+    public function testGetStoreLabelWithException(): void
     {
         $this->customerMetadata->expects(
             $this->any()
@@ -432,9 +478,11 @@ class NameTest extends TestCase
      * Helper method for testing all show*() methods.
      *
      * @param array $data Customer attribute(s)
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    private function _setUpShowAttribute(array $data)
+    private function _setUpShowAttribute(array $data): void
     {
         $customer = $this->getMockBuilder(CustomerInterface::class)
             ->getMockForAbstractClass();
@@ -451,13 +499,20 @@ class NameTest extends TestCase
          * first call to the method. Subsequent calls may return true or false depending on the returnValue
          * of the at({0, 1, 2, 3, ...}), etc. calls as set and configured in a particular test.
          */
-        $this->attribute->expects($this->at(0))->method('isVisible')->willReturn(true);
+        $testClass = $this;
+        $this->attribute
+            ->method('isVisible')
+            ->willReturnCallback(function () use ($testClass) {
+                return $testClass->isVisibleAttribute;
+            });
     }
 
     /**
      * Helper method for testing all is*Required() methods.
+     *
+     * @return void
      */
-    private function _setUpIsAttributeRequired()
+    private function _setUpIsAttributeRequired(): void
     {
         /**
          * These settings cause the first code path in Name::_getAttribute() to be skipped so that the rest of
@@ -474,8 +529,8 @@ class NameTest extends TestCase
          * all code paths in Name::_getAttribute() will be executed. Returning true for the third isRequired()
          * call causes the is*Required() method of the block to return true for the attribute.
          */
-        $this->attribute->expects($this->at(0))->method('isRequired')->willReturn(false);
-        $this->attribute->expects($this->at(1))->method('isRequired')->willReturn(true);
-        $this->attribute->expects($this->at(2))->method('isRequired')->willReturn(true);
+        $this->attribute
+            ->method('isRequired')
+            ->willReturnOnConsecutiveCalls(false, true, true);
     }
 }

--- a/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Controller/Adminhtml/Index/InlineEditTest.php
@@ -40,72 +40,113 @@ use Psr\Log\LoggerInterface;
  */
 class InlineEditTest extends TestCase
 {
-    /** @var InlineEdit */
+    /**
+     * @var InlineEdit
+     */
     private $controller;
 
-    /** @var Context */
+    /**
+     * @var Context
+     */
     private $context;
 
-    /** @var RequestInterface|MockObject*/
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
-    /** @var ManagerInterface|MockObject*/
+    /**
+     * @var ManagerInterface|MockObject
+     */
     private $messageManager;
 
-    /** @var CustomerInterface|MockObject*/
+    /**
+     * @var CustomerInterface|MockObject
+     */
     protected $customerData;
 
-    /** @var AddressInterface|MockObject*/
+    /**
+     * @var AddressInterface|MockObject
+     */
     private $address;
 
-    /** @var JsonFactory|MockObject*/
+    /**
+     * @var JsonFactory|MockObject
+     */
     private $resultJsonFactory;
 
-    /** @var Json|MockObject*/
+    /**
+     * @var Json|MockObject
+     */
     private $resultJson;
 
-    /** @var CustomerRepositoryInterface|MockObject*/
+    /**
+     * @var CustomerRepositoryInterface|MockObject
+     */
     private $customerRepository;
 
-    /** @var Mapper|MockObject*/
+    /**
+     * @var Mapper|MockObject
+     */
     private $addressMapper;
 
-    /** @var \Magento\Customer\Model\Customer\Mapper|MockObject*/
+    /**
+     * @var \Magento\Customer\Model\Customer\Mapper|MockObject
+     */
     private $customerMapper;
 
-    /** @var DataObjectHelper|MockObject*/
+    /**
+     * @var DataObjectHelper|MockObject
+     */
     private $dataObjectHelper;
 
-    /** @var AddressInterfaceFactory|MockObject*/
+    /**
+     * @var AddressInterfaceFactory|MockObject
+     */
     private $addressDataFactory;
 
-    /** @var AddressRepositoryInterface|MockObject*/
+    /**
+     * @var AddressRepositoryInterface|MockObject
+     */
     private $addressRepository;
 
-    /** @var Collection|MockObject*/
+    /**
+     * @var Collection|MockObject
+     */
     private $messageCollection;
 
-    /** @var MessageInterface|MockObject*/
+    /**
+     * @var MessageInterface|MockObject
+     */
     private $message;
 
-    /** @var LoggerInterface|MockObject*/
+    /**
+     * @var LoggerInterface|MockObject
+     */
     private $logger;
 
-    /** @var EmailNotificationInterface|MockObject */
+    /**
+     * @var EmailNotificationInterface|MockObject
+     */
     private $emailNotification;
 
-    /** @var AddressRegistry|MockObject */
+    /**
+     * @var AddressRegistry|MockObject
+     */
     private $addressRegistry;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private $items;
 
-    /** @var Escaper */
+    /**
+     * @var Escaper
+     */
     private $escaper;
 
     /**
-     * Sets up mocks
-     *
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -198,7 +239,7 @@ class InlineEditTest extends TestCase
                 'addressRepository' => $this->addressRepository,
                 'logger' => $this->logger,
                 'addressRegistry' => $this->addressRegistry,
-                'escaper' => $this->escaper,
+                'escaper' => $this->escaper
             ]
         );
         $reflection = new \ReflectionClass(get_class($this->controller));
@@ -209,29 +250,25 @@ class InlineEditTest extends TestCase
         $this->items = [
             14 => [
                 'email' => 'test@test.ua',
-                'billing_postcode' => '07294',
+                'billing_postcode' => '07294'
             ]
         ];
     }
 
     /**
-     * Prepare mocks for tests
+     * Prepare mocks for tests.
      *
-     * @param int $populateSequence
+     * @return void
      */
-    protected function prepareMocksForTesting($populateSequence = 0)
+    protected function prepareMocksForTesting(): void
     {
         $this->resultJsonFactory->expects($this->once())
             ->method('create')
             ->willReturn($this->resultJson);
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with('items', [])
-            ->willReturn($this->items);
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('isAjax')
-            ->willReturn(true);
+            ->withConsecutive(['items', []], ['isAjax'])
+            ->willReturnOnConsecutiveCalls($this->items, true);
         $this->customerRepository->expects($this->once())
             ->method('getById')
             ->with(14)
@@ -240,32 +277,19 @@ class InlineEditTest extends TestCase
             ->method('toFlatArray')
             ->with($this->customerData)
             ->willReturn(['name' => 'Firstname Lastname']);
-        $this->dataObjectHelper->expects($this->at($populateSequence))
-            ->method('populateWithArray')
-            ->with(
-                $this->customerData,
-                [
-                    'name' => 'Firstname Lastname',
-                    'email' => 'test@test.ua',
-                ],
-                CustomerInterface::class
-            );
         $this->customerData->expects($this->any())
             ->method('getId')
             ->willReturn(12);
     }
 
     /**
-     * Prepare mocks for update customers default billing address use case
+     * Prepare mocks for update customers default billing address use case.
+     *
+     * @return void
      */
-    protected function prepareMocksForUpdateDefaultBilling()
+    protected function prepareMocksForUpdateDefaultBilling(): void
     {
         $this->prepareMocksForProcessAddressData();
-        $addressData = [
-            'postcode' => '07294',
-            'firstname' => 'Firstname',
-            'lastname' => 'Lastname',
-        ];
         $this->customerData->expects($this->exactly(2))
             ->method('getAddresses')
             ->willReturn([$this->address]);
@@ -275,19 +299,14 @@ class InlineEditTest extends TestCase
         $this->addressRegistry->expects($this->once())
             ->method('retrieve')
             ->willReturn(new DataObject());
-        $this->dataObjectHelper->expects($this->at(0))
-            ->method('populateWithArray')
-            ->with(
-                $this->address,
-                $addressData,
-                AddressInterface::class
-            );
     }
 
     /**
-     * Prepare mocks for processing customers address data use case
+     * Prepare mocks for processing customers address data use case.
+     *
+     * @return void
      */
-    protected function prepareMocksForProcessAddressData()
+    protected function prepareMocksForProcessAddressData(): void
     {
         $this->customerData->expects($this->once())
             ->method('getFirstname')
@@ -298,9 +317,11 @@ class InlineEditTest extends TestCase
     }
 
     /**
-     * Prepare mocks for error messages processing test
+     * Prepare mocks for error messages processing test.
+     *
+     * @return void
      */
-    protected function prepareMocksForErrorMessagesProcessing()
+    protected function prepareMocksForErrorMessagesProcessing(): void
     {
         $this->messageManager->expects($this->atLeastOnce())
             ->method('getMessages')
@@ -320,20 +341,44 @@ class InlineEditTest extends TestCase
             ->with(
                 [
                     'messages' => [
-                        'Error text',
+                        'Error text'
                     ],
-                    'error' => true,
+                    'error' => true
                 ]
             )
             ->willReturnSelf();
     }
 
     /**
-     * Unit test for updating customers billing address use case
+     * Unit test for updating customers billing address use case.
+     *
+     * @return void
      */
-    public function testExecuteWithUpdateBilling()
+    public function testExecuteWithUpdateBilling(): void
     {
-        $this->prepareMocksForTesting(1);
+        $this->prepareMocksForTesting();
+        $this->dataObjectHelper
+            ->method('populateWithArray')
+            ->withConsecutive(
+                [
+                    $this->address,
+                    [
+                        'postcode' => '07294',
+                        'firstname' => 'Firstname',
+                        'lastname' => 'Lastname'
+                    ],
+                    AddressInterface::class
+                ],
+                [
+                    $this->customerData,
+                    [
+                        'name' => 'Firstname Lastname',
+                        'email' => 'test@test.ua'
+                    ],
+                    CustomerInterface::class
+                ]
+            );
+
         $this->customerData->expects($this->once())
             ->method('getDefaultBilling')
             ->willReturn(23);
@@ -352,30 +397,28 @@ class InlineEditTest extends TestCase
     }
 
     /**
-     * Unit test for creating customer with empty data use case
+     * Unit test for creating customer with empty data use case.
+     *
+     * @return void
      */
-    public function testExecuteWithoutItems()
+    public function testExecuteWithoutItems(): void
     {
         $this->resultJsonFactory->expects($this->once())
             ->method('create')
             ->willReturn($this->resultJson);
-        $this->request->expects($this->at(0))
+        $this->request
             ->method('getParam')
-            ->with('items', [])
-            ->willReturn([]);
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('isAjax')
-            ->willReturn(false);
+            ->withConsecutive(['items', []], ['isAjax'])
+            ->willReturnOnConsecutiveCalls([], false);
         $this->resultJson
             ->expects($this->once())
             ->method('setData')
             ->with(
                 [
                     'messages' => [
-                        __('Please correct the data sent.'),
+                        __('Please correct the data sent.')
                     ],
-                    'error' => true,
+                    'error' => true
                 ]
             )
             ->willReturnSelf();
@@ -383,12 +426,27 @@ class InlineEditTest extends TestCase
     }
 
     /**
-     * Unit test for verifying Localized Exception during inline edit
+     * Unit test for verifying Localized Exception during inline edit.
+     *
+     * @return void
      */
-    public function testExecuteLocalizedException()
+    public function testExecuteLocalizedException(): void
     {
         $exception = new LocalizedException(__('Exception message'));
         $this->prepareMocksForTesting();
+        $this->dataObjectHelper
+            ->method('populateWithArray')
+            ->withConsecutive(
+                [
+                    $this->customerData,
+                    [
+                        'name' => 'Firstname Lastname',
+                        'email' => 'test@test.ua'
+                    ],
+                    CustomerInterface::class
+                ]
+            );
+
         $this->customerData->expects($this->once())
             ->method('getDefaultBilling')
             ->willReturn(false);
@@ -412,12 +470,26 @@ class InlineEditTest extends TestCase
     }
 
     /**
-     * Unit test for verifying Execute Exception during inline edit
+     * Unit test for verifying Execute Exception during inline edit.
+     *
+     * @return void
      */
-    public function testExecuteException()
+    public function testExecuteException(): void
     {
         $exception = new \Exception('Exception message');
         $this->prepareMocksForTesting();
+        $this->dataObjectHelper
+            ->method('populateWithArray')
+            ->withConsecutive(
+                [
+                    $this->customerData,
+                    [
+                        'name' => 'Firstname Lastname',
+                        'email' => 'test@test.ua'
+                    ],
+                    CustomerInterface::class
+                ]
+            );
         $this->customerData->expects($this->once())
             ->method('getDefaultBilling')
             ->willReturn(false);

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -12,8 +12,8 @@ use Magento\Customer\Api\CustomerMetadataInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\CustomerInterface;
-use Magento\Customer\Api\SessionCleanerInterface;
 use Magento\Customer\Api\Data\ValidationResultsInterfaceFactory;
+use Magento\Customer\Api\SessionCleanerInterface;
 use Magento\Customer\Helper\View;
 use Magento\Customer\Model\AccountConfirmation;
 use Magento\Customer\Model\AccountManagement;
@@ -28,7 +28,6 @@ use Magento\Customer\Model\Data\CustomerSecure;
 use Magento\Customer\Model\EmailNotificationInterface;
 use Magento\Customer\Model\Metadata\Validator;
 use Magento\Customer\Model\ResourceModel\Visitor\CollectionFactory;
-use Magento\Customer\Model\Visitor;
 use Magento\Directory\Model\AllowedCountries;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -69,79 +68,129 @@ use Psr\Log\LoggerInterface;
  */
 class AccountManagementTest extends TestCase
 {
-    /** @var AccountManagement */
+    /**
+     * @var AccountManagement
+     */
     protected $accountManagement;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
-    /** @var CustomerFactory|MockObject */
+    /**
+     * @var CustomerFactory|MockObject
+     */
     protected $customerFactory;
 
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     protected $manager;
 
-    /** @var StoreManagerInterface|MockObject */
+    /**
+     * @var StoreManagerInterface|MockObject
+     */
     protected $storeManager;
 
-    /** @var Random|MockObject */
+    /**
+     * @var Random|MockObject
+     */
     protected $random;
 
-    /** @var Validator|MockObject */
+    /**
+     * @var Validator|MockObject
+     */
     protected $validator;
 
-    /** @var ValidationResultsInterfaceFactory|MockObject */
+    /**
+     * @var ValidationResultsInterfaceFactory|MockObject
+     */
     protected $validationResultsInterfaceFactory;
 
-    /** @var AddressRepositoryInterface|MockObject */
+    /**
+     * @var AddressRepositoryInterface|MockObject
+     */
     protected $addressRepository;
 
-    /** @var CustomerMetadataInterface|MockObject */
+    /**
+     * @var CustomerMetadataInterface|MockObject
+     */
     protected $customerMetadata;
 
-    /** @var CustomerRegistry|MockObject */
+    /**
+     * @var CustomerRegistry|MockObject
+     */
     protected $customerRegistry;
 
-    /** @var LoggerInterface|MockObject */
+    /**
+     * @var LoggerInterface|MockObject
+     */
     protected $logger;
 
-    /** @var EncryptorInterface|MockObject */
+    /**
+     * @var EncryptorInterface|MockObject
+     */
     protected $encryptor;
 
-    /** @var Share|MockObject */
+    /**
+     * @var Share|MockObject
+     */
     protected $share;
 
-    /** @var StringUtils|MockObject */
+    /**
+     * @var StringUtils|MockObject
+     */
     protected $string;
 
-    /** @var CustomerRepositoryInterface|MockObject */
+    /**
+     * @var CustomerRepositoryInterface|MockObject
+     */
     protected $customerRepository;
 
-    /** @var ScopeConfigInterface|MockObject */
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
     protected $scopeConfig;
 
-    /** @var TransportBuilder|MockObject */
+    /**
+     * @var TransportBuilder|MockObject
+     */
     protected $transportBuilder;
 
-    /** @var DataObjectProcessor|MockObject */
+    /**
+     * @var DataObjectProcessor|MockObject
+     */
     protected $dataObjectProcessor;
 
-    /** @var Registry|MockObject */
+    /**
+     * @var Registry|MockObject
+     */
     protected $registry;
 
-    /** @var View|MockObject */
+    /**
+     * @var View|MockObject
+     */
     protected $customerViewHelper;
 
-    /** @var \Magento\Framework\Stdlib\DateTime|MockObject */
+    /**
+     * @var \Magento\Framework\Stdlib\DateTime|MockObject
+     */
     protected $dateTime;
 
-    /** @var \Magento\Customer\Model\Customer|MockObject */
+    /**
+     * @var \Magento\Customer\Model\Customer|MockObject
+     */
     protected $customer;
 
-    /** @var DataObjectFactory|MockObject */
+    /**
+     * @var DataObjectFactory|MockObject
+     */
     protected $objectFactory;
 
-    /** @var ExtensibleDataObjectConverter|MockObject */
+    /**
+     * @var ExtensibleDataObjectConverter|MockObject
+     */
     protected $extensibleDataObjectConverter;
 
     /**
@@ -205,11 +254,12 @@ class AccountManagementTest extends TestCase
     private $allowedCountriesReader;
 
     /**
-     * @var SessionCleanerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var SessionCleanerInterface|MockObject
      */
     private $sessionCleanerMock;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -256,7 +306,8 @@ class AccountManagementTest extends TestCase
             ->getMockForAbstractClass();
 
         $this->customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['setRpToken', 'addData', 'setRpTokenCreatedAt', 'setData'])
+            ->onlyMethods(['addData', 'setData'])
+            ->addMethods(['setRpToken', 'setRpTokenCreatedAt'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -264,11 +315,9 @@ class AccountManagementTest extends TestCase
         $this->accountConfirmation = $this->createMock(AccountConfirmation::class);
         $this->searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
 
-        $this->visitorCollectionFactory = $this->getMockBuilder(
-            CollectionFactory::class
-        )
+        $this->visitorCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->sessionManager = $this->getMockBuilder(SessionManagerInterface::class)
             ->disableOriginalConstructor()
@@ -311,7 +360,7 @@ class AccountManagementTest extends TestCase
                 'visitorCollectionFactory' => $this->visitorCollectionFactory,
                 'searchCriteriaBuilder' => $this->searchCriteriaBuilderMock,
                 'addressRegistry' => $this->addressRegistryMock,
-                'allowedCountriesReader' => $this->allowedCountriesReader,
+                'allowedCountriesReader' => $this->allowedCountriesReader
             ]
         );
         $this->objectManagerHelper->setBackwardCompatibleProperty(
@@ -326,7 +375,10 @@ class AccountManagementTest extends TestCase
         );
     }
 
-    public function testCreateAccountWithPasswordHashWithExistingCustomer()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashWithExistingCustomer(): void
     {
         $this->expectException(InputException::class);
 
@@ -374,7 +426,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->createAccountWithPasswordHash($customer, $hash);
     }
 
-    public function testCreateAccountWithPasswordHashWithCustomerWithoutStoreId()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashWithCustomerWithoutStoreId(): void
     {
         $this->expectException(InputMismatchException::class);
 
@@ -414,9 +469,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(10))
+        $customer
             ->method('getStoreId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -452,7 +507,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->createAccountWithPasswordHash($customer, $hash);
     }
 
-    public function testCreateAccountWithPasswordHashWithLocalizedException()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashWithLocalizedException(): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -491,9 +549,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(10))
+        $customer
             ->method('getStoreId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -529,7 +587,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->createAccountWithPasswordHash($customer, $hash);
     }
 
-    public function testCreateAccountWithPasswordHashWithAddressException()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashWithAddressException(): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -571,9 +632,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(10))
+        $customer
             ->method('getStoreId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -625,7 +686,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->createAccountWithPasswordHash($customer, $hash);
     }
 
-    public function testCreateAccountWithPasswordHashWithNewCustomerAndLocalizedException()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashWithNewCustomerAndLocalizedException(): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -699,9 +763,10 @@ class AccountManagementTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreateAccountWithoutPassword()
+    public function testCreateAccountWithoutPassword(): void
     {
         $websiteId = 1;
         $defaultStoreId = 1;
@@ -744,8 +809,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(10))->method('getStoreId')
-            ->willReturn(1);
+        $customer
+            ->method('getStoreId')
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -780,7 +846,7 @@ class AccountManagementTest extends TestCase
             ->method('getUniqueHash')
             ->willReturn($newLinkToken);
         $customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
+            ->addMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
             ->disableOriginalConstructor()
             ->getMock();
         $customerSecure->expects($this->any())
@@ -812,25 +878,25 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * Data provider for testCreateAccountWithPasswordInputException test
+     * Data provider for testCreateAccountWithPasswordInputException test.
      *
      * @return array
      */
-    public function dataProviderCheckPasswordStrength()
+    public function dataProviderCheckPasswordStrength(): array
     {
         return [
             [
                 'testNumber' => 1,
                 'password' => 'qwer',
                 'minPasswordLength' => 5,
-                'minCharacterSetsNum' => 1,
+                'minCharacterSetsNum' => 1
             ],
             [
                 'testNumber' => 2,
                 'password' => 'wrfewqedf1',
                 'minPasswordLength' => 5,
-                'minCharacterSetsNum' => 3,
-            ],
+                'minCharacterSetsNum' => 3
+            ]
         ];
     }
 
@@ -839,6 +905,8 @@ class AccountManagementTest extends TestCase
      * @param string $password
      * @param int $minPasswordLength
      * @param int $minCharacterSetsNum
+     *
+     * @return void
      * @dataProvider dataProviderCheckPasswordStrength
      */
     public function testCreateAccountWithPasswordInputException(
@@ -846,7 +914,7 @@ class AccountManagementTest extends TestCase
         $password,
         $minPasswordLength,
         $minCharacterSetsNum
-    ) {
+    ): void {
         $this->scopeConfig->expects($this->any())
             ->method('getValue')
             ->willReturnMap(
@@ -855,14 +923,14 @@ class AccountManagementTest extends TestCase
                         AccountManagement::XML_PATH_MINIMUM_PASSWORD_LENGTH,
                         'default',
                         null,
-                        $minPasswordLength,
+                        $minPasswordLength
                     ],
                     [
                         AccountManagement::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER,
                         'default',
                         null,
-                        $minCharacterSetsNum,
-                    ],
+                        $minCharacterSetsNum
+                    ]
                 ]
             );
 
@@ -894,9 +962,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return void
      */
-    public function testCreateAccountInputExceptionExtraLongPassword()
+    public function testCreateAccountInputExceptionExtraLongPassword(): void
     {
         $password = '257*chars*************************************************************************************'
             . '****************************************************************************************************'
@@ -917,9 +985,10 @@ class AccountManagementTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreateAccountWithPassword()
+    public function testCreateAccountWithPassword(): void
     {
         $websiteId = 1;
         $defaultStoreId = 1;
@@ -1006,9 +1075,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(11))
+        $customer
             ->method('getStoreId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -1043,7 +1112,7 @@ class AccountManagementTest extends TestCase
             ->method('getUniqueHash')
             ->willReturn($newLinkToken);
         $customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
+            ->addMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
             ->disableOriginalConstructor()
             ->getMock();
         $customerSecure->expects($this->any())
@@ -1075,9 +1144,10 @@ class AccountManagementTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSendPasswordReminderEmail()
+    public function testSendPasswordReminderEmail(): void
     {
         $customerId = 1;
         $customerStoreId = 2;
@@ -1104,14 +1174,10 @@ class AccountManagementTest extends TestCase
             ->method('getId')
             ->willReturn($customerStoreId);
 
-        $this->storeManager->expects($this->at(0))
+        $this->storeManager
             ->method('getStore')
-            ->willReturn($this->store);
-
-        $this->storeManager->expects($this->at(1))
-            ->method('getStore')
-            ->with($customerStoreId)
-            ->willReturn($this->store);
+            ->withConsecutive([], [$customerStoreId])
+            ->willReturnOnConsecutiveCalls($this->store, $this->store);
 
         $this->customerRegistry->expects($this->once())
             ->method('retrieveSecureData')
@@ -1137,14 +1203,20 @@ class AccountManagementTest extends TestCase
             ->with('name', $customerName)
             ->willReturnSelf();
 
-        $this->scopeConfig->expects($this->at(0))
+        $this->scopeConfig
             ->method('getValue')
-            ->with(AccountManagement::XML_PATH_REMIND_EMAIL_TEMPLATE, ScopeInterface::SCOPE_STORE, $customerStoreId)
-            ->willReturn($templateIdentifier);
-        $this->scopeConfig->expects($this->at(1))
-            ->method('getValue')
-            ->with(AccountManagement::XML_PATH_FORGOT_EMAIL_IDENTITY, ScopeInterface::SCOPE_STORE, $customerStoreId)
-            ->willReturn($sender);
+            ->withConsecutive(
+                [
+                    AccountManagement::XML_PATH_REMIND_EMAIL_TEMPLATE,
+                    ScopeInterface::SCOPE_STORE,
+                    $customerStoreId
+                ], [
+                    AccountManagement::XML_PATH_FORGOT_EMAIL_IDENTITY,
+                    ScopeInterface::SCOPE_STORE,
+                    $customerStoreId
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($templateIdentifier, $sender);
 
         $transport = $this->getMockBuilder(TransportInterface::class)
             ->getMock();
@@ -1186,9 +1258,17 @@ class AccountManagementTest extends TestCase
      * @param int $storeId
      * @param int $customerId
      * @param string $hash
+     *
+     * @return void
      */
-    protected function prepareInitiatePasswordReset($email, $templateIdentifier, $sender, $storeId, $customerId, $hash)
-    {
+    protected function prepareInitiatePasswordReset(
+        $email,
+        $templateIdentifier,
+        $sender,
+        $storeId,
+        $customerId,
+        $hash
+    ): void {
         $websiteId = 1;
         $addressId = 5;
         $datetime = $this->prepareDateTimeFactory();
@@ -1208,7 +1288,8 @@ class AccountManagementTest extends TestCase
         /** @var Address|MockObject $addressModel */
         $addressModel = $this->getMockBuilder(Address::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setShouldIgnoreValidation'])->getMock();
+            ->addMethods(['setShouldIgnoreValidation'])
+            ->getMock();
 
         /** @var AddressInterface|MockObject $customer */
         $address = $this->getMockForAbstractClass(AddressInterface::class);
@@ -1291,8 +1372,10 @@ class AccountManagementTest extends TestCase
      * @param string $sender
      * @param int $storeId
      * @param string $customerName
+     *
+     * @return void
      */
-    protected function prepareEmailSend($email, $templateIdentifier, $sender, $storeId, $customerName)
+    protected function prepareEmailSend($email, $templateIdentifier, $sender, $storeId, $customerName): void
     {
         $transport = $this->getMockBuilder(TransportInterface::class)
             ->getMock();
@@ -1326,9 +1409,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return void
      */
-    public function testInitiatePasswordResetEmailReminder()
+    public function testInitiatePasswordResetEmailReminder(): void
     {
         $customerId = 1;
 
@@ -1351,9 +1434,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return void
      */
-    public function testInitiatePasswordResetEmailReset()
+    public function testInitiatePasswordResetEmailReset(): void
     {
         $storeId = 1;
         $customerId = 1;
@@ -1375,9 +1458,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return void
      */
-    public function testInitiatePasswordResetNoTemplate()
+    public function testInitiatePasswordResetNoTemplate(): void
     {
         $storeId = 1;
         $customerId = 1;
@@ -1398,7 +1481,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->initiatePasswordReset($email, $template);
     }
 
-    public function testValidateResetPasswordTokenBadCustomerId()
+    /**
+    * @return void
+    */
+    public function testValidateResetPasswordTokenBadCustomerId(): void
     {
         $this->expectException(InputException::class);
         $this->expectExceptionMessage('Invalid value of "0" provided for the customerId field');
@@ -1406,7 +1492,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->validateResetPasswordLinkToken(0, '');
     }
 
-    public function testValidateResetPasswordTokenBadResetPasswordLinkToken()
+    /**
+    * @return void
+    */
+    public function testValidateResetPasswordTokenBadResetPasswordLinkToken(): void
     {
         $this->expectException(InputException::class);
         $this->expectExceptionMessage('"resetPasswordLinkToken" is required. Enter and try again.');
@@ -1414,7 +1503,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->validateResetPasswordLinkToken(22, null);
     }
 
-    public function testValidateResetPasswordTokenTokenMismatch()
+    /**
+    * @return void
+    */
+    public function testValidateResetPasswordTokenTokenMismatch(): void
     {
         $this->expectException(InputMismatchException::class);
         $this->expectExceptionMessage('The password token is mismatched. Reset and try again.');
@@ -1426,7 +1518,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->validateResetPasswordLinkToken(22, 'newStringToken');
     }
 
-    public function testValidateResetPasswordTokenTokenExpired()
+    /**
+    * @return void
+    */
+    public function testValidateResetPasswordTokenTokenExpired(): void
     {
         $this->expectException(ExpiredException::class);
         $this->expectExceptionMessage('The password token is expired. Reset and try again.');
@@ -1440,9 +1535,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * return bool
+     * @return void
      */
-    public function testValidateResetPasswordToken()
+    public function testValidateResetPasswordToken(): void
     {
         $this->reInitModel();
 
@@ -1459,20 +1554,22 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * reInit $this->accountManagement object
+     * reInit $this->accountManagement object.
+     *
+     * @return void
      */
-    private function reInitModel()
+    private function reInitModel(): void
     {
         $this->customerSecure = $this->getMockBuilder(CustomerSecure::class)
             ->disableOriginalConstructor()
-            ->setMethods(
+            ->addMethods(
                 [
                     'getRpToken',
                     'getRpTokenCreatedAt',
                     'getPasswordHash',
                     'setPasswordHash',
                     'setRpToken',
-                    'setRpTokenCreatedAt',
+                    'setRpTokenCreatedAt'
                 ]
             )
             ->getMock();
@@ -1485,29 +1582,27 @@ class AccountManagementTest extends TestCase
             ->willReturn($pastDateTime);
         $this->customer = $this->getMockBuilder(\Magento\Customer\Model\Customer::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getResetPasswordLinkExpirationPeriod'])
+            ->onlyMethods(['getResetPasswordLinkExpirationPeriod'])
             ->getMock();
 
         $this->prepareDateTimeFactory();
         $this->sessionManager = $this->getMockBuilder(SessionManagerInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
-        $this->visitorCollectionFactory = $this->getMockBuilder(
-            CollectionFactory::class
-        )
+        $this->visitorCollectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->saveHandler = $this->getMockBuilder(SaveHandlerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['destroy'])
+            ->onlyMethods(['destroy'])
             ->getMockForAbstractClass();
 
         $dateTime = '2017-10-25 18:57:08';
         $timestamp = '1508983028';
         $dateTimeMock = $this->getMockBuilder(\DateTime::class)
             ->disableOriginalConstructor()
-            ->setMethods(['format', 'getTimestamp', 'setTimestamp'])
+            ->onlyMethods(['format', 'getTimestamp', 'setTimestamp'])
             ->getMock();
 
         $dateTimeMock->expects($this->any())
@@ -1522,7 +1617,7 @@ class AccountManagementTest extends TestCase
             ->willReturnSelf();
         $dateTimeFactory = $this->getMockBuilder(DateTimeFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $dateTimeFactory->expects($this->any())->method('create')->willReturn($dateTimeMock);
         $this->sessionCleanerMock = $this->createMock(SessionCleanerInterface::class);
@@ -1546,7 +1641,7 @@ class AccountManagementTest extends TestCase
                 'storeManager' => $this->storeManager,
                 'addressRegistry' => $this->addressRegistryMock,
                 'transportBuilder' => $this->transportBuilder,
-                'sessionCleaner' => $this->sessionCleanerMock,
+                'sessionCleaner' => $this->sessionCleanerMock
             ]
         );
         $this->objectManagerHelper->setBackwardCompatibleProperty(
@@ -1559,7 +1654,7 @@ class AccountManagementTest extends TestCase
     /**
      * @return void
      */
-    public function testChangePassword()
+    public function testChangePassword(): void
     {
         $customerId = 7;
         $email = 'test@example.com';
@@ -1610,14 +1705,14 @@ class AccountManagementTest extends TestCase
                         AccountManagement::XML_PATH_MINIMUM_PASSWORD_LENGTH,
                         'default',
                         null,
-                        7,
+                        7
                     ],
                     [
                         AccountManagement::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER,
                         'default',
                         null,
-                        1,
-                    ],
+                        1
+                    ]
                 ]
             );
         $this->string->expects($this->any())
@@ -1636,9 +1731,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return void
      */
-    public function testResetPassword()
+    public function testResetPassword(): void
     {
         $customerEmail = 'customer@example.com';
         $customerId = '1';
@@ -1650,7 +1745,8 @@ class AccountManagementTest extends TestCase
         /** @var Address|MockObject $addressModel */
         $addressModel = $this->getMockBuilder(Address::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setShouldIgnoreValidation'])->getMock();
+            ->addMethods(['setShouldIgnoreValidation'])
+            ->getMock();
 
         /** @var AddressInterface|MockObject $customer */
         $address = $this->getMockForAbstractClass(AddressInterface::class);
@@ -1696,7 +1792,7 @@ class AccountManagementTest extends TestCase
     /**
      * @return void
      */
-    public function testChangePasswordException()
+    public function testChangePasswordException(): void
     {
         $email = 'test@example.com';
         $currentPassword = '1234567';
@@ -1720,7 +1816,7 @@ class AccountManagementTest extends TestCase
     /**
      * @return void
      */
-    public function testAuthenticate()
+    public function testAuthenticate(): void
     {
         $username = 'login';
         $password = '1234567';
@@ -1747,7 +1843,7 @@ class AccountManagementTest extends TestCase
             ->method('authenticate');
 
         $customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['getPasswordHash'])
+            ->addMethods(['getPasswordHash'])
             ->disableOriginalConstructor()
             ->getMock();
         $customerSecure->expects($this->any())
@@ -1781,13 +1877,15 @@ class AccountManagementTest extends TestCase
      * @param int $isConfirmationRequired
      * @param string|null $confirmation
      * @param string $expected
+     *
+     * @return void
      * @dataProvider dataProviderGetConfirmationStatus
      */
     public function testGetConfirmationStatus(
         $isConfirmationRequired,
         $confirmation,
         $expected
-    ) {
+    ): void {
         $websiteId = 1;
         $customerId = 1;
         $customerEmail = 'test1@example.com';
@@ -1824,18 +1922,21 @@ class AccountManagementTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderGetConfirmationStatus()
+    public function dataProviderGetConfirmationStatus(): array
     {
         return [
             [0, null, AccountManagement::ACCOUNT_CONFIRMATION_NOT_REQUIRED],
             [0, null, AccountManagement::ACCOUNT_CONFIRMATION_NOT_REQUIRED],
             [0, null, AccountManagement::ACCOUNT_CONFIRMATION_NOT_REQUIRED],
             [1, null, AccountManagement::ACCOUNT_CONFIRMED],
-            [1, 'test', AccountManagement::ACCOUNT_CONFIRMATION_REQUIRED],
+            [1, 'test', AccountManagement::ACCOUNT_CONFIRMATION_REQUIRED]
         ];
     }
 
-    public function testCreateAccountWithPasswordHashForGuestException()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithPasswordHashForGuestException(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Exception message');
@@ -1855,18 +1956,15 @@ class AccountManagementTest extends TestCase
         $customerMock = $this->getMockBuilder(Customer::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $customerMock->expects($this->at(1))
+        $customerMock
             ->method('getStoreId')
             ->willReturn($storeId);
-        $customerMock->expects($this->at(4))
-            ->method('getStoreId')
-            ->willReturn($storeId);
-        $customerMock->expects($this->at(2))
+        $customerMock
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customerMock->expects($this->at(5))
+        $customerMock
             ->method('getId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, 1);
 
         $this->customerRepository
             ->expects($this->once())
@@ -1878,9 +1976,10 @@ class AccountManagementTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreateAccountWithPasswordHashWithCustomerAddresses()
+    public function testCreateAccountWithPasswordHashWithCustomerAddresses(): void
     {
         $websiteId = 1;
         $addressId = 2;
@@ -1949,7 +2048,7 @@ class AccountManagementTest extends TestCase
             ->with($customerId)
             ->willReturn($customer);
         $customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
+            ->addMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
             ->disableOriginalConstructor()
             ->getMock();
         $customerSecure->expects($this->once())
@@ -2008,7 +2107,7 @@ class AccountManagementTest extends TestCase
     /**
      * @return string
      */
-    private function prepareDateTimeFactory()
+    private function prepareDateTimeFactory(): string
     {
         $dateTime = '2017-10-25 18:57:08';
         $timestamp = '1508983028';
@@ -2069,9 +2168,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer->expects($this->at(10))
+        $customer
             ->method('getStoreId')
-            ->willReturn(1);
+            ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
             ->with($defaultStoreId);
@@ -2131,7 +2230,10 @@ class AccountManagementTest extends TestCase
         $this->accountManagement->createAccount($customer);
     }
 
-    public function testCreateAccountWithStoreNotInWebsite()
+    /**
+    * @return void
+    */
+    public function testCreateAccountWithStoreNotInWebsite(): void
     {
         $this->expectException(LocalizedException::class);
 
@@ -2192,8 +2294,9 @@ class AccountManagementTest extends TestCase
     }
 
     /**
-     * Test for validating customer store id by customer website id with Exception
+     * Test for validating customer store id by customer website id with Exception.
      *
+     * @return void
      */
     public function testValidateCustomerStoreIdByWebsiteIdException(): void
     {

--- a/app/code/Magento/Customer/Test/Unit/Model/AttributeMetadataResolverTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AttributeMetadataResolverTest.php
@@ -56,7 +56,7 @@ class AttributeMetadataResolverTest extends TestCase
     private $context;
 
     /**
-     * @var  AttributeMetadataResolver
+     * @var AttributeMetadataResolver
      */
     private $model;
 
@@ -66,20 +66,20 @@ class AttributeMetadataResolverTest extends TestCase
     private $attribute;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->countryWithWebsiteSource = $this->getMockBuilder(CountryWithWebsites::class)
-            ->setMethods(['getAllOptions'])
+            ->onlyMethods(['getAllOptions'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->eavValidationRules = $this->getMockBuilder(EavValidationRules::class)
-            ->setMethods(['build'])
+            ->onlyMethods(['build'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->fileUploaderDataResolver = $this->getMockBuilder(FileUploaderDataResolver::class)
-            ->setMethods(['overrideFileUploaderMetadata'])
+            ->onlyMethods(['overrideFileUploaderMetadata'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->context =  $this->getMockBuilder(ContextInterface::class)
@@ -89,18 +89,21 @@ class AttributeMetadataResolverTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->groupManagement =  $this->getMockBuilder(GroupManagement::class)
-            ->setMethods(['getId', 'getDefaultGroup'])
+            ->onlyMethods(['getDefaultGroup'])
+            ->addMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->attribute = $this->getMockBuilder(Attribute::class)
-            ->setMethods([
-                'usesSource',
-                'getDataUsingMethod',
-                'getAttributeCode',
-                'getFrontendInput',
-                'getSource',
-                'setDataUsingMethod'
-            ])
+            ->onlyMethods(
+                [
+                    'usesSource',
+                    'getDataUsingMethod',
+                    'getAttributeCode',
+                    'getFrontendInput',
+                    'getSource',
+                    'setDataUsingMethod'
+                ]
+            )
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -115,7 +118,7 @@ class AttributeMetadataResolverTest extends TestCase
     }
 
     /**
-     * Test to get meta data of the customer or customer address attribute
+     * Test to get meta data of the customer or customer address attribute.
      *
      * @return void
      */
@@ -142,10 +145,10 @@ class AttributeMetadataResolverTest extends TestCase
         $this->groupManagement->expects($this->once())
             ->method('getId')
             ->willReturn($defaultGroupId);
-        $this->attribute->expects($this->at(9))
+        $this->attribute
             ->method('getDataUsingMethod')
-            ->with('default_value')
-            ->willReturn($defaultGroupId);
+            ->withConsecutive([], [], [], [], [], [], ['default_value'])
+            ->willReturnOnConsecutiveCalls(null, null, null, null, null, null, $defaultGroupId);
         $this->attribute->expects($this->once())
             ->method('setDataUsingMethod')
             ->willReturnSelf();

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataHydratorTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/AttributeMetadataHydratorTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -58,6 +57,9 @@ class AttributeMetadataHydratorTest extends TestCase
      */
     private $attributeMetadataHydrator;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -81,9 +83,10 @@ class AttributeMetadataHydratorTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $optionOneData = [
             'label' => 'Label 1',
@@ -113,30 +116,23 @@ class AttributeMetadataHydratorTest extends TestCase
         ];
 
         $optionOne = new Option($optionOneData);
-        $this->optionFactoryMock->expects($this->at(0))
-            ->method('create')
-            ->with(['data' => $optionOneData])
-            ->willReturn($optionOne);
         $optionThree = new Option($optionThreeData);
-        $this->optionFactoryMock->expects($this->at(1))
-            ->method('create')
-            ->with(['data' => $optionThreeData])
-            ->willReturn($optionThree);
         $optionFour = new Option($optionFourData);
-        $this->optionFactoryMock->expects($this->at(2))
-            ->method('create')
-            ->with(['data' => $optionFourData])
-            ->willReturn($optionFour);
 
         $optionTwoDataPartiallyConverted = [
             'label' => 'Label 2',
             'options' => [$optionThree, $optionFour]
         ];
-        $optionFour = new Option($optionTwoDataPartiallyConverted);
-        $this->optionFactoryMock->expects($this->at(3))
+        $optionFive = new Option($optionTwoDataPartiallyConverted);
+        $this->optionFactoryMock
             ->method('create')
-            ->with(['data' => $optionTwoDataPartiallyConverted])
-            ->willReturn($optionFour);
+            ->withConsecutive(
+                [['data' => $optionOneData]],
+                [['data' => $optionThreeData]],
+                [['data' => $optionFourData]],
+                [['data' => $optionTwoDataPartiallyConverted]]
+            )
+            ->willReturnOnConsecutiveCalls($optionOne, $optionThree, $optionFour, $optionFive);
 
         $validationRuleOne = new ValidationRule($validationRuleOneData);
         $this->validationRuleFactoryMock->expects($this->once())
@@ -147,7 +143,7 @@ class AttributeMetadataHydratorTest extends TestCase
         $attributeMetadataPartiallyConverted = [
             'attribute_code' => 'attribute_code',
             'frontend_input' => 'hidden',
-            'options' => [$optionOne, $optionFour],
+            'options' => [$optionOne, $optionFive],
             'validation_rules' => [$validationRuleOne]
         ];
 
@@ -194,7 +190,10 @@ class AttributeMetadataHydratorTest extends TestCase
         );
     }
 
-    public function testExtract()
+    /**
+    * @return void
+    */
+    public function testExtract(): void
     {
         $data = ['foo' => 'bar'];
         $this->dataObjectProcessorMock->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/FileTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/FileTest.php
@@ -10,7 +10,6 @@ namespace Magento\Customer\Test\Unit\Model\Metadata\Form;
 use Magento\Customer\Model\FileProcessor;
 use Magento\Customer\Model\FileProcessorFactory;
 use Magento\Customer\Model\Metadata\ElementFactory;
-use Magento\Customer\Model\Metadata\Form\File;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Exception\LocalizedException;
@@ -64,6 +63,9 @@ class FileTest extends AbstractFormTestCase
      */
     private $fileProcessorFactoryMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -84,7 +86,7 @@ class FileTest extends AbstractFormTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->fileProcessorFactoryMock = $this->getMockBuilder(FileProcessorFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->fileProcessorFactoryMock->expects($this->any())
@@ -97,19 +99,17 @@ class FileTest extends AbstractFormTestCase
      * @param string $attributeCode
      * @param bool $isAjax
      * @param string $delete
+     *
+     * @return void
      * @dataProvider extractValueNoRequestScopeDataProvider
      */
-    public function testExtractValueNoRequestScope($expected, $attributeCode = '', $delete = '')
+    public function testExtractValueNoRequestScope($expected, $attributeCode = '', $delete = ''): void
     {
         $value = 'value';
 
-        $this->requestMock->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->will(
-            $this->returnValue(['delete' => $delete])
-        );
+        $this->requestMock
+            ->method('getParam')
+            ->willReturnOnConsecutiveCalls($this->returnValue(['delete' => $delete]));
 
         $this->attributeMetadataMock->expects(
             $this->any()
@@ -139,7 +139,7 @@ class FileTest extends AbstractFormTestCase
     /**
      * @return array
      */
-    public function extractValueNoRequestScopeDataProvider()
+    public function extractValueNoRequestScopeDataProvider(): array
     {
         return [
             'no_file' => [[]],
@@ -153,19 +153,13 @@ class FileTest extends AbstractFormTestCase
      * @param array $expected
      * @param string $requestScope
      * @param $mainScope
+     *
+     * @return void
      * @dataProvider extractValueWithRequestScopeDataProvider
      */
-    public function testExtractValueWithRequestScope($expected, $requestScope, $mainScope = false)
+    public function testExtractValueWithRequestScope($expected, $requestScope, $mainScope = false): void
     {
         $value = 'value';
-
-        $this->requestMock->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->will(
-            $this->returnValue(['delete' => true])
-        );
         $this->requestMock->expects(
             $this->any()
         )->method(
@@ -186,7 +180,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -204,19 +198,19 @@ class FileTest extends AbstractFormTestCase
     /**
      * @return array
      */
-    public function extractValueWithRequestScopeDataProvider()
+    public function extractValueWithRequestScopeDataProvider(): array
     {
         return [
             'requestScope' => [[], 'requestScope'],
             'mainScope' => [
                 ['fileKey' => 'attributeValue'],
                 'mainScope',
-                ['fileKey' => ['attributeCode' => 'attributeValue']],
+                ['fileKey' => ['attributeCode' => 'attributeValue']]
             ],
             'mainScope/scopeName' => [
                 ['fileKey' => 'attributeValue'],
                 'mainScope/scopeName',
-                ['fileKey' => ['scopeName' => ['attributeCode' => 'attributeValue']]],
+                ['fileKey' => ['scopeName' => ['attributeCode' => 'attributeValue']]]
             ]
         ];
     }
@@ -226,9 +220,11 @@ class FileTest extends AbstractFormTestCase
      * @param array $value
      * @param bool $isAjax
      * @param bool $isRequired
+     *
+     * @return void
      * @dataProvider validateValueNotToUploadDataProvider
      */
-    public function testValidateValueNotToUpload($expected, $value, $isAjax = false, $isRequired = true)
+    public function testValidateValueNotToUpload($expected, $value, $isAjax = false, $isRequired = true): void
     {
         $this->attributeMetadataMock->expects(
             $this->any()
@@ -249,7 +245,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => $isAjax,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -259,7 +255,7 @@ class FileTest extends AbstractFormTestCase
     /**
      * @return array
      */
-    public function validateValueNotToUploadDataProvider()
+    public function validateValueNotToUploadDataProvider(): array
     {
         return [
             'emptyValue' => [true, [], true],
@@ -273,9 +269,11 @@ class FileTest extends AbstractFormTestCase
      * @param array $expected
      * @param array $value
      * @param array $parameters
+     *
+     * @return void
      * @dataProvider validateValueToUploadDataProvider
      */
-    public function testValidateValueToUpload($expected, $value, $parameters = [])
+    public function testValidateValueToUpload($expected, $value, $parameters = []): void
     {
         $parameters = array_merge(['uploaded' => true, 'valid' => true], $parameters);
 
@@ -328,7 +326,7 @@ class FileTest extends AbstractFormTestCase
     /**
      * @return array
      */
-    public function validateValueToUploadDataProvider()
+    public function validateValueToUploadDataProvider(): array
     {
         return [
             'notValid' => [
@@ -337,9 +335,9 @@ class FileTest extends AbstractFormTestCase
                     'tmp_name' => 'tempName_0001.bin',
                     'name' => 'realFileName.bin',
                     'extension' => 'bin',
-                    'basename' => 'realFileName.bin',
+                    'basename' => 'realFileName.bin'
                 ],
-                ['valid' => false],
+                ['valid' => false]
             ],
             'notUploaded' => [
                 ['"realFileName.bin" is not a valid file.'],
@@ -347,9 +345,9 @@ class FileTest extends AbstractFormTestCase
                     'tmp_name' => 'tempName_0001.bin',
                     'name' => 'realFileName.bin',
                     'extension' => 'bin',
-                    'basename' => 'realFileName.bin',
+                    'basename' => 'realFileName.bin'
                 ],
-                ['uploaded' => false],
+                ['uploaded' => false]
             ],
             'isValid' => [
                 true,
@@ -357,26 +355,32 @@ class FileTest extends AbstractFormTestCase
                     'tmp_name' => 'tempName_0001.txt',
                     'name' => 'realFileName.txt',
                     'extension' => 'txt',
-                    'basename' => 'realFileName.txt',
-                ],
-            ],
+                    'basename' => 'realFileName.txt'
+                ]
+            ]
         ];
     }
 
-    public function testCompactValueIsAjax()
+    /**
+    * @return void
+    */
+    public function testCompactValueIsAjax(): void
     {
         $model = $this->initialize(
             [
                 'value' => 'value',
                 'isAjax' => true,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
         $this->assertSame('', $model->compactValue('aValue'));
     }
 
-    public function testCompactValueNoDelete()
+    /**
+    * @return void
+    */
+    public function testCompactValueNoDelete(): void
     {
         $this->attributeMetadataMock->expects($this->any())->method('isRequired')->will($this->returnValue(false));
 
@@ -384,7 +388,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => 'value',
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -396,7 +400,10 @@ class FileTest extends AbstractFormTestCase
         $this->assertSame([], $model->compactValue([]));
     }
 
-    public function testCompactValueDelete()
+    /**
+    * @return void
+    */
+    public function testCompactValueDelete(): void
     {
         $this->attributeMetadataMock->expects($this->any())->method('isRequired')->will($this->returnValue(false));
 
@@ -423,7 +430,10 @@ class FileTest extends AbstractFormTestCase
         $this->assertIsArray($model->compactValue(['delete' => true]));
     }
 
-    public function testCompactValueTmpFile()
+    /**
+    * @return void
+    */
+    public function testCompactValueTmpFile(): void
     {
         $value = ['tmp_name' => 'tmp.file', 'name' => 'new.file'];
         $expected = 'saved.file';
@@ -468,14 +478,17 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => null,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
         $this->assertSame($expected, $model->compactValue($value));
     }
 
-    public function testRestoreValue()
+    /**
+    * @return void
+    */
+    public function testRestoreValue(): void
     {
         $value = 'value';
 
@@ -483,7 +496,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -492,15 +505,17 @@ class FileTest extends AbstractFormTestCase
 
     /**
      * @param string $format
+     *
+     * @return void
      * @dataProvider outputValueDataProvider
      */
-    public function testOutputValueNonJson($format)
+    public function testOutputValueNonJson($format): void
     {
         $model = $this->initialize(
             [
                 'value' => 'value',
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -510,7 +525,7 @@ class FileTest extends AbstractFormTestCase
     /**
      * @return array
      */
-    public function outputValueDataProvider()
+    public function outputValueDataProvider(): array
     {
         return [
             ElementFactory::OUTPUT_FORMAT_TEXT => [ElementFactory::OUTPUT_FORMAT_TEXT],
@@ -521,7 +536,10 @@ class FileTest extends AbstractFormTestCase
         ];
     }
 
-    public function testOutputValueJson()
+    /**
+    * @return void
+    */
+    public function testOutputValueJson(): void
     {
         $value = 'value';
         $urlKey = 'url_key';
@@ -542,7 +560,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -551,6 +569,7 @@ class FileTest extends AbstractFormTestCase
 
     /**
      * @param array $data
+     *
      * @return \Magento\Customer\Model\Metadata\Form\File
      */
     private function initialize(array $data)
@@ -571,7 +590,10 @@ class FileTest extends AbstractFormTestCase
         );
     }
 
-    public function testExtractValueFileUploaderUIComponent()
+    /**
+    * @return void
+    */
+    public function testExtractValueFileUploaderUIComponent(): void
     {
         $attributeCode = 'img1';
         $requestScope = 'customer';
@@ -581,16 +603,16 @@ class FileTest extends AbstractFormTestCase
             ->method('getAttributeCode')
             ->willReturn($attributeCode);
 
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with($requestScope)
-            ->willReturn(
+            ->withConsecutive([$requestScope])
+            ->willReturnOnConsecutiveCalls(
                 [
                     $attributeCode => [
                         [
-                            'file' => $fileName,
-                        ],
-                    ],
+                            'file' => $fileName
+                        ]
+                    ]
                 ]
             );
 
@@ -598,7 +620,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => 'value',
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -608,7 +630,10 @@ class FileTest extends AbstractFormTestCase
         $this->assertEquals(['file' => $fileName], $result);
     }
 
-    public function testCompactValueRemoveUiComponentValue()
+    /**
+    * @return void
+    */
+    public function testCompactValueRemoveUiComponentValue(): void
     {
         $value = 'value';
 
@@ -616,7 +641,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -628,7 +653,10 @@ class FileTest extends AbstractFormTestCase
         $this->assertEquals([], $model->compactValue([]));
     }
 
-    public function testCompactValueNoAction()
+    /**
+    * @return void
+    */
+    public function testCompactValueNoAction(): void
     {
         $value = 'value';
 
@@ -636,24 +664,27 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
         $this->assertEquals($value, $model->compactValue($value));
     }
 
-    public function testCompactValueUiComponent()
+    /**
+    * @return void
+    */
+    public function testCompactValueUiComponent(): void
     {
         $value = [
-            'file' => 'filename',
+            'file' => 'filename'
         ];
 
         $model = $this->initialize(
             [
                 'value' => null,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -665,11 +696,14 @@ class FileTest extends AbstractFormTestCase
         $this->assertTrue($model->compactValue($value));
     }
 
-    public function testCompactValueInputField()
+    /**
+    * @return void
+    */
+    public function testCompactValueInputField(): void
     {
         $value = [
             'name' => 'filename.ext1',
-            'tmp_name' => 'tmpfilename.ext1',
+            'tmp_name' => 'tmpfilename.ext1'
         ];
 
         $absolutePath = 'absolute_path';
@@ -727,18 +761,21 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => null,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
         $this->assertEquals($uploadedFilename, $model->compactValue($value));
     }
 
-    public function testCompactValueInputFieldWithException()
+    /**
+    * @return void
+    */
+    public function testCompactValueInputFieldWithException(): void
     {
         $value = [
             'name' => 'filename.ext1',
-            'tmp_name' => 'tmpfilename.ext1',
+            'tmp_name' => 'tmpfilename.ext1'
         ];
 
         $originValue = 'origin';
@@ -793,7 +830,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $originValue,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE,
+                'entityTypeCode' => self::ENTITY_TYPE
             ]
         );
 
@@ -807,7 +844,7 @@ class FileTest extends AbstractFormTestCase
     {
         $value = [
             'name' => 'filename.php',
-            'tmp_name' => 'tmpfilename.php',
+            'tmp_name' => 'tmpfilename.php'
         ];
 
         $originValue = 'origin';
@@ -837,7 +874,7 @@ class FileTest extends AbstractFormTestCase
         $this->fileValidatorMock->expects($this->once())
             ->method('getMessages')
             ->willReturn([
-                'php' => __('File with an extension php is protected and cannot be uploaded'),
+                'php' => __('File with an extension php is protected and cannot be uploaded')
             ]);
 
         $model = $this->initialize([

--- a/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/ResourceModel/CustomerRepositoryTest.php
@@ -124,6 +124,9 @@ class CustomerRepositoryTest extends TestCase
      */
     private $model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->customerResourceModel =
@@ -211,9 +214,10 @@ class CustomerRepositoryTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSave()
+    public function testSave(): void
     {
         $customerId = 1;
 
@@ -250,7 +254,7 @@ class CustomerRepositoryTest extends TestCase
                 'getWebsiteId',
                 'getAddresses',
                 'setAddresses',
-                'getGroupId',
+                'getGroupId'
             ]
         );
         $customerSecureData = $this->getMockBuilder(CustomerSecure::class)
@@ -269,12 +273,9 @@ class CustomerRepositoryTest extends TestCase
         $this->customer->expects($this->atLeastOnce())
             ->method('getId')
             ->willReturn($customerId);
-        $this->customer->expects($this->at(4))
+        $this->customer
             ->method('__toArray')
-            ->willReturn([]);
-        $this->customer->expects($this->at(3))
-            ->method('__toArray')
-            ->willReturn(['group_id' => 1]);
+            ->willReturnOnConsecutiveCalls(['group_id' => 1], []);
         $customerModel->expects($this->once())
             ->method('setGroupId')
             ->with(1);
@@ -337,7 +338,7 @@ class CustomerRepositoryTest extends TestCase
             ->willReturnMap(
                 [
                     ['rpToken', $customerModel],
-                    [null, $customerModel],
+                    [null, $customerModel]
                 ]
             );
         $customerModel->expects($this->once())
@@ -345,7 +346,7 @@ class CustomerRepositoryTest extends TestCase
             ->willReturnMap(
                 [
                     ['rpTokenCreatedAt', $customerModel],
-                    [null, $customerModel],
+                    [null, $customerModel]
                 ]
             );
 
@@ -386,7 +387,7 @@ class CustomerRepositoryTest extends TestCase
                 [
                     'customer_data_object' => $this->customer,
                     'orig_customer_data_object' => $origCustomer,
-                    'delegate_data' => [],
+                    'delegate_data' => []
                 ]
             );
 
@@ -394,9 +395,10 @@ class CustomerRepositoryTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testSaveWithPasswordHash()
+    public function testSaveWithPasswordHash(): void
     {
         $customerId = 1;
         $passwordHash = 'ukfa4sdfa56s5df02asdf4rt';
@@ -530,7 +532,7 @@ class CustomerRepositoryTest extends TestCase
                 [
                     'customer_data_object' => $this->customer,
                     'orig_customer_data_object' => $origCustomer,
-                    'delegate_data' => [],
+                    'delegate_data' => []
                 ]
             );
 
@@ -538,9 +540,10 @@ class CustomerRepositoryTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testGetList()
+    public function testGetList(): void
     {
         $collection = $this->createMock(Collection::class);
         $searchResults = $this->getMockForAbstractClass(
@@ -556,19 +559,23 @@ class CustomerRepositoryTest extends TestCase
             false
         );
         $customerModel = $this->getMockBuilder(\Magento\Customer\Model\Customer::class)
-            ->setMethods(
+            ->onlyMethods(
                 [
                     'getId',
                     'setId',
+                    'getAttributeSetId',
+                    'getDataModel',
+                    'getCollection'
+                ]
+            )
+            ->addMethods(
+                [
                     'setStoreId',
                     'getStoreId',
-                    'getAttributeSetId',
                     'setAttributeSetId',
                     'setRpToken',
                     'setRpTokenCreatedAt',
-                    'getDataModel',
-                    'setPasswordHash',
-                    'getCollection'
+                    'setPasswordHash'
                 ]
             )
             ->setMockClassName('customerModel')
@@ -607,30 +614,60 @@ class CustomerRepositoryTest extends TestCase
             ->with('attribute-code');
         $collection->expects($this->once())
             ->method('addNameToSelect');
-        $collection->expects($this->at(2))
+        $collection
             ->method('joinAttribute')
-            ->with('billing_postcode', 'customer_address/postcode', 'default_billing', null, 'left')
-            ->willReturnSelf();
-        $collection->expects($this->at(3))
-            ->method('joinAttribute')
-            ->with('billing_city', 'customer_address/city', 'default_billing', null, 'left')
-            ->willReturnSelf();
-        $collection->expects($this->at(4))
-            ->method('joinAttribute')
-            ->with('billing_telephone', 'customer_address/telephone', 'default_billing', null, 'left')
-            ->willReturnSelf();
-        $collection->expects($this->at(5))
-            ->method('joinAttribute')
-            ->with('billing_region', 'customer_address/region', 'default_billing', null, 'left')
-            ->willReturnSelf();
-        $collection->expects($this->at(6))
-            ->method('joinAttribute')
-            ->with('billing_country_id', 'customer_address/country_id', 'default_billing', null, 'left')
-            ->willReturnSelf();
-        $collection->expects($this->at(7))
-            ->method('joinAttribute')
-            ->with('billing_company', 'customer_address/company', 'default_billing', null, 'left')
-            ->willReturnSelf();
+            ->withConsecutive(
+                [
+                    'billing_postcode',
+                    'customer_address/postcode',
+                    'default_billing',
+                    null,
+                    'left'
+                ],
+                [
+                    'billing_city',
+                    'customer_address/city',
+                    'default_billing',
+                    null,
+                    'left'
+                ],
+                [
+                    'billing_telephone',
+                    'customer_address/telephone',
+                    'default_billing',
+                    null,
+                    'left'
+                ],
+                [
+                    'billing_region',
+                    'customer_address/region',
+                    'default_billing',
+                    null,
+                    'left'
+                ],
+                [
+                    'billing_country_id',
+                    'customer_address/country_id',
+                    'default_billing',
+                    null,
+                    'left'
+                ],
+                [
+                    'billing_company',
+                    'customer_address/company',
+                    'default_billing',
+                    null,
+                    'left'
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $collection,
+                $collection,
+                $collection,
+                $collection,
+                $collection,
+                $collection
+            );
         $this->collectionProcessorMock->expects($this->once())
             ->method('process')
             ->with($searchCriteria, $collection);
@@ -653,7 +690,10 @@ class CustomerRepositoryTest extends TestCase
         $this->assertSame($searchResults, $this->model->getList($searchCriteria));
     }
 
-    public function testDeleteById()
+    /**
+    * @return void
+    */
+    public function testDeleteById(): void
     {
         $customerId = 14;
         $customerModel = $this->createPartialMock(\Magento\Customer\Model\Customer::class, ['delete']);
@@ -671,7 +711,10 @@ class CustomerRepositoryTest extends TestCase
         $this->assertTrue($this->model->deleteById($customerId));
     }
 
-    public function testDelete()
+    /**
+    * @return void
+    */
+    public function testDelete(): void
     {
         $customerId = 14;
         $customerModel = $this->createPartialMock(\Magento\Customer\Model\Customer::class, ['delete']);

--- a/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Model/FilesystemTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\Deploy\Test\Unit\Model;
 
 use Magento\Deploy\Model\Filesystem as DeployFilesystem;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\ObjectManagerInterface;
@@ -74,7 +73,7 @@ class FilesystemTest extends TestCase
     private $cmdPrefix;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -113,7 +112,7 @@ class FilesystemTest extends TestCase
                 'fr_FR' => 'France',
                 'de_DE' => 'Germany',
                 'nl_NL' => 'Netherlands',
-                'en_US' => 'USA',
+                'en_US' => 'USA'
             ]);
         $locale = $objectManager->getObject(Locale::class, ['lists' => $lists]);
 
@@ -124,7 +123,7 @@ class FilesystemTest extends TestCase
                 'shell' => $this->shell,
                 'filesystem' => $this->filesystem,
                 'userCollection' => $this->userCollection,
-                'locale' => $locale,
+                'locale' => $locale
             ]
         );
 
@@ -132,9 +131,9 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * @throws LocalizedException
+     * @return void
      */
-    public function testRegenerateStatic()
+    public function testRegenerateStatic(): void
     {
         $storeLocales = ['fr_FR', 'de_DE', 'nl_NL'];
         $this->storeView->method('retrieveLocales')
@@ -152,18 +151,14 @@ class FilesystemTest extends TestCase
             ->method('execute')
             ->withConsecutive([$cacheFlushCmd], [$setupDiCompileCmd], [$cacheFlushCmd], [$staticContentDeployCmd]);
 
-        $this->output->expects(self::at(0))
+        $this->output
             ->method('writeln')
-            ->with('Starting compilation');
-        $this->output->expects(self::at(2))
-            ->method('writeln')
-            ->with('Compilation complete');
-        $this->output->expects(self::at(3))
-            ->method('writeln')
-            ->with('Starting deployment of static content');
-        $this->output->expects(self::at(5))
-            ->method('writeln')
-            ->with('Deployment of static content complete');
+            ->withConsecutive(
+                ['Starting compilation'],
+                ['Compilation complete'],
+                ['Starting deployment of static content'],
+                ['Deployment of static content complete']
+            );
 
         $this->deployFilesystem->regenerateStatic($this->output);
     }
@@ -172,9 +167,8 @@ class FilesystemTest extends TestCase
      * Checks a case when configuration contains incorrect locale code.
      *
      * @return void
-     * @throws LocalizedException
      */
-    public function testGenerateStaticForNotAllowedStoreViewLocale()
+    public function testGenerateStaticForNotAllowedStoreViewLocale(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage(
@@ -193,9 +187,8 @@ class FilesystemTest extends TestCase
      * Checks as case when admin locale is incorrect.
      *
      * @return void
-     * @throws LocalizedException
      */
-    public function testGenerateStaticForNotAllowedAdminLocale()
+    public function testGenerateStaticForNotAllowedAdminLocale(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage(
@@ -214,9 +207,10 @@ class FilesystemTest extends TestCase
      * Initializes admin user locale.
      *
      * @param string $locale
+     *
      * @return void
      */
-    private function initAdminLocaleMock($locale)
+    private function initAdminLocaleMock($locale): void
     {
         /** @var User|MockObject $user */
         $user = $this->getMockBuilder(User::class)

--- a/app/code/Magento/Developer/Test/Unit/Model/XmlCatalog/Format/VsCodeTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Model/XmlCatalog/Format/VsCodeTest.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Developer\Test\Unit\Model\XmlCatalog\Format;
 
@@ -46,6 +47,9 @@ class VsCodeTest extends TestCase
      */
     private $objectManagerHelper;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManagerHelper = new ObjectManager($this);
@@ -71,7 +75,7 @@ class VsCodeTest extends TestCase
             [
                 'readFactory' => $this->readFactoryMock,
                 'fileWriteFactory' => $this->fileWriteFactoryMock,
-                'domDocumentFactory' => $this->domFactory,
+                'domDocumentFactory' => $this->domFactory
             ]
         );
 
@@ -79,183 +83,153 @@ class VsCodeTest extends TestCase
     }
 
     /**
-     * Test generation of new valid catalog
+     * Test generation of new valid catalog.
      *
      * @param string $content
      * @param array $dictionary
-     * @dataProvider dictionaryDataProvider
+     *
      * @return void
+     * @dataProvider dictionaryDataProvider
      */
-    public function testGenerateNewValidCatalog($content, $dictionary)
+    public function testGenerateNewValidCatalog($content, $dictionary): void
     {
         $configFile = 'test';
 
         $message = __("The \"%1.xml\" file doesn't exist.", $configFile);
 
-        $this->fileWriteFactoryMock->expects($this->at(0))
-            ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_READ
-            )
-            ->willThrowException(new FileSystemException($message));
-
         $fileMock = $this->createMock(Write::class);
         $fileMock->expects($this->once())
             ->method('write')
             ->with($content);
 
-        $this->fileWriteFactoryMock->expects($this->at(1))
+        $this->fileWriteFactoryMock
             ->method('create')
-            ->with(
+            ->withConsecutive(
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_READ], [
                 $configFile,
                 DriverPool::FILE,
                 VsCode::FILE_MODE_WRITE
+            ]
             )
-            ->willReturn($fileMock);
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new FileSystemException($message)),
+                $fileMock
+            );
 
         $this->vscodeFormat->generateCatalog($dictionary, $configFile);
     }
 
     /**
-     * Test modify existing valid catalog
+     * Test modify existing valid catalog.
      *
      * @param string $content
      * @param array $dictionary
-     * @dataProvider dictionaryDataProvider
+     *
      * @return void
+     * @dataProvider dictionaryDataProvider
      */
-    public function testGenerateExistingValidCatalog($content, $dictionary)
+    public function testGenerateExistingValidCatalog($content, $dictionary): void
     {
         $configFile = 'test';
 
-        $fileMock = $this->createMock(Read::class);
-        $fileMock->expects($this->once())
+        $fileMock1 = $this->createMock(Read::class);
+        $fileMock1->expects($this->once())
             ->method('readAll')
             ->withAnyParameters()
             ->willReturn($content);
 
-        $this->fileWriteFactoryMock->expects($this->at(0))
-            ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_READ
-            )
-            ->willReturn($fileMock);
-
-        $fileMock = $this->createMock(Write::class);
-        $fileMock->expects($this->once())
+        $fileMock2 = $this->createMock(Write::class);
+        $fileMock2->expects($this->once())
             ->method('write')
             ->with($content);
 
-        $this->fileWriteFactoryMock->expects($this->at(1))
+        $this->fileWriteFactoryMock
             ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_WRITE
+            ->withConsecutive(
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_READ],
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_WRITE]
             )
-            ->willReturn($fileMock);
+            ->willReturnOnConsecutiveCalls($fileMock1, $fileMock2);
 
         $this->vscodeFormat->generateCatalog($dictionary, $configFile);
     }
 
     /**
-     * Test modify existing empty catalog
+     * Test modify existing empty catalog.
      *
      * @param string $content
      * @param array $dictionary
-     * @dataProvider dictionaryDataProvider
+     *
      * @return void
+     * @dataProvider dictionaryDataProvider
      */
-    public function testGenerateExistingEmptyValidCatalog($content, $dictionary)
+    public function testGenerateExistingEmptyValidCatalog($content, $dictionary): void
     {
         $configFile = 'test';
 
-        $fileMock = $this->createMock(Read::class);
-        $fileMock->expects($this->once())
+        $fileMock1 = $this->createMock(Read::class);
+        $fileMock1->expects($this->once())
             ->method('readAll')
             ->withAnyParameters()
             ->willReturn('');
 
-        $this->fileWriteFactoryMock->expects($this->at(0))
-            ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_READ
-            )
-            ->willReturn($fileMock);
-
-        $fileMock = $this->createMock(Write::class);
-        $fileMock->expects($this->once())
+        $fileMock2 = $this->createMock(Write::class);
+        $fileMock2->expects($this->once())
             ->method('write')
             ->with($content);
 
-        $this->fileWriteFactoryMock->expects($this->at(1))
+        $this->fileWriteFactoryMock
             ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_WRITE
+            ->withConsecutive(
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_READ],
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_WRITE]
             )
-            ->willReturn($fileMock);
+            ->willReturnOnConsecutiveCalls($fileMock1, $fileMock2);
 
         $this->vscodeFormat->generateCatalog($dictionary, $configFile);
     }
 
     /**
-     * Test modify existing invalid catalog
+     * Test modify existing invalid catalog.
      *
      * @param string $content
      * @param array $dictionary
-     * @dataProvider dictionaryDataProvider
+     *
      * @return void
+     * @dataProvider dictionaryDataProvider
      */
-    public function testGenerateExistingInvalidValidCatalog($content, $dictionary, $invalidContent)
+    public function testGenerateExistingInvalidValidCatalog($content, $dictionary, $invalidContent): void
     {
         $configFile = 'test';
 
-        $fileMock = $this->createMock(Read::class);
-        $fileMock->expects($this->once())
+        $fileMock1 = $this->createMock(Read::class);
+        $fileMock1->expects($this->once())
             ->method('readAll')
             ->withAnyParameters()
             ->willReturn($invalidContent);
 
-        $this->fileWriteFactoryMock->expects($this->at(0))
-            ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_READ
-            )
-            ->willReturn($fileMock);
-
-        $fileMock = $this->createMock(Write::class);
-        $fileMock->expects($this->once())
+        $fileMock2 = $this->createMock(Write::class);
+        $fileMock2->expects($this->once())
             ->method('write')
             ->with($content);
 
-        $this->fileWriteFactoryMock->expects($this->at(1))
+        $this->fileWriteFactoryMock
             ->method('create')
-            ->with(
-                $configFile,
-                DriverPool::FILE,
-                VsCode::FILE_MODE_WRITE
+            ->withConsecutive(
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_READ],
+                [$configFile, DriverPool::FILE, VsCode::FILE_MODE_WRITE]
             )
-            ->willReturn($fileMock);
+            ->willReturnOnConsecutiveCalls($fileMock1, $fileMock2);
 
         $this->vscodeFormat->generateCatalog($dictionary, $configFile);
     }
 
     /**
-     * Data provider for test
+     * Data provider for test.
      *
      * @return array
      */
-    public function dictionaryDataProvider()
+    public function dictionaryDataProvider(): array
     {
         $fixtureXmlFile = __DIR__ . '/_files/valid_catalog.xml';
         $content = file_get_contents($fixtureXmlFile);
@@ -270,10 +244,10 @@ class VsCodeTest extends TestCase
                     'urn:magento:module:Magento_Store:etc/config.xsd' => 'vendor/magento/module-store/etc/config.xsd',
                     'urn:magento:module:Magento_Cron:etc/crontab.xsd' => 'vendor/magento/module-cron/etc/crontab.xsd',
                     'urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd' =>
-                        'vendor/magento/framework/Setup/Declaration/Schema/etc/schema.xsd',
+                        'vendor/magento/framework/Setup/Declaration/Schema/etc/schema.xsd'
                 ],
-                $invalidContent,
-            ],
+                $invalidContent
+            ]
         ];
     }
 }

--- a/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Controller/Download/LinkTest.php
@@ -29,10 +29,14 @@ use PHPUnit\Framework\TestCase;
  */
 class LinkTest extends TestCase
 {
-    /** @var Link */
+    /**
+     * @var Link
+     */
     protected $link;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     protected $objectManagerHelper;
 
     /**
@@ -96,6 +100,7 @@ class LinkTest extends TestCase
     protected $urlInterface;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -170,7 +175,10 @@ class LinkTest extends TestCase
         );
     }
 
-    public function testAbsentLinkId()
+    /**
+    * @return void
+    */
+    public function testAbsentLinkId(): void
     {
         $this->objectManager->expects($this->once())
             ->method('get')
@@ -194,35 +202,22 @@ class LinkTest extends TestCase
         $this->assertEquals($this->response, $this->link->execute());
     }
 
-    public function testGetLinkForGuestCustomer()
+    /**
+    * @return void
+    */
+    public function testGetLinkForGuestCustomer(): void
     {
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(Session::class)
-            ->willReturn($this->session);
         $this->request->expects($this->once())->method('getParam')->with('id', 0)->willReturn('some_id');
-        $this->objectManager->expects($this->at(1))
-            ->method('create')
-            ->with(Item::class)
-            ->willReturn($this->linkPurchasedItem);
         $this->linkPurchasedItem->expects($this->once())
             ->method('load')
             ->with('some_id', 'link_hash')
             ->willReturnSelf();
         $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(5);
-        $this->objectManager->expects($this->at(2))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->helperData);
         $this->helperData->expects($this->once())
             ->method('getIsShareable')
             ->with($this->linkPurchasedItem)
             ->willReturn(false);
         $this->session->expects($this->once())->method('getCustomerId')->willReturn(null);
-        $this->objectManager->expects($this->at(3))
-            ->method('create')
-            ->with(Product::class)
-            ->willReturn($this->product);
         $this->linkPurchasedItem->expects($this->once())->method('getProductId')->willReturn('product_id');
         $this->product->expects($this->once())->method('load')->with('product_id')->willReturnSelf();
         $this->product->expects($this->once())->method('getId')->willReturn('product_id');
@@ -232,10 +227,14 @@ class LinkTest extends TestCase
             ->method('addNotice')
             ->with('Please sign in to download your product or purchase <a href="product_url">product_name</a>.');
         $this->session->expects($this->once())->method('authenticate')->willReturn(true);
-        $this->objectManager->expects($this->at(4))
+        $this->objectManager
+            ->method('get')
+            ->withConsecutive([Session::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($this->session, $this->helperData);
+        $this->objectManager
             ->method('create')
-            ->with(UrlInterface::class)
-            ->willReturn($this->urlInterface);
+            ->withConsecutive([Item::class], [Product::class], [UrlInterface::class])
+            ->willReturnOnConsecutiveCalls($this->linkPurchasedItem, $this->product, $this->urlInterface);
         $this->urlInterface->expects($this->once())
             ->method('getUrl')
             ->with('downloadable/customer/products/', ['_secure' => true])
@@ -245,35 +244,30 @@ class LinkTest extends TestCase
         $this->assertNull($this->link->execute());
     }
 
-    public function testGetLinkForWrongCustomer()
+    /**
+    * @return void
+    */
+    public function testGetLinkForWrongCustomer(): void
     {
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(Session::class)
-            ->willReturn($this->session);
         $this->request->expects($this->once())->method('getParam')->with('id', 0)->willReturn('some_id');
-        $this->objectManager->expects($this->at(1))
-            ->method('create')
-            ->with(Item::class)
-            ->willReturn($this->linkPurchasedItem);
         $this->linkPurchasedItem->expects($this->once())
             ->method('load')
             ->with('some_id', 'link_hash')
             ->willReturnSelf();
         $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(5);
-        $this->objectManager->expects($this->at(2))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->helperData);
         $this->helperData->expects($this->once())
             ->method('getIsShareable')
             ->with($this->linkPurchasedItem)
             ->willReturn(false);
         $this->session->expects($this->once())->method('getCustomerId')->willReturn('customer_id');
-        $this->objectManager->expects($this->at(3))
+        $this->objectManager
+            ->method('get')
+            ->withConsecutive([Session::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($this->session, $this->helperData);
+        $this->objectManager
             ->method('create')
-            ->with(Purchased::class)
-            ->willReturn($this->linkPurchased);
+            ->withConsecutive([Item::class], [Purchased::class])
+            ->willReturnOnConsecutiveCalls($this->linkPurchasedItem, $this->linkPurchased);
         $this->linkPurchasedItem->expects($this->once())->method('getPurchasedId')->willReturn('purchased_id');
         $this->linkPurchased->expects($this->once())->method('load')->with('purchased_id')->willReturnSelf();
         $this->linkPurchased->expects($this->once())->method('getCustomerId')->willReturn('other_customer_id');
@@ -288,29 +282,26 @@ class LinkTest extends TestCase
     /**
      * @param string $mimeType
      * @param string $disposition
-     * @dataProvider downloadTypesDataProvider
+     *
      * @return void
+     * @dataProvider downloadTypesDataProvider
      */
-    public function testExceptionInUpdateLinkStatus($mimeType, $disposition)
+    public function testExceptionInUpdateLinkStatus($mimeType, $disposition): void
     {
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(Session::class)
-            ->willReturn($this->session);
         $this->request->expects($this->once())->method('getParam')->with('id', 0)->willReturn('some_id');
-        $this->objectManager->expects($this->at(1))
-            ->method('create')
-            ->with(Item::class)
-            ->willReturn($this->linkPurchasedItem);
         $this->linkPurchasedItem->expects($this->once())
             ->method('load')
             ->with('some_id', 'link_hash')
             ->willReturnSelf();
-        $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(5);
-        $this->objectManager->expects($this->at(2))
+        $this->objectManager
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->helperData);
+            ->withConsecutive([\Magento\Customer\Model\Session::class], [Data::class], [Download::class])
+            ->willReturnOnConsecutiveCalls($this->session, $this->helperData, $this->downloadHelper);
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive([Item::class])
+            ->willReturnOnConsecutiveCalls($this->linkPurchasedItem);
+        $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(5);
         $this->helperData->expects($this->once())
             ->method('getIsShareable')
             ->with($this->linkPurchasedItem)
@@ -340,17 +331,14 @@ class LinkTest extends TestCase
      * @param string $resourceType
      * @param string $mimeType
      * @param string $disposition
+     *
      * @return void
      */
-    private function processDownload($resource, $resourceType, $mimeType, $disposition)
+    private function processDownload($resource, $resourceType, $mimeType, $disposition): void
     {
         $fileSize = 58493;
         $fileName = 'link.jpg';
 
-        $this->objectManager->expects($this->at(3))
-            ->method('get')
-            ->with(Download::class)
-            ->willReturn($this->downloadHelper);
         $this->downloadHelper->expects($this->once())
             ->method('setResource')
             ->with($resource, $resourceType)
@@ -381,28 +369,26 @@ class LinkTest extends TestCase
      * @param string $messageType
      * @param string $status
      * @param string $notice
+     *
+     * @return void
      * @dataProvider linkNotAvailableDataProvider
      */
-    public function testLinkNotAvailable($messageType, $status, $notice)
+    public function testLinkNotAvailable($messageType, $status, $notice): void
     {
-        $this->objectManager->expects($this->at(0))
-            ->method('get')
-            ->with(Session::class)
-            ->willReturn($this->session);
         $this->request->expects($this->once())->method('getParam')->with('id', 0)->willReturn('some_id');
-        $this->objectManager->expects($this->at(1))
-            ->method('create')
-            ->with(Item::class)
-            ->willReturn($this->linkPurchasedItem);
         $this->linkPurchasedItem->expects($this->once())
             ->method('load')
             ->with('some_id', 'link_hash')
             ->willReturnSelf();
         $this->linkPurchasedItem->expects($this->once())->method('getId')->willReturn(5);
-        $this->objectManager->expects($this->at(2))
+        $this->objectManager
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->helperData);
+            ->withConsecutive([Session::class], [Data::class])
+            ->willReturnOnConsecutiveCalls($this->session, $this->helperData);
+        $this->objectManager
+            ->method('create')
+            ->with(Item::class)
+            ->willReturn($this->linkPurchasedItem);
         $this->helperData->expects($this->once())
             ->method('getIsShareable')
             ->with($this->linkPurchasedItem)
@@ -418,30 +404,31 @@ class LinkTest extends TestCase
     /**
      * @param string $mimeType
      * @param string $disposition
-     * @dataProvider downloadTypesDataProvider
+     *
      * @return void
+     * @dataProvider downloadTypesDataProvider
      */
-    public function testContentDisposition($mimeType, $disposition)
+    public function testContentDisposition($mimeType, $disposition): void
     {
         $this->objectManager->expects($this->any())
             ->method('get')
             ->willReturnMap([
                 [
                     Session::class,
-                    $this->session,
+                    $this->session
                 ],
                 [
                     Data::class,
-                    $this->helperData,
+                    $this->helperData
                 ],
                 [
                     Download::class,
-                    $this->downloadHelper,
-                ],
+                    $this->downloadHelper
+                ]
             ]);
 
         $this->request->expects($this->once())->method('getParam')->with('id', 0)->willReturn('some_id');
-        $this->objectManager->expects($this->at(1))
+        $this->objectManager
             ->method('create')
             ->with(Item::class)
             ->willReturn($this->linkPurchasedItem);
@@ -488,7 +475,7 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function linkNotAvailableDataProvider()
+    public function linkNotAvailableDataProvider(): array
     {
         return [
             ['addNotice', 'expired', 'The link has expired.'],
@@ -501,11 +488,11 @@ class LinkTest extends TestCase
     /**
      * @return array
      */
-    public function downloadTypesDataProvider()
+    public function downloadTypesDataProvider(): array
     {
         return [
             ['mimeType' => 'text/html',  'disposition' => Mime::DISPOSITION_ATTACHMENT],
-            ['mimeType' => 'image/jpeg', 'disposition' => Mime::DISPOSITION_INLINE],
+            ['mimeType' => 'image/jpeg', 'disposition' => Mime::DISPOSITION_INLINE]
         ];
     }
 }

--- a/app/code/Magento/DownloadableImportExport/Test/Unit/Model/Import/Product/Type/DownloadableTest.php
+++ b/app/code/Magento/DownloadableImportExport/Test/Unit/Model/Import/Product/Type/DownloadableTest.php
@@ -32,13 +32,19 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class DownloadableTest extends AbstractImportTestCase
 {
-    /** @var ObjectManager|Downloadable */
+    /**
+     * @var ObjectManager|Downloadable
+     */
     protected $downloadableModelMock;
 
-    /** @var Mysql|MockObject */
+    /**
+     * @var Mysql|MockObject
+     */
     protected $connectionMock;
 
-    /** @var Select|MockObject */
+    /**
+     * @var Select|MockObject
+     */
     protected $select;
 
     /**
@@ -66,19 +72,29 @@ class DownloadableTest extends AbstractImportTestCase
      */
     protected $prodAttrColMock;
 
-    /** @var ResourceConnection|MockObject */
+    /**
+     * @var ResourceConnection|MockObject
+     */
     protected $resourceMock;
 
-    /** @var \Magento\CatalogImportExport\Model\Import\Product|MockObject */
+    /**
+     * @var \Magento\CatalogImportExport\Model\Import\Product|MockObject
+     */
     protected $entityModelMock;
 
-    /** @var array|mixed */
+    /**
+     * @var array|mixed
+     */
     protected $paramsArray;
 
-    /** @var Uploader|MockObject */
+    /**
+     * @var Uploader|MockObject
+     */
     protected $uploaderMock;
 
-    /** @var Write|MockObject */
+    /**
+     * @var Write|MockObject
+     */
     protected $directoryWriteMock;
 
     /**
@@ -92,6 +108,7 @@ class DownloadableTest extends AbstractImportTestCase
     protected $downloadableHelper;
 
     /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -199,13 +216,15 @@ class DownloadableTest extends AbstractImportTestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataForSave
      */
-    public function testSaveDataAppend($newSku, $bunch, $allowImport, $fetchResult)
+    public function testSaveDataAppend($newSku, $bunch, $allowImport, $fetchResult): void
     {
         $this->entityModelMock->expects($this->once())->method('getNewSku')->willReturn($newSku);
-        $this->entityModelMock->expects($this->at(1))->method('getNextBunch')->willReturn($bunch);
-        $this->entityModelMock->expects($this->at(2))->method('getNextBunch')->willReturn(null);
+        $this->entityModelMock
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls(null, $bunch, null);
         $this->entityModelMock->expects($this->any())->method('isRowAllowedToImport')->willReturn($allowImport);
 
         $this->uploaderMock->expects($this->any())->method('setTmpDir')->willReturn(true);
@@ -217,12 +236,12 @@ class DownloadableTest extends AbstractImportTestCase
             [
                 [
                     'attribute_set_name' => '1',
-                    'attribute_id' => '1',
+                    'attribute_id' => '1'
                 ],
                 [
                     'attribute_set_name' => '2',
-                    'attribute_id' => '2',
-                ],
+                    'attribute_id' => '2'
+                ]
             ],
             $fetchResult['sample'],
             $fetchResult['sample'],
@@ -246,12 +265,12 @@ class DownloadableTest extends AbstractImportTestCase
     }
 
     /**
-     * Data for method testSaveDataAppend
+     * Data for method testSaveDataAppend.
      *
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function dataForSave()
+    public function dataForSave(): array
     {
         return [
             [
@@ -260,8 +279,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'downloadable',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -272,8 +291,8 @@ class DownloadableTest extends AbstractImportTestCase
                             . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                         'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                             . ' downloads=unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title,'
-                            . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
-                    ],
+                            . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
+                    ]
                 ],
                 'allowImport' => true,
                 [
@@ -284,7 +303,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => null,
                             'sample_file' => '',
                             'sample_type' => 'file',
-                            'sort_order' => '1',
+                            'sort_order' => '1'
                         ],
                         [
                             'sample_id' => '66',
@@ -292,7 +311,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => 'media/file2.mp4',
                             'sample_file' => null,
                             'sample_type' => 'url',
-                            'sort_order' => '0',
+                            'sort_order' => '0'
                         ]
                     ],
                     'link' => [
@@ -307,7 +326,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'file',
                             'sample_url' => null,
                             'sample_file' => null,
-                            'sample_type' => null,
+                            'sample_type' => null
                         ],
                         [
                             'link_id' => '66',
@@ -320,7 +339,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'url',
                             'sample_url' => null,
                             'sample_file' => null,
-                            'sample_type' => null,
+                            'sample_type' => null
                         ]
                     ]
                 ]
@@ -331,8 +350,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'downloadable',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -343,8 +362,8 @@ class DownloadableTest extends AbstractImportTestCase
                             . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                         'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                             . ' downloads=unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title, '
-                            . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
-                    ],
+                            . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
+                    ]
                 ],
                 'allowImport' => false,
                 ['sample' => [], 'link' => []]
@@ -355,8 +374,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'simple',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -367,8 +386,8 @@ class DownloadableTest extends AbstractImportTestCase
                             . 'sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                         'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                             . ' downloads=unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title,'
-                            . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
-                    ],
+                            . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
+                    ]
                 ],
                 'allowImport' => true,
                 ['sample' => [], 'link' => []]
@@ -379,8 +398,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'downloadable',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -391,8 +410,8 @@ class DownloadableTest extends AbstractImportTestCase
                             . 'sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                         'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                             . ' downloads=unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title,'
-                            . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
-                    ],
+                            . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
+                    ]
                 ],
                 'allowImport' => true,
                 [
@@ -403,7 +422,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => null,
                             'sample_file' => '',
                             'sample_type' => 'file',
-                            'sort_order' => '1',
+                            'sort_order' => '1'
                         ],
                         [
                             'sample_id' => '66',
@@ -411,7 +430,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => 'media/some_another_file.mp4',
                             'sample_file' => null,
                             'sample_type' => 'url',
-                            'sort_order' => '0',
+                            'sort_order' => '0'
                         ]
                     ],
                     'link' => [
@@ -426,7 +445,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'file',
                             'sample_url' => null,
                             'sample_file' => null,
-                            'sample_type' => null,
+                            'sample_type' => null
                         ],
                         [
                             'link_id' => '66',
@@ -439,7 +458,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'url',
                             'sample_url' => null,
                             'sample_file' => null,
-                            'sample_type' => null,
+                            'sample_type' => null
                         ]
                     ]
                 ]
@@ -450,8 +469,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'downloadable',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -463,8 +482,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'downloadable_links' => 'group_title=Group Title, title=Title 2, price=10, downloads=unlimited,'
                             . ' url=http://www.sample.com/pic.jpg,sortorder=0,sample=http://www.sample.com/pic.jpg,'
                             . 'purchased_separately=1,shareable=1|group_title=Group Title, title=Title 2, price=10, '
-                            . 'downloads=unlimited, url=media/file2.mp4,sortorder=0,sample=media/file2mp4',
-                    ],
+                            . 'downloads=unlimited, url=media/file2.mp4,sortorder=0,sample=media/file2mp4'
+                    ]
                 ],
                 'allowImport' => true,
                 [
@@ -475,7 +494,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => null,
                             'sample_file' => '',
                             'sample_type' => 'file',
-                            'sort_order' => '1',
+                            'sort_order' => '1'
                         ],
                         [
                             'sample_id' => '66',
@@ -483,7 +502,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'sample_url' => 'media/file2.mp4',
                             'sample_file' => null,
                             'sample_type' => 'url',
-                            'sort_order' => '0',
+                            'sort_order' => '0'
                         ]
                     ],
                     'link' => [
@@ -498,7 +517,7 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'url',
                             'sample_url' => 'http://www.sample.com/pic.jpg',
                             'sample_file' => null,
-                            'sample_type' => 'url',
+                            'sample_type' => 'url'
                         ],
                         [
                             'link_id' => '66',
@@ -511,18 +530,19 @@ class DownloadableTest extends AbstractImportTestCase
                             'link_type' => 'url',
                             'sample_url' => null,
                             'sample_file' => 'f/i/file.png',
-                            'sample_type' => 'file',
+                            'sample_type' => 'file'
                         ]
                     ]
                 ]
-            ],
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider isRowValidData
      */
-    public function testIsRowValid(array $rowData, $rowNum, $isNewProduct, $isDomainValid, $expectedResult)
+    public function testIsRowValid(array $rowData, $rowNum, $isNewProduct, $isDomainValid, $expectedResult): void
     {
         $this->connectionMock->expects($this->any())->method('fetchAll')->with(
             $this->select
@@ -530,12 +550,12 @@ class DownloadableTest extends AbstractImportTestCase
             [
                 [
                     'attribute_set_name' => '1',
-                    'attribute_id' => '1',
+                    'attribute_id' => '1'
                 ],
                 [
                     'attribute_set_name' => '2',
-                    'attribute_id' => '2',
-                ],
+                    'attribute_id' => '2'
+                ]
             ]
         );
 
@@ -562,12 +582,12 @@ class DownloadableTest extends AbstractImportTestCase
     }
 
     /**
-     * Data for method testIsRowValid
+     * Data for method testIsRowValid.
      *
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function isRowValidData()
+    public function isRowValidData(): array
     {
         return [
             [
@@ -579,7 +599,7 @@ class DownloadableTest extends AbstractImportTestCase
                         . 'sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10, '
                         . 'downloads=unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title, '
-                        . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
+                        . 'title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 0,
                 'is_new_product' => true,
@@ -595,7 +615,7 @@ class DownloadableTest extends AbstractImportTestCase
                         . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                         . ' downloads=unlimited, file=media/file.mp4,sortorder=1|group_title=Group Title,'
-                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
+                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 1,
                 'is_new_product' => true,
@@ -611,7 +631,7 @@ class DownloadableTest extends AbstractImportTestCase
                         . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                         . ' downloads=unlimited, file=media/file.mp4,sortorder=1|group_title=Group Title,'
-                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
+                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 3,
                 'is_new_product' => true,
@@ -627,7 +647,7 @@ class DownloadableTest extends AbstractImportTestCase
                         ' group_title=Group Title, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'title=Title 1, price=10, downloads=unlimited, file=media/file.mp4,'
                         . 'sortorder=1|group_title=Group Title, title=Title 2, price=10, downloads=unlimited,'
-                        . ' url=media/file2.mp4,sortorder=0',
+                        . ' url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 4,
                 'is_new_product' => true,
@@ -643,7 +663,7 @@ class DownloadableTest extends AbstractImportTestCase
                         . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                         . ' downloads=unlimited, file=media/file.mp4,sortorder=1|group_title=Group Title,'
-                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
+                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 5,
                 'is_new_product' => true,
@@ -659,7 +679,7 @@ class DownloadableTest extends AbstractImportTestCase
                         . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                     'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10,'
                         . ' downloads=unlimited, file=media/file.mp4,sortorder=1|group_title=Group Title,'
-                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
+                        . ' title=Title 2, price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
                 ],
                 'row_num' => 6,
                 'is_new_product' => true,
@@ -670,7 +690,7 @@ class DownloadableTest extends AbstractImportTestCase
                 'row_data' => [
                     'sku' => 'downloadablesku12',
                     'product_type' => 'downloadable',
-                    'name' => 'Downloadable Product 2',
+                    'name' => 'Downloadable Product 2'
                 ],
                 'row_num' => 2,
                 'is_new_product' => false,
@@ -683,20 +703,21 @@ class DownloadableTest extends AbstractImportTestCase
                     'product_type' => 'downloadable',
                     'name' => 'Downloadable Product 2',
                     'downloadable_samples' => '',
-                    'downloadable_links' => '',
+                    'downloadable_links' => ''
                 ],
                 'row_num' => 7,
                 'is_new_product' => true,
                 'is_domain_valid' => true,
                 'expected_result' => false
-            ],
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider dataForUploaderDir
      */
-    public function testSetUploaderDirFalse($newSku, $bunch, $allowImport, $parsedOptions)
+    public function testSetUploaderDirFalse($newSku, $bunch, $allowImport, $parsedOptions): void
     {
         $this->connectionMock->expects($this->any())->method('fetchAll')->with(
             $this->select
@@ -722,12 +743,13 @@ class DownloadableTest extends AbstractImportTestCase
                 'params' => $this->paramsArray,
                 'uploaderHelper' => $this->uploaderHelper,
                 'downloadableHelper' => $this->downloadableHelper,
-                'metadataPool' => $metadataPoolMock,
+                'metadataPool' => $metadataPoolMock
             ]
         );
         $this->entityModelMock->expects($this->once())->method('getNewSku')->willReturn($newSku);
-        $this->entityModelMock->expects($this->at(1))->method('getNextBunch')->willReturn($bunch);
-        $this->entityModelMock->expects($this->at(2))->method('getNextBunch')->willReturn(null);
+        $this->entityModelMock
+            ->method('getNextBunch')
+            ->willReturnOnConsecutiveCalls($bunch, null);
         $this->entityModelMock->expects($this->any())->method('isRowAllowedToImport')->willReturn($allowImport);
         $exception = new LocalizedException(new Phrase('Error'));
         $this->uploaderMock->expects($this->any())->method('move')->willThrowException($exception);
@@ -741,7 +763,7 @@ class DownloadableTest extends AbstractImportTestCase
      *
      * @return array
      */
-    public function dataForUploaderDir()
+    public function dataForUploaderDir(): array
     {
         return [
             [
@@ -750,8 +772,8 @@ class DownloadableTest extends AbstractImportTestCase
                         'entity_id' => '25',
                         'type_id' => 'downloadable',
                         'attr_set_id' => '4',
-                        'attr_set_code' => 'Default',
-                    ],
+                        'attr_set_code' => 'Default'
+                    ]
                 ],
                 'bunch' => [
                     [
@@ -762,8 +784,8 @@ class DownloadableTest extends AbstractImportTestCase
                             . ',sortorder=1|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
                         'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10, downloads='
                             . 'unlimited, file=media/file_link.mp4,sortorder=1|group_title=Group Title, title=Title 2,'
-                            . ' price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0',
-                    ],
+                            . ' price=10, downloads=unlimited, url=media/file2.mp4,sortorder=0'
+                    ]
                 ],
                 'allowImport' => true,
                 'parsedOptions' => [
@@ -775,7 +797,7 @@ class DownloadableTest extends AbstractImportTestCase
                         'sample_type' => 'file',
                         'sort_order' => '1',
                         'group_title' => 'Group Title Samples',
-                        'title' => 'Title 1',
+                        'title' => 'Title 1'
                     ],
                     'link' => [
                         'link_id' => null,
@@ -794,14 +816,16 @@ class DownloadableTest extends AbstractImportTestCase
                         'price' => '10'
                     ]
                 ]
-            ],
+            ]
         ];
     }
 
     /**
-     * Test for method prepareAttributesWithDefaultValueForSave
+     * Test for method prepareAttributesWithDefaultValueForSave.
+     *
+     * @return void
      */
-    public function testPrepareAttributesWithDefaultValueForSave()
+    public function testPrepareAttributesWithDefaultValueForSave(): void
     {
         $rowData = [
             '_attribute_set' => 'Default',
@@ -812,7 +836,7 @@ class DownloadableTest extends AbstractImportTestCase
                 . '|group_title=Group Title, title=Title 2, url=media/file2.mp4,sortorder=0',
             'downloadable_links' => 'group_title=Group Title Links, title=Title 1, price=10, downloads=unlimited,'
                 . ' file=media/file_link.mp4,sortorder=1|group_title=Group Title, title=Title 2, price=10, downloads'
-                . '=unlimited, url=media/file2.mp4,sortorder=0',
+                . '=unlimited, url=media/file2.mp4,sortorder=0'
         ];
         $this->connectionMock->expects($this->any())->method('fetchAll')->with(
             $this->select
@@ -820,12 +844,12 @@ class DownloadableTest extends AbstractImportTestCase
             [
                 [
                     'attribute_set_name' => '1',
-                    'attribute_id' => '1',
+                    'attribute_id' => '1'
                 ],
                 [
                     'attribute_set_name' => '2',
-                    'attribute_id' => '2',
-                ],
+                    'attribute_id' => '2'
+                ]
             ]
         );
         $this->downloadableModelMock = $this->objectManagerHelper->getObject(
@@ -855,7 +879,7 @@ class DownloadableTest extends AbstractImportTestCase
                         'apply_to' => [],
                         'type' => 'varchar',
                         'default_value' => null,
-                        'options' => [],
+                        'options' => []
                     ],
                     'sku' => [
                         'id' => '70',
@@ -868,7 +892,7 @@ class DownloadableTest extends AbstractImportTestCase
                         'apply_to' => [],
                         'type' => 'varchar',
                         'default_value' => null,
-                        'options' => [],
+                        'options' => []
                     ]
                 ]
             ]

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/BooleanTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/BooleanTest.php
@@ -25,13 +25,19 @@ class BooleanTest extends TestCase
      */
     protected $_model;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
         $this->_model = $objectManager->getObject(Boolean::class);
     }
 
-    public function testGetFlatColumns()
+    /**
+    * @return void
+    */
+    public function testGetFlatColumns(): void
     {
         $abstractAttributeMock = $this->createPartialMock(
             AbstractAttribute::class,
@@ -58,26 +64,27 @@ class BooleanTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Eav\Model\Entity\Attribute\Source\Boolean::addValueSortToCollection
-     *
-     * @dataProvider addValueSortToCollectionDataProvider
      * @param string $direction
      * @param bool $isScopeGlobal
      * @param array $expectedJoinCondition
      * @param string $expectedOrder
+     *
+     * @return void
+     * @covers \Magento\Eav\Model\Entity\Attribute\Source\Boolean::addValueSortToCollection
+     * @dataProvider addValueSortToCollectionDataProvider
      */
     public function testAddValueSortToCollection(
         $direction,
         $isScopeGlobal,
         $expectedJoinCondition,
         $expectedOrder
-    ) {
+    ): void {
         $attributeMock = $this->getAttributeMock();
         $attributeMock->expects($this->any())->method('isScopeGlobal')->willReturn($isScopeGlobal);
 
         $entity = $this->getMockBuilder(AbstractEntity::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getLinkField'])
+            ->onlyMethods(['getLinkField'])
             ->getMockForAbstractClass();
         $entity->expects($this->once())->method('getLinkField')->willReturn('entity_id');
         $attributeMock->expects($this->once())->method('getEntity')->willReturn($entity);
@@ -86,11 +93,15 @@ class BooleanTest extends TestCase
 
         $collectionMock = $this->getCollectionMock();
         $collectionMock->expects($this->any())->method('getSelect')->willReturn($selectMock);
+        $withArgs = [];
 
-        foreach ($expectedJoinCondition as $step => $data) {
-            $selectMock->expects($this->at($step))->method('joinLeft')
-                ->with($data['requisites'], $data['condition'], [])->willReturnSelf();
+        foreach ($expectedJoinCondition as $data) {
+            $withArgs[] = [$data['requisites'], $data['condition'], []];
         }
+        $selectMock
+            ->method('joinLeft')
+            ->withConsecutive(...$withArgs)
+            ->willReturnSelf();
 
         $selectMock->expects($this->once())->method('order')->with($expectedOrder);
 
@@ -101,7 +112,7 @@ class BooleanTest extends TestCase
     /**
      * @return array
      */
-    public function addValueSortToCollectionDataProvider()
+    public function addValueSortToCollectionDataProvider(): array
     {
         return  [
             [
@@ -111,15 +122,15 @@ class BooleanTest extends TestCase
                     0 => [
                         'requisites' => ['code_t1' => "table"],
                         'condition' => "e.entity_id=code_t1.entity_id AND code_t1.attribute_id='123'"
-                            . " AND code_t1.store_id='0'",
+                            . " AND code_t1.store_id='0'"
                     ],
                     1 => [
                         'requisites' => ['code_t2' => "table"],
                         'condition' => "e.entity_id=code_t2.entity_id AND code_t2.attribute_id='123'"
-                            . " AND code_t2.store_id='12'",
+                            . " AND code_t2.store_id='12'"
                     ],
                 ],
-                'expectedOrder' => 'IF(code_t2.value_id > 0, code_t2.value, code_t1.value) ASC',
+                'expectedOrder' => 'IF(code_t2.value_id > 0, code_t2.value, code_t1.value) ASC'
             ],
             [
                 'direction' => 'DESC',
@@ -128,15 +139,15 @@ class BooleanTest extends TestCase
                     0 => [
                         'requisites' => ['code_t1' => "table"],
                         'condition' => "e.entity_id=code_t1.entity_id AND code_t1.attribute_id='123'"
-                            . " AND code_t1.store_id='0'",
+                            . " AND code_t1.store_id='0'"
                     ],
                     1 => [
                         'requisites' => ['code_t2' => "table"],
                         'condition' => "e.entity_id=code_t2.entity_id AND code_t2.attribute_id='123'"
-                            . " AND code_t2.store_id='12'",
-                    ],
+                            . " AND code_t2.store_id='12'"
+                    ]
                 ],
-                'expectedOrder' => 'IF(code_t2.value_id > 0, code_t2.value, code_t1.value) DESC',
+                'expectedOrder' => 'IF(code_t2.value_id > 0, code_t2.value, code_t1.value) DESC'
             ],
             [
                 'direction' => 'DESC',
@@ -145,10 +156,10 @@ class BooleanTest extends TestCase
                     0 => [
                         'requisites' => ['code_t' => "table"],
                         'condition' => "e.entity_id=code_t.entity_id AND code_t.attribute_id='123'"
-                            . " AND code_t.store_id='0'",
-                    ],
+                            . " AND code_t.store_id='0'"
+                    ]
                 ],
-                'expectedOrder' => 'code_t.value DESC',
+                'expectedOrder' => 'code_t.value DESC'
             ],
             [
                 'direction' => 'ASC',
@@ -157,18 +168,18 @@ class BooleanTest extends TestCase
                     0 => [
                         'requisites' => ['code_t' => "table"],
                         'condition' => "e.entity_id=code_t.entity_id AND code_t.attribute_id='123'"
-                            . " AND code_t.store_id='0'",
-                    ],
+                            . " AND code_t.store_id='0'"
+                    ]
                 ],
-                'expectedOrder' => 'code_t.value ASC',
-            ],
+                'expectedOrder' => 'code_t.value ASC'
+            ]
         ];
     }
 
     /**
      * @return MockObject
      */
-    protected function getCollectionMock()
+    protected function getCollectionMock(): MockObject
     {
         $collectionMock = $this->getMockBuilder(AbstractCollection::class)
             ->addMethods(['getStoreId'])
@@ -190,7 +201,7 @@ class BooleanTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getAttributeMock()
+    protected function getAttributeMock(): MockObject
     {
         $attributeMock = $this->getMockBuilder(AbstractAttribute::class)
             ->addMethods(['isScopeGlobal'])

--- a/app/code/Magento/Email/Test/Unit/Model/Template/Config/FileIteratorTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/Config/FileIteratorTest.php
@@ -43,6 +43,9 @@ class FileIteratorTest extends TestCase
      */
     protected $filePaths;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->filePaths = ['directory/path/file1', 'directory/path/file2'];
@@ -57,6 +60,9 @@ class FileIteratorTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         $this->fileIterator = null;
@@ -64,7 +70,10 @@ class FileIteratorTest extends TestCase
         $this->moduleDirResolverMock = null;
     }
 
-    public function testIterator()
+    /**
+    * @return void
+    */
+    public function testIterator(): void
     {
         $moduleName = 'Filesystem';
         $contents = ['<template 123>', '<template 321>'];
@@ -74,33 +83,49 @@ class FileIteratorTest extends TestCase
         ];
         $index = 0;
         $dirIndex = 0;
+
+        $moduleDirResolverWithArgs = $moduleDirResolverWillReturnArgs = [];
+        $fileReadFactoryWithArgs = $fileReadFactoryWillReturnArgs = [];
+        $fileReadWillReturnArgs = [];
+
         foreach ($this->filePaths as $filePath) {
-            $this->moduleDirResolverMock->expects($this->at($index))
-                ->method('getModuleName')
-                ->with($filePath)
-                ->willReturn($moduleName);
-            $this->fileReadFactory->expects($this->at($dirIndex))
-                ->method('create')
-                ->with($filePath)
-                ->willReturn($this->fileRead);
-            $this->fileRead->expects($this->at($dirIndex++))
-                ->method('readAll')
-                ->willReturn($contents[$index++]);
+            $moduleDirResolverWithArgs[] = [$filePath];
+            $moduleDirResolverWillReturnArgs[] = $moduleName;
+
+            $fileReadFactoryWithArgs[] = [$filePath];
+            $fileReadFactoryWillReturnArgs[] = $this->fileRead;
+
+            $fileReadWillReturnArgs[] = $contents[$index++];
         }
+        $this->moduleDirResolverMock
+            ->method('getModuleName')
+            ->withConsecutive(...$moduleDirResolverWithArgs)
+            ->willReturnOnConsecutiveCalls(...$moduleDirResolverWillReturnArgs);
+        $this->fileReadFactory
+            ->method('create')
+            ->withConsecutive(...$fileReadFactoryWithArgs)
+            ->willReturnOnConsecutiveCalls(...$fileReadFactoryWillReturnArgs);
+        $this->fileRead
+            ->method('readAll')
+            ->willReturnOnConsecutiveCalls(...$fileReadWillReturnArgs);
+
         $index = 0;
         foreach ($this->fileIterator as $fileContent) {
             $this->assertEquals($expectedResult[$index++], $fileContent);
         }
     }
 
-    public function testIteratorNegative()
+    /**
+    * @return void
+    */
+    public function testIteratorNegative(): void
     {
         $filePath = $this->filePaths[0];
 
         $this->expectException('UnexpectedValueException');
         $this->expectExceptionMessage(sprintf("Unable to determine a module, file '%s' belongs to.", $filePath));
 
-        $this->moduleDirResolverMock->expects($this->at(0))
+        $this->moduleDirResolverMock
             ->method('getModuleName')
             ->with($filePath)
             ->willReturn(false);

--- a/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Type/Grouped/PriceTest.php
+++ b/app/code/Magento/GroupedProduct/Test/Unit/Model/Product/Type/Grouped/PriceTest.php
@@ -27,6 +27,9 @@ class PriceTest extends TestCase
      */
     protected $productMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->productMock = $this->createMock(Product::class);
@@ -39,9 +42,10 @@ class PriceTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\GroupedProduct\Model\Product\Type\Grouped\Price::getFinalPrice
      */
-    public function testGetFinalPriceIfQtyIsNullAndFinalPriceExist()
+    public function testGetFinalPriceIfQtyIsNullAndFinalPriceExist(): void
     {
         $finalPrice = 15;
 
@@ -64,6 +68,7 @@ class PriceTest extends TestCase
      * @param $expectedPriceCall
      * @param $expectedFinalPrice
      *
+     * @return void
      * @dataProvider getFinalPriceDataProvider
      * @covers \Magento\GroupedProduct\Model\Product\Type\Grouped\Price::getFinalPrice
      */
@@ -72,9 +77,8 @@ class PriceTest extends TestCase
         array $options,
         $expectedPriceCall,
         $expectedFinalPrice
-    ) {
+    ): void {
         $rawFinalPrice = 10;
-        $rawPriceCheckStep = 5;
 
         $this->productMock->expects(
             $this->any()
@@ -87,17 +91,21 @@ class PriceTest extends TestCase
         //mock for parent::getFinal price call
         $this->productMock->expects($this->any())->method('getPrice')->willReturn($rawFinalPrice);
 
-        $this->productMock->expects(
-            $this->at($rawPriceCheckStep)
-        )->method(
-            'setFinalPrice'
-        )->with(
-            $rawFinalPrice
-        )->willReturn(
-            $this->productMock
-        );
+        $this->productMock
+            ->method('setFinalPrice')
+            ->withConsecutive([], [], [], [], [], [$rawFinalPrice])
+            ->willReturnOnConsecutiveCalls(null, null, null, null, null, $this->productMock);
 
-        $this->productMock->expects($this->at($expectedPriceCall))->method('setFinalPrice')->with($expectedFinalPrice);
+        $expectedPriceCallWithArgs = [];
+
+        for ($index = 0; $index < $expectedPriceCall; $index++) {
+            $expectedPriceCallWithArgs[] = [];
+        }
+        $expectedPriceCallWithArgs[] = [$expectedFinalPrice];
+
+        $this->productMock
+            ->method('setFinalPrice')
+            ->withConsecutive(...$expectedPriceCallWithArgs);
 
         $this->productMock->expects(
             $this->any()
@@ -151,11 +159,11 @@ class PriceTest extends TestCase
     }
 
     /**
-     * Data provider for testGetFinalPrice
+     * Data provider for testGetFinalPrice.
      *
      * @return array
      */
-    public function getFinalPriceDataProvider()
+    public function getFinalPriceDataProvider(): array
     {
         $optionMock = $this->getMockBuilder(Option::class)
             ->addMethods(['getValue'])
@@ -170,27 +178,27 @@ class PriceTest extends TestCase
                 'associatedProducts' => [],
                 'options' => [[], []],
                 'expectedPriceCall' => 5, /* product call number to check final price formed correctly */
-                'expectedFinalPrice' => 10, /* 10(product price) + 2(options count) * 5(qty) * 5(option price) */
+                'expectedFinalPrice' => 10 /* 10(product price) + 2(options count) * 5(qty) * 5(option price) */
             ],
             'custom_option_exist' => [
                 'associatedProducts' => $this->generateAssociatedProducts(),
                 'options' => [
                     ['associated_product_1', false],
                     ['associated_product_2', $optionMock],
-                    ['associated_product_3', $optionMock],
+                    ['associated_product_3', $optionMock]
                 ],
                 'expectedPriceCall' => 15, /* product call number to check final price formed correctly */
-                'expectedFinalPrice' => 35, /* 10(product price) + 2(options count) * 5(qty) * 5(option price) */
+                'expectedFinalPrice' => 35 /* 10(product price) + 2(options count) * 5(qty) * 5(option price) */
             ]
         ];
     }
 
     /**
-     * Generate associated product for every custom option
+     * Generate associated product for every custom option.
      *
      * @return array
      */
-    protected function generateAssociatedProducts()
+    protected function generateAssociatedProducts(): array
     {
         $childProductMock = $this->createPartialMock(
             Product::class,

--- a/app/code/Magento/Indexer/Test/Unit/Model/ProcessorTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/ProcessorTest.php
@@ -48,6 +48,9 @@ class ProcessorTest extends TestCase
      */
     protected $viewProcessorMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->configMock = $this->getMockForAbstractClass(
@@ -128,18 +131,21 @@ class ProcessorTest extends TestCase
         $indexer2Mock->expects($this->never())->method('reindexAll');
         $indexer2Mock->expects($this->once())->method('getState')->willReturn($state2Mock);
 
-        $this->indexerFactoryMock->expects($this->at(0))->method('create')->willReturn($indexer1Mock);
-        $this->indexerFactoryMock->expects($this->at(1))->method('create')->willReturn($indexer2Mock);
+        $this->indexerFactoryMock
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($indexer1Mock, $indexer2Mock);
 
         $this->model->reindexAllInvalid();
     }
 
     /**
-     * @dataProvider sharedIndexDataProvider
      * @param array $indexers
      * @param array $indexerStates
      * @param array $expectedReindexAllCalls
      * @param array $executedSharedIndexers
+     *
+     * @return void
+     * @dataProvider sharedIndexDataProvider
      */
     public function testReindexAllInvalidWithSharedIndex(
         array $indexers,
@@ -167,13 +173,12 @@ class ProcessorTest extends TestCase
             $indexerMock = $this->createPartialMock(Indexer::class, ['load', 'getState', 'reindexAll']);
             $indexerMock->expects($this->any())->method('getState')->willReturn($stateMock);
             $indexerMock->expects($expectedReindexAllCalls[$indexerData['indexer_id']])->method('reindexAll');
-
-            $this->indexerFactoryMock->expects($this->at(count($indexerMocks)))
-                ->method('create')
-                ->willReturn($indexerMock);
-
             $indexerMocks[] = $indexerMock;
         }
+        $this->indexerFactoryMock
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(...$indexerMocks);
+
         $indexerRegistryMock = $this->getIndexRegistryMock($executedSharedIndexers);
 
         $makeSharedValidMock = new MakeSharedIndexValid(
@@ -191,9 +196,9 @@ class ProcessorTest extends TestCase
     }
 
     /**
-     * Reindex all test
+     * Reindex all test.
      *
-     * return void
+     * @return void
      */
     public function testReindexAll(): void
     {
@@ -209,22 +214,22 @@ class ProcessorTest extends TestCase
     }
 
     /**
-     * Update mview test
+     * Update mview test.
      *
      * @return void
      */
-    public function testUpdateMview()
+    public function testUpdateMview(): void
     {
         $this->viewProcessorMock->expects($this->once())->method('update')->with('indexer')->willReturnSelf();
         $this->model->updateMview();
     }
 
     /**
-     * Clear change log test
+     * Clear change log test.
      *
      * @return void
      */
-    public function testClearChangelog()
+    public function testClearChangelog(): void
     {
         $this->viewProcessorMock->expects($this->once())->method('clearChangelog')->with('indexer')->willReturnSelf();
         $this->model->clearChangelog();
@@ -233,7 +238,7 @@ class ProcessorTest extends TestCase
     /**
      * @return array
      */
-    public function sharedIndexDataProvider()
+    public function sharedIndexDataProvider(): array
     {
         return [
             'Without dependencies' => [
@@ -242,32 +247,32 @@ class ProcessorTest extends TestCase
                         'indexer_id' => 'indexer_1',
                         'title' => 'Title_indexer_1',
                         'shared_index' => null,
-                        'dependencies' => [],
+                        'dependencies' => []
                     ],
                     'indexer_2' => [
                         'indexer_id' => 'indexer_2',
                         'title' => 'Title_indexer_2',
                         'shared_index' => 'with_indexer_3',
-                        'dependencies' => [],
+                        'dependencies' => []
                     ],
                     'indexer_3' => [
                         'indexer_id' => 'indexer_3',
                         'title' => 'Title_indexer_3',
                         'shared_index' => 'with_indexer_3',
-                        'dependencies' => [],
+                        'dependencies' => []
                     ],
                 ],
                 'indexer_states' => [
                     'indexer_1' => StateInterface::STATUS_INVALID,
                     'indexer_2' => StateInterface::STATUS_VALID,
-                    'indexer_3' => StateInterface::STATUS_VALID,
+                    'indexer_3' => StateInterface::STATUS_VALID
                 ],
                 'expected_reindex_all_calls' => [
                     'indexer_1' => $this->once(),
                     'indexer_2' => $this->never(),
-                    'indexer_3' => $this->never(),
+                    'indexer_3' => $this->never()
                 ],
-                'executed_shared_indexers' => [],
+                'executed_shared_indexers' => []
             ],
             'With dependencies and some indexers is invalid' => [
                 'indexers' => [
@@ -275,49 +280,50 @@ class ProcessorTest extends TestCase
                         'indexer_id' => 'indexer_1',
                         'title' => 'Title_indexer_1',
                         'shared_index' => null,
-                        'dependencies' => ['indexer_2', 'indexer_3'],
+                        'dependencies' => ['indexer_2', 'indexer_3']
                     ],
                     'indexer_2' => [
                         'indexer_id' => 'indexer_2',
                         'title' => 'Title_indexer_2',
                         'shared_index' => 'with_indexer_3',
-                        'dependencies' => [],
+                        'dependencies' => []
                     ],
                     'indexer_3' => [
                         'indexer_id' => 'indexer_3',
                         'title' => 'Title_indexer_3',
                         'shared_index' => 'with_indexer_3',
-                        'dependencies' => [],
+                        'dependencies' => []
                     ],
                     'indexer_4' => [
                         'indexer_id' => 'indexer_4',
                         'title' => 'Title_indexer_4',
                         'shared_index' => null,
-                        'dependencies' => ['indexer_1'],
-                    ],
+                        'dependencies' => ['indexer_1']
+                    ]
                 ],
                 'indexer_states' => [
                     'indexer_1' => StateInterface::STATUS_INVALID,
                     'indexer_2' => StateInterface::STATUS_VALID,
                     'indexer_3' => StateInterface::STATUS_INVALID,
-                    'indexer_4' => StateInterface::STATUS_VALID,
+                    'indexer_4' => StateInterface::STATUS_VALID
                 ],
                 'expected_reindex_all_calls' => [
                     'indexer_1' => $this->once(),
                     'indexer_2' => $this->never(),
                     'indexer_3' => $this->once(),
-                    'indexer_4' => $this->never(),
+                    'indexer_4' => $this->never()
                 ],
-                'executed_shared_indexers' => [['indexer_2'], ['indexer_3']],
-            ],
+                'executed_shared_indexers' => [['indexer_2'], ['indexer_3']]
+            ]
         ];
     }
 
     /**
      * @param array $executedSharedIndexers
+     *
      * @return IndexerRegistry|MockObject
      */
-    private function getIndexRegistryMock(array $executedSharedIndexers)
+    private function getIndexRegistryMock(array $executedSharedIndexers): MockObject
     {
         /** @var MockObject|IndexerRegistry $indexerRegistryMock */
         $indexerRegistryMock = $this->getMockBuilder(IndexerRegistry::class)
@@ -326,7 +332,8 @@ class ProcessorTest extends TestCase
         $emptyIndexer = $this->createPartialMock(Indexer::class, ['load', 'getState', 'reindexAll']);
         /** @var MockObject|StateInterface $state */
         $state = $this->getMockBuilder(StateInterface::class)
-            ->setMethods(['setStatus', 'save'])
+            ->onlyMethods(['setStatus'])
+            ->addMethods(['save'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $state->method('getStatus')

--- a/app/code/Magento/Integration/Test/Unit/Model/ManagerTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/ManagerTest.php
@@ -41,12 +41,14 @@ class ManagerTest extends TestCase
      */
     protected $integrationManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
-        $this->integrationServiceMock = $this->getMockBuilder(
-            IntegrationServiceInterface::class
-        )->disableOriginalConstructor()
-            ->setMethods(
+        $this->integrationServiceMock = $this->getMockBuilder(IntegrationServiceInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
                 [
                     'findByName',
                     'update',
@@ -61,12 +63,12 @@ class ManagerTest extends TestCase
 
         $this->aclRetriever = $this->getMockBuilder(AclRetriever::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getAllowedResourcesByUser'])
             ->getMock();
 
         $this->configMock = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getIntegrations'])
             ->getMock();
         $objectManagerHelper = new ObjectManager($this);
 
@@ -80,44 +82,53 @@ class ManagerTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         unset($this->integrationServiceMock);
         unset($this->integrationManager);
     }
 
-    public function testProcessIntegrationConfigNoIntegrations()
+    /**
+    * @return void
+    */
+    public function testProcessIntegrationConfigNoIntegrations(): void
     {
         $this->configMock->expects($this->never())->method('getIntegrations');
         $this->integrationManager->processIntegrationConfig([]);
     }
 
-    public function testProcessIntegrationConfigSuccess()
+    /**
+     * @return void
+     */
+    public function testProcessIntegrationConfigSuccess(): void
     {
         $this->configMock->expects(
             $this->once()
         )->method(
             'getIntegrations'
         )->willReturn(
-            
+
                 [
                     'TestIntegration1' => [
                         'email' => 'test-integration1@magento.com',
                         'endpoint_url' => 'http://endpoint.com',
-                        'identity_link_url' => 'http://www.example.com/identity',
+                        'identity_link_url' => 'http://www.example.com/identity'
                     ],
-                    'TestIntegration2' => ['email' => 'test-integration2@magento.com'],
+                    'TestIntegration2' => ['email' => 'test-integration2@magento.com']
                 ]
-            
+
         );
         $intLookupData1 = $this->getMockBuilder(Integration::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getId'])
             ->getMock();
         $intLookupData1->expects($this->any())->method('getId')->willReturn(1);
         $intLookupData2 = $this->getMockBuilder(Integration::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getId'])
             ->getMock();
         $intLookupData1->expects($this->any())->method('getId')->willReturn(false);
 
@@ -134,30 +145,21 @@ class ManagerTest extends TestCase
             Integration::EMAIL => 'test-integration2@magento.com',
             Integration::SETUP_TYPE => 1,
         ];
-        $this->integrationServiceMock->expects(
-            $this->at(0)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration1'
-        )->willReturn(
-            $intLookupData1
-        );
         $this->integrationServiceMock->expects($this->once())->method('create')->with($integrationsData2);
-        $this->integrationServiceMock->expects(
-            $this->at(2)
-        )->method(
-            'findByName'
-        )->with(
-            'TestIntegration2'
-        )->willReturn(
-            $intLookupData2
-        );
-        $this->integrationServiceMock->expects($this->at(1))->method('update')->with($intUpdateData1);
+        $this->integrationServiceMock
+            ->method('findByName')
+            ->withConsecutive(['TestIntegration1'], ['TestIntegration2'])
+            ->willReturnOnConsecutiveCalls($intLookupData1, $intLookupData2);
+        $this->integrationServiceMock
+            ->method('update')
+            ->with($intUpdateData1);
         $this->integrationManager->processIntegrationConfig(['TestIntegration1', 'TestIntegration2']);
     }
 
-    public function testProcessConfigBasedIntegrationsRecreateUpdatedConfigAfterResourceChange()
+    /**
+     * @return void
+     */
+    public function testProcessConfigBasedIntegrationsRecreateUpdatedConfigAfterResourceChange(): void
     {
         $originalData = [
             Integration::ID => 1,
@@ -188,13 +190,14 @@ class ManagerTest extends TestCase
 
         $integrationObject = $this->getMockBuilder(Integration::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getId', 'getOrigData', 'getData'])
             ->getMock();
 
         // Integration already exists, so update with new data and recreate
-        $this->integrationServiceMock->expects($this->at(0))->method('findByName')->with('TestIntegration1')->willReturn(
-            $integrationObject
-        );
+        $this->integrationServiceMock
+            ->method('findByName')
+            ->with('TestIntegration1')
+            ->willReturn($integrationObject);
         $this->aclRetriever->expects($this->once())->method('getAllowedResourcesByUser')
             ->willReturn($originalResources);
         $integrationObject->expects($this->any())->method('getId')->willReturn($originalData[Integration::ID]);
@@ -208,7 +211,10 @@ class ManagerTest extends TestCase
         $this->integrationManager->processConfigBasedIntegrations($integrations);
     }
 
-    public function testProcessConfigBasedIntegrationsCreateNewIntegrations()
+    /**
+     * @return void
+     */
+    public function testProcessConfigBasedIntegrationsCreateNewIntegrations(): void
     {
         $integrations = [
             'TestIntegration1' => [
@@ -223,26 +229,24 @@ class ManagerTest extends TestCase
             'TestIntegration2' => [
                 Integration::EMAIL => 'test-integration2@magento.com',
                 Integration::ENDPOINT => 'http://endpoint.com',
-                Integration::IDENTITY_LINK_URL => 'http://www.example.com/identity',
+                Integration::IDENTITY_LINK_URL => 'http://www.example.com/identity'
             ]
         ];
 
         $integrationObject = $this->getMockBuilder(Integration::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getId'])
             ->getMock();
 
         // Integration1 does not exist, so create it
-        $this->integrationServiceMock->expects($this->at(0))->method('findByName')->with('TestIntegration1')->willReturn(
-            $integrationObject
-        );
         $integrationObject->expects($this->any())->method('getId')->willReturn(false);
         $this->integrationServiceMock->expects($this->any())->method('create');
 
         // Integration2 does not exist, so create it
-        $this->integrationServiceMock->expects($this->at(2))->method('findByName')->with('TestIntegration2')->willReturn(
-            $integrationObject
-        );
+        $this->integrationServiceMock
+            ->method('findByName')
+            ->withConsecutive(['TestIntegration1'], ['TestIntegration2'])
+            ->willReturnOnConsecutiveCalls($integrationObject, $integrationObject);
 
         $this->integrationManager->processConfigBasedIntegrations($integrations);
     }

--- a/app/code/Magento/Integration/Test/Unit/Model/Plugin/IntegrationTest.php
+++ b/app/code/Magento/Integration/Test/Unit/Model/Plugin/IntegrationTest.php
@@ -56,6 +56,9 @@ class IntegrationTest extends TestCase
      */
     protected $consolidatedConfigMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->subjectMock = $this->createMock(IntegrationService::class);
@@ -69,11 +72,10 @@ class IntegrationTest extends TestCase
         );
         $this->integrationConfigMock = $this->getMockBuilder(IntegrationConfig::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->onlyMethods(['getIntegrations'])
             ->getMock();
         $this->consolidatedConfigMock = $this->getMockBuilder(ConsolidatedConfig::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $objectManagerHelper = new ObjectManager($this);
@@ -89,7 +91,10 @@ class IntegrationTest extends TestCase
         );
     }
 
-    public function testAfterDelete()
+    /**
+    * @return void
+    */
+    public function testAfterDelete(): void
     {
         $integrationId = 1;
         $integrationsData = [
@@ -106,7 +111,10 @@ class IntegrationTest extends TestCase
         $this->integrationPlugin->afterDelete($this->subjectMock, $integrationsData);
     }
 
-    public function testAfterCreateAllResources()
+    /**
+    * @return void
+    */
+    public function testAfterCreateAllResources(): void
     {
         $integrationId = 1;
         $integrationModelMock = $this->getMockBuilder(Integration::class)
@@ -127,7 +135,10 @@ class IntegrationTest extends TestCase
         $this->integrationPlugin->afterCreate($this->subjectMock, $integrationModelMock);
     }
 
-    public function testAfterCreateSomeResources()
+    /**
+    * @return void
+    */
+    public function testAfterCreateSomeResources(): void
     {
         $integrationId = 1;
         $integrationModelMock = $this->getMockBuilder(Integration::class)
@@ -136,18 +147,10 @@ class IntegrationTest extends TestCase
         $integrationModelMock->expects($this->exactly(2))
             ->method('getId')
             ->willReturn($integrationId);
-        $integrationModelMock->expects($this->at(2))
+        $integrationModelMock
             ->method('getData')
-            ->with('all_resources')
-            ->willReturn(null);
-        $integrationModelMock->expects($this->at(3))
-            ->method('getData')
-            ->with('resource')
-            ->willReturn(['testResource']);
-        $integrationModelMock->expects($this->at(5))
-            ->method('getData')
-            ->with('resource')
-            ->willReturn(['testResource']);
+            ->withConsecutive(['all_resources'], ['resource'], ['resource'])
+            ->willReturnOnConsecutiveCalls(null, ['testResource'], ['testResource']);
 
         $this->integrationAuthServiceMock->expects($this->once())
             ->method('grantPermissions')
@@ -156,7 +159,10 @@ class IntegrationTest extends TestCase
         $this->integrationPlugin->afterCreate($this->subjectMock, $integrationModelMock);
     }
 
-    public function testAfterCreateNoResource()
+    /**
+    * @return void
+    */
+    public function testAfterCreateNoResource(): void
     {
         $integrationId = 1;
         $integrationModelMock = $this->getMockBuilder(Integration::class)
@@ -165,14 +171,10 @@ class IntegrationTest extends TestCase
         $integrationModelMock->expects($this->exactly(2))
             ->method('getId')
             ->willReturn($integrationId);
-        $integrationModelMock->expects($this->at(2))
+        $integrationModelMock
             ->method('getData')
-            ->with('all_resources')
-            ->willReturn(null);
-        $integrationModelMock->expects($this->at(3))
-            ->method('getData')
-            ->with('resource')
-            ->willReturn(null);
+            ->withConsecutive(['all_resources'], ['resource'])
+            ->willReturnOnConsecutiveCalls(null, null);
 
         $this->integrationAuthServiceMock->expects($this->once())
             ->method('grantPermissions')
@@ -181,7 +183,10 @@ class IntegrationTest extends TestCase
         $this->integrationPlugin->afterCreate($this->subjectMock, $integrationModelMock);
     }
 
-    public function testAfterUpdateAllResources()
+    /**
+    * @return void
+    */
+    public function testAfterUpdateAllResources(): void
     {
         $integrationId = 1;
         $integrationModelMock = $this->getMockBuilder(Integration::class)
@@ -202,11 +207,15 @@ class IntegrationTest extends TestCase
         $this->integrationPlugin->afterUpdate($this->subjectMock, $integrationModelMock);
     }
 
-    public function testAfterGet()
+    /**
+    * @return void
+    */
+    public function testAfterGet(): void
     {
         $integrationId = 1;
         $integrationModelMock = $this->getMockBuilder(Integration::class)
             ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'setData'])
             ->getMock();
         $integrationModelMock->expects($this->exactly(2))
             ->method('getId')

--- a/app/code/Magento/OfflinePayments/Test/Unit/Block/Info/CheckmoTest.php
+++ b/app/code/Magento/OfflinePayments/Test/Unit/Block/Info/CheckmoTest.php
@@ -29,45 +29,48 @@ class CheckmoTest extends TestCase
     private $block;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $context = $this->getMockBuilder(Context::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMock();
 
         $this->infoMock = $this->getMockBuilder(Info::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getAdditionalInformation'])
+            ->onlyMethods(['getAdditionalInformation'])
             ->getMock();
 
         $this->block = new Checkmo($context);
     }
 
     /**
-     * @covers \Magento\OfflinePayments\Block\Info\Checkmo::getPayableTo
      * @param array $details
      * @param string|null $expected
+     *
+     * @return void
      * @dataProvider getPayableToDataProvider
+     * @covers \Magento\OfflinePayments\Block\Info\Checkmo::getPayableTo
      */
-    public function testGetPayableTo($details, $expected)
+    public function testGetPayableTo($details, $expected): void
     {
-        $this->infoMock->expects(static::at(0))
+        $this->infoMock
             ->method('getAdditionalInformation')
-            ->with('payable_to')
-            ->willReturn($details);
+            ->withConsecutive(['payable_to'])
+            ->willReturnOnConsecutiveCalls($details);
         $this->block->setData('info', $this->infoMock);
 
         static::assertEquals($expected, $this->block->getPayableTo());
     }
 
     /**
-     * Get list of variations for payable configuration option testing
+     * Get list of variations for payable configuration option testing.
+     *
      * @return array
      */
-    public function getPayableToDataProvider()
+    public function getPayableToDataProvider(): array
     {
         return [
             ['payable_to' => 'payable', 'payable'],
@@ -76,27 +79,30 @@ class CheckmoTest extends TestCase
     }
 
     /**
-     * @covers \Magento\OfflinePayments\Block\Info\Checkmo::getMailingAddress
      * @param array $details
      * @param string|null $expected
+     *
+     * @return void
      * @dataProvider getMailingAddressDataProvider
+     * @covers \Magento\OfflinePayments\Block\Info\Checkmo::getMailingAddress
      */
-    public function testGetMailingAddress($details, $expected)
+    public function testGetMailingAddress($details, $expected): void
     {
-        $this->infoMock->expects(static::at(1))
+        $this->infoMock
             ->method('getAdditionalInformation')
-            ->with('mailing_address')
-            ->willReturn($details);
+            ->withConsecutive([], ['mailing_address'])
+            ->willReturnOnConsecutiveCalls(null, $details);
         $this->block->setData('info', $this->infoMock);
 
         static::assertEquals($expected, $this->block->getMailingAddress());
     }
 
     /**
-     * Get list of variations for mailing address testing
+     * Get list of variations for mailing address testing.
+     *
      * @return array
      */
-    public function getMailingAddressDataProvider()
+    public function getMailingAddressDataProvider(): array
     {
         return [
             ['mailing_address' => 'blah@blah.com', 'blah@blah.com'],
@@ -105,15 +111,16 @@ class CheckmoTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\OfflinePayments\Block\Info\Checkmo::getMailingAddress
      */
-    public function testConvertAdditionalDataIsNeverCalled()
+    public function testConvertAdditionalDataIsNeverCalled(): void
     {
         $mailingAddress = 'blah@blah.com';
-        $this->infoMock->expects(static::at(1))
+        $this->infoMock
             ->method('getAdditionalInformation')
-            ->with('mailing_address')
-            ->willReturn($mailingAddress);
+            ->withConsecutive([], ['mailing_address'])
+            ->willReturnOnConsecutiveCalls(null, $mailingAddress);
         $this->block->setData('info', $this->infoMock);
 
         // First we set the property $this->_mailingAddress

--- a/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/ImportTest.php
+++ b/app/code/Magento/OfflineShipping/Test/Unit/Model/ResourceModel/Carrier/Tablerate/ImportTest.php
@@ -60,7 +60,7 @@ class ImportTest extends TestCase
     private $dataHashGeneratorMock;
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -75,7 +75,7 @@ class ImportTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->columnResolverFactoryMock = $this->getMockBuilder(ColumnResolverFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->dataHashGeneratorMock = $this->getMockBuilder(DataHashGenerator::class)
@@ -101,7 +101,7 @@ class ImportTest extends TestCase
     /**
      * @return void
      */
-    public function testGetColumns()
+    public function testGetColumns(): void
     {
         $columns = ['column_1', 'column_2'];
         $this->rowParserMock->expects($this->once())
@@ -114,7 +114,7 @@ class ImportTest extends TestCase
     /**
      * @return void
      */
-    public function testGetData()
+    public function testGetData(): void
     {
         $lines = [
             ['header_1', 'header_2', 'header_3', 'header_4', 'header_5'],
@@ -122,7 +122,7 @@ class ImportTest extends TestCase
             ['a2', 'b2', 'c2', 'd2', 'e2'],
             ['a3', 'b3', 'c3', 'd3', 'e3'],
             ['a4', 'b4', 'c4', 'd4', 'e4'],
-            ['a5', 'b5', 'c5', 'd5', 'e5'],
+            ['a5', 'b5', 'c5', 'd5', 'e5']
         ];
         $this->rowParserMock->expects($this->any())
             ->method('parse')
@@ -137,11 +137,11 @@ class ImportTest extends TestCase
         $expectedResult = [
             [
                 $lines[1],
-                $lines[2],
+                $lines[2]
             ],
             [
                 $lines[3],
-                $lines[4],
+                $lines[4]
             ],
             [
                 $lines[5]
@@ -169,14 +169,14 @@ class ImportTest extends TestCase
     /**
      * @return void
      */
-    public function testGetDataWithDuplicatedLine()
+    public function testGetDataWithDuplicatedLine(): void
     {
         $lines = [
             ['header_1', 'header_2', 'header_3', 'header_4', 'header_5'],
             ['a1', 'b1', 'c1', 'd1', 'e1'],
             ['a1', 'b1', 'c1', 'd1', 'e1'],
             [],
-            ['a2', 'b2', 'c2', 'd2', 'e2'],
+            ['a2', 'b2', 'c2', 'd2', 'e2']
         ];
         $this->rowParserMock->expects($this->any())
             ->method('parse')
@@ -189,8 +189,8 @@ class ImportTest extends TestCase
         $expectedResult = [
             [
                 $lines[1],
-                $lines[4],
-            ],
+                $lines[4]
+            ]
         ];
 
         $columnResolver = $this->getMockBuilder(ColumnResolver::class)
@@ -212,9 +212,10 @@ class ImportTest extends TestCase
     }
 
     /**
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function testGetDataFromEmptyFile()
+    public function testGetDataFromEmptyFile(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('The Table Rates File Format is incorrect. Verify the format and try again.');
@@ -227,23 +228,24 @@ class ImportTest extends TestCase
 
     /**
      * @param array $lines
+     *
      * @return ReadInterface|MockObject
      */
-    private function createFileMock(array $lines)
+    private function createFileMock(array $lines): MockObject
     {
         $file = $this->getMockBuilder(ReadInterface::class)
-            ->setMethods(['readCsv'])
+            ->onlyMethods(['readCsv'])
             ->getMockForAbstractClass();
-        $i = 0;
+        $willReturnArgs = [];
+
         foreach ($lines as $line) {
-            $file->expects($this->at($i))
-                ->method('readCsv')
-                ->willReturn($line);
-            $i++;
+            $willReturnArgs[] = $line;
         }
-        $file->expects($this->at($i))
+        $willReturnArgs[] = false;
+        $file
             ->method('readCsv')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
         return $file;
     }
 }

--- a/app/code/Magento/PageCache/Test/Unit/Controller/Block/RenderTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Controller/Block/RenderTest.php
@@ -70,7 +70,7 @@ class RenderTest extends TestCase
     protected $layoutCacheKeyMock;
 
     /**
-     * Set up before test
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -124,7 +124,10 @@ class RenderTest extends TestCase
         );
     }
 
-    public function testExecuteNotAjax()
+    /**
+    * @return void
+    */
+    public function testExecuteNotAjax(): void
     {
         $this->requestMock->expects($this->once())->method('isAjax')->willReturn(false);
         $this->requestMock->expects($this->once())->method('setActionName')->willReturn('noroute');
@@ -135,25 +138,26 @@ class RenderTest extends TestCase
     }
 
     /**
-     * Test no params: blocks, handles
+     * Test no params: blocks, handles.
+     *
+     * @return void
      */
-    public function testExecuteNoParams()
+    public function testExecuteNoParams(): void
     {
         $this->requestMock->expects($this->once())->method('isAjax')->willReturn(true);
-        $this->requestMock->expects($this->at(6))
+        $this->requestMock
             ->method('getParam')
-            ->with('blocks', '')
-            ->willReturn('');
-        $this->requestMock->expects($this->at(7))
-            ->method('getParam')
-            ->with('handles', '')
-            ->willReturn('');
+            ->withConsecutive([], [], [], [], [], [], ['blocks', ''], ['handles', ''])
+            ->willReturnOnConsecutiveCalls(null, null, null, null, null, null, '', '');
         $this->layoutCacheKeyMock->expects($this->never())
             ->method('addCacheKeys');
         $this->action->execute();
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $blocks = ['block1', 'block2'];
         $handles = ['handle1', 'handle2'];
@@ -174,45 +178,40 @@ class RenderTest extends TestCase
 
         $this->requestMock->expects($this->once())->method('isAjax')->willReturn(true);
 
-        $this->requestMock->expects($this->at(1))
+        $this->requestMock
             ->method('getRouteName')
             ->willReturn('magento_pagecache');
-        $this->requestMock->expects($this->at(2))
-            ->method('getControllerName')
-            ->willReturn('block');
-        $this->requestMock->expects($this->at(3))
-            ->method('getActionName')
-            ->willReturn('render');
-        $this->requestMock->expects($this->at(4))
+        $this->requestMock
+            ->method('getParam')
+            ->withConsecutive(
+                ['originalRequest'],
+                ['blocks', ''],
+                ['handles', '']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $originalRequest,
+                json_encode($blocks),
+                base64_encode(json_encode($handles))
+            );
+        $this->requestMock
             ->method('getRequestUri')
             ->willReturn('uri');
-        $this->requestMock->expects($this->at(5))
-            ->method('getParam')
-            ->with('originalRequest')
-            ->willReturn($originalRequest);
-
-        $this->requestMock->expects($this->at(10))
-            ->method('getParam')
-            ->with('blocks', '')
-            ->willReturn(json_encode($blocks));
-        $this->requestMock->expects($this->at(11))
-            ->method('getParam')
-            ->with('handles', '')
-            ->willReturn(base64_encode(json_encode($handles)));
+        $this->requestMock
+            ->method('getActionName')
+            ->willReturn('render');
+        $this->requestMock
+            ->method('getControllerName')
+            ->willReturn('block');
         $this->viewMock->expects($this->once())->method('loadLayout')->with($handles);
         $this->viewMock->expects($this->any())->method('getLayout')->willReturn($this->layoutMock);
         $this->layoutMock->expects($this->never())
             ->method('getUpdate');
         $this->layoutCacheKeyMock->expects($this->atLeastOnce())
             ->method('addCacheKeys');
-        $this->layoutMock->expects($this->at(0))
+        $this->layoutMock
             ->method('getBlock')
-            ->with($blocks[0])
-            ->willReturn($blockInstance1);
-        $this->layoutMock->expects($this->at(1))
-            ->method('getBlock')
-            ->with($blocks[1])
-            ->willReturn($blockInstance2);
+            ->withConsecutive([$blocks[0]], [$blocks[1]])
+            ->willReturnOnConsecutiveCalls($blockInstance1, $blockInstance2);
 
         $this->translateInline->expects($this->once())
             ->method('processResponseBody')

--- a/app/code/Magento/Paypal/Test/Unit/Block/Billing/Agreement/ViewTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Block/Billing/Agreement/ViewTest.php
@@ -32,6 +32,9 @@ class ViewTest extends TestCase
      */
     protected $block;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -46,12 +49,15 @@ class ViewTest extends TestCase
             View::class,
             [
                 'orderCollectionFactory' => $this->orderCollectionFactory,
-                'orderConfig' => $this->orderConfig,
+                'orderConfig' => $this->orderConfig
             ]
         );
     }
 
-    public function testGetRelatedOrders()
+    /**
+    * @return void
+    */
+    public function testGetRelatedOrders(): void
     {
         $visibleStatuses = [];
 
@@ -59,17 +65,14 @@ class ViewTest extends TestCase
             Collection::class,
             ['addFieldToSelect', 'addFieldToFilter', 'setOrder']
         );
-        $orderCollection->expects($this->at(0))
+        $orderCollection
             ->method('addFieldToSelect')
             ->willReturn($orderCollection);
-        $orderCollection->expects($this->at(1))
+        $orderCollection
             ->method('addFieldToFilter')
-            ->willReturn($orderCollection);
-        $orderCollection->expects($this->at(2))
-            ->method('addFieldToFilter')
-            ->with('status', ['in' => $visibleStatuses])
-            ->willReturn($orderCollection);
-        $orderCollection->expects($this->at(3))
+            ->withConsecutive([], ['status', ['in' => $visibleStatuses]])
+            ->willReturnOnConsecutiveCalls($orderCollection, $orderCollection);
+        $orderCollection
             ->method('setOrder')
             ->willReturn($orderCollection);
 

--- a/app/code/Magento/Paypal/Test/Unit/Model/PayflowConfigTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/PayflowConfigTest.php
@@ -19,7 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 class PayflowConfigTest extends TestCase
 {
-
     /**
      * @var ScopeConfigInterface|MockObject
      */
@@ -35,10 +34,13 @@ class PayflowConfigTest extends TestCase
      */
     protected $config;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)
-            ->setMethods(['getValue', 'isSetFlag'])
+            ->onlyMethods(['getValue', 'isSetFlag'])
             ->getMockForAbstractClass();
         $this->methodInterfaceMock = $this->getMockBuilder(MethodInterface::class)
             ->getMockForAbstractClass();
@@ -56,9 +58,10 @@ class PayflowConfigTest extends TestCase
      * @param string $paymentAction
      * @param string|null $expectedValue
      *
+     * @return void
      * @dataProvider getTrxTypeDataProvider
      */
-    public function testGetTrxType($paymentAction, $expectedValue)
+    public function testGetTrxType($paymentAction, $expectedValue): void
     {
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
@@ -70,12 +73,12 @@ class PayflowConfigTest extends TestCase
     /**
      * @return array
      */
-    public function getTrxTypeDataProvider()
+    public function getTrxTypeDataProvider(): array
     {
         return [
             [PayflowConfig::PAYMENT_ACTION_AUTH, PayflowConfig::TRXTYPE_AUTH_ONLY],
             [PayflowConfig::PAYMENT_ACTION_SALE, PayflowConfig::TRXTYPE_SALE],
-            ['other', null],
+            ['other', null]
         ];
     }
 
@@ -83,9 +86,10 @@ class PayflowConfigTest extends TestCase
      * @param string $paymentAction
      * @param string|null $expectedValue
      *
+     * @return void
      * @dataProvider getPaymentActionDataProvider
      */
-    public function testGetPaymentAction($paymentAction, $expectedValue)
+    public function testGetPaymentAction($paymentAction, $expectedValue): void
     {
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
@@ -97,16 +101,19 @@ class PayflowConfigTest extends TestCase
     /**
      * @return array
      */
-    public function getPaymentActionDataProvider()
+    public function getPaymentActionDataProvider(): array
     {
         return [
             [PayflowConfig::PAYMENT_ACTION_AUTH, AbstractMethod::ACTION_AUTHORIZE],
             [PayflowConfig::PAYMENT_ACTION_SALE, AbstractMethod::ACTION_AUTHORIZE_CAPTURE],
-            ['other', null],
+            ['other', null]
         ];
     }
 
-    public function testGetTransactionUrlWithTestModeOn()
+    /**
+    * @return void
+    */
+    public function testGetTransactionUrlWithTestModeOn(): void
     {
         $this->scopeConfigMock->expects($this->never())
             ->method('getValue');
@@ -119,7 +126,10 @@ class PayflowConfigTest extends TestCase
         $this->assertEquals('transaction_url_test_mode', $this->config->getTransactionUrl(1));
     }
 
-    public function testGetTransactionUrlWithTestModeOff()
+    /**
+    * @return void
+    */
+    public function testGetTransactionUrlWithTestModeOff(): void
     {
         $this->scopeConfigMock->expects($this->never())
             ->method('getValue');
@@ -132,7 +142,10 @@ class PayflowConfigTest extends TestCase
         $this->assertEquals('transaction_url', $this->config->getTransactionUrl(0));
     }
 
-    public function testGetTransactionUrlWithTestModeEmptyAndSandboxOn()
+    /**
+    * @return void
+    */
+    public function testGetTransactionUrlWithTestModeEmptyAndSandboxOn(): void
     {
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
@@ -146,7 +159,10 @@ class PayflowConfigTest extends TestCase
         $this->assertEquals('transaction_url_test_mode', $this->config->getTransactionUrl());
     }
 
-    public function testGetTransactionUrlWithTestModeEmptyAndSandboxOff()
+    /**
+    * @return void
+    */
+    public function testGetTransactionUrlWithTestModeEmptyAndSandboxOff(): void
     {
         $this->scopeConfigMock->expects($this->once())
             ->method('getValue')
@@ -165,9 +181,10 @@ class PayflowConfigTest extends TestCase
      * @param string $currentMethod
      * @param bool $result
      *
+     * @return void
      * @dataProvider dataProviderForTestIsMethodActive
      */
-    public function testIsMethodActive(array $expectsMethods, $currentMethod, $result)
+    public function testIsMethodActive(array $expectsMethods, $currentMethod, $result): void
     {
         $this->config->setStoreId(5);
 
@@ -176,16 +193,20 @@ class PayflowConfigTest extends TestCase
             ->with('paypal/general/merchant_country')
             ->willReturn('US');
 
-        $i = 0;
+        $withArgs = $willReturnArgs = [];
+
         foreach ($expectsMethods as $method => $isActive) {
-            $this->scopeConfigMock->expects($this->at($i++))
-                ->method('isSetFlag')
-                ->with(
-                    "payment/{$method}/active",
-                    ScopeInterface::SCOPE_STORE,
-                    5
-                )->willReturn($isActive);
+            $withArgs[] = [
+                "payment/{$method}/active",
+                ScopeInterface::SCOPE_STORE,
+                5
+            ];
+            $willReturnArgs[] = $isActive;
         }
+        $this->scopeConfigMock
+            ->method('isSetFlag')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->assertEquals($result, $this->config->isMethodActive($currentMethod));
     }
@@ -193,32 +214,32 @@ class PayflowConfigTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestIsMethodActive()
+    public function dataProviderForTestIsMethodActive(): array
     {
         return [
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYMENT_PRO => 0,
-                    Config::METHOD_PAYFLOWPRO => 1,
+                    Config::METHOD_PAYFLOWPRO => 1
                 ],
                 'currentMethod' => Config::METHOD_PAYMENT_PRO,
-                'result' => true,
+                'result' => true
             ],
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYMENT_PRO => 1
                 ],
                 'currentMethod' => Config::METHOD_PAYFLOWPRO,
-                'result' => true,
+                'result' => true
             ],
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYMENT_PRO => 0,
-                    Config::METHOD_PAYFLOWPRO => 0,
+                    Config::METHOD_PAYFLOWPRO => 0
                 ],
                 'currentMethod' => 777,
-                'result' => false,
-            ],
+                'result' => false
+            ]
         ];
     }
 }

--- a/app/code/Magento/Paypal/Test/Unit/Model/PayflowproTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Model/PayflowproTest.php
@@ -69,6 +69,9 @@ class PayflowproTest extends TestCase
      */
     private $eventManager;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->configMock = $this->getMockBuilder(PayflowConfig::class)
@@ -83,7 +86,7 @@ class PayflowproTest extends TestCase
             ->getMockForAbstractClass();
 
         $configFactoryMock = $this->getMockBuilder(ConfigInterfaceFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $configFactoryMock->method('create')
@@ -115,14 +118,15 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Paypal\Model\Payflowpro::canVoid
-     *
      * @param string $message
      * @param int|null $amountPaid
      * @param bool $expected
+     *
+     * @return void
      * @dataProvider canVoidDataProvider
+     * @covers \Magento\Paypal\Model\Payflowpro::canVoid
      */
-    public function testCanVoid($message, $amountPaid, $expected)
+    public function testCanVoid($message, $amountPaid, $expected): void
     {
         /** @var Payment|MockObject $payment */
         $payment = $this->getMockBuilder(Payment::class)
@@ -137,29 +141,37 @@ class PayflowproTest extends TestCase
     /**
      * @return array
      */
-    public function canVoidDataProvider()
+    public function canVoidDataProvider(): array
     {
         return [
             ["Can void transaction if order's paid amount not set", null, true],
             ["Can void transaction if order's paid amount equals zero", 0, true],
-            ["Can't void transaction if order's paid amount greater than zero", 10, false],
+            ["Can't void transaction if order's paid amount greater than zero", 10, false]
         ];
     }
 
-    public function testCanCapturePartial()
+    /**
+    * @return void
+    */
+    public function testCanCapturePartial(): void
     {
         $this->assertTrue($this->payflowpro->canCapturePartial());
     }
 
-    public function testCanRefundPartialPerInvoice()
+    /**
+    * @return void
+    */
+    public function testCanRefundPartialPerInvoice(): void
     {
         $this->assertTrue($this->payflowpro->canRefundPartialPerInvoice());
     }
 
     /**
-     * test for _buildBasicRequest (BDCODE)
+     * test for _buildBasicRequest (BDCODE).
+     *
+     * @return void
      */
-    public function testFetchTransactionInfoForBN()
+    public function testFetchTransactionInfoForBN(): void
     {
         $response = $this->getGatewayResponseObject();
 
@@ -179,10 +191,13 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * @param $response
+     * @param DataObject $response
+     * @param DataObject $paymentExpected
+     *
+     * @return void
      * @dataProvider setTransStatusDataProvider
      */
-    public function testSetTransStatus($response, $paymentExpected)
+    public function testSetTransStatus($response, $paymentExpected): void
     {
         $payment = $this->helper->getObject(Info::class);
         $this->payflowpro->setTransStatus($payment, $response);
@@ -192,20 +207,20 @@ class PayflowproTest extends TestCase
     /**
      * @return array
      */
-    public function setTransStatusDataProvider()
+    public function setTransStatusDataProvider(): array
     {
         return [
             [
                 'response' => new DataObject(
                     [
                         'pnref' => 'V19A3D27B61E',
-                        'result_code' => Payflowpro::RESPONSE_CODE_APPROVED,
+                        'result_code' => Payflowpro::RESPONSE_CODE_APPROVED
                     ]
                 ),
                 'paymentExpected' => new DataObject(
                     [
                         'transaction_id' => 'V19A3D27B61E',
-                        'is_transaction_closed' => 0,
+                        'is_transaction_closed' => 0
                     ]
                 ),
             ],
@@ -221,10 +236,10 @@ class PayflowproTest extends TestCase
                         'transaction_id' => 'V19A3D27B61E',
                         'is_transaction_closed' => 0,
                         'is_transaction_pending' => true,
-                        'is_fraud_detected' => true,
+                        'is_fraud_detected' => true
                     ]
-                ),
-            ],
+                )
+            ]
         ];
     }
 
@@ -232,30 +247,35 @@ class PayflowproTest extends TestCase
      * @param array $expectsMethods
      * @param bool $result
      *
+     * @return void
      * @dataProvider dataProviderForTestIsActive
      */
-    public function testIsActive(array $expectsMethods, $result)
+    public function testIsActive(array $expectsMethods, $result): void
     {
         $storeId = 15;
+        $withArgs = $willReturnArs = [];
 
-        $i = 0;
         foreach ($expectsMethods as $method => $isActive) {
-            $this->scopeConfigMock->expects($this->at($i++))
-                ->method('getValue')
-                ->with(
-                    "payment/{$method}/active",
-                    ScopeInterface::SCOPE_STORE,
-                    $storeId
-                )->willReturn($isActive);
+            $withArgs[] = [
+                "payment/{$method}/active",
+                ScopeInterface::SCOPE_STORE,
+                $storeId
+            ];
+            $willReturnArs[] = $isActive;
         }
+        $this->scopeConfigMock
+            ->method('getValue')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArs);
 
         $this->assertEquals($result, $this->payflowpro->isActive($storeId));
     }
 
     /**
+     * @return void
      * @covers \Magento\Paypal\Model\Payflowpro::capture
      */
-    public function testCaptureWithBuildPlaceRequest()
+    public function testCaptureWithBuildPlaceRequest(): void
     {
         $paymentMock = $this->getPaymentMock();
         $orderMock = $this->getOrderMock();
@@ -283,7 +303,7 @@ class PayflowproTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderCaptureAmountRounding()
+    public function dataProviderCaptureAmountRounding(): array
     {
         return [
             [
@@ -294,17 +314,17 @@ class PayflowproTest extends TestCase
             [
                 'amount' => 14.13199999999999999999999999999999999999999999999999,
                 'setAmount' => 49.99,
-                'expectedResult' => 14.13,
+                'expectedResult' => 14.13
             ],
             [
                 'amount' => 14.14,
                 'setAmount' => 49.99,
-                'expectedResult' => 14.14,
+                'expectedResult' => 14.14
             ],
             [
                 'amount' => 14.13999999999999999999999999999999999999999999999999,
                 'setAmount' => 14.14,
-                'expectedResult' => 0,
+                'expectedResult' => 0
             ]
         ];
     }
@@ -313,9 +333,11 @@ class PayflowproTest extends TestCase
      * @param float $amount
      * @param float $setAmount
      * @param float $expectedResult
+     *
+     * @return void
      * @dataProvider dataProviderCaptureAmountRounding
      */
-    public function testCaptureAmountRounding($amount, $setAmount, $expectedResult)
+    public function testCaptureAmountRounding($amount, $setAmount, $expectedResult): void
     {
         $paymentMock = $this->getPaymentMock();
         $orderMock = $this->getMockBuilder(Order::class)
@@ -372,9 +394,10 @@ class PayflowproTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\Paypal\Model\Payflowpro::authorize
      */
-    public function testAuthorize()
+    public function testAuthorize(): void
     {
         $paymentMock = $this->getPaymentMock();
         $orderMock = $this->getOrderMock();
@@ -393,36 +416,37 @@ class PayflowproTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForTestIsActive()
+    public function dataProviderForTestIsActive(): array
     {
         return [
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYFLOWPRO => 0,
-                    Config::METHOD_PAYMENT_PRO => 1,
+                    Config::METHOD_PAYMENT_PRO => 1
                 ],
-                'result' => true,
+                'result' => true
             ],
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYFLOWPRO => 1
                 ],
-                'result' => true,
+                'result' => true
             ],
             [
                 'expectsMethods' => [
                     Config::METHOD_PAYFLOWPRO => 0,
-                    Config::METHOD_PAYMENT_PRO => 0,
+                    Config::METHOD_PAYMENT_PRO => 0
                 ],
-                'result' => false,
-            ],
+                'result' => false
+            ]
         ];
     }
 
     /**
+     * @return void
      * @covers \Magento\Paypal\Model\Payflowpro::refund()
      */
-    public function testRefund()
+    public function testRefund(): void
     {
         /** @var Payment $paymentMock */
         $paymentMock = $this->getPaymentMock();
@@ -436,15 +460,15 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * Create mock object for store model
+     * Create mock object for store model.
+     *
      * @return void
      */
-    protected function initStoreMock()
+    protected function initStoreMock(): void
     {
         $storeId = 27;
-        $storeMock = $this->getMockBuilder(Store::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getId'])
+        $storeMock = $this->getMockBuilder(Store::class)->disableOriginalConstructor()
+            ->onlyMethods(['getId'])
             ->getMock();
         $this->storeManagerMock->expects(static::once())
             ->method('getStore')
@@ -455,10 +479,11 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * Create response object for Payflowpro gateway
-     * @return \Magento\Framework\DataObject
+     * Create response object for Payflowpro gateway.
+     *
+     * @return DataObject
      */
-    protected function getGatewayResponseObject()
+    protected function getGatewayResponseObject(): DataObject
     {
         return new DataObject(
             [
@@ -468,16 +493,17 @@ class PayflowproTest extends TestCase
                 'authcode' => '510PNI',
                 'hostcode' => 'A',
                 'request_id' => 'f930d3dc6824c1f7230c5529dc37ae5e',
-                'result_code' => '0',
+                'result_code' => '0'
             ]
         );
     }
 
     /**
-     * Call payflow gateway request and return response object
-     * @return \Magento\Framework\DataObject
+     * Call payflow gateway request and return response object.
+     *
+     * @return DataObject
      */
-    protected function execGatewayRequest()
+    protected function execGatewayRequest(): DataObject
     {
         $this->initStoreMock();
         $response = $this->getGatewayResponseObject();
@@ -492,17 +518,25 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * Create mock object for payment model
+     * Create mock object for payment model.
+     *
      * @return MockObject
      */
-    protected function getPaymentMock()
+    protected function getPaymentMock(): MockObject
     {
         $paymentMock = $this->getMockBuilder(Info::class)
             ->disableOriginalConstructor()
-            ->setMethods([
-                'getAdditionalInformation', 'getParentTransactionId', 'getOrder',
-                'getCcNumber', 'getCcExpMonth', 'getCcExpYear', 'getCcCid'
-            ])
+            ->onlyMethods(['getAdditionalInformation'])
+            ->addMethods(
+                [
+                    'getParentTransactionId',
+                    'getOrder',
+                    'getCcNumber',
+                    'getCcExpMonth',
+                    'getCcExpYear',
+                    'getCcCid'
+                ]
+            )
             ->getMock();
 
         $cardData = [
@@ -527,10 +561,11 @@ class PayflowproTest extends TestCase
     }
 
     /**
-     * Create mock object for order model
+     * Create mock object for order model.
+     *
      * @return MockObject
      */
-    protected function getOrderMock()
+    protected function getOrderMock(): MockObject
     {
         $orderData = [
             'currency' => 'USD',
@@ -539,7 +574,15 @@ class PayflowproTest extends TestCase
         ];
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getBaseCurrencyCode', 'getIncrementId', 'getId', 'getBillingAddress', 'getShippingAddress'])
+            ->onlyMethods(
+                [
+                    'getBaseCurrencyCode',
+                    'getIncrementId',
+                    'getId',
+                    'getBillingAddress',
+                    'getShippingAddress'
+                ]
+            )
             ->getMock();
 
         $orderMock->expects(static::once())
@@ -554,7 +597,10 @@ class PayflowproTest extends TestCase
         return $orderMock;
     }
 
-    public function testPostRequest()
+    /**
+    * @return void
+    */
+    public function testPostRequest(): void
     {
         $expectedResult = new DataObject();
 
@@ -571,7 +617,10 @@ class PayflowproTest extends TestCase
         static::assertSame($expectedResult, $this->payflowpro->postRequest($request, $config));
     }
 
-    public function testPostRequestException()
+    /**
+    * @return void
+    */
+    public function testPostRequestException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage(
@@ -591,9 +640,10 @@ class PayflowproTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\Paypal\Model\Payflowpro::addRequestOrderInfo
      */
-    public function testAddRequestOrderInfo()
+    public function testAddRequestOrderInfo(): void
     {
         $orderData = [
             'id' => 1,
@@ -610,7 +660,7 @@ class PayflowproTest extends TestCase
 
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getIncrementId', 'getId'])
+            ->onlyMethods(['getIncrementId', 'getId'])
             ->getMock();
         $orderMock->expects(static::once())
             ->method('getId')
@@ -625,9 +675,10 @@ class PayflowproTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\Paypal\Model\Payflowpro::assignData
      */
-    public function testAssignData()
+    public function testAssignData(): void
     {
         $data = [
             'cc_type' => 'VI',
@@ -651,9 +702,11 @@ class PayflowproTest extends TestCase
      *
      * @param array $postData
      * @param DataObject $expectedResponse
+     *
+     * @return void
      * @dataProvider dataProviderMapGatewayResponse
      */
-    public function testMapGatewayResponse($postData, $expectedResponse)
+    public function testMapGatewayResponse($postData, $expectedResponse): void
     {
         self::assertEquals(
             $this->payflowpro->mapGatewayResponse($postData, new DataObject()),
@@ -664,7 +717,7 @@ class PayflowproTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderMapGatewayResponse()
+    public function dataProviderMapGatewayResponse(): array
     {
         return [
             [
@@ -694,7 +747,7 @@ class PayflowproTest extends TestCase
                     'CARDTYPE' => '0',
                     'AVSDATA' => 'NNN',
                     'AVSZIP' => 'N',
-                    'AVSADDR' => 'N',
+                    'AVSADDR' => 'N'
                 ],
                 new DataObject([
                     'billtoname' => 'John Doe',
@@ -733,8 +786,8 @@ class PayflowproTest extends TestCase
                     'email' => 'user@magento.com',
                     'cscmatch' => 'Y',
                     'ccavsstatus' => 'NNN',
-                    'cc_type' => 'VI',
-                ]),
+                    'cc_type' => 'VI'
+                ])
             ]
         ];
     }

--- a/app/code/Magento/Reports/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Helper/DataTest.php
@@ -36,7 +36,7 @@ class DataTest extends TestCase
     protected $itemFactoryMock;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -44,7 +44,7 @@ class DataTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->itemFactoryMock = $this->getMockBuilder(ItemFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -59,10 +59,11 @@ class DataTest extends TestCase
      * @param string $to
      * @param string $period
      * @param array $results
-     * @dataProvider intervalsDataProvider
+     *
      * @return void
+     * @dataProvider intervalsDataProvider
      */
-    public function testGetIntervals($from, $to, $period, $results)
+    public function testGetIntervals($from, $to, $period, $results): void
     {
         $this->assertEquals($this->data->getIntervals($from, $to, $period), $results);
     }
@@ -72,19 +73,21 @@ class DataTest extends TestCase
      * @param string $to
      * @param string $period
      * @param array $results
-     * @dataProvider intervalsDataProvider
+     *
      * @return void
+     * @dataProvider intervalsDataProvider
      */
-    public function testPrepareIntervalsCollection($from, $to, $period, $results)
+    public function testPrepareIntervalsCollection($from, $to, $period, $results): void
     {
         $collection = $this->getMockBuilder(Collection::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addItem'])
+            ->onlyMethods(['addItem'])
             ->getMock();
 
         $item = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setPeriod', 'setIsEmpty'])
+            ->onlyMethods(['setIsEmpty'])
+            ->addMethods(['setPeriod'])
             ->getMock();
 
         $this->itemFactoryMock->expects($this->exactly(count($results)))
@@ -95,11 +98,14 @@ class DataTest extends TestCase
         $collection->expects($this->exactly(count($results)))
             ->method('addItem');
 
+        $withArgs = [];
+
         foreach ($results as $key => $result) {
-            $item->expects($this->at($key + $key))
-                ->method('setPeriod')
-                ->with($result);
+            $withArgs[] = [$result];
         }
+        $item
+            ->method('setPeriod')
+            ->withConsecutive(...$withArgs);
 
         $this->data->prepareIntervalsCollection($collection, $from, $to, $period);
     }
@@ -107,20 +113,20 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function intervalsDataProvider()
+    public function intervalsDataProvider(): array
     {
         return [
             [
                 'from' => '2000-01-15 10:00:00',
                 'to' => '2000-01-15 11:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_DAY,
-                'results' => ['2000-01-15'],
+                'results' => ['2000-01-15']
             ],
             [
                 'from' => '2000-01-15 10:00:00',
                 'to' => '2000-01-17 10:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_MONTH,
-                'results' => ['2000-01'],
+                'results' => ['2000-01']
             ],
             [
                 'from' => '2000-01-15 10:00:00',
@@ -132,31 +138,31 @@ class DataTest extends TestCase
                 'from' => '2000-01-15 10:00:00',
                 'to' => '2000-01-16 11:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_DAY,
-                'results' => ['2000-01-15', '2000-01-16'],
+                'results' => ['2000-01-15', '2000-01-16']
             ],
             [
                 'from' => '2000-01-15 10:00:00',
                 'to' => '2000-02-17 10:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_MONTH,
-                'results' => ['2000-01', '2000-02'],
+                'results' => ['2000-01', '2000-02']
             ],
             [
                 'from' => '2000-01-15 10:00:00',
                 'to' => '2003-02-15 10:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_YEAR,
-                'results' => ['2000', '2001', '2002', '2003'],
+                'results' => ['2000', '2001', '2002', '2003']
             ],
             [
                 'from' => '2000-12-31 10:00:00',
                 'to' => '2001-01-01 10:00:00',
                 'period' => Data::REPORT_PERIOD_TYPE_YEAR,
-                'results' => ['2000', '2001'],
+                'results' => ['2000', '2001']
             ],
             [
                 'from' => '',
                 'to' => '',
                 'period' => Data::REPORT_PERIOD_TYPE_YEAR,
-                'results' => [],
+                'results' => []
             ]
         ];
     }

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Product/Sold/Collection/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Product/Sold/Collection/CollectionTest.php
@@ -44,11 +44,7 @@ class CollectionTest extends TestCase
         $this->selectMock = $this->createMock(Select::class);
         $this->adapterMock = $this->getMockForAbstractClass(AdapterInterface::class);
         $this->collection = $this->getMockBuilder(Collection::class)
-            ->setMethods([
-                'getSelect',
-                'getConnection',
-                'getTable'
-            ])
+            ->onlyMethods(['getSelect', 'getConnection', 'getTable'])
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -69,15 +65,15 @@ class CollectionTest extends TestCase
         $this->selectMock->expects($this->exactly(2))
             ->method('columns')
             ->willReturnSelf();
-        $this->selectMock->expects($this->at(6))
+        $this->selectMock
             ->method('columns')
-            ->with('COUNT(DISTINCT main_table.entity_id)');
-        $this->selectMock->expects($this->at(7))
+            ->withConsecutive(
+                ['COUNT(DISTINCT main_table.entity_id)'],
+                ['COUNT(DISTINCT order_items.item_id)']
+            );
+        $this->selectMock
             ->method('reset')
-            ->with(Select::COLUMNS);
-        $this->selectMock->expects($this->at(8))
-            ->method('columns')
-            ->with('COUNT(DISTINCT order_items.item_id)');
+            ->withConsecutive([], [], [], [Select::COLUMNS]);
 
         $this->assertEquals($this->selectMock, $this->collection->getSelectCountSql());
     }

--- a/app/code/Magento/Review/Test/Unit/Block/Adminhtml/Rating/Edit/Tab/FormTest.php
+++ b/app/code/Magento/Review/Test/Unit/Block/Adminhtml/Rating/Edit/Tab/FormTest.php
@@ -109,6 +109,9 @@ class FormTest extends TestCase
      */
     protected $block;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->ratingOptionCollection = $this->createMock(
@@ -177,40 +180,61 @@ class FormTest extends TestCase
                 'systemStore' => $this->systemStore,
                 'session' => $this->session,
                 'viewFileSystem' => $this->viewFileSystem,
-                'filesystem' => $this->fileSystem,
+                'filesystem' => $this->fileSystem
             ]
         );
     }
 
-    public function testToHtmlSessionRatingData()
+    /**
+    * @return void
+    */
+    public function testToHtmlSessionRatingData(): void
     {
         $this->registry->expects($this->any())->method('registry')->willReturn($this->rating);
-        $this->form->expects($this->at(5))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(11))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(14))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(15))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->any())->method('getElement')->willReturn(false);
+        $this->form
+            ->method('getElement')
+            ->willReturnOnConsecutiveCalls(
+                null,
+                $this->element,
+                null,
+                $this->element,
+                $this->element,
+                $this->element,
+                false
+            );
         $ratingCodes = ['rating_codes' => ['0' => 'rating_code']];
         $this->session->expects($this->any())->method('getRatingData')->willReturn($ratingCodes);
         $this->session->expects($this->any())->method('setRatingData')->willReturnSelf();
         $this->block->toHtml();
     }
 
-    public function testToHtmlCoreRegistryRatingData()
+    /**
+    * @return void
+    */
+    public function testToHtmlCoreRegistryRatingData(): void
     {
         $this->registry->expects($this->any())->method('registry')->willReturn($this->rating);
-        $this->form->expects($this->at(5))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(11))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(14))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->at(15))->method('getElement')->willReturn($this->element);
-        $this->form->expects($this->any())->method('getElement')->willReturn(false);
+        $this->form
+            ->method('getElement')
+            ->willReturnOnConsecutiveCalls(
+                null,
+                $this->element,
+                null,
+                $this->element,
+                $this->element,
+                $this->element,
+                false
+            );
         $this->session->expects($this->any())->method('getRatingData')->willReturn(false);
         $ratingCodes = ['rating_codes' => ['0' => 'rating_code']];
         $this->rating->expects($this->any())->method('getRatingCodes')->willReturn($ratingCodes);
         $this->block->toHtml();
     }
 
-    public function testToHtmlWithoutRatingData()
+    /**
+    * @return void
+    */
+    public function testToHtmlWithoutRatingData(): void
     {
         $this->registry->expects($this->any())->method('registry')->willReturn(false);
         $this->systemStore->expects($this->atLeastOnce())->method('getStoreCollection')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ReorderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Create/ReorderTest.php
@@ -138,13 +138,13 @@ class ReorderTest extends TestCase
         $this->reorderHelperMock = $this->createMock(ReorderHelper::class);
         $this->unavailableProductsProviderMock = $this->createMock(UnavailableProductsProvider::class);
         $this->orderCreateMock = $this->createMock(Create::class);
-        $this->orderMock = $this->getMockBuilder(Order::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getEntityId', 'getId', 'setReordered'])
+        $this->orderMock = $this->getMockBuilder(Order::class)->disableOriginalConstructor()
+            ->onlyMethods(['getEntityId', 'getId'])
+            ->addMethods(['setReordered'])
             ->getMock();
-        $this->quoteSessionMock = $this->getMockBuilder(Quote::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['clearStorage', 'setUseOldShippingMethod'])
+        $this->quoteSessionMock = $this->getMockBuilder(Quote::class)->disableOriginalConstructor()
+            ->onlyMethods(['clearStorage'])
+            ->addMethods(['setUseOldShippingMethod'])
             ->getMock();
         $this->messageManagerMock = $this->getMockBuilder(ManagerInterface::class)
             ->getMockForAbstractClass();
@@ -190,7 +190,7 @@ class ReorderTest extends TestCase
     }
 
     /**
-     * Verify execute redirect order grid
+     * Verify execute redirect order grid.
      *
      * @return void
      */
@@ -232,13 +232,25 @@ class ReorderTest extends TestCase
      */
     public function testExecuteRedirectNewOrder(): void
     {
-        $this->clearStorage();
+        $this->quoteSessionMock->expects($this->once())->method('clearStorage')->willReturnSelf();
         $this->getOrder();
         $this->canReorder(true);
         $this->createRedirect();
         $this->getOrderId($this->orderId);
         $this->getUnavailableProducts([]);
-        $this->initFromOrder();
+        $this->orderMock->expects($this->once())->method('setReordered')->with(true)->willReturnSelf();
+        $this->quoteSessionMock->expects($this->once())
+            ->method('setUseOldShippingMethod')
+            ->with(true)
+            ->willReturnSelf();
+        $this->objectManagerMock
+            ->method('get')
+            ->withConsecutive([Quote::class], [Quote::class], [Create::class])
+            ->willReturnOnConsecutiveCalls($this->quoteSessionMock, $this->quoteSessionMock, $this->orderCreateMock);
+        $this->orderCreateMock->expects($this->once())
+            ->method('initFromOrder')
+            ->with($this->orderMock)
+            ->willReturnSelf();
         $this->setPath('sales/*');
 
         $this->assertInstanceOf(Redirect::class, $this->reorder->execute());
@@ -352,10 +364,10 @@ class ReorderTest extends TestCase
      */
     private function clearStorage(): void
     {
-        $this->objectManagerMock->expects($this->at(0))
+        $this->objectManagerMock
             ->method('get')
-            ->with(Quote::class)
-            ->willReturn($this->quoteSessionMock);
+            ->withConsecutive([Quote::class])
+            ->willReturnOnConsecutiveCalls($this->quoteSessionMock);
         $this->quoteSessionMock->expects($this->once())->method('clearStorage')->willReturnSelf();
     }
 
@@ -419,6 +431,7 @@ class ReorderTest extends TestCase
      * Mock order 'getId' method.
      *
      * @param null|int $orderId
+     *
      * @return void
      */
     private function getOrderId($orderId): void
@@ -431,6 +444,7 @@ class ReorderTest extends TestCase
      *
      * @param string $path
      * @param null|array $params
+     *
      * @return void
      */
     private function setPath(string $path, $params = []): void
@@ -442,6 +456,7 @@ class ReorderTest extends TestCase
      * Mock unavailable products provider.
      *
      * @param array $unavailableProducts
+     *
      * @return void
      */
     private function getUnavailableProducts(array $unavailableProducts): void
@@ -450,30 +465,5 @@ class ReorderTest extends TestCase
             ->method('getForOrder')
             ->with($this->orderMock)
             ->willReturn($unavailableProducts);
-    }
-
-    /**
-     * Mock init form order.
-     *
-     * @return void
-     */
-    private function initFromOrder(): void
-    {
-        $this->orderMock->expects($this->once())->method('setReordered')->with(true)->willReturnSelf();
-        $this->objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(Quote::class)
-            ->willReturn($this->quoteSessionMock);
-        $this->quoteSessionMock->expects($this->once())
-            ->method('setUseOldShippingMethod')
-            ->with(true)->willReturnSelf();
-        $this->objectManagerMock->expects($this->at(2))
-            ->method('get')
-            ->with(Create::class)
-            ->willReturn($this->orderCreateMock);
-        $this->orderCreateMock->expects($this->once())
-            ->method('initFromOrder')
-            ->with($this->orderMock)
-            ->willReturnSelf();
     }
 }

--- a/app/code/Magento/SalesSequence/Test/Unit/Model/SequenceTest.php
+++ b/app/code/Magento/SalesSequence/Test/Unit/Model/SequenceTest.php
@@ -43,6 +43,9 @@ class SequenceTest extends TestCase
      */
     private $sequence;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->meta = $this->getMockBuilder(Meta::class)
@@ -69,17 +72,23 @@ class SequenceTest extends TestCase
             Sequence::class,
             [
                 'meta' => $this->meta,
-                'resource' => $this->resource,
+                'resource' => $this->resource
             ]
         );
     }
 
-    public function testSequenceInitialNull()
+    /**
+    * @return void
+    */
+    public function testSequenceInitialNull(): void
     {
         $this->assertNull($this->sequence->getCurrentValue());
     }
 
-    public function testSequenceNextValue()
+    /**
+    * @return void
+    */
+    public function testSequenceNextValue(): void
     {
         $step = 777;
         $startValue = 3;
@@ -106,24 +115,32 @@ class SequenceTest extends TestCase
             $this->sequenceParameters()->prefix
         );
         $this->profile->expects($this->exactly(3))->method('getStep')->willReturn($step);
-        $lastInsertId = $this->nextIncrementStep($lastInsertId, 780);
-        $lastInsertId = $this->nextIncrementStep($lastInsertId, 1557);
-        $this->nextIncrementStep($lastInsertId, 2334);
+        $withArgs = $willReturnArgs = [];
+
+        $withArgs[] = [$this->sequenceParameters()->testTable];
+        $willReturnArgs[] = ++$lastInsertId;
+
+        $withArgs[] = [$this->sequenceParameters()->testTable];
+        $willReturnArgs[] = ++$lastInsertId;
+
+        $withArgs[] = [$this->sequenceParameters()->testTable];
+        $willReturnArgs[] = ++$lastInsertId;
+
+        $this->connectionMock
+            ->method('lastInsertId')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
+        $this->nextIncrementStep(780);
+        $this->nextIncrementStep(1557);
+        $this->nextIncrementStep(2334);
     }
 
     /**
-     * @param $lastInsertId
      * @param $sequenceNumber
-     * @return mixed
      */
-    private function nextIncrementStep($lastInsertId, $sequenceNumber)
+    private function nextIncrementStep($sequenceNumber)
     {
-        $lastInsertId++;
-        $this->connectionMock->expects($this->at(1))->method('lastInsertId')->with(
-            $this->sequenceParameters()->testTable
-        )->willReturn(
-            $lastInsertId
-        );
         $this->assertEquals(
             sprintf(
                 Sequence::DEFAULT_PATTERN,
@@ -133,13 +150,12 @@ class SequenceTest extends TestCase
             ),
             $this->sequence->getNextValue()
         );
-        return $lastInsertId;
     }
 
     /**
      * @return \stdClass
      */
-    private function sequenceParameters()
+    private function sequenceParameters(): \stdClass
     {
         $data = new \stdClass();
         $data->prefix = 'AA-';

--- a/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
+++ b/app/code/Magento/Search/Test/Unit/Controller/Adminhtml/Term/MassDeleteTest.php
@@ -22,25 +22,39 @@ use PHPUnit\Framework\TestCase;
 
 class MassDeleteTest extends TestCase
 {
-    /** @var ManagerInterface|MockObject */
+    /**
+     * @var ManagerInterface|MockObject
+     */
     private $messageManager;
 
-    /** @var  ObjectManagerInterface|MockObject */
+    /**
+     * @var ObjectManagerInterface|MockObject
+     */
     private $objectManager;
 
-    /** @var MassDelete */
+    /**
+     * @var MassDelete
+     */
     private $controller;
 
-    /** @var ObjectManagerHelper */
+    /**
+     * @var ObjectManagerHelper
+     */
     private $objectManagerHelper;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     private $context;
 
-    /** @var PageFactory|MockObject */
+    /**
+     * @var PageFactory|MockObject
+     */
     private $pageFactory;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     private $request;
 
     /**
@@ -53,22 +67,25 @@ class MassDeleteTest extends TestCase
      */
     private $resultRedirectMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
+            ->addMethods([])
             ->getMockForAbstractClass();
         $this->objectManager = $this->getMockBuilder(ObjectManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMockForAbstractClass();
         $this->messageManager = $this->getMockBuilder(ManagerInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['addSuccessMessage', 'addErrorMessage'])
+            ->onlyMethods(['addSuccessMessage', 'addErrorMessage'])
             ->getMockForAbstractClass();
         $this->pageFactory = $this->getMockBuilder(PageFactory::class)
-            ->setMethods([])
+            ->addMethods([])
             ->disableOriginalConstructor()
             ->getMock();
         $this->resultRedirectMock = $this->getMockBuilder(Redirect::class)
@@ -102,12 +119,15 @@ class MassDeleteTest extends TestCase
             MassDelete::class,
             [
                 'context' => $this->context,
-                'resultPageFactory' => $this->pageFactory,
+                'resultPageFactory' => $this->pageFactory
             ]
         );
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $ids = [1, 2];
         $this->request->expects($this->once())
@@ -115,8 +135,19 @@ class MassDeleteTest extends TestCase
             ->with('search')
             ->willReturn($ids);
 
-        $this->createQuery(0, 1);
-        $this->createQuery(1, 2);
+        $willReturnArgs = [];
+
+        $query = $this->createQuery(1);
+        $willReturnArgs[] = $query;
+
+        $query = $this->createQuery(2);
+        $willReturnArgs[] = $query;
+
+        $this->objectManager
+            ->method('create')
+            ->withConsecutive([Query::class], [Query::class])
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
         $this->messageManager->expects($this->once())
             ->method('addSuccessMessage')->willReturnSelf();
         $this->resultRedirectMock->expects($this->once())
@@ -128,25 +159,24 @@ class MassDeleteTest extends TestCase
     }
 
     /**
-     * @param $index
      * @param $id
+     *
      * @return Query|MockObject
      */
-    private function createQuery($index, $id)
+    private function createQuery($id): MockObject
     {
         $query = $this->getMockBuilder(Query::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'delete'])
+            ->onlyMethods(['load', 'delete'])
             ->getMock();
-        $query->expects($this->at(0))
-            ->method('delete')->willReturnSelf();
-        $query->expects($this->at(0))
-            ->method('load')
-            ->with($id)->willReturnSelf();
-        $this->objectManager->expects($this->at($index))
-            ->method('create')
-            ->with(Query::class)
+        $query
+            ->method('delete')
             ->willReturn($query);
+        $query
+            ->method('load')
+            ->with($id)
+            ->willReturn($query);
+
         return $query;
     }
 }

--- a/app/code/Magento/Shipping/Test/Unit/Model/Shipping/LabelGeneratorTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/Shipping/LabelGeneratorTest.php
@@ -68,6 +68,9 @@ class LabelGeneratorTest extends TestCase
      */
     private $labelGenerator;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->carrierFactory = $this->getMockBuilder(CarrierFactory::class)
@@ -75,12 +78,12 @@ class LabelGeneratorTest extends TestCase
             ->getMock();
         $this->labelsFactory = $this->getMockBuilder(LabelsFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->scopeConfig = $this->getMockForAbstractClass(ScopeConfigInterface::class);
         $this->trackFactory = $this->getMockBuilder(TrackFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->filesystem = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
@@ -96,11 +99,13 @@ class LabelGeneratorTest extends TestCase
     }
 
     /**
-     * @covers \Magento\Shipping\Model\Shipping\LabelGenerator
      * @param array $info
+     *
+     * @return void
+     * @covers \Magento\Shipping\Model\Shipping\LabelGenerator
      * @dataProvider labelInfoDataProvider
      */
-    public function testAddTrackingNumbersToShipment(array $info)
+    public function testAddTrackingNumbersToShipment(array $info): void
     {
         $order = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
@@ -152,26 +157,33 @@ class LabelGeneratorTest extends TestCase
             ->willReturn($labelsMock);
 
         $trackMock = $this->getMockBuilder(Track::class)
-            ->setMethods(['setNumber', 'setCarrierCode', 'setTitle'])
+            ->onlyMethods(['setNumber', 'setCarrierCode', 'setTitle'])
             ->disableOriginalConstructor()
             ->getMock();
-
-        $i = 0;
         $trackingNumbers = is_array($info['tracking_number']) ? $info['tracking_number'] : [$info['tracking_number']];
+
+        $setNumberWithArgs = $setCarrierCodeWithArgs = $setTitleWithArgs = $willReturnArgs = [];
+
         foreach ($trackingNumbers as $trackingNumber) {
-            $trackMock->expects(static::at($i++))
-                ->method('setNumber')
-                ->with($trackingNumber)
-                ->willReturnSelf();
-            $trackMock->expects(static::at($i++))
-                ->method('setCarrierCode')
-                ->with(self::CARRIER_CODE)
-                ->willReturnSelf();
-            $trackMock->expects(static::at($i++))
-                ->method('setTitle')
-                ->with(self::CARRIER_TITLE)
-                ->willReturnSelf();
+            $setNumberWithArgs[] = [$trackingNumber];
+            $willReturnArgs[] = $trackMock;
+
+            $setCarrierCodeWithArgs[] = [self::CARRIER_CODE];
+
+            $setTitleWithArgs[] = [self::CARRIER_TITLE];
         }
+        $trackMock
+            ->method('setNumber')
+            ->withConsecutive(...$setNumberWithArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+        $trackMock
+            ->method('setCarrierCode')
+            ->withConsecutive(...$setCarrierCodeWithArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+        $trackMock
+            ->method('setTitle')
+            ->withConsecutive(...$setTitleWithArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->trackFactory->expects(static::any())
             ->method('create')
@@ -187,11 +199,11 @@ class LabelGeneratorTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getShippingMethodMock()
+    private function getShippingMethodMock(): MockObject
     {
         $shippingMethod = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCarrierCode'])
+            ->addMethods(['getCarrierCode'])
             ->getMock();
         $shippingMethod->expects(static::once())
             ->method('getCarrierCode')
@@ -203,11 +215,11 @@ class LabelGeneratorTest extends TestCase
     /**
      * @return MockObject
      */
-    private function getCarrierMock()
+    private function getCarrierMock(): MockObject
     {
         $carrierMock = $this->getMockBuilder(AbstractCarrier::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isShippingLabelsAvailable', 'getCarrierCode'])
+            ->onlyMethods(['isShippingLabelsAvailable', 'getCarrierCode'])
             ->getMockForAbstractClass();
         $carrierMock->expects(static::once())
             ->method('isShippingLabelsAvailable')
@@ -221,12 +233,13 @@ class LabelGeneratorTest extends TestCase
 
     /**
      * @param array $info
+     *
      * @return MockObject
      */
-    private function getResponseMock(array $info)
+    private function getResponseMock(array $info): MockObject
     {
         $responseMock = $this->getMockBuilder(DataObject::class)
-            ->setMethods(['hasErrors', 'hasInfo', 'getInfo'])
+            ->addMethods(['hasErrors', 'hasInfo', 'getInfo'])
             ->disableOriginalConstructor()
             ->getMock();
         $responseMock->expects(static::once())
@@ -245,11 +258,11 @@ class LabelGeneratorTest extends TestCase
     /**
      * @return array
      */
-    public function labelInfoDataProvider()
+    public function labelInfoDataProvider(): array
     {
         return [
             [['tracking_number' => ['111111', '222222', '333333'], 'label_content' => 'some']],
-            [['tracking_number' => '111111', 'label_content' => 'some']],
+            [['tracking_number' => '111111', 'label_content' => 'some']]
         ];
     }
 }

--- a/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
@@ -35,55 +35,85 @@ use PHPUnit\Framework\TestCase;
  */
 class DataTest extends TestCase
 {
-    /** @var MockObject|Image */
+    /**
+     * @var MockObject|Image
+     */
     protected $imageHelperMock;
 
-    /** @var MockObject|CollectionFactory */
+    /**
+     * @var MockObject|CollectionFactory
+     */
     protected $productCollectionFactoryMock;
 
-    /** @var MockObject|\Magento\Catalog\Model\ResourceModel\Product\Collection */
+    /**
+     * @var MockObject|\Magento\Catalog\Model\ResourceModel\Product\Collection
+     */
     protected $productCollectionMock;
 
-    /** @var MockObject|Configurable */
+    /**
+     * @var MockObject|Configurable
+     */
     protected $configurableMock;
 
-    /** @var MockObject|ProductFactory */
+    /**
+     * @var MockObject|ProductFactory
+     */
     protected $productModelFactoryMock;
 
-    /** @var MockObject|Product */
+    /**
+     * @var MockObject|Product
+     */
     protected $productMock;
 
-    /** @var MockObject|StoreManager */
+    /**
+     * @var MockObject|StoreManager
+     */
     protected $storeManagerMock;
 
-    /** @var MockObject|\Magento\Swatches\Model\ResourceModel\Swatch\CollectionFactory */
+    /**
+     * @var MockObject|\Magento\Swatches\Model\ResourceModel\Swatch\CollectionFactory
+     */
     protected $swatchCollectionFactoryMock;
 
-    /** @var MockObject|Attribute */
+    /**
+     * @var MockObject|Attribute
+     */
     protected $attributeMock;
 
-    /** @var ObjectManager */
+    /**
+     * @var ObjectManager
+     */
     protected $objectManager;
 
-    /** @var ObjectManager|Data */
+    /**
+     * @var ObjectManager|Data
+     */
     protected $swatchHelperObject;
 
-    /** @var MockObject|ProductRepositoryInterface */
+    /**
+     * @var MockObject|ProductRepositoryInterface
+     */
     protected $productRepoMock;
 
-    /** @var   MockObject|MetadataPool */
+    /**
+     * @var MockObject|MetadataPool
+     */
     private $metaDataPoolMock;
 
     /**
+     *
      * @var SwatchAttributesProvider|MockObject
      */
     private $swatchAttributesProvider;
 
     /**
-     * @var  MockObject|UrlBuilder
+     * @var MockObject|UrlBuilder
      */
     private $imageUrlBuilderMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -97,7 +127,7 @@ class DataTest extends TestCase
             \Magento\Catalog\Model\ResourceModel\Product\Collection::class,
             [
                 $this->productMock,
-                $this->productMock,
+                $this->productMock
             ]
         );
 
@@ -119,7 +149,8 @@ class DataTest extends TestCase
 
         $this->attributeMock = $this->getMockBuilder(Attribute::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setStoreId', 'getData', 'setData', 'getSource', 'hasData'])
+            ->onlyMethods(['getData', 'setData', 'getSource', 'hasData'])
+            ->addMethods(['setStoreId'])
             ->getMock();
         $this->metaDataPoolMock = $this->getMockBuilder(MetadataPool::class)
             ->disableOriginalConstructor()
@@ -143,7 +174,7 @@ class DataTest extends TestCase
             ->getMock();
         $this->imageUrlBuilderMock = $this->getMockBuilder(UrlBuilder::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getUrl'])
+            ->onlyMethods(['getUrl'])
             ->getMock();
 
         $this->swatchHelperObject = $this->objectManager->getObject(
@@ -156,7 +187,7 @@ class DataTest extends TestCase
                 'swatchCollectionFactory' => $this->swatchCollectionFactoryMock,
                 'imageUrlBuilder' => $this->imageUrlBuilderMock,
                 'serializer' => $serializer,
-                'swatchAttributesProvider' => $this->swatchAttributesProvider,
+                'swatchAttributesProvider' => $this->swatchAttributesProvider
             ]
         );
         $this->objectManager->setBackwardCompatibleProperty(
@@ -169,7 +200,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForAdditionalData()
+    public function dataForAdditionalData(): array
     {
         $additionalData = [
             'swatch_input_type' => 'visual',
@@ -181,49 +212,46 @@ class DataTest extends TestCase
                 json_encode($additionalData),
                 [
                     'getData' => 1,
-                    'setData' => 3,
+                    'setData' => 3
                 ]
             ],
             [
                 null,
                 [
                     'getData' => 1,
-                    'setData' => 0,
+                    'setData' => 0
                 ]
-            ],
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider dataForAssembleEavAttribute
      */
-    public function testAssembleAdditionalDataEavAttribute($dataFromDb, $attributeData)
+    public function testAssembleAdditionalDataEavAttribute($dataFromDb, $attributeData): void
     {
-        $this->attributeMock
-            ->expects($this->at(0))
-            ->method('getData')
-            ->with('additional_data')
-            ->willReturn($dataFromDb);
+        $withArgs = $willReturnArgs = [];
+        $withArgs[] = ['additional_data'];
+        $willReturnArgs[] = $dataFromDb;
 
-        $i = 1;
         foreach ($attributeData as $key => $value) {
-            $this->attributeMock
-                ->expects($this->at($i))
-                ->method('getData')
-                ->with($key)
-                ->willReturn($value);
-            $i++;
+            $withArgs[] = [$key];
+            $willReturnArgs[] = $value;
         }
+        $this->attributeMock
+            ->method('getData')
+            ->withConsecutive(...$withArgs)
+            ->willReturn(...$willReturnArgs);
 
         $this->attributeMock->expects($this->once())->method('setData');
-
         $this->swatchHelperObject->assembleAdditionalDataEavAttribute($this->attributeMock);
     }
 
     /**
      * @return array
      */
-    public function dataForAssembleEavAttribute()
+    public function dataForAssembleEavAttribute(): array
     {
         $additionalData = [
             'swatch_input_type' => 'visual',
@@ -236,24 +264,25 @@ class DataTest extends TestCase
                 [
                     'swatch_input_type' => 'visual',
                     'update_product_preview_image' => 1,
-                    'use_product_image_for_swatch' => 1,
-                ],
+                    'use_product_image_for_swatch' => 1
+                ]
             ],
             [
                 null,
                 [
                     'swatch_input_type' => null,
                     'update_product_preview_image' => 0,
-                    'use_product_image_for_swatch' => 0,
-                ],
-            ],
+                    'use_product_image_for_swatch' => 0
+                ]
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider dataForVariationWithSwatchImage
      */
-    public function testLoadFirstVariationWithSwatchImage($imageTypes, $expected, $requiredAttributes)
+    public function testLoadFirstVariationWithSwatchImage($imageTypes, $expected, $requiredAttributes): void
     {
         $this->getSwatchAttributes();
         $this->getUsedProducts($imageTypes + $requiredAttributes, $imageTypes);
@@ -270,7 +299,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForVariationWithSwatchImage()
+    public function dataForVariationWithSwatchImage(): array
     {
         return [
             [
@@ -278,24 +307,27 @@ class DataTest extends TestCase
                     'image' => '/m/a/magento.png',
                     'small_image' => '/m/a/magento.png',
                     'thumbnail' => '/m/a/magento.png',
-                    'swatch_image' => '/m/a/magento.png', //important
+                    'swatch_image' => '/m/a/magento.png' //important
                 ],
                 Product::class,
-                ['color' => 31],
+                ['color' => 31]
             ],
             [
                 [
                     'image' => '/m/a/magento.png',
                     'small_image' => '/m/a/magento.png',
-                    'thumbnail' => '/m/a/magento.png',
+                    'thumbnail' => '/m/a/magento.png'
                 ],
                 false,
-                ['size' => 31],
-            ],
+                ['size' => 31]
+            ]
         ];
     }
 
-    public function testLoadVariationByFallback()
+    /**
+    * @return void
+    */
+    public function testLoadVariationByFallback(): void
     {
         $metadataMock = $this->getMockForAbstractClass(EntityMetadataInterface::class);
         $this->metaDataPoolMock->expects($this->once())->method('getMetadata')->willReturn($metadataMock);
@@ -314,9 +346,10 @@ class DataTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider dataForVariationWithImage
      */
-    public function testLoadFirstVariationWithImage($imageTypes, $expected, $requiredAttributes)
+    public function testLoadFirstVariationWithImage($imageTypes, $expected, $requiredAttributes): void
     {
         $this->getSwatchAttributes();
         $this->getUsedProducts($imageTypes + $requiredAttributes, $imageTypes);
@@ -333,7 +366,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForVariationWithImage()
+    public function dataForVariationWithImage(): array
     {
         return [
             [
@@ -341,39 +374,46 @@ class DataTest extends TestCase
                     'image' => '/m/a/magento.png', //important
                     'small_image' => '/m/a/magento.png',
                     'thumbnail' => '/m/a/magento.png',
-                    'swatch_image' => '/m/a/magento.png',
+                    'swatch_image' => '/m/a/magento.png'
                 ],
                 Product::class,
-                ['color' => 31],
+                ['color' => 31]
             ],
             [
                 [
                     'small_image' => '/m/a/magento.png',
                     'thumbnail' => '/m/a/magento.png',
-                    'swatch_image' => '/m/a/magento.png',
+                    'swatch_image' => '/m/a/magento.png'
                 ],
                 false,
-                ['size' => 31],
-            ],
+                ['size' => 31]
+            ]
         ];
     }
 
-    public function testLoadFirstVariationWithImageNoProduct()
+    /**
+    * @return void
+    */
+    public function testLoadFirstVariationWithImageNoProduct(): void
     {
         $result = $this->swatchHelperObject->loadVariationByFallback($this->productMock, ['color' => 31]);
         $this->assertFalse($result);
     }
 
-    public function testLoadVariationByFallbackWithoutProduct()
+    /**
+    * @return void
+    */
+    public function testLoadVariationByFallbackWithoutProduct(): void
     {
         $result = $this->swatchHelperObject->loadFirstVariationWithImage($this->productMock, ['color' => 31]);
         $this->assertFalse($result);
     }
 
     /**
+     * @return void
      * @dataProvider dataForMediaGallery
      */
-    public function testGetProductMediaGallery($mediaGallery, $image)
+    public function testGetProductMediaGallery($mediaGallery, $image): void
     {
         $mediaGalleryEntries = [];
         $id = 0;
@@ -424,7 +464,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForMediaGallery()
+    public function dataForMediaGallery(): array
     {
         return [
             [
@@ -432,26 +472,29 @@ class DataTest extends TestCase
                     'image' => '/m/a/magento1.png',
                     'small_image' => '/m/a/magento2.png',
                     'thumbnail' => '/m/a/magento3.png',
-                    'swatch_image' => '/m/a/magento4.png',
+                    'swatch_image' => '/m/a/magento4.png'
                 ],
-                '/m/a/magento1.png',
+                '/m/a/magento1.png'
             ],
             [
                 [
                     'small_image' => '/m/a/magento4.png',
                     'thumbnail' => '/m/a/magento5.png',
-                    'swatch_image' => '/m/a/magento6.png',
+                    'swatch_image' => '/m/a/magento6.png'
                 ],
-                '/m/a/magento4.png',
+                '/m/a/magento4.png'
             ],
             [
                 [],
                 ''
-            ],
+            ]
         ];
     }
 
-    protected function getSwatchAttributes()
+    /**
+    * @return void
+    */
+    protected function getSwatchAttributes(): void
     {
         $this->getAttributesFromConfigurable();
         $returnFromProvideMethod = [$this->attributeMock];
@@ -464,8 +507,10 @@ class DataTest extends TestCase
     /**
      * @param array $attributes
      * @param array $imageTypes
+     *
+     * @return void
      */
-    protected function getUsedProducts(array $attributes, array $imageTypes)
+    protected function getUsedProducts(array $attributes, array $imageTypes): void
     {
         $this->productMock
             ->expects($this->atLeastOnce())
@@ -476,7 +521,7 @@ class DataTest extends TestCase
         for ($i = 0; $i < 2; $i++) {
             $simpleProduct = $this->getMockBuilder(Product::class)
                 ->disableOriginalConstructor()
-                ->setMethods(['hasData', 'getMediaGalleryEntries'])
+                ->onlyMethods(['hasData', 'getMediaGalleryEntries'])
                 ->getMock();
             $simpleProduct->setData($attributes);
 
@@ -507,7 +552,10 @@ class DataTest extends TestCase
             ->willReturn($simpleProducts);
     }
 
-    protected function getAttributesFromConfigurable()
+    /**
+    * @return void
+    */
+    protected function getAttributesFromConfigurable(): void
     {
         $confAttribute = $this->createMock(
             \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute::class
@@ -526,7 +574,10 @@ class DataTest extends TestCase
             ->willReturn($this->attributeMock);
     }
 
-    protected function prepareVariationCollection()
+    /**
+    * @return void
+    */
+    protected function prepareVariationCollection(): void
     {
         $this->productCollectionFactoryMock
             ->expects($this->any())
@@ -536,7 +587,10 @@ class DataTest extends TestCase
         $this->addfilterByParent();
     }
 
-    protected function addfilterByParent()
+    /**
+    * @return void
+    */
+    protected function addfilterByParent(): void
     {
         $this->productCollectionMock
             ->method('getTable')
@@ -553,7 +607,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForCreateSwatchProduct()
+    public function dataForCreateSwatchProduct(): array
     {
         $productMock = $this->createMock(Product::class);
 
@@ -564,14 +618,14 @@ class DataTest extends TestCase
                     'image' => '',
                     'small_image' => '',
                     'thumbnail' => '',
-                    'swatch_image' => '',
+                    'swatch_image' => ''
                 ]
             ],
             [
                 $productMock,
                 [
                     'small_image' => 'img1.png',
-                    'thumbnail' => 'img1.png',
+                    'thumbnail' => 'img1.png'
                 ]
             ],
             [
@@ -583,16 +637,17 @@ class DataTest extends TestCase
                 [
                     'image' => 'img1.png',
                     'small_image' => 'img1.png',
-                    'thumbnail' => 'img1.png',
+                    'thumbnail' => 'img1.png'
                 ]
-            ],
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider dataForGettingSwatchAsArray
      */
-    public function testGetSwatchAttributesAsArray($optionsArray, $attributeData, $expected)
+    public function testGetSwatchAttributesAsArray($optionsArray, $attributeData, $expected): void
     {
         $this->swatchAttributesProvider
             ->method('provide')
@@ -619,7 +674,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataForGettingSwatchAsArray()
+    public function dataForGettingSwatchAsArray(): array
     {
         return [
             [
@@ -627,7 +682,7 @@ class DataTest extends TestCase
                     ['value' => 45, 'label' => 'green'],
                     ['value' => 46, 'label' => 'yellow'],
                     ['value' => 47, 'label' => 'red'],
-                    ['value' => 48, 'label' => 'blue'],
+                    ['value' => 48, 'label' => 'blue']
                 ],
                 [
                     'attribute_id' => 52
@@ -639,15 +694,15 @@ class DataTest extends TestCase
                             45 => 'green',
                             46 => 'yellow',
                             47 => 'red',
-                            48 => 'blue',
-                        ],
+                            48 => 'blue'
+                        ]
                     ]
-                ],
+                ]
             ],
             [
                 [
                     ['value' => 45, 'label' => 'green'],
-                    ['value' => 46, 'label' => 'yellow'],
+                    ['value' => 46, 'label' => 'yellow']
                 ],
                 [
                     'attribute_id' => 324
@@ -657,15 +712,18 @@ class DataTest extends TestCase
                         'attribute_id' => 324,
                         'options' => [
                             45 => 'green',
-                            46 => 'yellow',
-                        ],
+                            46 => 'yellow'
+                        ]
                     ]
-                ],
-            ],
+                ]
+            ]
         ];
     }
 
-    public function testGetSwatchesByOptionsIdIf1()
+    /**
+    * @return void
+    */
+    public function testGetSwatchesByOptionsIdIf1(): void
     {
         //Simulate behaviour of \Magento\Swatches\Model\Swatch as array item
         $swatchMock = $this->createMock(\ArrayAccess::class);
@@ -676,29 +734,35 @@ class DataTest extends TestCase
                 'store_id' => 1,
                 'value' => '#324234',
                 'option_id' => 35,
-                'id' => 423,
+                'id' => 423
             ],
             [
                 'type' => 0,
                 'store_id' => 0,
                 'value' => 'test2',
                 'option_id' => 35,
-                'id' => 424,
+                'id' => 424
             ]
         ];
 
-        $swatchMock->expects($this->at(0))->method('offsetGet')->with('type')
-            ->willReturn($optionsData[0]['type']);
-        $swatchMock->expects($this->at(1))->method('offsetGet')->with('option_id')
-            ->willReturn($optionsData[0]['option_id']);
-        $swatchMock->expects($this->at(2))->method('offsetGet')->with('type')
-            ->willReturn($optionsData[1]['type']);
-        $swatchMock->expects($this->at(3))->method('offsetGet')->with('store_id')
-            ->willReturn($optionsData[1]['store_id']);
-        $swatchMock->expects($this->at(4))->method('offsetGet')->with('store_id')
-            ->willReturn($optionsData[1]['store_id']);
-        $swatchMock->expects($this->at(5))->method('offsetGet')->with('option_id')
-            ->willReturn($optionsData[1]['option_id']);
+        $swatchMock
+            ->method('offsetGet')
+            ->withConsecutive(
+                ['type'],
+                ['option_id'],
+                ['type'],
+                ['store_id'],
+                ['store_id'],
+                ['option_id']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $optionsData[0]['type'],
+                $optionsData[0]['option_id'],
+                $optionsData[1]['type'],
+                $optionsData[1]['store_id'],
+                $optionsData[1]['store_id'],
+                $optionsData[1]['option_id']
+            );
 
         $swatchCollectionMock = $this->createMock(Collection::class);
         $swatchCollectionMock->method('addFilterByOptionsIds')->with([35])->willReturnSelf();
@@ -712,7 +776,10 @@ class DataTest extends TestCase
         $this->swatchHelperObject->getSwatchesByOptionsId([35]);
     }
 
-    public function testGetSwatchesByOptionsIdIf2()
+    /**
+    * @return void
+    */
+    public function testGetSwatchesByOptionsIdIf2(): void
     {
         //Simulate behaviour of \Magento\Swatches\Model\Swatch as array item
         $swatchMock = $this->createMock(\ArrayAccess::class);
@@ -723,26 +790,38 @@ class DataTest extends TestCase
                 'store_id' => 1,
                 'value' => 'test',
                 'option_id' => 35,
-                'id' => 487,
+                'id' => 487
             ],
             [
                 'type' => 0,
                 'store_id' => 1,
                 'value' => 'test2',
                 'option_id' => 36,
-                'id' => 488,
+                'id' => 488
             ]
         ];
-        // @codingStandardsIgnoreStart
-        $swatchMock->expects($this->at(0))->method('offsetGet')->with('type')->willReturn($optionsData[0]['type']);
-        $swatchMock->expects($this->at(1))->method('offsetGet')->with('store_id')->willReturn($optionsData[0]['store_id']);
-        $swatchMock->expects($this->at(2))->method('offsetGet')->with('value')->willReturn($optionsData[0]['value']);
-        $swatchMock->expects($this->at(3))->method('offsetGet')->with('option_id')->willReturn($optionsData[0]['option_id']);
-        $swatchMock->expects($this->at(4))->method('offsetGet')->with('type')->willReturn($optionsData[1]['type']);
-        $swatchMock->expects($this->at(5))->method('offsetGet')->with('store_id')->willReturn($optionsData[1]['store_id']);
-        $swatchMock->expects($this->at(6))->method('offsetGet')->with('value')->willReturn($optionsData[1]['value']);
-        $swatchMock->expects($this->at(7))->method('offsetGet')->with('option_id')->willReturn($optionsData[1]['option_id']);
-        // @codingStandardsIgnoreEnd
+        $swatchMock
+            ->method('offsetGet')
+            ->withConsecutive(
+                ['type'],
+                ['store_id'],
+                ['value'],
+                ['option_id'],
+                ['type'],
+                ['store_id'],
+                ['value'],
+                ['option_id']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $optionsData[0]['type'],
+                $optionsData[0]['store_id'],
+                $optionsData[0]['value'],
+                $optionsData[0]['option_id'],
+                $optionsData[1]['type'],
+                $optionsData[1]['store_id'],
+                $optionsData[1]['value'],
+                $optionsData[1]['option_id']
+            );
         $swatchCollectionMock = $this->createMock(Collection::class);
         $this->swatchCollectionFactoryMock->method('create')->willReturn($swatchCollectionMock);
 
@@ -756,7 +835,10 @@ class DataTest extends TestCase
         $this->swatchHelperObject->getSwatchesByOptionsId([35]);
     }
 
-    public function testGetSwatchesByOptionsIdIf3()
+    /**
+    * @return void
+    */
+    public function testGetSwatchesByOptionsIdIf3(): void
     {
         //Simulate behaviour of \Magento\Swatches\Model\Swatch as array item
         $swatchMock = $this->createMock(\ArrayAccess::class);
@@ -766,14 +848,22 @@ class DataTest extends TestCase
             'store_id' => 0,
             'value' => 'test_test',
             'option_id' => 35,
-            'id' => 423,
+            'id' => 423
         ];
-        // @codingStandardsIgnoreStart
-        $swatchMock->expects($this->at(0))->method('offsetGet')->with('type')->willReturn($optionsData['type']);
-        $swatchMock->expects($this->at(1))->method('offsetGet')->with('store_id')->willReturn($optionsData['store_id']);
-        $swatchMock->expects($this->at(2))->method('offsetGet')->with('store_id')->willReturn($optionsData['store_id']);
-        $swatchMock->expects($this->at(3))->method('offsetGet')->with('option_id')->willReturn($optionsData['option_id']);
-        // @codingStandardsIgnoreEnd
+        $swatchMock
+            ->method('offsetGet')
+            ->withConsecutive(
+                ['type'],
+                ['store_id'],
+                ['store_id'],
+                ['option_id']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $optionsData['type'],
+                $optionsData['store_id'],
+                $optionsData['store_id'],
+                $optionsData['option_id']
+            );
         $swatchCollectionMock = $this->createMock(Collection::class);
         $this->swatchCollectionFactoryMock->method('create')->willReturn($swatchCollectionMock);
 
@@ -787,7 +877,10 @@ class DataTest extends TestCase
         $this->swatchHelperObject->getSwatchesByOptionsId([35]);
     }
 
-    public function testIsProductHasSwatch()
+    /**
+    * @return void
+    */
+    public function testIsProductHasSwatch(): void
     {
         $this->getSwatchAttributes();
         $result = $this->swatchHelperObject->isProductHasSwatch($this->productMock);

--- a/app/code/Magento/Tax/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Helper/DataTest.php
@@ -32,18 +32,29 @@ class DataTest extends TestCase
      */
     protected $helper;
 
-    /** @var  MockObject */
+    /**
+     * @var MockObject
+     */
     protected $orderTaxManagementMock;
 
-    /** @var  MockObject */
+    /**
+     * @var MockObject
+     */
     protected $priceCurrencyMock;
 
-    /** @var  MockObject */
+    /**
+     * @var MockObject
+     */
     protected $taxConfigMock;
 
-    /** @var  MockObject */
+    /**
+     * @var MockObject
+     */
     protected $serializer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
@@ -86,13 +97,19 @@ class DataTest extends TestCase
         );
     }
 
-    public function testGetCalculatedTaxesEmptySource()
+    /**
+    * @return void
+    */
+    public function testGetCalculatedTaxesEmptySource(): void
     {
         $source = null;
         $this->assertEquals([], $this->helper->getCalculatedTaxes($source));
     }
 
-    public function testGetCalculatedTaxesForOrder()
+    /**
+    * @return void
+    */
+    public function testGetCalculatedTaxesForOrder(): void
     {
         $orderId = 1;
         $itemCode = 'test_code';
@@ -160,23 +177,22 @@ class DataTest extends TestCase
     }
 
     /**
-     * Create OrderTaxDetails mock from array of data
+     * Create OrderTaxDetails mock from array of data.
      *
      * @param $inputArray
+     *
      * @return MockObject|OrderTaxDetailsInterface
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    protected function mapOrderTaxItemDetail($inputArray)
+    protected function mapOrderTaxItemDetail($inputArray): MockObject
     {
         $orderTaxItemDetailsMock = $this->getMockBuilder(OrderTaxDetailsInterface::class)
             ->getMock();
         $itemMocks = [];
         foreach ($inputArray['items'] as $orderTaxDetailsItemData) {
-            $itemId = isset($orderTaxDetailsItemData['item_id']) ? $orderTaxDetailsItemData['item_id'] : null;
-            $associatedItemId = isset($orderTaxDetailsItemData['associated_item_id'])
-                ? $orderTaxDetailsItemData['associated_item_id']
-                : null;
-            $itemType = isset($orderTaxDetailsItemData['type']) ? $orderTaxDetailsItemData['type'] : null;
+            $itemId = $orderTaxDetailsItemData['item_id'] ?? null;
+            $associatedItemId = $orderTaxDetailsItemData['associated_item_id'] ?? null;
+            $itemType = $orderTaxDetailsItemData['type'] ?? null;
             $appliedTaxesData = $orderTaxDetailsItemData['applied_taxes'];
             $appliedTaxesMocks = [];
             foreach ($appliedTaxesData as $appliedTaxData) {
@@ -225,12 +241,13 @@ class DataTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider getCalculatedTaxesForOrderItemsDataProvider
      */
-    public function testGetCalculatedTaxesForOrderItems($orderData, $invoiceData, $expectedResults)
+    public function testGetCalculatedTaxesForOrderItems($orderData, $invoiceData, $expectedResults): void
     {
         $orderId = $orderData['order_id'];
-        $orderShippingTaxAmount = isset($orderData['shipping_tax_amount']) ? $orderData['shipping_tax_amount'] : 0;
+        $orderShippingTaxAmount = $orderData['shipping_tax_amount'] ?? 0;
         $orderTaxDetails = $orderData['order_tax_details'];
 
         /** @var MockObject|Order $orderMock */
@@ -250,8 +267,7 @@ class DataTest extends TestCase
             ->with($orderId)
             ->willReturn($orderTaxDetailsMock);
 
-        $invoiceShippingTaxAmount =
-            isset($invoiceData['shipping_tax_amount']) ? $invoiceData['shipping_tax_amount'] : 0;
+        $invoiceShippingTaxAmount = $invoiceData['shipping_tax_amount'] ?? 0;
         $invoiceItems = $invoiceData['invoice_items'];
         /** @var MockObject|Invoice $source */
         $source = $this->getMockBuilder(Invoice::class)
@@ -288,7 +304,7 @@ class DataTest extends TestCase
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @return array
      */
-    public function getCalculatedTaxesForOrderItemsDataProvider()
+    public function getCalculatedTaxesForOrderItemsDataProvider(): array
     {
         $data = [
             //Scenario 1: two items, one item with 0 tax
@@ -306,12 +322,12 @@ class DataTest extends TestCase
                                         'base_amount' => 5.0,
                                         'code' => 'US-CA',
                                         'title' => 'US-CA-Sales-Tax',
-                                        'percent' => 20.0,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
+                                        'percent' => 20.0
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ],
                 'invoice' => [
                     'invoice_items' => [
@@ -320,10 +336,10 @@ class DataTest extends TestCase
                                 'order_item' => new MagentoObject(
                                     [
                                         'id' => 1,
-                                        'tax_amount' => 5.00,
+                                        'tax_amount' => 5.00
                                     ]
                                 ),
-                                'tax_amount' => 2.50,
+                                'tax_amount' => 2.50
                             ]
                         ),
                         'item2' => new MagentoObject(
@@ -331,22 +347,22 @@ class DataTest extends TestCase
                                 'order_item' => new MagentoObject(
                                     [
                                         'id' => 2,
-                                        'tax_amount' => 0.0,
+                                        'tax_amount' => 0.0
                                     ]
                                 ),
-                                'tax_amount' => 0.0,
+                                'tax_amount' => 0.0
                             ]
-                        ),
-                    ],
+                        )
+                    ]
                 ],
                 'expected_results' => [
                     [
                         'title' => 'US-CA-Sales-Tax',
                         'percent' => 20.0,
                         'tax_amount' => 2.5,
-                        'base_tax_amount' => 2.5,
-                    ],
-                ],
+                        'base_tax_amount' => 2.5
+                    ]
+                ]
             ],
             //Scenario 2: one item with associated weee tax
             'item_with_weee_tax_partial_invoice' => [
@@ -363,9 +379,9 @@ class DataTest extends TestCase
                                         'base_amount' => 5.0,
                                         'code' => 'US-CA',
                                         'title' => 'US-CA-Sales-Tax',
-                                        'percent' => 20.0,
-                                    ],
-                                ],
+                                        'percent' => 20.0
+                                    ]
+                                ]
                             ],
                             'weeeTax1' => [
                                 'associated_item_id' => 1,
@@ -376,12 +392,12 @@ class DataTest extends TestCase
                                         'base_amount' => 3.0,
                                         'code' => 'US-CA',
                                         'title' => 'US-CA-Sales-Tax',
-                                        'percent' => 20.0,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
+                                        'percent' => 20.0
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ],
                 'invoice' => [
                     'invoice_items' => [
@@ -390,24 +406,24 @@ class DataTest extends TestCase
                                 'order_item' => new MagentoObject(
                                     [
                                         'id' => 1,
-                                        'tax_amount' => 5.00,
+                                        'tax_amount' => 5.00
                                     ]
                                 ),
                                 'tax_amount' => 5.0,
                                 //half of weee tax is invoiced
-                                'tax_ratio' => json_encode(['weee' => 0.5]),
+                                'tax_ratio' => json_encode(['weee' => 0.5])
                             ]
-                        ),
-                    ],
+                        )
+                    ]
                 ],
                 'expected_results' => [
                     [
                         'title' => 'US-CA-Sales-Tax',
                         'percent' => 20.0,
                         'tax_amount' => 6.5,
-                        'base_tax_amount' => 6.5,
-                    ],
-                ],
+                        'base_tax_amount' => 6.5
+                    ]
+                ]
             ],
             //Scenario 3: one item, with both shipping and product taxes
             // note that 'shipping tax' is listed before 'product tax'
@@ -426,9 +442,9 @@ class DataTest extends TestCase
                                         'base_amount' => 2.0,
                                         'code' => 'US-CA-Ship',
                                         'title' => 'US-CA-Sales-Tax-Ship',
-                                        'percent' => 10.0,
-                                    ],
-                                ],
+                                        'percent' => 10.0
+                                    ]
+                                ]
                             ],
                             'itemTax1' => [
                                 'item_id' => 1,
@@ -438,12 +454,12 @@ class DataTest extends TestCase
                                         'base_amount' => 5.0,
                                         'code' => 'US-CA',
                                         'title' => 'US-CA-Sales-Tax',
-                                        'percent' => 20.0,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
+                                        'percent' => 20.0
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
                 ],
                 'invoice' => [
                     'shipping_tax_amount' => 2,
@@ -453,13 +469,13 @@ class DataTest extends TestCase
                                 'order_item' => new MagentoObject(
                                     [
                                         'id' => 1,
-                                        'tax_amount' => 5.00,
+                                        'tax_amount' => 5.00
                                     ]
                                 ),
-                                'tax_amount' => 5.00,
+                                'tax_amount' => 5.00
                             ]
-                        ),
-                    ],
+                        )
+                    ]
                 ],
                 // note that 'shipping tax' is now listed after 'product tax'
                 'expected_results' => [
@@ -467,16 +483,16 @@ class DataTest extends TestCase
                         'title' => 'US-CA-Sales-Tax',
                         'percent' => 20.0,
                         'tax_amount' => 5.00,
-                        'base_tax_amount' => 5.00,
+                        'base_tax_amount' => 5.00
                     ],
                     [
                         'title' => 'US-CA-Sales-Tax-Ship',
                         'percent' => 10.0,
                         'tax_amount' => 2.00,
-                        'base_tax_amount' => 2.00,
-                    ],
-                ],
-            ],
+                        'base_tax_amount' => 2.00
+                    ]
+                ]
+            ]
         ];
 
         return $data;
@@ -488,6 +504,8 @@ class DataTest extends TestCase
      * @param bool $priceIncludesTax
      * @param bool $isCrossBorderTradeEnabled
      * @param bool $displayPriceIncludingTax
+     *
+     * @return void
      * @dataProvider dataProviderIsCatalogPriceDisplayAffectedByTax
      */
     public function testIsCatalogPriceDisplayAffectedByTax(
@@ -496,15 +514,13 @@ class DataTest extends TestCase
         $priceIncludesTax,
         $isCrossBorderTradeEnabled,
         $displayPriceIncludingTax
-    ) {
+    ): void {
+        $willReturnArgs = [];
+
         if ($displayBothPrices == true) {
-            $this->taxConfigMock->expects($this->at(0))
-                ->method('getPriceDisplayType')
-                ->willReturn(3);
+            $willReturnArgs[] = 3;
         } else {
-            $this->taxConfigMock->expects($this->at(0))
-                ->method('getPriceDisplayType')
-                ->willReturn(2);
+            $willReturnArgs[] = 2;
 
             $this->taxConfigMock->expects($this->any())
                 ->method('priceIncludesTax')
@@ -515,15 +531,14 @@ class DataTest extends TestCase
                 ->willReturn($isCrossBorderTradeEnabled);
 
             if ($displayPriceIncludingTax == true) {
-                $this->taxConfigMock->expects($this->at(3))
-                    ->method('getPriceDisplayType')
-                    ->willReturn(2);
+                $willReturnArgs[] = 2;
             } else {
-                $this->taxConfigMock->expects($this->at(2))
-                    ->method('getPriceDisplayType')
-                    ->willReturn(1);
+                $willReturnArgs[] = 1;
             }
         }
+        $this->taxConfigMock
+            ->method('getPriceDisplayType')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->assertSame($expected, $this->helper->isCatalogPriceDisplayAffectedByTax(null));
     }
@@ -531,7 +546,7 @@ class DataTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderIsCatalogPriceDisplayAffectedByTax()
+    public function dataProviderIsCatalogPriceDisplayAffectedByTax(): array
     {
         return [
             [true , true, false, false, false],

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/UploadJsTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/UploadJsTest.php
@@ -20,27 +20,44 @@ use Psr\Log\LoggerInterface;
 
 class UploadJsTest extends ThemeTest
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $name = 'UploadJs';
 
-    /** @var  Service|MockObject */
+    /**
+     * @var Service|MockObject
+     */
     protected $serviceModel;
 
-    /** @var  FlyweightFactory|MockObject */
+    /**
+     * @var FlyweightFactory|MockObject
+     */
     protected $themeFactory;
 
-    /** @var  Js|MockObject */
+    /**
+     * @var Js|MockObject
+     */
     protected $customizationJs;
 
-    /** @var  Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $jsonHelper;
 
-    /** @var LoggerInterface|MockObject  */
+    /**
+     * @var LoggerInterface|MockObject
+     */
     protected $logger;
 
-    /** @var CustomizationInterface|MockObject  */
+    /**
+     * @var CustomizationInterface|MockObject
+     */
     protected $themeCustomization;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -63,35 +80,32 @@ class UploadJsTest extends ThemeTest
         $this->customizationJs = $this->createMock(Js::class);
     }
 
-    public function testExecuteWithoutTheme()
+    /**
+    * @return void
+    */
+    public function testExecuteWithoutTheme(): void
     {
         $themeId = 23;
 
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
 
         $this->_objectManagerMock
-            ->expects($this->at(0))
             ->method('get')
-            ->with(Service::class)
-            ->willReturn($this->serviceModel);
-        $this->_objectManagerMock
-            ->expects($this->at(1))
-            ->method('get')
-            ->with(FlyweightFactory::class)
-            ->willReturn($this->themeFactory);
-        $this->_objectManagerMock
-            ->expects($this->at(2))
-            ->method('get')
-            ->with(Js::class)
-            ->willReturn($this->customizationJs);
-        $this->_objectManagerMock
-            ->expects($this->at(3))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->jsonHelper);
+            ->withConsecutive(
+                [Service::class],
+                [FlyweightFactory::class],
+                [Js::class],
+                [Data::class]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->serviceModel,
+                $this->themeFactory,
+                $this->customizationJs,
+                $this->jsonHelper
+            );
 
         $this->themeFactory->expects($this->once())
             ->method('create')
@@ -108,42 +122,38 @@ class UploadJsTest extends ThemeTest
         $this->_model->execute();
     }
 
-    public function testExecuteWithException()
+    /**
+    * @return void
+    */
+    public function testExecuteWithException(): void
     {
         $themeId = 23;
 
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
-
-        $this->_objectManagerMock->expects($this->at(0))
-            ->method('get')
-            ->with(Service::class)
-            ->willReturn($this->serviceModel);
-        $this->_objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(FlyweightFactory::class)
-            ->willReturn($this->themeFactory);
-        $this->_objectManagerMock
-            ->expects($this->at(2))
-            ->method('get')
-            ->with(Js::class)
-            ->willReturn($this->customizationJs);
-        $this->_objectManagerMock
-            ->expects($this->at(4))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->jsonHelper);
 
         $this->themeFactory->expects($this->once())
             ->method('create')
             ->willThrowException(new \Exception('Message'));
 
-        $this->_objectManagerMock->expects($this->at(3))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(LoggerInterface::class)
-            ->willReturn($this->logger);
+            ->withConsecutive(
+                [Service::class],
+                [FlyweightFactory::class],
+                [Js::class],
+                [LoggerInterface::class],
+                [Data::class]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->serviceModel,
+                $this->themeFactory,
+                $this->customizationJs,
+                $this->logger,
+                $this->jsonHelper
+            );
         $this->logger->expects($this->once())
             ->method('critical');
 
@@ -158,7 +168,10 @@ class UploadJsTest extends ThemeTest
         $this->_model->execute();
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $themeId = 23;
         $theme = $this->getMockForAbstractClass(ThemeInterface::class, [], '', false);
@@ -173,31 +186,29 @@ class UploadJsTest extends ThemeTest
                 'setTheme',
                 'setFileName',
                 'setData',
-                'save',
+                'save'
             ]
         );
 
-        $this->_request->expects($this->at(0))
+        $this->_request
             ->method('getParam')
             ->with('id')
             ->willReturn($themeId);
 
-        $this->_objectManagerMock->expects($this->at(0))
+        $this->_objectManagerMock
             ->method('get')
-            ->with(Service::class)
-            ->willReturn($this->serviceModel);
-        $this->_objectManagerMock->expects($this->at(1))
-            ->method('get')
-            ->with(FlyweightFactory::class)
-            ->willReturn($this->themeFactory);
-        $this->_objectManagerMock->expects($this->at(2))
-            ->method('get')
-            ->with(Js::class)
-            ->willReturn($this->customizationJs);
-        $this->_objectManagerMock->expects($this->at(4))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($this->jsonHelper);
+            ->withConsecutive(
+                [Service::class],
+                [FlyweightFactory::class],
+                [Js::class],
+                [Data::class]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->serviceModel,
+                $this->themeFactory,
+                $this->customizationJs,
+                $this->jsonHelper
+            );
 
         $this->themeFactory->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Theme/Test/Unit/Helper/StorageTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Helper/StorageTest.php
@@ -5,9 +5,6 @@
  */
 declare(strict_types=1);
 
-/**
- * Storage helper test
- */
 namespace Magento\Theme\Test\Unit\Helper;
 
 use Magento\Backend\Model\Session;
@@ -15,17 +12,18 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\Write;
+use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Url\DecoderInterface;
 use Magento\Framework\Url\EncoderInterface;
 use Magento\Framework\View\Design\Theme\Customization;
 use Magento\Framework\View\Design\Theme\FlyweightFactory;
-use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Theme\Helper\Storage;
-use PHPUnit\Framework\MockObject\MockObject;
 use Magento\Theme\Model\Theme;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Storage helper test.
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class StorageTest extends TestCase
@@ -90,13 +88,14 @@ class StorageTest extends TestCase
      */
     protected $urlDecoder;
 
-    protected $requestParams;
-
     /**
      * @var DriverInterface|MockObject
      */
     private $filesystemDriver;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->customizationPath = '/' . implode('/', ['var', 'theme']);
@@ -118,6 +117,8 @@ class StorageTest extends TestCase
         $this->urlDecoder = $this->getMockBuilder(DecoderInterface::class)
             ->getMock();
 
+        $this->initializeDefaultRequestMock();
+
         $this->directoryWrite->expects($this->any())->method('create')->willReturn(true);
         $this->contextHelper->expects($this->any())->method('getRequest')->willReturn($this->request);
         $this->contextHelper->expects($this->any())->method('getUrlEncoder')->willReturn($this->urlEncoder);
@@ -129,15 +130,6 @@ class StorageTest extends TestCase
             ->method('getCustomization')
             ->willReturn($this->customization);
 
-        $this->request->expects($this->at(0))
-            ->method('getParam')
-            ->with(Storage::PARAM_THEME_ID)
-            ->willReturn(6);
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with(Storage::PARAM_CONTENT_TYPE)
-            ->willReturn(\Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE);
-
         $this->helper = new Storage(
             $this->contextHelper,
             $this->filesystem,
@@ -148,6 +140,9 @@ class StorageTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         $this->request = null;
@@ -161,24 +156,34 @@ class StorageTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\Theme\Helper\Storage::getShortFilename
      * @covers \Magento\Theme\Helper\Storage::__construct
      */
-    public function testGetShortFilename()
+    public function testGetShortFilename(): void
     {
+        $this->initializeDefaultRequestMock();
         $longFileName = 'veryLongFileNameMoreThanTwenty';
         $expectedFileName = 'veryLongFileNameMore...';
         $this->assertEquals($expectedFileName, $this->helper->getShortFilename($longFileName, 20));
     }
 
-    public function testGetStorageRoot()
+    /**
+    * @return void
+    */
+    public function testGetStorageRoot(): void
     {
+        $this->initializeDefaultRequestMock();
         $expectedStorageRoot = '/' . \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE;
         $this->assertEquals($expectedStorageRoot, $this->helper->getStorageRoot());
     }
 
-    public function testGetThumbnailDirectory()
+    /**
+    * @return void
+    */
+    public function testGetThumbnailDirectory(): void
     {
+        $this->initializeDefaultRequestMock();
         $imagePath = implode('/', ['root', 'image', 'image_name.jpg']);
         $thumbnailDir = implode(
             '/',
@@ -188,7 +193,10 @@ class StorageTest extends TestCase
         $this->assertEquals($thumbnailDir, $this->helper->getThumbnailDirectory($imagePath));
     }
 
-    public function testGetThumbnailPath()
+    /**
+    * @return void
+    */
+    public function testGetThumbnailPath(): void
     {
         $image = 'image_name.jpg';
         $thumbnailPath = '/' . implode(
@@ -213,65 +221,41 @@ class StorageTest extends TestCase
         $this->assertEquals($thumbnailPath, $this->helper->getThumbnailPath($image));
     }
 
-    public function testGetRequestParams()
+    /**
+    * @return void
+    */
+    public function testGetRequestParams(): void
     {
-        $this->request->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->with(
-            Storage::PARAM_THEME_ID
-        )->willReturn(
-            6
-        );
-        $this->request->expects(
-            $this->at(1)
-        )->method(
-            'getParam'
-        )->with(
-            Storage::PARAM_CONTENT_TYPE
-        )->willReturn(
-            'image'
-        );
-        $this->request->expects(
-            $this->at(2)
-        )->method(
-            'getParam'
-        )->with(
-            Storage::PARAM_NODE
-        )->willReturn(
-            'node'
-        );
+        $withArgs = [
+            [Storage::PARAM_THEME_ID],
+            [Storage::PARAM_CONTENT_TYPE],
+            [Storage::PARAM_NODE]
+        ];
+        $willReturnArgs = [6, 'image', 'node'];
+        $this->resetRequestMock($withArgs, $willReturnArgs);
 
         $expectedResult = [
             Storage::PARAM_THEME_ID => 6,
             Storage::PARAM_CONTENT_TYPE => \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE,
-            Storage::PARAM_NODE => 'node',
+            Storage::PARAM_NODE => 'node'
         ];
         $this->assertEquals($expectedResult, $this->helper->getRequestParams());
     }
 
-    public function testGetAllowedExtensionsByType()
+    /**
+    * @return void
+    */
+    public function testGetAllowedExtensionsByType(): void
     {
-        $this->request->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->with(
-            Storage::PARAM_CONTENT_TYPE
-        )->willReturn(
-            \Magento\Theme\Model\Wysiwyg\Storage::TYPE_FONT
-        );
-
-        $this->request->expects(
-            $this->at(1)
-        )->method(
-            'getParam'
-        )->with(
-            Storage::PARAM_CONTENT_TYPE
-        )->willReturn(
+        $withArgs = [
+            [Storage::PARAM_CONTENT_TYPE],
+            [Storage::PARAM_CONTENT_TYPE]
+        ];
+        $willReturnArgs = [
+            \Magento\Theme\Model\Wysiwyg\Storage::TYPE_FONT,
             \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
-        );
+        ];
+        $this->resetRequestMock($withArgs, $willReturnArgs);
 
         $fontTypes = $this->helper->getAllowedExtensionsByType();
         $this->assertEquals(['ttf', 'otf', 'eot', 'svg', 'woff'], $fontTypes);
@@ -284,7 +268,7 @@ class StorageTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetThumbnailPathNotFound()
+    public function testGetThumbnailPathNotFound(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The image not found');
@@ -295,27 +279,29 @@ class StorageTest extends TestCase
         $root = '/image';
         $sourceNode = '/not/a/root';
         $node = base64_encode($sourceNode);
-        $this->request->expects($this->at(0))
-            ->method('getParam')
-            ->willReturnMap(
+
+        $withArgs = [];
+        $willReturnArg = $this->returnValueMap(
+            [
                 [
-                    [
-                        Storage::PARAM_THEME_ID,
-                        null,
-                        6,
-                    ],
-                    [
-                        Storage::PARAM_CONTENT_TYPE,
-                        null,
-                        \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
-                    ],
-                    [
-                        Storage::PARAM_NODE,
-                        null,
-                        $node
-                    ],
+                    Storage::PARAM_THEME_ID,
+                    null,
+                    6,
+                ],
+                [
+                    Storage::PARAM_CONTENT_TYPE,
+                    null,
+                    \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
+                ],
+                [
+                    Storage::PARAM_NODE,
+                    null,
+                    $node
                 ]
-            );
+            ]
+        );
+        $this->resetRequestMock($withArgs, [$willReturnArg]);
+
         $this->urlDecoder->expects($this->once())
             ->method('decode')
             ->with($node)
@@ -338,11 +324,13 @@ class StorageTest extends TestCase
     }
 
     /**
+     * @return void
      * @covers \Magento\Theme\Helper\Storage::convertPathToId
      * @covers \Magento\Theme\Helper\Storage::convertIdToPath
      */
-    public function testConvertPathToIdAndIdToPath()
+    public function testConvertPathToIdAndIdToPath(): void
     {
+        $this->initializeDefaultRequestMock();
         $path = '/image/path/to';
         $this->urlEncoder->expects($this->once())
             ->method('encode')
@@ -362,47 +350,32 @@ class StorageTest extends TestCase
         $this->assertEquals($path, $this->helper->convertIdToPath($value));
     }
 
-    public function testGetSession()
+    /**
+    * @return void
+    */
+    public function testGetSession(): void
     {
+        $this->initializeDefaultRequestMock();
         $this->assertInstanceOf(Session::class, $this->helper->getSession());
     }
 
-    public function testGetRelativeUrl()
+    /**
+    * @return void
+    */
+    public function testGetRelativeUrl(): void
     {
         $filename = base64_encode('filename.ext');
         $notRoot = base64_encode('not/a/root');
-        $this->request->expects($this->any())
-            ->method('getParam')
-            ->willReturnMap(
-                [
-                    'type' => [
-                        Storage::PARAM_CONTENT_TYPE,
-                        null,
-                        \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE,
-                    ],
-                    'node' => [
-                        Storage::PARAM_NODE,
-                        null,
-                        $notRoot,
-                    ],
-                    'filenaem' => [
-                        Storage::PARAM_FILENAME,
-                        null,
-                        $filename,
-                    ],
-                ]
-            );
+        $withArgs = [[Storage::PARAM_CONTENT_TYPE], [Storage::PARAM_NODE], [Storage::PARAM_FILENAME]];
+        $willReturnArgs = [\Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE, $notRoot, $filename];
+        $this->resetRequestMock($withArgs, $willReturnArgs);
         $decode = function ($value) {
             return base64_decode($value);
         };
-        $this->urlDecoder->expects($this->at(0))
+        $this->urlDecoder
             ->method('decode')
-            ->with($notRoot)
-            ->willReturnCallback($decode);
-        $this->urlDecoder->expects($this->at(1))
-            ->method('decode')
-            ->with($filename)
-            ->willReturnCallback($decode);
+            ->withConsecutive([$notRoot], [$filename])
+            ->willReturnOnConsecutiveCalls($this->returnCallback($decode), $this->returnCallback($decode));
 
         $this->assertEquals(
             '../image/not/a/root/filename.ext',
@@ -413,11 +386,11 @@ class StorageTest extends TestCase
     /**
      * @return array
      */
-    public function getStorageTypeForNameDataProvider()
+    public function getStorageTypeForNameDataProvider(): array
     {
         return [
             'font' => [\Magento\Theme\Model\Wysiwyg\Storage::TYPE_FONT, Storage::FONTS],
-            'image' => [\Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE, Storage::IMAGES],
+            'image' => [\Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE, Storage::IMAGES]
         ];
     }
 
@@ -425,15 +398,13 @@ class StorageTest extends TestCase
      * @test
      * @param string $type
      * @param string $name
+     *
      * @return void
      * @dataProvider getStorageTypeForNameDataProvider
      */
-    public function testGetStorageTypeName($type, $name)
+    public function testGetStorageTypeName($type, $name): void
     {
-        $this->request->expects($this->once())
-            ->method('getParam')
-            ->with(Storage::PARAM_CONTENT_TYPE)
-            ->willReturn($type);
+        $this->resetRequestMock([[Storage::PARAM_CONTENT_TYPE]], [$type]);
 
         $this->assertEquals($name, $this->helper->getStorageTypeName());
     }
@@ -442,7 +413,7 @@ class StorageTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetStorageTypeNameInvalid()
+    public function testGetStorageTypeNameInvalid(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionMessage('Invalid type');
@@ -453,8 +424,9 @@ class StorageTest extends TestCase
      * @test
      * @return void
      */
-    public function testGetThemeNotFound()
+    public function testGetThemeNotFound(): void
     {
+        $this->initializeDefaultRequestMock();
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('Theme was not found');
         $this->themeFactory->expects($this->once())
@@ -472,7 +444,7 @@ class StorageTest extends TestCase
     /**
      * @dataProvider getCurrentPathDataProvider
      */
-    public function testGetCurrentPathCachesResult()
+    public function testGetCurrentPathCachesResult(): void
     {
         $this->request->expects($this->once())
             ->method('getParam')
@@ -484,6 +456,7 @@ class StorageTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider getCurrentPathDataProvider
      */
     public function testGetCurrentPath(
@@ -492,7 +465,7 @@ class StorageTest extends TestCase
         ?bool $isDirectory = null,
         ?string $relativePath = null,
         ?string $resolvedPath = null
-    ) {
+    ): void {
         $this->directoryWrite->method('isDirectory')
             ->willReturn($isDirectory);
 
@@ -509,16 +482,16 @@ class StorageTest extends TestCase
             $this->filesystemDriver->method('getRealpathSafety')
                 ->willReturnArgument(0);
         }
-
-        $this->request->method('getParam')
-            ->with(Storage::PARAM_NODE)
-            ->willReturn($requestedPath);
+        $this->resetRequestMock([[Storage::PARAM_NODE]], [$requestedPath]);
 
         $actualPath = $this->helper->getCurrentPath();
 
         self::assertSame($expectedPath, $actualPath);
     }
 
+    /**
+     * @return array
+     */
     public function getCurrentPathDataProvider(): array
     {
         $rootPath = '/' . \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE;
@@ -528,7 +501,54 @@ class StorageTest extends TestCase
             'non-existent directory should default to the base path' => [$rootPath, $rootPath . '/foo'],
             'requested path that resolves to a bad path should default to root' =>
                 [$rootPath, $rootPath . '/something', true, null, '/bar'],
-            'real path should resolve to relative path' => ['foo/', $rootPath . '/foo', true, 'foo/'],
+            'real path should resolve to relative path' => ['foo/', $rootPath . '/foo', true, 'foo/']
         ];
+    }
+
+    /**
+    * @return void
+    */
+    private function initializeDefaultRequestMock(): void
+    {
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(
+                [Storage::PARAM_THEME_ID],
+                [Storage::PARAM_CONTENT_TYPE]
+            )
+            ->willReturnOnConsecutiveCalls(
+                6,
+                \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE
+            );
+    }
+
+    /**
+     * @param array $withArgs
+     * @param array $willReturnArgs
+     *
+     * @return void
+     */
+    private function resetRequestMock(array $withArgs, array $willReturnArgs): void
+    {
+        array_unshift($withArgs, [Storage::PARAM_THEME_ID], [Storage::PARAM_CONTENT_TYPE]);
+        array_unshift($willReturnArgs, 6,  \Magento\Theme\Model\Wysiwyg\Storage::TYPE_IMAGE);
+        $this->request = $this->createMock(Http::class);
+        $this->contextHelper = $this->createMock(Context::class);
+        $this->contextHelper->expects($this->any())->method('getUrlEncoder')->willReturn($this->urlEncoder);
+        $this->contextHelper->expects($this->any())->method('getUrlDecoder')->willReturn($this->urlDecoder);
+        $this->contextHelper->expects($this->any())->method('getRequest')->willReturn($this->request);
+        $this->request
+            ->method('getParam')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
+        $this->helper = new Storage(
+            $this->contextHelper,
+            $this->filesystem,
+            $this->session,
+            $this->themeFactory,
+            null,
+            $this->filesystemDriver
+        );
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/CopyServiceTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/CopyServiceTest.php
@@ -99,7 +99,17 @@ class CopyServiceTest extends TestCase
     protected $dirWriteMock;
 
     /**
-     * @return void
+     * @var array
+     */
+    private $updateFactoryReturn = [];
+
+    /**
+     * @var int
+     */
+    private $updateFactoryCalls = 0;
+
+    /**
+     * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -110,7 +120,7 @@ class CopyServiceTest extends TestCase
                 'file_path' => 'fixture_file_path_one',
                 'file_type' => 'fixture_file_type_one',
                 'content' => 'fixture_content_one',
-                'sort_order' => 10,
+                'sort_order' => 10
             ]
         );
         $sourceFileTwo = $this->createPartialMock(File::class, ['__wakeup', 'delete']);
@@ -119,7 +129,7 @@ class CopyServiceTest extends TestCase
                 'file_path' => 'fixture_file_path_two',
                 'file_type' => 'fixture_file_type_two',
                 'content' => 'fixture_content_two',
-                'sort_order' => 20,
+                'sort_order' => 20
             ]
         );
         $this->sourceFiles = [$sourceFileOne, $sourceFileTwo];
@@ -130,7 +140,7 @@ class CopyServiceTest extends TestCase
 
         $this->targetFiles = [
             $this->createPartialMock(File::class, ['__wakeup', 'delete']),
-            $this->createPartialMock(File::class, ['__wakeup', 'delete']),
+            $this->createPartialMock(File::class, ['__wakeup', 'delete'])
         ];
         $this->targetTheme = $this->createPartialMock(
             Theme::class,
@@ -167,7 +177,15 @@ class CopyServiceTest extends TestCase
             Update::class,
             ['__wakeup', 'getCollection']
         );
-        $this->updateFactory->expects($this->at(0))->method('create')->willReturn($this->update);
+        $this->updateFactoryReturn = [$this->update];
+        $classInstance = $this;
+        $this->updateFactory
+            ->method('create')
+            ->will(
+                $this->returnCallback(function () use ($classInstance) {
+                    return $classInstance->updateFactoryReturn[$classInstance->updateFactoryCalls++];
+                })
+            );
         $this->updateCollection = $this->createPartialMock(
             Collection::class,
             ['addThemeFilter', 'delete', 'getIterator']
@@ -200,6 +218,9 @@ class CopyServiceTest extends TestCase
         );
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         $this->object = null;
@@ -216,9 +237,10 @@ class CopyServiceTest extends TestCase
     }
 
     /**
+     * @return void
      * cover \Magento\Theme\Model\CopyService::_copyLayoutCustomization
      */
-    public function testCopyLayoutUpdates()
+    public function testCopyLayoutUpdates(): void
     {
         $customization = $this->createPartialMock(
             Customization::class,
@@ -256,15 +278,29 @@ class CopyServiceTest extends TestCase
             ->getMock();
         $targetLinkTwo->setData(['id' => 2, 'layout_update_id' => 2]);
 
-        $targetLinkOne->expects($this->at(0))->method('setThemeId')->with(123);
-        $targetLinkOne->expects($this->at(1))->method('setLayoutUpdateId')->with(1);
-        $targetLinkOne->expects($this->at(2))->method('setId')->with(null);
-        $targetLinkOne->expects($this->at(3))->method('save');
+        $targetLinkOne
+            ->method('setThemeId')
+            ->withConsecutive([123]);
+        $targetLinkOne
+            ->method('setLayoutUpdateId')
+            ->withConsecutive([1]);
+        $targetLinkOne
+            ->method('setId')
+            ->withConsecutive([null]);
+        $targetLinkOne
+            ->method('save');
 
-        $targetLinkTwo->expects($this->at(0))->method('setThemeId')->with(123);
-        $targetLinkTwo->expects($this->at(1))->method('setLayoutUpdateId')->with(2);
-        $targetLinkTwo->expects($this->at(2))->method('setId')->with(null);
-        $targetLinkTwo->expects($this->at(3))->method('save');
+        $targetLinkTwo
+            ->method('setThemeId')
+            ->withConsecutive([123]);
+        $targetLinkTwo
+            ->method('setLayoutUpdateId')
+            ->withConsecutive([2]);
+        $targetLinkTwo
+            ->method('setId')
+            ->withConsecutive([null]);
+        $targetLinkTwo
+            ->method('save');
 
         $linkReturnValues = $this->onConsecutiveCalls(new \ArrayIterator([$targetLinkOne, $targetLinkTwo]));
         $this->linkCollection->expects($this->any())->method('getIterator')->will($linkReturnValues);
@@ -279,17 +315,24 @@ class CopyServiceTest extends TestCase
             ['__wakeup', 'setId', 'load', 'save']
         );
         $targetUpdateTwo->setData(['id' => 2]);
-        $updateReturnValues = $this->onConsecutiveCalls($this->update, $targetUpdateOne, $targetUpdateTwo);
-        $this->updateFactory->expects($this->any())->method('create')->will($updateReturnValues);
+
+        $this->updateFactoryReturn = array_merge(
+            $this->updateFactoryReturn,
+            [
+                $targetUpdateOne,
+                $targetUpdateTwo
+            ]
+        );
 
         $this->object->copy($this->sourceTheme, $this->targetTheme);
     }
 
     /**
+     * @return void
      * cover \Magento\Theme\Model\CopyService::_copyDatabaseCustomization
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCopyDatabaseCustomization()
+    public function testCopyDatabaseCustomization(): void
     {
         $sourceCustom = $this->createPartialMock(
             Customization::class,
@@ -349,34 +392,33 @@ class CopyServiceTest extends TestCase
 
         $newFileOne = $this->createPartialMock(File::class, ['__wakeup', 'setData', 'save']);
         $newFileTwo = $this->createPartialMock(File::class, ['__wakeup', 'setData', 'save']);
-        $newFileOne->expects(
-            $this->at(0)
-        )->method(
-            'setData'
-        )->with(
-            [
-                'theme_id' => 123,
-                'file_path' => 'fixture_file_path_one',
-                'file_type' => 'fixture_file_type_one',
-                'content' => 'fixture_content_one',
-                'sort_order' => 10,
-            ]
-        );
-        $newFileOne->expects($this->at(1))->method('save');
-        $newFileTwo->expects(
-            $this->at(0)
-        )->method(
-            'setData'
-        )->with(
-            [
-                'theme_id' => 123,
-                'file_path' => 'fixture_file_path_two',
-                'file_type' => 'fixture_file_type_two',
-                'content' => 'fixture_content_two',
-                'sort_order' => 20,
-            ]
-        );
-        $newFileTwo->expects($this->at(1))->method('save');
+
+        $newFileOne
+            ->method('setData')
+            ->with(
+                [
+                    'theme_id' => 123,
+                    'file_path' => 'fixture_file_path_one',
+                    'file_type' => 'fixture_file_type_one',
+                    'content' => 'fixture_content_one',
+                    'sort_order' => 10
+                ]
+            );
+        $newFileOne->method('save');
+
+        $newFileTwo
+            ->method('setData')
+            ->with(
+                [
+                    'theme_id' => 123,
+                    'file_path' => 'fixture_file_path_two',
+                    'file_type' => 'fixture_file_type_two',
+                    'content' => 'fixture_content_two',
+                    'sort_order' => 20
+                ]
+            );
+        $newFileTwo->method('save');
+
         $this->fileFactory->expects(
             $this->any()
         )->method(
@@ -391,11 +433,11 @@ class CopyServiceTest extends TestCase
     }
 
     /**
+     * @return void
      * cover \Magento\Theme\Model\CopyService::_copyFilesystemCustomization
-     *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCopyFilesystemCustomization()
+    public function testCopyFilesystemCustomization(): void
     {
         $customization = $this->createPartialMock(
             Customization::class,
@@ -432,21 +474,9 @@ class CopyServiceTest extends TestCase
             new \ArrayIterator([])
         );
 
-        $this->customizationPath->expects(
-            $this->at(0)
-        )->method(
-            'getCustomizationPath'
-        )->willReturn(
-            'source/path'
-        );
-
-        $this->customizationPath->expects(
-            $this->at(1)
-        )->method(
-            'getCustomizationPath'
-        )->willReturn(
-            'target/path'
-        );
+        $this->customizationPath
+            ->method('getCustomizationPath')
+            ->willReturnOnConsecutiveCalls('source/path', 'target/path');
 
         $this->dirWriteMock->expects(
             $this->any()
@@ -474,7 +504,7 @@ class CopyServiceTest extends TestCase
             [
                 ['target/path', ['target/path/subdir']],
                 ['source/path', ['source/path/subdir']],
-                ['source/path/subdir', ['source/path/subdir/file_one.jpg', 'source/path/subdir/file_two.png']],
+                ['source/path/subdir', ['source/path/subdir/file_one.jpg', 'source/path/subdir/file_two.png']]
             ]
         );
 

--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -92,6 +92,7 @@ class DataProviderTest extends TestCase
      * Verify data translate.
      *
      * @param array $config
+     *
      * @return void
      * @dataProvider configDataProvider
      */
@@ -121,11 +122,14 @@ class DataProviderTest extends TestCase
             ->method('getStaticHtmlFiles')
             ->willReturnMap($staticFilesMap);
 
-        foreach ($config['contentsMap'] as $index => $content) {
-            $this->fileReadMock->expects($this->at($index))
-                ->method('readAll')
-                ->willReturn($content);
+        $willReturn = [];
+
+        foreach ($config['contentsMap'] as $content) {
+            $willReturn[] = $content;
         }
+        $this->fileReadMock
+            ->method('readAll')
+            ->willReturnOnConsecutiveCalls(...$willReturn);
 
         $this->configMock->expects($this->any())
             ->method('getPatterns')
@@ -147,6 +151,7 @@ class DataProviderTest extends TestCase
      * Verify get data throwing exception.
      *
      * @param array $config
+     *
      * @return void
      * @dataProvider configDataProvider
      */
@@ -194,7 +199,7 @@ class DataProviderTest extends TestCase
                         '~(?:i18n\:|_\.i18n\()\s*(["\'])(.*?)(?<!\\\\)\1~',
                         '~translate\=("\')([^\'].*?)\'\"~',
                         '~(?s)\$t\(\s*([\'"])(\?\<translate\>.+?)(?<!\\\)\1\s*(*SKIP)\)(?s)~',
-                        '~translate args\=("|\'|"\'|\\\"\')([^\'].*?)(\'\\\"|\'"|\'|")~',
+                        '~translate args\=("|\'|"\'|\\\"\')([^\'].*?)(\'\\\"|\'"|\'|")~'
                     ],
                     'expectedResult' => [
                         'hello1' => 'hello1translated',
@@ -202,13 +207,13 @@ class DataProviderTest extends TestCase
                         'hello3' => 'hello3translated',
                         'hello4' => 'hello4translated',
                         'ko i18' => 'ko i18 translated',
-                        'underscore i18' => 'underscore i18 translated',
+                        'underscore i18' => 'underscore i18 translated'
                     ],
                     'contentsMap' => [
                         'content1$.mage.__("hello1")content1',
                         'content2$.mage.__("hello2")content2',
                         'content2$.mage.__("hello4")content4 <!-- ko i18n: "ko i18" --><!-- /ko -->',
-                        'content2$.mage.__("hello3")content3 <% _.i18n("underscore i18") %>',
+                        'content2$.mage.__("hello3")content3 <% _.i18n("underscore i18") %>'
                     ],
                     'translateMap' => [
                         [['hello1'], [], 'hello1translated'],
@@ -216,9 +221,9 @@ class DataProviderTest extends TestCase
                         [['hello3'], [], 'hello3translated'],
                         [['hello4'], [], 'hello4translated'],
                         [['ko i18'], [], 'ko i18 translated'],
-                        [['underscore i18'], [], 'underscore i18 translated'],
+                        [['underscore i18'], [], 'underscore i18 translated']
                     ]
-                ],
+                ]
             ]
         ];
     }

--- a/app/code/Magento/Ui/Test/Unit/Component/Filters/Type/DateTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/Filters/Type/DateTest.php
@@ -50,13 +50,13 @@ class DateTest extends TestCase
     private $dataProviderMock;
 
     /**
-     * Set up
+     * @inheritDoc
      */
     protected function setUp(): void
     {
         $this->contextMock = $this->getMockForAbstractClass(ContextInterface::class);
         $this->uiComponentFactory = $this->getMockBuilder(UiComponentFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->filterBuilderMock = $this->getMockBuilder(FilterBuilder::class)
@@ -64,7 +64,7 @@ class DateTest extends TestCase
             ->getMock();
 
         $this->filterModifierMock = $this->getMockBuilder(FilterModifier::class)
-            ->setMethods(['applyFilterModifier'])
+            ->onlyMethods(['applyFilterModifier'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -72,11 +72,11 @@ class DateTest extends TestCase
     }
 
     /**
-     * Run test getComponentName method
+     * Run test getComponentName method.
      *
      * @return void
      */
-    public function testGetComponentName()
+    public function testGetComponentName(): void
     {
         $this->contextMock->expects(static::never())->method('getProcessor');
         $date = new Date(
@@ -97,10 +97,11 @@ class DateTest extends TestCase
      * @param bool $showsTime
      * @param array $filterData
      * @param array|null $expectedCondition
-     * @dataProvider getPrepareDataProvider
+     *
      * @return void
+     * @dataProvider getPrepareDataProvider
      */
-    public function testPrepare(string $name, bool $showsTime, array $filterData, ?array $expectedCondition)
+    public function testPrepare(string $name, bool $showsTime, array $filterData, ?array $expectedCondition): void
     {
         $processor = $this->getMockBuilder(Processor::class)
             ->disableOriginalConstructor()
@@ -154,55 +155,22 @@ class DateTest extends TestCase
     }
 
     /**
-     * Gets Filter mock
-     *
-     * @param string $name
-     * @param string $expectedType
-     * @param string $expectedDate
-     * @param int $i
-     *
-     * @return Filter|MockObject
-     */
-    private function getFilterMock($name, $expectedType, $expectedDate, &$i)
-    {
-        $this->filterBuilderMock->expects(static::at($i++))
-            ->method('setConditionType')
-            ->with($expectedType)
-            ->willReturnSelf();
-        $this->filterBuilderMock->expects(static::at($i++))
-            ->method('setField')
-            ->with($name)
-            ->willReturnSelf();
-        $this->filterBuilderMock->expects(static::at($i++))
-            ->method('setValue')
-            ->with($expectedDate)
-            ->willReturnSelf();
-
-        $filterMock = $this->createMock(Filter::class);
-        $this->filterBuilderMock->expects(static::at($i++))
-            ->method('create')
-            ->willReturn($filterMock);
-
-        return $filterMock;
-    }
-
-    /**
      * @return array
      */
-    public function getPrepareDataProvider()
+    public function getPrepareDataProvider(): array
     {
         return [
             [
                 'name' => 'test_date',
                 'showsTime' => false,
                 'filterData' => ['test_date' => ['from' => '11-05-2015', 'to' => null]],
-                'expectedCondition' => ['date' => '2015-05-11 00:00:00', 'type' => 'gteq'],
+                'expectedCondition' => ['date' => '2015-05-11 00:00:00', 'type' => 'gteq']
             ],
             [
                 'name' => 'test_date',
                 'showsTime' => false,
                 'filterData' => ['test_date' => ['from' => null, 'to' => '11-05-2015']],
-                'expectedCondition' => ['date' => '2015-05-11 23:59:59', 'type' => 'lteq'],
+                'expectedCondition' => ['date' => '2015-05-11 23:59:59', 'type' => 'lteq']
             ],
             [
                 'name' => 'test_date',
@@ -211,19 +179,19 @@ class DateTest extends TestCase
                 'expectedCondition' => [
                     'date_from' => '2015-05-11 00:00:00', 'type_from' => 'gteq',
                     'date_to' => '2015-05-11 23:59:59', 'type_to' => 'lteq'
-                ],
+                ]
             ],
             [
                 'name' => 'test_date',
                 'showsTime' => false,
                 'filterData' => ['test_date' => '11-05-2015'],
-                'expectedCondition' => ['date' => '2015-05-11 00:00:00', 'type' => 'eq'],
+                'expectedCondition' => ['date' => '2015-05-11 00:00:00', 'type' => 'eq']
             ],
             [
                 'name' => 'test_date',
                 'showsTime' => false,
                 'filterData' => ['test_date' => ['from' => '', 'to' => '']],
-                'expectedCondition' => null,
+                'expectedCondition' => null
             ],
             [
                 'name' => 'test_date',
@@ -232,8 +200,8 @@ class DateTest extends TestCase
                 'expectedCondition' => [
                     'date_from' => '2015-05-11 10:20:00', 'type_from' => 'gteq',
                     'date_to' => '2015-05-11 18:25:00', 'type_to' => 'lteq'
-                ],
-            ],
+                ]
+            ]
         ];
     }
 
@@ -243,6 +211,8 @@ class DateTest extends TestCase
      * @param array $filterData
      * @param array $expectedCondition
      * @param MockObject $uiComponent
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
     private function processFilters(
@@ -251,7 +221,7 @@ class DateTest extends TestCase
         array $filterData,
         array $expectedCondition,
         FormDate $uiComponent
-    ) {
+    ): void {
         if (is_string($filterData[$name])) {
             $uiComponent->expects(static::once())
                 ->method($showsTime ? 'convertDatetime' : 'convertDate')
@@ -280,39 +250,57 @@ class DateTest extends TestCase
                     );
             }
         }
+        $setConditionTypeWithArgs = [];
+        $setFieldWithArgs = [];
+        $setValueWithArgs = [];
+        $createReturnArgs = [];
 
-        $i = 0;
         switch (true) {
             case is_string($filterData[$name]):
             case isset($filterData[$name]['from']) && !isset($filterData[$name]['to']):
             case !isset($filterData[$name]['from']) && isset($filterData[$name]['to']):
-                $filterMock = $this->getFilterMock(
-                    $name,
-                    $expectedCondition['type'],
-                    $expectedCondition['date'],
-                    $i
-                );
+                $filterMock = $this->createMock(Filter::class);
+                $createReturnArgs[] = $filterMock;
+                $setConditionTypeWithArgs[] = [$expectedCondition['type']];
+                $setFieldWithArgs[] = [$name];
+                $setValueWithArgs[] = [$expectedCondition['date']];
+
                 $this->dataProviderMock->expects(static::once())
                     ->method('addFilter')
                     ->with($filterMock);
                 break;
             case isset($filterData[$name]['from']) && isset($filterData[$name]['to']):
-                $this->getFilterMock(
-                    $name,
-                    $expectedCondition['type_from'],
-                    $expectedCondition['date_from'],
-                    $i
-                );
-                $filterMock = $this->getFilterMock(
-                    $name,
-                    $expectedCondition['type_to'],
-                    $expectedCondition['date_to'],
-                    $i
-                );
+                $filterMock = $this->createMock(Filter::class);
+                $createReturnArgs[] = $filterMock;
+                $setConditionTypeWithArgs[] = [$expectedCondition['type_from']];
+                $setFieldWithArgs[] = [$name];
+                $setValueWithArgs[] = [$expectedCondition['date_from']];
+
+                $filterMock = $this->createMock(Filter::class);
+                $createReturnArgs[] = $filterMock;
+                $setConditionTypeWithArgs[] = [$expectedCondition['type_to']];
+                $setFieldWithArgs[] = [$name];
+                $setValueWithArgs[] = [$expectedCondition['date_to']];
+
                 $this->dataProviderMock->expects(static::exactly(2))
                     ->method('addFilter')
                     ->with($filterMock);
                 break;
         }
+        $this->filterBuilderMock
+            ->method('setConditionType')
+            ->withConsecutive(...$setConditionTypeWithArgs)
+            ->willReturnSelf();
+        $this->filterBuilderMock
+            ->method('setField')
+            ->withConsecutive(...$setFieldWithArgs)
+            ->willReturnSelf();
+        $this->filterBuilderMock
+            ->method('setValue')
+            ->withConsecutive(...$setValueWithArgs)
+            ->willReturnSelf();
+        $this->filterBuilderMock
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(...$createReturnArgs);
     }
 }

--- a/app/code/Magento/Ui/Test/Unit/Component/MassAction/FilterTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Component/MassAction/FilterTest.php
@@ -33,17 +33,17 @@ use PHPUnit\Framework\TestCase;
 class FilterTest extends TestCase
 {
     /**
-     * MockObject
+     * @var MockObject
      */
     private $requestMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $uiComponentFactoryMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $filterBuilderMock;
 
@@ -58,27 +58,27 @@ class FilterTest extends TestCase
     private $objectManager;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $dataProviderMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $abstractDbMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $searchResultMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $uiComponentMock;
 
     /**
-     * MockObject
+     * @var MockObject
      */
     private $contextMock;
 
@@ -88,7 +88,7 @@ class FilterTest extends TestCase
     private $resourceAbstractDbMock;
 
     /**
-     * Set up
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -139,19 +139,31 @@ class FilterTest extends TestCase
      * @param int[]|bool $excludedIds
      * @param int $filterExpected
      * @param string $conditionExpected
+     *
+     * @return void
      * @throws LocalizedException
      * @dataProvider applySelectionOnTargetProviderDataProvider
      */
-    public function testApplySelectionOnTargetProvider($selectedIds, $excludedIds, $filterExpected, $conditionExpected)
-    {
-        $this->setUpApplySelection($selectedIds, $excludedIds, $filterExpected, $conditionExpected);
+    public function testApplySelectionOnTargetProvider(
+        $selectedIds,
+        $excludedIds,
+        $filterExpected,
+        $conditionExpected
+    ): void {
+        $this->setUpApplySelection($filterExpected, $conditionExpected);
+        $this->requestMock
+            ->method('getParam')
+            ->withConsecutive([Filter::SELECTED_PARAM], [Filter::EXCLUDED_PARAM])
+            ->willReturnOnConsecutiveCalls($selectedIds, $excludedIds);
         $this->filter->applySelectionOnTargetProvider();
     }
 
     /**
-     * Data provider for testApplySelectionOnTargetProvider
+     * Data provider for testApplySelectionOnTargetProvider.
+     *
+     * @return array
      */
-    public function applySelectionOnTargetProviderDataProvider()
+    public function applySelectionOnTargetProviderDataProvider(): array
     {
         return [
             [[1, 2, 3], 'false', 0, 'in'],
@@ -162,9 +174,9 @@ class FilterTest extends TestCase
     }
 
     /**
-     * @throws \Exception
+     * @return void
      */
-    public function testApplySelectionOnTargetProviderException()
+    public function testApplySelectionOnTargetProviderException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->contextMock->expects($this->any())
@@ -189,14 +201,10 @@ class FilterTest extends TestCase
         $this->filterBuilderMock->expects($this->any())
             ->method('setField')
             ->willReturn($this->filterBuilderMock);
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
-            ->with(Filter::SELECTED_PARAM)
-            ->willReturn([1]);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with(Filter::EXCLUDED_PARAM)
-            ->willReturn([]);
+            ->withConsecutive([Filter::SELECTED_PARAM], [Filter::EXCLUDED_PARAM])
+            ->willReturnOnConsecutiveCalls([1], []);
         $this->dataProviderMock->expects($this->any())
             ->method('addFilter')
             ->with($filterMock)
@@ -205,30 +213,29 @@ class FilterTest extends TestCase
     }
 
     /**
-     * Run test for getCollection method with SearchResultInterface
+     * Run test for getCollection method with SearchResultInterface.
      *
      * @param int[]|bool $selectedIds
      * @param int[]|bool $excludedIds
      * @param int $filterExpected
      * @param string $conditionExpected
-     * @throws LocalizedException
+     *
+     * @return void
      * @dataProvider applySelectionOnTargetProviderDataProvider
      */
-    public function testGetCollection($selectedIds, $excludedIds, $filterExpected, $conditionExpected)
+    public function testGetCollection($selectedIds, $excludedIds, $filterExpected, $conditionExpected): void
     {
-        $this->setUpApplySelection($selectedIds, $excludedIds, $filterExpected, $conditionExpected);
-        $this->requestMock->expects($this->at(4))
+        $this->setUpApplySelection($filterExpected, $conditionExpected);
+        $this->requestMock
             ->method('getParam')
-            ->with('namespace')
-            ->willReturn('');
-        $this->requestMock->expects($this->at(2))
-            ->method('getParam')
-            ->with(Filter::SELECTED_PARAM)
-            ->willReturn($selectedIds);
-        $this->requestMock->expects($this->at(3))
-            ->method('getParam')
-            ->with(Filter::EXCLUDED_PARAM)
-            ->willReturn($excludedIds);
+            ->withConsecutive(
+                [Filter::SELECTED_PARAM],
+                [Filter::EXCLUDED_PARAM],
+                [Filter::SELECTED_PARAM],
+                [Filter::EXCLUDED_PARAM],
+                ['namespace']
+            )
+            ->willReturnOnConsecutiveCalls($selectedIds, $excludedIds, $selectedIds, $excludedIds, '');
         $this->abstractDbMock->expects($this->once())
             ->method('getResource')
             ->willReturn($this->resourceAbstractDbMock);
@@ -245,11 +252,16 @@ class FilterTest extends TestCase
      * @param int[]|bool $excludedIds
      * @param int $filterExpected
      * @param string $conditionExpected
-     * @throws LocalizedException
+     *
+     * @return void
      * @dataProvider applySelectionOnTargetProviderDataProvider
      */
-    public function testGetCollectionWithCollection($selectedIds, $excludedIds, $filterExpected, $conditionExpected)
-    {
+    public function testGetCollectionWithCollection(
+        $selectedIds,
+        $excludedIds,
+        $filterExpected,
+        $conditionExpected
+    ): void {
         $this->dataProviderMock = $this->createMock(AbstractDataProvider::class);
         $this->contextMock->expects($this->any())
             ->method('getDataProvider')
@@ -258,7 +270,7 @@ class FilterTest extends TestCase
             ->method('getAllIds')
             ->willReturn([1, 2, 3]);
 
-        $this->setUpApplySelection($selectedIds, $excludedIds, $filterExpected, $conditionExpected);
+        $this->setUpApplySelection($filterExpected, $conditionExpected);
 
         $this->requestMock->expects($this->any())
             ->method('getParam')
@@ -281,20 +293,24 @@ class FilterTest extends TestCase
     }
 
     /**
-     * This tests the method prepareComponent()
+     * This tests the method prepareComponent().
+     *
+     * @return void
      */
-    public function testPrepareComponent()
+    public function testPrepareComponent(): void
     {
         $result = $this->filter->prepareComponent($this->uiComponentMock);
         $this->assertNull($result);
     }
 
     /**
-     * This tests the method getComponent()
+     * This tests the method getComponent().
+     *
+     * @return void
      */
-    public function testGetComponent()
+    public function testGetComponent(): void
     {
-        $this->requestMock->expects($this->at(0))
+        $this->requestMock
             ->method('getParam')
             ->with('namespace')
             ->willReturn('');
@@ -302,9 +318,11 @@ class FilterTest extends TestCase
     }
 
     /**
-     * This tests the method getComponentRefererUrl()
+     * This tests the method getComponentRefererUrl().
+     *
+     * @return void
      */
-    public function testGetComponentRefererUrlIsNotNull()
+    public function testGetComponentRefererUrlIsNotNull(): void
     {
         $this->contextMock->expects($this->any())
             ->method('getDataProvider')
@@ -319,9 +337,11 @@ class FilterTest extends TestCase
     }
 
     /**
-     * This tests the method getComponentRefererUrl()
+     * This tests the method getComponentRefererUrl().
+     *
+     * @return void
      */
-    public function testGetComponentRefererUrlIsNull()
+    public function testGetComponentRefererUrlIsNull(): void
     {
         $this->contextMock->expects($this->any())
             ->method('getDataProvider')
@@ -330,14 +350,14 @@ class FilterTest extends TestCase
     }
 
     /**
-     * Apply mocks for current parameters from datasource
+     * Apply mocks for current parameters from datasource.
      *
-     * @param int[]|bool $selectedIds
-     * @param int[]|bool $excludedIds
      * @param int $filterExpected
      * @param string $conditionExpected
+     *
+     * @return void
      */
-    private function setUpApplySelection($selectedIds, $excludedIds, $filterExpected, $conditionExpected)
+    private function setUpApplySelection($filterExpected, $conditionExpected): void
     {
         $this->contextMock->expects($this->any())
             ->method('getDataProvider')
@@ -351,14 +371,6 @@ class FilterTest extends TestCase
             ->method('getItems')
             ->willReturn([new DataObject(['id' => 1])]);
         $filterMock = $this->createMock(ApiFilter::class);
-        $this->requestMock->expects($this->at(0))
-            ->method('getParam')
-            ->with(Filter::SELECTED_PARAM)
-            ->willReturn($selectedIds);
-        $this->requestMock->expects($this->at(1))
-            ->method('getParam')
-            ->with(Filter::EXCLUDED_PARAM)
-            ->willReturn($excludedIds);
         $this->dataProviderMock->expects($this->exactly($filterExpected))
             ->method('addFilter')
             ->with($filterMock);

--- a/app/code/Magento/Ui/Test/Unit/Model/ManagerTest.php
+++ b/app/code/Magento/Ui/Test/Unit/Model/ManagerTest.php
@@ -79,9 +79,14 @@ class ManagerTest extends TestCase
      */
     protected $aggregatedFileCollectorFactory;
 
-    /** @var SerializerInterface|MockObject */
+    /**
+     * @var SerializerInterface|MockObject
+     */
     private $serializer;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->componentConfigProvider = $this->getMockBuilder(
@@ -103,7 +108,7 @@ class ManagerTest extends TestCase
             ArrayObjectFactory::class
         )->disableOriginalConstructor()
             ->getMock();
-        $this->arrayObjectFactory->expects($this->at(0))
+        $this->arrayObjectFactory
             ->method('create')
             ->willReturn(new \ArrayObject([]));
         $this->uiReader = $this->getMockBuilder(
@@ -147,7 +152,10 @@ class ManagerTest extends TestCase
         );
     }
 
-    public function testGetReader()
+    /**
+    * @return void
+    */
+    public function testGetReader(): void
     {
         $this->readerFactory->expects($this->once())
             ->method('create')
@@ -159,7 +167,10 @@ class ManagerTest extends TestCase
         $this->assertEquals($this->uiReader, $this->manager->getReader('some_name'));
     }
 
-    public function testPrepareDataWithoutName()
+    /**
+    * @return void
+    */
+    public function testPrepareDataWithoutName(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage(
@@ -169,10 +180,29 @@ class ManagerTest extends TestCase
     }
 
     /**
+     * @return void
      * @dataProvider getComponentData()
      */
-    public function testPrepareGetData($componentName, $componentData, $isCached, $readerData, $expectedResult)
+    public function testPrepareGetData($componentName, $componentData, $isCached, $readerData, $expectedResult): void
     {
+        $this->arrayObjectFactory = $this->getMockBuilder(ArrayObjectFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->arrayObjectFactory
+            ->method('create')
+            ->willReturnOnConsecutiveCalls(new \ArrayObject([]), $componentData);
+
+        $this->manager = new Manager(
+            $this->componentConfigProvider,
+            $this->domMerger,
+            $this->readerFactory,
+            $this->arrayObjectFactory,
+            $this->aggregatedFileCollectorFactory,
+            $this->cacheConfig,
+            $this->argumentInterpreter,
+            $this->serializer
+        );
+
         $this->readerFactory->expects($this->any())
             ->method('create')
             ->with(['fileCollector' => $this->aggregatedFileCollector, 'domMerger' => $this->domMerger])
@@ -185,9 +215,6 @@ class ManagerTest extends TestCase
             ->willReturnCallback(function ($argument) {
                 return ['argument' => $argument['value']];
             });
-        $this->arrayObjectFactory->expects($this->any())
-            ->method('create')
-            ->willReturn($componentData);
         $this->cacheConfig->expects($this->any())
             ->method('load')
             ->with(Manager::CACHE_ID . '_' . $componentName)
@@ -205,20 +232,21 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function getComponentData()
+    public function getComponentData(): array
     {
         $cachedData = new \ArrayObject(
-            ['test_component1' => [
-                ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name1' => ['value' => 'value1']],
-                ManagerInterface::CHILDREN_KEY => [
-                    'custom' => [
-                        ManagerInterface::COMPONENT_ARGUMENTS_KEY => [
-                            'custom_name1' => ['value' => 'custom_value1']
-                        ],
-                        ManagerInterface::CHILDREN_KEY => [],
-                    ],
-                ],
-            ]
+            [
+                'test_component1' => [
+                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name1' => ['value' => 'value1']],
+                    ManagerInterface::CHILDREN_KEY => [
+                        'custom' => [
+                            ManagerInterface::COMPONENT_ARGUMENTS_KEY => [
+                                'custom_name1' => ['value' => 'custom_value1']
+                            ],
+                            ManagerInterface::CHILDREN_KEY => []
+                        ]
+                    ]
+                ]
             ]
         );
 
@@ -236,38 +264,44 @@ class ManagerTest extends TestCase
                                 ManagerInterface::COMPONENT_ARGUMENTS_KEY => [
                                     'custom_name1' => ['argument' => 'custom_value1']
                                 ],
-                                ManagerInterface::CHILDREN_KEY => [],
+                                ManagerInterface::CHILDREN_KEY => []
                             ]
                         ]
-                    ],
-                ],
+                    ]
+                ]
             ],
             [
                 'test_component2',
                 new \ArrayObject(
-                    ['test_component2' => [
-                        ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
-                        ManagerInterface::CHILDREN_KEY => [
-                            'test_component21' => [
-                                ManagerInterface::COMPONENT_ARGUMENTS_KEY => [
-                                    'argument_name21' => ['value' => 'value21']
-                                ],
-                                ManagerInterface::CHILDREN_KEY => [],
-                            ],
-                        ],
-                    ]
+                    [
+                        'test_component2' => [
+                            ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
+                            ManagerInterface::CHILDREN_KEY => [
+                                'test_component21' => [
+                                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => [
+                                        'argument_name21' => ['value' => 'value21']
+                                    ],
+                                    ManagerInterface::CHILDREN_KEY => []
+                                ]
+                            ]
+                        ]
                     ]
                 ),
                 false,
-                ['componentGroup' => [0 => [
-                    Converter::DATA_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
-                    Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name2'],
-                    'test_component21' => [0 => [
-                        Converter::DATA_ARGUMENTS_KEY => ['argument_name21' => ['value' => 'value21']],
-                        Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name21'],
+                [
+                    'componentGroup' => [
+                        0 => [
+                            Converter::DATA_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
+                            Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name2'],
+                            'test_component21' => [
+                                0 => [
+                                    Converter::DATA_ARGUMENTS_KEY => ['argument_name21' => ['value' => 'value21']],
+                                    Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name21']
+                                ]
+                            ]
+                        ]
                     ]
-                    ],
-                ]]],
+                ],
                 [
                     'test_component2' => [
                         ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name2' => ['argument' => 'value2']],
@@ -278,19 +312,20 @@ class ManagerTest extends TestCase
                                     'argument_name21' => ['argument' => 'value21']
                                 ],
                                 ManagerInterface::COMPONENT_ATTRIBUTES_KEY => ['name' => 'attribute_name21'],
-                                ManagerInterface::CHILDREN_KEY => [],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+                                ManagerInterface::CHILDREN_KEY => []
+                            ]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider getComponentDataProvider()
      */
-    public function testCreateRawComponentData($componentName, $configData, $componentData, $needEvaluate)
+    public function testCreateRawComponentData($componentName, $configData, $componentData, $needEvaluate): void
     {
         $this->componentConfigProvider->expects($this->any())
             ->method('getComponentData')
@@ -310,17 +345,17 @@ class ManagerTest extends TestCase
     /**
      * @return array
      */
-    public function getComponentDataProvider()
+    public function getComponentDataProvider(): array
     {
         return [
             [
                 'test_component1',
                 [
-                    Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name1'],
+                    Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name1']
                 ],
                 [
                     ManagerInterface::COMPONENT_ATTRIBUTES_KEY => ['name' => 'attribute_name1'],
-                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => [],
+                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => []
 
                 ],
                 false,
@@ -328,28 +363,28 @@ class ManagerTest extends TestCase
             [
                 'test_component2',
                 [
-                    Converter::DATA_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
+                    Converter::DATA_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']]
                 ],
                 [
                     ManagerInterface::COMPONENT_ATTRIBUTES_KEY => [],
-                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']],
+                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name2' => ['value' => 'value2']]
 
                 ],
-                false,
+                false
             ],
             [
                 'test_component3',
                 [
                     Converter::DATA_ATTRIBUTES_KEY => ['name' => 'attribute_name3'],
-                    Converter::DATA_ARGUMENTS_KEY => ['argument_name3' => ['value' => 'value3']],
+                    Converter::DATA_ARGUMENTS_KEY => ['argument_name3' => ['value' => 'value3']]
                 ],
                 [
                     ManagerInterface::COMPONENT_ATTRIBUTES_KEY => ['name' => 'attribute_name3'],
-                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name3' => ['argument' => 'value3']],
+                    ManagerInterface::COMPONENT_ARGUMENTS_KEY => ['argument_name3' => ['argument' => 'value3']]
 
                 ],
-                true,
-            ],
+                true
+            ]
         ];
     }
 }

--- a/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Ups/Test/Unit/Model/CarrierTest.php
@@ -5,7 +5,6 @@
  */
 declare(strict_types=1);
 
-
 namespace Magento\Ups\Test\Unit\Model;
 
 use Magento\Directory\Model\Country;
@@ -106,7 +105,7 @@ class CarrierTest extends TestCase
     private $configHelper;
 
     /**
-     * @inheritdoc
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -114,16 +113,16 @@ class CarrierTest extends TestCase
 
         $this->scope = $this->getMockBuilder(ScopeConfigInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getValue', 'isSetFlag'])
+            ->onlyMethods(['getValue', 'isSetFlag'])
             ->getMockForAbstractClass();
 
         $this->error = $this->getMockBuilder(Error::class)
-            ->setMethods(['setCarrier', 'setCarrierTitle', 'setErrorMessage'])
+            ->addMethods(['setCarrier', 'setCarrierTitle', 'setErrorMessage'])
             ->getMock();
 
         $this->errorFactory = $this->getMockBuilder(ErrorFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->errorFactory->method('create')
@@ -133,12 +132,12 @@ class CarrierTest extends TestCase
 
         $this->country = $this->getMockBuilder(Country::class)
             ->disableOriginalConstructor()
-            ->setMethods(['load', 'getData'])
+            ->onlyMethods(['load', 'getData'])
             ->getMock();
 
         $this->abstractModel = $this->getMockBuilder(AbstractModel::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getData'])
+            ->onlyMethods(['getData'])
             ->getMock();
 
         $this->country->method('load')
@@ -146,7 +145,7 @@ class CarrierTest extends TestCase
 
         $this->countryFactory = $this->getMockBuilder(CountryFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->countryFactory->method('create')
@@ -159,7 +158,7 @@ class CarrierTest extends TestCase
 
         $this->configHelper = $this->getMockBuilder(Config::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCode'])
+            ->onlyMethods(['getCode'])
             ->getMock();
 
         $this->model = $this->helper->getObject(
@@ -172,7 +171,7 @@ class CarrierTest extends TestCase
                 'xmlElFactory' => $xmlFactory,
                 'logger' => $this->logger,
                 'httpClientFactory' => $httpClientFactory,
-                'configHelper' => $this->configHelper,
+                'configHelper' => $this->configHelper
             ]
         );
     }
@@ -181,7 +180,8 @@ class CarrierTest extends TestCase
      * Callback function, emulates getValue function.
      *
      * @param string $path
-     * @return null|string
+     *
+     * @return null|string|int
      */
     public function scopeConfigGetValue(string $path)
     {
@@ -196,7 +196,7 @@ class CarrierTest extends TestCase
             'carriers/ups/debug' => 1,
             'carriers/ups/username' => 'user',
             'carriers/ups/password' => 'pass',
-            'carriers/ups/access_license_number' => 'acn',
+            'carriers/ups/access_license_number' => 'acn'
         ];
 
         return $pathMap[$path] ?? null;
@@ -233,11 +233,11 @@ class CarrierTest extends TestCase
     }
 
     /**
-     * Data provider for testGenerate method
+     * Data provider for testGenerate method.
      *
      * @return array
      */
-    public function getMethodPriceProvider()
+    public function getMethodPriceProvider(): array
     {
         return [
             [3, self::FREE_METHOD_NAME, true, 6, 0],
@@ -292,9 +292,11 @@ class CarrierTest extends TestCase
      * @param string $data
      * @param array $maskFields
      * @param string $expected
+     *
+     * @return void
      * @dataProvider logDataProvider
      */
-    public function testFilterDebugData($data, array $maskFields, $expected)
+    public function testFilterDebugData($data, array $maskFields, $expected): void
     {
         $refClass = new \ReflectionClass(Carrier::class);
         $property = $refClass->getProperty('_debugReplacePrivateDataKeys');
@@ -310,9 +312,11 @@ class CarrierTest extends TestCase
     }
 
     /**
-     * Get list of variations
+     * Get list of variations.
+     *
+     * @return array
      */
-    public function logDataProvider()
+    public function logDataProvider(): array
     {
         return [
             [
@@ -332,7 +336,7 @@ class CarrierTest extends TestCase
                     <Package ID="0">
                         <Service>ALL</Service>
                     </Package>
-                </RateRequest>',
+                </RateRequest>'
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"?>
@@ -353,7 +357,7 @@ class CarrierTest extends TestCase
                     <Package ID="0">
                         <Service>ALL</Service>
                     </Package>
-                </RateRequest>',
+                </RateRequest>'
             ]
         ];
     }
@@ -361,9 +365,11 @@ class CarrierTest extends TestCase
     /**
      * @param string $countryCode
      * @param string $foundCountryCode
+     *
+     * @return void
      * @dataProvider countryDataProvider
      */
-    public function testSetRequest($countryCode, $foundCountryCode)
+    public function testSetRequest($countryCode, $foundCountryCode): void
     {
         /** @var RateRequest $request */
         $request = $this->helper->getObject(RateRequest::class);
@@ -373,13 +379,13 @@ class CarrierTest extends TestCase
                 'orig_region_code' => 'CA',
                 'orig_post_code' => 90230,
                 'orig_city' => 'Culver City',
-                'dest_country_id' => $countryCode,
+                'dest_country_id' => $countryCode
             ]
         );
 
-        $this->country->expects($this->at(1))
+        $this->country
             ->method('load')
-            ->with($countryCode)
+            ->withConsecutive([], [$countryCode])
             ->willReturnSelf();
 
         $this->country->method('getData')
@@ -390,26 +396,28 @@ class CarrierTest extends TestCase
     }
 
     /**
-     * Get list of country variations
+     * Get list of country variations.
+     *
      * @return array
      */
-    public function countryDataProvider()
+    public function countryDataProvider(): array
     {
         return [
             ['countryCode' => 'PR', 'foundCountryCode' => null],
-            ['countryCode' => 'US', 'foundCountryCode' => 'US'],
+            ['countryCode' => 'US', 'foundCountryCode' => 'US']
         ];
     }
 
     /**
-     * @dataProvider allowedMethodsDataProvider
      * @param string $carrierType
      * @param string $methodType
      * @param string $methodCode
      * @param string $methodTitle
      * @param string $allowedMethods
      * @param array $expectedMethods
+     *
      * @return void
+     * @dataProvider allowedMethodsDataProvider
      */
     public function testGetAllowedMethods(
         string $carrierType,
@@ -426,20 +434,20 @@ class CarrierTest extends TestCase
                         'carriers/ups/allowed_methods',
                         ScopeInterface::SCOPE_STORE,
                         null,
-                        $allowedMethods,
+                        $allowedMethods
                     ],
                     [
                         'carriers/ups/type',
                         ScopeInterface::SCOPE_STORE,
                         null,
-                        $carrierType,
+                        $carrierType
                     ],
                     [
                         'carriers/ups/origin_shipment',
                         ScopeInterface::SCOPE_STORE,
                         null,
-                        'Shipments Originating in United States',
-                    ],
+                        'Shipments Originating in United States'
+                    ]
                 ]
             );
         $this->configHelper->method('getCode')
@@ -461,7 +469,7 @@ class CarrierTest extends TestCase
                 '1DM',
                 'Next Day Air Early AM',
                 '',
-                [],
+                []
             ],
             [
                 'UPS',
@@ -469,7 +477,7 @@ class CarrierTest extends TestCase
                 '1DM',
                 'Next Day Air Early AM',
                 '1DM,1DML,1DA',
-                ['1DM' => 'Next Day Air Early AM'],
+                ['1DM' => 'Next Day Air Early AM']
             ],
             [
                 'UPS_XML',
@@ -477,8 +485,8 @@ class CarrierTest extends TestCase
                 '01',
                 'UPS Next Day Air',
                 '01,02,03',
-                ['01' => 'UPS Next Day Air'],
-            ],
+                ['01' => 'UPS Next Day Air']
+            ]
         ];
     }
 
@@ -491,7 +499,7 @@ class CarrierTest extends TestCase
     {
         $xmlElFactory = $this->getMockBuilder(ElementFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $xmlElFactory->method('create')
             ->willReturnCallback(
@@ -517,7 +525,7 @@ class CarrierTest extends TestCase
     {
         $httpClientFactory = $this->getMockBuilder(ClientFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $this->httpClient = $this->getMockForAbstractClass(ClientInterface::class);
         $httpClientFactory->method('create')

--- a/app/code/Magento/User/Test/Unit/Block/Role/Grid/UserTest.php
+++ b/app/code/Magento/User/Test/Unit/Block/Role/Grid/UserTest.php
@@ -32,82 +32,95 @@ use PHPUnit\Framework\TestCase;
  */
 class UserTest extends TestCase
 {
-    /** @var User */
+    /**
+     * @var User
+     */
     protected $model;
 
-    /** @var Data|MockObject */
+    /**
+     * @var Data|MockObject
+     */
     protected $backendHelperMock;
 
-    /** @var EncoderInterface|MockObject */
+    /**
+     * @var EncoderInterface|MockObject
+     */
     protected $jsonEncoderMock;
 
-    /** @var Registry|MockObject */
+    /**
+     * @var Registry|MockObject
+     */
     protected $registryMock;
 
-    /** @var RoleFactory|MockObject */
+    /**
+     * @var RoleFactory|MockObject
+     */
     protected $roleFactoryMock;
 
-    /** @var CollectionFactory|MockObject */
+    /**
+     * @var CollectionFactory|MockObject
+     */
     protected $userRolesFactoryMock;
 
-    /** @var RequestInterface|MockObject */
+    /**
+     * @var RequestInterface|MockObject
+     */
     protected $requestInterfaceMock;
 
-    /** @var UrlInterface|MockObject */
+    /**
+     * @var UrlInterface|MockObject
+     */
     protected $urlInterfaceMock;
 
-    /** @var LayoutInterface|MockObject */
+    /**
+     * @var LayoutInterface|MockObject
+     */
     protected $layoutMock;
 
-    /** @var Filesystem|MockObject */
+    /**
+     * @var Filesystem|MockObject
+     */
     protected $filesystemMock;
 
     protected function setUp(): void
     {
         $this->backendHelperMock = $this->getMockBuilder(Data::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->jsonEncoderMock = $this->getMockBuilder(EncoderInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
 
         $this->registryMock = $this->getMockBuilder(Registry::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $this->roleFactoryMock = $this->getMockBuilder(RoleFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->userRolesFactoryMock = $this
             ->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $this->requestInterfaceMock = $this->getMockBuilder(RequestInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
 
         $this->urlInterfaceMock = $this->getMockBuilder(UrlInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
 
         $this->layoutMock = $this->getMockBuilder(LayoutInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
 
         $this->filesystemMock = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
         $objectManagerHelper = new ObjectManager($this);
@@ -127,7 +140,10 @@ class UserTest extends TestCase
         );
     }
 
-    public function testGetGridUrlSuccessfulUrl()
+    /**
+     * @return void
+     */
+    public function testGetGridUrlSuccessfulUrl(): void
     {
         $roleId = 1;
         $url = 'http://Success';
@@ -138,18 +154,20 @@ class UserTest extends TestCase
         $this->assertEquals($url, $this->model->getGridUrl());
     }
 
-    public function testGetUsersPositiveNumberOfRolesAndJsonFalse()
+    /**
+     * @return void
+     */
+    public function testGetUsersPositiveNumberOfRolesAndJsonFalse(): void
     {
         $roleId = 1;
         $roles = ['role1', 'role2', 'role3'];
         /** @var Role|MockObject */
         $roleModelMock = $this->getMockBuilder(Role::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
-        $this->requestInterfaceMock->expects($this->at(0))->method('getParam')->willReturn("");
-        $this->requestInterfaceMock->expects($this->at(1))->method('getParam')->willReturn($roleId);
+        $this->requestInterfaceMock->method('getParam')
+            ->willReturnOnConsecutiveCalls('', $roleId);
 
         $this->registryMock->expects($this->once())
             ->method('registry')
@@ -164,18 +182,20 @@ class UserTest extends TestCase
         $this->assertEquals($roles, $this->model->getUsers());
     }
 
-    public function testGetUsersPositiveNumberOfRolesAndJsonTrue()
+    /**
+     * @return void
+     */
+    public function testGetUsersPositiveNumberOfRolesAndJsonTrue(): void
     {
         $roleId = 1;
         $roles = ['role1', 'role2', 'role3'];
         /** @var Role|MockObject */
         $roleModelMock = $this->getMockBuilder(Role::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
-        $this->requestInterfaceMock->expects($this->at(0))->method('getParam')->willReturn("");
-        $this->requestInterfaceMock->expects($this->at(1))->method('getParam')->willReturn($roleId);
+        $this->requestInterfaceMock->method('getParam')
+            ->willReturnOnConsecutiveCalls('', $roleId);
 
         $this->registryMock->expects($this->once())
             ->method('registry')
@@ -188,18 +208,20 @@ class UserTest extends TestCase
         $this->assertEquals($roles, $this->model->getUsers(true));
     }
 
-    public function testGetUsersNoRolesAndJsonFalse()
+    /**
+     * @return void
+     */
+    public function testGetUsersNoRolesAndJsonFalse(): void
     {
         $roleId = 1;
         $roles = [];
         /** @var Role|MockObject */
         $roleModelMock = $this->getMockBuilder(Role::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMock();
 
-        $this->requestInterfaceMock->expects($this->at(0))->method('getParam')->willReturn("");
-        $this->requestInterfaceMock->expects($this->at(1))->method('getParam')->willReturn($roleId);
+        $this->requestInterfaceMock->method('getParam')
+            ->willReturnOnConsecutiveCalls('', $roleId);
 
         $this->registryMock->expects($this->once())
             ->method('registry')
@@ -213,16 +235,19 @@ class UserTest extends TestCase
         $this->assertEquals($roles, $this->model->getUsers());
     }
 
-    public function testPrepareColumns()
+    /**
+    * @return void
+    */
+    public function testPrepareColumns(): void
     {
         $this->requestInterfaceMock->expects($this->any())->method('getParam')->willReturn(1);
         $layoutBlockMock = $this->getMockBuilder(LayoutInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
         $blockMock = $this->getMockBuilder(AbstractBlock::class)
             ->disableOriginalConstructor()
-            ->setMethods(['setGrid', 'setId', 'setData', 'getLayout', 'getChildNames', 'isAvailable'])
+            ->onlyMethods(['setData', 'getLayout', 'getChildNames'])
+            ->addMethods(['setGrid', 'setId', 'isAvailable'])
             ->setMockClassName('mainblock')
             ->getMock();
         $blockMock->expects($this->any())->method('getLayout')->willReturn($layoutBlockMock);
@@ -238,7 +263,6 @@ class UserTest extends TestCase
         $layoutBlockMock->expects($this->any())->method('createBlock')->willReturn($blockMock);
         $directoryMock = $this->getMockBuilder(ReadInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods([])
             ->getMockForAbstractClass();
         $this->filesystemMock->expects($this->any())->method('getDirectoryRead')->willReturn($directoryMock);
         $directoryMock->expects($this->any())->method('getRelativePath')->willReturn('filename');
@@ -256,7 +280,10 @@ class UserTest extends TestCase
         $this->model->toHtml();
     }
 
-    public function testGetUsersCorrectInRoleUser()
+    /**
+     * @return void
+     */
+    public function testGetUsersCorrectInRoleUser(): void
     {
         $param = 'in_role_user';
         $paramValue = '{"a":"role1","1":"role2","2":"role3"}';
@@ -265,7 +292,10 @@ class UserTest extends TestCase
         $this->assertEquals($paramValue, $this->model->getUsers(true));
     }
 
-    public function testGetUsersIncorrectInRoleUser()
+    /**
+     * @return void
+     */
+    public function testGetUsersIncorrectInRoleUser(): void
     {
         $param = 'in_role_user';
         $paramValue = 'not_JSON';

--- a/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Controller/Index/UpdateItemOptionsTest.php
@@ -99,9 +99,7 @@ class UpdateItemOptionsTest extends TestCase
     protected $formKeyValidator;
 
     /**
-     * SetUp method
-     *
-     * @return void
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -132,9 +130,7 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * TearDown method
-     *
-     * @return void
+     * @inheritDoc
      */
     protected function tearDown(): void
     {
@@ -155,7 +151,7 @@ class UpdateItemOptionsTest extends TestCase
      *
      * @return void
      */
-    public function prepareContext()
+    public function prepareContext(): void
     {
         $actionFlag = $this->createMock(ActionFlag::class);
 
@@ -211,7 +207,10 @@ class UpdateItemOptionsTest extends TestCase
         );
     }
 
-    public function testExecuteWithInvalidFormKey()
+    /**
+     * @return void
+     */
+    public function testExecuteWithInvalidFormKey(): void
     {
         $this->prepareContext();
 
@@ -235,11 +234,11 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * Test execute without product id
+     * Test execute without product id.
      *
      * @return void
      */
-    public function testExecuteWithoutProductId()
+    public function testExecuteWithoutProductId(): void
     {
         $this->request
             ->expects($this->once())
@@ -255,11 +254,11 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * Test execute without product
+     * Test execute without product.
      *
      * @return void
      */
-    public function testExecuteWithoutProduct()
+    public function testExecuteWithoutProduct(): void
     {
         $this->request
             ->expects($this->once())
@@ -287,11 +286,11 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * Test execute without wish list
+     * Test execute without wish list.
      *
      * @return void
      */
-    public function testExecuteWithoutWishList()
+    public function testExecuteWithoutWishList(): void
     {
         $product = $this->createMock(Product::class);
         $item = $this->createMock(Item::class);
@@ -302,15 +301,9 @@ class UpdateItemOptionsTest extends TestCase
             ->willReturn(true);
 
         $this->request
-            ->expects($this->at(0))
             ->method('getParam')
-            ->with('product', null)
-            ->willReturn(2);
-        $this->request
-            ->expects($this->at(1))
-            ->method('getParam')
-            ->with('id', null)
-            ->willReturn(3);
+            ->withConsecutive(['product', null], ['id', null])
+            ->willReturnOnConsecutiveCalls(2, 3);
 
         $this->productRepository
             ->expects($this->once())
@@ -355,12 +348,12 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * Test execute add success exception
+     * Test execute add success exception.
      *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecuteAddSuccessException()
+    public function testExecuteAddSuccessException(): void
     {
         $wishlist = $this->createMock(Wishlist::class);
         $product = $this->createMock(Product::class);
@@ -401,15 +394,9 @@ class UpdateItemOptionsTest extends TestCase
             ->willReturn('Test name');
 
         $this->request
-            ->expects($this->at(0))
             ->method('getParam')
-            ->with('product', null)
-            ->willReturn(2);
-        $this->request
-            ->expects($this->at(1))
-            ->method('getParam')
-            ->with('id', null)
-            ->willReturn(3);
+            ->withConsecutive(['product', null], ['id', null])
+            ->willReturnOnConsecutiveCalls(2, 3);
 
         $this->productRepository
             ->expects($this->once())
@@ -476,12 +463,12 @@ class UpdateItemOptionsTest extends TestCase
     }
 
     /**
-     * Test execute add success critical exception
+     * Test execute add success critical exception.
      *
      * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecuteAddSuccessCriticalException()
+    public function testExecuteAddSuccessCriticalException(): void
     {
         $wishlist = $this->createMock(Wishlist::class);
         $product = $this->createMock(Product::class);
@@ -493,8 +480,7 @@ class UpdateItemOptionsTest extends TestCase
         $logger
             ->expects($this->once())
             ->method('critical')
-            ->with($exception)
-            ->willReturn(true);
+            ->with($exception);
 
         $helper
             ->expects($this->exactly(2))
@@ -530,15 +516,9 @@ class UpdateItemOptionsTest extends TestCase
             ->willReturn('Test name');
 
         $this->request
-            ->expects($this->at(0))
             ->method('getParam')
-            ->with('product', null)
-            ->willReturn(2);
-        $this->request
-            ->expects($this->at(1))
-            ->method('getParam')
-            ->with('id', null)
-            ->willReturn(3);
+            ->withConsecutive(['product', null], ['id', null])
+            ->willReturnOnConsecutiveCalls(2, 3);
 
         $this->productRepository
             ->expects($this->once())
@@ -575,20 +555,9 @@ class UpdateItemOptionsTest extends TestCase
             ->willReturn([]);
 
         $this->om
-            ->expects($this->at(1))
             ->method('get')
-            ->with(Data::class)
-            ->willReturn($helper);
-        $this->om
-            ->expects($this->at(2))
-            ->method('get')
-            ->with(Data::class)
-            ->willReturn($helper);
-        $this->om
-            ->expects($this->at(3))
-            ->method('get')
-            ->with(LoggerInterface::class)
-            ->willReturn($logger);
+            ->withConsecutive([Data::class], [Data::class], [LoggerInterface::class])
+            ->willReturnOnConsecutiveCalls($helper, $helper, $logger);
 
         $this->eventManager
             ->expects($this->once())

--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -6,12 +6,24 @@
  */
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/9.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          colors="true"
          columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="./framework/bootstrap.php"
-        >
+         bootstrap="./framework/bootstrap.php">
+    <coverage>
+        <include>
+            <directory suffix=".php">../../../app/code/*</directory>
+            <directory suffix=".php">../../../lib/internal/Magento</directory>
+            <directory suffix=".php">../../../setup/src/*</directory>
+        </include>
+        <exclude>
+            <directory>../../../app/code/*/*/Test</directory>
+            <directory>../../../lib/internal/*/*/Test</directory>
+            <directory>../../../lib/internal/*/*/*/Test</directory>
+            <directory>../../../setup/src/*/*/Test</directory>
+        </exclude>
+    </coverage>
     <testsuites>
         <testsuite name="Magento_Unit_Tests_App_Code">
             <directory>../../../app/code/*/*/Test/Unit</directory>
@@ -31,19 +43,6 @@
         <ini name="date.timezone" value="America/Los_Angeles"/>
         <ini name="xdebug.max_nesting_level" value="200"/>
     </php>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">../../../app/code/*</directory>
-            <directory suffix=".php">../../../lib/internal/Magento</directory>
-            <directory suffix=".php">../../../setup/src/*</directory>
-            <exclude>
-                <directory>../../../app/code/*/*/Test</directory>
-                <directory>../../../lib/internal/*/*/Test</directory>
-                <directory>../../../lib/internal/*/*/*/Test</directory>
-                <directory>../../../setup/src/*/*/Test</directory>
-            </exclude>
-        </whitelist>
-    </filter>
     <listeners>
         <listener class="Yandex\Allure\PhpUnit\AllurePhpUnit">
             <arguments>

--- a/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/EntityChildTestAbstract.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/Code/Generator/EntityChildTestAbstract.php
@@ -133,7 +133,7 @@ abstract class EntityChildTestAbstract extends TestCase
 
     protected function mockDefinedClassesCall()
     {
-        $this->definedClassesMock->expects($this->at(0))
+        $this->definedClassesMock
             ->method('isClassLoadable')
             ->with($this->getSourceClassName())
             ->willReturn(true);

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/FileResolverTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/FileResolverTest.php
@@ -44,6 +44,9 @@ class FileResolverTest extends TestCase
      */
     protected $moduleReader;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->iteratorFactory = $this->getMockBuilder(FileIteratorFactory::class)
@@ -64,14 +67,16 @@ class FileResolverTest extends TestCase
     }
 
     /**
-     * Test for get method with primary scope
+     * Test for get method with primary scope.
      *
-     * @dataProvider providerGet
      * @param string $filename
      * @param array $fileList
+     *
+     * @return void
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     * @dataProvider providerGet
      */
-    public function testGetPrimary($filename, $fileList)
+    public function testGetPrimary($filename, $fileList): void
     {
         $scope = 'primary';
         $directory = $this->createMock(Read::class);
@@ -84,10 +89,15 @@ class FileResolverTest extends TestCase
         )->willReturn(
             $fileList
         );
-        $i = 1;
+        $willReturnArgs = [];
+
         foreach ($fileList as $file) {
-            $directory->expects($this->at($i++))->method('getAbsolutePath')->willReturn($file);
+            $willReturnArgs[] = $file;
         }
+        $directory
+            ->method('getAbsolutePath')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
         $this->filesystem->expects(
             $this->once()
         )->method(
@@ -110,13 +120,15 @@ class FileResolverTest extends TestCase
     }
 
     /**
-     * Test for get method with global scope
+     * Test for get method with global scope.
      *
-     * @dataProvider providerGet
      * @param string $filename
      * @param array $fileList
+     *
+     * @return void
+     * @dataProvider providerGet
      */
-    public function testGetGlobal($filename, $fileList)
+    public function testGetGlobal($filename, $fileList): void
     {
         $scope = 'global';
         $this->moduleReader->expects(
@@ -132,13 +144,15 @@ class FileResolverTest extends TestCase
     }
 
     /**
-     * Test for get method with default scope
+     * Test for get method with default scope.
      *
-     * @dataProvider providerGet
      * @param string $filename
      * @param array $fileList
+     *
+     * @return void
+     * @dataProvider providerGet
      */
-    public function testGetDefault($filename, $fileList)
+    public function testGetDefault($filename, $fileList): void
     {
         $scope = 'some_scope';
         $this->moduleReader->expects(
@@ -154,11 +168,11 @@ class FileResolverTest extends TestCase
     }
 
     /**
-     * Data provider for get tests
+     * Data provider for get tests.
      *
      * @return array
      */
-    public function providerGet()
+    public function providerGet(): array
     {
         return [
             ['di.xml', ['di.xml', 'anotherfolder/di.xml']],

--- a/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
@@ -64,12 +64,12 @@ class FrontControllerTest extends TestCase
     private $requestValidator;
 
     /**
-     * @var MockObject|\MessageManager
+     * @var MockObject|MessageManager
      */
     private $messages;
 
     /**
-     * @var MockObject|\LoggerInterface
+     * @var MockObject|LoggerInterface
      */
     private $logger;
 
@@ -88,11 +88,14 @@ class FrontControllerTest extends TestCase
      */
     private $areaMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->request = $this->getMockBuilder(\Magento\Framework\App\Request\Http::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isDispatched', 'setDispatched', 'initForward', 'setActionName'])
+            ->onlyMethods(['isDispatched', 'setDispatched', 'initForward', 'setActionName'])
             ->getMock();
 
         $this->router = $this->getMockForAbstractClass(RouterInterface::class);
@@ -123,7 +126,10 @@ class FrontControllerTest extends TestCase
         );
     }
 
-    public function testDispatchThrowException()
+    /**
+    * @return void
+    */
+    public function testDispatchThrowException(): void
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Front controller reached 100 router match iterations');
@@ -150,15 +156,19 @@ class FrontControllerTest extends TestCase
 
     /**
      * Check adding validation failure message to debug log.
+     *
+     * @return void
      */
-    public function testAddingValidationFailureMessageToDebugLog()
+    public function testAddingValidationFailureMessageToDebugLog(): void
     {
         $exceptionMessage = 'exception_message';
         $exception = new InvalidRequestException($exceptionMessage);
 
         $this->appStateMock->expects($this->any())->method('getAreaCode')->willReturn('frontend');
-        $this->areaMock->expects($this->at(0))->method('load')->with(Area::PART_DESIGN)->willReturnSelf();
-        $this->areaMock->expects($this->at(1))->method('load')->with(Area::PART_TRANSLATE)->willReturnSelf();
+        $this->areaMock
+            ->method('load')
+            ->withConsecutive([Area::PART_DESIGN], [Area::PART_TRANSLATE])
+            ->willReturnOnConsecutiveCalls($this->areaMock, $this->areaMock);
         $this->areaListMock->expects($this->any())->method('getArea')->willReturn($this->areaMock);
         $this->routerList->expects($this->any())
             ->method('valid')
@@ -172,22 +182,21 @@ class FrontControllerTest extends TestCase
             ->method('dispatch')
             ->with($this->request)
             ->willReturn($response);
-        $this->router->expects($this->at(0))
+        $this->router
             ->method('match')
-            ->with($this->request)
-            ->willReturn(false);
-        $this->router->expects($this->at(1))
-            ->method('match')
-            ->with($this->request)
-            ->willReturn($controllerInstance);
+            ->withConsecutive([$this->request], [$this->request])
+            ->willReturnOnConsecutiveCalls(false, $controllerInstance);
 
         $this->routerList->expects($this->any())
             ->method('current')
             ->willReturn($this->router);
 
-        $this->request->expects($this->at(0))->method('isDispatched')->willReturn(false);
-        $this->request->expects($this->at(1))->method('setDispatched')->with(true);
-        $this->request->expects($this->at(2))->method('isDispatched')->willReturn(true);
+        $this->request
+            ->method('isDispatched')
+            ->willReturnOnConsecutiveCalls(false, true);
+        $this->request
+            ->method('setDispatched')
+            ->withConsecutive([true]);
 
         $this->requestValidator->expects($this->once())
             ->method('validate')->with($this->request, $controllerInstance)->willThrowException($exception);
@@ -200,7 +209,10 @@ class FrontControllerTest extends TestCase
         $this->assertEquals($exceptionMessage, $this->model->dispatch($this->request));
     }
 
-    public function testDispatched()
+    /**
+    * @return void
+    */
+    public function testDispatched(): void
     {
         $this->routerList->expects($this->any())
             ->method('valid')
@@ -214,30 +226,34 @@ class FrontControllerTest extends TestCase
             ->method('dispatch')
             ->with($this->request)
             ->willReturn($response);
-        $this->router->expects($this->at(0))
+        $this->router
             ->method('match')
-            ->with($this->request)
-            ->willReturn(false);
-        $this->router->expects($this->at(1))
-            ->method('match')
-            ->with($this->request)
-            ->willReturn($controllerInstance);
+            ->withConsecutive([$this->request], [$this->request])
+            ->willReturnOnConsecutiveCalls(false, $controllerInstance);
 
         $this->routerList->expects($this->any())
             ->method('current')
             ->willReturn($this->router);
         $this->appStateMock->expects($this->any())->method('getAreaCode')->willReturn('frontend');
-        $this->areaMock->expects($this->at(0))->method('load')->with(Area::PART_DESIGN)->willReturnSelf();
-        $this->areaMock->expects($this->at(1))->method('load')->with(Area::PART_TRANSLATE)->willReturnSelf();
+        $this->areaMock
+            ->method('load')
+            ->withConsecutive([Area::PART_DESIGN], [Area::PART_TRANSLATE])
+            ->willReturnOnConsecutiveCalls($this->areaMock, $this->areaMock);
         $this->areaListMock->expects($this->any())->method('getArea')->willReturn($this->areaMock);
-        $this->request->expects($this->at(0))->method('isDispatched')->willReturn(false);
-        $this->request->expects($this->at(1))->method('setDispatched')->with(true);
-        $this->request->expects($this->at(2))->method('isDispatched')->willReturn(true);
+        $this->request
+            ->method('isDispatched')
+            ->willReturnOnConsecutiveCalls(false, true);
+        $this->request
+            ->method('setDispatched')
+            ->with(true);
 
         $this->assertEquals($response, $this->model->dispatch($this->request));
     }
 
-    public function testDispatchedNotFoundException()
+    /**
+    * @return void
+    */
+    public function testDispatchedNotFoundException(): void
     {
         $this->routerList->expects($this->any())
             ->method('valid')
@@ -251,30 +267,35 @@ class FrontControllerTest extends TestCase
             ->method('dispatch')
             ->with($this->request)
             ->willReturn($response);
-        $this->router->expects($this->at(0))
+        $this->router
             ->method('match')
-            ->with($this->request)
-            ->willThrowException(new NotFoundException(new Phrase('Page not found.')));
-        $this->router->expects($this->at(1))
-            ->method('match')
-            ->with($this->request)
-            ->willReturn($controllerInstance);
+            ->withConsecutive([$this->request], [$this->request])
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new NotFoundException(new Phrase('Page not found.'))),
+                $controllerInstance
+            );
 
         $this->routerList->expects($this->any())
             ->method('current')
             ->willReturn($this->router);
 
         $this->appStateMock->expects($this->any())->method('getAreaCode')->willReturn('frontend');
-        $this->areaMock->expects($this->at(0))->method('load')->with(Area::PART_DESIGN)->willReturnSelf();
-        $this->areaMock->expects($this->at(1))->method('load')->with(Area::PART_TRANSLATE)->willReturnSelf();
+        $this->areaMock
+            ->method('load')
+            ->withConsecutive([Area::PART_DESIGN], [Area::PART_TRANSLATE])
+            ->willReturnOnConsecutiveCalls($this->areaMock, $this->areaMock);
         $this->areaListMock->expects($this->any())->method('getArea')->willReturn($this->areaMock);
-        $this->request->expects($this->at(0))->method('isDispatched')->willReturn(false);
-        $this->request->expects($this->at(1))->method('initForward');
-        $this->request->expects($this->at(2))->method('setActionName')->with('noroute');
-        $this->request->expects($this->at(3))->method('setDispatched')->with(false);
-        $this->request->expects($this->at(4))->method('isDispatched')->willReturn(false);
-        $this->request->expects($this->at(5))->method('setDispatched')->with(true);
-        $this->request->expects($this->at(6))->method('isDispatched')->willReturn(true);
+        $this->request
+            ->method('isDispatched')
+            ->willReturnOnConsecutiveCalls(false, false, true);
+        $this->request
+            ->method('setDispatched')
+            ->withConsecutive([false], [true]);
+        $this->request
+            ->method('setActionName')
+            ->with('noroute');
+        $this->request
+            ->method('initForward');
 
         $this->assertEquals($response, $this->model->dispatch($this->request));
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Language/DictionaryTest.php
@@ -38,18 +38,24 @@ class DictionaryTest extends TestCase
      */
     private $configFactory;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->readFactory = $this->createMock(ReadFactory::class);
         $this->componentRegistrar = $this->createMock(ComponentRegistrar::class);
         $this->configFactory = $this->getMockBuilder(ConfigFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->model = new Dictionary($this->readFactory, $this->componentRegistrar, $this->configFactory);
     }
 
-    public function testDictionaryGetter()
+    /**
+    * @return void
+    */
+    public function testDictionaryGetter(): void
     {
         $csvFileName = 'abc.csv';
         $data = [['one', '1'], ['two', '2']];
@@ -59,10 +65,15 @@ class DictionaryTest extends TestCase
         }
 
         $file = $this->getMockForAbstractClass(ReadInterface::class);
+        $willReturnArgs = [];
+
         for ($i = 0, $count = count($data); $i < $count; $i++) {
-            $file->expects($this->at($i))->method('readCsv')->willReturn($data[$i]);
+            $willReturnArgs[] = $data[$i];
         }
-        $file->expects($this->at($i))->method('readCsv')->willReturn(false);
+        $willReturnArgs[] = false;
+        $file
+            ->method('readCsv')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $readMock = $this->getMockForAbstractClass(\Magento\Framework\Filesystem\Directory\ReadInterface::class);
         $readMock->expects($this->any())->method('readFile')->willReturnMap([

--- a/lib/internal/Magento/Framework/App/Test/Unit/PageCache/KernelTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/PageCache/KernelTest.php
@@ -26,41 +26,63 @@ use PHPUnit\Framework\TestCase;
  */
 class KernelTest extends TestCase
 {
-    /** @var Kernel */
+    /**
+     * @var Kernel
+     */
     protected $kernel;
 
-    /** @var Cache|MockObject */
+    /**
+     * @var Cache|MockObject
+     */
     protected $cacheMock;
 
-    /** @var Identifier|MockObject */
+    /**
+     * @var Identifier|MockObject
+     */
     protected $identifierMock;
 
-    /** @var Http|MockObject */
+    /**
+     * @var Http|MockObject
+     */
     protected $requestMock;
 
-    /** @var \Magento\Framework\App\Response\Http|MockObject */
+    /**
+     * @var \Magento\Framework\App\Response\Http|MockObject
+     */
     protected $responseMock;
 
-    /** @var  MockObject|Type */
+    /**
+     * @var MockObject|Type
+     */
     private $fullPageCacheMock;
 
-    /** @var \Magento\Framework\App\Response\Http|MockObject */
+    /**
+     * @var \Magento\Framework\App\Response\Http|MockObject
+     */
     private $httpResponseMock;
 
-    /** @var ContextFactory|MockObject */
+    /**
+     * @var ContextFactory|MockObject
+     */
     private $contextFactoryMock;
 
-    /** @var HttpFactory|MockObject */
+    /**
+     * @var HttpFactory|MockObject
+     */
     private $httpFactoryMock;
 
-    /** @var SerializerInterface|MockObject */
+    /**
+     * @var SerializerInterface|MockObject
+     */
     private $serializer;
 
-    /** @var Context|MockObject */
+    /**
+     * @var Context|MockObject
+     */
     private $contextMock;
 
     /**
-     * Setup
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -94,13 +116,15 @@ class KernelTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForResultWithCachedData
      * @param string $id
      * @param mixed $cache
      * @param bool $isGet
      * @param bool $isHead
+     *
+     * @return void
+     * @dataProvider dataProviderForResultWithCachedData
      */
-    public function testLoadWithCachedData($id, $cache, $isGet, $isHead)
+    public function testLoadWithCachedData($id, $cache, $isGet, $isHead): void
     {
         $this->serializer->expects($this->once())
             ->method('unserialize')
@@ -148,7 +172,7 @@ class KernelTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForResultWithCachedData()
+    public function dataProviderForResultWithCachedData(): array
     {
         $data = [
             'context' => [
@@ -162,18 +186,20 @@ class KernelTest extends TestCase
 
         return [
             ['existing key', $data, true, false],
-            ['existing key', $data, false, true],
+            ['existing key', $data, false, true]
         ];
     }
 
     /**
-     * @dataProvider dataProviderForResultWithoutCachedData
      * @param string $id
      * @param mixed $cache
      * @param bool $isGet
      * @param bool $isHead
+     *
+     * @return void
+     * @dataProvider dataProviderForResultWithoutCachedData
      */
-    public function testLoadWithoutCachedData($id, $cache, $isGet, $isHead)
+    public function testLoadWithoutCachedData($id, $cache, $isGet, $isHead): void
     {
         $this->requestMock->expects($this->once())->method('isGet')->willReturn($isGet);
         $this->requestMock->expects($this->any())->method('isHead')->willReturn($isHead);
@@ -193,7 +219,7 @@ class KernelTest extends TestCase
     /**
      * @return array
      */
-    public function dataProviderForResultWithoutCachedData()
+    public function dataProviderForResultWithoutCachedData(): array
     {
         return [
             ['existing key', [], false, false],
@@ -204,9 +230,11 @@ class KernelTest extends TestCase
 
     /**
      * @param $httpCode
+     *
+     * @return void
      * @dataProvider testProcessSaveCacheDataProvider
      */
-    public function testProcessSaveCache($httpCode, $at)
+    public function testProcessSaveCache($httpCode, $at): void
     {
         $this->serializer->expects($this->once())
             ->method('serialize')
@@ -220,15 +248,10 @@ class KernelTest extends TestCase
             'Cache-Control: public, max-age=100, s-maxage=100'
         );
 
-        $this->responseMock->expects(
-            $this->at(0)
-        )->method(
-            'getHeader'
-        )->with(
-            'Cache-Control'
-        )->willReturn(
-            $cacheControlHeader
-        );
+        $this->responseMock
+            ->method('getHeader')
+            ->withConsecutive(['Cache-Control'], ['X-Magento-Tags'])
+            ->willReturn($cacheControlHeader,null);
         $this->responseMock->expects(
             $this->any()
         )->method(
@@ -239,15 +262,9 @@ class KernelTest extends TestCase
             ->willReturn(true);
         $this->responseMock->expects($this->once())
             ->method('setNoCacheHeaders');
-        $this->responseMock->expects($this->at($at[0]))
-            ->method('getHeader')
-            ->with('X-Magento-Tags');
-        $this->responseMock->expects($this->at($at[1]))
+        $this->responseMock
             ->method('clearHeader')
-            ->with('Set-Cookie');
-        $this->responseMock->expects($this->at($at[2]))
-            ->method('clearHeader')
-            ->with('X-Magento-Tags');
+            ->withConsecutive(['Set-Cookie'], ['X-Magento-Tags']);
         $this->fullPageCacheMock->expects($this->once())
             ->method('save');
         $this->kernel->process($this->responseMock);
@@ -256,7 +273,7 @@ class KernelTest extends TestCase
     /**
      * @return array
      */
-    public function testProcessSaveCacheDataProvider()
+    public function testProcessSaveCacheDataProvider(): array
     {
         return [
             [200, [3, 4, 5]],
@@ -265,13 +282,15 @@ class KernelTest extends TestCase
     }
 
     /**
-     * @dataProvider processNotSaveCacheProvider
      * @param string $cacheControlHeader
      * @param int $httpCode
      * @param bool $isGet
      * @param bool $overrideHeaders
+     *
+     * @return void
+     * @dataProvider processNotSaveCacheProvider
      */
-    public function testProcessNotSaveCache($cacheControlHeader, $httpCode, $isGet, $overrideHeaders)
+    public function testProcessNotSaveCache($cacheControlHeader, $httpCode, $isGet, $overrideHeaders): void
     {
         $header = CacheControl::fromString("Cache-Control: $cacheControlHeader");
         $this->responseMock->expects(
@@ -295,7 +314,7 @@ class KernelTest extends TestCase
     /**
      * @return array
      */
-    public function processNotSaveCacheProvider()
+    public function processNotSaveCacheProvider(): array
     {
         return [
             ['private, max-age=100', 200, true, false],

--- a/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Response/Http/FileFactoryTest.php
@@ -39,6 +39,9 @@ class FileFactoryTest extends TestCase
      */
     protected $dirMock;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -74,13 +77,19 @@ class FileFactoryTest extends TestCase
         );
     }
 
-    public function testCreateIfContentDoesntHaveRequiredKeys()
+    /**
+    * @return void
+    */
+    public function testCreateIfContentDoesntHaveRequiredKeys(): void
     {
         $this->expectException('InvalidArgumentException');
         $this->getModel()->create('fileName', []);
     }
 
-    public function testCreateIfFileNotExist()
+    /**
+    * @return void
+    */
+    public function testCreateIfFileNotExist(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('File not found');
@@ -100,7 +109,10 @@ class FileFactoryTest extends TestCase
         $this->getModel()->create('fileName', $content);
     }
 
-    public function testCreateArrayContent()
+    /**
+    * @return void
+    */
+    public function testCreateArrayContent(): void
     {
         $file = 'some_file';
         $content = ['type' => 'filename', 'value' => $file];
@@ -128,12 +140,9 @@ class FileFactoryTest extends TestCase
         $this->dirMock->expects($this->never())
             ->method('delete')
             ->willReturn($streamMock);
-        $streamMock->expects($this->at(1))
+        $streamMock
             ->method('eof')
-            ->willReturn(false);
-        $streamMock->expects($this->at(2))
-            ->method('eof')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, true);
         $streamMock->expects($this->once())
             ->method('read');
         $streamMock->expects($this->once())
@@ -141,7 +150,10 @@ class FileFactoryTest extends TestCase
         $this->getModelMock()->create('fileName', $content);
     }
 
-    public function testCreateArrayContentRm()
+    /**
+    * @return void
+    */
+    public function testCreateArrayContentRm(): void
     {
         $file = 'some_file';
         $content = ['type' => 'filename', 'value' => $file, 'rm' => 1];
@@ -169,12 +181,9 @@ class FileFactoryTest extends TestCase
         $this->dirMock->expects($this->once())
             ->method('delete')
             ->willReturn($streamMock);
-        $streamMock->expects($this->at(1))
+        $streamMock
             ->method('eof')
-            ->willReturn(false);
-        $streamMock->expects($this->at(2))
-            ->method('eof')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, true);
         $streamMock->expects($this->once())
             ->method('read');
         $streamMock->expects($this->once())
@@ -182,7 +191,10 @@ class FileFactoryTest extends TestCase
         $this->getModelMock()->create('fileName', $content);
     }
 
-    public function testCreateStringContent()
+    /**
+    * @return void
+    */
+    public function testCreateStringContent(): void
     {
         $this->dirMock->expects($this->never())
             ->method('isFile')
@@ -215,9 +227,9 @@ class FileFactoryTest extends TestCase
     }
 
     /**
-     * Get model
+     * Get model.
      *
-     * @return FileFactory
+     * @return FileFactory|object
      */
     private function getModel()
     {
@@ -225,24 +237,24 @@ class FileFactoryTest extends TestCase
             FileFactory::class,
             [
                 'response' => $this->responseMock,
-                'filesystem' => $this->fileSystemMock,
+                'filesystem' => $this->fileSystemMock
             ]
         );
     }
 
     /**
-     * Get model mock
+     * Get model mock.
      *
      * @return FileFactory|MockObject
      */
-    private function getModelMock()
+    private function getModelMock(): MockObject
     {
         $modelMock = $this->getMockBuilder(FileFactory::class)
-            ->setMethods(null)
+            ->onlyMethods([])
             ->setConstructorArgs(
                 [
                     'response' => $this->responseMock,
-                    'filesystem' => $this->fileSystemMock,
+                    'filesystem' => $this->fileSystemMock
                 ]
             )
             ->getMock();

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/RemoteSynchronizedCacheTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Backend/RemoteSynchronizedCacheTest.php
@@ -36,6 +36,9 @@ class RemoteSynchronizedCacheTest extends TestCase
      */
     private $remoteSyncCacheInstance;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -54,8 +57,8 @@ class RemoteSynchronizedCacheTest extends TestCase
             [
                 'options' => [
                     'remote_backend' => $this->remoteCacheMockExample,
-                    'local_backend' => $this->localCacheMockExample,
-                ],
+                    'local_backend' => $this->localCacheMockExample
+                ]
             ]
         );
     }
@@ -65,6 +68,7 @@ class RemoteSynchronizedCacheTest extends TestCase
      *
      * @param array $options
      *
+     * @return void
      * @dataProvider initializeWithExceptionDataProvider
      */
     public function testInitializeWithException($options): void
@@ -73,7 +77,7 @@ class RemoteSynchronizedCacheTest extends TestCase
         $this->objectManager->getObject(
             RemoteSynchronizedCache::class,
             [
-                'options' => $options,
+                'options' => $options
             ]
         );
     }
@@ -87,21 +91,21 @@ class RemoteSynchronizedCacheTest extends TestCase
             'empty_backend_option' => [
                 'options' => [
                     'remote_backend' => null,
-                    'local_backend' => null,
-                ],
+                    'local_backend' => null
+                ]
             ],
             'empty_remote_backend_option' => [
                 'options' => [
                     'remote_backend' => Database::class,
-                    'local_backend' => null,
-                ],
+                    'local_backend' => null
+                ]
             ],
             'empty_local_backend_option' => [
                 'options' => [
                     'remote_backend' => null,
-                    'local_backend' => \Cm_Cache_Backend_File::class,
-                ],
-            ],
+                    'local_backend' => \Cm_Cache_Backend_File::class
+                ]
+            ]
         ];
     }
 
@@ -110,6 +114,7 @@ class RemoteSynchronizedCacheTest extends TestCase
      *
      * @param array $options
      *
+     * @return void
      * @dataProvider initializeWithOutExceptionDataProvider
      */
     public function testInitializeWithOutException($options): void
@@ -117,7 +122,7 @@ class RemoteSynchronizedCacheTest extends TestCase
         $result = $this->objectManager->getObject(
             RemoteSynchronizedCache::class,
             [
-                'options' => $options,
+                'options' => $options
             ]
         );
         $this->assertInstanceOf(RemoteSynchronizedCache::class, $result);
@@ -143,14 +148,14 @@ class RemoteSynchronizedCacheTest extends TestCase
                         'tags_table' => 'tags_table',
                         'tags_table_callback' => 'tags_table_callback',
                         'store_data' => '',
-                        'adapter' => $connectionMock,
+                        'adapter' => $connectionMock
                     ],
                     'local_backend' => \Cm_Cache_Backend_File::class,
                     'local_backend_options' => [
-                        'cache_dir' => '/tmp',
-                    ],
-                ],
-            ],
+                        'cache_dir' => '/tmp'
+                    ]
+                ]
+            ]
         ];
     }
 
@@ -165,19 +170,12 @@ class RemoteSynchronizedCacheTest extends TestCase
         $remoteData = 2;
 
         $this->localCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($localData);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
-            ->willReturn(\hash('sha256', (string)$remoteData));
-
-        $this->remoteCacheMockExample
-            ->expects($this->at(1))
-            ->method('load')
-            ->willReturn($remoteData);
+            ->willReturnOnConsecutiveCalls(\hash('sha256', (string)$remoteData), $remoteData);
 
         $this->localCacheMockExample
             ->expects($this->atLeastOnce())
@@ -199,12 +197,10 @@ class RemoteSynchronizedCacheTest extends TestCase
         $remoteData = false;
 
         $this->localCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($localData);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($remoteData);
 
@@ -227,7 +223,6 @@ class RemoteSynchronizedCacheTest extends TestCase
             ->willReturn($localData);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($remoteData);
 
@@ -250,12 +245,10 @@ class RemoteSynchronizedCacheTest extends TestCase
         $remoteData = 1;
 
         $this->localCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($localData);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn(\hash('sha256', (string)$remoteData));
 
@@ -272,14 +265,8 @@ class RemoteSynchronizedCacheTest extends TestCase
         $localData = 1;
 
         $this->localCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn($localData);
-
-        $this->remoteCacheMockExample
-            ->expects($this->at(0))
-            ->method('load')
-            ->willReturn(false);
 
         $closure = \Closure::bind(function ($cacheInstance) {
             $cacheInstance->_options['use_stale_cache'] = true;
@@ -287,9 +274,8 @@ class RemoteSynchronizedCacheTest extends TestCase
         $closure($this->remoteSyncCacheInstance);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(2))
             ->method('load')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(false, true);
 
         $this->assertEquals($localData, $this->remoteSyncCacheInstance->load(1));
     }
@@ -304,24 +290,13 @@ class RemoteSynchronizedCacheTest extends TestCase
         $localData = 1;
 
         $this->localCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
-            ->willReturn($localData);
-
-        $this->remoteCacheMockExample
-            ->expects($this->at(0))
-            ->method('load')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls($localData);
 
         $closure = \Closure::bind(function ($cacheInstance) {
             $cacheInstance->_options['use_stale_cache'] = true;
         }, null, $this->remoteSyncCacheInstance);
         $closure($this->remoteSyncCacheInstance);
-
-        $this->remoteCacheMockExample
-            ->expects($this->at(2))
-            ->method('load')
-            ->willReturn(false);
 
         $closure = \Closure::bind(function ($cacheInstance) {
             return $cacheInstance->lockSign;
@@ -329,9 +304,8 @@ class RemoteSynchronizedCacheTest extends TestCase
         $lockSign = $closure($this->remoteSyncCacheInstance);
 
         $this->remoteCacheMockExample
-            ->expects($this->at(4))
             ->method('load')
-            ->willReturn($lockSign);
+            ->willReturnOnConsecutiveCalls(null, false, false, $lockSign);
 
         $this->assertEquals(false, $this->remoteSyncCacheInstance->load(1));
     }
@@ -381,14 +355,8 @@ class RemoteSynchronizedCacheTest extends TestCase
         $remoteData = 1;
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
-            ->willReturn(\hash('sha256', (string)$remoteData));
-
-        $this->remoteCacheMockExample
-            ->expects($this->at(1))
-            ->method('load')
-            ->willReturn($remoteData);
+            ->willReturnOnConsecutiveCalls(\hash('sha256', (string)$remoteData), $remoteData);
 
         $this->localCacheMockExample
             ->expects($this->once())
@@ -398,12 +366,14 @@ class RemoteSynchronizedCacheTest extends TestCase
         $this->remoteSyncCacheInstance->save($remoteData, 1);
     }
 
-    public function testSaveWithMismatchedRemoteData()
+    /**
+    * @return void
+    */
+    public function testSaveWithMismatchedRemoteData(): void
     {
         $remoteData = '1';
 
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn(\hash('sha256', $remoteData));
 
@@ -421,7 +391,6 @@ class RemoteSynchronizedCacheTest extends TestCase
     public function testSaveWithoutRemoteData(): void
     {
         $this->remoteCacheMockExample
-            ->expects($this->at(0))
             ->method('load')
             ->willReturn(false);
 

--- a/lib/internal/Magento/Framework/Composer/Test/Unit/DependencyCheckerTest.php
+++ b/lib/internal/Magento/Framework/Composer/Test/Unit/DependencyCheckerTest.php
@@ -14,7 +14,10 @@ use PHPUnit\Framework\TestCase;
 
 class DependencyCheckerTest extends TestCase
 {
-    public function testCheckDependencies()
+    /**
+    * @return void
+    */
+    public function testCheckDependencies(): void
     {
         $composerApp =
             $this->createPartialMock(Application::class, ['setAutoExit', 'resetComposer', 'run']);
@@ -22,21 +25,25 @@ class DependencyCheckerTest extends TestCase
         $directoryList->expects($this->exactly(2))->method('getRoot');
         $composerApp->expects($this->once())->method('setAutoExit')->with(false);
 
-        $composerApp->expects($this->at(2))->method('run')->willReturnCallback(
-            function ($input, $buffer) {
-                $output = 'magento/package-b requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/package-c requires magento/package-a (1.0)' . PHP_EOL;
-                $buffer->writeln($output);
-            }
-        );
-        $composerApp->expects($this->at(4))->method('run')->willReturnCallback(
-            function ($input, $buffer) {
-                $output = 'magento/package-c requires magento/package-b (1.0)' . PHP_EOL .
-                    'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/package-d requires magento/package-b (1.0)' . PHP_EOL;
-                $buffer->writeln($output);
-            }
+        $composerApp
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(
+                $this->returnCallback(
+                    function ($input, $buffer) {
+                        $output = 'magento/package-b requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/package-c requires magento/package-a (1.0)' . PHP_EOL;
+                        $buffer->writeln($output);
+                    }
+                ),
+                $this->returnCallback(
+                    function ($input, $buffer) {
+                        $output = 'magento/package-c requires magento/package-b (1.0)' . PHP_EOL .
+                            'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/package-d requires magento/package-b (1.0)' . PHP_EOL;
+                        $buffer->writeln($output);
+                    }
+                )
         );
 
         $dependencyChecker = new DependencyChecker($composerApp, $directoryList);
@@ -50,7 +57,10 @@ class DependencyCheckerTest extends TestCase
         );
     }
 
-    public function testCheckDependenciesExcludeSelf()
+    /**
+    * @return void
+    */
+    public function testCheckDependenciesExcludeSelf(): void
     {
         $composerApp =
             $this->createPartialMock(Application::class, ['setAutoExit', 'resetComposer', 'run']);
@@ -58,35 +68,39 @@ class DependencyCheckerTest extends TestCase
         $directoryList->expects($this->exactly(3))->method('getRoot');
         $composerApp->expects($this->once())->method('setAutoExit')->with(false);
 
-        $composerApp->expects($this->at(2))->method('run')->willReturnCallback(
-            function ($input, $buffer) {
-                $output = 'magento/package-b requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/package-c requires magento/package-a (1.0)' . PHP_EOL;
-                $buffer->writeln($output);
-            }
-        );
-        $composerApp->expects($this->at(4))->method('run')->willReturnCallback(
-            function ($input, $buffer) {
-                $output = 'magento/package-c requires magento/package-b (1.0)' . PHP_EOL .
-                    'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
-                    'magento/package-d requires magento/package-b (1.0)' . PHP_EOL;
-                $buffer->writeln($output);
-            }
-        );
-        $composerApp->expects($this->at(6))->method('run')->willReturnCallback(
-            function ($input, $buffer) {
-                $output = 'magento/package-d requires magento/package-c (1.0)' . PHP_EOL .
-                    'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL;
-                $buffer->writeln($output);
-            }
-        );
+        $composerApp
+            ->method('run')
+            ->willReturnOnConsecutiveCalls(
+                $this->returnCallback(
+                    function ($input, $buffer) {
+                        $output = 'magento/package-b requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/package-c requires magento/package-a (1.0)' . PHP_EOL;
+                        $buffer->writeln($output);
+                    }
+                ),
+                $this->returnCallback(
+                    function ($input, $buffer) {
+                        $output = 'magento/package-c requires magento/package-b (1.0)' . PHP_EOL .
+                            'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL .
+                            'magento/package-d requires magento/package-b (1.0)' . PHP_EOL;
+                        $buffer->writeln($output);
+                    }
+                ),
+                $this->returnCallback(
+                    function ($input, $buffer) {
+                        $output = 'magento/package-d requires magento/package-c (1.0)' . PHP_EOL .
+                            'magento/project-community-edition requires magento/package-a (1.0)' . PHP_EOL;
+                        $buffer->writeln($output);
+                    }
+                )
+            );
 
         $dependencyChecker = new DependencyChecker($composerApp, $directoryList);
         $expected = [
             'magento/package-a' => [],
             'magento/package-b' => ['magento/package-d'],
-            'magento/package-c' => ['magento/package-d'],
+            'magento/package-c' => ['magento/package-d']
         ];
         $this->assertEquals(
             $expected,

--- a/lib/internal/Magento/Framework/Config/Test/Unit/FileIteratorTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/FileIteratorTest.php
@@ -37,6 +37,9 @@ class FileIteratorTest extends TestCase
      */
     protected $fileReadFactory;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->filePaths = ['/file1', '/file2'];
@@ -45,46 +48,66 @@ class FileIteratorTest extends TestCase
         $this->fileIterator = new FileIterator($this->fileReadFactory, $this->filePaths);
     }
 
+    /**
+     * @inheritDoc
+     */
     protected function tearDown(): void
     {
         $this->fileIterator = null;
         $this->filePaths = null;
     }
 
-    public function testIterator()
+    /**
+    * @return void
+    */
+    public function testIterator(): void
     {
         $contents = ['content1', 'content2'];
+        $createWithArgs = $createWillReturnArgs = $readAllWillReturnArgs = [];
         $index = 0;
+
         foreach ($this->filePaths as $filePath) {
-            $this->fileReadFactory->expects($this->at($index))
-                ->method('create')
-                ->with($filePath)
-                ->willReturn($this->fileRead);
-            $this->fileRead->expects($this->at($index))
-                ->method('readAll')
-                ->willReturn($contents[$index++]);
+            $createWithArgs[] = [$filePath];
+            $createWillReturnArgs[] = $this->fileRead;
+            $readAllWillReturnArgs[] = $contents[$index++];
         }
+        $this->fileReadFactory
+            ->method('create')
+            ->withConsecutive(...$createWithArgs)
+            ->willReturnOnConsecutiveCalls(...$createWillReturnArgs);
+        $this->fileRead
+            ->method('readAll')
+            ->willReturnOnConsecutiveCalls(...$readAllWillReturnArgs);
         $index = 0;
+
         foreach ($this->fileIterator as $fileContent) {
             $this->assertEquals($contents[$index++], $fileContent);
         }
     }
 
-    public function testToArray()
+    /**
+    * @return void
+    */
+    public function testToArray(): void
     {
         $contents = ['content1', 'content2'];
         $expectedArray = [];
+        $createWithArgs = $createWillReturnArgs = $readAllWillReturnArgs = [];
         $index = 0;
         foreach ($this->filePaths as $filePath) {
             $expectedArray[$filePath] = $contents[$index];
-            $this->fileReadFactory->expects($this->at($index))
-                ->method('create')
-                ->with($filePath)
-                ->willReturn($this->fileRead);
-            $this->fileRead->expects($this->at($index))
-                ->method('readAll')
-                ->willReturn($contents[$index++]);
+            $createWithArgs[] = [$filePath];
+            $createWillReturnArgs[] = $this->fileRead;
+            $readAllWillReturnArgs[] = $contents[$index++];
         }
+        $this->fileReadFactory
+            ->method('create')
+            ->withConsecutive(...$createWithArgs)
+            ->willReturnOnConsecutiveCalls(...$createWillReturnArgs);
+        $this->fileRead
+            ->method('readAll')
+            ->willReturnOnConsecutiveCalls(...$readAllWillReturnArgs);
+
         $this->assertEquals($expectedArray, $this->fileIterator->toArray());
     }
 }

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexStructureTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/IndexStructureTest.php
@@ -48,28 +48,27 @@ class IndexStructureTest extends TestCase
      */
     private $target;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->connectionInterface = $this->getMockBuilder(AdapterInterface::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->resource = $this->getMockBuilder(ResourceConnection::class)
-            ->setMethods(['getConnection'])
+            ->onlyMethods(['getConnection'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->resource->expects($this->atLeastOnce())
             ->method('getConnection')
             ->willReturn($this->connectionInterface);
-        $this->indexScopeResolver = $this->getMockBuilder(
-            IndexScopeResolver::class
-        )
-            ->setMethods(['resolve'])
+        $this->indexScopeResolver = $this->getMockBuilder(IndexScopeResolver::class)
+            ->onlyMethods(['resolve'])
             ->disableOriginalConstructor()
             ->getMock();
-        $this->flatScopeResolver = $this->getMockBuilder(
-            FlatScopeResolver::class
-        )
-            ->setMethods(['resolve'])
+        $this->flatScopeResolver = $this->getMockBuilder(FlatScopeResolver::class)
+            ->onlyMethods(['resolve'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -86,17 +85,15 @@ class IndexStructureTest extends TestCase
     }
 
     /**
-     * @param string $table
-     * @param array $dimensions
-     * @param bool $isTableExist
+     * @return void
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $index = 'index_name';
         $dimensions = [
             'index_name_scope_3' => $this->createDimensionMock('scope', 3),
             'index_name_scope_5' => $this->createDimensionMock('scope', 5),
-            'index_name_scope_1' => $this->createDimensionMock('scope', 1),
+            'index_name_scope_1' => $this->createDimensionMock('scope', 1)
         ];
         $expectedTable = 'index_name_scope3_scope5_scope1';
         $this->indexScopeResolver->expects($this->once())
@@ -107,48 +104,56 @@ class IndexStructureTest extends TestCase
             ->method('resolve')
             ->with($index, $dimensions)
             ->willReturn($index . '_flat');
-        $position = 0;
-        $position = $this->mockDropTable($position, $expectedTable, true);
-        $this->mockDropTable($position, $index . '_flat', true);
+        $this->connectionInterface
+            ->method('isTableExists')
+            ->withConsecutive([$expectedTable], [$index . '_flat'])
+            ->willReturn(true, true);
+        $this->connectionInterface
+            ->method('dropTable')
+            ->withConsecutive([$expectedTable], [$index . '_flat'])
+            ->willReturnOnConsecutiveCalls(true, true);
 
         $this->target->delete($index, $dimensions);
     }
 
-    public function testCreateWithEmptyFields()
+    /**
+    * @return void
+    */
+    public function testCreateWithEmptyFields(): void
     {
         $fields = [
             [
                 'name' => 'fieldName1',
                 'type' => 'fieldType1',
-                'size' => 'fieldSize1',
+                'size' => 'fieldSize1'
             ],
             [
                 'name' => 'fieldName2',
                 'type' => 'fieldType2',
-                'size' => 'fieldSize2',
+                'size' => 'fieldSize2'
             ],
             [
                 'name' => 'fieldName3',
                 'type' => 'fieldType3',
-                'size' => 'fieldSize3',
+                'size' => 'fieldSize3'
             ],
             [
                 'name' => 'fieldName3',
                 'dataType' => 'varchar',
                 'type' => 'text',
-                'size' => '255',
+                'size' => '255'
             ],
             [
                 'name' => 'fieldName3',
                 'dataType' => 'mediumtext',
                 'type' => 'text',
-                'size' => '16777216',
+                'size' => '16777216'
             ],
             [
                 'name' => 'fieldName3',
                 'dataType' => 'text',
                 'type' => 'text',
-                'size' => '65536',
+                'size' => '65536'
             ]
         ];
         $index = 'index_name';
@@ -156,9 +161,8 @@ class IndexStructureTest extends TestCase
         $dimensions = [
             'index_name_scope_3' => $this->createDimensionMock('scope', 3),
             'index_name_scope_5' => $this->createDimensionMock('scope', 5),
-            'index_name_scope_1' => $this->createDimensionMock('scope', 1),
+            'index_name_scope_1' => $this->createDimensionMock('scope', 1)
         ];
-        $position = 0;
         $this->indexScopeResolver->expects($this->once())
             ->method('resolve')
             ->with($index, $dimensions)
@@ -167,8 +171,17 @@ class IndexStructureTest extends TestCase
             ->method('resolve')
             ->with($index, $dimensions)
             ->willReturn($index . '_flat');
-        $position = $this->mockFulltextTable($position, $expectedTable);
-        $this->mockFlatTable($position, $index . '_flat');
+        $table = $this->mockFulltextTable();
+        $table2 = $this->mockFlatTable();
+
+        $this->connectionInterface
+            ->method('newTable')
+            ->withConsecutive([$expectedTable], [$index . '_flat'])
+            ->willReturnOnConsecutiveCalls($table, $table2);
+        $this->connectionInterface
+            ->method('createTable')
+            ->withConsecutive([$table], [$table2])
+            ->willReturnSelf();
 
         $this->target->create($index, $fields, $dimensions);
     }
@@ -176,12 +189,13 @@ class IndexStructureTest extends TestCase
     /**
      * @param string $name
      * @param string $value
+     *
      * @return MockObject
      */
-    private function createDimensionMock($name, $value)
+    private function createDimensionMock($name, $value): MockObject
     {
         $dimension = $this->getMockBuilder(Dimension::class)
-            ->setMethods(['getName', 'getValue'])
+            ->onlyMethods(['getName', 'getValue'])
             ->disableOriginalConstructor()
             ->getMock();
         $dimension->expects($this->any())
@@ -194,116 +208,72 @@ class IndexStructureTest extends TestCase
     }
 
     /**
-     * @param $callNumber
-     * @param $tableName
-     * @param $isTableExist
-     * @return mixed
+     * @return MockObject
      */
-    private function mockDropTable($callNumber, $tableName, $isTableExist)
-    {
-        $this->connectionInterface->expects($this->at($callNumber++))
-            ->method('isTableExists')
-            ->with($tableName)
-            ->willReturn($isTableExist);
-        if ($isTableExist) {
-            $this->connectionInterface->expects($this->at($callNumber++))
-                ->method('dropTable')
-                ->with($tableName)
-                ->willReturn(true);
-        }
-        return $callNumber;
-    }
-
-    /**
-     * @param $callNumber
-     * @param $tableName
-     * @return mixed
-     */
-    private function mockFlatTable($callNumber, $tableName)
+    private function mockFlatTable(): MockObject
     {
         $table = $this->getMockBuilder(Table::class)
-            ->setMethods(['addColumn', 'getColumns'])
+            ->onlyMethods(['addColumn', 'getColumns'])
             ->disableOriginalConstructor()
             ->getMock();
         $table->expects($this->any())
             ->method('addColumn')
             ->willReturnSelf();
 
-        $this->connectionInterface->expects($this->at($callNumber++))
-            ->method('newTable')
-            ->with($tableName)
-            ->willReturn($table);
-        $this->connectionInterface->expects($this->at($callNumber++))
-            ->method('createTable')
-            ->with($table)
-            ->willReturnSelf();
-
-        return $callNumber;
+        return $table;
     }
 
     /**
-     * @param $callNumber
-     * @param $tableName
-     * @return mixed
+     * @return MockObject
      */
-    private function mockFulltextTable($callNumber, $tableName)
+    private function mockFulltextTable(): MockObject
     {
         $table = $this->getMockBuilder(Table::class)
-            ->setMethods(['addColumn', 'addIndex'])
+            ->onlyMethods(['addColumn', 'addIndex'])
             ->disableOriginalConstructor()
             ->getMock();
-        $table->expects($this->at(0))
-            ->method('addColumn')
-            ->with(
-                'entity_id',
-                Table::TYPE_INTEGER,
-                10,
-                ['unsigned' => true, 'nullable' => false],
-                'Entity ID'
-            )->willReturnSelf();
-        $table->expects($this->at(1))
-            ->method('addColumn')
-            ->with(
-                'attribute_id',
-                Table::TYPE_TEXT,
-                255,
-                ['unsigned' => true, 'nullable' => true]
-            )->willReturnSelf();
 
-        $table->expects($this->at(2))
+        $table
             ->method('addColumn')
-            ->with(
-                'data_index',
-                Table::TYPE_TEXT,
-                '4g',
-                ['nullable' => true],
-                'Data index'
-            )->willReturnSelf();
-
-        $table->expects($this->at(3))
+            ->withConsecutive(
+                [
+                    'entity_id',
+                    Table::TYPE_INTEGER,
+                    10,
+                    ['unsigned' => true, 'nullable' => false],
+                    'Entity ID'
+                ],
+                [
+                    'attribute_id',
+                    Table::TYPE_TEXT,
+                    255,
+                    ['unsigned' => true, 'nullable' => true]
+                ],
+                [
+                    'data_index',
+                    Table::TYPE_TEXT,
+                    '4g',
+                    ['nullable' => true],
+                    'Data index'
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($table, $table, $table);
+        $table
             ->method('addIndex')
-            ->with(
-                'idx_primary',
-                ['entity_id', 'attribute_id'],
-                ['type' => AdapterInterface::INDEX_TYPE_PRIMARY]
-            )->willReturnSelf();
-        $table->expects($this->at(4))
-            ->method('addIndex')
-            ->with(
-                'FTI_FULLTEXT_DATA_INDEX',
-                ['data_index'],
-                ['type' => AdapterInterface::INDEX_TYPE_FULLTEXT]
-            )->willReturnSelf();
+            ->withConsecutive(
+                [
+                    'idx_primary',
+                    ['entity_id', 'attribute_id'],
+                    ['type' => AdapterInterface::INDEX_TYPE_PRIMARY]
+                ],
+                [
+                    'FTI_FULLTEXT_DATA_INDEX',
+                    ['data_index'],
+                    ['type' => AdapterInterface::INDEX_TYPE_FULLTEXT]
+                ]
+            )
+            ->willReturnOnConsecutiveCalls($table, $table);
 
-        $this->connectionInterface->expects($this->at($callNumber++))
-            ->method('newTable')
-            ->with($tableName)
-            ->willReturn($table);
-        $this->connectionInterface->expects($this->at($callNumber++))
-            ->method('createTable')
-            ->with($table)
-            ->willReturnSelf();
-
-        return $callNumber;
+        return $table;
     }
 }

--- a/lib/internal/Magento/Framework/Logger/Test/Unit/LoggerProxyTest.php
+++ b/lib/internal/Magento/Framework/Logger/Test/Unit/LoggerProxyTest.php
@@ -3,21 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Logger\Test\Unit;
 
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Logger\LoggerProxy;
 use Magento\Framework\Logger\Monolog;
 use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class LoggerProxyTest extends \PHPUnit\Framework\TestCase
+class LoggerProxyTest extends TestCase
 {
     /**
      * @return array
      */
-    public static function methodsList()
+    public static function methodsList(): array
     {
         return [
             [LogLevel::EMERGENCY],
@@ -27,16 +30,19 @@ class LoggerProxyTest extends \PHPUnit\Framework\TestCase
             [LogLevel::WARNING],
             [LogLevel::NOTICE],
             [LogLevel::INFO],
-            [LogLevel::DEBUG],
+            [LogLevel::DEBUG]
         ];
     }
 
     /**
      * @test
-     * @dataProvider methodsList
+     *
      * @param $method
+     *
+     * @return void
+     * @dataProvider methodsList
      */
-    public function logMessage($method)
+    public function logMessage($method): void
     {
         $deploymentConfig = $this->getMockBuilder(DeploymentConfig::class)
             ->disableOriginalConstructor()
@@ -47,15 +53,10 @@ class LoggerProxyTest extends \PHPUnit\Framework\TestCase
         $logger = $this->getMockBuilder(LoggerInterface::class)
             ->getMockForAbstractClass();
 
-        $objectManager->expects($this->at(0))
+        $objectManager
             ->method('get')
-            ->with(DeploymentConfig::class)
-            ->willReturn($deploymentConfig);
-
-        $objectManager->expects($this->at(1))
-            ->method('get')
-            ->with(Monolog::class)
-            ->willReturn($logger);
+            ->withConsecutive([DeploymentConfig::class], [Monolog::class])
+            ->willReturnOnConsecutiveCalls($deploymentConfig, $logger);
         $logger->expects($this->once())->method($method)->with('test');
 
         $loggerProxy = new LoggerProxy($objectManager);
@@ -64,8 +65,10 @@ class LoggerProxyTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
+     *
+     * @return void
      */
-    public function createWithArguments()
+    public function createWithArguments(): void
     {
         $deploymentConfig = $this->getMockBuilder(DeploymentConfig::class)
             ->disableOriginalConstructor()
@@ -77,15 +80,15 @@ class LoggerProxyTest extends \PHPUnit\Framework\TestCase
             ->getMockForAbstractClass();
 
         $args = ['name' => 'test'];
-        $deploymentConfig->expects($this->at(1))
+        $deploymentConfig
             ->method('get')
-            ->with('log/args')
-            ->willReturn($args);
+            ->withConsecutive([], ['log/args'])
+            ->willReturnOnConsecutiveCalls(null, $args);
 
-        $objectManager->expects($this->at(0))
+        $objectManager
             ->method('get')
-            ->with(DeploymentConfig::class)
-            ->willReturn($deploymentConfig);
+            ->withConsecutive([DeploymentConfig::class])
+            ->willReturnOnConsecutiveCalls($deploymentConfig);
 
         $objectManager->expects($this->once())
             ->method('create')

--- a/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
+++ b/lib/internal/Magento/Framework/Module/Test/Unit/ModuleList/LoaderTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\Framework\Module\Test\Unit\ModuleList;
 
 use Magento\Framework\Component\ComponentRegistrarInterface;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\Module\Declaration\Converter\Dom;
 use Magento\Framework\Module\ModuleList\Loader;
@@ -55,6 +54,9 @@ class LoaderTest extends TestCase
      */
     private $loadFixture;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->converter = $this->createMock(Dom::class);
@@ -67,9 +69,11 @@ class LoaderTest extends TestCase
 
     /**
      * @param $paths
+     *
+     * @return void
      * @dataProvider testLoadDataProvider
      */
-    public function testLoad($paths)
+    public function testLoad($paths): void
     {
         $this->registry->expects($this->once())
             ->method('getPaths')
@@ -79,25 +83,32 @@ class LoaderTest extends TestCase
             'b' => ['name' => 'b', 'sequence' => ['d']], // b is after d
             'c' => ['name' => 'c', 'sequence' => ['e']], // c is after e
             'd' => ['name' => 'd', 'sequence' => ['c']], // d is after c
-            'e' => ['name' => 'e', 'sequence' => ['a']], // e is after a
+            'e' => ['name' => 'e', 'sequence' => ['a']] // e is after a
             // so expected sequence is a -> e -> c -> d -> b
         ];
-        $this->driver->expects($this->exactly(5))->method('fileGetContents')->willReturnMap([
-            ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/b/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/c/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/d/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/e/etc/module.xml', null, null, self::$sampleXml],
-        ]);
-        $index = 0;
+        $this->driver->expects($this->exactly(5))->method('fileGetContents')->willReturnMap(
+            [
+                ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/b/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/c/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/d/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/e/etc/module.xml', null, null, self::$sampleXml]
+            ]
+        );
+        $willReturnArgs = [];
+
         foreach ($this->loadFixture as $name => $fixture) {
-            $this->converter->expects($this->at($index++))->method('convert')->willReturn([$name => $fixture]);
+            $willReturnArgs[] = [$name => $fixture];
         }
+        $this->converter
+            ->method('convert')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
         $this->parser->expects($this->atLeastOnce())->method('loadXML')
             ->with(self::$sampleXml);
         $this->parser->expects($this->atLeastOnce())->method('getDom');
         $result = $this->loader->load();
         $this->assertSame(['a', 'e', 'c', 'd', 'b'], array_keys($result));
+
         foreach ($this->loadFixture as $name => $fixture) {
             $this->assertSame($fixture, $result[$name]);
         }
@@ -106,40 +117,61 @@ class LoaderTest extends TestCase
     /**
      * @return array
      */
-    public function testLoadDataProvider()
+    public function testLoadDataProvider(): array
     {
         return [
-            'Ordered modules list returned by registrar' => [[
-                '/path/to/a', '/path/to/b', '/path/to/c', '/path/to/d', '/path/to/e'
-            ]],
-            'UnOrdered modules list returned by registrar' => [[
-                '/path/to/b', '/path/to/a', '/path/to/c', '/path/to/e', '/path/to/d'
-            ]],
+            'Ordered modules list returned by registrar' => [
+                [
+                    '/path/to/a',
+                    '/path/to/b',
+                    '/path/to/c',
+                    '/path/to/d',
+                    '/path/to/e'
+                ]
+            ],
+            'UnOrdered modules list returned by registrar' => [
+                [
+                    '/path/to/b',
+                    '/path/to/a',
+                    '/path/to/c',
+                    '/path/to/e',
+                    '/path/to/d'
+                ]
+            ]
         ];
     }
 
-    public function testLoadExclude()
+    /**
+    * @return void
+    */
+    public function testLoadExclude(): void
     {
         $fixture = [
             'a' => ['name' => 'a', 'sequence' => []],    // a is on its own
             'b' => ['name' => 'b', 'sequence' => ['c']], // b is after c
             'c' => ['name' => 'c', 'sequence' => ['a']], // c is after a
-            'd' => ['name' => 'd', 'sequence' => ['a']], // d is after a
+            'd' => ['name' => 'd', 'sequence' => ['a']] // d is after a
             // exclude d, so expected sequence is a -> c -> b
         ];
         $this->registry->expects($this->once())
             ->method('getPaths')
             ->willReturn(['/path/to/a', '/path/to/b', '/path/to/c', '/path/to/d']);
-        $this->driver->expects($this->exactly(4))->method('fileGetContents')->willReturnMap([
-            ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/b/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/c/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/d/etc/module.xml', null, null, self::$sampleXml],
-        ]);
-        $this->converter->expects($this->at(0))->method('convert')->willReturn(['a' => $fixture['a']]);
-        $this->converter->expects($this->at(1))->method('convert')->willReturn(['b' => $fixture['b']]);
-        $this->converter->expects($this->at(2))->method('convert')->willReturn(['c' => $fixture['c']]);
-        $this->converter->expects($this->at(3))->method('convert')->willReturn(['d' => $fixture['d']]);
+        $this->driver->expects($this->exactly(4))->method('fileGetContents')->willReturnMap(
+            [
+                ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/b/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/c/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/d/etc/module.xml', null, null, self::$sampleXml]
+            ]
+        );
+        $this->converter
+            ->method('convert')
+            ->willReturnOnConsecutiveCalls(
+                ['a' => $fixture['a']],
+                ['b' => $fixture['b']],
+                ['c' => $fixture['c']],
+                ['d' => $fixture['d']]
+            );
         $this->parser->expects($this->atLeastOnce())->method('loadXML');
         $this->parser->expects($this->atLeastOnce())->method('getDom');
         $result = $this->loader->load(['d']);
@@ -149,26 +181,32 @@ class LoaderTest extends TestCase
         $this->assertSame($fixture['c'], $result['c']);
     }
 
-    public function testLoadCircular()
+    /**
+    * @return void
+    */
+    public function testLoadCircular(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Circular sequence reference from \'b\' to \'a\'');
         $fixture = [
             'a' => ['name' => 'a', 'sequence' => ['b']],
-            'b' => ['name' => 'b', 'sequence' => ['a']],
+            'b' => ['name' => 'b', 'sequence' => ['a']]
         ];
-        $this->converter->expects($this->at(0))->method('convert')->willReturn(['a' => $fixture['a']]);
-        $this->converter->expects($this->at(1))->method('convert')->willReturn(['b' => $fixture['b']]);
+        $this->converter
+            ->method('convert')
+            ->willReturnOnConsecutiveCalls(['a' => $fixture['a']], ['b' => $fixture['b']]);
         $this->registry->expects($this->once())->method('getPaths')->willReturn(['/path/to/a', '/path/to/b']);
-        $this->driver->expects($this->exactly(2))->method('fileGetContents')->willReturnMap([
-            ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
-            ['/path/to/b/etc/module.xml', null, null, self::$sampleXml],
-        ]);
+        $this->driver->expects($this->exactly(2))->method('fileGetContents')->willReturnMap(
+            [
+                ['/path/to/a/etc/module.xml', null, null, self::$sampleXml],
+                ['/path/to/b/etc/module.xml', null, null, self::$sampleXml]
+            ]
+        );
         $this->loader->load();
     }
 
     /**
-     * @throws LocalizedException
+     * @return void
      */
     public function testLoadPrearranged(): void
     {
@@ -180,30 +218,38 @@ class LoaderTest extends TestCase
             'Test_HelloWorld' => ['name' => 'Test_HelloWorld', 'sequence' => ['Magento_Theme']]
         ];
 
-        $index = 0;
+        $willReturnArgs = [];
+
         foreach ($fixtures as $name => $fixture) {
-            $this->converter->expects($this->at($index++))->method('convert')->willReturn([$name => $fixture]);
+            $willReturnArgs[] = [$name => $fixture];
         }
+        $this->converter
+            ->method('convert')
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->registry->expects($this->once())
             ->method('getPaths')
-            ->willReturn([
-                '/path/to/Foo_Bar',
-                '/path/to/Magento_Directory',
-                '/path/to/Magento_Store',
-                '/path/to/Magento_Theme',
-                '/path/to/Test_HelloWorld'
-            ]);
+            ->willReturn(
+                [
+                    '/path/to/Foo_Bar',
+                    '/path/to/Magento_Directory',
+                    '/path/to/Magento_Store',
+                    '/path/to/Magento_Theme',
+                    '/path/to/Test_HelloWorld'
+                ]
+            );
 
         $this->driver->expects($this->exactly(5))
             ->method('fileGetContents')
-            ->willReturnMap([
-                ['/path/to/Foo_Bar/etc/module.xml', null, null, self::$sampleXml],
-                ['/path/to/Magento_Directory/etc/module.xml', null, null, self::$sampleXml],
-                ['/path/to/Magento_Store/etc/module.xml', null, null, self::$sampleXml],
-                ['/path/to/Magento_Theme/etc/module.xml', null, null, self::$sampleXml],
-                ['/path/to/Test_HelloWorld/etc/module.xml', null, null, self::$sampleXml],
-            ]);
+            ->willReturnMap(
+                [
+                    ['/path/to/Foo_Bar/etc/module.xml', null, null, self::$sampleXml],
+                    ['/path/to/Magento_Directory/etc/module.xml', null, null, self::$sampleXml],
+                    ['/path/to/Magento_Store/etc/module.xml', null, null, self::$sampleXml],
+                    ['/path/to/Magento_Theme/etc/module.xml', null, null, self::$sampleXml],
+                    ['/path/to/Test_HelloWorld/etc/module.xml', null, null, self::$sampleXml]
+                ]
+            );
 
         // Load the full module list information
         $result = $this->loader->load();

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Code/Generator/RepositoryTest.php
@@ -46,7 +46,7 @@ class RepositoryTest extends EntityChildTestAbstract
 
     protected function mockDefinedClassesCall()
     {
-        $this->definedClassesMock->expects($this->at(0))
+        $this->definedClassesMock
             ->method('isClassLoadable')
             ->with($this->getSourceClassName() . 'Interface')
             ->willReturn(true);

--- a/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/TemporaryStorageTest.php
+++ b/lib/internal/Magento/Framework/Search/Test/Unit/Adapter/Mysql/TemporaryStorageTest.php
@@ -41,6 +41,9 @@ class TemporaryStorageTest extends TestCase
      */
     private $config;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->tableName = 'some_table_name';
@@ -69,7 +72,10 @@ class TemporaryStorageTest extends TestCase
         );
     }
 
-    public function testStoreDocumentsFromSelect()
+    /**
+    * @return void
+    */
+    public function testStoreDocumentsFromSelect(): void
     {
         $sql = 'some SQL query';
 
@@ -97,7 +103,10 @@ class TemporaryStorageTest extends TestCase
         $this->assertEquals($table, $result);
     }
 
-    public function testStoreDocuments()
+    /**
+    * @return void
+    */
+    public function testStoreDocuments(): void
     {
         $documentId = 312432;
         $documentValue = 1.235123;
@@ -127,7 +136,10 @@ class TemporaryStorageTest extends TestCase
         $this->assertEquals($result, $table);
     }
 
-    public function testStoreApiDocuments()
+    /**
+    * @return void
+    */
+    public function testStoreApiDocuments(): void
     {
         $documentId = 312432;
         $documentValue = 1.235123;
@@ -157,7 +169,10 @@ class TemporaryStorageTest extends TestCase
         $this->assertEquals($result, $table);
     }
 
-    public function testNoDropIfNotPersistent()
+    /**
+    * @return void
+    */
+    public function testNoDropIfNotPersistent(): void
     {
         $this->createTemporaryTable(false);
 
@@ -171,7 +186,7 @@ class TemporaryStorageTest extends TestCase
     /**
      * @return Table|MockObject
      */
-    private function createTemporaryTable($persistentConnection = true)
+    private function createTemporaryTable($persistentConnection = true): MockObject
     {
         $this->config->expects($this->any())
             ->method('get')
@@ -182,30 +197,27 @@ class TemporaryStorageTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $tableInteractionCount = 0;
         if ($persistentConnection) {
             $this->adapter->expects($this->once())
                 ->method('dropTemporaryTable');
-            $tableInteractionCount++;
         }
-        $table->expects($this->at($tableInteractionCount))
+        $table
             ->method('addColumn')
-            ->with(
-                TemporaryStorage::FIELD_ENTITY_ID,
-                Table::TYPE_INTEGER,
-                10,
-                ['unsigned' => true, 'nullable' => false, 'primary' => true],
-                'Entity ID'
-            );
-        $tableInteractionCount++;
-        $table->expects($this->at($tableInteractionCount))
-            ->method('addColumn')
-            ->with(
-                'score',
-                Table::TYPE_DECIMAL,
-                [32, 16],
-                ['unsigned' => true, 'nullable' => true],
-                'Score'
+            ->withConsecutive(
+                [
+                    TemporaryStorage::FIELD_ENTITY_ID,
+                    Table::TYPE_INTEGER,
+                    10,
+                    ['unsigned' => true, 'nullable' => false, 'primary' => true],
+                    'Entity ID'
+                ],
+                [
+                    'score',
+                    Table::TYPE_DECIMAL,
+                    [32, 16],
+                    ['unsigned' => true, 'nullable' => true],
+                    'Score'
+                ]
             );
         $table->expects($this->once())
             ->method('setOption')

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
@@ -42,6 +42,9 @@ class FilePermissionsTest extends TestCase
      */
     private $filePermissions;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->directoryWriteMock = $this->createMock(Write::class);
@@ -63,9 +66,11 @@ class FilePermissionsTest extends TestCase
 
     /**
      * @param string $mageMode
+     *
+     * @return void
      * @dataProvider modeDataProvider
      */
-    public function testGetInstallationWritableDirectories($mageMode)
+    public function testGetInstallationWritableDirectories($mageMode): void
     {
         $this->setUpDirectoryListInstallation();
         $this->stateMock->expects($this->once())
@@ -77,13 +82,16 @@ class FilePermissionsTest extends TestCase
             BP . '/var',
             BP . '/pub/media',
             BP . '/generated',
-            BP . '/pub/static',
+            BP . '/pub/static'
         ];
 
         $this->assertEquals($expected, $this->filePermissions->getInstallationWritableDirectories());
     }
 
-    public function testGetInstallationWritableDirectoriesInProduction()
+    /**
+    * @return void
+    */
+    public function testGetInstallationWritableDirectoriesInProduction(): void
     {
         $this->setUpDirectoryListInstallationInProduction();
         $this->stateMock->expects($this->once())
@@ -93,13 +101,16 @@ class FilePermissionsTest extends TestCase
         $expected = [
             BP . '/app/etc',
             BP . '/var',
-            BP . '/pub/media',
+            BP . '/pub/media'
         ];
 
         $this->assertEquals($expected, $this->filePermissions->getInstallationWritableDirectories());
     }
 
-    public function testGetApplicationNonWritableDirectories()
+    /**
+    * @return void
+    */
+    public function testGetApplicationNonWritableDirectories(): void
     {
         $this->directoryListMock
             ->expects($this->once())
@@ -111,7 +122,10 @@ class FilePermissionsTest extends TestCase
         $this->assertEquals($expected, $this->filePermissions->getApplicationNonWritableDirectories());
     }
 
-    public function testGetInstallationCurrentWritableDirectories()
+    /**
+    * @return void
+    */
+    public function testGetInstallationCurrentWritableDirectories(): void
     {
         $this->setUpDirectoryListInstallation();
         $this->setUpDirectoryWriteInstallation();
@@ -126,23 +140,21 @@ class FilePermissionsTest extends TestCase
     /**
      * @param array $mockMethods
      * @param array $expected
+     *
+     * @return void
      * @dataProvider getApplicationCurrentNonWritableDirectoriesDataProvider
      */
-    public function testGetApplicationCurrentNonWritableDirectories(array $mockMethods, array $expected)
+    public function testGetApplicationCurrentNonWritableDirectories(array $mockMethods, array $expected): void
     {
         $this->directoryListMock
-            ->expects($this->at(0))
             ->method('getPath')
             ->with(DirectoryList::CONFIG)
             ->willReturn(BP . '/app/etc');
 
-        $index = 0;
         foreach ($mockMethods as $mockMethod => $returnValue) {
             $this->directoryWriteMock
-                ->expects($this->at($index))
                 ->method($mockMethod)
-                ->willReturn($returnValue);
-            $index++;
+                ->willReturnOnConsecutiveCalls($returnValue);
         }
 
         $this->filePermissions->getApplicationNonWritableDirectories();
@@ -152,7 +164,7 @@ class FilePermissionsTest extends TestCase
     /**
      * @return array
      */
-    public function getApplicationCurrentNonWritableDirectoriesDataProvider()
+    public function getApplicationCurrentNonWritableDirectoriesDataProvider(): array
     {
         return [
             [
@@ -162,21 +174,23 @@ class FilePermissionsTest extends TestCase
                     'isReadable' => true,
                     'isWritable' => false
                 ],
-                [BP . '/app/etc'],
+                [BP . '/app/etc']
             ],
             [['isExist' => false], []],
             [['isExist' => true, 'isDirectory' => false], []],
-            [['isExist' => true, 'isDirectory' => true, 'isReadable' => true, 'isWritable' => true], []],
+            [['isExist' => true, 'isDirectory' => true, 'isReadable' => true, 'isWritable' => true], []]
         ];
     }
 
     /**
      * @param string $mageMode
+     *
+     * @return void
      * @dataProvider modeDataProvider
      * @covers \Magento\Framework\Setup\FilePermissions::getMissingWritableDirectoriesForInstallation
      * @covers \Magento\Framework\Setup\FilePermissions::getMissingWritablePathsForInstallation
      */
-    public function testGetMissingWritableDirectoriesAndPathsForInstallation($mageMode)
+    public function testGetMissingWritableDirectoriesAndPathsForInstallation($mageMode): void
     {
         $this->setUpDirectoryListInstallation();
         $this->setUpDirectoryWriteInstallation();
@@ -188,7 +202,7 @@ class FilePermissionsTest extends TestCase
             BP . '/var',
             BP . '/pub/media',
             BP . '/generated',
-            BP . '/pub/static',
+            BP . '/pub/static'
         ];
 
         $this->assertEquals(
@@ -202,7 +216,10 @@ class FilePermissionsTest extends TestCase
         );
     }
 
-    public function testGetMissingWritableDirectoriesAndPathsForInstallationInProduction()
+    /**
+    * @return void
+    */
+    public function testGetMissingWritableDirectoriesAndPathsForInstallationInProduction(): void
     {
         $this->setUpDirectoryListInstallationInProduction();
         $this->setUpDirectoryWriteInstallation();
@@ -226,7 +243,10 @@ class FilePermissionsTest extends TestCase
         );
     }
 
-    public function testGetMissingWritableDirectoriesForDbUpgrade()
+    /**
+    * @return void
+    */
+    public function testGetMissingWritableDirectoriesForDbUpgrade(): void
     {
         $directoryMethods = ['isExist', 'isDirectory', 'isReadable', 'isWritable'];
         foreach ($directoryMethods as $method) {
@@ -241,23 +261,21 @@ class FilePermissionsTest extends TestCase
     /**
      * @param array $mockMethods
      * @param array $expected
+     *
+     * @return void
      * @dataProvider getUnnecessaryWritableDirectoriesForApplicationDataProvider
      */
-    public function testGetUnnecessaryWritableDirectoriesForApplication(array $mockMethods, array $expected)
+    public function testGetUnnecessaryWritableDirectoriesForApplication(array $mockMethods, array $expected): void
     {
         $this->directoryListMock
-            ->expects($this->at(0))
             ->method('getPath')
             ->with(DirectoryList::CONFIG)
             ->willReturn(BP . '/app/etc');
 
-        $index = 0;
         foreach ($mockMethods as $mockMethod => $returnValue) {
             $this->directoryWriteMock
-                ->expects($this->at($index))
                 ->method($mockMethod)
-                ->willReturn($returnValue);
-            $index++;
+                ->willReturnOnConsecutiveCalls($returnValue);
         }
 
         $this->assertEquals(
@@ -269,93 +287,75 @@ class FilePermissionsTest extends TestCase
     /**
      * @return array
      */
-    public function getUnnecessaryWritableDirectoriesForApplicationDataProvider()
+    public function getUnnecessaryWritableDirectoriesForApplicationDataProvider(): array
     {
         return [
             [['isExist' => true, 'isDirectory' => true, 'isReadable' => true, 'isWritable' => false], []],
-            [['isExist' => false], [BP . '/app/etc']],
+            [['isExist' => false], [BP . '/app/etc']]
         ];
     }
 
-    public function setUpDirectoryListInstallation()
+    /**
+    * @return void
+    */
+    public function setUpDirectoryListInstallation(): void
     {
-        $this->setUpDirectoryListInstallationInProduction();
         $this->directoryListMock
-            ->expects($this->at(3))
             ->method('getPath')
-            ->with(DirectoryList::GENERATED)
-            ->willReturn(BP . '/generated');
-        $this->directoryListMock
-            ->expects($this->at(4))
-            ->method('getPath')
-            ->with(DirectoryList::STATIC_VIEW)
-            ->willReturn(BP . '/pub/static');
+            ->withConsecutive(
+                [DirectoryList::CONFIG],
+                [DirectoryList::VAR_DIR],
+                [DirectoryList::MEDIA],
+                [DirectoryList::GENERATED],
+                [DirectoryList::STATIC_VIEW]
+            )
+            ->willReturnOnConsecutiveCalls(
+                BP . '/app/etc',
+                BP . '/var',
+                BP . '/pub/media',
+                BP . '/generated',
+                BP . '/pub/static'
+            );
     }
 
-    public function setUpDirectoryListInstallationInProduction()
+    /**
+    * @return void
+    */
+    public function setUpDirectoryListInstallationInProduction(): void
     {
         $this->directoryListMock
-            ->expects($this->at(0))
             ->method('getPath')
-            ->with(DirectoryList::CONFIG)
-            ->willReturn(BP . '/app/etc');
-        $this->directoryListMock
-            ->expects($this->at(1))
-            ->method('getPath')
-            ->with(DirectoryList::VAR_DIR)
-            ->willReturn(BP . '/var');
-        $this->directoryListMock
-            ->expects($this->at(2))
-            ->method('getPath')
-            ->with(DirectoryList::MEDIA)
-            ->willReturn(BP . '/pub/media');
+            ->withConsecutive([DirectoryList::CONFIG], [DirectoryList::VAR_DIR], [DirectoryList::MEDIA])
+            ->willReturnOnConsecutiveCalls(BP . '/app/etc', BP . '/var', BP . '/pub/media');
     }
 
-    public function setUpDirectoryWriteInstallation()
+    /**
+    * @return void
+    */
+    public function setUpDirectoryWriteInstallation(): void
     {
-        // CONFIG
         $this->directoryWriteMock
-            ->expects($this->at(0))
             ->method('isExist')
+            ->willReturnOnConsecutiveCalls(true, false, true);
+        $this->directoryWriteMock
+            ->method('isWritable')
             ->willReturn(true);
         $this->directoryWriteMock
-            ->expects($this->at(1))
-            ->method('isDirectory')
-            ->willReturn(true);
-        $this->directoryWriteMock
-            ->expects($this->at(2))
             ->method('isReadable')
             ->willReturn(true);
         $this->directoryWriteMock
-            ->expects($this->at(3))
-            ->method('isWritable')
-            ->willReturn(true);
-
-        // VAR
-        $this->directoryWriteMock
-            ->expects($this->at(4))
-            ->method('isExist')
-            ->willReturn(false);
-
-        // MEDIA
-        $this->directoryWriteMock
-            ->expects($this->at(5))
-            ->method('isExist')
-            ->willReturn(true);
-        $this->directoryWriteMock
-            ->expects($this->at(6))
             ->method('isDirectory')
-            ->willReturn(false);
+            ->willReturnOnConsecutiveCalls(true, false);
     }
 
     /**
      * @return array
      */
-    public function modeDataProvider()
+    public function modeDataProvider(): array
     {
         return [
             [State::MODE_DEFAULT],
-            [State::MODE_DEVELOPER],
+            [State::MODE_DEVELOPER]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
@@ -88,9 +88,10 @@ class BatchIteratorTest extends TestCase
      * 1. $iterator->current();
      * 2. $iterator->current();
      * 3. $iterator->key();
+     *
      * @return void
      */
-    public function testCurrent()
+    public function testCurrent(): void
     {
         $filed = $this->correlationName . '.' . $this->rangeField;
 
@@ -141,28 +142,21 @@ class BatchIteratorTest extends TestCase
      *
      * 1. $iterator->next()
      * 2. $iterator->valid();
+     *
      * @return void
      */
-    public function testIterations()
+    public function testIterations(): void
     {
-        $startCallIndex = 3;
-        $stepCall = 4;
+        $willReturnArgs = [
+            ['max' => 10, 'cnt' => 10],
+            ['max' => 20, 'cnt' => 10],
+            ['max' => 25, 'cnt' => 5],
+            ['max' => null, 'cnt' => 0]
+        ];
 
-        $this->connectionMock->expects($this->at($startCallIndex))
+        $this->connectionMock
             ->method('fetchRow')
-            ->willReturn(['max' => 10, 'cnt' => 10]);
-
-        $this->connectionMock->expects($this->at($startCallIndex += $stepCall))
-            ->method('fetchRow')
-            ->willReturn(['max' => 20, 'cnt' => 10]);
-
-        $this->connectionMock->expects($this->at($startCallIndex += $stepCall))
-            ->method('fetchRow')
-            ->willReturn(['max' => 25, 'cnt' => 5]);
-
-        $this->connectionMock->expects($this->at($startCallIndex += $stepCall))
-            ->method('fetchRow')
-            ->willReturn(['max' => null, 'cnt' => 0]);
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         /**
          * Test 3 iterations
@@ -185,15 +179,17 @@ class BatchIteratorTest extends TestCase
      * 3. $iterator->next();
      * 4. $iterator->current()
      * 5. $iterator->key()
+     *
      * @return void
      */
-    public function testNext()
+    public function testNext(): void
     {
         $filed = $this->correlationName . '.' . $this->rangeField;
-        $this->selectMock->expects($this->at(0))->method('where')->with($filed . ' > ?', 0);
         $this->selectMock->expects($this->exactly(3))->method('limit')->with($this->batchSize);
         $this->selectMock->expects($this->exactly(3))->method('order')->with($filed . ' ASC');
-        $this->selectMock->expects($this->at(3))->method('where')->with($filed . ' > ?', 25);
+        $this->selectMock
+            ->method('where')
+            ->withConsecutive([$filed . ' > ?', 0], [$filed . ' > ?', 25]);
 
         $this->wrapperSelectMock->expects($this->exactly(3))->method('from')->with(
             $this->selectMock,

--- a/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/ShellTest.php
@@ -27,6 +27,9 @@ class ShellTest extends TestCase
      */
     protected $logger;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->logger = $this->getMockBuilder(LoggerInterface::class)
@@ -36,14 +39,16 @@ class ShellTest extends TestCase
     }
 
     /**
-     * Test that a command with input arguments returns an expected result
+     * Test that a command with input arguments returns an expected result.
      *
      * @param Shell $shell
      * @param string $command
      * @param array $commandArgs
      * @param string $expectedResult
+     *
+     * @return void
      */
-    protected function _testExecuteCommand(Shell $shell, $command, $commandArgs, $expectedResult)
+    protected function _testExecuteCommand(Shell $shell, $command, $commandArgs, $expectedResult): void
     {
         $this->expectOutputString('');
         // nothing is expected to be ever printed to the standard output
@@ -55,9 +60,11 @@ class ShellTest extends TestCase
      * @param string $command
      * @param array $commandArgs
      * @param string $expectedResult
+     *
+     * @return void
      * @dataProvider executeDataProvider
      */
-    public function testExecute($command, $commandArgs, $expectedResult)
+    public function testExecute($command, $commandArgs, $expectedResult): void
     {
         $this->_testExecuteCommand(
             new Shell($this->commandRenderer, $this->logger),
@@ -72,18 +79,23 @@ class ShellTest extends TestCase
      * @param array $commandArgs
      * @param string $expectedResult
      * @param array $expectedLogRecords
+     *
+     * @return void
      * @dataProvider executeDataProvider
      */
-    public function testExecuteLog($command, $commandArgs, $expectedResult, $expectedLogRecords)
+    public function testExecuteLog($command, $commandArgs, $expectedResult, $expectedLogRecords): void
     {
         $quoteChar = substr(escapeshellarg(' '), 0, 1);
+        $withArgs = [];
         // environment-dependent quote character
-        foreach ($expectedLogRecords as $logRecordIndex => $expectedLogMessage) {
+        foreach ($expectedLogRecords as $expectedLogMessage) {
             $expectedLogMessage = str_replace('`', $quoteChar, $expectedLogMessage);
-            $this->logger->expects($this->at($logRecordIndex))
-                ->method('info')
-                ->with($expectedLogMessage);
+            $withArgs[] = [$expectedLogMessage];
         }
+        $this->logger
+            ->method('info')
+            ->withConsecutive(...$withArgs);
+
         $this->_testExecuteCommand(
             new Shell($this->commandRenderer, $this->logger),
             $command,
@@ -95,7 +107,7 @@ class ShellTest extends TestCase
     /**
      * @return array
      */
-    public function executeDataProvider()
+    public function executeDataProvider(): array
     {
         // backtick symbol (`) has to be replaced with environment-dependent quote character
         return [
@@ -104,25 +116,28 @@ class ShellTest extends TestCase
                 'php -r %s',
                 ['fwrite(STDERR, 27182);'],
                 '27182',
-                ['php -r `fwrite(STDERR, 27182);` 2>&1', '27182'],
+                ['php -r `fwrite(STDERR, 27182);` 2>&1', '27182']
             ],
             'piping STDERR -> STDOUT' => [
                 // intentionally no spaces around the pipe symbol
                 'php -r %s|php -r %s',
                 ['fwrite(STDERR, 27183);', 'echo fgets(STDIN);'],
                 '27183',
-                ['php -r `fwrite(STDERR, 27183);` 2>&1|php -r `echo fgets(STDIN);` 2>&1', '27183'],
+                ['php -r `fwrite(STDERR, 27183);` 2>&1|php -r `echo fgets(STDIN);` 2>&1', '27183']
             ],
             'piping STDERR -> STDERR' => [
                 'php -r %s | php -r %s',
                 ['fwrite(STDERR, 27184);', 'fwrite(STDERR, fgets(STDIN));'],
                 '27184',
-                ['php -r `fwrite(STDERR, 27184);` 2>&1 | php -r `fwrite(STDERR, fgets(STDIN));` 2>&1', '27184'],
+                ['php -r `fwrite(STDERR, 27184);` 2>&1 | php -r `fwrite(STDERR, fgets(STDIN));` 2>&1', '27184']
             ]
         ];
     }
 
-    public function testExecuteFailure()
+    /**
+    * @return void
+    */
+    public function testExecuteFailure(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
         $this->expectExceptionCode('0');
@@ -135,9 +150,11 @@ class ShellTest extends TestCase
      * @param string $command
      * @param array $commandArgs
      * @param string $expectedError
+     *
+     * @return void
      * @dataProvider executeDataProvider
      */
-    public function testExecuteFailureDetails($command, $commandArgs, $expectedError)
+    public function testExecuteFailureDetails($command, $commandArgs, $expectedError): void
     {
         try {
             /* Force command to return non-zero exit code */

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Html/Link/CurrentTest.php
@@ -52,7 +52,9 @@ class CurrentTest extends TestCase
     }
 
     /**
-     * Test get Url
+     * Test get Url.
+     *
+     * @return void
      */
     public function testGetUrl(): void
     {
@@ -70,7 +72,9 @@ class CurrentTest extends TestCase
     }
 
     /**
-     * Test if set current
+     * Test if set current.
+     *
+     * @return void
      */
     public function testIsCurrentIfIsset(): void
     {
@@ -79,12 +83,14 @@ class CurrentTest extends TestCase
     }
 
     /**
-     * Test if the current url is the same as link path
+     * Test if the current url is the same as link path.
      *
      * @param string $pathStub
      * @param string $urlStub
      * @param array $request
      * @param bool $expected
+     *
+     * @return void
      * @dataProvider isCurrentDataProvider
      */
     public function testIsCurrent($pathStub, $urlStub, $request, $expected): void
@@ -102,28 +108,30 @@ class CurrentTest extends TestCase
             ->method('getActionName')
             ->will($this->returnValue($request['actionStub']));
 
-        $this->_urlBuilderMock->expects($this->at(0))
-            ->method('getUrl')
-            ->with($pathStub)
-            ->will($this->returnValue($urlStub));
-        $this->_urlBuilderMock->expects($this->at(1))
-            ->method('getUrl')
-            ->with($request['mcaStub'])
-            ->will($this->returnValue($request['getUrl']));
+        $withArgs = $willReturnArgs = [];
+
+        $withArgs[] = [$pathStub];
+        $willReturnArgs[] = $this->returnValue($urlStub);
+        $withArgs[] = [$request['mcaStub']];
+        $willReturnArgs[] = $this->returnValue($request['getUrl']);
 
         if ($request['mcaStub'] == '') {
-            $this->_urlBuilderMock->expects($this->at(2))
-                ->method('getUrl')
-                ->with('*/*/*', ['_current' => false, '_use_rewrite' => true])
-                ->will($this->returnValue($urlStub));
+            $withArgs[] = ['*/*/*', ['_current' => false, '_use_rewrite' => true]];
+            $willReturnArgs[] = $this->returnValue($urlStub);
         }
+        $this->_urlBuilderMock
+            ->method('getUrl')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->currentLink->setPath($pathStub);
         $this->assertEquals($expected, $this->currentLink->isCurrent());
     }
 
     /**
-     * Data provider for is current
+     * Data provider for is current.
+     *
+     * @return array
      */
     public function isCurrentDataProvider(): array
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/BaseTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/Override/BaseTest.php
@@ -51,6 +51,9 @@ class BaseTest extends TestCase
      */
     private $componentRegistrar;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->themeDirectory = $this->createPartialMock(
@@ -77,7 +80,10 @@ class BaseTest extends TestCase
         );
     }
 
-    public function testGetFilesWrongTheme()
+    /**
+    * @return void
+    */
+    public function testGetFilesWrongTheme(): void
     {
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
@@ -94,9 +100,10 @@ class BaseTest extends TestCase
      * @param string $filePath
      * @param string $pathPattern
      *
+     * @return void
      * @dataProvider getFilesDataProvider
      */
-    public function testGetFiles($files, $filePath, $pathPattern)
+    public function testGetFiles($files, $filePath, $pathPattern): void
     {
         $themePath = 'area/theme/path';
         $theme = $this->getMockForAbstractClass(ThemeInterface::class);
@@ -124,14 +131,17 @@ class BaseTest extends TestCase
             ->willReturnArgument(0);
 
         $checkResult = [];
+        $withArgs = $willReturnArgs = [];
+
         foreach ($files as $key => $file) {
             $checkResult[$key] = new File($file['handle'], $file['module']);
-            $this->fileFactory
-                ->expects($this->at($key))
-                ->method('create')
-                ->with(sprintf($handlePath, $file['module'], $file['handle']), $file['module'])
-                ->willReturn($checkResult[$key]);
+            $withArgs[] = [sprintf($handlePath, $file['module'], $file['handle']), $file['module']];
+            $willReturnArgs[] = $checkResult[$key];
         }
+        $this->fileFactory
+            ->method('create')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
 
         $this->assertSame($checkResult, $this->model->getFiles($theme, $filePath));
     }
@@ -139,14 +149,14 @@ class BaseTest extends TestCase
     /**
      * @return array
      */
-    public function getFilesDataProvider()
+    public function getFilesDataProvider(): array
     {
         return [
             [
                 [
                     ['handle' => '1.xml', 'module' => 'Module_One'],
                     ['handle' => '2.xml', 'module' => 'Module_One'],
-                    ['handle' => '3.xml', 'module' => 'Module_Two'],
+                    ['handle' => '3.xml', 'module' => 'Module_Two']
                 ],
                 '*.xml',
                 '[^/]*\\.xml'
@@ -157,7 +167,7 @@ class BaseTest extends TestCase
                 ],
                 'preset/4',
                 'preset/4'
-            ],
+            ]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeModularTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/File/Collector/ThemeModularTest.php
@@ -51,6 +51,9 @@ class ThemeModularTest extends TestCase
      */
     private $componentRegistrar;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->themeDirectory = $this->createPartialMock(
@@ -77,7 +80,10 @@ class ThemeModularTest extends TestCase
         );
     }
 
-    public function testGetFilesWrongTheme()
+    /**
+    * @return void
+    */
+    public function testGetFilesWrongTheme(): void
     {
         $this->componentRegistrar->expects($this->once())
             ->method('getPath')
@@ -94,9 +100,10 @@ class ThemeModularTest extends TestCase
      * @param string $filePath
      * @param string $pathPattern
      *
+     * @return void
      * @dataProvider getFilesDataProvider
      */
-    public function testGetFiles($files, $filePath, $pathPattern)
+    public function testGetFiles($files, $filePath, $pathPattern): void
     {
         $theme = $this->getMockForAbstractClass(ThemeInterface::class);
         $themePath = 'area/theme/path';
@@ -124,29 +131,33 @@ class ThemeModularTest extends TestCase
             ->willReturnArgument(0);
 
         $checkResult = [];
+        $withArgs = $willReturnArgs = [];
+
         foreach ($files as $key => $file) {
             $checkResult[$key] = new File($file['handle'], $file['module'], $theme);
             $checkResult[$key] = $this->createMock(File::class);
-            $this->fileFactory
-                ->expects($this->at($key))
-                ->method('create')
-                ->with(sprintf($handlePath, $file['module'], $file['handle']), $file['module'], $theme)
-                ->willReturn($checkResult[$key]);
+            $withArgs[] = [sprintf($handlePath, $file['module'], $file['handle']), $file['module'], $theme];
+            $willReturnArgs[] = $checkResult[$key];
         }
+        $this->fileFactory
+            ->method('create')
+            ->withConsecutive(...$withArgs)
+            ->willReturnOnConsecutiveCalls(...$willReturnArgs);
+
         $this->assertSame($checkResult, $this->model->getFiles($theme, $filePath));
     }
 
     /**
      * @return array
      */
-    public function getFilesDataProvider()
+    public function getFilesDataProvider(): array
     {
         return [
             [
                 [
                     ['handle' => '1.xml', 'module' => 'Module_One'],
                     ['handle' => '2.xml', 'module' => 'Module_One'],
-                    ['handle' => '3.xml', 'module' => 'Module_Two'],
+                    ['handle' => '3.xml', 'module' => 'Module_Two']
                 ],
                 '*.xml',
                 '[^/]*\\.xml'
@@ -157,7 +168,7 @@ class ThemeModularTest extends TestCase
                 ],
                 'preset/4',
                 'preset/4'
-            ],
+            ]
         ];
     }
 }

--- a/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Template/Html/MinifierTest.php
@@ -52,7 +52,7 @@ class MinifierTest extends TestCase
     protected $filesystemMock;
 
     /**
-     * Initialize testable object
+     * @inheritDoc
      */
     protected function setUp(): void
     {
@@ -93,10 +93,12 @@ class MinifierTest extends TestCase
     }
 
     /**
-     * Covered method getPathToMinified
+     * Covered method getPathToMinified.
+     *
+     * @return void
      * @test
      */
-    public function testGetPathToMinified()
+    public function testGetPathToMinified(): void
     {
         $file = '/absolute/path/to/phtml/template/file';
         $relativeGeneratedPath = 'absolute/path/to/phtml/template/file';
@@ -113,12 +115,13 @@ class MinifierTest extends TestCase
     // @codingStandardsIgnoreStart
 
     /**
-     * Covered method minify and test regular expressions
+     * Covered method minify and test regular expressions.
      * @test
      *
+     * @return void
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testMinify()
+    public function testMinify(): void
     {
         $file = '/absolute/path/to/phtml/template/file';
         $relativeGeneratedPath = 'absolute/path/to/phtml/template/file';
@@ -227,10 +230,12 @@ TEXT;
     // @codingStandardsIgnoreEnd
 
     /**
-     * Contain method modify and getPathToModified
+     * Contain method modify and getPathToModified.
+     *
+     * @return void
      * @test
      */
-    public function testGetMinified()
+    public function testGetMinified(): void
     {
         $file = '/absolute/path/to/phtml/template/file';
         $relativeGeneratedPath = 'absolute/path/to/phtml/template/file';
@@ -242,10 +247,9 @@ TEXT;
             ->willReturn($file);
 
         $this->htmlDirectoryMock
-            ->expects($this->at(1))
             ->method('isExist')
-            ->with($relativeGeneratedPath)
-            ->willReturn(false);
+            ->withConsecutive([$relativeGeneratedPath])
+            ->willReturnOnConsecutiveCalls(false);
 
         $this->htmlDirectoryMock
             ->expects($this->once())

--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/AdminUserCreateCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/AdminUserCreateCommandTest.php
@@ -41,6 +41,9 @@ class AdminUserCreateCommandTest extends TestCase
      */
     private $command;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->installerFactoryMock = $this->createMock(InstallerFactory::class);
@@ -51,14 +54,17 @@ class AdminUserCreateCommandTest extends TestCase
             ->getMock();
     }
 
-    public function testExecute()
+    /**
+    * @return void
+    */
+    public function testExecute(): void
     {
         $options = [
             '--' . AdminAccount::KEY_USER => 'user',
             '--' . AdminAccount::KEY_PASSWORD => '123123q',
             '--' . AdminAccount::KEY_EMAIL => 'test@test.com',
             '--' . AdminAccount::KEY_FIRST_NAME => 'John',
-            '--' . AdminAccount::KEY_LAST_NAME => 'Doe',
+            '--' . AdminAccount::KEY_LAST_NAME => 'Doe'
         ];
         $data = [
             AdminAccount::KEY_USER => 'user',
@@ -66,7 +72,7 @@ class AdminUserCreateCommandTest extends TestCase
             AdminAccount::KEY_EMAIL => 'test@test.com',
             AdminAccount::KEY_FIRST_NAME => 'John',
             AdminAccount::KEY_LAST_NAME => 'Doe',
-            InitParamListener::BOOTSTRAP_PARAM => null,
+            InitParamListener::BOOTSTRAP_PARAM => null
         ];
         $commandTester = new CommandTester($this->command);
         $installerMock = $this->createMock(Installer::class);
@@ -76,30 +82,17 @@ class AdminUserCreateCommandTest extends TestCase
         $this->assertEquals('Created Magento administrator user named user' . PHP_EOL, $commandTester->getDisplay());
     }
 
-    public function testInteraction()
+    /**
+    * @return void
+    */
+    public function testInteraction(): void
     {
         $application = new Application();
         $application->add($this->command);
 
-        $this->questionHelperMock->expects($this->at(0))
+        $this->questionHelperMock
             ->method('ask')
-            ->willReturn('admin');
-
-        $this->questionHelperMock->expects($this->at(1))
-            ->method('ask')
-            ->willReturn('Password123');
-
-        $this->questionHelperMock->expects($this->at(2))
-            ->method('ask')
-            ->willReturn('john.doe@example.com');
-
-        $this->questionHelperMock->expects($this->at(3))
-            ->method('ask')
-            ->willReturn('John');
-
-        $this->questionHelperMock->expects($this->at(4))
-            ->method('ask')
-            ->willReturn('Doe');
+            ->willReturnOnConsecutiveCalls('admin', 'Password123', 'john.doe@example.com', 'John', 'Doe');
 
         // We override the standard helper with our mock
         $this->command->getHelperSet()->set($this->questionHelperMock, 'question');
@@ -119,7 +112,7 @@ class AdminUserCreateCommandTest extends TestCase
             'version' => false,
             'ansi' => false,
             'no-ansi' => false,
-            'no-interaction' => false,
+            'no-interaction' => false
         ];
 
         $installerMock->expects($this->once())->method('installAdminUser')->with($expectedData);
@@ -139,9 +132,11 @@ class AdminUserCreateCommandTest extends TestCase
     /**
      * @param int $mode
      * @param string $description
+     *
+     * @return void
      * @dataProvider getOptionListDataProvider
      */
-    public function testGetOptionsList($mode, $description)
+    public function testGetOptionsList($mode, $description): void
     {
         /* @var $argsList \Symfony\Component\Console\Input\InputArgument[] */
         $argsList = $this->command->getOptionsList($mode);
@@ -152,26 +147,27 @@ class AdminUserCreateCommandTest extends TestCase
     /**
      * @return array
      */
-    public function getOptionListDataProvider()
+    public function getOptionListDataProvider(): array
     {
         return [
             [
                 'mode' => InputOption::VALUE_REQUIRED,
-                'description' => '(Required) Admin email',
+                'description' => '(Required) Admin email'
             ],
             [
                 'mode' => InputOption::VALUE_OPTIONAL,
-                'description' => 'Admin email',
-            ],
+                'description' => 'Admin email'
+            ]
         ];
     }
 
     /**
-     * @dataProvider validateDataProvider
      * @param bool[] $options
      * @param string[] $errors
+     *
+     * @dataProvider validateDataProvider
      */
-    public function testValidate(array $options, array $errors)
+    public function testValidate(array $options, array $errors): void
     {
         $inputMock = $this->getMockForAbstractClass(
             InputInterface::class,
@@ -179,17 +175,17 @@ class AdminUserCreateCommandTest extends TestCase
             '',
             false
         );
-        $index = 0;
-        foreach ($options as $option) {
-            $inputMock->expects($this->at($index++))->method('getOption')->willReturn($option);
-        }
+        $inputMock
+            ->method('getOption')
+            ->willReturnOnConsecutiveCalls(...$options);
+
         $this->assertEquals($errors, $this->command->validate($inputMock));
     }
 
     /**
      * @return array
      */
-    public function validateDataProvider()
+    public function validateDataProvider(): array
     {
         return [
             [

--- a/setup/src/Magento/Setup/Test/Unit/Model/AdminAccountTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/AdminAccountTest.php
@@ -35,6 +35,9 @@ class AdminAccountTest extends TestCase
      */
     private $prefix;
 
+    /**
+     * @inheritDoc
+     */
     protected function setUp(): void
     {
         $this->dbAdapter = $this->getMockBuilder(Mysql::class)
@@ -56,7 +59,7 @@ class AdminAccountTest extends TestCase
             AdminAccount::KEY_EMAIL => 'john.doe@test.com',
             AdminAccount::KEY_PASSWORD => '123123q',
             AdminAccount::KEY_USER => 'admin',
-            AdminAccount::KEY_PREFIX => 'pre_',
+            AdminAccount::KEY_PREFIX => 'pre_'
         ];
 
         $this->prefix = $data[AdminAccount::KEY_PREFIX];
@@ -68,13 +71,16 @@ class AdminAccountTest extends TestCase
         );
     }
 
-    public function testSaveUserExistsAdminRoleExists()
+    /**
+    * @return void
+    */
+    public function testSaveUserExistsAdminRoleExists(): void
     {
         // existing user data
         $existingUserData = [
             'email' => 'john.doe@test.com',
             'username' => 'admin',
-            'user_id' => 1,
+            'user_id' => 1
         ];
 
         // existing admin role data
@@ -85,7 +91,7 @@ class AdminAccountTest extends TestCase
             'user_id'    => 1,
             'user_type'  => 2,
             'role_name'  => 'admin',
-            'role_id'    => 1,
+            'role_id'    => 1
         ];
 
         $returnValueMap = [
@@ -94,22 +100,22 @@ class AdminAccountTest extends TestCase
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ],
             [
                 'SELECT user_id, username, email FROM ' . $this->prefix .
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
                 'authorization_role WHERE user_id = :user_id AND user_type = :user_type',
                 ['user_id' => 1, 'user_type' => 2],
                 null,
-                $existingAdminRoleData,
-            ],
+                $existingAdminRoleData
+            ]
         ];
         $this->dbAdapter
             ->expects($this->exactly(3))
@@ -125,13 +131,16 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveUserExistsNewAdminRole()
+    /**
+    * @return void
+    */
+    public function testSaveUserExistsNewAdminRole(): void
     {
         // existing user data
         $existingUserData = [
             'email' => 'john.doe@test.com',
             'username' => 'admin',
-            'user_id' => 1,
+            'user_id' => 1
         ];
 
         // speical admin role data
@@ -142,7 +151,7 @@ class AdminAccountTest extends TestCase
             'user_id' => 0,
             'user_type' => 2,
             'role_name' => 'Administrators',
-            'role_id' => 0,
+            'role_id' => 0
         ];
 
         $returnValueMap = [
@@ -151,21 +160,21 @@ class AdminAccountTest extends TestCase
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ],
             [
                 'SELECT user_id, username, email FROM ' . $this->prefix .
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
                 'authorization_role WHERE user_id = :user_id AND user_type = :user_type',
                 ['user_id' => 1, 'user_type' => 2],
                 null,
-                [],
+                []
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
@@ -181,8 +190,8 @@ class AdminAccountTest extends TestCase
                     'role_name' => 'Administrators',
                 ],
                 null,
-                $administratorRoleData,
-            ],
+                $administratorRoleData
+            ]
         ];
 
         $this->dbAdapter
@@ -195,18 +204,21 @@ class AdminAccountTest extends TestCase
             ->with(self::equalTo('pre_admin_user'), self::anything())
             ->willReturn(1);
 
-        $this->dbAdapter->expects(self::at(8))
-            ->method('insert')
-            ->with(self::equalTo('pre_admin_passwords'), self::anything());
         // should only insert once (admin role)
-        $this->dbAdapter->expects(self::at(14))
+        $this->dbAdapter
             ->method('insert')
-            ->with(self::equalTo('pre_authorization_role'), self::anything());
+            ->withConsecutive(
+                [self::equalTo('pre_admin_passwords'), self::anything()],
+                [self::equalTo('pre_authorization_role'), self::anything()]
+            );
 
         $this->adminAccount->save();
     }
 
-    public function testSaveNewUserAdminRoleExists()
+    /**
+    * @return void
+    */
+    public function testSaveNewUserAdminRoleExists(): void
     {
         // existing admin role data
         $existingAdminRoleData = [
@@ -216,7 +228,7 @@ class AdminAccountTest extends TestCase
             'user_id'    => 1,
             'user_type'  => 2,
             'role_name'  => 'admin',
-            'role_id'    => 1,
+            'role_id'    => 1
         ];
 
         $returnValueMap = [
@@ -225,15 +237,15 @@ class AdminAccountTest extends TestCase
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                [],
+                []
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
                 'authorization_role WHERE user_id = :user_id AND user_type = :user_type',
                 ['user_id' => 1, 'user_type' => 2],
                 null,
-                $existingAdminRoleData,
-            ],
+                $existingAdminRoleData
+            ]
         ];
 
         $this->dbAdapter
@@ -241,12 +253,9 @@ class AdminAccountTest extends TestCase
             ->method('fetchRow')
             ->willReturnMap($returnValueMap);
         // insert only once (new user)
-        $this->dbAdapter->expects($this->at(3))
+        $this->dbAdapter
             ->method('insert')
-            ->with('pre_admin_user', $this->anything());
-        $this->dbAdapter->expects($this->at(6))
-            ->method('insert')
-            ->with('pre_admin_passwords', $this->anything());
+            ->withConsecutive(['pre_admin_user', $this->anything()], ['pre_admin_passwords', $this->anything()]);
 
         // after inserting new user
         $this->dbAdapter->expects($this->once())->method('lastInsertId')->willReturn(1);
@@ -254,7 +263,10 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveNewUserNewAdminRole()
+    /**
+    * @return void
+    */
+    public function testSaveNewUserNewAdminRole(): void
     {
         // special admin role data
         $administratorRoleData = [
@@ -264,7 +276,7 @@ class AdminAccountTest extends TestCase
             'user_id' => 0,
             'user_type' => 2,
             'role_name' => 'Administrators',
-            'role_id' => 0,
+            'role_id' => 0
         ];
 
         $returnValueMap = [
@@ -273,14 +285,14 @@ class AdminAccountTest extends TestCase
                 'admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                [],
+                []
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
                 'authorization_role WHERE user_id = :user_id AND user_type = :user_type',
                 ['user_id' => 1, 'user_type' => 2],
                 null,
-                [],
+                []
             ],
             [
                 'SELECT * FROM ' . $this->prefix .
@@ -296,7 +308,7 @@ class AdminAccountTest extends TestCase
                     'role_name' => 'Administrators',
                 ],
                 null,
-                $administratorRoleData,
+                $administratorRoleData
             ]
 
         ];
@@ -314,14 +326,17 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveExceptionUsernameNotMatch()
+    /**
+    * @return void
+    */
+    public function testSaveExceptionUsernameNotMatch(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('An existing user has the given email but different username.');
         // existing user in db
         $existingUserData = [
             'email' => 'john.doe@test.com',
-            'username' => 'Another.name',
+            'username' => 'Another.name'
         ];
 
         $this->dbAdapter->expects($this->exactly(2))
@@ -333,13 +348,16 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveExceptionEmailNotMatch()
+    /**
+    * @return void
+    */
+    public function testSaveExceptionEmailNotMatch(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('An existing user has the given username but different email.');
         $existingUserData = [
             'email' => 'another.email@test.com',
-            'username' => 'admin',
+            'username' => 'admin'
         ];
 
         $this->dbAdapter->expects($this->exactly(2))
@@ -351,7 +369,10 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveExceptionSpecialAdminRoleNotFound()
+    /**
+    * @return void
+    */
+    public function testSaveExceptionSpecialAdminRoleNotFound(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('No Administrators role was found, data fixture needs to be run');
@@ -361,7 +382,10 @@ class AdminAccountTest extends TestCase
         $this->adminAccount->save();
     }
 
-    public function testSaveExceptionPasswordEmpty()
+    /**
+    * @return void
+    */
+    public function testSaveExceptionPasswordEmpty(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('"Password" is required. Enter and try again.');
@@ -372,7 +396,7 @@ class AdminAccountTest extends TestCase
             AdminAccount::KEY_EMAIL => 'john.doe@test.com',
             AdminAccount::KEY_PASSWORD => '',
             AdminAccount::KEY_USER => 'admin',
-            AdminAccount::KEY_PREFIX => '',
+            AdminAccount::KEY_PREFIX => ''
         ];
 
         $adminAccount = new AdminAccount(
@@ -393,7 +417,7 @@ class AdminAccountTest extends TestCase
                 'SELECT user_id, username, email FROM admin_user WHERE username = :username OR email = :email',
                 ['username' => 'admin', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ]
 
         ];
@@ -407,7 +431,10 @@ class AdminAccountTest extends TestCase
         $adminAccount->save();
     }
 
-    public function testSaveExceptionPasswordAndUsernameEqual()
+    /**
+    * @return void
+    */
+    public function testSaveExceptionPasswordAndUsernameEqual(): void
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Password cannot be the same as the user name.');
@@ -418,7 +445,7 @@ class AdminAccountTest extends TestCase
             AdminAccount::KEY_EMAIL => 'john.doe@test.com',
             AdminAccount::KEY_PASSWORD => 'passMatch2Username',
             AdminAccount::KEY_USER => 'passMatch2Username',
-            AdminAccount::KEY_PREFIX => '',
+            AdminAccount::KEY_PREFIX => ''
         ];
 
         $adminAccount = new AdminAccount(
@@ -431,7 +458,7 @@ class AdminAccountTest extends TestCase
         $existingUserData = [
             'email' => 'john.doe@test.com',
             'username' => 'passMatch2Username',
-            'user_id' => 1,
+            'user_id' => 1
         ];
 
         $returnValueMap = [
@@ -439,7 +466,7 @@ class AdminAccountTest extends TestCase
                 'SELECT user_id, username, email FROM admin_user WHERE username = :username OR email = :email',
                 ['username' => 'passMatch2Username', 'email' => 'john.doe@test.com'],
                 null,
-                $existingUserData,
+                $existingUserData
             ]
         ];
         $this->dbAdapter

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
@@ -69,7 +69,7 @@ namespace Magento\Setup\Test\Unit\Model {
             ConfigOptionsListConstants::INPUT_KEY_DB_NAME => 'magento',
             ConfigOptionsListConstants::INPUT_KEY_DB_USER => 'magento',
             ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY => 'encryption_key',
-            ConfigOptionsList::INPUT_KEY_BACKEND_FRONTNAME => 'backend',
+            ConfigOptionsList::INPUT_KEY_BACKEND_FRONTNAME => 'backend'
         ];
 
         /**
@@ -206,7 +206,7 @@ namespace Magento\Setup\Test\Unit\Model {
                 ConfigOptionsListConstants::KEY_HOST => '127.0.0.1',
                 ConfigOptionsListConstants::KEY_NAME => 'magento',
                 ConfigOptionsListConstants::KEY_USER => 'magento',
-                ConfigOptionsListConstants::KEY_PASSWORD => '',
+                ConfigOptionsListConstants::KEY_PASSWORD => ''
             ]
         ];
 
@@ -225,6 +225,9 @@ namespace Magento\Setup\Test\Unit\Model {
          */
         private $patchApplierFactoryMock;
 
+        /**
+         * @inheritDoc
+         */
         protected function setUp(): void
         {
             $this->filePermissions = $this->createMock(FilePermissions::class);
@@ -271,9 +274,11 @@ namespace Magento\Setup\Test\Unit\Model {
         }
 
         /**
-         * Instantiates the object with mocks
+         * Instantiates the object with mocks.
+         *
          * @param MockObject|bool $connectionFactory
          * @param MockObject|bool $objectManagerProvider
+         *
          * @return Installer
          */
         private function createObject($connectionFactory = false, $objectManagerProvider = false)
@@ -316,10 +321,12 @@ namespace Magento\Setup\Test\Unit\Model {
         /**
          * @param array $request
          * @param array $logMessages
+         *
+         * @return void
          * @dataProvider installDataProvider
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-        public function testInstall(array $request, array $logMessages)
+        public function testInstall(array $request, array $logMessages): void
         {
             $this->config->expects($this->atLeastOnce())
                 ->method('get')
@@ -337,7 +344,8 @@ namespace Magento\Setup\Test\Unit\Model {
             $setup = $this->createMock(Setup::class);
             $table = $this->createMock(Table::class);
             $connection = $this->getMockBuilder(AdapterInterface::class)
-                ->setMethods(['getSchemaListener', 'newTable', 'getTables'])
+                ->onlyMethods(['newTable', 'getTables'])
+                ->addMethods(['getSchemaListener'])
                 ->getMockForAbstractClass();
             $connection->expects($this->any())->method('getSchemaListener')->willReturn($this->schemaListenerMock);
             $connection->expects($this->once())->method('getTables')->willReturn([]);
@@ -433,7 +441,7 @@ namespace Magento\Setup\Test\Unit\Model {
          * @return array
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-        public function installDataProvider()
+        public function installDataProvider(): array
         {
             return [
                 [
@@ -474,7 +482,7 @@ namespace Magento\Setup\Test\Unit\Model {
                         ['Post installation file permissions check...'],
                         ['Write installation date...'],
                         ['Sample Data is installed with errors. See log file for details']
-                    ],
+                    ]
                 ],
                 [
                     'request' => [
@@ -487,7 +495,7 @@ namespace Magento\Setup\Test\Unit\Model {
                         AdminAccount::KEY_PASSWORD => '123',
                         AdminAccount::KEY_EMAIL => 'admin@example.com',
                         AdminAccount::KEY_FIRST_NAME => 'John',
-                        AdminAccount::KEY_LAST_NAME => 'Doe',
+                        AdminAccount::KEY_LAST_NAME => 'Doe'
                     ],
                     'logMessages' => [
                         ['Starting Magento installation:'],
@@ -526,19 +534,19 @@ namespace Magento\Setup\Test\Unit\Model {
                         ['Post installation file permissions check...'],
                         ['Write installation date...'],
                         ['Sample Data is installed with errors. See log file for details']
-                    ],
-                ],
+                    ]
+                ]
             ];
         }
 
         /**
          * Test for InstallDataFixtures
          *
-         * @dataProvider testInstallDataFixturesDataProvider
-         *
          * @param bool $keepCache
          * @param array $expectedToEnableCacheTypes
+         *
          * @return void
+         * @dataProvider testInstallDataFixturesDataProvider
          */
         public function testInstallDataFixtures(bool $keepCache, array $expectedToEnableCacheTypes): void
         {
@@ -621,11 +629,14 @@ namespace Magento\Setup\Test\Unit\Model {
                 'do not keep a cache' => [
                     false,
                     ['block_html', 'full_page', 'layout']
-                ],
+                ]
             ];
         }
 
-        public function testCheckInstallationFilePermissions()
+        /**
+        * @return void
+        */
+        public function testCheckInstallationFilePermissions(): void
         {
             $this->filePermissions
                 ->expects($this->once())
@@ -634,7 +645,10 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->object->checkInstallationFilePermissions();
         }
 
-        public function testCheckInstallationFilePermissionsError()
+        /**
+         * @return void
+         */
+        public function testCheckInstallationFilePermissionsError(): void
         {
             $this->expectException('Exception');
             $this->expectExceptionMessage('Missing write permissions to the following paths:');
@@ -645,7 +659,10 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->object->checkInstallationFilePermissions();
         }
 
-        public function testCheckExtensions()
+        /**
+         * @return void
+         */
+        public function testCheckExtensions(): void
         {
             $this->phpReadinessCheck->expects($this->once())->method('checkPhpExtensions')->willReturn(
                 ['responseType' => ResponseTypeInterface::RESPONSE_TYPE_SUCCESS]
@@ -653,7 +670,10 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->object->checkExtensions();
         }
 
-        public function testCheckExtensionsError()
+        /**
+        * @return void
+        */
+        public function testCheckExtensionsError(): void
         {
             $this->expectException('Exception');
             $this->expectExceptionMessage('Missing following extensions: \'foo\'');
@@ -666,7 +686,10 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->object->checkExtensions();
         }
 
-        public function testCheckApplicationFilePermissions()
+        /**
+        * @return void
+        */
+        public function testCheckApplicationFilePermissions(): void
         {
             $this->filePermissions
                 ->expects($this->once())
@@ -678,7 +701,10 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->assertSame(['message' => [$expectedMessage]], $this->object->getInstallInfo());
         }
 
-        public function testUpdateModulesSequence()
+        /**
+        * @return void
+        */
+        public function testUpdateModulesSequence(): void
         {
             $this->cleanupFiles->expects($this->once())->method('clearCodeGeneratedFiles')->willReturn(
                 [
@@ -687,28 +713,43 @@ namespace Magento\Setup\Test\Unit\Model {
             );
             $installer = $this->prepareForUpdateModulesTests();
 
-            $this->logger->expects($this->at(0))->method('log')->with('Cache types config flushed successfully');
-            $this->logger->expects($this->at(1))->method('log')->with('Cache cleared successfully');
-            $this->logger->expects($this->at(2))->method('log')->with('File system cleanup:');
-            $this->logger->expects($this->at(3))->method('log')
-                ->with('The directory \'/generation\' doesn\'t exist - skipping cleanup');
-            $this->logger->expects($this->at(4))->method('log')->with('Updating modules:');
+            $this->logger
+                ->method('log')
+                ->withConsecutive(
+                    ['Cache types config flushed successfully'],
+                    ['Cache cleared successfully'],
+                    ['File system cleanup:'],
+                    ['The directory \'/generation\' doesn\'t exist - skipping cleanup'],
+                    ['Updating modules:']
+                );
+
             $installer->updateModulesSequence(false);
         }
 
-        public function testUpdateModulesSequenceKeepGenerated()
+        /**
+        * @return void
+        */
+        public function testUpdateModulesSequenceKeepGenerated(): void
         {
             $this->cleanupFiles->expects($this->never())->method('clearCodeGeneratedClasses');
 
             $installer = $this->prepareForUpdateModulesTests();
 
-            $this->logger->expects($this->at(0))->method('log')->with('Cache types config flushed successfully');
-            $this->logger->expects($this->at(1))->method('log')->with('Cache cleared successfully');
-            $this->logger->expects($this->at(2))->method('log')->with('Updating modules:');
+            $this->logger
+                ->method('log')
+                ->withConsecutive(
+                    ['Cache types config flushed successfully'],
+                    ['Cache cleared successfully'],
+                    ['Updating modules:']
+                );
+
             $installer->updateModulesSequence(true);
         }
 
-        public function testUninstall()
+        /**
+        * @return void
+        */
+        public function testUninstall(): void
         {
             $this->config->expects($this->once())
                 ->method('get')
@@ -736,11 +777,6 @@ namespace Magento\Setup\Test\Unit\Model {
                 ->willReturnMap([
                     [DirectoryList::CONFIG, DriverPool::FILE, $configDir],
                 ]);
-            $this->logger->expects($this->at(0))->method('log')->with('Starting Magento uninstallation:');
-            $this->logger
-                ->expects($this->at(2))
-                ->method('log')
-                ->with('No database connection defined - skipping database cleanup');
             $cacheManager = $this->createMock(Manager::class);
             $cacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['foo', 'bar']);
             $cacheManager->expects($this->once())->method('clean');
@@ -748,24 +784,20 @@ namespace Magento\Setup\Test\Unit\Model {
                 ->method('get')
                 ->with(Manager::class)
                 ->willReturn($cacheManager);
-            $this->logger->expects($this->at(1))->method('log')->with('Cache cleared successfully');
-            $this->logger->expects($this->at(3))->method('log')->with('File system cleanup:');
+
             $this->logger
-                ->expects($this->at(4))
                 ->method('log')
-                ->with("The directory '/var' doesn't exist - skipping cleanup");
-            $this->logger
-                ->expects($this->at(5))
-                ->method('log')
-                ->with("The directory '/static' doesn't exist - skipping cleanup");
-            $this->logger
-                ->expects($this->at(6))
-                ->method('log')
-                ->with("The file '/config/ConfigOne.php' doesn't exist - skipping cleanup");
-            $this->logger
-                ->expects($this->at(7))
-                ->method('log')
-                ->with("The file '/config/ConfigTwo.php' doesn't exist - skipping cleanup");
+                ->withConsecutive(
+                    ['Starting Magento uninstallation:'],
+                    ['Cache cleared successfully'],
+                    ['No database connection defined - skipping database cleanup'],
+                    ['File system cleanup:'],
+                    ["The directory '/var' doesn't exist - skipping cleanup"],
+                    ["The directory '/static' doesn't exist - skipping cleanup"],
+                    ["The file '/config/ConfigOne.php' doesn't exist - skipping cleanup"],
+                    ["The file '/config/ConfigTwo.php' doesn't exist - skipping cleanup"]
+                );
+
             $this->logger->expects($this->once())->method('logSuccess')->with('Magento uninstallation complete.');
             $this->cleanupFiles->expects($this->once())->method('clearAllFiles')->willReturn(
                 [
@@ -777,23 +809,33 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->object->uninstall();
         }
 
-        public function testCleanupDb()
+        /**
+        * @return void
+        */
+        public function testCleanupDb(): void
         {
             $this->config->expects($this->once())
                 ->method('get')
                 ->with(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS)
                 ->willReturn(self::$dbConfig);
-            $this->connection->expects($this->at(0))->method('quoteIdentifier')->with('magento')->willReturn(
-                '`magento`'
-            );
-            $this->connection->expects($this->at(1))->method('query')->with('DROP DATABASE IF EXISTS `magento`');
-            $this->connection->expects($this->at(2))->method('query')->with('CREATE DATABASE IF NOT EXISTS `magento`');
+            $this->connection
+                ->method('quoteIdentifier')
+                ->with('magento')
+                ->willReturn('`magento`');
+
+            $this->connection
+                ->method('query')
+                ->withConsecutive(
+                    ['DROP DATABASE IF EXISTS `magento`'],
+                    ['CREATE DATABASE IF NOT EXISTS `magento`'],
+                );
             $this->logger->expects($this->once())->method('log')->with('Cleaning up database `magento`');
             $this->object->cleanupDb();
         }
 
         /**
-         * Prepare mocks for update modules tests and returns the installer to use
+         * Prepare mocks for update modules tests and returns the installer to use.
+         *
          * @return Installer
          */
         private function prepareForUpdateModulesTests()
@@ -801,7 +843,7 @@ namespace Magento\Setup\Test\Unit\Model {
             $allModules = [
                 'Foo_One' => [],
                 'Bar_Two' => [],
-                'New_Module' => [],
+                'New_Module' => []
             ];
 
             $cacheManager = $this->createMock(Manager::class);

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
@@ -73,7 +73,7 @@ namespace Magento\Setup\Test\Unit\Model {
             ConfigOptionsListConstants::INPUT_KEY_DB_NAME => 'magento',
             ConfigOptionsListConstants::INPUT_KEY_DB_USER => 'magento',
             ConfigOptionsListConstants::INPUT_KEY_ENCRYPTION_KEY => 'encryption_key',
-            ConfigOptionsList::INPUT_KEY_BACKEND_FRONTNAME => 'backend',
+            ConfigOptionsList::INPUT_KEY_BACKEND_FRONTNAME => 'backend'
         ];
 
         /**
@@ -200,7 +200,7 @@ namespace Magento\Setup\Test\Unit\Model {
                 ConfigOptionsListConstants::KEY_HOST => '127.0.0.1',
                 ConfigOptionsListConstants::KEY_NAME => 'magento',
                 ConfigOptionsListConstants::KEY_USER => 'magento',
-                ConfigOptionsListConstants::KEY_PASSWORD => '',
+                ConfigOptionsListConstants::KEY_PASSWORD => ''
             ]
         ];
 
@@ -219,6 +219,9 @@ namespace Magento\Setup\Test\Unit\Model {
          */
         private $patchApplierFactoryMock;
 
+        /**
+         * @inheritdoc
+         */
         protected function setUp(): void
         {
             $this->filePermissions = $this->createMock(FilePermissions::class);
@@ -368,37 +371,41 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->dataSetupFactory->expects($this->atLeastOnce())->method('create')->willReturn($dataSetup);
             $this->objectManager->expects($this->any())
                 ->method('create')
-                ->willReturnMap([
-                                    [Manager::class, [], $cacheManager],
-                                    [\Magento\Framework\App\State::class, [], $appState],
-                                    [
-                                        PatchApplierFactory::class,
-                                        ['objectManager' => $this->objectManager],
-                                        $this->patchApplierFactoryMock
-                                    ],
-                                ]);
+                ->willReturnMap(
+                    [
+                        [Manager::class, [], $cacheManager],
+                        [\Magento\Framework\App\State::class, [], $appState],
+                        [
+                            PatchApplierFactory::class,
+                            ['objectManager' => $this->objectManager],
+                            $this->patchApplierFactoryMock
+                        ],
+                    ]
+                );
             $this->patchApplierMock->expects($this->exactly(2))->method('applySchemaPatch')->willReturnMap(
                 [
                     ['Bar_Two'],
-                    ['Foo_One'],
+                    ['Foo_One']
                 ]
             );
             $this->patchApplierMock->expects($this->exactly(2))->method('applyDataPatch')->willReturnMap(
                 [
                     ['Bar_Two'],
-                    ['Foo_One'],
+                    ['Foo_One']
                 ]
             );
             $this->objectManager->expects($this->any())
                 ->method('get')
-                ->willReturnMap([
-                                    [\Magento\Framework\App\State::class, $appState],
-                                    [Manager::class, $cacheManager],
-                                    [DeclarationInstaller::class, $this->declarationInstallerMock],
-                                    [Registry::class, $registry],
-                                    [SearchConfig::class, $searchConfigMock],
-                                    [RemoteStorageValidator::class, $remoteStorageValidatorMock],
-                                ]);
+                ->willReturnMap(
+                    [
+                        [\Magento\Framework\App\State::class, $appState],
+                        [Manager::class, $cacheManager],
+                        [DeclarationInstaller::class, $this->declarationInstallerMock],
+                        [Registry::class, $registry],
+                        [SearchConfig::class, $searchConfigMock],
+                        [RemoteStorageValidator::class, $remoteStorageValidatorMock]
+                    ]
+                );
             $this->adminFactory->expects($this->any())->method('create')->willReturn(
                 $this->createMock(AdminAccount::class)
             );
@@ -488,7 +495,7 @@ namespace Magento\Setup\Test\Unit\Model {
                         AdminAccount::KEY_PASSWORD => '123',
                         AdminAccount::KEY_EMAIL => 'admin@example.com',
                         AdminAccount::KEY_FIRST_NAME => 'John',
-                        AdminAccount::KEY_LAST_NAME => 'Doe',
+                        AdminAccount::KEY_LAST_NAME => 'Doe'
                     ],
                     'logMessages' => [
                         ['Starting Magento installation:'],
@@ -654,31 +661,35 @@ namespace Magento\Setup\Test\Unit\Model {
 
             $this->objectManager->expects(static::any())
                 ->method('create')
-                ->willReturnMap([
-                                    [Manager::class, [], $cacheManager],
-                                    [\Magento\Framework\App\State::class, [], $appState],
-                                    [
-                                        PatchApplierFactory::class,
-                                        ['objectManager' => $this->objectManager],
-                                        $this->patchApplierFactoryMock
-                                    ]
-                                ]);
+                ->willReturnMap(
+                    [
+                        [Manager::class, [], $cacheManager],
+                        [\Magento\Framework\App\State::class, [], $appState],
+                        [
+                            PatchApplierFactory::class,
+                            ['objectManager' => $this->objectManager],
+                            $this->patchApplierFactoryMock
+                        ]
+                    ]
+                );
             $this->patchApplierMock->expects(static::exactly(2))->method('applySchemaPatch')->willReturnMap(
                 [
                     ['Bar_Two'],
-                    ['Foo_One'],
+                    ['Foo_One']
                 ]
             );
             $this->objectManager->expects(static::any())
                 ->method('get')
-                ->willReturnMap([
-                                    [\Magento\Framework\App\State::class, $appState],
-                                    [Manager::class, $cacheManager],
-                                    [DeclarationInstaller::class, $this->declarationInstallerMock],
-                                    [Registry::class, $registry],
-                                    [SearchConfig::class, $searchConfigMock],
-                                    [RemoteStorageValidator::class, $remoteStorageValidatorMock]
-                                ]);
+                ->willReturnMap(
+                    [
+                        [\Magento\Framework\App\State::class, $appState],
+                        [Manager::class, $cacheManager],
+                        [DeclarationInstaller::class, $this->declarationInstallerMock],
+                        [Registry::class, $registry],
+                        [SearchConfig::class, $searchConfigMock],
+                        [RemoteStorageValidator::class, $remoteStorageValidatorMock]
+                    ]
+                );
 
             $this->sampleDataState->expects(static::never())->method('hasError');
 
@@ -808,25 +819,27 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->dataSetupFactory->expects(static::atLeastOnce())->method('create')->willReturn($dataSetup);
             $this->objectManager->expects(static::any())
                 ->method('create')
-                ->willReturnMap([
-                                    [Manager::class, [], $cacheManager],
-                                    [\Magento\Framework\App\State::class, [], $appState],
-                                    [
-                                        PatchApplierFactory::class,
-                                        ['objectManager' => $this->objectManager],
-                                        $this->patchApplierFactoryMock
-                                    ],
-                                ]);
+                ->willReturnMap(
+                    [
+                        [Manager::class, [], $cacheManager],
+                        [\Magento\Framework\App\State::class, [], $appState],
+                        [
+                            PatchApplierFactory::class,
+                            ['objectManager' => $this->objectManager],
+                            $this->patchApplierFactoryMock
+                        ]
+                    ]
+                );
             $this->patchApplierMock->expects(static::exactly(2))->method('applySchemaPatch')->willReturnMap(
                 [
                     ['Bar_Two'],
-                    ['Foo_One'],
+                    ['Foo_One']
                 ]
             );
             $this->patchApplierMock->expects(static::exactly(2))->method('applyDataPatch')->willReturnMap(
                 [
                     ['Bar_Two'],
-                    ['Foo_One'],
+                    ['Foo_One']
                 ]
             );
 
@@ -836,11 +849,11 @@ namespace Magento\Setup\Test\Unit\Model {
                 3 => [SearchConfig::class, $searchConfigMock],
                 4 => [
                     RemoteStorageValidator::class,
-                    new ReflectionException('Class ' . RemoteStorageValidator::class . ' does not exist'),
+                    new ReflectionException('Class ' . RemoteStorageValidator::class . ' does not exist')
                 ],
                 5 => [\Magento\Framework\App\State::class, $appState],
                 7 => [Registry::class, $registry],
-                11 => [Manager::class, $cacheManager],
+                11 => [Manager::class, $cacheManager]
             ];
             $withArgs = $willReturnArgs = [];
 
@@ -989,10 +1002,12 @@ namespace Magento\Setup\Test\Unit\Model {
 
             $this->objectManager->expects(static::any())
                 ->method('get')
-                ->willReturnMap([
-                                    [DeclarationInstaller::class, $this->declarationInstallerMock],
-                                    [Registry::class, $registry]
-                                ]);
+                ->willReturnMap(
+                    [
+                        [DeclarationInstaller::class, $this->declarationInstallerMock],
+                        [Registry::class, $registry]
+                    ]
+                );
 
             $this->sampleDataState->expects(static::never())->method('hasError');
 
@@ -1051,14 +1066,16 @@ namespace Magento\Setup\Test\Unit\Model {
 
             $this->objectManager->expects($this->atLeastOnce())
                 ->method('create')
-                ->willReturnMap([
-                                    [Manager::class, [], $cacheManagerMock],
-                                    [
-                                        PatchApplierFactory::class,
-                                        ['objectManager' => $this->objectManager],
-                                        $this->patchApplierFactoryMock
-                                    ],
-                                ]);
+                ->willReturnMap(
+                    [
+                        [Manager::class, [], $cacheManagerMock],
+                        [
+                            PatchApplierFactory::class,
+                            ['objectManager' => $this->objectManager],
+                            $this->patchApplierFactoryMock
+                        ],
+                    ]
+                );
 
             $registryMock = $this->createMock(Registry::class);
             $this->objectManager->expects($this->atLeastOnce())
@@ -1219,10 +1236,12 @@ namespace Magento\Setup\Test\Unit\Model {
                 ->method('get')
                 ->with(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS)
                 ->willReturn([]);
-            $this->configReader->expects($this->once())->method('getFiles')->willReturn([
-                                                                                            'ConfigOne.php',
-                                                                                            'ConfigTwo.php'
-                                                                                        ]);
+            $this->configReader->expects($this->once())->method('getFiles')->willReturn(
+                [
+                    'ConfigOne.php',
+                    'ConfigTwo.php'
+                ]
+            );
             $configDir = $this->getMockForAbstractClass(
                 WriteInterface::class
             );
@@ -1238,9 +1257,11 @@ namespace Magento\Setup\Test\Unit\Model {
             $this->filesystem
                 ->expects($this->any())
                 ->method('getDirectoryWrite')
-                ->willReturnMap([
-                                    [DirectoryList::CONFIG, DriverPool::FILE, $configDir],
-                                ]);
+                ->willReturnMap(
+                    [
+                        [DirectoryList::CONFIG, DriverPool::FILE, $configDir],
+                    ]
+                );
             $cacheManager = $this->createMock(Manager::class);
             $cacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['foo', 'bar']);
             $cacheManager->expects($this->once())->method('clean');
@@ -1307,7 +1328,7 @@ namespace Magento\Setup\Test\Unit\Model {
             $allModules = [
                 'Foo_One' => [],
                 'Bar_Two' => [],
-                'New_Module' => [],
+                'New_Module' => []
             ];
 
             $cacheManager = $this->createMock(Manager::class);
@@ -1315,9 +1336,11 @@ namespace Magento\Setup\Test\Unit\Model {
             $cacheManager->expects($this->once())->method('clean');
             $this->objectManager->expects($this->any())
                 ->method('get')
-                ->willReturnMap([
-                                    [Manager::class, $cacheManager]
-                                ]);
+                ->willReturnMap(
+                    [
+                        [Manager::class, $cacheManager]
+                    ]
+                );
             $this->moduleLoader->expects($this->once())->method('load')->willReturn($allModules);
 
             $expectedModules = [


### PR DESCRIPTION
### Description (*)
This PR fixes CE project codebase compatibility problems with the PHPUnit v.9.3.0.
See changes here: [PHPUnit 9.3.0 ChangeLog](https://github.com/sebastianbergmann/phpunit/blob/9.3.0/ChangeLog-9.3.md#configuration-of-code-coverage-and-logging-in-phpunitxml)

In this PR was changed 183 files where the main problem was using at() matcher that has been deprecated.

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/576
https://github.com/magento/partners-magento2b2b/pull/579
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#33707

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)