### PR TITLE
Fix method signature

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -469,7 +469,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      * Set curl option directly
      *
      * @param string $name
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
     protected function curlOption($name, $value)
@@ -503,7 +503,7 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      * Set curl option
      *
      * @param string $name
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
     public function setOption($name, $value)


### PR DESCRIPTION
### Description

`curl_setopt` accepts `mixed` as value. I get an invalid type when calling these methods in the `Magento\Framework\HTTP\Client\Curl`:

```
   ERROR: InvalidArgument - app/code/My/Module/Model.php:30:73 - Argument 2 of Magento\Framework\HTTP\Client\Curl::setOption cannot be false, string value expected (see https://psalm.dev/004)
                  $subject->curlClient->setOption(CURLOPT_SSL_VERIFYHOST, true);
```

### Manual testing scenarios

1. Run psalm/phpstan against a class that calls `Magento\Framework\HTTP\Client\Curl::setOption`


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34439: Fix method signature