### PR TITLE
Backend category performance fix

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -169,7 +169,7 @@ abstract class AbstractAction
      */
     protected function reindex()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             if ($this->getPathFromCategoryId($store->getRootCategoryId())) {
                 $this->currentStoreId = $store->getId();
                 $this->reindexRootCategory($store);
@@ -246,7 +246,7 @@ abstract class AbstractAction
                     ['path']
                 )->where(
                     'entity_id = ?',
-                    $categoryId
+                    $categoryId == 0 ? 1 : $categoryId
                 )
             );
         }
@@ -284,10 +284,6 @@ abstract class AbstractAction
                 'ccp.category_id = cc.entity_id',
                 []
             )->joinInner(
-                ['cpw' => $this->getTable('catalog_product_website')],
-                'cpw.product_id = ccp.product_id',
-                []
-            )->joinInner(
                 ['cpe' => $this->getTable('catalog_product_entity')],
                 'ccp.product_id = cpe.entity_id',
                 []
@@ -316,11 +312,6 @@ abstract class AbstractAction
                 $store->getId(),
                 []
             )->where(
-                'cc.path LIKE ' . $this->connection->quote($rootPath . '/%')
-            )->where(
-                'cpw.website_id = ?',
-                $store->getWebsiteId()
-            )->where(
                 $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
@@ -342,6 +333,19 @@ abstract class AbstractAction
                     ),
                 ]
             );
+
+            if ($store->getId() != 0) {
+                $select->joinInner(
+                    ['cpw' => $this->getTable('catalog_product_website')],
+                    'cpw.product_id = ccp.product_id',
+                    []
+                )->where(
+                    'cpw.website_id = ?',
+                    $store->getWebsiteId()
+                )->where(
+                    'cc.path LIKE ' . $this->connection->quote($rootPath . '/%')
+                );
+            }
 
             $this->addFilteringByChildProductsToSelect($select, $store);
 
@@ -524,10 +528,6 @@ abstract class AbstractAction
             'ccp.product_id = cpe.entity_id',
             []
         )->joinInner(
-            ['cpw' => $this->getTable('catalog_product_website')],
-            'cpw.product_id = ccp.product_id',
-            []
-        )->joinInner(
             ['cpsd' => $this->getTable('catalog_product_entity_int')],
             'cpsd.' . $productLinkField . ' = cpe.' . $productLinkField . ' AND cpsd.store_id = 0'
                 . ' AND cpsd.attribute_id = ' . $statusAttributeId,
@@ -562,9 +562,6 @@ abstract class AbstractAction
             $store->getId(),
             []
         )->where(
-            'cpw.website_id = ?',
-            $store->getWebsiteId()
-        )->where(
             $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
             \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
         )->where(
@@ -589,6 +586,17 @@ abstract class AbstractAction
                 'visibility' => new \Zend_Db_Expr($this->connection->getIfNullSql('cpvs.value', 'cpvd.value')),
             ]
         );
+
+        if ($store->getId() != 0) {
+            $select->joinInner(
+                ['cpw' => $this->getTable('catalog_product_website')],
+                'cpw.product_id = ccp.product_id',
+                []
+            )->where(
+                'cpw.website_id = ?',
+                $store->getWebsiteId()
+            );
+        }
 
         $this->addFilteringByChildProductsToSelect($select, $store);
 
@@ -772,10 +780,6 @@ abstract class AbstractAction
                 ['cp' => $this->getTable('catalog_product_entity')],
                 []
             )->joinInner(
-                ['cpw' => $this->getTable('catalog_product_website')],
-                'cpw.product_id = cp.entity_id',
-                []
-            )->joinInner(
                 ['cpsd' => $this->getTable('catalog_product_entity_int')],
                 'cpsd.' . $linkField . ' = cp.' . $linkField . ' AND cpsd.store_id = 0' .
                 ' AND cpsd.attribute_id = ' .
@@ -804,9 +808,6 @@ abstract class AbstractAction
                 'ccp.product_id = cp.entity_id',
                 []
             )->where(
-                'cpw.website_id = ?',
-                $store->getWebsiteId()
-            )->where(
                 $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
@@ -834,6 +835,17 @@ abstract class AbstractAction
                     ),
                 ]
             );
+
+            if ($store->getId() != 0) {
+                $select->joinInner(
+                    ['cpw' => $this->getTable('catalog_product_website')],
+                    'cpw.product_id = ccp.product_id',
+                    []
+                )->where(
+                    'cpw.website_id = ?',
+                    $store->getWebsiteId()
+                );
+            }
 
             $this->productsSelects[$store->getId()] = $select;
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -133,7 +133,7 @@ class Full extends AbstractAction
      */
     private function createTables(): void
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->tableMaintainer->createTablesForStore((int)$store->getId());
         }
     }
@@ -145,7 +145,7 @@ class Full extends AbstractAction
      */
     private function clearReplicaTables(): void
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->connection->truncateTable($this->tableMaintainer->getMainReplicaTable((int)$store->getId()));
         }
     }
@@ -158,7 +158,7 @@ class Full extends AbstractAction
     private function switchTables(): void
     {
         $tablesToSwitch = [];
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $tablesToSwitch[] = $this->tableMaintainer->getMainTable((int)$store->getId());
         }
         $this->activeTableSwitcher->switchTable($this->connection, $tablesToSwitch);
@@ -188,7 +188,7 @@ class Full extends AbstractAction
     {
         $userFunctions = [];
 
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             if ($this->getPathFromCategoryId($store->getRootCategoryId())) {
                 $userFunctions[$store->getId()] = function () use ($store) {
                     $this->reindexStore($store);

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
@@ -117,7 +117,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             || ($indexer->isScheduled() && !$useTempTable)
             || ($indexer->isScheduled() && $useTempTable && !$workingState)) {
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->truncateTable($this->getIndexTable($store->getId()));
                 }
             } else {
@@ -130,7 +130,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $workingState = $this->isWorkingState();
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $removalCategoryIds = array_diff($this->limitationByCategories, [$this->getRootCategoryId($store)]);
                     $this->connection->delete(
                         $this->tableMaintainer->getMainTable($store->getId()),
@@ -204,7 +204,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     private function removeEntries()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $removalCategoryIds = array_diff($this->limitationByCategories, [$this->getRootCategoryId($store)]);
             $this->connection->delete(
                 $this->getIndexTable($store->getId()),

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
@@ -78,7 +78,7 @@ class StoreGroup
      */
     public function afterDelete(AbstractDb $subject, AbstractDb $objectResource, AbstractModel $storeGroup)
     {
-        foreach ($storeGroup->getStores() as $store) {
+        foreach ($storeGroup->getStores(true) as $store) {
             $this->tableMaintainer->dropTablesForStore((int)$store->getId());
         }
         return $objectResource;

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
@@ -115,7 +115,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $affectedCategories = $this->getCategoryIdsFromIndex($idsToBeReIndexed);
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->truncateTable($this->getIndexTable($store->getId()));
                 }
             } else {
@@ -127,7 +127,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $workingState = $this->isWorkingState();
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->delete(
                         $this->tableMaintainer->getMainTable($store->getId()),
                         ['product_id IN (?)' => $this->limitationByProducts]
@@ -236,7 +236,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     protected function removeEntries()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->connection->delete(
                 $this->getIndexTable($store->getId()),
                 ['product_id IN (?)' => $this->limitationByProducts]
@@ -299,7 +299,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
     private function getCategoryIdsFromIndex(array $productIds): array
     {
         $categoryIds = [];
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $storeCategories = $this->connection->fetchCol(
                 $this->connection->select()
                     ->from($this->getIndexTable($store->getId()), ['category_id'])

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -11,6 +11,7 @@ use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DB\Select;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
 
 /**
  * Category resource collection
@@ -327,7 +328,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $countSelect = $this->getProductsCountQuery($categoryIds, (bool)$websiteId);
             $categoryProductsCount = $this->_conn->fetchPairs($countSelect);
             foreach ($anchor as $item) {
-                $productsCount = isset($categoriesProductsCount[$item->getId()])
+                $productsCount = isset($categoryProductsCount[$item->getId()])
                     ? (int)$categoryProductsCount[$item->getId()]
                     : $this->getProductsCountFromCategoryTable($item, $websiteId);
                 $item->setProductCount($productsCount);
@@ -556,7 +557,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     private function getProductsCountQuery(array $categoryIds, $addVisibilityFilter = true): Select
     {
-        $categoryTable = $this->getTable('catalog_category_product_index');
+        $tableMaintainer = \Magento\Framework\App\ObjectManager::getInstance()->get(TableMaintainer::class);
+        $categoryTable = $tableMaintainer->getMainTable($this->getProductStoreId());
         $select = $this->_conn->select()
             ->from(
                 ['cat_index' => $categoryTable],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

- Add product-category index table for default store (used for backend category page - product count)
- Use index table in backend category page for product count

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#34109 

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Measure time (or count SQL requests, in my case 14K+) of /admin/catalog/category/ and /admin/catalog/category/store/X pages
2. Pull changees
3. Reindex catalog_category_product
4. Measure again (or count again, in my care 7K~)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
To make the change work on default store (admin store), I had to enable reindexing catalog_product_category on default store.
Which mean there is a new table created and indexed : catalog_category_product_index_store0 (and catalog_category_product_index_store0_replica)

In Collection class, you see I use ObjectManager instead of passing class through constructor. I did that to avoid break classes that could extends this one (third par modules). But if you want, I can change that, I don't know what your policy is about that.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
