### PR TITLE
[MFTF] Repetitive elements replaced by AssertStorefrontProductDescriptionActionGroup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml
@@ -105,7 +105,9 @@
         <seeElement selector="{{StorefrontProductRelatedProductsSection.relatedProductName($$createSecondRelatedProduct.name$$)}}" stepKey="seeSecondRelatedProductInStorefront"/>
 
         <!-- Assert product content -->
-        <see selector="{{StorefrontProductInfoMainSection.productDescription}}" userInput="{{ApiProductDescription.value}}" stepKey="seeLongDescriptionStorefront"/>
+        <actionGroup ref="AssertStorefrontProductDescriptionActionGroup" stepKey="seeLongDescriptionStorefront">
+            <argument name="productDescription" value="{{ApiProductDescription.value}}"/>
+        </actionGroup>
         <see selector="{{StorefrontProductInfoMainSection.productShortDescription}}" userInput="{{ApiProductShortDescription.value}}" stepKey="seeShortDescriptionStorefront"/>
 
         <!-- Assert product design settings "page layout 1 column" -->

--- a/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/StorefrontEnsureThatAccordionAnchorIsVisibleOnViewportOnceClickedTest.xml
@@ -130,7 +130,9 @@
             <argument name="productUrl" value="$$createProduct.custom_attributes[url_key]$$"/>
         </actionGroup>
         <click selector="{{StorefrontProductInfoDetailsSection.detailsTab}}" stepKey="clickDetailsTab"/>
-        <see selector="{{StorefrontProductInfoMainSection.productDescription}}" userInput="$$createProduct.custom_attributes[description]$$" stepKey="assertProductDescription"/>
+        <actionGroup ref="AssertStorefrontProductDescriptionActionGroup" stepKey="assertProductDescription">
+            <argument name="productDescription" value="$$createProduct.custom_attributes[description]$$"/>
+        </actionGroup>
 
         <!-- Assert that product page has added reviews -->
         <click selector="{{StorefrontProductReviewsSection.reviewsTab}}" stepKey="clickReviewTab"/>

--- a/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEIsNativeWYSIWYGOnProductTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/VerifyTinyMCEIsNativeWYSIWYGOnProductTest.xml
@@ -55,7 +55,9 @@
         <amOnPage url="{{_defaultProduct.urlKey}}.html" stepKey="navigateToProductPage"/>
         <waitForPageLoad stepKey="waitForPageLoad2"/>
         <scrollTo selector="{{StorefrontProductInfoMainSection.stock}}" stepKey="scrollToStock"/>
-        <see userInput="Hello World!" selector="{{StorefrontProductInfoMainSection.productDescription}}" stepKey="assertProductDescription"/>
+        <actionGroup ref="AssertStorefrontProductDescriptionActionGroup" stepKey="assertProductDescription">
+            <argument name="productDescription" value="Hello World!"/>
+        </actionGroup>
         <see userInput="Hello World! Short Content" selector="{{StorefrontProductInfoMainSection.productShortDescription}}" stepKey="assertProductShortDescription"/>
         <after>
             <actionGroup ref="DisabledWYSIWYGActionGroup" stepKey="disableWYSIWYG"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR replacesrepetitive elements by `AssertStorefrontProductDescriptionActionGroup`
