### PR TITLE
Fix Status Payment Review is not visible in frontend

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -54,8 +54,7 @@ class Config
      */
     protected $maskStatusesMapping = [
         Area::AREA_FRONTEND => [
-            \Magento\Sales\Model\Order::STATUS_FRAUD => \Magento\Sales\Model\Order::STATUS_FRAUD,
-            \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW => \Magento\Sales\Model\Order::STATE_PROCESSING
+            \Magento\Sales\Model\Order::STATUS_FRAUD => \Magento\Sales\Model\Order::STATUS_FRAUD
         ]
     ];
 

--- a/app/code/Magento/Sales/Model/Order/Config.php
+++ b/app/code/Magento/Sales/Model/Order/Config.php
@@ -54,7 +54,8 @@ class Config
      */
     protected $maskStatusesMapping = [
         Area::AREA_FRONTEND => [
-            \Magento\Sales\Model\Order::STATUS_FRAUD => \Magento\Sales\Model\Order::STATUS_FRAUD
+            \Magento\Sales\Model\Order::STATUS_FRAUD => \Magento\Sales\Model\Order::STATUS_FRAUD,
+            \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW => \Magento\Sales\Model\Order::STATE_PROCESSING
         ]
     ];
 
@@ -128,7 +129,6 @@ class Config
         }
         return $status;
     }
-
 
     /**
      * Retrieve status label for detected area


### PR DESCRIPTION
### Description
Orders with payment_review and state status other than "fraud" are visible on the store frontend as "processing".

### Fixed Issues
1. Fixes magento/magento2#30520

### Manual testing scenarios (*)
1. Implement a customized payment method that will reach the status of payment_review.
2. Make the purchase using this method.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
