### PR TITLE
Added "Today" to dashboard report

### DIFF
--- a/app/code/Magento/Backend/Model/Dashboard/Chart/Date.php
+++ b/app/code/Magento/Backend/Model/Dashboard/Chart/Date.php
@@ -63,6 +63,8 @@ class Date
 
         if ($period === Period::PERIOD_24_HOURS) {
             $dateEnd->modify('-1 hour');
+        } elseif ($period === Period::PERIOD_TODAY) {
+            $dateEnd->modify('now');
         } else {
             $dateEnd->setTime(23, 59, 59);
             $dateStart->setTime(0, 0, 0);

--- a/app/code/Magento/Backend/Model/Dashboard/Period.php
+++ b/app/code/Magento/Backend/Model/Dashboard/Period.php
@@ -12,6 +12,7 @@ namespace Magento\Backend\Model\Dashboard;
  */
 class Period
 {
+    public const PERIOD_TODAY = 'today';
     public const PERIOD_24_HOURS = '24h';
     public const PERIOD_7_DAYS = '7d';
     public const PERIOD_1_MONTH = '1m';
@@ -30,6 +31,7 @@ class Period
     public function getDatePeriods(): array
     {
         return [
+            static::PERIOD_TODAY => __('Today'),
             static::PERIOD_24_HOURS => __('Last 24 Hours'),
             static::PERIOD_7_DAYS => __('Last 7 Days'),
             static::PERIOD_1_MONTH => __('Current Month'),
@@ -46,6 +48,7 @@ class Period
     public function getPeriodChartUnits(): array
     {
         return [
+            static::PERIOD_TODAY => self::PERIOD_UNIT_HOUR,
             static::PERIOD_24_HOURS => self::PERIOD_UNIT_HOUR,
             static::PERIOD_7_DAYS => self::PERIOD_UNIT_DAY,
             static::PERIOD_1_MONTH => self::PERIOD_UNIT_DAY,

--- a/app/code/Magento/Backend/Test/Unit/Model/Dashboard/PeriodTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Dashboard/PeriodTest.php
@@ -37,6 +37,7 @@ class PeriodTest extends TestCase
     {
         $this->assertEquals(
             [
+                Period::PERIOD_TODAY => (string)__('Today'),
                 Period::PERIOD_24_HOURS => (string)__('Last 24 Hours'),
                 Period::PERIOD_7_DAYS => (string)__('Last 7 Days'),
                 Period::PERIOD_1_MONTH => (string)__('Current Month'),

--- a/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Order/Collection.php
@@ -318,6 +318,7 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
     protected function _getRangeExpression($range)
     {
         switch ($range) {
+            case 'today':
             case '24h':
                 $expression = $this->getConnection()->getConcatSql(
                     [
@@ -420,6 +421,9 @@ class Collection extends \Magento\Sales\Model\ResourceModel\Order\Collection
         $dateStart->setTime(0, 0, 0);
 
         switch ($range) {
+            case 'today':
+                $dateEnd->modify('now');
+                break;
             case '24h':
                 $dateEnd = new \DateTime();
                 $dateEnd->modify('+1 hour');

--- a/dev/tests/integration/testsuite/Magento/Backend/Block/Dashboard/Chart/PeriodTest.php
+++ b/dev/tests/integration/testsuite/Magento/Backend/Block/Dashboard/Chart/PeriodTest.php
@@ -52,6 +52,7 @@ class PeriodTest extends TestCase
     {
         $html = $this->block->toHtml();
         $dropDownList = [
+            __('Today'),
             __('Last 24 Hours'),
             __('Last 7 Days'),
             __('Current Month'),


### PR DESCRIPTION
### Description (*)
Adds "Today" to the dashboard charts, so we can get a summary of sales/orders throughout the day.

![image](https://user-images.githubusercontent.com/3066337/130241196-4c3756cd-864a-459a-b45e-fe64f1cbad5b.png)

### Manual testing scenarios (*)
1. Checkout an order as a customer
2. Log in to the backend
3. Enable Charts
4. Select "Today" From either the Orders or Amounts tab on the dashboard
5. Check the Graph and figures update accordingly


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34008: Added "Today" to dashboard report