### PR TITLE
Fix missing name in layout issue

### DIFF
--- a/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog/Edit/Tab/Conditions.php
+++ b/app/code/Magento/CatalogRule/Block/Adminhtml/Promo/Catalog/Edit/Tab/Conditions.php
@@ -5,15 +5,15 @@
  */
 namespace Magento\CatalogRule\Block\Adminhtml\Promo\Catalog\Edit\Tab;
 
-use Magento\Backend\Block\Widget\Form;
 use Magento\Backend\Block\Widget\Form\Generic;
+use Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
 use Magento\Ui\Component\Layout\Tabs\TabInterface;
 use Magento\Rule\Model\Condition\AbstractCondition;
 
 class Conditions extends Generic implements TabInterface
 {
     /**
-     * @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset
+     * @var Fieldset
      */
     protected $_rendererFieldset;
 
@@ -27,7 +27,7 @@ class Conditions extends Generic implements TabInterface
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Data\FormFactory $formFactory
      * @param \Magento\Rule\Block\Conditions $conditions
-     * @param \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $rendererFieldset
+     * @param Fieldset $rendererFieldset
      * @param array $data
      */
     public function __construct(
@@ -35,7 +35,7 @@ class Conditions extends Generic implements TabInterface
         \Magento\Framework\Registry $registry,
         \Magento\Framework\Data\FormFactory $formFactory,
         \Magento\Rule\Block\Conditions $conditions,
-        \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $rendererFieldset,
+        Fieldset $rendererFieldset,
         array $data = []
     ) {
         $this->_rendererFieldset = $rendererFieldset;
@@ -121,7 +121,7 @@ class Conditions extends Generic implements TabInterface
     }
 
     /**
-     * @return Form
+     * @inheritdoc
      */
     protected function _prepareForm()
     {
@@ -135,6 +135,8 @@ class Conditions extends Generic implements TabInterface
     }
 
     /**
+     * Adds 'Conditions' to the form.
+     *
      * @param \Magento\CatalogRule\Api\Data\RuleInterface $model
      * @param string $fieldsetId
      * @param string $formName
@@ -154,7 +156,8 @@ class Conditions extends Generic implements TabInterface
             ['form_namespace' => $formName]
         );
 
-        $renderer = $this->_rendererFieldset->setTemplate('Magento_CatalogRule::promo/fieldset.phtml')
+        $renderer = $this->getLayout()->createBlock(Fieldset::class);
+        $renderer->setTemplate('Magento_CatalogRule::promo/fieldset.phtml')
             ->setNewChildUrl($newChildUrl)
             ->setFieldSetId($conditionsFieldSetId);
 
@@ -183,6 +186,8 @@ class Conditions extends Generic implements TabInterface
     }
 
     /**
+     * Sets form name for Condition section.
+     *
      * @param AbstractCondition $conditions
      * @param string $formName
      * @param string $jsFormName

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Actions.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Actions.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab;
 
+use Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
 use Magento\Framework\App\ObjectManager;
 
 class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
@@ -69,7 +70,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTabClass()
     {
@@ -77,7 +78,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTabUrl()
     {
@@ -85,7 +86,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function isAjaxLoaded()
     {
@@ -93,7 +94,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTabLabel()
     {
@@ -101,7 +102,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getTabTitle()
     {
@@ -109,7 +110,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function canShowTab()
     {
@@ -117,7 +118,7 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function isHidden()
     {
@@ -165,7 +166,9 @@ class Actions extends \Magento\Backend\Block\Widget\Form\Generic implements
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create();
         $form->setHtmlIdPrefix('rule_');
-        $renderer = $this->_rendererFieldset->setTemplate(
+
+        $renderer = $this->getLayout()->createBlock(Fieldset::class);
+        $renderer->setTemplate(
             'Magento_CatalogRule::promo/fieldset.phtml'
         )->setNewChildUrl(
             $newChildUrl

--- a/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Conditions.php
+++ b/app/code/Magento/SalesRule/Block/Adminhtml/Promo/Quote/Edit/Tab/Conditions.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Magento\SalesRule\Block\Adminhtml\Promo\Quote\Edit\Tab;
 
 use Magento\Framework\App\ObjectManager;
-use Magento\Framework\Data\Form\Element\Fieldset;
+use Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
 use Magento\SalesRule\Model\Rule;
 
 /**
@@ -163,7 +163,9 @@ class Conditions extends \Magento\Backend\Block\Widget\Form\Generic implements
         /** @var \Magento\Framework\Data\Form $form */
         $form = $this->_formFactory->create();
         $form->setHtmlIdPrefix('rule_');
-        $renderer = $this->_rendererFieldset->setTemplate(
+
+        $renderer = $this->getLayout()->createBlock(Fieldset::class);
+        $renderer->setTemplate(
             'Magento_CatalogRule::promo/fieldset.phtml'
         )->setNewChildUrl(
             $newChildUrl


### PR DESCRIPTION
### Description (*)
With PHP 8.1 we sometimes have a deprecation warning in this line (**EE**)
`app/code/Magento/PricePermissions/Observer/AdminhtmlBlockHtmlBeforeObserver.php`

`if (stripos($block->getNameInLayout(), ...`

Block in layout should always have name (at least auto-generated).
A case when block doesn't have a name caused by using \Magento\Backend\Block\Widget\Form\Renderer\Fieldset through block constructor.

This PR fixes this behaviour to avoid a block without name.

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues
1. magento/magento2#34567
2. magento/magento2#34778

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)

### Release Note