### PR TITLE
Enforce array type in DesignTheme config processor

### DIFF
--- a/app/code/Magento/Theme/Model/Config/Processor/DesignTheme.php
+++ b/app/code/Magento/Theme/Model/Config/Processor/DesignTheme.php
@@ -42,6 +42,7 @@ class DesignTheme implements PreProcessorInterface
 
     /**
      * Change value from theme_full_path (Ex. "frontend/Magento/blank") to theme_id field for every existed scope.
+     *
      * All other values leave without changes.
      *
      * @param array $config
@@ -63,8 +64,10 @@ class DesignTheme implements PreProcessorInterface
     }
 
     /**
-     * Check \Magento\Framework\View\DesignInterface::XML_PATH_THEME_ID config path
-     * and convert theme_full_path (Ex. "frontend/Magento/blank") to theme_id
+     * Convert theme_full_path from config (Ex. "frontend/Magento/blank") to theme_id.
+     *
+     * @see \Magento\Framework\View\DesignInterface::XML_PATH_THEME_ID
+     * @param array $configItems complete store configuration for a single scope as nested array
      */
     private function changeThemeFullPathToIdentifier(array $configItems): array
     {

--- a/app/code/Magento/Theme/Model/Config/Processor/DesignTheme.php
+++ b/app/code/Magento/Theme/Model/Config/Processor/DesignTheme.php
@@ -51,10 +51,10 @@ class DesignTheme implements PreProcessorInterface
     {
         foreach ($config as $scope => &$item) {
             if ($scope === \Magento\Framework\App\Config\ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
-                $item = $this->changeThemeFullPathToIdentifier($item);
+                $item = $this->changeThemeFullPathToIdentifier($item ?? []);
             } else {
                 foreach ($item as &$scopeItems) {
-                    $scopeItems = $this->changeThemeFullPathToIdentifier($scopeItems);
+                    $scopeItems = $this->changeThemeFullPathToIdentifier($scopeItems ?? []);
                 }
             }
         }
@@ -65,11 +65,8 @@ class DesignTheme implements PreProcessorInterface
     /**
      * Check \Magento\Framework\View\DesignInterface::XML_PATH_THEME_ID config path
      * and convert theme_full_path (Ex. "frontend/Magento/blank") to theme_id
-     *
-     * @param array $configItems
-     * @return array
      */
-    private function changeThemeFullPathToIdentifier($configItems)
+    private function changeThemeFullPathToIdentifier(array $configItems): array
     {
         $theme = null;
         $themeIdentifier = $this->arrayManager->get(DesignInterface::XML_PATH_THEME_ID, $configItems);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Without the type check, an empty config node like `<my_store />` in a `config.xml` breaks installation, as `null` is passed to the private method.


### Related Pull Requests
<!-- related pull request placeholder -->
none

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
none (can be created if desired)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create module with store specific configuration in `config.xml`
2. use empty node for one store, like `<my_store />`
3. run `bin/magento setup:install` or integration test suite

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Since the changed method is private, this change is 100% backwards compatible. I'm not adding a test case since not having regressions should be a sufficient merge criteria when adding types.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34440: Enforce array type in DesignTheme config processor