### PR TITLE
Fixed customertoken not generating after configured failure in a row

### DIFF
--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
@@ -58,11 +58,14 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
      */
     public function getFailuresCount($userName, $userType)
     {
+        $date = (new \DateTime())->setTimestamp($this->dateTime->gmtTimestamp());
+        $dateTime = $date->format(\Magento\Framework\Stdlib\DateTime::DATETIME_PHP_FORMAT);
+        
         $select = $this->getConnection()->select();
         $select->from($this->getMainTable(), 'failures_count')
-            ->where('user_name = :user_name AND user_type = :user_type');
+            ->where('user_name = :user_name AND user_type = :user_type AND lock_expires_at > :expiration_time');
 
-        return (int)$this->getConnection()->fetchOne($select, ['user_name' => $userName, 'user_type' => $userType]);
+        return (int)$this->getConnection()->fetchOne($select, ['user_name' => $userName, 'user_type' => $userType, 'expiration_time' => $dateTime]);
     }
 
     /**

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
@@ -65,7 +65,14 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
         $select->from($this->getMainTable(), 'failures_count')
             ->where('user_name = :user_name AND user_type = :user_type AND lock_expires_at > :expiration_time');
 
-        return (int)$this->getConnection()->fetchOne($select, ['user_name' => $userName, 'user_type' => $userType, 'expiration_time' => $dateTime]);
+        return (int)$this->getConnection()->fetchOne(
+             $select, 
+             [
+                 'user_name' => $userName, 
+                 'user_type' => $userType, 
+                 'expiration_time' => $dateTime,
+             ]
+        );
     }
 
     /**

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Token/RequestLog.php
@@ -46,7 +46,7 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function _construct()
     {
@@ -54,7 +54,9 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     * @param string $userName
+     * @param int $userType
      */
     public function getFailuresCount($userName, $userType)
     {
@@ -66,17 +68,19 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
             ->where('user_name = :user_name AND user_type = :user_type AND lock_expires_at > :expiration_time');
 
         return (int)$this->getConnection()->fetchOne(
-             $select, 
-             [
-                 'user_name' => $userName, 
-                 'user_type' => $userType, 
-                 'expiration_time' => $dateTime,
-             ]
+            $select,
+            [
+                'user_name' => $userName,
+                'user_type' => $userType,
+                'expiration_time' => $dateTime,
+            ]
         );
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     * @param string $userName
+     * @param int $userType
      */
     public function resetFailuresCount($userName, $userType)
     {
@@ -87,7 +91,9 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
+     * @param string $userName
+     * @param int $userType
      */
     public function incrementFailuresCount($userName, $userType)
     {
@@ -111,7 +117,7 @@ class RequestLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb im
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function clearExpiredFailures()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This pull request solves the issue when a customer has tried too many fail attempt (i.e more no of times than in the configuration)for generating the customer token via graphql or rest api. Then the customer is not able to log into the system ever.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make more number of unsuccessful attempt than the configured number of times (configuration can be found in Services->Oauth) to generate the customer token via generateCustomerToken graphql api. 
2. After that, the customer would not be able to generate the token even with correct credentials.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

The issue was occuring because in the current system, there was no any check if `lock_expires_at` in  `oauth_token_request_log`  is greater than current date time. So, the system always returns the no of failed attempts. 

For example, let's say, if the configured no of failed attempt is 6. And the customer has tried 7 times to generate the customer token via graphql api. Now, after the expiry time of `lock_expires_at` even when he/she tries with correct credentials, he/she is not able to generate the customer token and get the exception 

'The account sign-in was incorrect or your account is disabled temporarily. '
                    . 'Please wait and try again later.'
![image](https://user-images.githubusercontent.com/16735854/132213560-70cf5869-b445-4d13-bba3-05a8e8e1aa3a.png)

This is a major issue for the Scandi PWA login as customer is not able to logged into the PWA after trying too many unsuccessful attempt.

To resolve the issue, i have applied the check if `lock_expires_at` is greater than current date time. Then we got zero token in that case and when the customer login with correct credentials, he/she will log into the system.

Please let me know if you need additional test cases (i have to make the test cases, lol) or any other description you want. 
### Contribution checklist (*)
 - [ *] Pull request has a meaningful description of its purpose
 - [ *] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34067: Fixed customertoken not generating after configured failure in a row