### PR TITLE
Fixed undefined index error in advanced search

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -424,7 +424,7 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
         } elseif ($attribute->getFrontendInput() == 'select' || $attribute->getFrontendInput() == 'multiselect') {
             $value = $attribute->getSource()->getOptionText($value);
             if (is_array($value)) {
-                $value = $value['label'];
+                $value = $value['label'] ?? false;
             }
         } elseif ($attribute->getFrontendInput() == 'boolean') {
             if (is_numeric($value)) {


### PR DESCRIPTION
### Description (*)
### Fixed Issues (if relevant)

1. Fixes magento/magento2#33408

### Manual testing scenarios (*)

####Preconditions (*)
1. Magento version 2.4.2,
2. No sample data.
3. Navigate to admin
4. Go to admin > Stores > Attributes> Product
5. Choose any select attribute (E.g. manufacturer)
6. Go to Properties > Manage Options (Values of Your Attribute)
7. Check that at least one option is added, or add one option (if the attribute has no values, the issue is not reproduced).
8. Save the attribute.

####Steps to reproduce

1. Go to the frontend
2. Go to the link your-website .com/catalogsearch/advanced/result?manufacturer=%27%2C+test+%3D
3. Check that you see 500 error
4. Check report: Undefined index: label in /var/www/html/m242/vendor/magento/module-catalog-search/Model/Advanced.php on line 414

####Expected result 
- Redirect to catalogsearch/advanced/index page with the message 'Enter a search term and try again.'

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
