### PR TITLE
33916: CE eliminated calls deprecated methods of the phpunit/phpunit

### DIFF
--- a/app/code/Magento/Analytics/Test/Unit/Model/Connector/Http/Client/CurlTest.php
+++ b/app/code/Magento/Analytics/Test/Unit/Model/Connector/Http/Client/CurlTest.php
@@ -50,7 +50,7 @@ class CurlTest extends TestCase
     private $converterMock;
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function setUp(): void
     {
@@ -58,7 +58,7 @@ class CurlTest extends TestCase
 
         $this->loggerMock = $this->getMockForAbstractClass(LoggerInterface::class);
         $curlFactoryMock = $this->getMockBuilder(CurlFactory::class)
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $curlFactoryMock
@@ -76,7 +76,7 @@ class CurlTest extends TestCase
                 'curlFactory' => $curlFactoryMock,
                 'responseFactory' => $this->responseFactoryMock,
                 'converter' => $this->converterMock,
-                'logger' => $this->loggerMock,
+                'logger' => $this->loggerMock
             ]
         );
     }
@@ -94,7 +94,7 @@ class CurlTest extends TestCase
                     'version' => '1.1',
                     'body'=> ['name' => 'value'],
                     'url' => 'http://www.mystore.com',
-                    'method' => ZendClient::POST,
+                    'method' => ZendClient::POST
                 ]
             ]
         ];
@@ -122,14 +122,8 @@ class CurlTest extends TestCase
         $this->curlAdapterMock->expects($this->once())
             ->method('read')
             ->willReturn($responseString);
-        $this->curlAdapterMock
-            ->method('getErrno')
-            ->willReturn(0);
-
-        $this->responseFactoryMock
-            ->method('create')
-            ->with($responseString)
-            ->willReturn($response);
+        $this->curlAdapterMock->method('getErrno')->willReturn(0);
+        $this->responseFactoryMock->method('create')->with($responseString)->willReturn($response);
 
         $this->assertEquals(
             $response,
@@ -196,7 +190,7 @@ class CurlTest extends TestCase
     private function createJsonConverter()
     {
         $converterMock = $this->getMockBuilder(JsonConverter::class)
-            ->setMethodsExcept(['getContentTypeHeader'])
+            ->onlyMethods(['getContentTypeHeader','toBody'])
             ->disableOriginalConstructor()
             ->getMock();
         $converterMock->method('toBody')->willReturnCallback(function ($value) {

--- a/app/code/Magento/Backup/Test/Unit/Model/Fs/CollectionTest.php
+++ b/app/code/Magento/Backup/Test/Unit/Model/Fs/CollectionTest.php
@@ -17,7 +17,10 @@ use PHPUnit\Framework\TestCase;
 
 class CollectionTest extends TestCase
 {
-    public function testConstructor()
+    /**
+     * @return void
+     */
+    public function testConstructor(): void
     {
         $helper = new ObjectManager($this);
         $filesystem = $this->getMockBuilder(Filesystem::class)
@@ -39,8 +42,9 @@ class CollectionTest extends TestCase
         )->disableOriginalConstructor()
             ->getMock();
         $directoryWrite->expects($this->any())->method('create')->with('backups');
-        $directoryWrite->expects($this->any())->method('getAbsolutePath')->willReturn('');
-        $directoryWrite->expects($this->at(3))->method('getAbsolutePath')->with('backups');
+        $directoryWrite->method('getAbsolutePath')
+            ->withConsecutive([], [], ['backups'])
+            ->willReturnOnConsecutiveCalls('', '');
         $directoryWrite->expects($this->any())->method('isDirectory')->willReturn(true);
         $directoryWrite->expects($this->any())->method('getDriver')->willReturn($driver);
         $targetDirectory = $this->getMockBuilder(TargetDirectory::class)

--- a/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Controller/Adminhtml/Category/SaveTest.php
@@ -82,9 +82,9 @@ class SaveTest extends TestCase
     private $save;
 
     /**
-     * Set up
+     * Set up.
      *
-     * @return void
+     * @inheritdoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -144,17 +144,17 @@ class SaveTest extends TestCase
     }
 
     /**
-     * Run test execute method
+     * Run test execute method.
      *
      * @param int|bool $categoryId
      * @param int $storeId
      * @param int|null $parentId
-     * @return void
      *
+     * @return void
      * @dataProvider dataProviderExecute
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testExecute($categoryId, $storeId, $parentId)
+    public function testExecute($categoryId, $storeId, $parentId): void
     {
         $this->markTestSkipped('Due to MAGETWO-48956');
 
@@ -407,9 +407,7 @@ class SaveTest extends TestCase
         $this->messageManagerMock->expects($this->once())
             ->method('addSuccessMessage')
             ->with(__('You saved the category.'));
-        $categoryMock->expects($this->at(1))
-            ->method('getId')
-            ->willReturn(111);
+        $categoryMock->method('getId')->willReturn(111);
         $this->layoutFactoryMock->expects($this->once())
             ->method('create')
             ->willReturn($layoutMock);
@@ -449,22 +447,22 @@ class SaveTest extends TestCase
     }
 
     /**
-     * Data provider for execute
+     * Data provider for execute.
      *
      * @return array
      */
-    public function dataProviderExecute()
+    public function dataProviderExecute(): array
     {
         return [
             [
                 'categoryId' => false,
                 'storeId' => 7,
-                'parentId' => 123,
+                'parentId' => 123
             ],
             [
                 'categoryId' => false,
                 'storeId' => 7,
-                'parentId' => null,
+                'parentId' => null
             ]
         ];
     }
@@ -472,7 +470,7 @@ class SaveTest extends TestCase
     /**
      * @return array
      */
-    public function imagePreprocessingDataProvider()
+    public function imagePreprocessingDataProvider(): array
     {
         $dataWithImage = [
             'image' => 'path.jpg',
@@ -502,7 +500,7 @@ class SaveTest extends TestCase
      * @param array $data
      * @param array $expected
      */
-    public function testImagePreprocessing($data, $expected)
+    public function testImagePreprocessing($data, $expected): void
     {
         $eavConfig = $this->createPartialMock(\Magento\Eav\Model\Config::class, ['getEntityType']);
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/SortbyTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Category/Attribute/Backend/SortbyTest.php
@@ -23,33 +23,36 @@ class SortbyTest extends TestCase
     /**
      * @var Sortby
      */
-    protected $_model;
+    private $model;
 
     /**
      * @var ObjectManager
      */
-    protected $_objectHelper;
+    private $objectHelper;
 
     /**
      * @var AbstractAttribute
      */
-    protected $_attribute;
+    private $attribute;
 
     /**
      * @var ScopeConfigInterface
      */
-    protected $_scopeConfig;
+    private $scopeConfig;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         $this->markTestSkipped('Due to MAGETWO-48956');
-        $this->_objectHelper = new ObjectManager($this);
-        $this->_scopeConfig = $this->getMockForAbstractClass(ScopeConfigInterface::class);
-        $this->_model = $this->_objectHelper->getObject(
+        $this->objectHelper = new ObjectManager($this);
+        $this->scopeConfig = $this->getMockForAbstractClass(ScopeConfigInterface::class);
+        $this->model = $this->objectHelper->getObject(
             Sortby::class,
-            ['scopeConfig' => $this->_scopeConfig]
+            ['scopeConfig' => $this->scopeConfig]
         );
-        $this->_attribute = $this->createPartialMock(
+        $this->attribute = $this->createPartialMock(
             AbstractAttribute::class,
             [
                 'getName',
@@ -62,20 +65,22 @@ class SortbyTest extends TestCase
             ]
         );
 
-        $this->_model->setAttribute($this->_attribute);
+        $this->model->setAttribute($this->attribute);
     }
 
     /**
      * @param $attributeCode
      * @param $data
      * @param $expected
+     *
+     * @return void
      * @dataProvider beforeSaveDataProvider
      */
-    public function testBeforeSave($attributeCode, $data, $expected)
+    public function testBeforeSave($attributeCode, $data, $expected): void
     {
-        $this->_attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
+        $this->attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
         $object = new DataObject($data);
-        $this->_model->beforeSave($object);
+        $this->model->beforeSave($object);
         $this->assertTrue($object->hasData($attributeCode));
         $this->assertSame($expected, $object->getData($attributeCode));
     }
@@ -83,33 +88,33 @@ class SortbyTest extends TestCase
     /**
      * @return array
      */
-    public function beforeSaveDataProvider()
+    public function beforeSaveDataProvider(): array
     {
         return [
             'attribute with specified value' => [
                 self::DEFAULT_ATTRIBUTE_CODE,
                 [self::DEFAULT_ATTRIBUTE_CODE => 'test_value'],
-                'test_value',
+                'test_value'
             ],
             'attribute with default value' => [
                 self::DEFAULT_ATTRIBUTE_CODE,
                 [self::DEFAULT_ATTRIBUTE_CODE => null],
-                null,
+                null
             ],
             'attribute does not exist' => [
                 self::DEFAULT_ATTRIBUTE_CODE,
                 [],
-                null,
+                null
             ],
             'attribute sort by empty' => [
                 'available_sort_by',
                 ['available_sort_by' => null],
-                null,
+                null
             ],
             'attribute sort by' => [
                 'available_sort_by',
                 ['available_sort_by' => ['test', 'value']],
-                'test,value',
+                'test,value'
             ]
         ];
     }
@@ -118,13 +123,15 @@ class SortbyTest extends TestCase
      * @param $attributeCode
      * @param $data
      * @param $expected
+     *
+     * @return void
      * @dataProvider afterLoadDataProvider
      */
-    public function testAfterLoad($attributeCode, $data, $expected)
+    public function testAfterLoad($attributeCode, $data, $expected): void
     {
-        $this->_attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
+        $this->attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
         $object = new DataObject($data);
-        $this->_model->afterLoad($object);
+        $this->model->afterLoad($object);
         $this->assertTrue($object->hasData($attributeCode));
         $this->assertSame($expected, $object->getData($attributeCode));
     }
@@ -132,23 +139,23 @@ class SortbyTest extends TestCase
     /**
      * @return array
      */
-    public function afterLoadDataProvider()
+    public function afterLoadDataProvider(): array
     {
         return [
             'attribute with specified value' => [
                 self::DEFAULT_ATTRIBUTE_CODE,
                 [self::DEFAULT_ATTRIBUTE_CODE => 'test_value'],
-                'test_value',
+                'test_value'
             ],
             'attribute sort by empty' => [
                 'available_sort_by',
                 ['available_sort_by' => null],
-                null,
+                null
             ],
             'attribute sort by' => [
                 'available_sort_by',
                 ['available_sort_by' => 'test,value'],
-                ['test', 'value'],
+                ['test', 'value']
             ]
         ];
     }
@@ -157,57 +164,61 @@ class SortbyTest extends TestCase
      * @param $attributeData
      * @param $data
      * @param $expected
+     *
+     * @return void
      * @dataProvider validateDataProvider
      */
-    public function testValidate($attributeData, $data, $expected)
+    public function testValidate($attributeData, $data, $expected): void
     {
-        $this->_attribute->expects($this->any())->method('getName')->willReturn($attributeData['code']);
-        $this->_attribute
-            ->expects($this->at(1))
-            ->method('getIsRequired')
+        $this->attribute->expects($this->any())->method('getName')->willReturn($attributeData['code']);
+        $this->attribute->method('getIsRequired')
             ->willReturn($attributeData['isRequired']);
-        $this->_attribute
+        $this->attribute
             ->expects($this->any())
             ->method('isValueEmpty')
             ->willReturn($attributeData['isValueEmpty']);
         $object = new DataObject($data);
-        $this->assertSame($expected, $this->_model->validate($object));
+        $this->assertSame($expected, $this->model->validate($object));
     }
 
     /**
      * @return array
      */
-    public function validateDataProvider()
+    public function validateDataProvider(): array
     {
         return [
             'is not required' => [
                 ['code' => self::DEFAULT_ATTRIBUTE_CODE, 'isRequired' => false, 'isValueEmpty' => false],
                 [],
-                true,
+                true
             ],
             'required, empty, not use config case 1' => [
                 ['code' => self::DEFAULT_ATTRIBUTE_CODE, 'isRequired' => true, 'isValueEmpty' => true],
                 [self::DEFAULT_ATTRIBUTE_CODE => [], 'use_post_data_config' => []],
-                false,
+                false
             ],
             'required, empty, not use config case 2' => [
                 ['code' => self::DEFAULT_ATTRIBUTE_CODE, 'isRequired' => true, 'isValueEmpty' => true],
                 [self::DEFAULT_ATTRIBUTE_CODE => [], 'use_post_data_config' => ['config']],
-                false,
+                false
             ],
             'required, empty, use config' => [
                 ['code' => self::DEFAULT_ATTRIBUTE_CODE, 'isRequired' => true, 'isValueEmpty' => true],
                 [self::DEFAULT_ATTRIBUTE_CODE => [], 'use_post_data_config' => [self::DEFAULT_ATTRIBUTE_CODE]],
-                true,
-            ],
+                true
+            ]
         ];
     }
 
-    public function testValidateUnique()
+    /**
+     * @return void
+     */
+    public function testValidateUnique(): void
     {
-        $this->_attribute->expects($this->any())->method('getName')->willReturn('attribute_name');
-        $this->_attribute->expects($this->at(1))->method('getIsRequired');
-        $this->_attribute->expects($this->at(2))->method('getIsUnique')->willReturn(true);
+        $this->attribute->expects($this->any())->method('getName')->willReturn('attribute_name');
+        $this->attribute->method('getIsRequired');
+        $this->attribute§('getIsUnique')
+            ->willReturn(true);
 
         $entityMock = $this->getMockForAbstractClass(
             AbstractEntity::class,
@@ -218,17 +229,21 @@ class SortbyTest extends TestCase
             true,
             ['checkAttributeUniqueValue']
         );
-        $this->_attribute->expects($this->any())->method('getEntity')->willReturn($entityMock);
-        $entityMock->expects($this->at(0))->method('checkAttributeUniqueValue')->willReturn(true);
-        $this->assertTrue($this->_model->validate(new DataObject()));
+        $this->attribute->expects($this->any())->method('getEntity')->willReturn($entityMock);
+        $entityMock->method('checkAttributeUniqueValue')
+            ->willReturn(true);
+        $this->assertTrue($this->model->validate(new DataObject()));
     }
 
-    public function testValidateUniqueException()
+    /**
+     * @return void
+     */
+    public function testValidateUniqueException(): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
-        $this->_attribute->expects($this->any())->method('getName')->willReturn('attribute_name');
-        $this->_attribute->expects($this->at(1))->method('getIsRequired');
-        $this->_attribute->expects($this->at(2))->method('getIsUnique')->willReturn(true);
+        $this->attribute->expects($this->any())->method('getName')->willReturn('attribute_name');
+        $this->attribute->method('getIsRequired');
+        $this->attribute->method('getIsUnique')->willReturn(true);
 
         $entityMock = $this->getMockForAbstractClass(
             AbstractEntity::class,
@@ -248,29 +263,31 @@ class SortbyTest extends TestCase
             true,
             ['getLabel']
         );
-        $this->_attribute->expects($this->any())->method('getEntity')->willReturn($entityMock);
-        $this->_attribute->expects($this->any())->method('getFrontend')->willReturn($frontMock);
-        $entityMock->expects($this->at(0))->method('checkAttributeUniqueValue')->willReturn(false);
-        $this->assertTrue($this->_model->validate(new DataObject()));
+        $this->attribute->expects($this->any())->method('getEntity')->willReturn($entityMock);
+        $this->attribute->expects($this->any())->method('getFrontend')->willReturn($frontMock);
+        $entityMock->method('checkAttributeUniqueValue')->willReturn(false);
+        $this->assertTrue($this->model->validate(new DataObject()));
     }
 
     /**
      * @param $attributeCode
      * @param $data
+     *
+     * @return void
      * @dataProvider validateDefaultSortDataProvider
      */
-    public function testValidateDefaultSort($attributeCode, $data)
+    public function testValidateDefaultSort($attributeCode, $data): void
     {
-        $this->_attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
-        $this->_scopeConfig->expects($this->any())->method('getValue')->willReturn('value2');
+        $this->attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
+        $this->scopeConfig->expects($this->any())->method('getValue')->willReturn('value2');
         $object = new DataObject($data);
-        $this->assertTrue($this->_model->validate($object));
+        $this->assertTrue($this->model->validate($object));
     }
 
     /**
      * @return array
      */
-    public function validateDefaultSortDataProvider()
+    public function validateDefaultSortDataProvider(): array
     {
         return [
             [
@@ -279,7 +296,7 @@ class SortbyTest extends TestCase
                     'available_sort_by' => ['value1', 'value2'],
                     'default_sort_by' => 'value2',
                     'use_post_data_config' => []
-                ],
+                ]
             ],
             [
                 'default_sort_by',
@@ -295,28 +312,30 @@ class SortbyTest extends TestCase
                     'default_sort_by' => null,
                     'use_post_data_config' => ['available_sort_by', 'default_sort_by', 'filter_price_range']
                 ]
-            ],
+            ]
         ];
     }
 
     /**
      * @param $attributeCode
      * @param $data
+     *
+     * @return void
      * @dataProvider validateDefaultSortException
      */
-    public function testValidateDefaultSortException($attributeCode, $data)
+    public function testValidateDefaultSortException($attributeCode, $data): void
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');
-        $this->_attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
-        $this->_scopeConfig->expects($this->any())->method('getValue')->willReturn('another value');
+        $this->attribute->expects($this->any())->method('getName')->willReturn($attributeCode);
+        $this->scopeConfig->expects($this->any())->method('getValue')->willReturn('another value');
         $object = new DataObject($data);
-        $this->_model->validate($object);
+        $this->model->validate($object);
     }
 
     /**
      * @return array
      */
-    public function validateDefaultSortException()
+    public function validateDefaultSortException(): array
     {
         return [
             [
@@ -324,7 +343,7 @@ class SortbyTest extends TestCase
                 [
                     'available_sort_by' => null,
                     'use_post_data_config' => ['default_sort_by']
-                ],
+                ]
             ],
             [
                 'default_sort_by',
@@ -347,7 +366,7 @@ class SortbyTest extends TestCase
                     'available_sort_by' => 'value1',
                     'use_post_data_config' => []
                 ]
-            ],
+            ]
         ];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ActionTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/ActionTest.php
@@ -102,6 +102,9 @@ class ActionTest extends TestCase
      */
     private $productCollectionMock;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         $this->contextMock = $this->getMockBuilder(Context::class)
@@ -163,7 +166,10 @@ class ActionTest extends TestCase
         );
     }
 
-    private function prepareAdapter()
+    /**
+     * @return void
+     */
+    private function prepareAdapter(): void
     {
         $this->connectionMock = $this->getMockBuilder(AdapterInterface::class)
             ->getMockForAbstractClass();
@@ -173,7 +179,12 @@ class ActionTest extends TestCase
             ->willReturn('catalog_product_entity');
     }
 
-    private function prepareProductCollection($items)
+    /**
+     * @param $items
+     *
+     * @return void
+     */
+    private function prepareProductCollection($items): void
     {
         $this->productCollectionMock = $this->getMockBuilder(ProductCollection::class)
             ->disableOriginalConstructor()
@@ -196,9 +207,11 @@ class ActionTest extends TestCase
      * @param string $typeId
      * @param Product[] $items
      * @param int[] $entityIds
+     *
+     * @return void
      * @dataProvider updateProductHasWeightAttributesDataProvider
      */
-    public function testUpdateProductHasWeightAttributes($hasWeight, $typeId, $items, $entityIds)
+    public function testUpdateProductHasWeightAttributes($hasWeight, $typeId, $items, $entityIds): void
     {
         $this->prepareAdapter();
         $this->prepareProductCollection($items);
@@ -233,7 +246,7 @@ class ActionTest extends TestCase
      *
      * @return array
      */
-    public function updateProductHasWeightAttributesDataProvider()
+    public function updateProductHasWeightAttributesDataProvider(): array
     {
         return [
             [
@@ -257,7 +270,10 @@ class ActionTest extends TestCase
         ];
     }
 
-    private function getProductsSimpleToVirtual()
+    /**
+     * @return array
+     */
+    private function getProductsSimpleToVirtual(): array
     {
         $result = [];
 
@@ -265,17 +281,13 @@ class ActionTest extends TestCase
             $productMock = $this->getMockBuilder(Product::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-            $productMock->method('getId')
-                ->willReturn($entityId);
-            $productMock->expects($this->at(1))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_SIMPLE);
-            $productMock->expects($this->at(2))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_VIRTUAL);
-            $productMock->expects($this->at(3))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_VIRTUAL);
+            $productMock->method('getId')->willReturn($entityId);
+            $productMock->method('getTypeId')
+                ->willReturnOnConsecutiveCalls(
+                    Type::TYPE_SIMPLE,
+                    Type::TYPE_VIRTUAL,
+                    Type::TYPE_VIRTUAL
+                );
 
             $result[] = $productMock;
         }
@@ -283,7 +295,10 @@ class ActionTest extends TestCase
         return $result;
     }
 
-    private function getProductsVirtualToSimple()
+    /**
+     * @return array
+     */
+    private function getProductsVirtualToSimple(): array
     {
         $result = [];
 
@@ -291,17 +306,13 @@ class ActionTest extends TestCase
             $productMock = $this->getMockBuilder(Product::class)
                 ->disableOriginalConstructor()
                 ->getMock();
-            $productMock->method('getId')
-                ->willReturn($entityId);
-            $productMock->expects($this->at(1))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_VIRTUAL);
-            $productMock->expects($this->at(2))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_SIMPLE);
-            $productMock->expects($this->at(3))
-                ->method('getTypeId')
-                ->willReturn(Type::TYPE_SIMPLE);
+            $productMock->method('getId')->willReturn($entityId);
+            $productMock->method('getTypeId')
+                ->willReturnOnConsecutiveCalls(
+                    Type::TYPE_VIRTUAL,
+                    Type::TYPE_SIMPLE,
+                    Type::TYPE_SIMPLE
+                );
 
             $result[] = $productMock;
         }
@@ -309,7 +320,10 @@ class ActionTest extends TestCase
         return $result;
     }
 
-    private function getProductsMixedTypes()
+    /**
+     * @return array
+     */
+    private function getProductsMixedTypes(): array
     {
         $result = [];
 
@@ -322,22 +336,15 @@ class ActionTest extends TestCase
                 ->willReturn($entityId);
 
             if ($i < 2) {
-                $productMock->expects($this->at(1))
-                    ->method('getTypeId')
-                    ->willReturn(Type::TYPE_SIMPLE);
-                $productMock->expects($this->at(2))
-                    ->method('getTypeId')
+                $productMock->method('getTypeId')
                     ->willReturn(Type::TYPE_SIMPLE);
             } else {
-                $productMock->expects($this->at(1))
-                    ->method('getTypeId')
-                    ->willReturn(Type::TYPE_SIMPLE);
-                $productMock->expects($this->at(2))
-                    ->method('getTypeId')
-                    ->willReturn(Type::TYPE_VIRTUAL);
-                $productMock->expects($this->at(3))
-                    ->method('getTypeId')
-                    ->willReturn(Type::TYPE_VIRTUAL);
+                $productMock->method('getTypeId')
+                    ->willReturnOnConsecutiveCalls(
+                        Type::TYPE_SIMPLE,
+                        Type::TYPE_VIRTUAL,
+                        Type::TYPE_VIRTUAL
+                    );
             }
 
             $result[] = $productMock;

--- a/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Fulltext/CollectionTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Model/ResourceModel/Fulltext/CollectionTest.php
@@ -3,17 +3,35 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\CatalogSearch\Test\Unit\Model\ResourceModel\Fulltext;
 
+use Magento\Catalog\Model\ResourceModel\Product\Collection\ProductLimitation;
 use Magento\Catalog\Model\ResourceModel\Product\Collection\ProductLimitationFactory;
+use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\SearchCriteriaResolverFactory;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\SearchCriteriaResolverInterface;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\SearchResultApplierFactory;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\TotalRecordsResolverFactory;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\SearchResultApplierInterface;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection\TotalRecordsResolverInterface;
+use Magento\Eav\Model\Entity\AbstractEntity;
+use Magento\Framework\Api\Filter;
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\SearchCriteriaBuilder;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DB\Adapter\Pdo\Mysql;
+use Magento\Framework\DB\Select;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Validator\UniversalFactory;
+use Magento\Search\Api\SearchInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * Test class for Fulltext Collection
@@ -23,12 +41,12 @@ use PHPUnit\Framework\TestCase;
 class CollectionTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\TestFramework\Unit\Helper\ObjectManager
+     * @var ObjectManager
      */
     private $objectManager;
 
     /**
-     * @var \Magento\Search\Api\SearchInterface|MockObject
+     * @var SearchInterface|MockObject
      */
     private $search;
 
@@ -63,12 +81,12 @@ class CollectionTest extends TestCase
     private $searchResultApplierFactory;
 
     /**
-     * @var \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection
+     * @var Collection
      */
     private $model;
 
     /**
-     * @var \Magento\Framework\Api\Filter
+     * @var Filter
      */
     private $filter;
 
@@ -77,30 +95,28 @@ class CollectionTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->objectManager = new ObjectManager($this);
         $this->storeManager = $this->getStoreManager();
         $this->universalFactory = $this->getUniversalFactory();
         $this->scopeConfig = $this->getScopeConfig();
         $this->criteriaBuilder = $this->getCriteriaBuilder();
         $this->filterBuilder = $this->getFilterBuilder();
 
-        $productLimitationMock = $this->createMock(
-            \Magento\Catalog\Model\ResourceModel\Product\Collection\ProductLimitation::class
-        );
+        $productLimitationMock = $this->createMock(ProductLimitation::class);
         $productLimitationFactoryMock = $this->getMockBuilder(ProductLimitationFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $productLimitationFactoryMock->method('create')
             ->willReturn($productLimitationMock);
 
         $searchCriteriaResolver = $this->getMockBuilder(SearchCriteriaResolverInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['resolve'])
+            ->onlyMethods(['resolve'])
             ->getMockForAbstractClass();
         $searchCriteriaResolverFactory = $this->getMockBuilder(SearchCriteriaResolverFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $searchCriteriaResolverFactory->expects($this->any())
             ->method('create')
@@ -108,23 +124,23 @@ class CollectionTest extends TestCase
 
         $this->searchResultApplierFactory = $this->getMockBuilder(SearchResultApplierFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
 
         $totalRecordsResolver = $this->getMockBuilder(TotalRecordsResolverInterface::class)
             ->disableOriginalConstructor()
-            ->setMethods(['resolve'])
+            ->onlyMethods(['resolve'])
             ->getMockForAbstractClass();
         $totalRecordsResolverFactory = $this->getMockBuilder(TotalRecordsResolverFactory::class)
             ->disableOriginalConstructor()
-            ->setMethods(['create'])
+            ->onlyMethods(['create'])
             ->getMock();
         $totalRecordsResolverFactory->expects($this->any())
             ->method('create')
             ->willReturn($totalRecordsResolver);
 
         $this->model = $this->objectManager->getObject(
-            \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::class,
+            Collection::class,
             [
                 'storeManager' => $this->storeManager,
                 'universalFactory' => $this->universalFactory,
@@ -132,12 +148,12 @@ class CollectionTest extends TestCase
                 'productLimitationFactory' => $productLimitationFactoryMock,
                 'searchCriteriaResolverFactory' => $searchCriteriaResolverFactory,
                 'searchResultApplierFactory' => $this->searchResultApplierFactory,
-                'totalRecordsResolverFactory' => $totalRecordsResolverFactory,
+                'totalRecordsResolverFactory' => $totalRecordsResolverFactory
             ]
         );
 
-        $this->search = $this->getMockBuilder(\Magento\Search\Api\SearchInterface::class)
-            ->setMethods(['search'])
+        $this->search = $this->getMockBuilder(SearchInterface::class)
+            ->onlyMethods(['search'])
             ->getMockForAbstractClass();
         $this->model->setSearchCriteriaBuilder($this->criteriaBuilder);
         $this->model->setSearch($this->search);
@@ -149,19 +165,21 @@ class CollectionTest extends TestCase
      */
     protected function tearDown(): void
     {
-        $reflectionProperty = new \ReflectionProperty(\Magento\Framework\App\ObjectManager::class, '_instance');
+        $reflectionProperty = new ReflectionProperty(\Magento\Framework\App\ObjectManager::class, '_instance');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue(null);
     }
 
     /**
-     * Test to Return field faceted data from faceted search result
+     * Test to Return field faceted data from faceted search result.
+     *
+     * @return void
      */
-    public function testGetFacetedDataWithEmptyAggregations()
+    public function testGetFacetedDataWithEmptyAggregations(): void
     {
         $pageSize = 10;
 
-        $searchResult = $this->getMockBuilder(\Magento\Framework\Api\Search\SearchResultInterface::class)
+        $searchResult = $this->getMockBuilder(SearchResultInterface::class)
             ->getMockForAbstractClass();
         $this->search->expects($this->once())
             ->method('search')
@@ -212,8 +230,8 @@ class CollectionTest extends TestCase
      */
     protected function getScopeConfig()
     {
-        $scopeConfig = $this->getMockBuilder(\Magento\Framework\App\Config\ScopeConfigInterface::class)
-            ->setMethods(['getValue'])
+        $scopeConfig = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->onlyMethods(['getValue'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -223,10 +241,11 @@ class CollectionTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getCriteriaBuilder()
+    protected function getCriteriaBuilder(): MockObject
     {
-        $criteriaBuilder = $this->getMockBuilder(\Magento\Framework\Api\Search\SearchCriteriaBuilder::class)
-            ->setMethods(['addFilter', 'create', 'setRequestName'])
+        $criteriaBuilder = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->addMethods(['setRequestName'])
+            ->onlyMethods(['addFilter','create'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -236,9 +255,9 @@ class CollectionTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function getFilterBuilder()
+    protected function getFilterBuilder(): MockObject
     {
-        $filterBuilder = $this->createMock(\Magento\Framework\Api\FilterBuilder::class);
+        $filterBuilder = $this->createMock(FilterBuilder::class);
 
         return $filterBuilder;
     }
@@ -246,21 +265,24 @@ class CollectionTest extends TestCase
     /**
      * @param MockObject $filterBuilder
      * @param array $filters
+     *
      * @return MockObject
      */
-    protected function addFiltersToFilterBuilder(MockObject $filterBuilder, array $filters)
+    protected function addFiltersToFilterBuilder(MockObject $filterBuilder, array $filters): MockObject
     {
-        $i = 1;
+        $fields = $values = [];
+
         foreach ($filters as $field => $value) {
-            $filterBuilder->expects($this->at($i++))
-                ->method('setField')
-                ->with($field)
-                ->willReturnSelf();
-            $filterBuilder->expects($this->at($i++))
-                ->method('setValue')
-                ->with($value)
-                ->willReturnSelf();
+            $fields[] = $field;
+            $values[] = $value;
         }
+
+        $filterBuilder->method('setField')
+            ->with(...$fields)
+            ->willReturnSelf();
+        $filterBuilder->method('setValue')
+            ->with(...$values)
+            ->willReturnSelf();
 
         return $filterBuilder;
     }
@@ -268,9 +290,9 @@ class CollectionTest extends TestCase
     /**
      * @return MockObject
      */
-    protected function createFilter()
+    protected function createFilter(): MockObject
     {
-        $filter = $this->getMockBuilder(\Magento\Framework\Api\Filter::class)
+        $filter = $this->getMockBuilder(Filter::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -280,20 +302,20 @@ class CollectionTest extends TestCase
     /**
      * Get Mocks for StoreManager so Collection can be used.
      *
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      */
-    private function getStoreManager()
+    private function getStoreManager(): MockObject
     {
-        $store = $this->getMockBuilder(\Magento\Store\Model\Store::class)
-            ->setMethods(['getId'])
+        $store = $this->getMockBuilder(Store::class)
+            ->onlyMethods(['getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $store->expects($this->once())
             ->method('getId')
             ->willReturn(1);
 
-        $storeManager = $this->getMockBuilder(\Magento\Store\Model\StoreManagerInterface::class)
-            ->setMethods(['getStore'])
+        $storeManager = $this->getMockBuilder(StoreManagerInterface::class)
+            ->onlyMethods(['getStore'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $storeManager->expects($this->once())
@@ -306,21 +328,21 @@ class CollectionTest extends TestCase
     /**
      * Get mock for UniversalFactory so Collection can be used.
      *
-     * @return \PHPUnit\Framework\MockObject\MockObject
+     * @return MockObject
      */
-    private function getUniversalFactory()
+    private function getUniversalFactory(): MockObject
     {
-        $connection = $this->getMockBuilder(\Magento\Framework\DB\Adapter\Pdo\Mysql::class)
+        $connection = $this->getMockBuilder(Mysql::class)
             ->disableOriginalConstructor()
-            ->setMethods(['select'])
+            ->onlyMethods(['select'])
             ->getMockForAbstractClass();
-        $select = $this->getMockBuilder(\Magento\Framework\DB\Select::class)
+        $select = $this->getMockBuilder(Select::class)
             ->disableOriginalConstructor()
             ->getMock();
         $connection->expects($this->any())->method('select')->willReturn($select);
 
-        $entity = $this->getMockBuilder(\Magento\Eav\Model\Entity\AbstractEntity::class)
-            ->setMethods(['getConnection', 'getTable', 'getDefaultAttributes', 'getEntityTable'])
+        $entity = $this->getMockBuilder(AbstractEntity::class)
+            ->onlyMethods(['getConnection', 'getTable', 'getDefaultAttributes', 'getEntityTable'])
             ->disableOriginalConstructor()
             ->getMock();
         $entity->expects($this->once())
@@ -336,8 +358,8 @@ class CollectionTest extends TestCase
             ->method('getEntityTable')
             ->willReturn('table');
 
-        $universalFactory = $this->getMockBuilder(\Magento\Framework\Validator\UniversalFactory::class)
-            ->setMethods(['create'])
+        $universalFactory = $this->getMockBuilder(UniversalFactory::class)
+            ->onlyMethods(['create'])
             ->disableOriginalConstructor()
             ->getMock();
         $universalFactory->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/AccountManagementTest.php
@@ -71,147 +71,147 @@ class AccountManagementTest extends TestCase
     /**
      * @var AccountManagement
      */
-    protected $accountManagement;
+    private $accountManagement;
 
     /**
      * @var ObjectManagerHelper
      */
-    protected $objectManagerHelper;
+    private $objectManagerHelper;
 
     /**
      * @var CustomerFactory|MockObject
      */
-    protected $customerFactory;
+    private $customerFactory;
 
     /**
      * @var ManagerInterface|MockObject
      */
-    protected $manager;
+    private $manager;
 
     /**
      * @var StoreManagerInterface|MockObject
      */
-    protected $storeManager;
+    private $storeManager;
 
     /**
      * @var Random|MockObject
      */
-    protected $random;
+    private $random;
 
     /**
      * @var Validator|MockObject
      */
-    protected $validator;
+    private $validator;
 
     /**
      * @var ValidationResultsInterfaceFactory|MockObject
      */
-    protected $validationResultsInterfaceFactory;
+    private $validationResultsInterfaceFactory;
 
     /**
      * @var AddressRepositoryInterface|MockObject
      */
-    protected $addressRepository;
+    private $addressRepository;
 
     /**
      * @var CustomerMetadataInterface|MockObject
      */
-    protected $customerMetadata;
+    private $customerMetadata;
 
     /**
      * @var CustomerRegistry|MockObject
      */
-    protected $customerRegistry;
+    private $customerRegistry;
 
     /**
      * @var LoggerInterface|MockObject
      */
-    protected $logger;
+    private $logger;
 
     /**
      * @var EncryptorInterface|MockObject
      */
-    protected $encryptor;
+    private $encryptor;
 
     /**
      * @var Share|MockObject
      */
-    protected $share;
+    private $share;
 
     /**
      * @var StringUtils|MockObject
      */
-    protected $string;
+    private $string;
 
     /**
      * @var CustomerRepositoryInterface|MockObject
      */
-    protected $customerRepository;
+    private $customerRepository;
 
     /**
      * @var ScopeConfigInterface|MockObject
      */
-    protected $scopeConfig;
+    private $scopeConfig;
 
     /**
      * @var TransportBuilder|MockObject
      */
-    protected $transportBuilder;
+    private $transportBuilder;
 
     /**
      * @var DataObjectProcessor|MockObject
      */
-    protected $dataObjectProcessor;
+    private $dataObjectProcessor;
 
     /**
      * @var Registry|MockObject
      */
-    protected $registry;
+    private $registry;
 
     /**
      * @var View|MockObject
      */
-    protected $customerViewHelper;
+    private $customerViewHelper;
 
     /**
      * @var \Magento\Framework\Stdlib\DateTime|MockObject
      */
-    protected $dateTime;
+    private $dateTime;
 
     /**
      * @var \Magento\Customer\Model\Customer|MockObject
      */
-    protected $customer;
+    private $customer;
 
     /**
      * @var DataObjectFactory|MockObject
      */
-    protected $objectFactory;
+    private $objectFactory;
 
     /**
      * @var ExtensibleDataObjectConverter|MockObject
      */
-    protected $extensibleDataObjectConverter;
+    private $extensibleDataObjectConverter;
 
     /**
      * @var MockObject|Store
      */
-    protected $store;
+    private $store;
 
     /**
      * @var MockObject|CustomerSecure
      */
-    protected $customerSecure;
+    private $customerSecure;
 
     /**
      * @var AuthenticationInterface|MockObject
      */
-    protected $authenticationMock;
+    private $authenticationMock;
 
     /**
      * @var EmailNotificationInterface|MockObject
      */
-    protected $emailNotificationMock;
+    private $emailNotificationMock;
 
     /**
      * @var DateTimeFactory|MockObject
@@ -487,8 +487,7 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer
-            ->method('getStoreId')
+        $customer->method('getStoreId')
             ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
@@ -567,8 +566,7 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getWebsiteId')
             ->willReturn($websiteId);
-        $customer
-            ->method('getStoreId')
+        $customer->method('getStoreId')
             ->willReturnOnConsecutiveCalls(null, null, 1);
         $customer->expects($this->once())
             ->method('setStoreId')
@@ -1177,7 +1175,7 @@ class AccountManagementTest extends TestCase
             ->method('getUniqueHash')
             ->willReturn($newLinkToken);
         $customerSecure = $this->getMockBuilder(CustomerSecure::class)
-            ->setMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
+            ->addMethods(['setRpToken', 'setRpTokenCreatedAt', 'getPasswordHash'])
             ->disableOriginalConstructor()
             ->getMock();
         $customerSecure->expects($this->any())
@@ -1210,7 +1208,7 @@ class AccountManagementTest extends TestCase
     /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function testCreateAccountWithGroupId()
+    public function testCreateAccountWithGroupId(): void
     {
         $websiteId = 1;
         $defaultStoreId = 1;
@@ -1304,12 +1302,9 @@ class AccountManagementTest extends TestCase
         $customer->expects($this->atLeastOnce())
             ->method('getGroupId')
             ->willReturn($requestedGroupId);
-        $customer->expects($this->at(0))
+        $customer
             ->method('setGroupId')
-            ->willReturn(null);
-        $customer->expects($this->at(1))
-            ->method('setGroupId')
-            ->willReturn($defaultGroupId);
+            ->willReturnOnConsecutiveCalls(null, $defaultGroupId);
         $customer->expects($this->atLeastOnce())
             ->method('getEmail')
             ->willReturn($customerEmail);
@@ -1458,14 +1453,14 @@ class AccountManagementTest extends TestCase
             ->with('name', $customerName)
             ->willReturnSelf();
 
-        $this->scopeConfig
-            ->method('getValue')
+        $this->scopeConfig->method('getValue')
             ->withConsecutive(
                 [
                     AccountManagement::XML_PATH_REMIND_EMAIL_TEMPLATE,
                     ScopeInterface::SCOPE_STORE,
                     $customerStoreId
-                ], [
+                ],
+                [
                     AccountManagement::XML_PATH_FORGOT_EMAIL_IDENTITY,
                     ScopeInterface::SCOPE_STORE,
                     $customerStoreId
@@ -2125,10 +2120,10 @@ class AccountManagementTest extends TestCase
             ->withConsecutive(
                 [
                     'customer_customer_authenticated',
-                    ['model' => $customerModel, 'password' => $password],
+                    ['model' => $customerModel, 'password' => $password]
                 ],
                 [
-                    'customer_data_object_login', ['customer' => $customerData],
+                    'customer_data_object_login', ['customer' => $customerData]
                 ]
             );
 
@@ -2219,15 +2214,9 @@ class AccountManagementTest extends TestCase
         $customerMock = $this->getMockBuilder(Customer::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $customerMock
-            ->method('getStoreId')
-            ->willReturn($storeId);
-        $customerMock
-            ->method('getWebsiteId')
-            ->willReturn($websiteId);
-        $customerMock
-            ->method('getId')
-            ->willReturnOnConsecutiveCalls(null, 1);
+        $customerMock->method('getStoreId')->willReturn($storeId);
+        $customerMock->method('getWebsiteId')->willReturn($websiteId);
+        $customerMock->method('getId')->willReturnOnConsecutiveCalls(null, 1);
 
         $this->customerRepository
             ->expects($this->once())

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/AbstractDataTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/AbstractDataTest.php
@@ -25,123 +25,158 @@ class AbstractDataTest extends TestCase
 {
     const MODEL = 'MODEL';
 
-    /** @var ExtendsAbstractData */
-    protected $_model;
+    /**
+     * @var ExtendsAbstractData
+     */
+    private $model;
 
-    /** @var MockObject|TimezoneInterface */
-    protected $_localeMock;
+    /**
+     * @var MockObject|TimezoneInterface
+     */
+    private $localeMock;
 
-    /** @var MockObject|ResolverInterface */
-    protected $_localeResolverMock;
+    /**
+     * @var MockObject|ResolverInterface
+     */
+    private $localeResolverMock;
 
-    /** @var MockObject|LoggerInterface */
-    protected $_loggerMock;
+    /**
+     * @var MockObject|LoggerInterface
+     */
+    private $loggerMock;
 
-    /** @var MockObject|AttributeMetadataInterface */
-    protected $_attributeMock;
+    /**
+     * @var MockObject|AttributeMetadataInterface
+     */
+    private $attributeMock;
 
-    /** @var string */
-    protected $_value;
+    /**
+     * @var string
+     */
+    private $value;
 
-    /** @var string */
-    protected $_entityTypeCode;
+    /**
+     * @var string
+     */
+    private $entityTypeCode;
 
-    /** @var string */
-    protected $_isAjax;
+    /**
+     * @var string
+     */
+    private $isAjax;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
-        $this->_localeMock = $this->getMockBuilder(
+        $this->localeMock = $this->getMockBuilder(
             TimezoneInterface::class
         )->disableOriginalConstructor()
             ->getMock();
-        $this->_localeResolverMock = $this->getMockBuilder(
+        $this->localeResolverMock = $this->getMockBuilder(
             ResolverInterface::class
         )->disableOriginalConstructor()
             ->getMock();
-        $this->_loggerMock = $this->getMockBuilder(LoggerInterface::class)
+        $this->loggerMock = $this->getMockBuilder(LoggerInterface::class)
             ->getMock();
-        $this->_attributeMock = $this->getMockForAbstractClass(AttributeMetadataInterface::class);
-        $this->_value = 'VALUE';
-        $this->_entityTypeCode = 'ENTITY_TYPE_CODE';
-        $this->_isAjax = false;
+        $this->attributeMock = $this->getMockForAbstractClass(AttributeMetadataInterface::class);
+        $this->value = 'VALUE';
+        $this->entityTypeCode = 'ENTITY_TYPE_CODE';
+        $this->isAjax = false;
 
-        $this->_model = new ExtendsAbstractData(
-            $this->_localeMock,
-            $this->_loggerMock,
-            $this->_attributeMock,
-            $this->_localeResolverMock,
-            $this->_value,
-            $this->_entityTypeCode,
-            $this->_isAjax
+        $this->model = new ExtendsAbstractData(
+            $this->localeMock,
+            $this->loggerMock,
+            $this->attributeMock,
+            $this->localeResolverMock,
+            $this->value,
+            $this->entityTypeCode,
+            $this->isAjax
         );
     }
 
-    public function testGetAttribute()
+    /**
+     * @return void
+     */
+    public function testGetAttribute(): void
     {
-        $this->assertSame($this->_attributeMock, $this->_model->getAttribute());
+        $this->assertSame($this->attributeMock, $this->model->getAttribute());
     }
 
-    public function testGetAttributeException()
+    /**
+     * @return void
+     */
+    public function testGetAttributeException(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Attribute object is undefined');
 
-        $this->_model->setAttribute(false);
-        $this->_model->getAttribute();
+        $this->model->setAttribute(false);
+        $this->model->getAttribute();
     }
 
-    public function testSetRequestScope()
+    /**
+     * @return void
+     */
+    public function testSetRequestScope(): void
     {
-        $this->assertSame($this->_model, $this->_model->setRequestScope('REQUEST_SCOPE'));
-        $this->assertSame('REQUEST_SCOPE', $this->_model->getRequestScope());
+        $this->assertSame($this->model, $this->model->setRequestScope('REQUEST_SCOPE'));
+        $this->assertSame('REQUEST_SCOPE', $this->model->getRequestScope());
     }
 
     /**
      * @param bool $bool
+     *
+     * @return void
      * @dataProvider trueFalseDataProvider
      */
-    public function testSetRequestScopeOnly($bool)
+    public function testSetRequestScopeOnly($bool): void
     {
-        $this->assertSame($this->_model, $this->_model->setRequestScopeOnly($bool));
-        $this->assertSame($bool, $this->_model->isRequestScopeOnly());
+        $this->assertSame($this->model, $this->model->setRequestScopeOnly($bool));
+        $this->assertSame($bool, $this->model->isRequestScopeOnly());
     }
 
     /**
      * @return array
      */
-    public function trueFalseDataProvider()
+    public function trueFalseDataProvider(): array
     {
         return [[true], [false]];
     }
 
-    public function testGetSetExtractedData()
+    /**
+     * @return void
+     */
+    public function testGetSetExtractedData(): void
     {
         $data = ['KEY' => 'VALUE'];
-        $this->assertSame($this->_model, $this->_model->setExtractedData($data));
-        $this->assertSame($data, $this->_model->getExtractedData());
-        $this->assertSame('VALUE', $this->_model->getExtractedData('KEY'));
-        $this->assertNull($this->_model->getExtractedData('BAD_KEY'));
+        $this->assertSame($this->model, $this->model->setExtractedData($data));
+        $this->assertSame($data, $this->model->getExtractedData());
+        $this->assertSame('VALUE', $this->model->getExtractedData('KEY'));
+        $this->assertNull($this->model->getExtractedData('BAD_KEY'));
     }
 
     /**
      * @param bool|string $input
      * @param bool|string $output
      * @param bool|string $filter
+     *
+     * @return void
      * @dataProvider applyInputFilterProvider
      */
-    public function testApplyInputFilter($input, $output, $filter)
+    public function testApplyInputFilter($input, $output, $filter): void
     {
         if ($input) {
-            $this->_attributeMock->expects($this->once())->method('getInputFilter')->willReturn($filter);
+            $this->attributeMock->expects($this->once())->method('getInputFilter')->willReturn($filter);
         }
-        $this->assertEquals($output, $this->_model->applyInputFilter($input));
+        $this->assertEquals($output, $this->model->applyInputFilter($input));
     }
 
     /**
      * @return array
      */
-    public function applyInputFilterProvider()
+    public function applyInputFilterProvider(): array
     {
         return [
             [false, false, false],
@@ -155,17 +190,19 @@ class AbstractDataTest extends TestCase
     /**
      * @param null|bool|string $format
      * @param string           $output
+     *
+     * @return void
      * @dataProvider dateFilterFormatProvider
      */
-    public function testDateFilterFormat($format, $output)
+    public function testDateFilterFormat($format, $output): void
     {
         // Since model is instantiated in setup, if I use it directly in the dataProvider, it will be null.
         // I use this value to indicate the model is to be used for output
         if (self::MODEL == $output) {
-            $output = $this->_model;
+            $output = $this->model;
         }
         if ($format === null) {
-            $this->_localeMock->expects(
+            $this->localeMock->expects(
                 $this->once()
             )->method(
                 'getDateFormat'
@@ -175,14 +212,14 @@ class AbstractDataTest extends TestCase
                 $output
             );
         }
-        $actual = $this->_model->dateFilterFormat($format);
+        $actual = $this->model->dateFilterFormat($format);
         $this->assertEquals($output, $actual);
     }
 
     /**
      * @return array
      */
-    public function dateFilterFormatProvider()
+    public function dateFilterFormatProvider(): array
     {
         return [[null, 'Whatever I put'], [false, self::MODEL], ['something else', self::MODEL]];
     }
@@ -191,22 +228,24 @@ class AbstractDataTest extends TestCase
      * @param bool|string $input
      * @param bool|string $output
      * @param bool|string $filter
+     *
+     * @return void
      * @dataProvider applyOutputFilterDataProvider
      */
-    public function testApplyOutputFilter($input, $output, $filter)
+    public function testApplyOutputFilter($input, $output, $filter): void
     {
         if ($input) {
-            $this->_attributeMock->expects($this->once())->method('getInputFilter')->willReturn($filter);
+            $this->attributeMock->expects($this->once())->method('getInputFilter')->willReturn($filter);
         }
-        $this->assertEquals($output, $this->_model->applyOutputFilter($input));
+        $this->assertEquals($output, $this->model->applyOutputFilter($input));
     }
 
     /**
-     * This is similar to applyInputFilterProvider except for striptags
+     * This is similar to applyInputFilterProvider except for striptags.
      *
      * @return array
      */
-    public function applyOutputFilterDataProvider()
+    public function applyOutputFilterDataProvider(): array
     {
         return [
             [false, false, false],
@@ -224,13 +263,14 @@ class AbstractDataTest extends TestCase
      * @param null|string $label
      * @param null|string $inputValidation
      * @param bool|array  $expectedOutput
+     *
+     * @return void
      * @dataProvider validateInputRuleDataProvider
      */
     public function testValidateInputRule($value, $label, $inputValidation, $expectedOutput): void
     {
-        $validationRule = $this->getMockBuilder(ValidationRuleInterface::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getName', 'getValue'])
+        $validationRule = $this->getMockBuilder(ValidationRuleInterface::class)->disableOriginalConstructor()
+            ->onlyMethods(['getName', 'getValue'])
             ->getMockForAbstractClass();
 
         $validationRule->method('getName')
@@ -239,19 +279,19 @@ class AbstractDataTest extends TestCase
         $validationRule->method('getValue')
             ->willReturn($inputValidation);
 
-        $this->_attributeMock->method('getStoreLabel')
+        $this->attributeMock->method('getStoreLabel')
             ->willReturn($label);
 
-        $this->_attributeMock->method('getValidationRules')
+        $this->attributeMock->method('getValidationRules')
             ->willReturn([$validationRule]);
 
-        $this->assertEquals($expectedOutput, $this->_model->validateInputRule($value));
+        $this->assertEquals($expectedOutput, $this->model->validateInputRule($value));
     }
 
     /**
      * @return array
      */
-    public function validateInputRuleDataProvider()
+    public function validateInputRuleDataProvider(): array
     {
         return [
             [null, null, null, true],
@@ -311,20 +351,22 @@ class AbstractDataTest extends TestCase
 
     /**
      * @param bool $ajaxRequest
+     *
+     * @return void
      * @dataProvider trueFalseDataProvider
      */
-    public function testGetIsAjaxRequest($ajaxRequest)
+    public function testGetIsAjaxRequest($ajaxRequest): void
     {
-        $this->_model = new ExtendsAbstractData(
-            $this->_localeMock,
-            $this->_loggerMock,
-            $this->_attributeMock,
-            $this->_localeResolverMock,
-            $this->_value,
-            $this->_entityTypeCode,
+        $this->model = new ExtendsAbstractData(
+            $this->localeMock,
+            $this->loggerMock,
+            $this->attributeMock,
+            $this->localeResolverMock,
+            $this->value,
+            $this->entityTypeCode,
             $ajaxRequest
         );
-        $this->assertSame($ajaxRequest, $this->_model->getIsAjaxRequest());
+        $this->assertSame($ajaxRequest, $this->model->getIsAjaxRequest());
     }
 
     /**
@@ -333,80 +375,54 @@ class AbstractDataTest extends TestCase
      * @param bool|string                   $requestScope
      * @param bool                          $requestScopeOnly
      * @param string                        $expectedValue
+     *
+     * @return void
      * @dataProvider getRequestValueDataProvider
      */
-    public function testGetRequestValue($request, $attributeCode, $requestScope, $requestScopeOnly, $expectedValue)
-    {
-        $this->_attributeMock->expects(
+    public function testGetRequestValue(
+        $request,
+        $attributeCode,
+        $requestScope,
+        $requestScopeOnly,
+        $expectedValue
+    ): void {
+        $this->attributeMock->expects(
             $this->once()
         )->method(
             'getAttributeCode'
         )->willReturn(
             $attributeCode
         );
-        $this->_model->setRequestScope($requestScope);
-        $this->_model->setRequestScopeOnly($requestScopeOnly);
-        $this->assertEquals($expectedValue, $this->_model->getRequestValue($request));
+        $this->model->setRequestScope($requestScope);
+        $this->model->setRequestScopeOnly($requestScopeOnly);
+        $this->assertEquals($expectedValue, $this->model->getRequestValue($request));
     }
 
     /**
      * @return array
      */
-    public function getRequestValueDataProvider()
+    public function getRequestValueDataProvider(): array
     {
         $expectedValue = 'EXPECTED_VALUE';
-        $requestMockOne = $this->getMockBuilder(RequestInterface::class)
+        $requestMock = $this->getMockBuilder(RequestInterface::class)
             ->getMock();
-        $requestMockOne->expects(
-            $this->any()
-        )->method(
-            'getParam'
-        )->with(
-            'ATTR_CODE'
-        )->willReturn(
-            $expectedValue
-        );
+        $requestMock->method('getParam')
+            ->withConsecutive(['ATTR_CODE'], ['REQUEST_SCOPE'], ['REQUEST_SCOPE'])
+            ->willReturn($expectedValue, ['ATTR_CODE' => $expectedValue], []);
 
-        $requestMockTwo = $this->getMockBuilder(RequestInterface::class)
+        $requestMockHttp = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
             ->getMock();
-        $requestMockTwo->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->with(
-            'REQUEST_SCOPE'
-        )->willReturn(
-            ['ATTR_CODE' => $expectedValue]
-        );
+        $requestMockHttp
+            ->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['REQUEST' => ['SCOPE' => ['ATTR_CODE' => $expectedValue]]]);
 
-        $requestMockFour = $this->getMockBuilder(RequestInterface::class)
-            ->getMock();
-        $requestMockFour->expects(
-            $this->at(0)
-        )->method(
-            'getParam'
-        )->with(
-            'REQUEST_SCOPE'
-        )->willReturn(
-            []
-        );
-
-        $requestMockThree = $this->getMockBuilder(
-            Http::class
-        )->disableOriginalConstructor()
-            ->getMock();
-        $requestMockThree->expects(
-            $this->once()
-        )->method(
-            'getParams'
-        )->willReturn(
-            ['REQUEST' => ['SCOPE' => ['ATTR_CODE' => $expectedValue]]]
-        );
         return [
-            [$requestMockOne, 'ATTR_CODE', false, false, $expectedValue],
-            [$requestMockTwo, 'ATTR_CODE', 'REQUEST_SCOPE', false, $expectedValue],
-            [$requestMockThree, 'ATTR_CODE', 'REQUEST/SCOPE', false, $expectedValue],
-            [$requestMockFour, 'ATTR_CODE', 'REQUEST_SCOPE', false, false],
+            [$requestMock, 'ATTR_CODE', false, false, $expectedValue],
+            [$requestMock, 'ATTR_CODE', 'REQUEST_SCOPE', false, $expectedValue],
+            [$requestMock, 'ATTR_CODE', 'REQUEST_SCOPE', false, false],
+            [$requestMockHttp, 'ATTR_CODE', 'REQUEST/SCOPE', false, $expectedValue]
         ];
     }
 }

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/Source/ZipTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/Source/ZipTest.php
@@ -17,52 +17,55 @@ class ZipTest extends TestCase
     /**
      * @var Write|MockObject
      */
-    protected $directory;
+    private $directory;
 
     /**
      * @var Zip|MockObject
      */
-    protected $zip;
+    private $zip;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
-        $this->directory = $this->getMockBuilder(Write::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getRelativePath'])
+        $this->directory = $this->getMockBuilder(Write::class)->disableOriginalConstructor()
+            ->onlyMethods(['getRelativePath'])
             ->getMock();
     }
 
     /**
      * Test destination argument for the second getRelativePath after preg_replace.
      *
+     * @return void
      * @dataProvider constructorFileDestinationMatchDataProvider
      */
-    public function testConstructorFileDestinationMatch($fileName, $expectedfileName)
+    public function testConstructorFileDestinationMatch($fileName, $expectedfileName): void
     {
         $this->markTestIncomplete('The implementation of constructor has changed. Rewrite test to cover changes.');
 
-        $this->directory->expects($this->at(0))->method('getRelativePath')->with($fileName);
-        $this->directory->expects($this->at(1))->method('getRelativePath')->with($expectedfileName);
-        $this->_invokeConstructor($fileName);
+        $this->directory->method('getRelativePath')
+            ->withConsecutive([$fileName], [$expectedfileName]);
+        $this->invokeConstructor($fileName);
     }
 
     /**
      * @return array
      */
-    public function constructorFileDestinationMatchDataProvider()
+    public function constructorFileDestinationMatchDataProvider(): array
     {
         return [
             [
                 '$fileName' => 'test_file.txt',
-                '$expectedfileName' => 'test_file.txt',
+                '$expectedfileName' => 'test_file.txt'
             ],
             [
                 '$fileName' => 'test_file.zip',
-                '$expectedfileName' => 'test_file.csv',
+                '$expectedfileName' => 'test_file.csv'
             ],
             [
                 '$fileName' => '.ziptest_.zip.file.zip.ZIP',
-                '$expectedfileName' => '.ziptest_.zip.file.zip.csv',
+                '$expectedfileName' => '.ziptest_.zip.file.zip.csv'
             ]
         ];
     }
@@ -70,9 +73,10 @@ class ZipTest extends TestCase
     /**
      * Instantiate zip mock and invoke its constructor.
      *
+     * @return void
      * @param string $fileName
      */
-    protected function _invokeConstructor($fileName)
+    private function invokeConstructor($fileName): void
     {
         try {
             $this->zip = $this->getMockBuilder(

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Express/ReturnActionTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Express/ReturnActionTest.php
@@ -16,15 +16,20 @@ class ReturnActionTest extends ExpressTest
 
     /**
      * @param string $path
+     *
+     * @return void
      */
-    protected function _expectRedirect($path = '*/*/review')
+    protected function expectRedirect($path = '*/*/review'): void
     {
         $this->redirect->expects($this->once())
             ->method('redirect')
             ->with($this->anything(), $path, []);
     }
 
-    public function testExecuteAuthorizationRetrial()
+    /**
+     * @return void
+     */
+    public function testExecuteAuthorizationRetrial(): void
     {
         $this->request->expects($this->once())
             ->method('getParam')
@@ -34,39 +39,43 @@ class ReturnActionTest extends ExpressTest
             ->method('__call')
             ->with('getPaypalTransactionData')
             ->willReturn(['any array']);
-        $this->_expectForwardPlaceOrder();
+        $this->expectForwardPlaceOrder();
         $this->model->execute();
     }
 
     /**
      * @return array
      */
-    public function trueFalseDataProvider()
+    public function trueFalseDataProvider(): array
     {
         return [[true], [false]];
     }
 
     /**
      * @param bool $canSkipOrderReviewStep
+     *
+     * @return void
      * @dataProvider trueFalseDataProvider
      */
-    public function testExecute($canSkipOrderReviewStep)
+    public function testExecute($canSkipOrderReviewStep): void
     {
-        $this->checkoutSession->expects($this->at(0))
-            ->method('__call')
+        $this->checkoutSession->method('__call')
             ->with('unsPaypalTransactionData');
         $this->checkout->expects($this->once())
             ->method('canSkipOrderReviewStep')
             ->willReturn($canSkipOrderReviewStep);
         if ($canSkipOrderReviewStep) {
-            $this->_expectForwardPlaceOrder();
+            $this->expectForwardPlaceOrder();
         } else {
-            $this->_expectRedirect();
+            $this->expectRedirect();
         }
         $this->model->execute();
     }
 
-    private function _expectForwardPlaceOrder()
+    /**
+     * @return void
+     */
+    private function expectForwardPlaceOrder(): void
     {
         $this->request->expects($this->once())
             ->method('setActionName')

--- a/app/code/Magento/Paypal/Test/Unit/Controller/Express/StartTest.php
+++ b/app/code/Magento/Paypal/Test/Unit/Controller/Express/StartTest.php
@@ -17,22 +17,19 @@ class StartTest extends ExpressTest
 
     /**
      * @param null|bool $buttonParam
+     *
+     * @return void
      * @dataProvider startActionDataProvider
      */
-    public function testStartAction($buttonParam)
+    public function testStartAction($buttonParam): void
     {
-        $this->request->expects($this->at(1))
-            ->method('getParam')
-            ->with('bml')
-            ->willReturn($buttonParam);
         $this->checkout->expects($this->once())
             ->method('setIsBml')
             ->with((bool)$buttonParam);
 
-        $this->request->expects($this->at(2))
-            ->method('getParam')
-            ->with(Checkout::PAYMENT_INFO_BUTTON)
-            ->willReturn($buttonParam);
+        $this->request->method('getParam')
+            ->withConsecutive(['bml'], [Checkout::PAYMENT_INFO_BUTTON])
+            ->willReturnOnConsecutiveCalls($buttonParam, $buttonParam);
         $this->customerData->expects($this->any())
             ->method('getId')
             ->willReturn(1);
@@ -45,7 +42,7 @@ class StartTest extends ExpressTest
     /**
      * @return array
      */
-    public function startActionDataProvider()
+    public function startActionDataProvider(): array
     {
         return [['1'], [null]];
     }

--- a/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/Product/CollectionTest.php
+++ b/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/Product/CollectionTest.php
@@ -36,18 +36,21 @@ class CollectionTest extends TestCase
     /**
      * @var Collection
      */
-    protected $model;
+    private $model;
 
     /**
      * @var MockObject
      */
-    protected $connectionMock;
+    private $connectionMock;
 
     /**
      * @var MockObject
      */
-    protected $dbSelect;
+    private $dbSelect;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         $this->markTestSkipped('MAGETWO-59234: Code under the test depends on a virtual type which cannot be mocked.');
@@ -105,10 +108,12 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @dataProvider addAttributeToFilterDataProvider
      * @param $attribute
+     *
+     * @return void
+     * @dataProvider addAttributeToFilterDataProvider
      */
-    public function testAddAttributeToFilter($attribute)
+    public function testAddAttributeToFilter($attribute): void
     {
         $conditionSqlQuery = 'sqlQuery';
         $condition = ['eq' => 'value'];
@@ -127,7 +132,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function addAttributeToFilterDataProvider()
+    public function addAttributeToFilterDataProvider(): array
     {
         return [
             ['rt.review_id'],
@@ -135,17 +140,17 @@ class CollectionTest extends TestCase
             ['rt.status_id'],
             ['rdt.title'],
             ['rdt.nickname'],
-            ['rdt.detail'],
-
+            ['rdt.detail']
         ];
     }
 
-    public function testAddAttributeToFilterWithAttributeStore()
+    /**
+     * @return void
+     */
+    public function testAddAttributeToFilterWithAttributeStore(): void
     {
         $storeId = 1;
-        $this->connectionMock
-            ->expects($this->at(0))
-            ->method('quoteInto')
+        $this->connectionMock->method('quoteInto')
             ->with('rt.review_id=store.review_id AND store.store_id = ?', $storeId)
             ->willReturn('sqlQuery');
         $this->model->addAttributeToFilter('stores', ['eq' => $storeId]);
@@ -153,29 +158,29 @@ class CollectionTest extends TestCase
     }
 
     /**
-     * @dataProvider addAttributeToFilterWithAttributeTypeDataProvider
      * @param $condition
      * @param $sqlConditionWith
      * @param $sqlConditionWithSec
      * @param $doubleConditionSqlQuery
+     *
+     * @return void
+     * @dataProvider addAttributeToFilterWithAttributeTypeDataProvider
      */
     public function testAddAttributeToFilterWithAttributeType(
         $condition,
         $sqlConditionWith,
         $sqlConditionWithSec,
         $doubleConditionSqlQuery
-    ) {
+    ): void {
         $conditionSqlQuery = 'sqlQuery';
-        $this->connectionMock
-            ->expects($this->at(0))
-            ->method('prepareSqlCondition')
-            ->with('rdt.customer_id', $sqlConditionWith)
-            ->willReturn($conditionSqlQuery);
+
         if ($sqlConditionWithSec) {
-            $this->connectionMock
-                ->expects($this->at(1))
-                ->method('prepareSqlCondition')
-                ->with('rdt.store_id', $sqlConditionWithSec)
+            $this->connectionMock->method('prepareSqlCondition')
+                ->withConsecutive(['rdt.customer_id', $sqlConditionWith], ['rdt.store_id', $sqlConditionWithSec])
+                ->willReturnOnConsecutiveCalls($conditionSqlQuery, $conditionSqlQuery);
+        } else {
+            $this->connectionMock->method('prepareSqlCondition')
+                ->with('rdt.customer_id', $sqlConditionWith)
                 ->willReturn($conditionSqlQuery);
         }
         $conditionSqlQuery = $doubleConditionSqlQuery
@@ -191,7 +196,7 @@ class CollectionTest extends TestCase
     /**
      * @return array
      */
-    public function addAttributeToFilterWithAttributeTypeDataProvider()
+    public function addAttributeToFilterWithAttributeTypeDataProvider(): array
     {
         $exprNull = new \Zend_Db_Expr('NULL');
         $defaultStore = Store::DEFAULT_STORE_ID;

--- a/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/TestCase/AbstractController.php
@@ -181,7 +181,7 @@ abstract class AbstractController extends TestCase
         foreach ($headers as $header) {
             if ($header->getFieldName() === $headerName) {
                 $headerFound = true;
-                $this->assertRegExp($valueRegex, $header->getFieldValue());
+                $this->assertMatchesRegularExpression($valueRegex, $header->getFieldValue());
             }
         }
         if (!$headerFound) {

--- a/dev/tests/integration/testsuite/Magento/Framework/View/LayoutTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/LayoutTest.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 /**
  * Layout integration tests
@@ -13,35 +14,52 @@
  */
 namespace Magento\Framework\View;
 
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Element\Messages;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Text;
+use Magento\Framework\View\Element\Text\ListText;
+use Magento\Framework\View\Layout\Data\Structure;
+use Magento\Framework\View\Layout\Element;
+use Magento\Framework\View\Layout\ProcessorInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class LayoutTest extends \PHPUnit\Framework\TestCase
+class LayoutTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\View\Layout
+     * @var Layout
      */
-    protected $_layout;
+    private $layout;
 
     /**
-     * @var \Magento\Framework\View\LayoutFactory
+     * @var LayoutFactory
      */
-    protected $layoutFactory;
+    private $layoutFactory;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->layoutFactory = $objectManager->get(\Magento\Framework\View\LayoutFactory::class);
-        $this->_layout = $this->layoutFactory->create();
+        $objectManager = Bootstrap::getObjectManager();
+        $this->layoutFactory = $objectManager->get(LayoutFactory::class);
+        $this->layout = $this->layoutFactory->create();
         $objectManager->get(\Magento\Framework\App\Cache\Type\Layout::class)->clean();
     }
 
-    public function testConstructorStructure()
+    /**
+     * @return void
+     */
+    public function testConstructorStructure(): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $structure = $objectManager->get(\Magento\Framework\View\Layout\Data\Structure::class);
+        $objectManager = Bootstrap::getObjectManager();
+        $structure = $objectManager->get(Structure::class);
         $structure->createElement('test.container', []);
-        /** @var $layout \Magento\Framework\View\LayoutInterface */
+        /** @var $layout LayoutInterface */
         $layout = $this->layoutFactory->create(['structure' => $structure]);
         $this->assertTrue($layout->hasElement('test.container'));
     }
@@ -49,42 +67,53 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
     /**
      * @magentoAppIsolation enabled
      * @magentoAppArea frontend
+     *
+     * @return void
      */
-    public function testDestructor()
+    public function testDestructor(): void
     {
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'test');
-        $this->assertNotEmpty($this->_layout->getAllBlocks());
-        $this->_layout->__destruct();
-        $this->assertEmpty($this->_layout->getAllBlocks());
+        $this->layout->addBlock(Text::class, 'test');
+        $this->assertNotEmpty($this->layout->getAllBlocks());
+        $this->layout->__destruct();
+        $this->assertEmpty($this->layout->getAllBlocks());
     }
 
-    public function testGetUpdate()
+    /**
+     * @return void
+     */
+    public function testGetUpdate(): void
     {
-        $this->assertInstanceOf(\Magento\Framework\View\Layout\ProcessorInterface::class, $this->_layout->getUpdate());
+        $this->assertInstanceOf(ProcessorInterface::class, $this->layout->getUpdate());
     }
 
-    public function testGenerateXml()
+    /**
+     * @return void
+     */
+    public function testGenerateXml(): void
     {
         $layoutUtility = new Utility\Layout($this);
-        /** @var $layout \Magento\Framework\View\LayoutInterface */
-        $layout = $this->getMockBuilder(\Magento\Framework\View\Layout::class)
-            ->setMethods(['getUpdate'])
+        /** @var $layout LayoutInterface */
+        $layout = $this->getMockBuilder(Layout::class)
+            ->onlyMethods(['getUpdate'])
             ->setConstructorArgs($layoutUtility->getLayoutDependencies())
             ->getMock();
 
-        $merge = $this->createPartialMock(\StdClass::class, ['asSimplexml']);
-        $merge->expects(
-            $this->once()
-        )->method(
-            'asSimplexml'
-        )->willReturn(
-            
+        $merge = $this->getMockBuilder(\StdClass::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->addMethods(['asSimplexml'])
+            ->getMock();
+
+        $merge->expects($this->once())
+            ->method('asSimplexml')
+            ->willReturn(
                 simplexml_load_string(
                     '<layout><container name="container1"></container></layout>',
-                    \Magento\Framework\View\Layout\Element::class
+                    Element::class
                 )
-            
-        );
+            );
         $layout->expects($this->once())->method('getUpdate')->willReturn($merge);
         $this->assertEmpty($layout->getXpath('/layout/container[@name="container1"]'));
         $layout->generateXml();
@@ -92,15 +121,17 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * A smoke test for generating elements
+     * A smoke test for generating elements.
      *
      * See sophisticated tests at \Magento\Framework\View\LayoutDirectivesTest
      * @see \Magento\Framework\View\LayoutDirectivesTest
      * @magentoAppIsolation enabled
+     *
+     * @return void
      */
-    public function testGenerateGetAllBlocks()
+    public function testGenerateGetAllBlocks(): void
     {
-        $this->_layout->setXml(
+        $this->layout->setXml(
             simplexml_load_string(
                 '<layout>
                 <block class="Magento\Framework\View\Element\Text" name="block1">
@@ -109,149 +140,172 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
                 <block class="Magento\Framework\View\Element\Text" template="test" ttl="360"/>
                 <block class="Magento\Framework\View\Element\Text"/>
             </layout>',
-                \Magento\Framework\View\Layout\Element::class
+                Element::class
             )
         );
-        $this->assertEquals([], $this->_layout->getAllBlocks());
-        $this->_layout->generateElements();
+        $this->assertEquals([], $this->layout->getAllBlocks());
+        $this->layout->generateElements();
         $expected = ['block1', 'block1_schedule_block0', 'schedule_block1', 'schedule_block2'];
-        $this->assertSame($expected, array_keys($this->_layout->getAllBlocks()));
-        $child = $this->_layout->getBlock('block1_schedule_block0');
-        $this->assertSame($this->_layout->getBlock('block1'), $child->getParentBlock());
-        $this->assertEquals('test', $this->_layout->getBlock('schedule_block1')->getData('template'));
-        $this->assertEquals('360', $this->_layout->getBlock('schedule_block1')->getData('ttl'));
-        $this->assertFalse($this->_layout->getBlock('nonexisting'));
+        $this->assertSame($expected, array_keys($this->layout->getAllBlocks()));
+        $child = $this->layout->getBlock('block1_schedule_block0');
+        $this->assertSame($this->layout->getBlock('block1'), $child->getParentBlock());
+        $this->assertEquals('test', $this->layout->getBlock('schedule_block1')->getData('template'));
+        $this->assertEquals('360', $this->layout->getBlock('schedule_block1')->getData('ttl'));
+        $this->assertFalse($this->layout->getBlock('nonexisting'));
     }
 
-    public function testGetElementProperty()
+    /**
+     * @return void
+     */
+    public function testGetElementProperty(): void
     {
         $name = 'test';
-        $this->_layout->addContainer($name, 'Test', ['option1' => 1, 'option2' => 2]);
+        $this->layout->addContainer($name, 'Test', ['option1' => 1, 'option2' => 2]);
         $this->assertEquals(
             'Test',
-            $this->_layout->getElementProperty($name, \Magento\Framework\View\Layout\Element::CONTAINER_OPT_LABEL)
+            $this->layout->getElementProperty($name, Element::CONTAINER_OPT_LABEL)
         );
         $this->assertEquals(
-            \Magento\Framework\View\Layout\Element::TYPE_CONTAINER,
-            $this->_layout->getElementProperty($name, 'type')
+            Element::TYPE_CONTAINER,
+            $this->layout->getElementProperty($name, 'type')
         );
-        $this->assertSame(2, $this->_layout->getElementProperty($name, 'option2'));
+        $this->assertSame(2, $this->layout->getElementProperty($name, 'option2'));
 
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'text', $name);
+        $this->layout->addBlock(Text::class, 'text', $name);
         $this->assertEquals(
-            \Magento\Framework\View\Layout\Element::TYPE_BLOCK,
-            $this->_layout->getElementProperty('text', 'type')
+            Element::TYPE_BLOCK,
+            $this->layout->getElementProperty('text', 'type')
         );
         $this->assertSame(
             ['text' => 'text'],
-            $this->_layout->getElementProperty($name, \Magento\Framework\Data\Structure::CHILDREN)
+            $this->layout->getElementProperty($name, \Magento\Framework\Data\Structure::CHILDREN)
         );
     }
 
     /**
      * @magentoAppIsolation enabled
+     *
+     * @return void
      */
-    public function testIsBlock()
+    public function testIsBlock(): void
     {
-        $this->assertFalse($this->_layout->isBlock('container'));
-        $this->assertFalse($this->_layout->isBlock('block'));
-        $this->_layout->addContainer('container', 'Container');
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block');
-        $this->assertFalse($this->_layout->isBlock('container'));
-        $this->assertTrue($this->_layout->isBlock('block'));
-    }
-
-    public function testSetUnsetBlock()
-    {
-        $expectedBlockName = 'block_' . __METHOD__;
-        $expectedBlock = $this->_layout->createBlock(\Magento\Framework\View\Element\Text::class);
-
-        $this->_layout->setBlock($expectedBlockName, $expectedBlock);
-        $this->assertSame($expectedBlock, $this->_layout->getBlock($expectedBlockName));
-
-        $this->_layout->unsetElement($expectedBlockName);
-        $this->assertFalse($this->_layout->getBlock($expectedBlockName));
-        $this->assertFalse($this->_layout->hasElement($expectedBlockName));
+        $this->assertFalse($this->layout->isBlock('container'));
+        $this->assertFalse($this->layout->isBlock('block'));
+        $this->layout->addContainer('container', 'Container');
+        $this->layout->addBlock(Text::class, 'block');
+        $this->assertFalse($this->layout->isBlock('container'));
+        $this->assertTrue($this->layout->isBlock('block'));
     }
 
     /**
+     * @return void
+     */
+    public function testSetUnsetBlock(): void
+    {
+        $expectedBlockName = 'block_' . __METHOD__;
+        $expectedBlock = $this->layout->createBlock(Text::class);
+
+        $this->layout->setBlock($expectedBlockName, $expectedBlock);
+        $this->assertSame($expectedBlock, $this->layout->getBlock($expectedBlockName));
+
+        $this->layout->unsetElement($expectedBlockName);
+        $this->assertFalse($this->layout->getBlock($expectedBlockName));
+        $this->assertFalse($this->layout->hasElement($expectedBlockName));
+    }
+
+    /**
+     * @return void
      * @dataProvider createBlockDataProvider
      */
-    public function testCreateBlock($blockType, $blockName, array $blockData, $expectedName)
+    public function testCreateBlock($blockType, $blockName, array $blockData, $expectedName): void
     {
         $expectedData = $blockData + ['type' => $blockType];
 
-        $block = $this->_layout->createBlock($blockType, $blockName, ['data' => $blockData]);
+        $block = $this->layout->createBlock($blockType, $blockName, ['data' => $blockData]);
 
         $this->assertMatchesRegularExpression($expectedName, $block->getNameInLayout());
         $this->assertEquals($expectedData, $block->getData());
     }
 
-    public function createBlockDataProvider()
+    /**
+     * @return array
+     */
+    public function createBlockDataProvider(): array
     {
         return [
-            'named block' => [\Magento\Framework\View\Element\Template::class,
+            'named block' => [Template::class,
                 'some_block_name_full_class',
-                ['type' => \Magento\Framework\View\Element\Template::class, 'is_anonymous' => false],
+                ['type' => Template::class, 'is_anonymous' => false],
                 '/^some_block_name_full_class$/',
             ],
-            'no name block' => [\Magento\Framework\View\Element\Text\ListText::class,
+            'no name block' => [ListText::class,
                 '',
-                ['type' => \Magento\Framework\View\Element\Text\ListText::class, 'key1' => 'value1'],
+                ['type' => ListText::class, 'key1' => 'value1'],
                 '/text\\\\list/',
             ]
         ];
     }
 
     /**
+     * @return void
      * @dataProvider blockNotExistsDataProvider
      */
-    public function testCreateBlockNotExists($name)
+    public function testCreateBlockNotExists($name): void
     {
-        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectException(LocalizedException::class);
 
-        $this->_layout->createBlock($name);
+        $this->layout->createBlock($name);
     }
 
-    public function blockNotExistsDataProvider()
+    /**
+     * @return array
+     */
+    public function blockNotExistsDataProvider(): array
     {
         return [[''], ['block_not_exists']];
     }
 
-    public function testAddBlock()
+    /**
+     * @return void
+     */
+    public function testAddBlock(): void
     {
         $this->assertInstanceOf(
-            \Magento\Framework\View\Element\Text::class,
-            $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block1')
+            Text::class,
+            $this->layout->addBlock(Text::class, 'block1')
         );
-        $block2 = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Framework\View\Element\Text::class
+        $block2 = Bootstrap::getObjectManager()->create(
+            Text::class
         );
         $block2->setNameInLayout('block2');
-        $this->_layout->addBlock($block2, '', 'block1');
+        $this->layout->addBlock($block2, '', 'block1');
 
-        $this->assertTrue($this->_layout->hasElement('block1'));
-        $this->assertTrue($this->_layout->hasElement('block2'));
-        $this->assertEquals('block1', $this->_layout->getParentName('block2'));
+        $this->assertTrue($this->layout->hasElement('block1'));
+        $this->assertTrue($this->layout->hasElement('block2'));
+        $this->assertEquals('block1', $this->layout->getParentName('block2'));
     }
 
     /**
      * @magentoAppIsolation enabled
+     * @return void
      * @dataProvider addContainerDataProvider()
      */
-    public function testAddContainer($htmlTag)
+    public function testAddContainer($htmlTag): void
     {
-        $this->assertFalse($this->_layout->hasElement('container'));
-        $this->_layout->addContainer('container', 'Container', ['htmlTag' => $htmlTag]);
-        $this->assertTrue($this->_layout->hasElement('container'));
-        $this->assertTrue($this->_layout->isContainer('container'));
-        $this->assertEquals($htmlTag, $this->_layout->getElementProperty('container', 'htmlTag'));
+        $this->assertFalse($this->layout->hasElement('container'));
+        $this->layout->addContainer('container', 'Container', ['htmlTag' => $htmlTag]);
+        $this->assertTrue($this->layout->hasElement('container'));
+        $this->assertTrue($this->layout->isContainer('container'));
+        $this->assertEquals($htmlTag, $this->layout->getElementProperty('container', 'htmlTag'));
 
-        $this->_layout->addContainer('container1', 'Container 1', [], 'container', 'c1');
-        $this->assertEquals('container1', $this->_layout->getChildName('container', 'c1'));
+        $this->layout->addContainer('container1', 'Container 1', [], 'container', 'c1');
+        $this->assertEquals('container1', $this->layout->getChildName('container', 'c1'));
     }
 
-    public function addContainerDataProvider()
+    /**
+     * @return array
+     */
+    public function addContainerDataProvider(): array
     {
         return [
             ['aside'],
@@ -281,53 +335,57 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @magentoAppIsolation enabled
+     * @return void
      */
-    public function testAddContainerInvalidHtmlTag()
+    public function testAddContainerInvalidHtmlTag(): void
     {
         $msg = 'Html tag "span" is forbidden for usage in containers. ' .
             'Consider to use one of the allowed: aside, dd, div, dl, fieldset, main, nav, ' .
             'header, footer, ol, p, section, table, tfoot, ul, article, h1, h2, h3, h4, h5, h6.';
-        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage($msg);
-        $this->_layout->addContainer('container', 'Container', ['htmlTag' => 'span']);
+        $this->layout->addContainer('container', 'Container', ['htmlTag' => 'span']);
     }
 
     /**
      * @magentoAppIsolation enabled
+     * @return void
      */
-    public function testGetChildBlock()
+    public function testGetChildBlock(): void
     {
-        $this->_layout->addContainer('parent', 'Parent');
-        $block = $this->_layout->addBlock(
-            \Magento\Framework\View\Element\Text::class,
+        $this->layout->addContainer('parent', 'Parent');
+        $block = $this->layout->addBlock(
+            Text::class,
             'block',
             'parent',
             'block_alias'
         );
-        $this->_layout->addContainer('container', 'Container', [], 'parent', 'container_alias');
-        $this->assertSame($block, $this->_layout->getChildBlock('parent', 'block_alias'));
-        $this->assertFalse($this->_layout->getChildBlock('parent', 'container_alias'));
+        $this->layout->addContainer('container', 'Container', [], 'parent', 'container_alias');
+        $this->assertSame($block, $this->layout->getChildBlock('parent', 'block_alias'));
+        $this->assertFalse($this->layout->getChildBlock('parent', 'container_alias'));
     }
 
     /**
-     * @return \Magento\Framework\View\Layout
+     * @return Layout
      */
-    public function testSetChild()
+    public function testSetChild(): Layout
     {
-        $this->_layout->addContainer('one', 'One');
-        $this->_layout->addContainer('two', 'Two');
-        $this->_layout->addContainer('three', 'Three');
-        $this->assertSame($this->_layout, $this->_layout->setChild('one', 'two', ''));
-        $this->_layout->setChild('one', 'three', 'three_alias');
-        $this->assertSame(['two', 'three'], $this->_layout->getChildNames('one'));
-        return $this->_layout;
+        $this->layout->addContainer('one', 'One');
+        $this->layout->addContainer('two', 'Two');
+        $this->layout->addContainer('three', 'Three');
+        $this->assertSame($this->layout, $this->layout->setChild('one', 'two', ''));
+        $this->layout->setChild('one', 'three', 'three_alias');
+        $this->assertSame(['two', 'three'], $this->layout->getChildNames('one'));
+
+        return $this->layout;
     }
 
     /**
-     * @param \Magento\Framework\View\LayoutInterface $layout
+     * @param LayoutInterface $layout
      * @depends testSetChild
+     * @return void
      */
-    public function testReorderChild(\Magento\Framework\View\LayoutInterface $layout)
+    public function testReorderChild(LayoutInterface $layout): void
     {
         $layout->addContainer('four', 'Four', [], 'one');
 
@@ -362,173 +420,208 @@ class LayoutTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @magentoAppIsolation enabled
+     * @return void
      */
-    public function testGetChildBlocks()
+    public function testGetChildBlocks(): void
     {
-        $this->_layout->addContainer('parent', 'Parent');
-        $block1 = $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block1', 'parent');
-        $this->_layout->addContainer('container', 'Container', [], 'parent');
-        $block2 = $this->_layout->addBlock(\Magento\Framework\View\Element\Template::class, 'block2', 'parent');
-        $this->assertSame(['block1' => $block1, 'block2' => $block2], $this->_layout->getChildBlocks('parent'));
+        $this->layout->addContainer('parent', 'Parent');
+        $block1 = $this->layout->addBlock(Text::class, 'block1', 'parent');
+        $this->layout->addContainer('container', 'Container', [], 'parent');
+        $block2 = $this->layout->addBlock(Template::class, 'block2', 'parent');
+        $this->assertSame(['block1' => $block1, 'block2' => $block2], $this->layout->getChildBlocks('parent'));
     }
 
     /**
+     * @return void
      */
-    public function testAddBlockInvalidType()
+    public function testAddBlockInvalidType(): void
     {
-        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectException(LocalizedException::class);
 
-        $this->_layout->addBlock('invalid_name', 'child');
+        $this->layout->addBlock('invalid_name', 'child');
     }
 
     /**
      * @magentoAppIsolation enabled
+     *
+     * @return void
      */
-    public function testIsContainer()
+    public function testIsContainer(): void
     {
         $block = 'block';
         $container = 'container';
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, $block);
-        $this->_layout->addContainer($container, 'Container');
-        $this->assertFalse($this->_layout->isContainer($block));
-        $this->assertTrue($this->_layout->isContainer($container));
-        $this->assertFalse($this->_layout->isContainer('invalid_name'));
+        $this->layout->addBlock(Text::class, $block);
+        $this->layout->addContainer($container, 'Container');
+        $this->assertFalse($this->layout->isContainer($block));
+        $this->assertTrue($this->layout->isContainer($container));
+        $this->assertFalse($this->layout->isContainer('invalid_name'));
     }
 
-    public function testIsManipulationAllowed()
+    /**
+     * @return void
+     */
+    public function testIsManipulationAllowed(): void
     {
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block1');
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block2', 'block1');
-        $this->assertFalse($this->_layout->isManipulationAllowed('block1'));
-        $this->assertFalse($this->_layout->isManipulationAllowed('block2'));
+        $this->layout->addBlock(Text::class, 'block1');
+        $this->layout->addBlock(Text::class, 'block2', 'block1');
+        $this->assertFalse($this->layout->isManipulationAllowed('block1'));
+        $this->assertFalse($this->layout->isManipulationAllowed('block2'));
 
-        $this->_layout->addContainer('container1', 'Container 1');
-        $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, 'block3', 'container1');
-        $this->_layout->addContainer('container2', 'Container 2', [], 'container1');
-        $this->assertFalse($this->_layout->isManipulationAllowed('container1'));
-        $this->assertTrue($this->_layout->isManipulationAllowed('block3'));
-        $this->assertTrue($this->_layout->isManipulationAllowed('container2'));
+        $this->layout->addContainer('container1', 'Container 1');
+        $this->layout->addBlock(Text::class, 'block3', 'container1');
+        $this->layout->addContainer('container2', 'Container 2', [], 'container1');
+        $this->assertFalse($this->layout->isManipulationAllowed('container1'));
+        $this->assertTrue($this->layout->isManipulationAllowed('block3'));
+        $this->assertTrue($this->layout->isManipulationAllowed('container2'));
     }
 
-    public function testRenameElement()
+    /**
+     * @return void
+     */
+    public function testRenameElement(): void
     {
         $blockName = 'block';
         $expBlockName = 'block_renamed';
         $containerName = 'container';
         $expContainerName = 'container_renamed';
-        $block = $this->_layout->createBlock(\Magento\Framework\View\Element\Text::class, $blockName);
-        $this->_layout->addContainer($containerName, 'Container');
+        $block = $this->layout->createBlock(Text::class, $blockName);
+        $this->layout->addContainer($containerName, 'Container');
 
-        $this->assertEquals($block, $this->_layout->getBlock($blockName));
-        $this->_layout->renameElement($blockName, $expBlockName);
-        $this->assertEquals($block, $this->_layout->getBlock($expBlockName));
+        $this->assertEquals($block, $this->layout->getBlock($blockName));
+        $this->layout->renameElement($blockName, $expBlockName);
+        $this->assertEquals($block, $this->layout->getBlock($expBlockName));
 
-        $this->_layout->hasElement($containerName);
-        $this->_layout->renameElement($containerName, $expContainerName);
-        $this->_layout->hasElement($expContainerName);
+        $this->layout->hasElement($containerName);
+        $this->layout->renameElement($containerName, $expContainerName);
+        $this->layout->hasElement($expContainerName);
     }
 
-    public function testGetBlock()
+    /**
+     * @return void
+     */
+    public function testGetBlock(): void
     {
-        $this->assertFalse($this->_layout->getBlock('test'));
-        $block = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Framework\View\Layout::class
+        $this->assertFalse($this->layout->getBlock('test'));
+        $block = Bootstrap::getObjectManager()->get(
+            Layout::class
         )->createBlock(
-            \Magento\Framework\View\Element\Text::class
+            Text::class
         );
-        $this->_layout->setBlock('test', $block);
-        $this->assertSame($block, $this->_layout->getBlock('test'));
+        $this->layout->setBlock('test', $block);
+        $this->assertSame($block, $this->layout->getBlock('test'));
     }
 
     /**
      * @magentoAppIsolation enabled
+     *
+     * @return void
      */
-    public function testGetParentName()
+    public function testGetParentName(): void
     {
-        $this->_layout->addContainer('one', 'One');
-        $this->_layout->addContainer('two', 'Two', [], 'one');
-        $this->assertFalse($this->_layout->getParentName('one'));
-        $this->assertEquals('one', $this->_layout->getParentName('two'));
+        $this->layout->addContainer('one', 'One');
+        $this->layout->addContainer('two', 'Two', [], 'one');
+        $this->assertFalse($this->layout->getParentName('one'));
+        $this->assertEquals('one', $this->layout->getParentName('two'));
     }
 
-    public function testGetElementAlias()
+    /**
+     * @return void
+     */
+    public function testGetElementAlias(): void
     {
-        $this->_layout->addContainer('one', 'One');
-        $this->_layout->addContainer('two', 'One', [], 'one', '1');
-        $this->assertFalse($this->_layout->getElementAlias('one'));
-        $this->assertEquals('1', $this->_layout->getElementAlias('two'));
+        $this->layout->addContainer('one', 'One');
+        $this->layout->addContainer('two', 'One', [], 'one', '1');
+        $this->assertFalse($this->layout->getElementAlias('one'));
+        $this->assertEquals('1', $this->layout->getElementAlias('two'));
     }
 
     /**
      * @covers \Magento\Framework\View\Layout::addOutputElement
      * @covers \Magento\Framework\View\Layout::getOutput
      * @covers \Magento\Framework\View\Layout::removeOutputElement
+     *
+     * @return void
      */
-    public function testGetOutput()
+    public function testGetOutput(): void
     {
         $blockName = 'block_' . __METHOD__;
         $expectedText = "some_text_for_{$blockName}";
 
-        $block = $this->_layout->addBlock(\Magento\Framework\View\Element\Text::class, $blockName);
+        $block = $this->layout->addBlock(Text::class, $blockName);
         $block->setText($expectedText);
 
-        $this->_layout->addOutputElement($blockName);
+        $this->layout->addOutputElement($blockName);
         // add the same element twice should not produce output duplicate
-        $this->_layout->addOutputElement($blockName);
-        $this->assertEquals($expectedText, $this->_layout->getOutput());
+        $this->layout->addOutputElement($blockName);
+        $this->assertEquals($expectedText, $this->layout->getOutput());
 
-        $this->_layout->removeOutputElement($blockName);
-        $this->assertEmpty($this->_layout->getOutput());
+        $this->layout->removeOutputElement($blockName);
+        $this->assertEmpty($this->layout->getOutput());
     }
 
-    public function testGetMessagesBlock()
+    /**
+     * @return void
+     */
+    public function testGetMessagesBlock(): void
     {
-        $this->assertInstanceOf(\Magento\Framework\View\Element\Messages::class, $this->_layout->getMessagesBlock());
+        $this->assertInstanceOf(Messages::class, $this->layout->getMessagesBlock());
     }
 
-    public function testGetBlockSingleton()
+    /**
+     * @return void
+     */
+    public function testGetBlockSingleton(): void
     {
-        $block = $this->_layout->getBlockSingleton(\Magento\Framework\View\Element\Text::class);
-        $this->assertInstanceOf(\Magento\Framework\View\Element\Text::class, $block);
-        $this->assertSame($block, $this->_layout->getBlockSingleton(\Magento\Framework\View\Element\Text::class));
+        $block = $this->layout->getBlockSingleton(Text::class);
+        $this->assertInstanceOf(Text::class, $block);
+        $this->assertSame($block, $this->layout->getBlockSingleton(Text::class));
     }
 
-    public function testUpdateContainerAttributes()
+    /**
+     * @return void
+     */
+    public function testUpdateContainerAttributes(): void
     {
-        $this->_layout->setXml(
+        $this->layout->setXml(
             simplexml_load_file(
                 __DIR__ . '/_files/layout/container_attributes.xml',
-                \Magento\Framework\View\Layout\Element::class
+                Element::class
             )
         );
-        $this->_layout->generateElements();
-        $result = $this->_layout->renderElement('container1', false);
+        $this->layout->generateElements();
+        $result = $this->layout->renderElement('container1', false);
         $this->assertEquals('<div id="container1-2" class="class12">Test11Test12</div>', $result);
-        $result = $this->_layout->renderElement('container2', false);
+        $result = $this->layout->renderElement('container2', false);
         $this->assertEquals('<div id="container2-2" class="class22">Test21Test22</div>', $result);
     }
 
-    public function testIsCacheable()
+    /**
+     * @return void
+     */
+    public function testIsCacheable(): void
     {
-        $this->_layout->setXml(
+        $this->layout->setXml(
             simplexml_load_file(
                 __DIR__ . '/_files/layout/cacheable.xml',
-                \Magento\Framework\View\Layout\Element::class
+                Element::class
             )
         );
-        $this->_layout->generateElements();
-        $this->assertTrue($this->_layout->isCacheable());
+        $this->layout->generateElements();
+        $this->assertTrue($this->layout->isCacheable());
     }
 
-    public function testIsNonCacheable()
+    /**
+     * @return void
+     */
+    public function testIsNonCacheable(): void
     {
-        $this->_layout->setXml(
+        $this->layout->setXml(
             simplexml_load_file(
                 __DIR__ . '/_files/layout/non_cacheable.xml',
-                \Magento\Framework\View\Layout\Element::class
+                Element::class
             )
         );
-        $this->_layout->generateElements();
-        $this->assertFalse($this->_layout->isCacheable());
+        $this->layout->generateElements();
+        $this->assertFalse($this->layout->isCacheable());
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStartTest.php
+++ b/dev/tests/integration/testsuite/Magento/Reports/Block/Adminhtml/Config/Form/Field/YtdStartTest.php
@@ -51,7 +51,7 @@ class YtdStartTest extends AbstractBackendController
                 $regEx .= 'selected\=\"selected\"[^\>]*?';
             }
             $regEx .= "\>$monthNumber\<\/option\>";
-            $this->assertRegExp("#$regEx#", $content);
+            $this->assertMatchesRegularExpression("#$regEx#", $content);
         }
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
+++ b/dev/tests/integration/testsuite/Magento/Test/Integrity/Modular/ResourcesConfigFilesTest.php
@@ -3,39 +3,56 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Test\Integrity\Modular;
 
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ResourceConnection\Config\Reader;
 use Magento\Framework\Component\ComponentRegistrar;
+use Magento\Framework\Component\DirSearch;
+use Magento\Framework\Config\FileIteratorFactory;
+use Magento\Framework\Config\FileResolverInterface;
+use Magento\Framework\Config\ValidationStateInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
 
-class ResourcesConfigFilesTest extends \PHPUnit\Framework\TestCase
+class ResourcesConfigFilesTest extends TestCase
 {
     /**
-     * @var \Magento\Framework\App\ResourceConnection\Config\Reader
+     * @var Reader
      */
-    protected $_model;
+    protected $model;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        /** @var $moduleDirSearch \Magento\Framework\Component\DirSearch */
-        $moduleDirSearch = $objectManager->get(\Magento\Framework\Component\DirSearch::class);
-        $fileIteratorFactory = $objectManager->get(\Magento\Framework\Config\FileIteratorFactory::class);
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var $moduleDirSearch DirSearch */
+        $moduleDirSearch = $objectManager->get(DirSearch::class);
+        $fileIteratorFactory = $objectManager->get(FileIteratorFactory::class);
         $xmlFiles = $fileIteratorFactory->create(
             $moduleDirSearch->collectFiles(ComponentRegistrar::MODULE, 'etc/{*/resources.xml,resources.xml}')
         );
 
-        $fileResolverMock = $this->createMock(\Magento\Framework\Config\FileResolverInterface::class);
+        $fileResolverMock = $this->createMock(FileResolverInterface::class);
         $fileResolverMock->expects($this->any())->method('get')->willReturn($xmlFiles);
-        $validationStateMock = $this->createMock(\Magento\Framework\Config\ValidationStateInterface::class);
+        $validationStateMock = $this->createMock(ValidationStateInterface::class);
         $validationStateMock->expects($this->any())->method('isValidationRequired')->willReturn(true);
-        $deploymentConfigMock = $this->createPartialMock(
-            \Magento\Framework\App\DeploymentConfig::class,
-            ['getConfiguration']
-        );
+        $deploymentConfigMock = $this->getMockBuilder(DeploymentConfig::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->addMethods(['getConfiguration'])
+            ->getMock();
+
         $deploymentConfigMock->expects($this->any())->method('getConfiguration')->willReturn([]);
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $this->_model = $objectManager->create(
-            \Magento\Framework\App\ResourceConnection\Config\Reader::class,
+        $objectManager = Bootstrap::getObjectManager();
+        $this->model = $objectManager->create(
+            Reader::class,
             [
                 'fileResolver' => $fileResolverMock,
                 'validationState' => $validationStateMock,
@@ -46,6 +63,6 @@ class ResourcesConfigFilesTest extends \PHPUnit\Framework\TestCase
 
     public function testResourcesXmlFiles()
     {
-        $this->_model->read('global');
+        $this->model->read('global');
     }
 }

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Category/EditTest.php
@@ -3,13 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\UrlRewrite\Block\Catalog\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\Framework\View\LayoutFactory;
+use Magento\Framework\View\LayoutInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Helper\Xpath;
+use Magento\UrlRewrite\Block\Catalog\Edit\Form;
+use Magento\UrlRewrite\Block\Link;
+use Magento\UrlRewrite\Block\Selector;
+use Magento\UrlRewrite\Model\UrlRewrite;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for \Magento\UrlRewrite\Block\Catalog\Category\Edit
  * @magentoAppArea adminhtml
  */
-class EditTest extends \PHPUnit\Framework\TestCase
+class EditTest extends TestCase
 {
     /**
      * Test prepare layout
@@ -19,46 +32,49 @@ class EditTest extends \PHPUnit\Framework\TestCase
      * @param array $blockAttributes
      * @param array $expected
      *
+     * @return void
      * @magentoAppIsolation enabled
      */
-    public function testPrepareLayout($blockAttributes, $expected)
+    public function testPrepareLayout($blockAttributes, $expected): void
     {
-        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
-        $layoutFactory = $objectManager->get(\Magento\Framework\View\LayoutFactory::class);
-        /** @var $layout \Magento\Framework\View\LayoutInterface */
+        $objectManager = Bootstrap::getObjectManager();
+        $layoutFactory = $objectManager->get(LayoutFactory::class);
+        /** @var $layout LayoutInterface */
         $layout = $layoutFactory->create();
 
-        /** @var $block \Magento\UrlRewrite\Block\Catalog\Category\Edit */
+        /** @var $block Edit */
         $block = $layout->createBlock(
-            \Magento\UrlRewrite\Block\Catalog\Category\Edit::class,
+            Edit::class,
             '',
             ['data' => $blockAttributes]
         );
 
-        $this->_checkSelector($block, $expected);
-        $this->_checkLinks($block, $expected);
-        $this->_checkButtons($block, $expected);
-        $this->_checkForm($block, $expected);
-        $this->_checkCategoriesTree($block, $expected);
+        $this->checkSelector($block, $expected);
+        $this->checkLinks($block, $expected);
+        $this->checkButtons($block, $expected);
+        $this->checkForm($block, $expected);
+        $this->checkCategoriesTree($block, $expected);
     }
 
     /**
      * Check selector
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Category\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkSelector($block, $expected)
+    private function checkSelector($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $selectorBlock \Magento\UrlRewrite\Block\Selector|bool */
+        /** @var $selectorBlock Selector|bool */
         $selectorBlock = $layout->getChildBlock($blockName, 'selector');
 
         if ($expected['selector']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Selector::class,
+                Selector::class,
                 $selectorBlock,
                 'Child block with entity selector is invalid'
             );
@@ -70,20 +86,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check links
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Category\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkLinks($block, $expected)
+    private function checkLinks($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $categoryBlock \Magento\UrlRewrite\Block\Link|bool */
+        /** @var $categoryBlock Link|bool */
         $categoryBlock = $layout->getChildBlock($blockName, 'category_link');
 
         if ($expected['category_link']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Link::class,
+                Link::class,
                 $categoryBlock,
                 'Child block with category link is invalid'
             );
@@ -113,17 +131,19 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check buttons
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Category\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkButtons($block, $expected)
+    private function checkButtons($block, $expected): void
     {
         $buttonsHtml = $block->getButtonsHtml();
 
         if (isset($expected['back_button'])) {
             if ($expected['back_button']) {
                 if ($block->getCategory()->getId()) {
-                    $this->assertRegExp(
+                    $this->assertMatchesRegularExpression(
                         '/setLocation\([\\\'\"]\S+?\/category/i',
                         $buttonsHtml,
                         'Back button is not present in category URL rewrite edit block'
@@ -131,7 +151,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
                 }
                 $this->assertEquals(
                     1,
-                    \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                    Xpath::getElementsCountForXpath(
                         '//button[contains(@class,"back")]',
                         $buttonsHtml
                     ),
@@ -140,7 +160,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             } else {
                 $this->assertEquals(
                     0,
-                    \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                    Xpath::getElementsCountForXpath(
                         '//button[contains(@class,"back")]',
                         $buttonsHtml
                     ),
@@ -152,7 +172,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['save_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"save")]',
                     $buttonsHtml
                 ),
@@ -161,7 +181,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"save")]',
                     $buttonsHtml
                 ),
@@ -172,7 +192,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['reset_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[@title="Reset"]',
                     $buttonsHtml
                 ),
@@ -181,7 +201,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[@title="Reset"]',
                     $buttonsHtml
                 ),
@@ -192,7 +212,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['delete_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"delete")]',
                     $buttonsHtml
                 ),
@@ -201,7 +221,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"delete")]',
                     $buttonsHtml
                 ),
@@ -213,20 +233,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check form
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Category\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkForm($block, $expected)
+    private function checkForm($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $formBlock \Magento\UrlRewrite\Block\Catalog\Edit\Form|bool */
+        /** @var $formBlock Form|bool */
         $formBlock = $layout->getChildBlock($blockName, 'form');
 
         if ($expected['form']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Catalog\Edit\Form::class,
+                Form::class,
                 $formBlock,
                 'Child block with form is invalid'
             );
@@ -250,20 +272,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check categories tree
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Category\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkCategoriesTree($block, $expected)
+    private function checkCategoriesTree($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $categoriesTreeBlock \Magento\UrlRewrite\Block\Catalog\Category\Tree|bool */
+        /** @var $categoriesTreeBlock Tree|bool */
         $categoriesTreeBlock = $layout->getChildBlock($blockName, 'categories_tree');
 
         if ($expected['categories_tree']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Catalog\Category\Tree::class,
+                Tree::class,
                 $categoriesTreeBlock,
                 'Child block with categories tree is invalid'
             );
@@ -277,20 +301,20 @@ class EditTest extends \PHPUnit\Framework\TestCase
      *
      * @return array
      */
-    public function prepareLayoutDataProvider()
+    public function prepareLayoutDataProvider(): array
     {
-        /** @var $urlRewrite \Magento\UrlRewrite\Model\UrlRewrite */
-        $urlRewrite = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\UrlRewrite\Model\UrlRewrite::class
+        /** @var $urlRewrite UrlRewrite */
+        $urlRewrite = Bootstrap::getObjectManager()->create(
+            UrlRewrite::class
         );
-        /** @var $category \Magento\Catalog\Model\Category */
-        $category = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Catalog\Model\Category::class,
+        /** @var $category Category */
+        $category = Bootstrap::getObjectManager()->create(
+            Category::class,
             ['data' => ['entity_id' => 1, 'name' => 'Test category']]
         );
-        /** @var $existingUrlRewrite \Magento\UrlRewrite\Model\UrlRewrite */
-        $existingUrlRewrite = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\UrlRewrite\Model\UrlRewrite::class,
+        /** @var $existingUrlRewrite UrlRewrite */
+        $existingUrlRewrite = Bootstrap::getObjectManager()->create(
+            UrlRewrite::class,
             ['data' => ['url_rewrite_id' => 1]]
         );
 

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Product/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Catalog/Product/EditTest.php
@@ -3,63 +3,79 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\UrlRewrite\Block\Catalog\Product;
+
+use Magento\Backend\Block\Widget\Button;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\View\LayoutInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Helper\Xpath;
+use Magento\UrlRewrite\Block\Catalog\Category\Tree;
+use Magento\UrlRewrite\Block\Catalog\Edit\Form;
+use Magento\UrlRewrite\Block\Link;
+use Magento\UrlRewrite\Block\Selector;
+use Magento\UrlRewrite\Model\UrlRewrite;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @magentoAppArea adminhtml
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class EditTest extends \PHPUnit\Framework\TestCase
+class EditTest extends TestCase
 {
     /**
-     * Test prepare layout
+     * Test prepare layout.
      *
      * @dataProvider prepareLayoutDataProvider
      *
      * @param array $blockAttributes
      * @param array $expected
      *
+     * @return void
      * @magentoAppIsolation enabled
      */
-    public function testPrepareLayout($blockAttributes, $expected)
+    public function testPrepareLayout($blockAttributes, $expected): void
     {
-        /** @var $layout \Magento\Framework\View\LayoutInterface */
-        $layout = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Framework\View\LayoutInterface::class
+        /** @var $layout LayoutInterface */
+        $layout = Bootstrap::getObjectManager()->get(
+            LayoutInterface::class
         );
 
-        /** @var $block \Magento\UrlRewrite\Block\Catalog\Product\Edit */
+        /** @var $block Edit */
         $block = $layout->createBlock(
-            \Magento\UrlRewrite\Block\Catalog\Product\Edit::class,
+            Edit::class,
             '',
             ['data' => $blockAttributes]
         );
 
-        $this->_checkSelector($block, $expected);
-        $this->_checkLinks($block, $expected);
-        $this->_checkButtons($block, $expected);
-        $this->_checkForm($block, $expected);
-        $this->_checkGrid($block, $expected);
-        $this->_checkCategories($block, $expected);
+        $this->checkSelector($block, $expected);
+        $this->checkLinks($block, $expected);
+        $this->checkButtons($block, $expected);
+        $this->checkForm($block, $expected);
+        $this->checkGrid($block, $expected);
+        $this->checkCategories($block, $expected);
     }
 
     /**
-     * Check selector
+     * Check selector.
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
      */
-    private function _checkSelector($block, $expected)
+    private function checkSelector($block, $expected)
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $selectorBlock \Magento\UrlRewrite\Block\Selector|bool */
+        /** @var $selectorBlock Selector|bool */
         $selectorBlock = $layout->getChildBlock($blockName, 'selector');
 
         if ($expected['selector']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Selector::class,
+                Selector::class,
                 $selectorBlock,
                 'Child block with entity selector is invalid'
             );
@@ -71,20 +87,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check links
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkLinks($block, $expected)
+    private function checkLinks($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $productLinkBlock \Magento\UrlRewrite\Block\Link|bool */
+        /** @var $productLinkBlock Link|bool */
         $productLinkBlock = $layout->getChildBlock($blockName, 'product_link');
 
         if ($expected['product_link']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Link::class,
+                Link::class,
                 $productLinkBlock,
                 'Child block with product link is invalid'
             );
@@ -110,12 +128,12 @@ class EditTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($productLinkBlock, 'Child block with product link should not present in block');
         }
 
-        /** @var $categoryLinkBlock \Magento\UrlRewrite\Block\Link|bool */
+        /** @var $categoryLinkBlock Link|bool */
         $categoryLinkBlock = $layout->getChildBlock($blockName, 'category_link');
 
         if ($expected['category_link']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Link::class,
+                Link::class,
                 $categoryLinkBlock,
                 'Child block with category link is invalid'
             );
@@ -145,17 +163,19 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check buttons
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkButtons($block, $expected)
+    private function checkButtons($block, $expected): void
     {
         $buttonsHtml = $block->getButtonsHtml();
 
         if (isset($expected['back_button'])) {
             if ($expected['back_button']) {
                 if ($block->getProduct()->getId()) {
-                    $this->assertRegExp(
+                    $this->assertMatchesRegularExpression(
                         '/setLocation\([\\\'\"]\S+?\/product/i',
                         $buttonsHtml,
                         'Back button is not present in category URL rewrite edit block'
@@ -163,7 +183,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
                 }
                 $this->assertEquals(
                     1,
-                    \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                    Xpath::getElementsCountForXpath(
                         '//button[contains(@class,"back")]',
                         $buttonsHtml
                     ),
@@ -172,7 +192,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
             } else {
                 $this->assertEquals(
                     0,
-                    \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                    Xpath::getElementsCountForXpath(
                         '//button[contains(@class,"back")]',
                         $buttonsHtml
                     ),
@@ -184,7 +204,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['save_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"save")]',
                     $buttonsHtml
                 ),
@@ -193,7 +213,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"save")]',
                     $buttonsHtml
                 ),
@@ -204,7 +224,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['reset_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[@title="Reset"]',
                     $buttonsHtml
                 ),
@@ -213,7 +233,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[@title="Reset"]',
                     $buttonsHtml
                 ),
@@ -224,7 +244,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if ($expected['delete_button']) {
             $this->assertEquals(
                 1,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"delete")]',
                     $buttonsHtml
                 ),
@@ -233,7 +253,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         } else {
             $this->assertEquals(
                 0,
-                \Magento\TestFramework\Helper\Xpath::getElementsCountForXpath(
+                Xpath::getElementsCountForXpath(
                     '//button[contains(@class,"delete")]',
                     $buttonsHtml
                 ),
@@ -245,20 +265,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check form
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkForm($block, $expected)
+    private function checkForm($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $formBlock \Magento\UrlRewrite\Block\Catalog\Edit\Form|bool */
+        /** @var $formBlock Form|bool */
         $formBlock = $layout->getChildBlock($blockName, 'form');
 
         if ($expected['form']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Catalog\Edit\Form::class,
+                Form::class,
                 $formBlock,
                 'Child block with form is invalid'
             );
@@ -290,20 +312,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check grid
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkGrid($block, $expected)
+    private function checkGrid($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $gridBlock \Magento\UrlRewrite\Block\Catalog\Product\Grid|bool */
+        /** @var $gridBlock Grid|bool */
         $gridBlock = $layout->getChildBlock($blockName, 'products_grid');
 
         if ($expected['products_grid']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Catalog\Product\Grid::class,
+                Grid::class,
                 $gridBlock,
                 'Child block with product grid is invalid'
             );
@@ -315,20 +339,22 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Check categories
      *
-     * @param \Magento\UrlRewrite\Block\Catalog\Product\Edit $block
+     * @param Edit $block
      * @param array $expected
+     *
+     * @return void
      */
-    private function _checkCategories($block, $expected)
+    private function checkCategories($block, $expected): void
     {
         $layout = $block->getLayout();
         $blockName = $block->getNameInLayout();
 
-        /** @var $categoriesTreeBlock \Magento\UrlRewrite\Block\Catalog\Category\Tree|bool */
+        /** @var $categoriesTreeBlock Tree|bool */
         $categoriesTreeBlock = $layout->getChildBlock($blockName, 'categories_tree');
 
         if ($expected['categories_tree']) {
             $this->assertInstanceOf(
-                \Magento\UrlRewrite\Block\Catalog\Category\Tree::class,
+                Tree::class,
                 $categoriesTreeBlock,
                 'Child block with categories tree is invalid'
             );
@@ -336,12 +362,12 @@ class EditTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse($categoriesTreeBlock, 'Child block with categories tree should not present in block');
         }
 
-        /** @var $skipCategoriesBlock \Magento\Backend\Block\Widget\Button|bool */
+        /** @var $skipCategoriesBlock Button|bool */
         $skipCategoriesBlock = $layout->getChildBlock($blockName, 'skip_categories');
 
         if ($expected['skip_categories']) {
             $this->assertInstanceOf(
-                \Magento\Backend\Block\Widget\Button::class,
+                Button::class,
                 $skipCategoriesBlock,
                 'Child block with skip categories is invalid'
             );
@@ -353,28 +379,28 @@ class EditTest extends \PHPUnit\Framework\TestCase
     /**
      * Data provider
      *
-     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @return array
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function prepareLayoutDataProvider()
+    public function prepareLayoutDataProvider(): array
     {
-        /** @var $urlRewrite \Magento\UrlRewrite\Model\UrlRewrite */
-        $urlRewrite = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\UrlRewrite\Model\UrlRewrite::class
+        /** @var $urlRewrite UrlRewrite */
+        $urlRewrite = Bootstrap::getObjectManager()->create(
+            UrlRewrite::class
         );
-        /** @var $product \Magento\Catalog\Model\Product */
-        $product = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Catalog\Model\Product::class,
+        /** @var $product Product */
+        $product = Bootstrap::getObjectManager()->create(
+            Product::class,
             ['data' => ['entity_id' => 1, 'name' => 'Test product']]
         );
-        /** @var $category \Magento\Catalog\Model\Category */
-        $category = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Catalog\Model\Category::class,
+        /** @var $category Category */
+        $category = Bootstrap::getObjectManager()->create(
+            Category::class,
             ['data' => ['entity_id' => 1, 'name' => 'Test category']]
         );
-        /** @var $existingUrlRewrite \Magento\UrlRewrite\Model\UrlRewrite */
-        $existingUrlRewrite = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\UrlRewrite\Model\UrlRewrite::class,
+        /** @var $existingUrlRewrite UrlRewrite */
+        $existingUrlRewrite = Bootstrap::getObjectManager()->create(
+            UrlRewrite::class,
             ['data' => ['url_rewrite_id' => 1]]
         );
         return [

--- a/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Cms/Page/EditTest.php
+++ b/dev/tests/integration/testsuite/Magento/UrlRewrite/Block/Cms/Page/EditTest.php
@@ -5,11 +5,13 @@
  */
 namespace Magento\UrlRewrite\Block\Cms\Page;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for \Magento\UrlRewrite\Block\Cms\Page\Edit
  * @magentoAppArea adminhtml
  */
-class EditTest extends \PHPUnit\Framework\TestCase
+class EditTest extends TestCase
 {
     /**
      * Test prepare layout
@@ -123,7 +125,7 @@ class EditTest extends \PHPUnit\Framework\TestCase
         if (isset($expected['back_button'])) {
             if ($expected['back_button']) {
                 if ($block->getCmsPage()->getId()) {
-                    $this->assertRegExp(
+                    $this->assertMatchesRegularExpression(
                         '/setLocation\([\\\'\"]\S+?\/cms_page/i',
                         $buttonsHtml,
                         'Back button is not present in category URL rewrite edit block'

--- a/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/Widget/InstanceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Widget/Controller/Adminhtml/Widget/InstanceTest.php
@@ -3,56 +3,77 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Widget\Controller\Adminhtml\Widget;
+
+use Magento\Backend\App\Area\FrontNameResolver;
+use Magento\Cms\Block\Widget\Page\Link;
+use Magento\Framework\App\Area;
+use Magento\Framework\View\DesignInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\AbstractBackendController;
+use Magento\Widget\Model\Widget\Instance;
 
 /**
  * @magentoAppArea adminhtml
  */
-class InstanceTest extends \Magento\TestFramework\TestCase\AbstractBackendController
+class InstanceTest extends AbstractBackendController
 {
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        \Magento\TestFramework\Helper\Bootstrap::getInstance()
-            ->loadArea(\Magento\Backend\App\Area\FrontNameResolver::AREA_CODE);
+        Bootstrap::getInstance()
+            ->loadArea(FrontNameResolver::AREA_CODE);
 
-        $theme = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Framework\View\DesignInterface::class
+        $theme = Bootstrap::getObjectManager()->get(
+            DesignInterface::class
         )->setDefaultDesignTheme()->getDesignTheme();
-        $type = \Magento\Cms\Block\Widget\Page\Link::class;
-        /** @var $model \Magento\Widget\Model\Widget\Instance */
-        $model = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->create(
-            \Magento\Widget\Model\Widget\Instance::class
+        $type = Link::class;
+        /** @var $model Instance */
+        $model = Bootstrap::getObjectManager()->create(
+            Instance::class
         );
         $code = $model->setType($type)->getWidgetReference('type', $type, 'code');
         $this->getRequest()->setParam('code', $code);
         $this->getRequest()->setParam('theme_id', $theme->getId());
     }
 
-    public function testEditAction()
+    /**
+     * @return void
+     */
+    public function testEditAction(): void
     {
         $this->dispatch('backend/admin/widget_instance/edit');
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '/<option value="cms_page_link".*?selected="selected"\>/is',
             $this->getResponse()->getBody()
         );
     }
 
-    public function testBlocksAction()
+    /**
+     * @return void
+     */
+    public function testBlocksAction(): void
     {
-        \Magento\TestFramework\Helper\Bootstrap::getInstance()
-            ->loadArea(\Magento\Framework\App\Area::AREA_FRONTEND);
-        $theme = \Magento\TestFramework\Helper\Bootstrap::getObjectManager()->get(
-            \Magento\Framework\View\DesignInterface::class
+        Bootstrap::getInstance()
+            ->loadArea(Area::AREA_FRONTEND);
+        $theme = Bootstrap::getObjectManager()->get(
+            DesignInterface::class
         )->setDefaultDesignTheme()->getDesignTheme();
         $this->getRequest()->setParam('theme_id', $theme->getId());
         $this->dispatch('backend/admin/widget_instance/blocks');
         $this->assertStringStartsWith('<select name="block" id=""', $this->getResponse()->getBody());
     }
 
-    public function testTemplateAction()
+    /**
+     * @return void
+     */
+    public function testTemplateAction(): void
     {
         $this->getRequest()->setMethod('POST');
         $this->dispatch('backend/admin/widget_instance/template');

--- a/dev/tests/static/testsuite/Magento/Test/Legacy/PhtmlTemplateTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Legacy/PhtmlTemplateTest.php
@@ -5,18 +5,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Test\Legacy;
 
+use Magento\Framework\App\Utility\AggregateInvoker;
+use Magento\Framework\App\Utility\Files;
 use Magento\Framework\Component\ComponentRegistrar;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Static test for phtml template files.
  */
-class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
+class PhtmlTemplateTest extends TestCase
 {
-    public function testBlockVariableInsteadOfThis()
+    /**
+     * @return void
+     */
+    public function testBlockVariableInsteadOfThis(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * Test usage of methods and variables in template through $this
@@ -31,13 +39,16 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                     'obsolete in phtml templates. Use only $block instead of $this.'
                 );
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 
-    public function testObsoleteBlockMethods()
+    /**
+     * @return void
+     */
+    public function testObsoleteBlockMethods(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * Test usage of protected and private methods and variables in template
@@ -58,13 +69,16 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                     'obsolete in phtml templates. Use only public members.'
                 );
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 
-    public function testObsoleteJavascriptAttributeType()
+    /**
+     * @return void
+     */
+    public function testObsoleteJavascriptAttributeType(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * "text/javascript" type attribute in not obligatory to use in templates due to HTML5 standards.
@@ -79,13 +93,16 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                     'Please do not use "text/javascript" type attribute.'
                 );
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 
-    public function testJqueryUiLibraryIsNotUsedInTemplates()
+    /**
+     * @return void
+     */
+    public function testJqueryUiLibraryIsNotUsedInTemplates(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * 'jquery/ui' library is not obligatory to use in phtml files.
@@ -104,13 +121,16 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                     );
                 }
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 
-    public function testJsComponentsAreProperlyInitializedInDataMageInitAttribute()
+    /**
+     * @return void
+     */
+    public function testJsComponentsAreProperlyInitializedInDataMageInitAttribute(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * JS components in data-mage-init attributes should be initialized not in php.
@@ -131,41 +151,49 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                     );
                 }
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 
     /**
      * @return array
      */
-    private function getWhiteList()
+    private function getWhiteList(): array
     {
         $whiteListFiles = [];
         $componentRegistrar = new ComponentRegistrar();
+
         foreach ($this->getFilesData('data_mage_init/whitelist.php') as $fileInfo) {
             $whiteListFiles[] = $componentRegistrar->getPath(ComponentRegistrar::MODULE, $fileInfo[0])
                 . DIRECTORY_SEPARATOR . $fileInfo[1];
         }
+
         return $whiteListFiles;
     }
 
     /**
      * @param string $filePattern
+     *
      * @return array
      */
-    private function getFilesData($filePattern)
+    private function getFilesData($filePattern): array
     {
         $result = [];
+
         foreach (glob(__DIR__ . '/_files/initialize_javascript/' . $filePattern) as $file) {
             $fileData = include $file;
             $result = array_merge($result, $fileData);
         }
+
         return $result;
     }
 
-    public function testJsComponentsAreProperlyInitializedInXMagentoInitAttribute()
+    /**
+     * @return void
+     */
+    public function testJsComponentsAreProperlyInitializedInXMagentoInitAttribute(): void
     {
-        $invoker = new \Magento\Framework\App\Utility\AggregateInvoker($this);
+        $invoker = new AggregateInvoker($this);
         $invoker(
             /**
              * JS components in x-magento-init attributes should be initialized not in php.
@@ -177,14 +205,14 @@ class PhtmlTemplateTest extends \PHPUnit\Framework\TestCase
                 if (strpos($file, '/view/frontend/templates/') !== false
                     || strpos($file, '/view/base/templates/') !== false
                 ) {
-                    self::assertNotRegExp(
+                    self::assertDoesNotMatchRegularExpression(
                         '@x-magento-init.>(?!\s*+{\s*"[^"]+"\s*:\s*{\s*"[\w/-]+")@i',
                         file_get_contents($file),
                         'Please do not initialize JS component in php. Do it in template.'
                     );
                 }
             },
-            \Magento\Framework\App\Utility\Files::init()->getPhtmlFiles()
+            Files::init()->getPhtmlFiles()
         );
     }
 }

--- a/lib/internal/Magento/Framework/Profiler/Test/Unit/Driver/StandardTest.php
+++ b/lib/internal/Magento/Framework/Profiler/Test/Unit/Driver/StandardTest.php
@@ -1,10 +1,12 @@
-<?php declare(strict_types=1);
+<?php
 /**
  * Test class for \Magento\Framework\Profiler\Driver\Standard
  *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\Profiler\Test\Unit\Driver;
 
 use Magento\Framework\Profiler;
@@ -14,34 +16,43 @@ use Magento\Framework\Profiler\Driver\Standard\OutputInterface;
 use Magento\Framework\Profiler\Driver\Standard\Stat;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class StandardTest extends TestCase
 {
     /**
      * @var Stat|MockObject
      */
-    protected $_stat;
+    private $stat;
 
     /**
      * @var Standard
      */
-    protected $_driver;
+    private $driver;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
-        $this->_stat = $this->createMock(Stat::class);
-        $this->_driver = new Standard(['stat' => $this->_stat]);
+        $this->stat = $this->createMock(Stat::class);
+        $this->driver = new Standard(['stat' => $this->stat]);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function tearDown(): void
     {
         Profiler::reset();
     }
 
     /**
-     * Test __construct method with no arguments
+     * Test __construct method with no arguments.
+     *
+     * @return void
      */
-    public function testDefaultConstructor()
+    public function testDefaultConstructor(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -50,20 +61,24 @@ class StandardTest extends TestCase
     }
 
     /**
-     * Test clear method
+     * Test clear method.
+     *
+     * @return void
      */
-    public function testClear()
+    public function testClear(): void
     {
-        $this->_stat->expects($this->once())->method('clear')->with('timer_id');
-        $this->_driver->clear('timer_id');
+        $this->stat->expects($this->once())->method('clear')->with('timer_id');
+        $this->driver->clear('timer_id');
     }
 
     /**
-     * Test start method
+     * Test start method.
+     *
+     * @return void
      */
-    public function testStart()
+    public function testStart(): void
     {
-        $this->_stat->expects(
+        $this->stat->expects(
             $this->once()
         )->method(
             'start'
@@ -73,15 +88,17 @@ class StandardTest extends TestCase
             $this->greaterThanOrEqual(0),
             $this->greaterThanOrEqual(0)
         );
-        $this->_driver->start('timer_id');
+        $this->driver->start('timer_id');
     }
 
     /**
-     * Test stop method
+     * Test stop method.
+     *
+     * @return void
      */
-    public function testStop()
+    public function testStop(): void
     {
-        $this->_stat->expects(
+        $this->stat->expects(
             $this->once()
         )->method(
             'stop'
@@ -91,13 +108,15 @@ class StandardTest extends TestCase
             $this->greaterThanOrEqual(0),
             $this->greaterThanOrEqual(0)
         );
-        $this->_driver->stop('timer_id');
+        $this->driver->stop('timer_id');
     }
 
     /**
-     * Test _initOutputs method
+     * Test _initOutputs method.
+     *
+     * @return void
      */
-    public function testInitOutputs()
+    public function testInitOutputs(): void
     {
         $this->markTestSkipped('Skipped in #27500 due to testing protected/private methods and properties');
 
@@ -105,34 +124,21 @@ class StandardTest extends TestCase
         $config = [
             'outputs' => [
                 'outputTypeOne' => ['baseDir' => '/custom/base/dir'],
-                'outputTypeTwo' => ['type' => 'specificOutputTypeTwo'],
+                'outputTypeTwo' => ['type' => 'specificOutputTypeTwo']
             ],
             'baseDir' => '/base/dir',
-            'outputFactory' => $outputFactory,
+            'outputFactory' => $outputFactory
         ];
 
         $outputOne = $this->getMockForAbstractClass(OutputInterface::class);
         $outputTwo = $this->getMockForAbstractClass(OutputInterface::class);
 
-        $outputFactory->expects(
-            $this->at(0)
-        )->method(
-            'create'
-        )->with(
-            ['baseDir' => '/custom/base/dir', 'type' => 'outputTypeOne']
-        )->willReturn(
-            $outputOne
-        );
-
-        $outputFactory->expects(
-            $this->at(1)
-        )->method(
-            'create'
-        )->with(
-            ['type' => 'specificOutputTypeTwo', 'baseDir' => '/base/dir']
-        )->willReturn(
-            $outputTwo
-        );
+        $outputFactory->method('create')
+            ->withConsecutive(
+                [['baseDir' => '/custom/base/dir', 'type' => 'outputTypeOne']],
+                [['type' => 'specificOutputTypeTwo', 'baseDir' => '/base/dir']]
+            )
+            ->willReturnOnConsecutiveCalls($outputOne, $outputTwo);
 
         $driver = new Standard($config);
         $this->assertAttributeCount(2, '_outputs', $driver);
@@ -140,33 +146,37 @@ class StandardTest extends TestCase
     }
 
     /**
-     * Test display method
+     * Test display method.
+     *
+     * @return void
      */
-    public function testDisplayAndRegisterOutput()
+    public function testDisplayAndRegisterOutput(): void
     {
         $outputOne = $this->getMockForAbstractClass(OutputInterface::class);
-        $outputOne->expects($this->once())->method('display')->with($this->_stat);
+        $outputOne->expects($this->once())->method('display')->with($this->stat);
         $outputTwo = $this->getMockForAbstractClass(OutputInterface::class);
-        $outputTwo->expects($this->once())->method('display')->with($this->_stat);
+        $outputTwo->expects($this->once())->method('display')->with($this->stat);
 
-        $this->_driver->registerOutput($outputOne);
-        $this->_driver->registerOutput($outputTwo);
+        $this->driver->registerOutput($outputOne);
+        $this->driver->registerOutput($outputTwo);
         Profiler::enable();
-        $this->_driver->display();
+        $this->driver->display();
         Profiler::disable();
-        $this->_driver->display();
+        $this->driver->display();
     }
 
     /**
-     * Test _getOutputFactory method creating new object by default
+     * Test _getOutputFactory method creating new object by default.
+     *
+     * @return void
      */
-    public function testDefaultOutputFactory()
+    public function testDefaultOutputFactory(): void
     {
-        $method = new \ReflectionMethod($this->_driver, '_getOutputFactory');
+        $method = new ReflectionMethod($this->driver, '_getOutputFactory');
         $method->setAccessible(true);
         $this->assertInstanceOf(
             Factory::class,
-            $method->invoke($this->_driver)
+            $method->invoke($this->driver)
         );
     }
 }


### PR DESCRIPTION
### Description (*)
I've eliminate calls deprecated methods of the phpunit/phpunit, now it provokes warning, but it will provoke error in future.

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/599
https://github.com/magento/partners-magento2b2b/pull/585
https://github.com/magento/adobe-stock-integration/pull/1864
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#33916

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
