### PR TITLE
Revert constraint for `magento/magento-coding-standard` to "*"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "friendsofphp/php-cs-fixer": "~3.0.0",
         "lusitanian/oauth": "~0.8.10",
-        "magento/magento-coding-standard": "13",
+        "magento/magento-coding-standard": "*",
         "magento/magento2-functional-testing-framework": "^3.7",
         "pdepend/pdepend": "~2.10.0",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6a8e2b9da47595e816bb976abd16693",
+    "content-hash": "01ecd4b9a2ab2413556bda12499bd724",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Some time ago we fixed the constraint for `magento/magento-coding-standard` on version 8.
This pull request (PR) provides the revert constraint to "*".

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/629
<!-- related pull request placeholder -->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
