### PR TITLE
Fix incorrect binding in Store resource model (PHP 8 compatibility)

### DIFF
--- a/app/code/Magento/Store/Model/ResourceModel/Store.php
+++ b/app/code/Magento/Store/Model/ResourceModel/Store.php
@@ -147,7 +147,7 @@ class Store extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             )->where(
                 $connection->quoteInto('group_id=?', $model->getOriginalGroupId())
             );
-            $storeId = $connection->fetchOne($select, 'default_store_id');
+            $storeId = $connection->fetchOne($select);
 
             if ($storeId == $model->getId()) {
                 $bind = ['default_store_id' => \Magento\Store\Model\Store::DEFAULT_STORE_ID];


### PR DESCRIPTION
### Description (*)
in PHP 8, incorrect binding is no longer ignored and throws an error "number of bound variables does not match number of tokens".
This PR fixes the unnecessary incorrect bind in Store Resource model.
It should fix failed Mftf test  (AdminMoveStoreToOtherGroupSameWebsiteTest) 

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues
1. https://github.com/magento/magento2/issues/34327

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
