### PR TITLE
Fix issue with PayPal express

### DIFF
--- a/app/code/Magento/Paypal/view/frontend/web/js/in-context/button.js
+++ b/app/code/Magento/Paypal/view/frontend/web/js/in-context/button.js
@@ -18,11 +18,18 @@ define([
         /** @inheritdoc */
         initialize: function (config, element) {
             var cart = customerData.get('cart'),
-                customer = customerData.get('customer');
+                customer = customerData.get('customer'),
+                updateDeclinePayment = function () {
+                    this.declinePayment = !customer().firstname && !cart().isGuestCheckoutAllowed;
+                }.bind(this);
 
             this._super();
             this.renderPayPalButtons(element);
-            this.declinePayment = !customer().firstname && !cart().isGuestCheckoutAllowed;
+
+            updateDeclinePayment();
+
+            cart.subscribe(updateDeclinePayment);
+            customer.subscribe(updateDeclinePayment);
 
             return this;
         },


### PR DESCRIPTION
Sometimes the `customer()` and `cart()` were empty objects because they weren't initialized yet. To fix this behavior, we're updating the value that we have right now and triggering re-calculation of this value on change to any of them.

Our local tests showed that this fixes the issue.

### Fixed Issues
1. Fixes magento/magento2#33445
2. Fixes magento/magento2#23761

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
