### PR TITLE
Fix shipping email replacing with billing email.

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -1663,7 +1663,7 @@ class Address extends AbstractAddress implements
     public function getEmail()
     {
         $email = $this->getData(self::KEY_EMAIL);
-        if ($this->getQuote() && (!$email || $this->getQuote()->dataHasChangedFor('customer_email'))) {
+        if ($this->getQuote() && !$email) {
             $email = $this->getQuote()->getCustomerEmail();
             $this->setEmail($email);
         }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -552,7 +552,7 @@ class QuoteManagement implements CartManagementInterface
                 $quote->getShippingAddress(),
                 [
                     'address_type' => 'shipping',
-                    'email' => $quote->getCustomerEmail()
+                    'email' => $quote->getShippingAddress()->getEmail() ?: $quote->getCustomerEmail()
                 ]
             );
             $shippingAddress->setData('quote_address_id', $quote->getShippingAddress()->getId());
@@ -564,7 +564,7 @@ class QuoteManagement implements CartManagementInterface
             $quote->getBillingAddress(),
             [
                 'address_type' => 'billing',
-                'email' => $quote->getCustomerEmail()
+                'email' => $quote->getBillingAddress()->getEmail() ?: $quote->getCustomerEmail()
             ]
         );
         $billingAddress->setData('quote_address_id', $quote->getBillingAddress()->getId());

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1059,7 +1059,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         }
 
         if (!empty($address)) {
-            $address->setEmail($this->getCustomerEmail());
+            $address->getEmail() ?: $address->setEmail($this->getCustomerEmail());
             $this->addAddress($address->setAddressType('shipping'));
         }
         return $this;

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/order.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/order.php
@@ -18,6 +18,7 @@ Resolver::getInstance()->requireDataFixture('Magento/Catalog/_files/product_simp
 /** @var \Magento\Catalog\Model\Product $product */
 
 $addressData = include __DIR__ . '/address_data.php';
+$shippingAddressData = include __DIR__ . '/shipping_address_data.php';
 
 $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
 /** @var ProductRepositoryInterface $productRepository */
@@ -26,8 +27,8 @@ $product = $productRepository->get('simple');
 $billingAddress = $objectManager->create(OrderAddress::class, ['data' => $addressData]);
 $billingAddress->setAddressType('billing');
 
-$shippingAddress = clone $billingAddress;
-$shippingAddress->setId(null)->setAddressType('shipping');
+$shippingAddress = $objectManager->create(OrderAddress::class, ['data' => $shippingAddressData]);
+$shippingAddress->setAddressType('shipping');
 
 /** @var Payment $payment */
 $payment = $objectManager->create(Payment::class);

--- a/dev/tests/integration/testsuite/Magento/Sales/_files/shipping_address_data.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/_files/shipping_address_data.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'region' => 'CA',
+    'region_id' => '12',
+    'postcode' => '11111',
+    'company' => 'Test Company',
+    'lastname' => 'lastname',
+    'firstname' => 'firstname',
+    'street' => 'street',
+    'city' => 'Los Angeles',
+    'email' => 'customer@null.com',
+    'telephone' => '11111111',
+    'country_id' => 'US'
+];


### PR DESCRIPTION
### Description (*)
When creating an order out of the guest cart is being done, the shipping email is being replaced by the billing email. 
The reason is the absence of checks for the presence of email in the shipping address. The shipping email is always set from the customer email. Added checks for shipping email present and use it for shipping address instead of using customer address. 

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34614

### Manual testing scenarios (*)
Precondition: Using REST API of magento
1. Create a guest Cart using a POST request to this endpoint `https://magento.test/rest/default/V1/guest-carts`
2. Add an item to the created guest cart using this endpoint `https://magento.test/rest/default/V1/guest-carts/{created-guest-cart-step-1}/items`. Example body `{ "cartItem":{ "sku": "sample-sku", "qty": "1" } }`
3. Add shipping info using a POST request to this endpoint `https://magento.test/rest/default/V1/guest-carts/{created-guest-cart-step-1}/shipping-information`. Example body 
```
{
  "addressInformation": {
    "billingAddress": {
      "country_id": "FI",
      "street": [ "Testikatu 1 C 44" ],
      "company": "",
      "telephone": "0",
      "postcode": "02230",
      "city": "Espoo",
      "firstname": "Siamak Rahimi Motem",
      "lastname": "Siamak Rahimi Motem",
      "email":"billing@address.co"
  },
  "shippingAddress": {
    "country_id": "FI",
    "street": [ "Testikat" ],
    "company": "",
    "telephone": "0",
    "postcode": "15877",
    "city": "gisha",
    "firstname": "Mona",
    "lastname": "Pourdeljoo",
    "email": "shipping@adress.co",
    "same_as_billing": 0
  },
  "shipping_method_code": "flatrate",
  "shipping_carrier_code": "flatrate",
  "extension_attributes": {}
}}

```
on this step in table `quote_address` you can see that  addressed have correct emails
![image](https://user-images.githubusercontent.com/48456860/150823980-818aa04e-610f-4c17-a7b0-07dbaeff26b4.png)

4. Make a PUT request to create order endpoint `https://magento.test/rest/default/V1/guest-carts/{created-guest-cart-step-1}/order ` . Example body `{"paymentMethod": {"method": "checkmo"}}`
5. Check if `sales_order_address` table contain correct emails
![image](https://user-images.githubusercontent.com/48456860/150825167-9181c91c-3e59-4e1b-828e-3227d8a2c5cb.png)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
