### PR TITLE
mark a class with money_format usage as deprecated

### DIFF
--- a/lib/internal/Magento/Framework/Filter/Money.php
+++ b/lib/internal/Magento/Framework/Filter/Money.php
@@ -5,6 +5,10 @@
  */
 namespace Magento\Framework\Filter;
 
+/**
+ * @deprecated As money_format() was removed in PHP 8.0
+ * @see https://www.php.net/manual/en/function.money-format.php
+ */
 class Money implements \Zend_Filter_Interface
 {
     /**
@@ -21,11 +25,17 @@ class Money implements \Zend_Filter_Interface
     }
 
     /**
+     * Returns the result of filtering $value
+     *
      * @param float $value
+     *
      * @return string
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @deprecated
      */
     public function filter($value)
     {
-        return money_format($this->_format, $value);
+        trigger_error('Class is deprecated', E_USER_DEPRECATED);
+        return '';
     }
 }


### PR DESCRIPTION
### Description (*)
This PR deprecates `lib/internal/Magento/Framework/Filter/Money.php` as it contains money_format() function that was removed in PHP 8, and this class is not used anywhere in the codebase.
It was decided that it will be removed when Magento stops supporting php 7.4.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#33870

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
