### PR TITLE
fix Newsletter Queue method for a case with invalid start_at param

### DIFF
--- a/app/code/Magento/Newsletter/Model/Queue.php
+++ b/app/code/Magento/Newsletter/Model/Queue.php
@@ -202,11 +202,14 @@ class Queue extends \Magento\Framework\Model\AbstractModel implements TemplateTy
      */
     public function setQueueStartAtByString($startAt)
     {
-        if ($startAt === null || $startAt == '') {
-            $this->setQueueStartAt(null);
-        } else {
-            $this->setQueueStartAt($this->utcConverter->convertLocalizedDateToUtc($startAt));
-        }
+        // Cast start_at value to null if value is incorrect ("0", "" must be casted to null)
+        $startAt = (string) $startAt ?: null;
+        // Convert start_at value using UTC converter if start_at value is not null
+        $startAt = $startAt === null
+            ? $startAt
+            : $this->utcConverter->convertLocalizedDateToUtc($startAt);
+        $this->setQueueStartAt($startAt);
+
         return $this;
     }
 

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterQueueTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterQueueTest.php
@@ -46,15 +46,10 @@ class NewsletterQueueTest extends \Magento\TestFramework\TestCase\AbstractBacken
 
     /**
      * @magentoDataFixture Magento/Newsletter/_files/newsletter_sample.php
+     * @dataProvider postValuesForRequest
      */
-    public function testSaveActionQueueTemplateAndVerifySuccessMessage()
+    public function testSaveActionQueueTemplateAndVerifySuccessMessage(array $postForQueue)
     {
-        $postForQueue = [
-            'sender_email' => 'johndoe_gieee@unknown-domain.com',
-            'sender_name' => 'john doe',
-            'subject' => 'test subject',
-            'text' => 'newsletter text',
-        ];
         $this->getRequest()->setMethod(HttpRequest::METHOD_POST);
         $this->getRequest()->setPostValue($postForQueue);
 
@@ -80,5 +75,60 @@ class NewsletterQueueTest extends \Magento\TestFramework\TestCase\AbstractBacken
             $this->equalTo(['You saved the newsletter queue.']),
             \Magento\Framework\Message\MessageInterface::TYPE_SUCCESS
         );
+    }
+
+    /**
+     * The data provider for possible request values of the start_at.
+     *
+     * @return array
+     */
+    public function postValuesForRequest(): array
+    {
+        return [
+            'start_at_value_is_integer_zero' => [
+                [
+                    'sender_email' => 'johndoe_gieee@unknown-domain.com',
+                    'sender_name' => 'john doe',
+                    'subject' => 'test subject',
+                    'text' => 'newsletter text',
+                    'start_at' => 0
+                ]
+            ],
+            'start_at_value_is_string_zero' => [
+                [
+                    'sender_email' => 'johndoe_gieee@unknown-domain.com',
+                    'sender_name' => 'john doe',
+                    'subject' => 'test subject',
+                    'text' => 'newsletter text',
+                    'start_at' => '0'
+                ]
+            ],
+            'start_at_value_is_empty_string' => [
+                [
+                    'sender_email' => 'johndoe_gieee@unknown-domain.com',
+                    'sender_name' => 'john doe',
+                    'subject' => 'test subject',
+                    'text' => 'newsletter text',
+                    'start_at' => ''
+                ]
+            ],
+            'start_at_value_not_provided' => [
+                [
+                    'sender_email' => 'johndoe_gieee@unknown-domain.com',
+                    'sender_name' => 'john doe',
+                    'subject' => 'test subject',
+                    'text' => 'newsletter text'
+                ]
+            ],
+            'start_at_value_is_date_time_string' => [
+                [
+                    'sender_email' => 'johndoe_gieee@unknown-domain.com',
+                    'sender_name' => 'john doe',
+                    'subject' => 'test subject',
+                    'text' => 'newsletter text',
+                    'start_at' => date('Y-m-d H:i:s')
+                ]
+            ]
+        ];
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Newsletter/_files/queue.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/_files/queue.php
@@ -33,7 +33,7 @@ $queue->setTemplateId(
 )->setQueueStatus(
     \Magento\Newsletter\Model\Queue::STATUS_NEVER
 )->setQueueStartAtByString(
-    0
+    null
 )->setStores(
     [$currentStore, $otherStore]
 )->save();


### PR DESCRIPTION
### Description (*)
Fix for a Newsletter Queue method, which causes a fatal error in integration tests (on PHP 8.0 env)

### Related Issues (if relevant)
1. magento/magento2#34020

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
