### PR TITLE
Fixed minimum qty allowed in wishlist

### DIFF
--- a/app/code/Magento/Wishlist/Model/Wishlist.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist.php
@@ -150,6 +150,11 @@ class Wishlist extends AbstractModel implements IdentityInterface
     private $stockConfiguration;
 
     /**
+     * @var StockRegistryInterface|null
+     */
+    private $stockRegistry;
+
+    /**
      * Constructor
      *
      * @param Context $context
@@ -212,6 +217,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
         $this->productRepository = $productRepository;
         $this->stockConfiguration = $stockConfiguration
             ?: ObjectManager::getInstance()->get(StockConfigurationInterface::class);
+        $this->stockRegistry = $stockRegistry ?: ObjectManager::getInstance()->get(StockRegistryInterface::class);
     }
 
     /**
@@ -517,7 +523,7 @@ class Wishlist extends AbstractModel implements IdentityInterface
             }
             $candidate->setWishlistStoreId($storeId);
 
-            $qty = $candidate->getQty() ? $candidate->getQty() : 1;
+            $qty = $candidate->getQty() ?: $this->getMinSaleQty($candidate);
             // No null values as qty. Convert zero to 1.
             $item = $this->_addCatalogProduct($candidate, $qty, $forciblySetQty);
             $items[] = $item;
@@ -781,5 +787,22 @@ class Wishlist extends AbstractModel implements IdentityInterface
             $identities = [self::CACHE_TAG . '_' . $this->getId()];
         }
         return $identities;
+    }
+
+    /**
+     * Returns min sale qty for product
+     *
+     * @param Product $product
+     *
+     * @return float
+     */
+    private function getMinSaleQty(Product $product): float
+    {
+        $stockItem = $this->stockRegistry->getStockItem(
+            $product->getId(),
+            $product->getStore()->getWebsiteId()
+        );
+
+        return $stockItem && $stockItem->getMinSaleQty() ? $stockItem->getMinSaleQty() : 1;
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/WishlistTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/WishlistTest.php
@@ -262,7 +262,7 @@ class WishlistTest extends TestCase
     {
         $storeId = 1;
         $productId = 1;
-        $stores = [(new DataObject())->setId($storeId)];
+        $stores = [(new DataObject())->setId($storeId)->setWebsiteId(1)];
 
         $newItem = $this->prepareWishlistItem();
 
@@ -290,13 +290,13 @@ class WishlistTest extends TestCase
         $instanceType = $this->getMockBuilder(AbstractType::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $cartCandidate = $this->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cartCandidate->expects($this->any())->method('getStore')->willReturn($stores[0]);
         $instanceType->expects($this->once())
             ->method('processConfiguration')
-            ->willReturn(
-                $this->getMockBuilder(Product::class)
-                    ->disableOriginalConstructor()
-                    ->getMock()
-            );
+            ->willReturn($cartCandidate);
 
         $newProduct = $this->getMockBuilder(
             Product::class


### PR DESCRIPTION
### Description (*)
Fixed issue with adding product with decimal Minimum Qty Allowed in Shopping Cart to the Wishlist
### Fixed Issues (if relevant)
1. Fixes magento/magento2#34565

### Manual testing scenarios (*)
1. Login to the Admin panel
2. Admin - Catalog - Products - Edit - Quantity - Advanced Inventory - Minimum Qty Allowed in Shopping Cart - 0.5 , Qty Uses Decimals - Yes (Set 0.5 minumum qty in product)
3. Go to the Storefront
4. Login as Customer
5. Open edited product
6. Add product to wishlist without editing qty

**Expected result**
1. Product added to the wishlist
2. Qty: 0.5

![1640685835157](https://user-images.githubusercontent.com/41998275/147554950-d10e1daa-9bda-4586-b1f5-32973b0e0803.jpg)
![1640685892024](https://user-images.githubusercontent.com/41998275/147554961-91d612aa-5d72-4a88-a45b-ceed356774ec.jpg)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
