### PR TITLE
Replaced PHP8-only str_contains method.

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
@@ -71,7 +71,7 @@ class DenyListPathValidator implements PathValidatorInterface
 
         foreach ($this->fileDenyList as $file) {
             $baseName = pathinfo($actualPath, PATHINFO_BASENAME);
-            if (stripos($baseName, $file) !== false || preg_match('#' . "\." . $file . '#', $fullPath)) {
+            if ('' === $needle || false !== strpos($haystack, $needle) || preg_match('#' . "\." . $file . '#', $fullPath)) {
                 throw new ValidatorException(
                     new Phrase('"%1" is not a valid file path', [$path])
                 );

--- a/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
@@ -71,7 +71,7 @@ class DenyListPathValidator implements PathValidatorInterface
 
         foreach ($this->fileDenyList as $file) {
             $baseName = pathinfo($actualPath, PATHINFO_BASENAME);
-            if ('' === $file || false !== strpos($baseName, $file) || preg_match('#' . "\." . $file . '#', $fullPath)) {
+            if (strpos($baseName, $file) !== false || preg_match('#' . "\." . $file . '#', $fullPath)) {
                 throw new ValidatorException(
                     new Phrase('"%1" is not a valid file path', [$path])
                 );

--- a/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
@@ -71,7 +71,7 @@ class DenyListPathValidator implements PathValidatorInterface
 
         foreach ($this->fileDenyList as $file) {
             $baseName = pathinfo($actualPath, PATHINFO_BASENAME);
-            if (str_contains($baseName, $file) || preg_match('#' . "\." . $file . '#', $fullPath)) {
+            if (stripos($baseName, $file) !== false || preg_match('#' . "\." . $file . '#', $fullPath)) {
                 throw new ValidatorException(
                     new Phrase('"%1" is not a valid file path', [$path])
                 );

--- a/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/DenyListPathValidator.php
@@ -71,7 +71,7 @@ class DenyListPathValidator implements PathValidatorInterface
 
         foreach ($this->fileDenyList as $file) {
             $baseName = pathinfo($actualPath, PATHINFO_BASENAME);
-            if ('' === $needle || false !== strpos($haystack, $needle) || preg_match('#' . "\." . $file . '#', $fullPath)) {
+            if ('' === $file || false !== strpos($baseName, $file) || preg_match('#' . "\." . $file . '#', $fullPath)) {
                 throw new ValidatorException(
                     new Phrase('"%1" is not a valid file path', [$path])
                 );


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR removes the PHP8-only method str_contains and replaces it with the traditional stripos() check with false, which is available since PHP5.

The reason for using this older method are the Magento 2.4 system requirements: Magento 2.4 supports PHP7.4 which does not contain the str_contains method [source](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html). The latest version of Magento, 2.4.3, does not even support PHP 8 [source](https://devdocs.magento.com/guides/v2.4/release-notes/open-source-2-4-3.html).

This issue has to be fixed, since it breaks upgrading a Magento instance on PHP 7.4. (see Manual error-reproducing scenario)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33680
2. Fixes https://github.com/magento/magento2/issues/33755
3. Fixes https://github.com/magento/magento2/issues/33945
### Manual error-reproducing scenario
1. Create a Magento installation on any version lower than 2.4.3.
2. Use PHP 7.4.
3. Run `composer require magento/product-community-edition=2.4.3 --no-update`
4. Run `composer update`
5. The update fails; saying `call to undefined method str_contains().`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
