### PR TITLE
Report cron error message where possible

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -366,7 +366,7 @@ class ProcessCronQueueObserver implements ObserverInterface
             );
             if (!$e instanceof \Exception) {
                 $e = new \RuntimeException(
-                    'Error when running a cron job',
+                    'Error when running a cron job: ' . $e->getMessage(),
                     0,
                     $e
                 );

--- a/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ProcessCronQueueObserverTest.php
@@ -617,7 +617,7 @@ class ProcessCronQueueObserverTest extends TestCase
      */
     public function dispatchExceptionInCallbackDataProvider(): array
     {
-        $throwable = new TypeError();
+        $throwable = new TypeError('Description of TypeError');
         return [
             'non-callable callback' => [
                 'Not_Existed_Class',
@@ -640,11 +640,11 @@ class ProcessCronQueueObserverTest extends TestCase
                 new CronJobException(
                     $throwable
                 ),
-                'Error when running a cron job',
+                'Error when running a cron job: Description of TypeError',
                 2,
                 1,
                 new \RuntimeException(
-                    'Error when running a cron job',
+                    'Error when running a cron job: Description of TypeError',
                     0,
                     $throwable
                 )


### PR DESCRIPTION
### Description
This pull request adds the error message to the new exception created in the exception handler for cron jobs. Without this, the real error message is lost.

### Related Pull Requests
<!-- related pull request placeholder -->
*None*

### Manual testing scenarios
1. Throw a generic exception with a helpful error message within a cron job.
1. Witness the helpful error message is not logged nor available anywhere.
1. Apply changes in this pull request.
1. Witness the helpful error message is preserved.

### Questions or comments
See also https://github.com/Ethan3600/magento2-CronjobManager/pull/164

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34941: Report cron error message where possible