### PR TITLE
[MFTF] Replaced by AdminGridAssertCurrentPageNumberActionGroup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminGridPageNumberAfterSaveAndCloseActionTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminGridPageNumberAfterSaveAndCloseActionTest.xml
@@ -61,6 +61,8 @@
         </actionGroup>
         <actionGroup ref="AdminFormSaveAndCloseActionGroup" stepKey="saveAndCloseProduct"/>
         <waitForPageLoad stepKey="waitForPageLoad1"/>
-        <seeInField selector="{{AdminDataGridPaginationSection.currentPage}}" userInput="2" stepKey="seeOnSecondPageOrderGrid"/>
+        <actionGroup ref="AdminGridAssertCurrentPageNumberActionGroup" stepKey="seeOnSecondPageOrderGrid">
+            <argument name="expectedCurrentPageNumber" value="2"/>
+        </actionGroup>
     </test>
 </tests>

--- a/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/EndToEndB2CAdminTest.xml
@@ -258,9 +258,13 @@
             <argument name="perPage" value="Const.one"/>
         </actionGroup>
         <seeNumberOfElements selector="{{AdminDataGridTableSection.rows}}" userInput="1" stepKey="see1RowOnFirstPage" after="select1OrderPerPage"/>
-        <seeInField selector="{{AdminDataGridPaginationSection.currentPage}}" userInput="1" stepKey="seeOnFirstPageOrderGrid" after="see1RowOnFirstPage"/>
+        <actionGroup ref="AdminGridAssertCurrentPageNumberActionGroup" stepKey="seeOnFirstPageOrderGrid" after="see1RowOnFirstPage">
+            <argument name="expectedCurrentPageNumber" value="1"/>
+        </actionGroup>
         <click selector="{{AdminDataGridPaginationSection.nextPage}}" stepKey="clickNextPageOrderGrid" after="seeOnFirstPageOrderGrid"/>
-        <seeInField selector="{{AdminDataGridPaginationSection.currentPage}}" userInput="2" stepKey="seeOnSecondPageOrderGrid" after="clickNextPageOrderGrid"/>
+        <actionGroup ref="AdminGridAssertCurrentPageNumberActionGroup" stepKey="seeOnSecondPageOrderGrid" after="clickNextPageOrderGrid">
+            <argument name="expectedCurrentPageNumber" value="2"/>
+        </actionGroup>
         <seeNumberOfElements selector="{{AdminDataGridTableSection.rows}}" userInput="1" stepKey="see1RowOnSecondPage" after="seeOnSecondPageOrderGrid"/>
         <actionGroup ref="AdminDataGridSelectPerPageActionGroup" stepKey="select50OrdersPerPage" after="see1RowOnSecondPage">
             <!--@TODO Change this to scalar when MQE-498 is implemented-->


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR replaced `<seeInField selector="{{AdminDataGridPaginationSection.currentPage}}" userInput="2" stepKey="seeOnSecondPageOrderGrid"/>` action by `AdminGridAssertCurrentPageNumberActionGroup `