### PR TITLE
Fix unable to remove parameter override for a webapi route

### DIFF
--- a/app/code/Magento/Webapi/Model/Config/Converter.php
+++ b/app/code/Magento/Webapi/Model/Config/Converter.php
@@ -138,7 +138,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
             $name = $parameter->attributes->getNamedItem('name')->nodeValue;
             $forceNode = $parameter->attributes->getNamedItem('force');
-            $force = filter_var($forceNode ? $forceNode->nodeValue : false, FILTER_VALIDATE_BOOLEAN);
+            $force = $forceNode ? filter_var($forceNode->nodeValue, FILTER_VALIDATE_BOOLEAN) : false;
             $value = $parameter->nodeValue;
             $data[$name] = [
                 self::KEY_FORCE => $force,

--- a/app/code/Magento/Webapi/Model/Config/Converter.php
+++ b/app/code/Magento/Webapi/Model/Config/Converter.php
@@ -83,6 +83,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             } else {
                 $serviceClassData[self::KEY_METHODS][$soapMethod][self::KEY_ACL_RESOURCES] =
                     array_unique(
+                        // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                         array_merge(
                             $serviceClassData[self::KEY_METHODS][$soapMethod][self::KEY_ACL_RESOURCES],
                             $resourcePermissionSet

--- a/app/code/Magento/Webapi/Model/Config/Converter.php
+++ b/app/code/Magento/Webapi/Model/Config/Converter.php
@@ -138,7 +138,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
             $name = $parameter->attributes->getNamedItem('name')->nodeValue;
             $forceNode = $parameter->attributes->getNamedItem('force');
-            $force = $forceNode ? (bool)$forceNode->nodeValue : false;
+            $force = filter_var($forceNode->nodeValue, FILTER_VALIDATE_BOOLEAN);
             $value = $parameter->nodeValue;
             $data[$name] = [
                 self::KEY_FORCE => $force,

--- a/app/code/Magento/Webapi/Model/Config/Converter.php
+++ b/app/code/Magento/Webapi/Model/Config/Converter.php
@@ -138,7 +138,7 @@ class Converter implements \Magento\Framework\Config\ConverterInterface
             }
             $name = $parameter->attributes->getNamedItem('name')->nodeValue;
             $forceNode = $parameter->attributes->getNamedItem('force');
-            $force = filter_var($forceNode->nodeValue, FILTER_VALIDATE_BOOLEAN);
+            $force = filter_var($forceNode ? $forceNode->nodeValue : false, FILTER_VALIDATE_BOOLEAN);
             $value = $parameter->nodeValue;
             $data[$name] = [
                 self::KEY_FORCE => $force,


### PR DESCRIPTION

### Description (*)
This PR contains the changes to fix #33843 - the `force` attribute in a `webapi.xml` is ignored in certain cases.


### Fixed Issues (if relevant)
1. Fixes magento/magento2#33843

### Manual testing scenarios (*)
1. Redefine a route parameter override in a new `webapi.xml`
2. Verify the webapi config with something like the `n98 dev:console` 

### Questions or comments


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
