### PR TITLE
Fix hidden characters causing error in layout update

### DIFF
--- a/app/code/Magento/Reports/Setup/Patch/Data/InitializeReportEntityTypesAndPages.php
+++ b/app/code/Magento/Reports/Setup/Patch/Data/InitializeReportEntityTypesAndPages.php
@@ -85,10 +85,7 @@ class InitializeReportEntityTypesAndPages implements DataPatchInterface, PatchVe
         $cms = $this->pageFactory->create();
         $cms->load('home', 'identifier');
         // @codingStandardsIgnoreStart
-        $reportLayoutUpdate = '<!--
-    <referenceContainer name="right">
-        <referenceBlock name="catalog.compare.sidebar" remove="true" />
-    </referenceContainer>-->';
+        $reportLayoutUpdate = '<!-- <referenceContainer name="right"><referenceBlock name="catalog.compare.sidebar" remove="true"/></referenceContainer> -->';
         // @codingStandardsIgnoreEnd
         /*
          * Merge and save old layout update data with report layout data


### PR DESCRIPTION
### Description (*)
Fix hidden characters causing the Exception "Custom layout update text cannot be changed, only removed" when trying to edit the home page (MariaDB)

### Manual testing scenarios (*)
1. Setup Magento with MariaDB
2. Try to edit home page via backend
3. Exception is thrown because old layout update diffs from current layout update:

```
string(146) "<!--
    <referenceContainer name="right">
        <referenceBlock name="catalog.compare.sidebar" remove="true" />
    </referenceContainer>-->"
string(143) "<!--
    <referenceContainer name="right">
        <referenceBlock name="catalog.compare.sidebar" remove="true" />
    </referenceContainer>-->"
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34962: Fix hidden characters causing error in layout update