### PR TITLE
Adding back the functionality to use the PHP cookie for GraphQL user

### DIFF
--- a/app/code/Magento/GraphQl/etc/graphql/di.xml
+++ b/app/code/Magento/GraphQl/etc/graphql/di.xml
@@ -15,6 +15,10 @@
                     <item name="type" xsi:type="object">Magento\Webapi\Model\Authorization\TokenUserContext</item>
                     <item name="sortOrder" xsi:type="string">10</item>
                 </item>
+                <item name="oauthUserContext" xsi:type="array">
+                    <item name="type" xsi:type="object">Magento\Webapi\Model\Authorization\OauthUserContext</item>
+                    <item name="sortOrder" xsi:type="string">40</item>
+                </item>
                 <item name="guestUserContext" xsi:type="array">
                     <item name="type" xsi:type="object">Magento\Webapi\Model\Authorization\GuestUserContext</item>
                     <item name="sortOrder" xsi:type="string">100</item>


### PR DESCRIPTION
Fixes #28040

### Preconditions (*)

- Sample data
- Login as Veronica Costello
- Add any product(s) into a shopping cart

### Steps to reproduce (*)
- Copy PHPSESSID value from a browser window
- Set PHPSESSID in a header

- Run the next GraphQL query to retrieve a customer's cart
```
 {
  cart(cart_id: "kSjlU0dTeaH9CUuaRGFSUTOejwTN9ZLn") {
    id
    items {
      id
      quantity
      product {
        sku
      }
    }
  }
}
```

### Expected result (*)
GraphQl should be authorized by the cookie set in PHP

### Actual result (*)
GraphQL call needs a bearer token and won't work

