### PR TITLE
Bug Fix: Missing region on shipping with some saved addresses

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -409,6 +409,8 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             }
         } elseif (is_string($region)) {
             $this->setData('region_code', $region);
+        } elseif (is_array($region) && isset($region['region_code'])) {
+            $this->setData('region_code', $region['region_code']);
         }
         return $this->getData('region_code');
     }

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -182,6 +182,19 @@ class AbstractAddressTest extends TestCase
         $this->assertEquals('UK', $this->model->getRegionCode());
     }
 
+    public function testGetRegionCodeWithRegionArray()
+    {
+        $this->regionFactoryMock->expects($this->never())->method('create');
+
+        $this->model->setData('region_id', '');
+        $this->model->setData('region', [
+            'region' => 'Essex',
+            'region_code' => 'Essex',
+            'region_id' => 0
+        ]);
+        $this->assertEquals('Essex', $this->model->getRegionCode());
+    }
+
     public function testGetRegionCodeWithoutRegion()
     {
         $this->regionFactoryMock->expects($this->never())->method('create');


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
When shipping using a saved address outside of the US/CA the `dest_region_code` is empty.   For example a saved address in the UK will expose the problem. I traced the issue back to the Customer\Model\Address\AbstractAddress class's getRegionCode method.

getRegionCode assumes there will be a valid `region_id` - which there isn't in this case - or that the `region` field will be a usable string instead.  However when converting the saved address into a quote address the `region` field is parsed as an associative array with three parts - `region`, `region_code`, and `region_id`.  So in this case `getRegionCode` needs an additional check to use `$region['region_code']` if available.

I've added a test to expose the problem and prove the fix.  The test is `Magento\Customer\Test\Unit\Model\Address\AbstractAddressTest::testGetRegionCodeWithRegionArray`

### Fixed Issues (if relevant)
I've not raised a separate issue, I'm using this PR as the bug report

### Manual testing scenarios (*)
I've provided a unit test that exposes the problem

This cannot be fully seen in the store's checkout with the builtin shipping methods as none of them support region based shipping outside the US/CA.  It does impact 3rd party shipping extensions however.

To manually test you'll have to use the debugger to view the details of the RateRequest when it's passed to one of the shipping carriers.  For example put a breakpoint at the top of `Magento\OfflineShipping\Model\Carrier\Flatrate::collectRates`

- Create a registered user with an address in the UK.  Set the region to anything - I use `Essex`.
- Put any item in your cart and proceed to checkout
- When your breakpoint trips inspect the value of `$request->getDestRegionCode()`

Expected: `"Essex"`
Actual: `null`

### Questions or comments
There is an unrelated test that was failing for me before I made my changes.  All tests related to shipping and address handling including my new test pass.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34493: Bug Fix: Missing region on shipping with some saved addresses

### Resolved issues:
1. [x] resolves magento/magento2#34525: Bug Fix: Missing region on shipping with some saved addresses