### PR TITLE
[MFTF] Elements replaced by AdminOpenContentSectionOnProductPageActionGroup

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Test/AdminCreateAndEditVirtualProductSettingsTest.xml
@@ -64,8 +64,8 @@
         </actionGroup>
 
         <!-- Set Content to the product -->
-        <scrollTo selector="{{AdminProductContentSection.sectionHeader}}" x="0" y="-100" stepKey="scrollToContent"/>
-        <click selector="{{AdminProductContentSection.sectionHeader}}" stepKey="openContentDropDown"/>
+        <actionGroup ref="AdminOpenContentSectionOnProductPageActionGroup" stepKey="scrollToContent"/>
+        <comment userInput="Comment is added to preserve the step key for backward compatibility" stepKey="openContentDropDown"/>
         <fillField selector="{{AdminProductContentSection.descriptionTextArea}}" userInput="{{ApiProductDescription.value}}" stepKey="fillLongDescription"/>
         <fillField selector="{{AdminProductContentSection.shortDescriptionTextArea}}" userInput="{{ApiProductShortDescription.value}}" stepKey="fillShortDescription"/>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR replaces repetitive elements to `AdminOpenContentSectionOnProductPageActionGroup`