### PR TITLE
[MFTF] Replaced by AdminGoToCacheManagementPageActionGroup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminMoveProductBetweenCategoriesTest.xml
@@ -114,7 +114,7 @@
         <magentoCLI command="cron:run --group=index" stepKey="runCron"/>
 
         <!-- Clear invalidated cache on System>Tools>Cache Management page  -->
-        <amOnPage url="{{AdminCacheManagementPage.url}}" stepKey="onCachePage"/>
+        <actionGroup ref="AdminGoToCacheManagementPageActionGroup" stepKey="onCachePage"/>
         <waitForPageLoad stepKey="waitForCacheManagementPage"/>
 
         <checkOption selector="{{AdminCacheManagementSection.configurationCheckbox}}" stepKey="checkConfigCache"/>

--- a/app/code/Magento/PageCache/Test/Mftf/Test/FlushStaticFilesCacheButtonVisibilityTest.xml
+++ b/app/code/Magento/PageCache/Test/Mftf/Test/FlushStaticFilesCacheButtonVisibilityTest.xml
@@ -27,7 +27,7 @@
         </before>
 
         <!-- Open Cache Management page -->
-        <amOnPage url="{{AdminCacheManagementPage.url}}" stepKey="amOnPageCacheManagement"/>
+        <actionGroup ref="AdminGoToCacheManagementPageActionGroup" stepKey="amOnPageCacheManagement"/>
         <waitForPageLoad stepKey="waitForPageCacheManagementLoad"/>
 
         <!-- Check 'Flush Static Files Cache' not visible in production mode. -->


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR replaces `<amOnPage url="{{AdminCacheManagementPage.url}}" stepKey="onCachePage"/>` action to `AdminGoToCacheManagementPageActionGroup`
