### PR TITLE
Update PHPDoc for markIndexerAsInvalid() method

### DIFF
--- a/lib/internal/Magento/Framework/Indexer/AbstractProcessor.php
+++ b/lib/internal/Magento/Framework/Indexer/AbstractProcessor.php
@@ -80,7 +80,7 @@ abstract class AbstractProcessor
     }
 
     /**
-     * Mark Product price indexer as invalid
+     * Mark indexer as invalid
      *
      * @return void
      */


### PR DESCRIPTION
### Description (*)
Update PHPDoc for method inside AbstractProcessor from Indexer.
The method `markIndexerAsInvalid()` works for more than "Product price indexer". This is why I propose to change this PHPDoc.

### Manual testing scenarios (*)

It is a update in PHPDoc, so there is no testing necessary.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
