### PR TITLE
Update PaypalExpressToken resolver to use correct input from GraphQL Schema.

### DIFF
--- a/app/code/Magento/PaypalGraphQl/Model/Resolver/PaypalExpressToken.php
+++ b/app/code/Magento/PaypalGraphQl/Model/Resolver/PaypalExpressToken.php
@@ -83,7 +83,7 @@ class PaypalExpressToken implements ResolverInterface
     ) {
         $cartId = $args['input']['cart_id'] ?? '';
         $paymentCode = $args['input']['code'] ?? '';
-        $usePaypalCredit = isset($args['input']['paypal_credit']) ? $args['input']['paypal_credit'] : false;
+        $usePaypalCredit = isset($args['input']['use_paypal_credit']) ? $args['input']['use_paypal_credit'] : false;
         $usedExpressButton = isset($args['input']['express_button']) ? $args['input']['express_button'] : false;
         $customerId = $context->getUserId();
 


### PR DESCRIPTION
### Description (*)

Update PaypalExpressToken resolver to use correct input from GraphQL Schema. Currently, adding the `use_paypal_credit` input defined in `etc/schema.graphqls` to `createPaypalExpressToken` requests does nothing, as the code is incorrectly checking for the presence of `paypal_credit` rather than `use_paypal_credit`.

Input defined in schema: 
- https://github.com/magento/magento2/blob/2.4.3-p1/app/code/Magento/PaypalGraphQl/etc/schema.graphqls#L19

### Manual testing scenarios (*)
- Make request to `createPaypalExpressToken` mutation via GraphQL
- Ensure `use_paypal_credit` field in request is set to `true`
- From the mutation response, navigate to the `start` URL returned in the `paypal_urls` output
- See that user is navigated to PayPal credit checkout - not standard PayPal checkout.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35180: Update PaypalExpressToken resolver to use correct input from GraphQL Schema.