### PR TITLE
#34437: include the store value in category list function

### DIFF
--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
@@ -20,6 +20,8 @@ use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -59,6 +61,16 @@ class CategoryListTest extends TestCase
     private $collectionProcessorMock;
 
     /**
+     * @var StoreManagerInterface|MockObject
+     */
+    private $storeManager;
+
+    /**
+     * @var store
+     */
+    private $store;
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -75,6 +87,12 @@ class CategoryListTest extends TestCase
         $this->categoryRepository = $this->getMockForAbstractClass(CategoryRepositoryInterface::class);
         $this->collectionProcessorMock = $this->getMockBuilder(CollectionProcessorInterface::class)
             ->getMock();
+        $this->storeManager = $this->getMockBuilder(StoreManagerInterface::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $this->store = $this->getMockBuilder(Store::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->model = (new ObjectManager($this))->getObject(
             CategoryList::class,
@@ -84,6 +102,7 @@ class CategoryListTest extends TestCase
                 'categorySearchResultsFactory' => $this->categorySearchResultsFactory,
                 'categoryRepository' => $this->categoryRepository,
                 'collectionProcessor' => $this->collectionProcessorMock,
+                'storeManager' => $this->storeManager
             ]
         );
     }
@@ -132,6 +151,11 @@ class CategoryListTest extends TestCase
         $this->categorySearchResultsFactory->expects($this->once())->method('create')->willReturn($searchResult);
         $this->categoryCollectionFactory->expects($this->once())->method('create')->willReturn($collection);
         $this->extensionAttributesJoinProcessor->expects($this->once())->method('process')->with($collection);
+
+        $this->storeManager->expects($this->any())
+            ->method('getStore')
+            ->willReturn($this->store);
+        $this->store->expects($this->any())->method('getId')->willReturn(1);
 
         $this->assertEquals($searchResult, $this->model->getList($searchCriteria));
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Category list function receive categories which doesn't consider a store-view value. So the store-view dependent properties of category are the same for different stores. This PR is fixing it by including the current store to get correct values for each category in the list.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#34437

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Manual testing was done according to reproduce steps.
1. Should be multiple store views.
2. Needed category, which has different name for each store view.
3. try to get a category name for each store with `\Magento\Catalog\Api\CategoryListInterface::getList()`
Modified code for test:
```
        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
        $storeManagerInterface = $objectManager->create(\Magento\Store\Model\StoreManagerInterface::class);
        $emulation = $objectManager->create(\Magento\Store\Model\App\Emulation::class);
        
        $searchCriteriaBuilder = $objectManager->create(\Magento\Framework\Api\SearchCriteriaBuilder::class);
        $categoryList = $objectManager->create(\Magento\Catalog\Api\CategoryListInterface::class);
        $testCategoryId = 41;

        foreach ($storeManagerInterface->getStores() as $store) {
            $emulation->startEnvironmentEmulation($store->getId());

            $searchCriteria = $searchCriteriaBuilder->create();
            $categories = $categoryList->getList($searchCriteria);

            foreach ($categories->getItems() as $category) {
                if ($category->getId() == $testCategoryId) {
                    echo "Store Id: " . $store->getName() . ". Store Id: " . $category->getStoreId() . ". Store Name: " . $category->getName() . "</br>";
                }
            }
            
            $emulation->stopEnvironmentEmulation();
        }

        die;
```
Notice: `$testCategoryId` - shoud be Id of category with different names for each store view.
4. Check category names for different stores, they should be correct at this moment.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
