### PR TITLE
29228 change order comments in order view page in admin panel

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1693,22 +1693,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     }
 
     /**
-     * Return collection of not visible on frontend order status history items.
-     *
-     * @return array
-     */
-    public function getAdminVisibleStatusHistory(): array
-    {
-        $history = [];
-        foreach ($this->getStatusHistoryCollection() as $status) {
-            if (!$status->isDeleted() && $status->getComment() && !$status->getIsVisibleOnFront()) {
-                $history[] = $status;
-            }
-        }
-        return $history;
-    }
-
-    /**
      * Return collection of visible on frontend order status history items.
      *
      * @return array

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1713,7 +1713,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      *
      * @return array
      */
-    public function getVisibleStatusHistory(): array
+    public function getVisibleStatusHistory()
     {
         $history = [];
         foreach ($this->getStatusHistoryCollection() as $status) {

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1693,11 +1693,27 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     }
 
     /**
+     * Return collection of not visible on frontend order status history items.
+     *
+     * @return array
+     */
+    public function getAdminVisibleStatusHistory(): array
+    {
+        $history = [];
+        foreach ($this->getStatusHistoryCollection() as $status) {
+            if (!$status->isDeleted() && $status->getComment() && !$status->getIsVisibleOnFront()) {
+                $history[] = $status;
+            }
+        }
+        return $history;
+    }
+
+    /**
      * Return collection of visible on frontend order status history items.
      *
      * @return array
      */
-    public function getVisibleStatusHistory()
+    public function getVisibleStatusHistory(): array
     {
         $history = [];
         foreach ($this->getStatusHistoryCollection() as $status) {

--- a/app/code/Magento/Sales/ViewModel/OrderHistoryComment.php
+++ b/app/code/Magento/Sales/ViewModel/OrderHistoryComment.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Sales\ViewModel;
+
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+use Magento\Sales\Model\Order\Status\History;
+use Magento\Sales\Model\ResourceModel\Order\Status\History\CollectionFactory;
+
+/**
+ * View model to add order history comment to Order View page
+ */
+class OrderHistoryComment implements ArgumentInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory
+    ) {
+        $this->collectionFactory = $collectionFactory;
+    }
+
+    /**
+     * Return collection of not visible on frontend order status history items.
+     *
+     * @param int $orderId
+     *
+     * @return History[]
+     */
+    public function getOrderComments(int $orderId): array
+    {
+        $history = [];
+        $collection = $this->collectionFactory->create();
+        $collection->setOrderFilter($orderId)
+            ->setOrder('created_at', 'desc')
+            ->setOrder('entity_id', 'desc');
+
+        foreach ($collection as $status) {
+            if (!$status->isDeleted() && $status->getComment() && !$status->getIsVisibleOnFront()) {
+                $history[] = $status;
+            }
+        }
+
+        return $history;
+    }
+}

--- a/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
+++ b/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml
@@ -64,7 +64,11 @@
 
                     <container name="payment_additional_info" htmlTag="div" htmlClass="order-payment-additional" />
                     <block class="Magento\Sales\Block\Adminhtml\Order\Payment" name="order_payment"/>
-                    <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="Magento_Sales::order/view/history.phtml"/>
+                    <block class="Magento\Sales\Block\Adminhtml\Order\View\History" name="order_history" template="Magento_Sales::order/view/history.phtml">
+                        <arguments>
+                            <argument name="orderCommentModel" xsi:type="object">Magento\Sales\ViewModel\OrderHistoryComment</argument>
+                        </arguments>
+                    </block>
                     <block class="Magento\Backend\Block\Template" name="gift_options" template="Magento_Sales::order/giftoptions.phtml">
                         <block class="Magento\Sales\Block\Adminhtml\Order\View\Giftmessage" name="order_giftmessage" template="Magento_Sales::order/view/giftmessage.phtml"/>
                     </block>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
@@ -4,8 +4,15 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Sales\Block\Adminhtml\Order\View\History $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Sales\Block\Adminhtml\Order\View\History;
+use Magento\Sales\ViewModel\OrderHistoryComment;
+
+/** @var History $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var  OrderHistoryComment $viewModel */
+
+$viewModel = $block->getData('orderCommentModel');
 ?>
 <div id="order_history_block" class="edit-order-comments">
     <?php if ($block->canAddComment()): ?>
@@ -74,7 +81,7 @@
     <?php endif;?>
 
     <ul class="note-list">
-    <?php foreach ($block->getOrder()->getAdminVisibleStatusHistory() as $_item): ?>
+    <?php foreach ($viewModel->getOrderComments($block->getOrder()->getId()) as $_item): ?>
         <li class="note-list-item">
             <span class="note-list-date">
                 <?= /* @noEscape */ $block->formatDate($_item->getCreatedAt(), \IntlDateFormatter::MEDIUM) ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml
@@ -74,7 +74,7 @@
     <?php endif;?>
 
     <ul class="note-list">
-    <?php foreach ($block->getOrder()->getStatusHistoryCollection(true) as $_item): ?>
+    <?php foreach ($block->getOrder()->getAdminVisibleStatusHistory() as $_item): ?>
         <li class="note-list-item">
             <span class="note-list-date">
                 <?= /* @noEscape */ $block->formatDate($_item->getCreatedAt(), \IntlDateFormatter::MEDIUM) ?>


### PR DESCRIPTION
I want to note that there is no duplicate comment on the order view page. There are 2 different comments with different visibility.

### Description (*)
I added a method to `\Magento\Sales\Model\Order` model to get history comment without visibility to frontend and changed a template for comments block for admin order view `app/code/Magento/Sales/view/adminhtml/templates/order/view/history.phtml`.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#29228

### Manual testing scenarios (*)

1. Login to Magento Admin - Enable Login an Customer feature (Stores - Settings - Configuration - Customers - Login as Customer)
2. Navigate to Customers - All Customers - Edit customer - Login as Customer
3. Add a product to cart and purchase the product 
4. Go to Magento Admin - Customers - All Customers - Edit same customer - Orders - view the order
Issue: In Magento Admin Order review page - 2 comment messages are getting displayed

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
