### PR TITLE
33729: clean the quote shipping address if a new address is passed

### DIFF
--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -161,6 +161,9 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
     ): PaymentDetailsInterface {
         /** @var Quote $quote */
         $quote = $this->quoteRepository->getActive($cartId);
+        if ($addressInformation->getShippingAddress()->getSaveInAddressBook()) {
+            $quote->removeAddress($quote->getShippingAddress()->getId());
+        }
         $this->validateQuote($quote);
 
         $address = $addressInformation->getShippingAddress();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33729

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Stores - Configuration - Customers - Customer Configuration - Show Company - Set to Optional and Save
2. Reindex and clear cache
3. Create Customer Account from front end and sign in
4. Added different Shipping Address and Billing Address for the customer from front-end/admin with Company name for both and saved.
5. Stores - Configuration - Customers - Customer Configuration - Show Company - Set to No and Save
6. Reindex and clear cache
7. Front-end - Login as Customer - Add a product to Cart - Checkout - go to Payment Step - Go back to Shipping step - Add different Shipping Address and place Order
8. Check DB tables: sales_order_address and customer_address_entity tables

Issue: After placing the order, the shipping address has the previous shipping address's company on it in the database.
Now: It's saving the correct information as we are cleaning the shipping address before setting the new one.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

This issue is caused because when Magento assign the new address to the quote address in `setShippingAddress` he merges with old data from the previous request, so now as we are cleaning when it's a new address, it's saving right on DB


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
