### PR TITLE
Fixed failed tests with UniqueValidator error

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Copier.php
+++ b/app/code/Magento/Catalog/Model/Product/Copier.php
@@ -145,6 +145,13 @@ class Copier
         do {
             $urlKey = $this->modifyUrl($urlKey);
             $duplicate->setUrlKey($urlKey);
+
+            // PHP 8.1 Compatibility fix for problem
+            // trim(): Passing null to parameter #1 ($string) of type string is deprecated
+            // If `entity_id` field is `false` the system works correctly and reset
+            // the `entity_id` during to save process
+            $fixedDuplicateEntityId = $duplicate->getEntityId() ?? false;
+            $duplicate->setEntityId($fixedDuplicateEntityId);
         } while (!$attribute->getEntity()->checkAttributeUniqueValue($attribute, $duplicate));
         $duplicate->setData('url_path', null);
         $duplicate->save();


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides needed fixes to fix PHP 8.1 compatibility problems

1. The error `Magento/CatalogStaging/Model/Product/Attribute/UniqueValidator.php:42 trim(): Passing null to parameter #1 ($string) of type string is deprecated` has been fixed

### Related Pull Requests
<!-- related pull request placeholder -->

### Related Issues (*)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#34567
2. magento/magento2#34778 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
