### PR TITLE
Fix Unit tests to be compatible with php8 [part 1]

### DIFF
--- a/app/code/Magento/Captcha/Test/Unit/Model/DefaultTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/DefaultTest.php
@@ -51,9 +51,9 @@ class DefaultTest extends TestCase
         'case_sensitive' => '0',
         'shown_to_logged_in_user' => ['contact_us' => 1],
         'always_for' => [
-            'user_create',
-            'user_forgotpassword',
-            'contact_us',
+            'user_create' => '1',
+            'user_forgotpassword' => '1',
+            'contact_us' => '1'
         ],
     ];
 

--- a/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
+++ b/app/code/Magento/Catalog/Model/ProductLink/CollectionProvider.php
@@ -88,7 +88,7 @@ class CollectionProvider
                 $posA = (int)$itemA['position'];
                 $posB = (int)$itemB['position'];
 
-                return $posA <=> $posB;
+                return (($posA - $posB) > 0) ? 1 : -1;  // for PHP 7 and 8 consistency
             }
         );
 

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -1607,10 +1607,12 @@ class ProductTest extends AbstractImportTestCase
      */
     public function testGetProductCategoriesDataSave(array $categoriesData, string $tableName, array $result)
     {
-        $this->_connection->expects($this->at(1))->method('fetchOne')->willReturn('0');
-        $this->_connection->expects($this->at(3))->method('fetchOne')->willReturn('-2');
-        $this->skuProcessor->expects($this->at(0))->method('getNewSku')->willReturn(['entity_id' => 2]);
-        $this->skuProcessor->expects($this->at(1))->method('getNewSku')->willReturn(['entity_id' => 5]);
+        $this->_connection->method('fetchOne')->willReturnOnConsecutiveCalls('0', '-2');
+        $this->skuProcessor->method('getNewSku')
+            ->willReturnOnConsecutiveCalls(
+                ['entity_id' => 2],
+                ['entity_id' => 5]
+            );
         $actualResult = $this->invokeMethod(
             $this->importProduct,
             'getProductCategoriesDataSave',

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/Config/Backend/ManagestockTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/Config/Backend/ManagestockTest.php
@@ -9,12 +9,18 @@ namespace Magento\CatalogInventory\Test\Unit\Model\Config\Backend;
 
 use Magento\CatalogInventory\Model\Config\Backend\Managestock;
 use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ManagestockTest extends TestCase
 {
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $configMock;
+
     /** @var  Processor|MockObject */
     protected $stockIndexerProcessor;
 
@@ -27,10 +33,15 @@ class ManagestockTest extends TestCase
             Processor::class
         )->disableOriginalConstructor()
             ->getMock();
+        $this->configMock = $this->getMockBuilder(ScopeConfigInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->model = (new ObjectManager($this))->getObject(
             Managestock::class,
             [
-                'stockIndexerProcessor' => $this->stockIndexerProcessor,
+                'config' => $this->configMock,
+                'stockIndexerProcessor' => $this->stockIndexerProcessor
             ]
         );
     }
@@ -57,6 +68,8 @@ class ManagestockTest extends TestCase
     {
         $this->model->setValue($newStockValue);
         $this->stockIndexerProcessor->expects($this->exactly($callCount))->method('markIndexerAsInvalid');
+        $this->configMock->method('getValue')->willReturn(0);   // old value for stock status
+
         $this->model->afterSave();
     }
 }

--- a/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
+++ b/app/code/Magento/CatalogRule/Test/Unit/Model/RuleTest.php
@@ -278,7 +278,7 @@ class RuleTest extends TestCase
             [
                 [
                     'simple_action' => 'by_percent',
-                    'discount_amount' => '9,99'
+                    'discount_amount' => '9.99'
                 ],
                 true
             ],
@@ -430,8 +430,8 @@ class RuleTest extends TestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testGetConditionsFieldSetId(): void
     {
         $formName = 'form_name';
@@ -441,8 +441,8 @@ class RuleTest extends TestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testReindex(): void
     {
         $this->ruleProductProcessor->expects($this->once())->method('reindexList');

--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\CatalogUrlRewrite\Observer;
 
 use Magento\Catalog\Model\Category;
@@ -397,7 +398,7 @@ class AfterImportDataObserver implements ObserverInterface
      */
     private function isGlobalScope($storeId)
     {
-        return null === $storeId || $storeId == Store::DEFAULT_STORE_ID;
+        return null === $storeId || Store::DEFAULT_STORE_ID === (int) $storeId;
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/FileTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Metadata/Form/FileTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Test\Unit\Model\Metadata\Form;
 
+use Magento\Customer\Model\Customer;
 use Magento\Customer\Model\FileProcessor;
 use Magento\Customer\Model\FileProcessorFactory;
 use Magento\Customer\Model\Metadata\ElementFactory;
@@ -362,8 +363,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueIsAjax(): void
     {
         $model = $this->initialize(
@@ -378,8 +379,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueNoDelete(): void
     {
         $this->attributeMetadataMock->expects($this->any())->method('isRequired')->will($this->returnValue(false));
@@ -388,7 +389,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => 'value',
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE
+                'entityTypeCode' => Customer::ENTITY
             ]
         );
 
@@ -401,8 +402,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueDelete(): void
     {
         $this->attributeMetadataMock->expects($this->any())->method('isRequired')->will($this->returnValue(false));
@@ -431,8 +432,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueTmpFile(): void
     {
         $value = ['tmp_name' => 'tmp.file', 'name' => 'new.file'];
@@ -486,8 +487,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testRestoreValue(): void
     {
         $value = 'value';
@@ -537,8 +538,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testOutputValueJson(): void
     {
         $value = 'value';
@@ -591,8 +592,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testExtractValueFileUploaderUIComponent(): void
     {
         $attributeCode = 'img1';
@@ -631,8 +632,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueRemoveUiComponentValue(): void
     {
         $value = 'value';
@@ -641,7 +642,7 @@ class FileTest extends AbstractFormTestCase
             [
                 'value' => $value,
                 'isAjax' => false,
-                'entityTypeCode' => self::ENTITY_TYPE
+                'entityTypeCode' => Customer::ENTITY
             ]
         );
 
@@ -654,8 +655,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueNoAction(): void
     {
         $value = 'value';
@@ -672,8 +673,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueUiComponent(): void
     {
         $value = [
@@ -697,8 +698,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueInputField(): void
     {
         $value = [
@@ -769,8 +770,8 @@ class FileTest extends AbstractFormTestCase
     }
 
     /**
-    * @return void
-    */
+     * @return void
+     */
     public function testCompactValueInputFieldWithException(): void
     {
         $value = [

--- a/app/code/Magento/ImportExport/Test/Unit/Model/Import/EntityAbstractTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/Import/EntityAbstractTest.php
@@ -71,7 +71,7 @@ class EntityAbstractTest extends AbstractImportTestCase
         $resource = $this->createMock(ResourceConnection::class);
 
         $data = [
-            'coreString' => $string,
+            'string' => $string,
             'scopeConfig' => $scopeConfig,
             'importFactory' => $importFactory,
             'resourceHelper' => $resourceHelper,
@@ -369,13 +369,17 @@ class EntityAbstractTest extends AbstractImportTestCase
      * @covers \Magento\ImportExport\Model\Import\AbstractEntity::getBehavior
      *
      * @dataProvider dataProviderForTestGetBehaviorWithRowData
-     * @param $inputBehavior
-     * @param $rowData
-     * @param $expectedBehavior
-     * @param null $availableBehaviors
+     * @param string $inputBehavior
+     * @param array|null $rowData
+     * @param string $expectedBehavior
+     * @param array|null $availableBehaviors
      */
-    public function testGetBehaviorWithRowData($inputBehavior, $rowData, $expectedBehavior, $availableBehaviors = null)
-    {
+    public function testGetBehaviorWithRowData(
+        string $inputBehavior,
+        ?array $rowData,
+        string $expectedBehavior,
+        ?array $availableBehaviors = null
+    ) {
         $property = new \ReflectionProperty($this->_model, '_availableBehaviors');
         $property->setAccessible(true);
 

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/UpdaterTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Item/UpdaterTest.php
@@ -142,7 +142,7 @@ class UpdaterTest extends TestCase
             ->method('getProduct')
             ->willReturn($this->productMock);
 
-        $result = $this->object->update($this->itemMock, ['qty' => $qty]);
+        $result = $this->object->update($this->itemMock, ['qty' => (double) $qty]);
         $this->assertEquals($result, $this->object);
     }
 
@@ -211,7 +211,7 @@ class UpdaterTest extends TestCase
             ->method('getProduct')
             ->willReturn($this->productMock);
 
-        $object = $this->object->update($this->itemMock, ['qty' => $qty]);
+        $object = $this->object->update($this->itemMock, ['qty' => (double) $qty]);
         $this->assertEquals($this->object, $object);
     }
 

--- a/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/QuoteManagementTest.php
@@ -717,6 +717,8 @@ class QuoteManagementTest extends TestCase
 
     /**
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function testSubmit(): void
     {
@@ -861,7 +863,7 @@ class QuoteManagementTest extends TestCase
             ->setConstructorArgs(
                 [
                     'eventManager' => $this->eventManager,
-                    'quoteValidator' => $this->submitQuoteValidator,
+                    'submitQuoteValidator' => $this->submitQuoteValidator,
                     'orderFactory' => $this->orderFactory,
                     'orderManagement' => $this->orderManagement,
                     'customerManagement' => $this->customerManagement,
@@ -929,7 +931,7 @@ class QuoteManagementTest extends TestCase
             ->setConstructorArgs(
                 [
                     'eventManager' => $this->eventManager,
-                    'quoteValidator' => $this->submitQuoteValidator,
+                    'submitQuoteValidator' => $this->submitQuoteValidator,
                     'orderFactory' => $this->orderFactory,
                     'orderManagement' => $this->orderManagement,
                     'customerManagement' => $this->customerManagement,

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Quote/DiscountTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Quote/DiscountTest.php
@@ -140,14 +140,6 @@ class DiscountTest extends TestCase
             ]
         );
         $discountData = $this->getMockBuilder(Data::class)
-            ->setConstructorArgs(
-                [
-                    'amount' => 0,
-                    'baseAmount' => 0,
-                    'originalAmount' => 0,
-                    'baseOriginalAmount' => 0
-                ]
-            )
             ->getMock();
         $this->discountFactory->expects($this->any())
             ->method('create')

--- a/app/code/Magento/SalesRule/Test/Unit/Model/RulesApplierTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/RulesApplierTest.php
@@ -110,14 +110,6 @@ class RulesApplierTest extends TestCase
         $ruleId = 1;
         $appliedRuleIds = [$ruleId => $ruleId];
         $discountData = $this->getMockBuilder(Data::class)
-            ->setConstructorArgs(
-                [
-                    'amount' => 0,
-                    'baseAmount' => 0,
-                    'originalAmount' => 0,
-                    'baseOriginalAmount' => 0
-                ]
-            )
             ->getMock();
         $this->discountFactory->expects($this->any())
             ->method('create')
@@ -294,14 +286,6 @@ class RulesApplierTest extends TestCase
             ['fixQuantity', 'calculate']
         );
         $discountData = $this->getMockBuilder(Data::class)
-            ->setConstructorArgs(
-                [
-                    'amount' => 30,
-                    'baseAmount' => 30,
-                    'originalAmount' => 30,
-                    'baseOriginalAmount' => 30
-                ]
-            )
             ->getMock();
         $this->validatorUtility->expects($this->any())
             ->method('getItemQty')

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/Delete.php
@@ -1,18 +1,21 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
 /**
- * Class Delete
+ * The admin area controller to delete theme.
+ *
  * @deprecated 100.2.0
  */
-class Delete extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
+class Delete extends Theme implements HttpGetActionInterface
 {
     /**
      * Delete action
@@ -29,7 +32,10 @@ class Delete extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
                     \Magento\Framework\View\Design\ThemeInterface::class
                 )->load($themeId);
                 if (!$theme->getId()) {
-                    throw new \InvalidArgumentException(sprintf('We cannot find a theme with id "%1".', $themeId));
+                    throw new \InvalidArgumentException(__(
+                        'We cannot find a theme with id "%1".',
+                        $themeId
+                    )->render());
                 }
                 if (!$theme->isVirtual()) {
                     throw new \InvalidArgumentException(

--- a/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
+++ b/app/code/Magento/Theme/Controller/Adminhtml/System/Design/Theme/DownloadCustomCss.php
@@ -1,19 +1,23 @@
 <?php
 /**
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Theme\Controller\Adminhtml\System\Design\Theme;
 
 /**
- * Class DownloadCustomCss
+ * The admin area controller to download custom css.
+ *
  * @deprecated 100.2.0
  */
-class DownloadCustomCss extends \Magento\Theme\Controller\Adminhtml\System\Design\Theme
+class DownloadCustomCss extends Theme implements HttpGetActionInterface, HttpPostActionInterface
 {
     /**
      * Download custom css file
@@ -27,8 +31,11 @@ class DownloadCustomCss extends \Magento\Theme\Controller\Adminhtml\System\Desig
             /** @var $themeFactory \Magento\Framework\View\Design\Theme\FlyweightFactory */
             $themeFactory = $this->_objectManager->create(\Magento\Framework\View\Design\Theme\FlyweightFactory::class);
             $theme = $themeFactory->create($themeId);
-            if (!$theme) {
-                throw new \InvalidArgumentException(sprintf('We cannot find a theme with id "%1".', $themeId));
+            if ($theme === null || !$theme->getId()) {
+                throw new \InvalidArgumentException(__(
+                    'We cannot find a theme with id "%1".',
+                    $themeId
+                )->render());
             }
 
             $customCssFiles = $theme->getCustomization()->getFilesByType(
@@ -44,7 +51,10 @@ class DownloadCustomCss extends \Magento\Theme\Controller\Adminhtml\System\Desig
                 );
             }
         } catch (\Exception $e) {
-            $this->messageManager->addException($e, __('We can\'t find file.'));
+            $this->messageManager->addExceptionMessage(
+                $e,
+                __('We can\'t find file.')->render()
+            );
             $this->getResponse()->setRedirect($this->_redirect->getRefererUrl());
             $this->_objectManager->get(\Psr\Log\LoggerInterface::class)->critical($e);
         }

--- a/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Controller/Adminhtml/System/Design/Theme/DownloadCustomCssTest.php
@@ -174,6 +174,8 @@ class DownloadCustomCssTest extends TestCase
         $file->expects($this->once())
             ->method('getFullPath')
             ->willReturn($fullPath);
+        $theme->method('getId')
+            ->willReturn($themeId);
         $theme->expects($this->once())
             ->method('getCustomization')
             ->willReturn($customization);
@@ -234,7 +236,7 @@ class DownloadCustomCssTest extends TestCase
             ->with($themeId)
             ->willReturn(null);
         $this->messageManager->expects($this->once())
-            ->method('addException');
+            ->method('addExceptionMessage');
         $logger->expects($this->once())
             ->method('critical');
         $this->redirect->expects($this->once())

--- a/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/Injectable.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/Injectable.php
@@ -42,8 +42,8 @@ class Injectable
                         $this->dependencies[] = $dependency->getName();
                     }
                 } catch (ReflectionException $e) {
-                    if (preg_match('#^Class ([A-Za-z0-9_\\\\]+) does not exist$#', $e->getMessage(), $result)) {
-                        $this->dependencies[] = $result[1];
+                    if (preg_match('#^Class ([A-Za-z0-9_\"\\\\]+) does not exist$#', $e->getMessage(), $result)) {
+                        $this->dependencies[] = trim($result[1], '"');
                     } else {
                         throw $e;
                     }

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Generator/EntityAbstractTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Generator/EntityAbstractTest.php
@@ -57,7 +57,7 @@ class EntityAbstractTest extends TestCase
     protected function setUp(): void
     {
         $this->sourceClass = '\\' . DataObject::class;
-        $this->resultClass = '\\' . \Magento\Framework\DataObject_MyResult::class;
+        $this->resultClass = '\\Magento\\Framework\\DataObject_MyResult';
         $this->_model = $this->getMockForAbstractClass(EntityAbstract::class);
     }
 
@@ -262,10 +262,10 @@ class EntityAbstractTest extends TestCase
         }
 
         return [
-            'source_class' => $this->sourceClass,
-            'result_class' => $this->resultClass,
-            'io_object' => $ioObject,
-            'code_generator' => null,
+            'sourceClassName' => $this->sourceClass,
+            'resultClassName' => $this->resultClass,
+            'ioObject' => $ioObject,
+            'classGenerator' => null,
             'definedClasses' => $definedClassesMock,
         ];
     }
@@ -298,17 +298,17 @@ class EntityAbstractTest extends TestCase
 
         // Add configuration for the generation step
         /** @var \PHPUnit\Framework\MockObject\MockObject $ioObject */
-        $ioObject = $mocks['io_object'];
+        $ioObject = $mocks['ioObject'];
         if ($willWriteCode) {
             $ioObject->expects($this->once())->method('writeResultFile')->with(self::RESULT_FILE, self::RESULT_CODE);
         }
         $ioObject->expects($this->any())->method('generateResultFileName')->willReturn(self::RESULT_FILE);
 
         return [
-            'source_class' => $mocks['source_class'],
-            'result_class' => $mocks['result_class'],
-            'io_object' => $ioObject,
-            'code_generator' => $codeGenerator,
+            'sourceClassName' => $mocks['sourceClassName'],
+            'resultClassName' => $mocks['resultClassName'],
+            'ioObject' => $ioObject,
+            'classGenerator' => $codeGenerator,
             'definedClasses' => $mocks['definedClasses'],
         ];
     }

--- a/lib/internal/Magento/Framework/DB/Statement/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Statement/Pdo/Mysql.php
@@ -14,7 +14,6 @@ use Magento\Framework\DB\Statement\Parameter;
  */
 class Mysql extends \Zend_Db_Statement_Pdo
 {
-
     /**
      * Executes statement with binding values to it. Allows transferring specific options to DB driver.
      *
@@ -40,13 +39,11 @@ class Mysql extends \Zend_Db_Statement_Pdo
         // Separate array with values, as they are bound by reference
         foreach ($params as $name => $param) {
             $dataType = \PDO::PARAM_STR;
-            $length = null;
+            $length = is_string($param) ? strlen($param) : 0;
             $driverOptions = null;
 
             if ($param instanceof Parameter) {
-                if ($param->getIsBlob()) {
-                    // Nothing to do there - default options are fine for MySQL driver
-                } else {
+                if (!$param->getIsBlob()) {
                     $dataType = $param->getDataType();
                     $length = $param->getLength();
                     $driverOptions = $param->getDriverOptions();
@@ -71,6 +68,8 @@ class Mysql extends \Zend_Db_Statement_Pdo
      * @param array $params OPTIONAL Values to bind to parameter placeholders.
      * @return bool
      * @throws \Zend_Db_Statement_Exception
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public function _execute(array $params = null)
     {
@@ -88,7 +87,7 @@ class Mysql extends \Zend_Db_Statement_Pdo
             return $this->_executeWithBinding($params);
         } else {
             return $this->tryExecute(function () use ($params) {
-                return $params !== null ? $this->_stmt->execute($params) : $this->_stmt->execute();
+                return !empty($params) ? $this->_stmt->execute($params) : $this->_stmt->execute();
             });
         }
     }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/DB/Statement/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/DB/Statement/MysqlTest.php
@@ -114,8 +114,8 @@ class MysqlTest extends TestCase
     {
         $param1 = $this->createMock(Parameter::class);
         $param1Value = 'SomeValue';
-        $param1DataType = 'dataType';
-        $param1Length = '9';
+        $param1DataType = \PDO::PARAM_STR;
+        $param1Length = 9;
         $param1DriverOptions = 'some driver options';
         $param1->expects($this->once())
             ->method('getIsBlob')
@@ -145,7 +145,7 @@ class MysqlTest extends TestCase
             ->method('bindParam')
             ->withConsecutive(
                 [':param1', $param1Value, $param1DataType, $param1Length, $param1DriverOptions],
-                [':param2', 'value2', \PDO::PARAM_STR, null, null]
+                [':param2', 'value2', \PDO::PARAM_STR, 6, null]
             );
         $this->pdoStatementMock->expects($this->once())
             ->method('execute');

--- a/lib/internal/Magento/Framework/DataObject/Test/Unit/CopyTest.php
+++ b/lib/internal/Magento/Framework/DataObject/Test/Unit/CopyTest.php
@@ -397,7 +397,7 @@ class CopyTest extends TestCase
         $targetMock
             ->expects($this->any())
             ->method('getExtensionAttributes')
-            ->willReturn(null);
+            ->willReturnSelf();
 
         $this->eventManagerMock->expects($this->once())->method('dispatch');
         $result = $this->copy->copyFieldsetToTarget('fieldset', 'aspect', $sourceMock, $targetMock);

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/TranslatedListsTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/TranslatedListsTest.php
@@ -82,7 +82,7 @@ class TranslatedListsTest extends TestCase
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
         $this->mockConfig->method('getAllowedLocales')
-            ->willReturn(array_keys($this->expectedLocales));
+            ->willReturn($this->expectedLocales);
         $this->mockConfig->method('getAllowedCurrencies')
             ->willReturn($this->expectedCurrencies);
 

--- a/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandlerTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/SaveHandlerTest.php
@@ -127,7 +127,8 @@ class SaveHandlerTest extends TestCase
 
         $this->saveHandlerAdapterMock->expects($this->once())
             ->method('read')
-            ->with('test_session_id');
+            ->with('test_session_id')
+            ->willReturn('test_session_data');
 
         $this->assertTrue($this->saveHandler->write("test_session_id", "testdata"));
     }

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/CurrencyTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/CurrencyTest.php
@@ -17,10 +17,10 @@ class CurrencyTest extends TestCase
      * @var array
      */
     protected $expectedCurrencies = [
-        'USD',
-        'EUR',
-        'UAH',
-        'GBP',
+        'USD' => 'US Dollar (USD)',
+        'EUR' => 'Euro (EUR)',
+        'UAH' => 'Ukrainian Hryvnia (UAH)',
+        'GBP' => 'British Pound (GBP)'
     ];
 
     public function testIsValid()

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/LocaleTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/LocaleTest.php
@@ -17,10 +17,10 @@ class LocaleTest extends TestCase
      * @var array
      */
     protected $expectedLocales = [
-        'en_US',
-        'en_GB',
-        'uk_UA',
-        'de_DE',
+        'en_US' => 'English (United States)',
+        'en_GB' => 'English (United Kingdom)',
+        'uk_UA' => 'Ukrainian (Ukraine)',
+        'de_DE' => 'German (Germany)'
     ];
 
     public function testIsValid()

--- a/lib/internal/Magento/Framework/Validator/Test/Unit/TimezoneTest.php
+++ b/lib/internal/Magento/Framework/Validator/Test/Unit/TimezoneTest.php
@@ -17,10 +17,10 @@ class TimezoneTest extends TestCase
      * @var array
      */
     protected $expectedTimezones = [
-        'Australia/Darwin',
-        'America/Los_Angeles',
-        'Europe/Kiev',
-        'Asia/Jerusalem',
+        'Australia/Darwin' => 'Darwind description',
+        'America/Los_Angeles' => 'Los_Angeles description',
+        'Europe/Kiev' => 'Kiev description',
+        'Asia/Jerusalem' => 'Jerusalem description'
     ];
 
     public function testIsValid()

--- a/lib/internal/Magento/Framework/View/Template/Html/Minifier.php
+++ b/lib/internal/Magento/Framework/View/Template/Html/Minifier.php
@@ -125,7 +125,7 @@ class Minifier implements MinifierInterface
 
                 return '__MINIFIED_HEREDOC__' .(count($heredocs) - 1);
             },
-            $content
+            ($content ?? '')
         );
         $content = preg_replace(
             '#(?<!]]>)\s+</#',
@@ -149,7 +149,7 @@ class Minifier implements MinifierInterface
                                 preg_replace(
                                     '#(?<!:)//[^\n\r]*(\<\?php)[^\n\r]*(\s\?\>)[^\n\r]*#',
                                     '',
-                                    $content
+                                    ($content ?? '')
                                 )
                             )
                         )
@@ -164,7 +164,7 @@ class Minifier implements MinifierInterface
             function ($match) use ($heredocs) {
                 return $heredocs[(int)$match[1]];
             },
-            $content
+            ($content ?? '')
         );
 
         if (!$this->htmlDirectory->isExist()) {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Layout/Generator/BlockTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Layout/Generator/BlockTest.php
@@ -74,9 +74,7 @@ class BlockTest extends TestCase
                         'actions' => [
                             [
                                 $methodName,
-                                [
-                                    'test_argument' => $argumentData
-                                ],
+                                [$argumentData],
                                 'config_path',
                                 'scope',
                             ],

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Generator/InterceptionConfigurationBuilderTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Generator/InterceptionConfigurationBuilderTest.php
@@ -16,6 +16,7 @@ use Magento\Setup\Module\Di\Code\Generator\PluginList;
 use Magento\Setup\Module\Di\Code\Reader\Type;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class InterceptionConfigurationBuilderTest extends TestCase
 {
@@ -114,10 +115,11 @@ class InterceptionConfigurationBuilderTest extends TestCase
      */
     public function getInterceptionConfigurationDataProvider()
     {
+        $someInstance = new stdClass();
         return [
             [null],
-            [['plugin' => ['instance' => 'someinstance']]],
-            [['plugin' => ['instance' => 'someinstance'], 'plugin2' => ['instance' => 'someinstance']]]
+            [['plugin' => ['instance' => $someInstance]]],
+            [['plugin' => ['instance' => $someInstance], 'plugin2' => ['instance' => $someInstance]]]
         ];
     }
 }


### PR DESCRIPTION
### Description (*)
Fixes existing Unit Tests (and related files from Magento Core) to be compatible both with PHP7 and PHP8.

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues (*)
1. magento/magento2#34019

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
