### PR TITLE
fix Uploader::getCorrectFileName regexp

### DIFF
--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -491,7 +491,7 @@ class Uploader
      */
     public static function getCorrectFileName($fileName)
     {
-        $fileName = preg_replace('/[^a-z0-9_\\-\\.]+/i', '_', $fileName);
+        $fileName = preg_replace('/[^a-z0-9\_\-](?=.*[.])/i', '_', $fileName);
         $fileInfo = pathinfo($fileName);
         $fileInfo['extension'] = $fileInfo['extension'] ?? '';
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The regular expression in the Uploader::getCorrectFileName now replaces all `.` except the last with the `_` symbol. 

    $fileName = Uploader::getCorrectFileName('91V8PZqs6+L._UY500__.jpg');
    $product->addImageToMediaGallery($someBasePath . $fileName, ...);

Expected result: image imported ok.
Actual result: 
`vendor/magento/module-catalog/Model/Product/Gallery/Processor.php (currently lines 160 - 167)` throws an exception:

    // phpcs:ignore Magento2.Functions.DiscouragedFunction
    $pathinfo = pathinfo($file);
    $imgExtensions = ['jpg', 'jpeg', 'gif', 'png'];
    if (!isset($pathinfo['extension']) || !in_array(strtolower($pathinfo['extension']), $imgExtensions)) {
        throw new LocalizedException(
            __('The image type for the file is invalid. Enter the correct image type and try again.')
        );
    }

The result with the fix applied: image imported ok.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Call `Uploader::getCorrectFileName('91V8PZqs6+L._UY500__.jpg')` before applying fix. Result filename will be `91V8PZqs6_L._UY500__.jpg` and found extension will be `_UY500__.jpg`
2. Apply the fix
3. Call `Uploader::getCorrectFileName('91V8PZqs6+L._UY500__.jpg')` again. Result filename will be `91V8PZqs6_L__UY500__.jpg` and found extension will be `jpg`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
