### PR TITLE
Update length of 'increment_id' field for consistency

### DIFF
--- a/app/code/Magento/Sales/etc/db_schema.xml
+++ b/app/code/Magento/Sales/etc/db_schema.xml
@@ -188,7 +188,7 @@
         <column xsi:type="decimal" name="weight" scale="4" precision="12" unsigned="false" nullable="true"
                 comment="Weight"/>
         <column xsi:type="datetime" name="customer_dob" on_update="false" nullable="true" comment="Customer Dob"/>
-        <column xsi:type="varchar" name="increment_id" nullable="true" length="32" comment="Increment ID"/>
+        <column xsi:type="varchar" name="increment_id" nullable="true" length="50" comment="Increment ID"/>
         <column xsi:type="varchar" name="applied_rule_ids" nullable="true" length="128" comment="Applied Rule Ids"/>
         <column xsi:type="varchar" name="base_currency_code" nullable="true" length="3" comment="Base Currency Code"/>
         <column xsi:type="varchar" name="customer_email" nullable="true" length="128" comment="Customer Email"/>
@@ -208,7 +208,7 @@
         <column xsi:type="varchar" name="hold_before_state" nullable="true" length="32" comment="Hold Before State"/>
         <column xsi:type="varchar" name="hold_before_status" nullable="true" length="32" comment="Hold Before Status"/>
         <column xsi:type="varchar" name="order_currency_code" nullable="true" length="3" comment="Order Currency Code"/>
-        <column xsi:type="varchar" name="original_increment_id" nullable="true" length="32"
+        <column xsi:type="varchar" name="original_increment_id" nullable="true" length="50"
                 comment="Original Increment ID"/>
         <column xsi:type="varchar" name="relation_child_id" nullable="true" length="32" comment="Relation Child ID"/>
         <column xsi:type="varchar" name="relation_child_real_id" nullable="true" length="32"


### PR DESCRIPTION
### Description
The 'increment_id' column on the `sales_order` table does not match other 'increment_id' columns elsewhere in the database. This pull request makes these all match.

### Related Pull Requests
*None*
<!-- related pull request placeholder -->

### Fixed Issues
- Fixes https://github.com/magento/magento2/issues/34521

### Manual testing scenarios
1. Inspect the column definitions of each table containing an 'increment_id' column.

### Questions or comments
*None*

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)