### PR TITLE
[WIP] fix deprecation warning on PHP 8.1

### DIFF
--- a/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Reader/ArgumentsReader.php
@@ -110,7 +110,8 @@ class ArgumentsReader
 
         $type = $parameter->detectType();
 
-        if ($type === 'null') {
+        if ($type === null || $type === 'null') {
+            // check on null for PHP 8.1 compatibility, emulates the behavior from PHP 7.4
             return null;
         }
 


### PR DESCRIPTION
### Description (*)
A Fix for deprecation warning on PHP 8.1 which leads to an error during compilation

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
