### PR TITLE
PHPDocs: correct return type for Payment Gateway Country validator

### DIFF
--- a/app/code/Magento/Payment/Gateway/Validator/CountryValidator.php
+++ b/app/code/Magento/Payment/Gateway/Validator/CountryValidator.php
@@ -36,7 +36,7 @@ class CountryValidator extends AbstractValidator
 
     /**
      * @param array $validationSubject
-     * @return bool
+     * @return \Magento\Payment\Gateway\Validator\ResultInterface
      * @throws NotFoundException
      * @throws \Exception
      */


### PR DESCRIPTION
### Description (*)
Looks like CountryValidator has invalid return type specified (bool) in PHPDocs, because its parent interface has ResultInterface (see \Magento\Payment\Gateway\Validator\ValidatorInterface::validate)

It causes PHPStan analyze error in case when we extend CountryValidator by custom class and specify PHP return type like this
```
public function validate(array $validationSubject): \Magento\Payment\Gateway\Validator\ResultInterface
{ }
```
In this case we can see foloowing PHPStan error
```
  17     Return type (Magento\Payment\Gateway\Validator\ResultInterface) of method <Vendor>\<Module>\Gateway\Validator\Method\CountryValidator::validate() should be compatible with return type (bool)  
         of method Magento\Payment\Gateway\Validator\CountryValidator::validate()   
```
So it thinks that return type should be bool, but it should be ResultInterface (because Interfaces has this one)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
