### PR TITLE
Fix reflection isBuiltin() method for PHP8 compatibility

### DIFF
--- a/dev/tests/static/framework/Magento/CodeMessDetector/Rule/Design/CookieAndSessionMisuse.php
+++ b/dev/tests/static/framework/Magento/CodeMessDetector/Rule/Design/CookieAndSessionMisuse.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Magento\CodeMessDetector\Rule\Design;
 
+use Magento\Framework\GetParameterClassTrait;
 use Magento\Framework\Session\SessionManagerInterface;
 use Magento\Framework\Stdlib\Cookie\CookieReaderInterface;
 use PDepend\Source\AST\ASTClass;
@@ -15,9 +16,6 @@ use PHPMD\AbstractNode;
 use PHPMD\AbstractRule;
 use PHPMD\Node\ClassNode;
 use PHPMD\Rule\ClassAware;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionParameter;
 
 /**
  * Session and Cookies must be used only in HTML Presentation layer.
@@ -26,6 +24,8 @@ use ReflectionParameter;
  */
 class CookieAndSessionMisuse extends AbstractRule implements ClassAware
 {
+    use GetParameterClassTrait;
+
     /**
      * Is given class a controller?
      *
@@ -196,22 +196,6 @@ class CookieAndSessionMisuse extends AbstractRule implements ClassAware
         }
 
         return false;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/Injectable.php
+++ b/dev/tests/static/framework/Magento/TestFramework/Integrity/Library/Injectable.php
@@ -6,15 +6,16 @@
 namespace Magento\TestFramework\Integrity\Library;
 
 use Laminas\Code\Reflection\ClassReflection;
-use ReflectionClass;
+use Magento\Framework\GetParameterClassTrait;
 use ReflectionException;
-use ReflectionParameter;
 
 /**
  * Provide dependencies for the file
  */
 class Injectable
 {
+    use GetParameterClassTrait;
+
     /**
      * @var string[]
      */
@@ -52,21 +53,5 @@ class Injectable
         }
 
         return $this->dependencies;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 }

--- a/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
+++ b/lib/internal/Magento/Framework/Code/Generator/EntityAbstract.php
@@ -6,15 +6,15 @@
 namespace Magento\Framework\Code\Generator;
 
 use Laminas\Code\Generator\ValueGenerator;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionParameter;
+use Magento\Framework\GetParameterClassTrait;
 
 /**
  * Abstract entity
  */
 abstract class EntityAbstract
 {
+    use GetParameterClassTrait;
+
     /**
      * Entity type abstract
      */
@@ -348,22 +348,6 @@ abstract class EntityAbstract
         }
 
         return $typeName;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
@@ -5,15 +5,15 @@
  */
 namespace Magento\Framework\Code\Reader;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionParameter;
+use Magento\Framework\GetParameterClassTrait;
 
 /**
  * The class arguments reader
  */
 class ArgumentsReader
 {
+    use GetParameterClassTrait;
+
     const NO_DEFAULT_VALUE = 'NO-DEFAULT';
 
     /**
@@ -125,22 +125,6 @@ class ArgumentsReader
         }
 
         return $type;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ClassReader.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\Code\Reader;
 
+use Magento\Framework\GetParameterClassTrait;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionParameter;
@@ -14,6 +15,11 @@ use ReflectionParameter;
  */
 class ClassReader implements ClassReaderInterface
 {
+    use GetParameterClassTrait;
+
+    /**
+     * @var array
+     */
     private $parentsCache = [];
 
     /**
@@ -54,26 +60,6 @@ class ClassReader implements ClassReaderInterface
         }
 
         return $result;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-        // In PHP8, $parameterType could be an instance of ReflectionUnionType, which doesn't have isBuiltin method.
-        if ($parameterType !== null && method_exists($parameterType, 'isBuiltin') === false) {
-            return null;
-        }
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Code/Reader/SourceArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/SourceArgumentsReader.php
@@ -5,12 +5,12 @@
  */
 namespace Magento\Framework\Code\Reader;
 
-use ReflectionClass;
-use ReflectionException;
-use ReflectionParameter;
+use Magento\Framework\GetParameterClassTrait;
 
 class SourceArgumentsReader
 {
+    use GetParameterClassTrait;
+
     /**
      * Namespace separator
      * @deprecated
@@ -84,22 +84,6 @@ class SourceArgumentsReader
         }
 
         return $types;
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/GetParameterClassTrait.php
+++ b/lib/internal/Magento/Framework/GetParameterClassTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Framework;
+
+use ReflectionClass;
+use ReflectionParameter;
+
+/**
+ * Returns a reflection parameter's class if possible.
+ */
+trait GetParameterClassTrait
+{
+    /**
+     * Get class by reflection parameter
+     *
+     * @param ReflectionParameter $reflectionParameter
+     *
+     * @return ReflectionClass|null
+     * @throws ReflectionException
+     */
+    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
+    {
+        $parameterType = $reflectionParameter->getType();
+        // In PHP8, $parameterType could be an instance of ReflectionUnionType, which doesn't have isBuiltin method.
+        if ($parameterType !== null && method_exists($parameterType, 'isBuiltin') === false) {
+            return null;
+        }
+
+        return $parameterType && !$parameterType->isBuiltin()
+            ? new ReflectionClass($parameterType->getName())
+            : null;
+    }
+}

--- a/lib/internal/Magento/Framework/Interception/Code/InterfaceValidator.php
+++ b/lib/internal/Magento/Framework/Interception/Code/InterfaceValidator.php
@@ -7,9 +7,8 @@ namespace Magento\Framework\Interception\Code;
 
 use Magento\Framework\Code\Reader\ArgumentsReader;
 use Magento\Framework\Exception\ValidatorException;
+use Magento\Framework\GetParameterClassTrait;
 use Magento\Framework\Phrase;
-use ReflectionClass;
-use ReflectionException;
 use ReflectionParameter;
 
 /**
@@ -17,6 +16,8 @@ use ReflectionParameter;
  */
 class InterfaceValidator
 {
+    use GetParameterClassTrait;
+
     public const METHOD_BEFORE = 'before';
     public const METHOD_AROUND = 'around';
     public const METHOD_AFTER = 'after';
@@ -176,22 +177,6 @@ class InterfaceValidator
         return $parameterClass ?
             '\\' . $parameterClass->getName() :
             ($parameterType && $parameterType->getName() === 'array' ? 'array' : null);
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -5,10 +5,8 @@
  */
 namespace Magento\Framework\TestFramework\Unit\Helper;
 
+use Magento\Framework\GetParameterClassTrait;
 use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
-use ReflectionException;
-use ReflectionParameter;
 
 /**
  * Helper class for basic object retrieving, such as blocks, models etc...
@@ -18,6 +16,8 @@ use ReflectionParameter;
  */
 class ObjectManager
 {
+    use GetParameterClassTrait;
+
     /**
      * Special cases configuration
      *
@@ -239,22 +239,6 @@ class ObjectManager
         }
 
         return new $className(...array_values($this->getConstructArguments($className, $arguments)));
-    }
-
-    /**
-     * Get class by reflection parameter
-     *
-     * @param ReflectionParameter $reflectionParameter
-     * @return ReflectionClass|null
-     * @throws ReflectionException
-     */
-    private function getParameterClass(ReflectionParameter $reflectionParameter): ?ReflectionClass
-    {
-        $parameterType = $reflectionParameter->getType();
-
-        return $parameterType && !$parameterType->isBuiltin()
-            ? new ReflectionClass($parameterType->getName())
-            : null;
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Fix for the issue with `ReflectionType::isBuiltin()` method for all occurrences in the CE repository

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34194: Check and update codebase to avoid fatal error for ReflectionType::isBuiltin()


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
