### PR TITLE
Fix Magento Unit Tests to be compatible with PHP 8.1

### DIFF
--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -91,7 +91,10 @@ class Post extends \Magento\Contact\Controller\Index implements HttpPostActionIn
     }
 
     /**
+     * Method to send email.
+     *
      * @param array $post Post data from contact form
+     *
      * @return void
      */
     private function sendEmail($post)
@@ -103,22 +106,25 @@ class Post extends \Magento\Contact\Controller\Index implements HttpPostActionIn
     }
 
     /**
+     * Method to validated params.
+     *
      * @return array
      * @throws \Exception
      */
     private function validatedParams()
     {
         $request = $this->getRequest();
-        if (trim($request->getParam('name')) === '') {
+
+        if (trim($request->getParam('name', '')) === '') {
             throw new LocalizedException(__('Enter the Name and try again.'));
         }
-        if (trim($request->getParam('comment')) === '') {
+        if (trim($request->getParam('comment', '')) === '') {
             throw new LocalizedException(__('Enter the comment and try again.'));
         }
-        if (false === \strpos($request->getParam('email'), '@')) {
+        if (\strpos($request->getParam('email', ''), '@') === false) {
             throw new LocalizedException(__('The email address is invalid. Verify the email address and try again.'));
         }
-        if (trim($request->getParam('hideit')) !== '') {
+        if (trim($request->getParam('hideit', '')) !== '') {
             throw new \Exception();
         }
 

--- a/app/code/Magento/Contact/Controller/Index/Post.php
+++ b/app/code/Magento/Contact/Controller/Index/Post.php
@@ -125,6 +125,7 @@ class Post extends \Magento\Contact\Controller\Index implements HttpPostActionIn
             throw new LocalizedException(__('The email address is invalid. Verify the email address and try again.'));
         }
         if (trim($request->getParam('hideit', '')) !== '') {
+            // phpcs:ignore Magento2.Exceptions.DirectThrow
             throw new \Exception();
         }
 

--- a/app/code/Magento/Contact/Test/Unit/Controller/Index/PostTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Controller/Index/PostTest.php
@@ -207,7 +207,7 @@ class PostTest extends TestCase
         $this->requestStub->method('getParams')->willReturn($post);
         $this->requestStub->method('getParam')->willReturnCallback(
             function ($key) use ($post) {
-                return $post[$key];
+                return $post[$key] ?? '';
             }
         );
     }

--- a/app/code/Magento/Contact/Test/Unit/Controller/Index/PostTest.php
+++ b/app/code/Magento/Contact/Test/Unit/Controller/Index/PostTest.php
@@ -137,21 +137,19 @@ class PostTest extends TestCase
 
     /**
      * Test exceute post validation
+     *
      * @param array $postData
-     * @param bool $exceptionExpected
      * @dataProvider postDataProvider
      */
-    public function testExecutePostValidation($postData, $exceptionExpected): void
+    public function testExecutePostValidation($postData): void
     {
         $this->stubRequestPostData($postData);
+        $this->messageManagerMock->expects($this->once())
+            ->method('addErrorMessage');
+        $this->dataPersistorMock->expects($this->once())
+            ->method('set')
+            ->with('contact_us', $postData);
 
-        if ($exceptionExpected) {
-            $this->messageManagerMock->expects($this->once())
-                ->method('addErrorMessage');
-            $this->dataPersistorMock->expects($this->once())
-                ->method('set')
-                ->with('contact_us', $postData);
-        }
 
         $this->controller->execute();
     }
@@ -162,12 +160,12 @@ class PostTest extends TestCase
     public function postDataProvider(): array
     {
         return [
-            [['name' => null, 'comment' => null, 'email' => '', 'hideit' => 'no'], true],
-            [['name' => 'test', 'comment' => '', 'email' => '', 'hideit' => 'no'], true],
-            [['name' => '', 'comment' => 'test', 'email' => '', 'hideit' => 'no'], true],
-            [['name' => '', 'comment' => '', 'email' => 'test', 'hideit' => 'no'], true],
-            [['name' => '', 'comment' => '', 'email' => '', 'hideit' => 'no'], true],
-            [['name' => 'Name', 'comment' => 'Name', 'email' => 'invalidmail', 'hideit' => 'no'], true],
+            [['name' => null, 'comment' => null, 'email' => '', 'hideit' => 'no']],
+            [['name' => 'test', 'comment' => '', 'email' => '', 'hideit' => 'no']],
+            [['name' => '', 'comment' => 'test', 'email' => '', 'hideit' => 'no']],
+            [['name' => '', 'comment' => '', 'email' => 'test', 'hideit' => 'no']],
+            [['name' => '', 'comment' => '', 'email' => '', 'hideit' => 'no']],
+            [['name' => 'Name', 'comment' => 'Name', 'email' => 'invalidmail', 'hideit' => 'no']],
         ];
     }
 
@@ -206,8 +204,8 @@ class PostTest extends TestCase
         $this->requestStub->method('getPostValue')->willReturn($post);
         $this->requestStub->method('getParams')->willReturn($post);
         $this->requestStub->method('getParam')->willReturnCallback(
-            function ($key) use ($post) {
-                return $post[$key] ?? '';
+            function ($key, $defaultValue) use ($post) {
+                return $post[$key] ?? $defaultValue;
             }
         );
     }

--- a/app/code/Magento/MediaStorage/Test/Unit/App/MediaTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/App/MediaTest.php
@@ -134,6 +134,9 @@ class MediaTest extends TestCase
         $this->responseMock->expects(self::once())
             ->method('setFilePath')
             ->with($filePath);
+        $this->configMock->expects($this->once())
+            ->method('getMediaDirectory')
+            ->willReturn('');
 
         $this->createMediaModel()->launch();
     }
@@ -161,6 +164,9 @@ class MediaTest extends TestCase
         $this->responseMock->expects(self::once())
             ->method('setFilePath')
             ->with($filePath);
+        $this->configMock->expects($this->once())
+            ->method('getMediaDirectory')
+            ->willReturn('');
 
         self::assertSame($this->responseMock, $this->mediaModel->launch());
     }
@@ -180,6 +186,10 @@ class MediaTest extends TestCase
             ->method('isReadable')
             ->with(self::RELATIVE_FILE_PATH)
             ->willReturn(false);
+        $this->configMock->expects($this->once())
+            ->method('getMediaDirectory')
+            ->willReturn('');
+        $this->directoryPubMock->method('getAbsolutePath')->willReturn('');
 
         self::assertSame($this->responseMock, $this->mediaModel->launch());
     }
@@ -225,6 +235,9 @@ class MediaTest extends TestCase
             ->willReturn($filePath);
         $this->configMock->expects(self::once())
             ->method('save');
+        $this->configMock->expects($this->once())
+            ->method('getMediaDirectory')
+            ->willReturn('');
 
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('The path is not allowed: ' . self::RELATIVE_FILE_PATH);
@@ -255,6 +268,8 @@ class MediaTest extends TestCase
             return $isAllowed;
         };
 
+        $driverFile =  $this->createMock(Filesystem\Driver\File::class);
+        $driverFile->method('getRealPath')->willReturn('');
         $placeholderFactory = $this->createMock(PlaceholderFactory::class);
         $placeholderFactory->method('create')
             ->willReturn($this->createMock(Placeholder::class));
@@ -271,7 +286,7 @@ class MediaTest extends TestCase
             $placeholderFactory,
             $this->createMock(State::class),
             $this->createMock(ImageResize::class),
-            $this->createMock(Filesystem\Driver\File::class),
+            $driverFile,
             $this->createMock(CatalogMediaConfig::class)
         );
     }

--- a/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/CurrencyTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Block/Adminhtml/Grid/Column/Renderer/CurrencyTest.php
@@ -154,7 +154,7 @@ class CurrencyTest extends TestCase
         );
 
         $this->gridColumnMock = $this->getMockBuilder(Column::class)
-            ->addMethods(['getIndex'])
+            ->addMethods(['getIndex', 'getRateField', 'getCurrency'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->model = $objectManager->getObject(
@@ -250,6 +250,8 @@ class CurrencyTest extends TestCase
             ->method('getCurrency')
             ->with($storeCurrencyCode)
             ->willReturn($currLocaleMock);
+        $this->gridColumnMock->method('getCurrency')->willReturn('USD');
+        $this->gridColumnMock->method('getRateField')->willReturn('test_rate_field');
         $actualAmount = $this->model->render($this->row);
         $this->assertEquals($convertedAmount, $actualAmount);
     }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MysqlTest extends TestCase
 {
-    const CUSTOM_ERROR_HANDLER_MESSAGE = 'Custom error handler message';
+    public const CUSTOM_ERROR_HANDLER_MESSAGE = 'Custom error handler message';
 
     /**
      * @var SelectFactory|MockObject
@@ -426,7 +426,7 @@ class MysqlTest extends TestCase
         );
         $adapter->expects($this->any())->method('getSchemaListener')->willReturn($this->schemaListenerMock);
         $adapter->expects($this->any())->method('_getTableName')->willReturnArgument(0);
-        $adapter->expects($this->any())->method('quote')->willReturnArgument(0);
+        $adapter->expects($this->any())->method('quote')->willReturnOnConsecutiveCalls('', 'Some field');
         $adapter->expects($this->once())->method('rawQuery')->with($expectedQuery);
         $adapter->addColumn('tableName', 'columnName', $options);
     }


### PR DESCRIPTION
### Description (*)

Fixed deprecations function php 8.1 to pass Unit Tests

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues (if relevant)
1. magento/magento2#34441


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
