### PR TITLE
disable welcome email when customer is not active

### DIFF
--- a/app/code/Magento/Customer/Model/EmailNotification.php
+++ b/app/code/Magento/Customer/Model/EmailNotification.php
@@ -404,6 +404,10 @@ class EmailNotification implements EmailNotificationInterface
 
         $customerEmailData = $this->getFullCustomerObject($customer);
 
+        if ($customer->getExtensionAttributes() && !is_null($customer->getExtensionAttributes()->getCompanyAttributes()) && $customer->getExtensionAttributes()->getCompanyAttributes()->getStatus()!=1) {
+            return;
+        }
+
         $this->sendEmailTemplate(
             $customer,
             $types[$type],

--- a/app/code/Magento/Customer/Model/EmailNotification.php
+++ b/app/code/Magento/Customer/Model/EmailNotification.php
@@ -19,6 +19,7 @@ use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Customer\Model\Data\CustomerSecure;
+use Magento\Company\Api\Data\CompanyCustomerInterface as CompanyCustomer;
 
 /**
  * Customer email notification
@@ -404,7 +405,9 @@ class EmailNotification implements EmailNotificationInterface
 
         $customerEmailData = $this->getFullCustomerObject($customer);
 
-        if ($customer->getExtensionAttributes() && !is_null($customer->getExtensionAttributes()->getCompanyAttributes()) && $customer->getExtensionAttributes()->getCompanyAttributes()->getStatus()!=1) {
+        if ($customer->getExtensionAttributes() &&
+            $customer->getExtensionAttributes()
+                ->getCompanyAttributes()->getStatus() !== CompanyCustomer::STATUS_ACTIVE) {
             return;
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    While creating B2B customer from the admin, if the customer is marked inactive then welcome email will not be sent. 

This is related to a issue posted - [33255](https://github.com/magento/magento2/issues/33255)
-->


1. Fixes magento/magento2#33255

### Manual testing scenarios (*)

B2B Features - enabled
Setup Email configuration
Steps to reproduce:

1. Navigate to Customers -> All Customers -> Add new Customer
2. Create Inactive customer
Expected behavior: Inactive customers should not be able to login or reset password. Hence email should not be triggered with password reset link.

### Questions or comments


### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
