### PR TITLE
Fix static errors for previously delivered code (phpstan)

### DIFF
--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/AddCommentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/AddCommentTest.php
@@ -106,9 +106,6 @@ class AddCommentTest extends TestCase
      */
     protected function setUp(): void
     {
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -117,7 +114,7 @@ class AddCommentTest extends TestCase
             ->getMock();
         $this->objectManagerMock = $this->getMockForAbstractClass(ObjectManagerInterface::class);
         $this->contextMock = $this->getMockBuilder(Context::class)
-            ->setMethods(['getRequest', 'getResponse', 'getObjectManager', 'getTitle'])
+            ->setMethods(['getRequest', 'getResponse', 'getObjectManager'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->contextMock->expects($this->any())
@@ -129,9 +126,6 @@ class AddCommentTest extends TestCase
         $this->contextMock->expects($this->any())
             ->method('getObjectManager')
             ->willReturn($this->objectManagerMock);
-        $this->contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $this->loaderMock = $this->getMockBuilder(CreditmemoLoader::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/CancelTest.php
@@ -107,9 +107,6 @@ class CancelTest extends TestCase
     protected function setUp(): void
     {
         $this->creditmemoManagementMock = $this->getMockForAbstractClass(CreditmemoManagementInterface::class);
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -148,7 +145,6 @@ class CancelTest extends TestCase
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -179,9 +175,6 @@ class CancelTest extends TestCase
         $this->contextMock->expects($this->any())
             ->method('getObjectManager')
             ->willReturn($this->objectManagerMock);
-        $this->contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $this->contextMock->expects($this->any())
             ->method('getMessageManager')
             ->willReturn($this->messageManagerMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/UpdateQtyTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/UpdateQtyTest.php
@@ -133,9 +133,6 @@ class UpdateQtyTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getInvoice', 'getOrder', 'cancel', 'getId'])
             ->getMock();
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -158,7 +155,6 @@ class UpdateQtyTest extends TestCase
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -189,9 +185,6 @@ class UpdateQtyTest extends TestCase
         $this->contextMock->expects($this->any())
             ->method('getObjectManager')
             ->willReturn($this->objectManagerMock);
-        $this->contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $this->contextMock->expects($this->any())
             ->method('getMessageManager')
             ->willReturn($this->messageManagerMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/VoidActionTest.php
@@ -127,9 +127,6 @@ class VoidActionTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getInvoice', 'getOrder', 'cancel', 'getId', 'void'])
             ->getMock();
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -155,7 +152,6 @@ class VoidActionTest extends TestCase
                     'getRequest',
                     'getResponse',
                     'getObjectManager',
-                    'getTitle',
                     'getSession',
                     'getHelper',
                     'getActionFlag',
@@ -206,9 +202,6 @@ class VoidActionTest extends TestCase
         $this->contextMock->expects($this->any())
             ->method('getObjectManager')
             ->willReturn($this->objectManagerMock);
-        $this->contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $this->contextMock->expects($this->any())
             ->method('getMessageManager')
             ->willReturn($this->messageManagerMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/AddCommentTest.php
@@ -110,9 +110,6 @@ class AddCommentTest extends TestCase
     {
         $objectManager = new ObjectManager($this);
 
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -145,7 +142,7 @@ class AddCommentTest extends TestCase
                     'getResultRedirectFactory',
                     'getView'
                 ]
-            )->addMethods(['getTitle'])
+            )
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -153,9 +150,6 @@ class AddCommentTest extends TestCase
         $contextMock->expects($this->any())
             ->method('getResponse')
             ->willReturn($this->responseMock);
-        $contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $contextMock->expects($this->any())
             ->method('getView')
             ->willReturn($this->viewMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/NewActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/NewActionTest.php
@@ -125,9 +125,6 @@ class NewActionTest extends TestCase
     {
         $objectManager = new ObjectManager($this);
 
-        $titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->viewMock = $this->getMockBuilder(View::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -185,7 +182,7 @@ class NewActionTest extends TestCase
                 'getMessageManager',
                 'getResultRedirectFactory',
                 'getView'
-            ])->addMethods(['getTitle'])
+            ])
             ->getMock();
         $contextMock->expects($this->any())
             ->method('getRequest')
@@ -193,9 +190,6 @@ class NewActionTest extends TestCase
         $contextMock->expects($this->any())
             ->method('getResponse')
             ->willReturn($this->responseMock);
-        $contextMock->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($titleMock);
         $contextMock->expects($this->any())
             ->method('getObjectManager')
             ->willReturn($this->objectManagerMock);

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Invoice/VoidActionTest.php
@@ -48,11 +48,6 @@ class VoidActionTest extends TestCase
     /**
      * @var MockObject
      */
-    protected $titleMock;
-
-    /**
-     * @var MockObject
-     */
     protected $objectManagerMock;
 
     /**
@@ -107,10 +102,6 @@ class VoidActionTest extends TestCase
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
-
-        $this->titleMock = $this->getMockBuilder(\Magento\Framework\App\Action\Title::class)
-            ->disableOriginalConstructor()
-            ->getMock();
 
         $this->requestMock = $this->getMockBuilder(Http::class)
             ->disableOriginalConstructor()
@@ -168,13 +159,12 @@ class VoidActionTest extends TestCase
                     'getMessageManager',
                     'getResultRedirectFactory'
                 ]
-            )->addMethods(['getTitle'])
+            )
             ->getMock();
         $contextMock->expects($this->any())->method('getRequest')->willReturn($this->requestMock);
         $contextMock->expects($this->any())->method('getResponse')->willReturn($this->responseMock);
         $contextMock->expects($this->any())->method('getObjectManager')->willReturn($this->objectManagerMock);
         $contextMock->expects($this->any())->method('getMessageManager')->willReturn($this->messageManagerMock);
-        $contextMock->expects($this->any())->method('getTitle')->willReturn($this->titleMock);
         $contextMock->expects($this->any())->method('getActionFlag')->willReturn($this->actionFlagMock);
         $contextMock->expects($this->any())->method('getSession')->willReturn($this->sessionMock);
         $contextMock->expects($this->any())->method('getHelper')->willReturn($this->helperMock);

--- a/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/View/SubscriptionTest.php
@@ -124,7 +124,6 @@ class SubscriptionTest extends TestCase
                     ]
                 ]
             ]);
-        $this->mviewConfig = $mviewConfigMock;
         $this->model = new Subscription(
             $this->resourceMock,
             $this->triggerFactoryMock,


### PR DESCRIPTION
### Description (*)
I removed `\Magento\Framework\App\Action\Title` class calls from Unit tests

### Related Pull Requests

### Related Issues (if relevant)
1. magento/magento2#34056
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
