### PR TITLE
Fixed remaining failed Integration Tests for PHP 8.1. compatibility

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
+++ b/app/code/Magento/CatalogInventory/Model/StockStateProvider.php
@@ -135,7 +135,7 @@ class StockStateProvider implements StockStateProviderInterface
         $result->addData($this->checkQtyIncrements($stockItem, $qty)->getData());
 
         $result->setItemIsQtyDecimal($stockItem->getIsQtyDecimal());
-        if (!$stockItem->getIsQtyDecimal() && (floor($qty) !== $qty)) {
+        if (!$stockItem->getIsQtyDecimal() && (floor($qty) !== (float) $qty)) {
             $result->setHasError(true)
                 ->setMessage(__('You cannot use decimal quantity for this product.'))
                 ->setErrorCode('qty_decimal')

--- a/dev/tests/api-functional/testsuite/Magento/Webapi/WsdlGenerationFromDataObjectTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Webapi/WsdlGenerationFromDataObjectTest.php
@@ -71,7 +71,10 @@ class WsdlGenerationFromDataObjectTest extends \Magento\TestFramework\TestCase\W
         curl_setopt($connection, CURLOPT_RETURNTRANSFER, 1);
         $responseContent = curl_exec($connection);
         $this->assertEquals(curl_getinfo($connection, CURLINFO_HTTP_CODE), 401);
-        $this->assertStringContainsString("The consumer isn't authorized to access %resources.", $responseContent);
+        $this->assertStringContainsString(
+            "The consumer isn't authorized to access %resources.",
+            htmlspecialchars_decode($responseContent, ENT_QUOTES)
+        );
     }
 
     public function testInvalidWsdlUrlNoServices()


### PR DESCRIPTION
### Description (*)
Fix for tests that remain failed after main 8.1 compatibility fixes
- dev/tests/integration/testsuite/Magento/AdvancedCheckout/Model/CartTest.php
- dev/tests/api-functional/testsuite/Magento/Webapi/WsdlGenerationFromDataObjectTest.php


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
