### PR TITLE
Updating npm packages

### DIFF
--- a/package.json.sample
+++ b/package.json.sample
@@ -28,7 +28,7 @@
     "grunt-styledocco": "~0.3.0",
     "grunt-template-jasmine-requirejs": "~0.2.3",
     "grunt-text-replace": "~0.4.0",
-    "imagemin-svgo": "~9.0.0",
+    "imagemin-svgo": "~6.0.0",
     "less": "3.13.1",
     "load-grunt-config": "~4.0.1",
     "morgan": "~1.10.0",

--- a/package.json.sample
+++ b/package.json.sample
@@ -28,7 +28,7 @@
     "grunt-styledocco": "~0.3.0",
     "grunt-template-jasmine-requirejs": "~0.2.3",
     "grunt-text-replace": "~0.4.0",
-    "imagemin-svgo": "~5.2.4",
+    "imagemin-svgo": "~9.0.0",
     "less": "3.13.1",
     "load-grunt-config": "~4.0.1",
     "morgan": "~1.10.0",

--- a/package.json.sample
+++ b/package.json.sample
@@ -28,7 +28,7 @@
     "grunt-styledocco": "~0.3.0",
     "grunt-template-jasmine-requirejs": "~0.2.3",
     "grunt-text-replace": "~0.4.0",
-    "imagemin-svgo": "~6.0.0",
+    "imagemin-svgo": "~7.1.0",
     "less": "3.13.1",
     "load-grunt-config": "~4.0.1",
     "morgan": "~1.10.0",

--- a/package.json.sample
+++ b/package.json.sample
@@ -36,7 +36,7 @@
     "path": "~0.12.7",
     "serve-static": "~1.14.1",
     "squirejs": "~0.2.1",
-    "strip-json-comments": "~2.0.1",
+    "strip-json-comments": "~3.1.1",
     "time-grunt": "~2.0.0",
     "underscore": "1.13.1"
   }


### PR DESCRIPTION
### Description (*)
Updating the npm packages:
- imagemin-svgo from `~5.2.4` to `7.1.0`
- strip-json-comments from `~2.0.1` to `~3.1.1`

As about the following packages:
- grunt-contrib-jasmine - from the next `2.0.0`, the library has switched from PhantomJS to Chrome Headless via puppeteer, and requires reconfiguring the extension.
- grunt-eslint - from the next `21.0.0` we're started getting the `Warning: must provide pattern`

⚠️ The upgraded versions are running on Node v14

### Related Pull Requests
https://github.com/magento/partners-magento2-infrastructure/pull/62
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33972

### Manual testing scenarios (*)
N/A

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
