### PR TITLE
Adds allow-plugins section to composer.json file for compatibility with Composer 2.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
         "AFL-3.0"
     ],
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "laminas/laminas-dependency-plugin": true,
+            "magento/*": true
+        },
         "preferred-install": "dist",
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -9563,9 +9563,6 @@
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
@@ -12802,5 +12799,5 @@
         "lib-libxml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### Description (*)
Composer 2.2 comes with [a new security feature](https://blog.packagist.com/composer-2-2/) where you have to specify the plugins you trust in your `composer.json` file before they will be executed. At first the plugins will still get installed to ensure backwards compatibility, but according to [the documentation around this new config option](https://getcomposer.org/doc/06-config.md#allow-plugins), this will change in July 2022 after which plugins will no longer be executed if they aren't specified in the `composer.json` file

### Related Pull Requests
https://github.com/magento/partners-magento2ee/pull/675
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34831

### Manual testing scenarios (*)
1. Make sure you use composer 2.2.1 or higher
2. Run `composer install`
3. Expect no prompts à la: `xxx contains a Composer plugin which is currently not in your allow-plugins config.`

### Questions or comments
The same changes should be made to the composer meta package that is used when you run `composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition`
Ideally before every new Magento release, all composer plugins being used should be found and added to the `allow-plugins` section and plugins that are no longer part of core Magento should be removed from that section.
@fascinosum 

Would be great if this gets included in Magento 2.4.4 and 2.4.3-p2 and 2.3.7-p3 as it would be the [only releases of Magento](https://devdocs.magento.com/release/) before July 2022

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
