### PR TITLE
Remove redundant COUNT() call for 1st page of results

### DIFF
--- a/app/code/Magento/Theme/Plugin/Data/Collection.php
+++ b/app/code/Magento/Theme/Plugin/Data/Collection.php
@@ -23,7 +23,7 @@ class Collection
      */
     public function afterGetCurPage(DataCollection $subject, int $result): int
     {
-        if ($result > $subject->getLastPageNumber()) {
+        if ($result > 1 && $result > $subject->getLastPageNumber()) {
             $result = 1;
         }
 

--- a/app/code/Magento/Theme/Test/Unit/Plugin/CollectionTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/CollectionTest.php
@@ -12,11 +12,21 @@ use Magento\Theme\Plugin\Data\Collection as CollectionPlugin;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * This Unit Test covers a Plugin (not Collection), overriding the `curPage` (current page)
+ *
+ * @see \Magento\Framework\Data\Collection
+ */
 class CollectionTest extends TestCase
 {
-    /** @var MockObject|Collection */
+    /**
+     * @var Collection|MockObject
+     */
     private $dataCollectionMock;
 
+    /**
+     * @inheritdoc
+     */
     protected function setUp(): void
     {
         $this->dataCollectionMock = $this->getMockBuilder(Collection::class)
@@ -25,7 +35,12 @@ class CollectionTest extends TestCase
             ->getMock();
     }
 
-    public function testCurrentPageIsNotOverriddenIfFirstPage()
+    /**
+     * Test covers use-case for the first page of results. We don't expect calculation of the last page to be executed.
+     *
+     * @return void
+     */
+    public function testCurrentPageIsNotOverriddenIfFirstPage(): void
     {
         // Given
         $currentPagePlugin = new CollectionPlugin();
@@ -38,7 +53,12 @@ class CollectionTest extends TestCase
         $currentPagePlugin->afterGetCurPage($this->dataCollectionMock, 1);
     }
 
-    public function testCurrentPageIsOverriddenIfNotAFirstPage()
+    /**
+     * Test covers use-case for non-first page of results. We expect calculation of the last page to be executed.
+     *
+     * @return void
+     */
+    public function testCurrentPageIsOverriddenIfNotAFirstPage(): void
     {
         // Given
         $currentPagePlugin = new CollectionPlugin();

--- a/app/code/Magento/Theme/Test/Unit/Plugin/CollectionTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/CollectionTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Test\Unit\Plugin;
+
+use Magento\Framework\Data\Collection;
+use Magento\Theme\Plugin\Data\Collection as CollectionPlugin;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CollectionTest extends TestCase
+{
+    /** @var MockObject|Collection */
+    private $dataCollectionMock;
+
+    protected function setUp(): void
+    {
+        $this->dataCollectionMock = $this->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getLastPageNumber'])
+            ->getMock();
+    }
+
+    public function testCurrentPageIsNotOverriddenIfFirstPage()
+    {
+        // Given
+        $currentPagePlugin = new CollectionPlugin();
+
+        // Expects
+        $this->dataCollectionMock->expects($this->never())
+            ->method('getLastPageNumber');
+
+        // When
+        $currentPagePlugin->afterGetCurPage($this->dataCollectionMock, 1);
+    }
+
+    public function testCurrentPageIsOverriddenIfNotAFirstPage()
+    {
+        // Given
+        $currentPagePlugin = new CollectionPlugin();
+
+        // Expects
+        $this->dataCollectionMock->expects($this->once())
+            ->method('getLastPageNumber');
+
+        // When
+        $currentPagePlugin->afterGetCurPage($this->dataCollectionMock, 2);
+    }
+}


### PR DESCRIPTION
### Description (*)
Magento is performing lots of redundant DB calls in all the places where pagination is used.

The Category Edit page is one of the examples. If you are on the 1st page, it does not make sense to calculate the last page and redirect to the 1st one... Because you are on the 1st one.

The results of this optimization are worth the change :)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
