### PR TITLE
Code simplification of isSessionExpired function

### DIFF
--- a/app/code/Magento/Security/Model/AdminSessionInfo.php
+++ b/app/code/Magento/Security/Model/AdminSessionInfo.php
@@ -131,12 +131,12 @@ class AdminSessionInfo extends \Magento\Framework\Model\AbstractModel
     {
         $lifetime = $this->securityConfig->getAdminSessionLifetime();
         $currentTime = $this->dateTime->gmtTimestamp();
-        $lastUpdatedTime = $this->getUpdatedAt();
+        $lastUpdatedTime = $this->getUpdatedAt() ?? 0;
         if (!is_numeric($lastUpdatedTime)) {
             $lastUpdatedTime = strtotime($lastUpdatedTime);
         }
 
-        return $lastUpdatedTime <= ($currentTime - $lifetime) ? true : false;
+        return $lastUpdatedTime <= ($currentTime - $lifetime);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
passing null to strtotime generates warnings in newer versions of PHP. Using a ternary if for a boolean is unnecessary.

### Manual testing scenarios (*)
Visiting the admin page with an expired session

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
