### PR TITLE
Use the translated tax rate title if it exists in the applied_taxes g…

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/CartPrices.php
@@ -83,12 +83,25 @@ class CartPrices implements ResolverInterface
             return $appliedTaxesData;
         }
 
+        $rates = [];
+
         foreach ($appliedTaxes as $appliedTax) {
+            foreach ($appliedTax['rates'] as $appliedTaxRate) {
+                $rateTitle = $appliedTaxRate['title'];
+                if (!array_key_exists($rateTitle, $rates)) {
+                    $rates[$rateTitle] = 0.0;
+                }
+                $rates[$rateTitle] += $appliedTax['amount'];
+            }
+        }
+
+        foreach ($rates as $title => $amount) {
             $appliedTaxesData[] = [
-                'label' => $appliedTax['id'],
-                'amount' => ['value' => $appliedTax['amount'], 'currency' => $currency]
+                'label' => $title,
+                'amount' => ['value' => $amount, 'currency' => $currency]
             ];
         }
+
         return $appliedTaxesData;
     }
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Customer/CartTotalsTest.php
@@ -71,6 +71,41 @@ class CartTotalsTest extends GraphQlAbstract
 
     /**
      * @magentoApiDataFixture Magento/Customer/_files/customer.php
+     * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/customer/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+     */
+    public function testGetCartTotalsWithTranslatedTaxTitles()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query, [], '', $this->getHeaderMap());
+
+        $cartItem = $response['cart']['items'][0];
+        self::assertEquals(10, $cartItem['prices']['price']['value']);
+        self::assertEquals(20, $cartItem['prices']['row_total']['value']);
+        self::assertEquals(21.5, $cartItem['prices']['row_total_including_tax']['value']);
+
+        self::assertArrayHasKey('prices', $response['cart']);
+        $pricesResponse = $response['cart']['prices'];
+        self::assertEquals(21.5, $pricesResponse['grand_total']['value']);
+        self::assertEquals(21.5, $pricesResponse['subtotal_including_tax']['value']);
+        self::assertEquals(20, $pricesResponse['subtotal_excluding_tax']['value']);
+        self::assertEquals(20, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+
+        $appliedTaxesResponse = $pricesResponse['applied_taxes'];
+
+        self::assertEquals('Rate Title on storeview 1', $appliedTaxesResponse[0]['label']);
+        self::assertEquals(1.5, $appliedTaxesResponse[0]['amount']['value']);
+        self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
+    }
+
+    /**
+     * @magentoApiDataFixture Magento/Customer/_files/customer.php
      * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_1.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Quote/Guest/CartTotalsTest.php
@@ -65,6 +65,40 @@ class CartTotalsTest extends GraphQlAbstract
     }
 
     /**
+     * @magentoApiDataFixture Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/apply_tax_for_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/add_simple_product.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_shipping_address.php
+     * @magentoApiDataFixture Magento/GraphQl/Quote/_files/set_new_billing_address.php
+     */
+    public function testGetCartTotalsWithTranslatedTaxTitles()
+    {
+        $maskedQuoteId = $this->getMaskedQuoteIdByReservedOrderId->execute('test_quote');
+        $query = $this->getQuery($maskedQuoteId);
+        $response = $this->graphQlQuery($query);
+
+        $cartItem = $response['cart']['items'][0];
+        self::assertEquals(10, $cartItem['prices']['price']['value']);
+        self::assertEquals(20, $cartItem['prices']['row_total']['value']);
+        self::assertEquals(21.5, $cartItem['prices']['row_total_including_tax']['value']);
+
+        self::assertArrayHasKey('prices', $response['cart']);
+        $pricesResponse = $response['cart']['prices'];
+        self::assertEquals(21.5, $pricesResponse['grand_total']['value']);
+        self::assertEquals(21.5, $pricesResponse['subtotal_including_tax']['value']);
+        self::assertEquals(20, $pricesResponse['subtotal_excluding_tax']['value']);
+        self::assertEquals(20, $pricesResponse['subtotal_with_discount_excluding_tax']['value']);
+
+        $appliedTaxesResponse = $pricesResponse['applied_taxes'];
+
+        self::assertEquals('Rate Title on storeview 1', $appliedTaxesResponse[0]['label']);
+        self::assertEquals(1.5, $appliedTaxesResponse[0]['amount']['value']);
+        self::assertEquals('USD', $appliedTaxesResponse[0]['amount']['currency']);
+    }
+
+    /**
      * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      * @magentoApiDataFixture Magento/CatalogRule/_files/catalog_rule_10_off_not_logged.php
      * @magentoApiDataFixture Magento/GraphQl/Quote/_files/guest/create_empty_cart.php

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Tax\Api\Data\TaxRateInterface;
+use Magento\Tax\Api\Data\TaxRateTitleInterface;
+use Magento\Tax\Api\Data\TaxRuleInterface;
+use Magento\Tax\Api\TaxRateRepositoryInterface;
+use Magento\Tax\Api\TaxRuleRepositoryInterface;
+use Magento\Tax\Model\Calculation\Rate;
+use Magento\Tax\Model\Calculation\Rate\Title as RateTitle;
+use Magento\Tax\Model\Calculation\Rate\TitleFactory as RateTitleFactory;
+use Magento\Tax\Model\Calculation\RateFactory;
+use Magento\Tax\Model\Calculation\RateRepository;
+use Magento\Tax\Model\Calculation\Rule;
+use Magento\Tax\Model\Calculation\RuleFactory;
+use Magento\Tax\Model\TaxRuleRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Framework\Api\DataObjectHelper;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var DataObjectHelper $dataObjectHelper */
+$dataObjectHelper = Bootstrap::getObjectManager()->get(DataObjectHelper::class);
+/** @var RateTitleFactory $rateTitleFactory */
+$rateTitleFactory = $objectManager->get(RateTitleFactory::class);
+/** @var RateFactory $rateFactory */
+$rateFactory = $objectManager->get(RateFactory::class);
+/** @var RuleFactory $ruleFactory */
+$ruleFactory = $objectManager->get(RuleFactory::class);
+/** @var RateRepository $rateRepository */
+$rateRepository = $objectManager->get(TaxRateRepositoryInterface::class);
+/** @var TaxRuleRepository $ruleRepository */
+$ruleRepository = $objectManager->get(TaxRuleRepositoryInterface::class);
+/** @var RateTitle */
+$rateTitle = $rateTitleFactory->create();
+$rateTitleData = [
+    RateTitle::KEY_STORE_ID => 1,
+    RateTitle::KEY_VALUE_ID => 'Rate Title on storeview 1',
+];
+/** @var Rate $rate */
+$rate = $rateFactory->create();
+$rateData = [
+    Rate::KEY_COUNTRY_ID => 'US',
+    Rate::KEY_REGION_ID => '1',
+    Rate::KEY_POSTCODE => '*',
+    Rate::KEY_CODE => 'US-TEST-*-Rate-1',
+    Rate::KEY_PERCENTAGE_RATE => '7.5',
+    Rate::KEY_TITLES => [$rateTitleData]
+];
+$dataObjectHelper->populateWithArray($rate, $rateData, TaxRateInterface::class);
+$rateRepository->save($rate);
+
+$rule = $ruleFactory->create();
+$ruleData = [
+    Rule::KEY_CODE=> 'GraphQl Test Rule',
+    Rule::KEY_PRIORITY => '0',
+    Rule::KEY_POSITION => '0',
+    Rule::KEY_CUSTOMER_TAX_CLASS_IDS => [3],
+    Rule::KEY_PRODUCT_TAX_CLASS_IDS => [2],
+    Rule::KEY_TAX_RATE_IDS => [$rate->getId()],
+];
+$dataObjectHelper->populateWithArray($rule, $ruleData, TaxRuleInterface::class);
+$ruleRepository->save($rule);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Tax/_files/tax_rule_for_region_with_translated_titles_rollback.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use Magento\Tax\Api\TaxRateRepositoryInterface;
+use Magento\Tax\Api\TaxRuleRepositoryInterface;
+use Magento\Tax\Model\Calculation\Rate;
+use Magento\Tax\Model\Calculation\RateFactory;
+use Magento\Tax\Model\Calculation\RateRepository;
+use Magento\Tax\Model\Calculation\Rule;
+use Magento\Tax\Model\Calculation\RuleFactory;
+use Magento\Tax\Model\TaxRuleRepository;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\Tax\Model\ResourceModel\Calculation\Rate as RateResource;
+use Magento\Tax\Model\ResourceModel\Calculation\Rule as RuleResource;
+
+$objectManager = Bootstrap::getObjectManager();
+/** @var RateFactory $rateFactory */
+$rateFactory = $objectManager->get(RateFactory::class);
+/** @var RuleFactory $ruleFactory */
+$ruleFactory = $objectManager->get(RuleFactory::class);
+/** @var RateRepository $rateRepository */
+$rateRepository = $objectManager->get(TaxRateRepositoryInterface::class);
+/** @var TaxRuleRepository $ruleRepository */
+$ruleRepository = $objectManager->get(TaxRuleRepositoryInterface::class);
+/** @var RateResource $rateResource */
+$rateResource = $objectManager->get(RateResource::class);
+/** @var RuleResource $ruleResource */
+$ruleResource = $objectManager->get(RuleResource::class);
+
+$rate = $rateFactory->create();
+$rateResource->load($rate, 'US-TEST-*-Rate-1', Rate::KEY_CODE);
+$rule = $ruleFactory->create();
+$ruleResource->load($rule, 'GraphQl Test Rule', Rule::KEY_CODE);
+$ruleRepository->delete($rule);
+$rateRepository->delete($rate);


### PR DESCRIPTION
…raphql data.

### Description (*)
When requesting the applied tax information from the current cart, the tax rate titles weren't getting translated when those translations were filled in into the backend of Magento.
This PR fixes that.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/30281

### Manual testing scenarios (*)
1. Have some sort of GraphQL tool installed (Altair GraphQL Client for example)
2. Start from a clean Magento installation
3. Make sure you have at least 2 storeviews, storeview codes I'm going to use: 'en' (English) & 'nl' (Dutch)
4. In the backend, go to Stores > Tax Rates and create 2 rates:
<img width="950" alt="Screenshot 2021-10-16 at 14 39 18" src="https://user-images.githubusercontent.com/85479/137587806-55bad8dd-35be-4630-b1c9-b53cf7589cf9.png">
5. For the second Tax Rate, make sure to also fill in translated Tax Titles (don't do this for the first one!):
<img width="932" alt="Screenshot 2021-10-16 at 14 41 28" src="https://user-images.githubusercontent.com/85479/137588556-3360d11f-5179-464e-9ae4-4db3b8bfeb30.png">
6. Go to Stores > Tax Rules and create 2 rules:
<img width="1213" alt="Screenshot 2021-10-16 at 14 42 45" src="https://user-images.githubusercontent.com/85479/137587890-7cec9922-0637-48ad-af49-3c0419efac4e.png">
7. Create 2 simple products, use SKUs: 'Product One' and 'Product Two', assign the first one to the 'Taxable Goods 1' tax class and the second to 'Taxable Goods 2', give them both a price of 100.
<img width="1083" alt="Screenshot 2021-10-16 at 14 46 01" src="https://user-images.githubusercontent.com/85479/137588036-da7fbfa2-3d7c-4c6f-b19d-fa44106b8aa3.png">
8. Reindex all indexers, flush all caches

9. In the GraphQL tool, configure it with the correct url `https://base_url/graphql`, modify the HTTP headers so it sends `Store: en`, and then execute the following mutations/queries:

```graphql
mutation createCart {
  createEmptyCart(input: { cart_id: "test_id_with_32_characters_12345" })
}

mutation addProductsToCart {
  addProductsToCart(
    cartId: "test_id_with_32_characters_12345"
    cartItems: [{ quantity: 1, sku: "Product One" },{ quantity: 1, sku: "Product Two" }]
  ) {
    cart {
      items {
        product {
          name
          sku
        }
        quantity
      }
    }
  }
}

mutation setShippingAddress {
  setShippingAddressesOnCart(
    input: {
      cart_id: "test_id_with_32_characters_12345"
      shipping_addresses: [
        {
          address: {
            firstname: "Bob"
            lastname: "Roll"
            company: "Magento"
            street: ["Magento Pkwy", "Main Street"]
            city: "Austin"
            region: "CA"
            postcode: "78758"
            country_code: "US"
            telephone: "8675309"
            save_in_address_book: false
          }
        }
      ]
    }
  ) {
    cart {
      shipping_addresses {
        region {
          code
          label
        }
        country {
          code
          label
        }
      }
    }
  }
}

query getCart {
  cart(cart_id: "test_id_with_32_characters_12345") {
    items {
      quantity
      product {
        name
        sku
        price_tiers {
          quantity
          final_price {
            value
          }
        }
      }
      prices {
        price {
          value
        }
      }
    }
    prices {
      applied_taxes {
        label
        amount {
          value
        }
      }
    }
    shipping_addresses {
      country {
        code
        label
      }
      region {
        code
        label
      }
    }    
  }
}
```

10. Inspect the results of the final query. The `applied_taxes` output should look like this:

```graphql
        "applied_taxes": [
          {
            "label": "Tax Rate One",
            "amount": {
              "value": 10
            }
          },
          {
            "label": "Tax Rate Two English",
            "amount": {
              "value": 20
            }
          }
        ]
```

11. Now repeat the last query with the HTTP header set to: `Store: nl` and now the `applied_taxes` output should look like this:

```graphql
        "applied_taxes": [
          {
            "label": "Tax Rate One",
            "amount": {
              "value": 10
            }
          },
          {
            "label": "Tax Rate Two Dutch",
            "amount": {
              "value": 20
            }
          }
        ]
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
