### PR TITLE
Ignore all .phpunit.result.cache files in the dev/tests directory

### DIFF
--- a/dev/tests/.gitignore
+++ b/dev/tests/.gitignore
@@ -1,0 +1,1 @@
+.phpunit.result.cache

--- a/dev/tests/static/.gitignore
+++ b/dev/tests/static/.gitignore
@@ -4,4 +4,3 @@
 /report/
 /tmp/
 allure-results/
-.phpunit.result.cache


### PR DESCRIPTION
### Description (*)
When following [the instructions](https://devdocs.magento.com/guides/v2.4/graphql/functional-testing.html#run-functional-tests) for running the functional graphql tests, you'll notice that afterwards your git status is dirty. Because the file `dev/tests/api-functional/.phpunit.result.cache` gets generated by running those tests. So we should ignore that file in git.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
1. Follow [the instructions](https://devdocs.magento.com/guides/v2.4/graphql/functional-testing.html#run-functional-tests) for running the functional graphql tests (you might need a workaround mentioned [over here](https://github.com/magento/magento2/issues/32252#issuecomment-899045068) to get it working)
2. Not expecting the git status to be dirty

### Note for the release notes writers
This doesn't deserve mentioning in the release notes, as it doesn't fix something that users of Magento run into.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
