### PR TITLE
Fix wrong credit card type comparation

### DIFF
--- a/app/code/Magento/Payment/view/base/web/js/model/credit-card-validation/validator.js
+++ b/app/code/Magento/Payment/view/base/web/js/model/credit-card-validation/validator.js
@@ -35,7 +35,7 @@ define([
                 cardInfo = creditCardNumberValidator(number).card;
 
                 for (i = 0, l = allowedTypes.length; i < l; i++) {
-                    if (cardInfo.title == allowedTypes[i].type) { //eslint-disable-line eqeqeq
+                    if (cardInfo.type == allowedTypes[i].type) { //eslint-disable-line eqeqeq
                         return true;
                     }
                 }


### PR DESCRIPTION
### Description 

Fix wrong credit card type comparation

`if (cardInfo.title == allowedTypes[i].type)` is incorrect comparation. `cardInfo.title` will be 'Visa', 'Master',.... but `allowedTypes[i].type` is VI, MC,...

### Resolved issues:
1. [x] resolves magento/magento2#35662: Fix wrong credit card type comparation