### PR TITLE
#33586: fix php warning message at search advansed result and index pages

### DIFF
--- a/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
@@ -26,15 +26,11 @@ use Magento\CatalogSearch\Helper\Data as CatalogSearchHelper;
 class Form extends Template
 {
     /**
-     * Currency factory
-     *
      * @var CurrencyFactory
      */
     protected $_currencyFactory;
 
     /**
-     * Catalog search advanced
-     *
      * @var Advanced
      */
     protected $_catalogSearchAdvanced;

--- a/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
+++ b/app/code/Magento/CatalogSearch/Block/Advanced/Form.php
@@ -125,15 +125,12 @@ class Form extends Template
     public function getAttributeValue($attribute, $part = null)
     {
         $value = $this->getRequest()->getQuery($attribute->getAttributeCode());
+
         if ($part && $value) {
-            if (isset($value[$part])) {
-                $value = $value[$part];
-            } else {
-                $value = '';
-            }
+            $value = $value[$part] ?? '';
         }
 
-        return $value;
+        return is_array($value) ? '' : $value;
     }
 
     /**

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -197,12 +197,15 @@ class Advanced extends \Magento\Framework\Model\AbstractModel
             if (!isset($values[$attribute->getAttributeCode()])) {
                 continue;
             }
-            if ($attribute->getFrontendInput() == 'text' || $attribute->getFrontendInput() == 'textarea') {
-                if (!trim($values[$attribute->getAttributeCode()])) {
-                    continue;
-                }
-            }
+
             $value = $values[$attribute->getAttributeCode()];
+
+            if (($attribute->getFrontendInput() == 'text' || $attribute->getFrontendInput() == 'textarea')
+                && (!is_string($value) || !trim($value))
+            ) {
+                continue;
+            }
+
             $preparedSearchValue = $this->getPreparedSearchCriteria($attribute, $value);
             if (false === $preparedSearchValue) {
                 continue;

--- a/app/code/Magento/CatalogSearch/Model/Advanced.php
+++ b/app/code/Magento/CatalogSearch/Model/Advanced.php
@@ -51,65 +51,47 @@ use Magento\Framework\App\ObjectManager;
 class Advanced extends \Magento\Framework\Model\AbstractModel
 {
     /**
-     * User friendly search criteria list
-     *
      * @var array
      */
     protected $_searchCriterias = [];
 
     /**
-     * Product collection
-     *
      * @var ProductCollection
      */
     protected $_productCollection;
 
     /**
-     * Initialize dependencies
-     *
      * @deprecated 101.0.2
      * @var Config
      */
     protected $_catalogConfig;
 
     /**
-     * Catalog product visibility
-     *
      * @var Visibility
      */
     protected $_catalogProductVisibility;
 
     /**
-     * Attribute collection factory
-     *
      * @var AttributeCollectionFactory
      */
     protected $_attributeCollectionFactory;
 
     /**
-     * Store manager
-     *
      * @var \Magento\Store\Model\StoreManagerInterface
      */
     protected $_storeManager;
 
     /**
-     * Product factory
-     *
      * @var ProductFactory
      */
     protected $_productFactory;
 
     /**
-     * Currency factory
-     *
      * @var CurrencyFactory
      */
     protected $_currencyFactory;
 
     /**
-     * Advanced Collection Factory
-     *
      * @deprecated
      * @see $collectionProvider
      * @var ProductCollectionFactory

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/IndexTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/IndexTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogSearch\Controller\Advanced;
+
+use Magento\TestFramework\TestCase\AbstractController;
+use Laminas\Stdlib\Parameters;
+
+/**
+ * Test cases for catalog advanced index using params.
+ *
+ * @magentoDbIsolation disabled
+ * @magentoAppIsolation enabled
+ */
+class IndexTest extends AbstractController
+{
+    /**
+     * Advanced index test by params with the array in params.
+     *
+     * @magentoAppArea frontend
+     * @dataProvider fromParamsInArrayDataProvider
+     *
+     * @param array $searchParams
+     * @return void
+     */
+    public function testExecuteWithArrayInParams(array $searchParams): void
+    {
+        $this->getRequest()->setQuery(
+            $this->_objectManager->create(
+                Parameters::class,
+                [
+                    'values' => $searchParams
+                ]
+            )
+        );
+        $this->dispatch('catalogsearch/advanced/index');
+        $this->assertEquals(200, $this->getResponse()->getStatusCode());
+        $this->getResponse()->getBody();
+    }
+
+    /**
+     * Data provider with array in param values.
+     *
+     * @return array
+     */
+    public function fromParamsInArrayDataProvider(): array
+    {
+        return [
+            'from_data_with_from_param_is_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => [],
+                        'to' => 1,
+                    ]
+                ]
+            ],
+            'from_data_with_to_param_is_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => 0,
+                        'to' => [],
+                    ]
+                ]
+            ],
+            'from_data_with_params_in_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => ['0' => 1],
+                        'to' => [1],
+                    ]
+                ]
+            ],
+            'from_data_with_params_in_array_in_array' => [
+                [
+                    'name' => '',
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => ['0' => ['0' => 1]],
+                        'to' => 1,
+                    ]
+                ]
+            ],
+            'from_data_with_name_param_is_array' => [
+                [
+                    'name' => [],
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => 0,
+                        'to' => 20,
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Controller/Advanced/ResultTest.php
@@ -219,6 +219,18 @@ class ResultTest extends AbstractController
                         'to' => 1,
                     ]
                 ]
+            ],
+            'search_with_name_param_is_array' => [
+                [
+                    'name' => [],
+                    'sku' => '',
+                    'description' => '',
+                    'short_description' => '',
+                    'price' => [
+                        'from' => 0,
+                        'to' => 20,
+                    ]
+                ]
             ]
         ];
     }


### PR DESCRIPTION
…ages

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Fixed PHP errors at the  `catalogsearch/advanced/result` and `catalogsearch/advanced/index` pages.


### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#33586

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Open page with URL and parametrs: `/catalogsearch/advanced/result/?name[]=somename`;
2.  Open page with URL and parametrs: `/catalogsearch/advanced/index/?name[]=somename`;

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
