### PR TITLE
Fix: invoices now show the invoice's address, instead of defaulting to the order's address

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice.php
@@ -260,7 +260,7 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
      */
     public function getBillingAddress()
     {
-        return $this->getOrder()->getBillingAddress();
+        return $this->_findAddress($this->getBillingAddressId()) ?: $this->getOrder()->getBillingAddress();
     }
 
     /**
@@ -270,7 +270,20 @@ class Invoice extends AbstractModel implements EntityInterface, InvoiceInterface
      */
     public function getShippingAddress()
     {
-        return $this->getOrder()->getShippingAddress();
+        return $this->_findAddress($this->getShippingAddressId()) ?: $this->getOrder()->getShippingAddress();
+    }
+
+    /**
+     * Fetch order address by id
+     *
+     * @return Address|null
+     */
+    protected function _findAddress($addressId) {
+        foreach($this->getOrder()->getAddresses() as $address) {
+            if($address->getId() == $addressId) {
+                return $address;
+            }
+        }
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Invoice.php
@@ -110,6 +110,20 @@ class Invoice extends AbstractPdf
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function _getBillingAddress($order, $invoice) {
+        return $invoice->getBillingAddress();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function _getShippingAddress($order, $invoice) {
+        return $invoice->getShippingAddress();
+    }
+
+    /**
      * Return PDF document
      *
      * @param array|Collection $invoices
@@ -148,7 +162,8 @@ class Invoice extends AbstractPdf
                     self::XML_PATH_SALES_PDF_INVOICE_PUT_ORDER_ID,
                     \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                     $order->getStoreId()
-                )
+                ),
+                $invoice
             );
             /* Add document text and number */
             $this->insertDocumentNumber($page, __('Invoice # ') . $invoice->getIncrementId());


### PR DESCRIPTION
### Description (*)

This PR changes the invoice generation to use the invoice's getShippingAddressId and getBillingAddressId, instead of just using the order's shipping and billing address. I have tried to make this change as backwards compatible as possible.

Let me know if this direction is ok, and I'll do the following before getting this PR merged:
- [ ] Apply similar changes for other models (credit notes, etc...)
- [ ] Fix Adminhtml so that it uses $invoice->getBillingAddress() instead of $order->getBillingAddress()

### Manual testing scenarios (*)
1. Create an invoice using Magento's PHP APIs
```php
$invoice = $invoiceService->prepareInvoice($order);
$invoice->setBillingAddressId($order->getShippingAddressId());
$invoice->setShippingAddressId($order->getBillingAddressId());
$invoice->register();
$invoice->save();
```
2. Download the PDF from the admin UI.
3. Expected: The billing and shipping address should be swapped (ie, order's billing address should be invoice shipping address)
4. Actual: The billing and shipping address are as per the order, and not as per the invoice object

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
