### PR TITLE
Add core/app as deps in requirejs config

### DIFF
--- a/app/code/Magento/Theme/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Theme/view/frontend/requirejs-config.js
@@ -34,8 +34,7 @@ var config = {
     deps: [
         'mage/common',
         'mage/dataPost',
-        'mage/bootstrap',
-        'Magento_Ui/js/core/app'
+        'mage/bootstrap'
     ],
     config: {
         mixins: {

--- a/app/code/Magento/Theme/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Theme/view/frontend/requirejs-config.js
@@ -34,7 +34,8 @@ var config = {
     deps: [
         'mage/common',
         'mage/dataPost',
-        'mage/bootstrap'
+        'mage/bootstrap',
+        'Magento_Ui/js/core/app'
     ],
     config: {
         mixins: {

--- a/app/code/Magento/Ui/view/frontend/requirejs-config.js
+++ b/app/code/Magento/Ui/view/frontend/requirejs-config.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+var config = {
+    deps: [
+        'Magento_Ui/js/core/app'
+    ]
+};


### PR DESCRIPTION
After many performance tests with the default luma theme and other themes I found out that the Magento_Ui/js/core/app should be inserted as deps because it managing the frontend components. This way the file is loaded earlier and does not block the rest of the JS files.  In some cases, an improvement of around 3 seconds in the total loading time has been measured.

CMS Home page:
with deps
![Ashampoo_Snap_Dienstag, 23  November 2021_17h32m41s_001_](https://user-images.githubusercontent.com/16542619/143066948-5f041ec4-4b12-4789-bc11-5c17d8b2fd7d.png)
without deps
![Ashampoo_Snap_Dienstag, 23  November 2021_17h40m45s_003_](https://user-images.githubusercontent.com/16542619/143066963-13d2feff-260b-4eab-b65a-28a9c7f469e7.png)

Women> Tops Categorie
with deps
![Ashampoo_Snap_Dienstag, 23  November 2021_17h35m20s_002_](https://user-images.githubusercontent.com/16542619/143067041-278d8482-7ac7-40cf-835d-8ad715537025.png)
without deps
![Ashampoo_Snap_Dienstag, 23  November 2021_17h43m18s_004_](https://user-images.githubusercontent.com/16542619/143067056-23d8f10a-7dfb-4b96-b1d1-31eb352494cf.png)

### Resolved issues:
1. [x] resolves magento/magento2#34847: Add core/app as deps in requirejs config