### PR TITLE
Update expires_at column type from table admin_user_expiration in ord…

### DIFF
--- a/app/code/Magento/Security/etc/db_schema.xml
+++ b/app/code/Magento/Security/etc/db_schema.xml
@@ -59,7 +59,7 @@
     <table name="admin_user_expiration" resource="default" engine="innodb" comment="Admin User expiration dates table">
         <column xsi:type="int" name="user_id" unsigned="true" nullable="false" identity="false"
                 comment="User ID"/>
-        <column xsi:type="timestamp" name="expires_at" nullable="false" default="0" comment="User Expiration Date"/>
+        <column xsi:type="datetime" name="expires_at" nullable="false" default="0" comment="User Expiration Date"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="user_id"/>
         </constraint>


### PR DESCRIPTION
### Description
  New admin account is disabled after a login attempt is made if the account's expiration date is greater than 2038. This is fixed by updating the expires_at column type from the admin_user_expiration table to datetime.

### Fixed Issues
https://github.com/magento/magento2/issues/34463

### Manual testing scenarios 
Create an admin user with an Expiration Date greater than 2038 and attempt a login to the admin area with this newly created user.