### PR TITLE
Product provider returns result with 'id'

### DIFF
--- a/app/code/Magento/CatalogUrlRewriteGraphQl/Model/DataProvider/UrlRewrite/ProductDataProvider.php
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/Model/DataProvider/UrlRewrite/ProductDataProvider.php
@@ -47,6 +47,7 @@ class ProductDataProvider implements EntityDataProviderInterface
     ): array {
         $product = $this->productRepository->getById($id, false, $storeId);
         $result = $product->getData();
+        $result['id'] = $id;
         $result['model'] = $product;
         return $result;
     }


### PR DESCRIPTION
### Description (*)
Product provider results contained entity_id instead of id. 
Added key id in results

### Related Pull Requests
[<!-- related pull request placeholder -->](https://github.com/magento/magento2/pull/34909)

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34908

### Manual testing scenarios (*)
1. Install Magento 2.4 and install sample data
2. execute GraphQL query `query {  route(url: "home") { __typename relative_url redirect_code } }`
3. X-Magento-Tags response header should contain 'cms_p,cms_p_2'

### Questions or comments

### Contribution checklist (*)
 - [ *] Pull request has a meaningful description of its purpose
 - [* ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
