### PR TITLE
Fixed different ways use of $useConfig on category save

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Category/Save.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Category/Save.php
@@ -168,7 +168,7 @@ class Save extends \Magento\Catalog\Controller\Adminhtml\Category implements Htt
             if (isset($categoryPostData['use_config']) && !empty($categoryPostData['use_config'])) {
                 foreach ($categoryPostData['use_config'] as $attributeCode => $attributeValue) {
                     if ($attributeValue) {
-                        $useConfig[] = $attributeValue;
+                        $useConfig[] = $attributeCode;
                         $category->setData($attributeCode, null);
                     }
                 }

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/NewCategoryDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/NewCategoryDataProvider.php
@@ -55,7 +55,7 @@ class NewCategoryDataProvider extends AbstractDataProvider
      * @return array
      * @since 101.0.0
      */
-    public function getData(): array
+    public function getData()
     {
         $this->data = array_replace_recursive(
             $this->data,
@@ -83,7 +83,7 @@ class NewCategoryDataProvider extends AbstractDataProvider
      * @return array
      * @since 101.0.0
      */
-    public function getMeta(): array
+    public function getMeta()
     {
         $this->meta = [
             'data' => [

--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/NewCategoryDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/NewCategoryDataProvider.php
@@ -3,8 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Ui\DataProvider\Product\Form;
 
+use Magento\Framework\Phrase;
 use Magento\Ui\DataProvider\AbstractDataProvider;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\UrlInterface;
@@ -47,10 +50,12 @@ class NewCategoryDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * Get data
+     *
+     * @return array
      * @since 101.0.0
      */
-    public function getData()
+    public function getData(): array
     {
         $this->data = array_replace_recursive(
             $this->data,
@@ -60,7 +65,10 @@ class NewCategoryDataProvider extends AbstractDataProvider
                         'is_active' => 1,
                         'include_in_menu' => 1,
                         'return_session_messages_only' => 1,
-                        'use_config' => ['available_sort_by', 'default_sort_by']
+                        'use_config' => [
+                            'available_sort_by' => true,
+                            'default_sort_by' => true
+                        ]
                     ]
                 ]
             ]
@@ -70,10 +78,12 @@ class NewCategoryDataProvider extends AbstractDataProvider
     }
 
     /**
-     * {@inheritdoc}
+     * Get meta
+     *
+     * @return array
      * @since 101.0.0
      */
-    public function getMeta()
+    public function getMeta(): array
     {
         $this->meta = [
             'data' => [
@@ -91,7 +101,7 @@ class NewCategoryDataProvider extends AbstractDataProvider
     /**
      * Get notice message
      *
-     * @return \Magento\Framework\Phrase
+     * @return Phrase
      * @since 101.0.0
      */
     protected function getNotice()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Category save use `$useConfig` config checkboxes for some attributes. We have 2 ways of creating category:
1. Catalog->Category
2. Catalog->Products->Create/Edit Product->New Category

Catalog->Category page use attribute codes as input name
Catalog->Products->Create/Edit Product->New Category use attribute codes as values.
As result it's not work correctly in `\Magento\Catalog\Model\Category\Attribute\Backend\Sortby::validate`

This PR partially rollback changes made in https://github.com/magento/magento2/pull/34343

### Related Pull Requests

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Save category from Catalog->Categories
2. Debug `\Magento\Catalog\Model\Category\Attribute\Backend\Sortby::validate` and verify that `$postDataConfig` is array of attribute codes
3. Save category from product edit page
4. Debug `\Magento\Catalog\Model\Category\Attribute\Backend\Sortby::validate` and verify that `$postDataConfig` is array of attribute codes

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
