### PR TITLE
ISSUE-34349 - Fixed requested store not found for creditmemos

### DIFF
--- a/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
+++ b/app/code/Magento/Sales/Ui/Component/Listing/Column/Price.php
@@ -78,8 +78,10 @@ class Price extends Column
             foreach ($dataSource['data']['items'] as & $item) {
                 $currencyCode = isset($item['base_currency_code']) ? $item['base_currency_code'] : null;
                 if (!$currencyCode) {
-                    $storeId = isset($item['store_id']) && (int)$item['store_id'] !== 0 ? $item['store_id'] :
-                        $this->context->getFilterParam('store_id', Store::DEFAULT_STORE_ID);
+                    $storeId = isset($item['store_id']) && is_numeric($item['store_id']) && (int)$item['store_id'] !== 0 
+                        ? $item['store_id'] 
+                        : $this->context->getFilterParam('store_id', Store::DEFAULT_STORE_ID);
+                    
                     $store = $this->storeManager->getStore(
                         $storeId
                     );


### PR DESCRIPTION
### Description (*)
ISSUE-34349 - Fixed requested store not found when store name contains digits

This pr resolves an isssue where the store name contains digits and are typecasted to an integer. Because of how PHP processes this the numbers remain as if it is a store id.

Sequentially the `getStore` function gets the full store name string instead of default store id which causes the exception "The store that was requested wasn't found. Verify the store and try again" 

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34349

### Manual testing scenarios (*)
1. Set website name + storename to something that has a number. Example: '2 Unlimited'
2. Create a new order. 
3. Refund the order just created
4. Credit Memos grid should not raise exception: The store that was requested wasn't found. Verify the store and try again.