### PR TITLE
Fixed failed MFTF tests to make system compatible with PHP 8.1

### DIFF
--- a/app/code/Magento/MediaStorage/App/Media.php
+++ b/app/code/Magento/MediaStorage/App/Media.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Media application
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -19,6 +17,7 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\App\State;
 use Magento\Framework\AppInterface;
+use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
@@ -26,11 +25,12 @@ use Magento\Framework\Filesystem\Driver\File;
 use Magento\MediaStorage\Model\File\Storage\Config;
 use Magento\MediaStorage\Model\File\Storage\ConfigFactory;
 use Magento\MediaStorage\Model\File\Storage\Response;
-use Magento\MediaStorage\Model\File\Storage\Synchronization;
 use Magento\MediaStorage\Model\File\Storage\SynchronizationFactory;
 use Magento\MediaStorage\Service\ImageResize;
 
 /**
+ * Media application.
+ *
  * The class resize original images
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -45,7 +45,6 @@ class Media implements AppInterface
     private $isAllowed;
 
     /**
-     * Media directory path
      *
      * @var string
      */
@@ -124,7 +123,7 @@ class Media implements AppInterface
      * @param ImageResize $imageResize
      * @param File $file
      * @param CatalogMediaConfig $catalogMediaConfig
-     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws FileSystemException
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -238,7 +237,11 @@ class Media implements AppInterface
      */
     private function checkMediaDirectoryChanged(): bool
     {
-        return rtrim($this->mediaDirectoryPath, '/') !== rtrim($this->directoryMedia->getAbsolutePath(), '/');
+        $mediaDirectoryAbsolutePath = $this->directoryMedia->getAbsolutePath();
+
+        return $this->mediaDirectoryPath !== null
+            && $mediaDirectoryAbsolutePath !== null
+            && rtrim($this->mediaDirectoryPath, '/') !== rtrim($mediaDirectoryAbsolutePath, '/');
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides required fixes to make system compatible with PHP 8.1

1. Fixed failed MFTF tests for media application 

- The error `app/code/Magento/MediaStorage/App/Media.php:241 rtrim(): Passing null to parameter #1 ($string) of type string is deprecated` has been fixed

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues (*)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34778

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
