### PR TITLE
#34063 fixed issue with price block cache for different zones

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
@@ -196,6 +196,7 @@ class FinalPriceBox extends BasePriceBox
         $cacheKeys['display_minimal_price'] = $this->getDisplayMinimalPrice();
         $cacheKeys['is_product_list'] = $this->isProductList();
         $cacheKeys['customer_group_id'] = $this->getSaleableItem()->getCustomerGroupId();
+        $cacheKeys['zone'] = $this->getZone();
         return $cacheKeys;
     }
 


### PR DESCRIPTION
### Description (*)
This PR fixes issue with price block cache for different zones. 
Price block cache for "related product view" and PDP view was the same. As result on PDP price block doesn't have Rich Snippets (offers) markup if it was already cached in related products section of other product.



### Fixed Issues (if relevant)
1. Fixes magento/magento2#34063

### Manual testing scenarios (*)
1. Create Product A
2. Create Product B as related of product A
3. Visit PDP of product A
4. Visit PDP of product B
5. Notice that price block doesn't have rich snippets.

