### PR TITLE
33729: clean the quote shipping address if a new address is passed

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -21,15 +21,11 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
     private const XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW = 'customer/address/company_show';
 
     /**
-     * Quote repository.
-     *
      * @var \Magento\Quote\Api\CartRepositoryInterface
      */
     protected $quoteRepository;
 
     /**
-     * Logger.
-     *
      * @var Logger
      */
     protected $logger;

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface as Logger;
  */
 class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressManagementInterface
 {
-    const XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW = 'customer/address/company_show';
+    private const XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW = 'customer/address/company_show';
 
     /**
      * Quote repository.

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Quote\Model;
 
@@ -140,6 +141,13 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         return $quote->getShippingAddress();
     }
 
+    /**
+     * Apply validation on quote before merging it with old one.
+     *
+     * @param \Magento\Quote\Model\Quote $quote
+     * @param \Magento\Quote\Api\Data\AddressInterface $address
+     * @return void
+     */
     private function validateBeforeMerge($quote, $address): void
     {
         $this->addressValidator->validateForCart($quote, $address);

--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -17,6 +17,8 @@ use Psr\Log\LoggerInterface as Logger;
  */
 class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressManagementInterface
 {
+    const XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW = 'customer/address/company_show';
+
     /**
      * Quote repository.
      *
@@ -95,7 +97,7 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         $saveInAddressBook = $address->getSaveInAddressBook() ? 1 : 0;
         $sameAsBilling = $address->getSameAsBilling() ? 1 : 0;
         $customerAddressId = $address->getCustomerAddressId();
-        $this->addressValidator->validateForCart($quote, $address);
+        $this->validateBeforeMerge($quote, $address);
         $quote->setShippingAddress($address);
         $address = $quote->getShippingAddress();
 
@@ -136,5 +138,14 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         }
         /** @var \Magento\Quote\Model\Quote\Address $address */
         return $quote->getShippingAddress();
+    }
+
+    private function validateBeforeMerge($quote, $address): void
+    {
+        $this->addressValidator->validateForCart($quote, $address);
+        if ($address->getSaveInAddressBook()
+            && !$this->scopeConfig->getValue(self::XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW)) {
+            $address->setCompany(null);
+        }
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ *
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Test\Unit\Model;
+
+use Magento\Customer\Model\ResourceModel\AddressRepository;
+use Magento\Framework\App\Config;
+use Magento\Framework\Logger\Monolog;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Model\QuoteAddressValidator;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\Quote\Model\ShippingAddressManagement;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ShippingAddressManagementTest extends TestCase
+{
+    /**
+     * @var ShippingAddressManagement
+     */
+    private $model;
+
+    /**
+     * @var MockObject
+     */
+    private $addressMock;
+
+    /**
+     * @var MockObject
+     */
+    private $quoteRepositoryMock;
+
+    /**
+     * @var MockObject
+     */
+    private $addressValidator;
+
+    /**
+     * @var MockObject
+     */
+    private $addressRepository;
+
+    /**
+     * @var MockObject
+     */
+    private $quote;
+
+    /**
+     * @var MockObject
+     */
+    private $scopeConfig;
+
+    /**
+     * @var MockObject
+     */
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+        $this->addressMock = $this->createMock(Address::class);
+        $this->quoteRepositoryMock = $this->createMock(QuoteRepository::class);
+        $this->addressValidator = $this->createMock(QuoteAddressValidator::class);
+        $this->addressRepository = $this->createMock(AddressRepository::class);
+        $this->quote = $this->createMock(Quote::class);
+        $this->scopeConfig = $this->createMock(Config::class);
+        $this->logger = $this->createMock(Monolog::class);
+        $this->model = $objectManager->getObject(
+            ShippingAddressManagement::class,
+            [
+                'quoteRepository' => $this->quoteRepositoryMock,
+                'addressValidator' => $this->addressValidator,
+                'addressRepository' => $this->addressRepository,
+                'logger' => $this->logger,
+                'scopeConfig' => $this->scopeConfig,
+            ]
+        );
+    }
+
+    public function testAssignNewAddressWithCompanyShowDisabled()
+    {
+        $cartId = 666;
+        $this->addressMock->expects($this->any())->method('getSaveInAddressBook')->willReturn(1);
+        $this->quote->expects($this->any())->method('getShippingAddress')->willReturn($this->addressMock);
+        $this->scopeConfig->expects($this->any())->method('getValue')
+            ->with(ShippingAddressManagement::XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW)
+            ->willReturn(false);
+        $this->addressMock->expects($this->any())->method('getCountryId')->willReturn(null);
+        $this->quoteRepositoryMock->expects($this->any())->method('getActive')->willReturn($this->quote);
+        $this->addressMock->expects($this->once())->method('setCompany')->with(null);
+
+        $this->model->assign($cartId, $this->addressMock);
+    }
+}

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingAddressManagementTest.php
@@ -90,7 +90,7 @@ class ShippingAddressManagementTest extends TestCase
         $this->addressMock->expects($this->any())->method('getSaveInAddressBook')->willReturn(1);
         $this->quote->expects($this->any())->method('getShippingAddress')->willReturn($this->addressMock);
         $this->scopeConfig->expects($this->any())->method('getValue')
-            ->with(ShippingAddressManagement::XML_PATH_CUSTOMER_ADDRESS_COMPANY_SHOW)
+            ->with('customer/address/company_show')
             ->willReturn(false);
         $this->addressMock->expects($this->any())->method('getCountryId')->willReturn(null);
         $this->quoteRepositoryMock->expects($this->any())->method('getActive')->willReturn($this->quote);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33729

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Stores - Configuration - Customers - Customer Configuration - Show Company - Set to Optional and Save
2. Reindex and clear cache
3. Create Customer Account from front end and sign in
4. Added different Shipping Address and Billing Address for the customer from front-end/admin with Company name for both and saved.
5. Stores - Configuration - Customers - Customer Configuration - Show Company - Set to No and Save
6. Reindex and clear cache
7. Front-end - Login as Customer - Add a product to Cart - Checkout - go to Payment Step - Go back to Shipping step - Add different Shipping Address and place Order
8. Check DB tables: sales_order_address and customer_address_entity tables

Issue: After placing the order, the shipping address has the previous shipping address's company on it in the database.
Now: It's saving the correct information as we are cleaning the shipping address before setting the new one.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

This issue is caused because when Magento assign the new address to the quote address in `setShippingAddress` he merges with old data from the previous request, so now as we are cleaning when it's a new address, it's saving right on DB


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
