### PR TITLE
Guard Magento_Catalog JavaScript from lack of minicart

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/product/provider-compared.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/provider-compared.js
@@ -35,7 +35,7 @@ define([
                 productCurrentScope,
                 scopeId;
 
-            if (typeof this.data.productCurrentScope !== 'undefined') {
+            if (typeof this.data.productCurrentScope !== 'undefined' && window.checkout && window.checkout.baseUrl) {
                 productCurrentScope = this.data.productCurrentScope;
                 scopeId = productCurrentScope === 'store' ? window.checkout.storeId :
                     productCurrentScope === 'group' ? window.checkout.storeGroupId :

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/provider.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/provider.js
@@ -93,6 +93,11 @@ define([
          * @private
          */
         _resolveDataByIds: function () {
+            if (!window.checkout || !window.checkout.baseUrl) {
+                // We need data that the minicart provdes to determine storeId/websiteId
+                return;
+            }
+
             this.initIdsListener();
             this.idsMerger(
                 this.idsStorage.get(),

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage-compare.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/storage/ids-storage-compare.js
@@ -28,7 +28,7 @@ define([
                 this.data = ko.observable({});
             }
 
-            if (this.provider) {
+            if (this.provider && window.checkout && window.checkout.baseUrl) {
                 this.providerDataHandler(customerData.get(this.provider)());
                 this.initProviderListener();
             }

--- a/app/code/Magento/Catalog/view/frontend/web/js/product/view/provider.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/product/view/provider.js
@@ -30,9 +30,13 @@ define([
          * @returns {Object} Chainable.
          */
         initialize: function () {
-            this._super()
-                .initIdsStorage()
-                .initDataStorage();
+            this._super();
+
+            if (window.checkout && window.checkout.baseUrl) {
+                this.initIdsStorage();
+            }
+
+            this.initDataStorage();
 
             return this;
         },


### PR DESCRIPTION
### Description
When the mini-cart is removed, or during the checkout, `Magento_Catalog::js/product/storage/ids-storage-compare.js` throws an error. The error is masked during checkout because there is a DOM element with `id="checkout"` which some browsers make available on `window.checkout` (so there's no error but the information assumed to be present isn't there).

This pull request changes the guard logic to protect against this error.

Edit: I found three more places where the lack of minicart causes errors. The minicart.js itself also suffers from this assumption, but I chose to not patch that here.

### Related Pull Requests
*None*
<!-- related pull request placeholder -->

### Manual testing scenarios (*)
1. Remove the mini cart via layout (`<referenceBlock name="minicart" remove="true" />`)
1. Add an item to the 'compare' list
1. Witness error on JavaScript console / lack of error after this change

![Screenshot_2021-09-28_22-05-27](https://user-images.githubusercontent.com/334786/135165638-9c7148fc-0634-49b9-b9aa-c53989b24224.png)

### Questions or comments
*None*

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34513: Guard Magento_Catalog JavaScript from lack of minicart