### PR TITLE
Deprecate document_root_is_pub from env.php

### DIFF
--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -35,7 +35,7 @@ class ConfigOptionsListConstants
     public const CONFIG_PATH_DB = 'db';
     public const CONFIG_PATH_RESOURCE = 'resource';
     public const CONFIG_PATH_CACHE_TYPES = 'cache_types';
-    public const CONFIG_PATH_DOCUMENT_ROOT_IS_PUB = 'directories/document_root_is_pub';
+    public const CONFIG_PATH_DOCUMENT_ROOT_IS_PUB = 'directories/document_root_is_pub'; /** @deprecated */
     public const CONFIG_PATH_DB_LOGGER_OUTPUT = 'db_logger/output';
     public const CONFIG_PATH_DB_LOGGER_LOG_EVERYTHING = 'db_logger/log_everything';
     public const CONFIG_PATH_DB_LOGGER_QUERY_TIME_THRESHOLD = 'db_logger/query_time_threshold';

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Directory.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Directory.php
@@ -15,7 +15,7 @@ use Magento\Framework\Setup\Option\SelectConfigOption;
 
 /**
  * Deployment configuration options for the folders.
- * @deprecared Magento always uses the pub directory
+ * @deprecated Magento always uses the pub directory
  */
 class Directory implements ConfigOptionsListInterface
 {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Since the `index.php` has been removed from Magento root, all installations have to be served via `pub` directory. 

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Install Magento
2. Following code will not be written to `env.php` anymore:
```
    'directories' => [
        'document_root_is_pub' => true
    ],
```

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
