### PR TITLE
34866: Save address data from shopping cart page

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-rates-validator.js
@@ -17,6 +17,7 @@ define([
     'mage/translate',
     'uiRegistry',
     'Magento_Checkout/js/model/shipping-address/form-popup-state',
+    'Magento_Checkout/js/action/set-shipping-information',
     'Magento_Checkout/js/model/quote'
 ], function (
     $,
@@ -28,7 +29,9 @@ define([
     defaultValidator,
     $t,
     uiRegistry,
-    formPopUpState
+    formPopUpState,
+    setShippingInformationAction,
+    quote
 ) {
     'use strict';
 
@@ -198,6 +201,10 @@ define([
                 addressFlat = uiRegistry.get('checkoutProvider').shippingAddress;
                 address = addressConverter.formAddressDataToQuoteAddress(addressFlat);
                 selectShippingAddress(address);
+
+                if (quote.shippingMethod()) {
+                    setShippingInformationAction();
+                }
             }
         },
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/shipping-save-processor/default.js
@@ -33,7 +33,8 @@ define([
          * @return {jQuery.Deferred}
          */
         saveShippingInformation: function () {
-            var payload;
+            var payload,
+                email;
 
             if (!quote.billingAddress() && quote.shippingAddress().canUseForBilling()) {
                 selectBillingAddressAction(quote.shippingAddress());
@@ -58,7 +59,12 @@ define([
             ).done(
                 function (response) {
                     quote.setTotals(response.totals);
-                    paymentService.setPaymentMethods(methodConverter(response['payment_methods']));
+                    email = quote.shippingAddress().email;
+
+                    if (!_.isUndefined(email) && email) {
+                        paymentService.setPaymentMethods(methodConverter(response['payment_methods']));
+                    }
+
                     fullScreenLoader.stopLoader();
                 }
             ).fail(

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-rates.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-rates.js
@@ -11,8 +11,9 @@ define([
     'Magento_Catalog/js/price-utils',
     'Magento_Checkout/js/model/quote',
     'Magento_Checkout/js/action/select-shipping-method',
+    'Magento_Checkout/js/action/set-shipping-information',
     'Magento_Checkout/js/checkout-data'
-], function (ko, _, Component, shippingService, priceUtils, quote, selectShippingMethodAction, checkoutData) {
+], function (ko, _, Component, shippingService, priceUtils, quote, selectShippingMethodAction, setShippingInformationAction, checkoutData) {
     'use strict';
 
     return Component.extend({
@@ -77,6 +78,10 @@ define([
         selectShippingMethod: function (methodData) {
             selectShippingMethodAction(methodData);
             checkoutData.setSelectedShippingRate(methodData['carrier_code'] + '_' + methodData['method_code']);
+
+            if (quote.shippingMethod()) {
+                setShippingInformationAction();
+            }
 
             return true;
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixed issue with Cart Price Rule and shipping method set as condition.
This problem is caused by the fact that the shipping address does not contain information about the shipping method when validating the coupon code. This is because Magento does not save this on the shopping cart page.
I added saving shipping information for this. 


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#34866



### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
