### PR TITLE
Fix static tests to be php8 compatible

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/Rest/CurlClient.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/Rest/CurlClient.php
@@ -13,7 +13,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class CurlClient extends \OAuth\Common\Http\Client\CurlClient
 {
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function retrieveResponse(
         UriInterface $endpoint,

--- a/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/PhpParser/StaticCalls.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/PhpParser/StaticCalls.php
@@ -82,6 +82,13 @@ class StaticCalls implements ParserInterface, DependenciesCollectorInterface
     {
         $step = 1;
         $staticClassParts = [];
+
+        $token = $this->tokens->getTokenCodeByKey($staticCall - $step);
+        if ($token === T_NAME_FULLY_QUALIFIED || $token === T_NAME_QUALIFIED) {
+            return $this->tokens->getTokenValueByKey($staticCall - $step);
+        }
+
+        // PHP 7 compatibility
         while ($this->tokens->getTokenCodeByKey(
             $staticCall - $step
         ) == T_STRING || $this->tokens->getTokenCodeByKey(
@@ -90,6 +97,7 @@ class StaticCalls implements ParserInterface, DependenciesCollectorInterface
             $staticClassParts[] = $this->tokens->getTokenValueByKey($staticCall - $step);
             $step++;
         }
+
         return implode(array_reverse($staticClassParts));
     }
 

--- a/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/PhpParser/Throws.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/PhpParser/Throws.php
@@ -57,14 +57,19 @@ class Throws implements ParserInterface, DependenciesCollectorInterface
             $class = '';
             if ($this->tokens->getTokenCodeByKey($throw + 2) == T_NEW) {
                 $step = 4;
-                while ($this->tokens->getTokenCodeByKey(
-                    $throw + $step
-                ) == T_STRING || $this->tokens->getTokenCodeByKey(
-                    $throw + $step
-                ) == T_NS_SEPARATOR) {
-                    $class .= trim($this->tokens->getTokenValueByKey($throw + $step));
-                    $step++;
+
+                $token = $this->tokens->getTokenCodeByKey($throw + $step);
+                if ($token === T_NAME_FULLY_QUALIFIED || $token === T_NAME_QUALIFIED) {
+                    $class = $this->tokens->getTokenValueByKey($throw + $step);
+                } else {
+                    // PHP 7 compatibility
+                    while ($this->tokens->getTokenCodeByKey($throw + $step) === T_STRING
+                        || $this->tokens->getTokenCodeByKey($throw + $step) === T_NS_SEPARATOR) {
+                        $class .= trim($this->tokens->getTokenValueByKey($throw + $step));
+                        $step++;
+                    }
                 }
+
                 if ($uses->hasUses()) {
                     $class = $uses->getClassNameWithNamespace($class);
                 }

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Di/CompilerTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Di/CompilerTest.php
@@ -127,12 +127,9 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             );
             $blacklistItems = [];
             foreach (glob($blacklistFiles) as $fileName) {
-                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $blacklistItems = array_merge(
-                    $blacklistItems,
-                    file($fileName, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
-                );
+                $blacklistItems[] = file($fileName, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
             }
+            $blacklistItems = array_merge([], ...$blacklistItems);
             $this->pluginBlacklist = $blacklistItems;
         }
         return $this->pluginBlacklist;
@@ -244,11 +241,10 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $allowedFiles = array_keys($classes);
         foreach ($classes as $class) {
             if (!in_array($class, $output)) {
-                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $output = array_merge($output, $this->_buildInheritanceHierarchyTree($class, $allowedFiles));
-                $output = array_unique($output);
+                $output[] = $this->_buildInheritanceHierarchyTree($class, $allowedFiles);
             }
         }
+        $output = array_unique(array_merge([], ...$output));
 
         /** Convert data into data provider format */
         $outputClasses = [];

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Di/CompilerTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Di/CompilerTest.php
@@ -127,6 +127,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
             );
             $blacklistItems = [];
             foreach (glob($blacklistFiles) as $fileName) {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                 $blacklistItems = array_merge(
                     $blacklistItems,
                     file($fileName, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES)
@@ -243,6 +244,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
         $allowedFiles = array_keys($classes);
         foreach ($classes as $class) {
             if (!in_array($class, $output)) {
+                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                 $output = array_merge($output, $this->_buildInheritanceHierarchyTree($class, $allowedFiles));
                 $output = array_unique($output);
             }
@@ -409,7 +411,7 @@ class CompilerTest extends \PHPUnit\Framework\TestCase
                     $plugin = $node->attributes->getNamedItem('type')->nodeValue;
                     if (!in_array($plugin, $this->getPluginBlacklist())) {
                         $plugin = \Magento\Framework\App\Utility\Classes::resolveVirtualType($plugin);
-                        $plugins[] = ['plugin' => $plugin, 'intercepted type' => $type];
+                        $plugins[] = [$plugin, $type];
                     }
                 }
             }

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Framework/Api/ExtensibleInterfacesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Framework/Api/ExtensibleInterfacesTest.php
@@ -135,7 +135,7 @@ class ExtensibleInterfacesTest extends \PHPUnit\Framework\TestCase
             } else {
                 // Get the parameter name via a regular expression capture because the class may
                 // not exist which causes a fatal error
-                preg_match('/\[\s\<\w+?>\s([\w]+)/s', $methodParameters[0]->__toString(), $matches);
+                preg_match('/\[\s\<\w+?>\s([?]?[\w]+)/s', $methodParameters[0]->__toString(), $matches);
                 $isCorrectParameter = false;
                 if (isset($matches[1]) && '\\' . $matches[1] != $extensionInterfaceName) {
                     $isCorrectParameter = true;

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Framework/Api/ExtensibleInterfacesTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Magento/Framework/Api/ExtensibleInterfacesTest.php
@@ -135,9 +135,10 @@ class ExtensibleInterfacesTest extends \PHPUnit\Framework\TestCase
             } else {
                 // Get the parameter name via a regular expression capture because the class may
                 // not exist which causes a fatal error
-                preg_match('/\[\s\<\w+?>\s([?]?[\w]+)/s', $methodParameters[0]->__toString(), $matches);
+                preg_match('/\[\s\<\w+?>\s([?]?[\w\\\]+)/s', $methodParameters[0]->__toString(), $matches);
                 $isCorrectParameter = false;
-                if (isset($matches[1]) && '\\' . $matches[1] != $extensionInterfaceName) {
+                if (isset($matches[1])
+                    && ('\\' . ltrim($matches[1], '?')) === $extensionInterfaceName) {
                     $isCorrectParameter = true;
                 }
 

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/Readme/ReadmeTest.php
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/Readme/ReadmeTest.php
@@ -57,7 +57,7 @@ class ReadmeTest extends \PHPUnit\Framework\TestCase
         $directories = [];
         foreach ($this->scanList as $dir) {
             if (!$this->isInBlacklist($dir)) {
-                $directories[][$dir] = $dir;
+                $directories[][] = $dir;
             }
         }
 


### PR DESCRIPTION
### Description (*)
Stabilisation of Static Tests to be compatible both with PHP7 and PHP8.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34188

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
