### PR TITLE
Fix Magento Unit Tests to be compatible with PHP 8.1

### DIFF
--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/Widget/ConditionsTest.php
@@ -223,6 +223,7 @@ class ConditionsTest extends TestCase
         $this->contextMock->expects($this->once())->method('getEnginePool')->willReturn($templateEnginePoolMock);
         $templateEnginePoolMock->expects($this->once())->method('get')->willReturn($templateEngineMock);
         $templateEngineMock->expects($this->once())->method('render')->willReturn('html');
+        $resolverMock->method('getTemplateFileName')->willReturn('');
 
         $this->widgetConditions = $this->objectManagerHelper->getObject(
             Conditions::class,

--- a/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
+++ b/app/code/Magento/Fedex/Test/Unit/Model/CarrierTest.php
@@ -455,7 +455,7 @@ class CarrierTest extends TestCase
         $this->trackErrorFactory->expects($this->once())
             ->method('create')
             ->willReturn($error);
-
+        $this->serializer->method('serialize')->willReturn('');
         $this->carrier->getTracking($tracking);
         $tracks = $this->carrier->getResult()->getAllTrackings();
 

--- a/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
@@ -940,6 +940,7 @@ class ImportTest extends AbstractImportTestCase
             ->expects($this->never())
             ->method('getRelativePath');
         $phrase = $this->createMock(Phrase::class);
+        $phrase->method('render')->willReturn('');
         $this->_driver
             ->expects($this->any())
             ->method('fileGetContents')

--- a/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
+++ b/app/code/Magento/ImportExport/Test/Unit/Model/ImportTest.php
@@ -43,15 +43,11 @@ class ImportTest extends AbstractImportTestCase
 {
 
     /**
-     * Entity adapter.
-     *
      * @var AbstractEntity|MockObject
      */
     protected $_entityAdapter;
 
     /**
-     * Import export data
-     *
      * @var Data|MockObject
      */
     protected $_importExportData = null;

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/Order/CollectionTest.php
@@ -247,6 +247,7 @@ class CollectionTest extends TestCase
         $orderMock = $this->getMockBuilder(Order::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $orderMock->method('getStoreTZOffsetQuery')->willReturn('');
 
         $this->orderFactoryMock
             ->expects($this->any())

--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -226,7 +226,7 @@ class DeploymentConfig
                 // allow reading values from env variables
                 // value need to be specified in %env(NAME, "default value")% format
                 // like #env(DB_PASSWORD), #env(DB_NAME, "test")
-                if (preg_match(self::ENV_NAME_PATTERN, $param, $matches)) {
+                if ($param !== null && preg_match(self::ENV_NAME_PATTERN, $param, $matches)) {
                     $param = getenv($matches['name']) ?: ($matches['default'] ?? null);
                 }
 

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Form/Element/MultiselectTest.php
@@ -73,6 +73,7 @@ class MultiselectTest extends TestCase
         $fieldId = 'fieldId';
         $this->_model->setCanBeEmpty(true);
         $this->_model->setName($fieldName);
+        $this->_model->setValue('');
         $this->_model->setId($fieldId);
         $elementHtml = $this->_model->getElementHtml();
         $this->assertStringContainsString(
@@ -91,6 +92,7 @@ class MultiselectTest extends TestCase
         $fieldName = 'fieldName';
         $this->_model->setDisabled(true);
         $this->_model->setName($fieldName);
+        $this->_model->setValue('');
         $elementHtml = $this->_model->getElementHtml();
         $this->assertStringContainsString('<input type="hidden" name="' . $fieldName . '_disabled"', $elementHtml);
     }
@@ -106,6 +108,7 @@ class MultiselectTest extends TestCase
         $fieldName = 'fieldName';
         $this->_model->setDisabled(false);
         $this->_model->setName($fieldName);
+        $this->_model->setValue('');
         $elementHtml = $this->_model->getElementHtml();
         $this->assertStringNotContainsString('<input type="hidden" name="' . $fieldName . '_disabled"', $elementHtml);
     }

--- a/lib/internal/Magento/Framework/Filesystem/Driver/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Driver/File.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 namespace Magento\Framework\Filesystem\Driver;
 
 use Magento\Framework\Exception\FileSystemException;
@@ -175,10 +176,13 @@ class File implements DriverInterface
     public function fileGetContents($path, $flag = null, $context = null)
     {
         $filename = $this->getScheme() . $path;
+
         if (!$this->stateful) {
             clearstatcache(false, $filename);
         }
+        $flag = $flag ?? false;
         $result = @file_get_contents($filename, $flag, $context);
+
         if (false === $result) {
             throw new FileSystemException(
                 new Phrase(
@@ -624,10 +628,13 @@ class File implements DriverInterface
      */
     public function filePutContents($path, $content, $mode = null)
     {
+        $mode = $mode ?? 0;
         $result = @file_put_contents($this->getScheme() . $path, $content, $mode);
+
         if ($this->stateful) {
             clearstatcache(true, $this->getScheme() . $path);
         }
+
         if ($result === false) {
             throw new FileSystemException(
                 new Phrase(
@@ -636,6 +643,7 @@ class File implements DriverInterface
                 )
             );
         }
+
         return $result;
     }
 

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -372,12 +372,10 @@ class RepositoryTest extends TestCase
 
         $originalAssetMock = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getModule', 'getContext'])
+            ->onlyMethods(['getModule', 'getContext', 'getFilePath'])
             ->getMock();
-        $originalAssetMock
-            ->expects($this->any())
-            ->method('getContext')
-            ->willReturn($originalContextMock);
+        $originalAssetMock->method('getContext')->willReturn($originalContextMock);
+        $originalAssetMock->method('getFilePath')->willReturn('');
 
         $assetMock = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()

--- a/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Asset/RepositoryTest.php
@@ -254,7 +254,13 @@ class RepositoryTest extends TestCase
                 ['area' => 'AREA', 'themeModel' => $this->getThemeMock(), 'module' => false, 'locale' => 'locale']],
             [
                 ['themeId' => 'ThemeID'],
-                ['area' => 'area', 'themeId' => 'ThemeID', 'themeModel' => 'ThemeID', 'module' => false, 'locale' => 'locale']
+                [
+                    'area' => 'area',
+                    'themeId' => 'ThemeID',
+                    'themeModel' => 'ThemeID',
+                    'module' => false,
+                    'locale' => 'locale'
+                ]
             ]
         ];
     }
@@ -270,7 +276,7 @@ class RepositoryTest extends TestCase
             ->method('getThemeByFullPath')
             ->willReturnArgument(0);
 
-        $fallbackContextMock = $this->getMockBuilder(\Magento\Framework\View\Asset\File\FallbackContex::class)
+        $fallbackContextMock = $this->getMockBuilder('Magento\Framework\View\Asset\File\FallbackContex')
             ->disableOriginalConstructor()
             ->getMock();
         $this->fallbackFactoryMock
@@ -335,7 +341,7 @@ class RepositoryTest extends TestCase
             ->method('isSecure')
             ->willReturn(false);
 
-        $fallbackContextMock = $this->getMockBuilder(\Magento\Framework\View\Asset\File\FallbackContex::class)
+        $fallbackContextMock = $this->getMockBuilder('Magento\Framework\View\Asset\File\FallbackContex')
             ->disableOriginalConstructor()
             ->getMock();
         $this->fallbackFactoryMock


### PR DESCRIPTION
### Description (*)

Fixed deprecations function php 8.1 to pass Unit Tests

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues (if relevant)
1. magento/magento2#34441


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
