### PR TITLE
Fix WebApi test to be compatible with php8

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/Rest/CurlClient.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/Authentication/Rest/CurlClient.php
@@ -24,4 +24,17 @@ class CurlClient extends \OAuth\Common\Http\Client\CurlClient
         $this->setCurlParameters([CURLOPT_FAILONERROR => true]);
         return parent::retrieveResponse($endpoint, $requestBody, $extraHeaders, $method);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function normalizeHeaders(&$headers)
+    {
+        array_walk(
+            $headers,
+            function (&$val, $key) {
+                $val = ucfirst(strtolower($key)) . ': ' . $val;
+            }
+        );
+    }
 }


### PR DESCRIPTION
### Description (*)

Stabilisation of WebApi Tests to be compatible both with PHP7 and PHP8.

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#34196

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
