### PR TITLE
[FEATURE] - Adds source model on saving of multiselect attribute

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product.php
+++ b/app/code/Magento/Catalog/Helper/Product.php
@@ -351,7 +351,10 @@ class Product extends \Magento\Framework\Url\Helper\Data
          * @todo specify there all relations for properties depending on input type
          */
         $inputTypes = [
-            'multiselect' => ['backend_model' => \Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend::class],
+            'multiselect' => [
+                'backend_model' => \Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend::class,
+                'source_model' => \Magento\Eav\Model\Entity\Attribute\Source\Table::class
+            ],
             'boolean' => ['source_model' => \Magento\Eav\Model\Entity\Attribute\Source\Boolean::class],
         ];
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When creating a multiselect product attribute, the source model is empty by default. This isn't necessary and can be replaced with the default Table source model (\Magento\Eav\Model\Entity\Attribute\Source\Table).

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a multiselect product attribute in Magento. Notice it won't have a source_model class in the eav_attribute table.
2. Apply these changes. Create a new multiselect attribute in Magento. Notice it contains the source_model \Magento\Eav\Model\Entity\Attribute\Source\Table.
3. Create a boolean product attribute in Magento. Notice it still has the \Magento\Eav\Model\Entity\Attribute\Source\Boolean source model.
4. Create a text product attribute in Magento. Notice it won't have a source_model.
5. Update the source_model of the newly created multiselect attribute in the eav_attribute table (no Magento, just plain MySQL) to be empty.
6. Update the newly created multiselect attribute label. Notice the source_model is still empty. These changes change the default source_model, but still allow for customisation.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
