### PR TITLE
Don't try to update with an empty price

### DIFF
--- a/app/code/Magento/Catalog/view/base/web/js/price-box.js
+++ b/app/code/Magento/Catalog/view/base/web/js/price-box.js
@@ -234,14 +234,16 @@ define([
                     tierPrice = this.options.priceConfig.tierPrices[i].price;
                 }
             }
-            prices = {
-                'prices': {
-                    'finalPrice': {
-                        'amount': tierPrice - originalPrice
+            if (tierPrice) {
+                prices = {
+                    'prices': {
+                        'finalPrice': {
+                            'amount': tierPrice - originalPrice
+                        }
                     }
-                }
-            };
-            this.updatePrice(prices);
+                };
+                this.updatePrice(prices);
+            }
         }
     });
 


### PR DESCRIPTION
When trying to update a product price according to the tier price, skip the product update when no tier price is found. 
### Description (*)
When no tier price was found the system still tried to update the price with an object of 
```
{
    'prices': {
        'finalPrice': {
            'amount': NaN
        }
    }
};
```
This caused configurable product display prices for configurations that add to the product price to reset on qty changes.

### Manual testing scenarios (*)
- Create a configurable product with an child product that has a different price
- Configure this product in the frontend. The displayed price should change to reflect the simple product's price.
- Change the quantity. Before this change this reset the product price back to the default price. After this change it should persist the correct price.

### Contribution checklist (*)
 - [ x] Pull request has a meaningful description of its purpose
 - [ x] All commits are accompanied by meaningful commit messages
 - [ x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ?] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35753: Configurable option tiered price reverts to lowest price