### PR TITLE
fixed status if status is null in order comment update RESTAPI

### DIFF
--- a/app/code/Magento/Sales/Model/Service/OrderService.php
+++ b/app/code/Magento/Sales/Model/Service/OrderService.php
@@ -139,6 +139,9 @@ class OrderService implements OrderManagementInterface
     public function addComment($id, \Magento\Sales\Api\Data\OrderStatusHistoryInterface $statusHistory)
     {
         $order = $this->orderRepository->get($id);
+        if(!$statusHistory->getStatus()){
+            $statusHistory->setStatus($order->getStatus());
+        }
         $order->addStatusHistory($statusHistory);
         $this->orderRepository->save($order);
         $notify = isset($statusHistory['is_customer_notified']) ? $statusHistory['is_customer_notified'] : false;

--- a/app/code/Magento/Sales/Model/Service/OrderService.php
+++ b/app/code/Magento/Sales/Model/Service/OrderService.php
@@ -139,7 +139,7 @@ class OrderService implements OrderManagementInterface
     public function addComment($id, \Magento\Sales\Api\Data\OrderStatusHistoryInterface $statusHistory)
     {
         $order = $this->orderRepository->get($id);
-        if(!$statusHistory->getStatus()){
+        if (!$statusHistory->getStatus()) {
             $statusHistory->setStatus($order->getStatus());
         }
         $order->addStatusHistory($statusHistory);


### PR DESCRIPTION
### Description (*)
Fixed : RestAPI add order comment without providing status sets status to NULL, preventing from showing in order grid #34180

### Fixed Issues (if relevant)

1. Fixes magento/magento2#34180

### Manual testing scenarios (*)
1. Created order in magento and updated the comment excluded "status" field using RestAPI postman. So order comment updated with given data also order status is existing status.
2. Updated the order with comment and different status and its also updating perfectly.
3. Updated order comment with NULL status and its also taking the existing order status.

### Questions or comments


### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
