### PR TITLE
[MFTF] Repetitive elements replaced by AdminProductPageOpenByIdActionGroup

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontGalleryConfigurableProductWithSeveralAttributesPrependMediaTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontGalleryConfigurableProductWithSeveralAttributesPrependMediaTest.xml
@@ -45,7 +45,9 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
 
             <!-- Open configurable product edit page -->
-            <amOnPage url="{{AdminProductEditPage.url($createConfigurableProduct.id$)}}" stepKey="goToProductIndex"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductIndex">
+                <argument name="productId" value="$createConfigurableProduct.id$"/>
+            </actionGroup>
 
             <!-- Add attributes to configurable product-->
             <conditionalClick selector="{{AdminProductFormConfigurationsSection.sectionHeader}}" dependentSelector="{{AdminProductFormConfigurationsSection.createConfigurations}}" visible="false" stepKey="openConfigurationSection"/>

--- a/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontGalleryConfigurableProductWithVisualSwatchAttributePrependMediaTest.xml
+++ b/app/code/Magento/ConfigurableProduct/Test/Mftf/Test/StorefrontGalleryConfigurableProductWithVisualSwatchAttributePrependMediaTest.xml
@@ -39,7 +39,9 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
 
             <!-- Open configurable product edit page -->
-            <amOnPage url="{{AdminProductEditPage.url($createConfigurableProduct.id$)}}" stepKey="goToProductIndex"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductIndex">
+                <argument name="productId" value="$createConfigurableProduct.id$"/>
+            </actionGroup>
 
             <!-- Add attribute to configurable product-->
             <conditionalClick selector="{{AdminProductFormConfigurationsSection.sectionHeader}}" dependentSelector="{{AdminProductFormConfigurationsSection.createConfigurations}}" visible="false" stepKey="openConfigurationSection"/>

--- a/app/code/Magento/LayeredNavigation/Test/Mftf/Test/StorefrontFilterableProductAttributeInLayeredNavigationWithoutReindexTest.xml
+++ b/app/code/Magento/LayeredNavigation/Test/Mftf/Test/StorefrontFilterableProductAttributeInLayeredNavigationWithoutReindexTest.xml
@@ -138,7 +138,9 @@
         </actionGroup>
         <actionGroup ref="SaveAttributeSetActionGroup" stepKey="saveAttributeSetWithDropdownAttribute"/>
         <!--Assign dropdown attribute to child product of configurable-->
-        <amOnPage url="{{AdminProductEditPage.url($createFirstSimpleProduct.id$)}}" stepKey="visitAdminEditProductPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="visitAdminEditProductPage">
+            <argument name="productId" value="$createFirstSimpleProduct.id$"/>
+        </actionGroup>
         <waitForElementVisible selector="{{AdminProductFormSection.customSelectField('$createDropdownAttribute.attribute_code$')}}" stepKey="waitForDropdownAttributeSelectVisible"/>
         <selectOption selector="{{AdminProductFormSection.customSelectField('$createDropdownAttribute.attribute_code$')}}" userInput="$getFirstDropdownOption.label$" stepKey="selectValueOfNewAttribute"/>
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveSimpleProduct"/>

--- a/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminAddRemoveDefaultVideoSimpleProductTest.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminAddRemoveDefaultVideoSimpleProductTest.xml
@@ -38,7 +38,9 @@
         </after>
 
         <!-- Open product edit page -->
-        <amOnPage url="{{AdminProductEditPage.url($createProduct.id$)}}" stepKey="goToProductEditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPage">
+            <argument name="productId" value="$createProduct.id$"/>
+        </actionGroup>
         <!-- Add product video -->
         <actionGroup ref="AddProductVideoActionGroup" stepKey="addProductVideo"/>
         <!-- Save product form -->
@@ -54,7 +56,9 @@
         <actionGroup ref="AssertProductVideoStorefrontProductPageActionGroup" stepKey="assertProductVideoPresentInStorefrontProductPage"/>
 
         <!-- Open product edit page to remove product video -->
-        <amOnPage url="{{AdminProductEditPage.url($createProduct.id$)}}" stepKey="goToProductEditPageToRemoveVideo"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProductEditPageToRemoveVideo">
+            <argument name="productId" value="$createProduct.id$"/>
+        </actionGroup>
         <!-- Remove product video -->
         <actionGroup ref="RemoveProductVideoActionGroup" stepKey="removeProductVideo"/>
         <!-- Save product form -->

--- a/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminUploadSameVimeoVideoForMultipleProductsTest.xml
+++ b/app/code/Magento/ProductVideo/Test/Mftf/Test/AdminUploadSameVimeoVideoForMultipleProductsTest.xml
@@ -35,7 +35,9 @@
         </after>
 
         <!-- Open product 1 edit page -->
-        <amOnPage url="{{AdminProductEditPage.url($createProduct1.id$)}}" stepKey="goToProduct1EditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct1EditPage">
+            <argument name="productId" value="$createProduct1.id$"/>
+        </actionGroup>
         <!-- Add product video -->
         <actionGroup ref="AddProductVideoActionGroup" stepKey="addProductVideoToProduct1">
             <argument name="video" value="VimeoProductVideo"/>
@@ -44,7 +46,9 @@
         <actionGroup ref="SaveProductFormActionGroup" stepKey="saveProductFormOfProduct1"/>
 
         <!-- Open product 2 edit page -->
-        <amOnPage url="{{AdminProductEditPage.url($createProduct2.id$)}}" stepKey="goToProduct2EditPage"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToProduct2EditPage">
+            <argument name="productId" value="$createProduct2.id$"/>
+        </actionGroup>
         <!-- Add product video -->
         <actionGroup ref="AddProductVideoActionGroup" stepKey="saveProductFormOfProduct2">
             <argument name="video" value="VimeoProductVideo"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchTierPriceTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchTierPriceTest.xml
@@ -48,7 +48,9 @@
             <argument name="option3" value="Blue"/>
         </actionGroup>
         <!-- Open configurable product edit page -->
-        <amOnPage url="{{AdminProductEditPage.url($createConfigurableProduct.id$)}}" stepKey="goToConfigurableProduct"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToConfigurableProduct">
+            <argument name="productId" value="$createConfigurableProduct.id$"/>
+        </actionGroup>
         <!-- Generate configurations for configurable product -->
         <actionGroup ref="GenerateConfigurationsByAttributeCodeActionGroup" stepKey="createProductConfigurations">
             <argument name="attributeCode" value="{{ProductColorAttribute.attribute_code}}"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchUpdateCartItemTierPriceTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontConfigurableProductSwatchUpdateCartItemTierPriceTest.xml
@@ -41,7 +41,9 @@
             <argument name="option3" value="Blue"/>
         </actionGroup>
 
-        <amOnPage url="{{AdminProductEditPage.url($createConfigurableProduct.id$)}}" stepKey="goToConfigurableProduct"/>
+        <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToConfigurableProduct">
+            <argument name="productId" value="$createConfigurableProduct.id$"/>
+        </actionGroup>
 
         <actionGroup ref="GenerateConfigurationsByAttributeCodeActionGroup" stepKey="createProductConfigurations">
             <argument name="attributeCode" value="{{ProductColorAttribute.attribute_code}}"/>

--- a/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchAttributeDisplayedInWidgetCMSTest.xml
+++ b/app/code/Magento/Swatches/Test/Mftf/Test/StorefrontSwatchAttributeDisplayedInWidgetCMSTest.xml
@@ -42,7 +42,9 @@
             <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
 
             <!-- Open configurable product edit page -->
-            <amOnPage url="{{AdminProductEditPage.url($createConfigurableProduct.id$)}}" stepKey="goToConfigurableProduct"/>
+            <actionGroup ref="AdminProductPageOpenByIdActionGroup" stepKey="goToConfigurableProduct">
+                <argument name="productId" value="$createConfigurableProduct.id$"/>
+            </actionGroup>
 
             <!-- Add attributes to configurable product-->
             <conditionalClick selector="{{AdminProductFormConfigurationsSection.sectionHeader}}" dependentSelector="{{AdminProductFormConfigurationsSection.createConfigurations}}" visible="false" stepKey="openConfigurationSection"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR replaces repetitive elements to `AdminProductPageOpenByIdActionGroup` 