### PR TITLE
CE Fix Unit tests to be compatible with php8 [part 2]

### DIFF
--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -57,6 +57,7 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
     /**
      * Config path to mail sending setting that shows if email communications are disabled
      * @deprecated
+     * @see https://github.com/magento/magento2/issues/5988
      */
     const XML_PATH_SYSTEM_SMTP_DISABLE = 'system/smtp/disable';
 

--- a/app/code/Magento/Email/Model/Template.php
+++ b/app/code/Magento/Email/Model/Template.php
@@ -252,7 +252,7 @@ class Template extends AbstractTemplate implements \Magento\Framework\Mail\Templ
         );
 
         try {
-            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject()));
+            $processedResult = $processor->setStoreId($storeId)->filter(__($this->getTemplateSubject())->render());
         } catch (\Exception $e) {
             $this->cancelDesignConfig();
             throw new \Magento\Framework\Exception\MailException(__($e->getMessage()), $e);

--- a/app/code/Magento/Theme/Model/Indexer/Design/Config.php
+++ b/app/code/Magento/Theme/Model/Indexer/Design/Config.php
@@ -174,7 +174,7 @@ class Config implements ActionInterface
                 $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['origin'] =
                     $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['origin']
                         ?: $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['name'];
-                if ($fieldsetName != 0) {
+                if ((int) $fieldsetName !== 0) {
                     $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['name'] =
                         $this->data['fieldsets'][$fieldsetName]['name'] . '_'
                         . $this->data['fieldsets'][$fieldsetName]['fields'][$fieldName]['name'];

--- a/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/Http.php
@@ -250,7 +250,7 @@ class Http extends File
      */
     protected function open($hostname, $port)
     {
-        $result = @fsockopen($hostname, $port, $errorNumber, $errorMessage);
+        $result = @fsockopen($hostname, $port, $errorNumber = null, $errorMessage = null);
         if ($result === false) {
             throw new FileSystemException(
                 new \Magento\Framework\Phrase(

--- a/lib/internal/Magento/Framework/Filter/Template.php
+++ b/lib/internal/Magento/Framework/Filter/Template.php
@@ -9,7 +9,6 @@
  */
 namespace Magento\Framework\Filter;
 
-use Exception;
 use InvalidArgumentException;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Filter\DirectiveProcessor\DependDirective;
@@ -170,12 +169,11 @@ class Template implements \Zend_Filter_Interface
      *
      * @param string $value
      * @return string
-     * @throws Exception
+     * @throws \Exception
      */
     public function filter($value)
     {
         if (!is_string($value)) {
-            //phpcs:ignore Magento2.Exceptions.DirectThrow
             throw new InvalidArgumentException(__(
                 'Argument \'value\' must be type of string, %1 given.',
                 gettype($value)

--- a/lib/internal/Magento/Framework/Indexer/Test/Unit/MultiDimensionProviderTest.php
+++ b/lib/internal/Magento/Framework/Indexer/Test/Unit/MultiDimensionProviderTest.php
@@ -221,14 +221,14 @@ class MultiDimensionProviderTest extends TestCase
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
-            ->setMethods(['getIterator'])
+            ->onlyMethods(['getIterator'])
             ->getMockForAbstractClass();
 
         $dimensionProviderMock->expects($this->any())
             ->method('getIterator')
             ->willReturnCallback(
                 function () use ($dimensions) {
-                    return \SplFixedArray::fromArray($dimensions);
+                    return new \ArrayIterator($dimensions);
                 }
             );
 
@@ -248,7 +248,7 @@ class MultiDimensionProviderTest extends TestCase
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->disallowMockingUnknownTypes()
-            ->setMethods(['getName', 'getValue'])
+            ->onlyMethods(['getName', 'getValue'])
             ->getMock();
 
         $dimensionMock->expects($this->any())


### PR DESCRIPTION
### Description (*)

Fixes existing Unit Tests (and related files from Magento Core) to be compatible both with PHP7 and PHP8.

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#34019

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
