### PR TITLE
Reset custom attribute value after it is updated with setData

### DIFF
--- a/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
+++ b/lib/internal/Magento/Framework/Model/AbstractExtensibleModel.php
@@ -221,6 +221,8 @@ abstract class AbstractExtensibleModel extends AbstractModel implements
         } elseif ($key == self::CUSTOM_ATTRIBUTES) {
             $filteredData = $this->filterCustomAttributes([self::CUSTOM_ATTRIBUTES => $value]);
             $value = $filteredData[self::CUSTOM_ATTRIBUTES];
+        } elseif (is_string($key) && isset($this->_data[self::CUSTOM_ATTRIBUTES][$key])) {
+            unset($this->_data[self::CUSTOM_ATTRIBUTES][$key]);
         }
         $this->customAttributesChanged = true;
         parent::setData($key, $value);

--- a/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
+++ b/lib/internal/Magento/Framework/Model/Test/Unit/AbstractExtensibleModelTest.php
@@ -255,6 +255,34 @@ class AbstractExtensibleModelTest extends TestCase
         );
     }
 
+    public function testSetDataChangesCustomAttribute()
+    {
+        $this->model
+            ->expects($this->any())
+            ->method('getCustomAttributesCodes')
+            ->willReturn(['attribute1']);
+
+        $attributesAsArray = [
+            'attribute1' => 'Initial value',
+        ];
+
+        $this->addCustomAttributesToModel($attributesAsArray, $this->model);
+
+        $this->assertEquals(
+            $attributesAsArray,
+            $this->model->getData(),
+            'All model data should be represented as a flat array, including custom attributes.'
+        );
+
+        $this->model->setData('attribute1', 'New value');
+
+        $this->assertEquals(
+            ['attribute1' => 'New value'],
+            $this->model->getData(),
+            'Direct changes to model data should be reflected in custom attributes.'
+        );
+    }
+
     /**
      * @param string[] $attributesAsArray
      * @param AbstractExtensibleModel $model


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This solves an issue where an old custom attribute value becomes stale in the
custom attributes array after the value of the custom attribute is changed
through `setData` instead of `setCustomAttribute`. The fix is to remove the value
from the custom attributes array in `setData`, which causes the value to be
updated to the custom attributes array the next time custom attributes are
accessed (due to `setData` setting the `customAttributesChanged` property as
enabled).

A concrete example of this issue (and what prompted this patch) is the
`\Magento\Eav\Model\Entity\Attribute\Backend\ArrayBackend` backend model for
multiselect attributes. Without this patch, a custom multiselect attribute's
value is not saved. The backend model does map the array value correctly
into a comma-separated string, and sets it to the object using `setData`, but it
does not update the attribute value to the custom attributes array. This is a
problem, because Magento ends up overwriting the correct comma-separated value
from the stale custom attributes array when extracting data to save in
`\Magento\Framework\EntityManager\Operation\Update\UpdateMain::execute`.

This is identical to what is done with custom attributes in `unsetData`.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

To reproduce the issue:

1. Create a new multiselect product attribute with a few options manually through Magento admin panel.
2. Add the attribute to an attribute set.
3. Open a product in said attribute set for editing.
4. Select some options for the multiselect attribute.
5. Save the product.
6. Observe, that the multiselect attribute value is not saved.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34982: Reset custom attribute value after it is updated with setData