### PR TITLE
Fix GraphQL login as customer token not working for multi stores

### DIFF
--- a/app/code/Magento/LoginAsCustomerGraphQl/Model/LoginAsCustomer/CreateCustomerToken.php
+++ b/app/code/Magento/LoginAsCustomerGraphQl/Model/LoginAsCustomer/CreateCustomerToken.php
@@ -52,7 +52,7 @@ class CreateCustomerToken
      */
     public function execute(string $email, StoreInterface $store): array
     {
-        $customer = $this->customerFactory->create()->setWebsiteId((int)$store->getId())->loadByEmail($email);
+        $customer = $this->customerFactory->create()->setWebsiteId((int)$store->getWebsiteId())->loadByEmail($email);
 
         /* Check if customer email exist */
         if (!$customer->getId()) {


### PR DESCRIPTION
### Description (*)
When a magento install with more than one store tries to utilize the login as Customer GraphQl to get a token for any store other than the default store- an error is thrown for customers not being found even when they exist.

### Manual testing scenarios (*)
1. For any multi store implementation of Magento Run the following mutation with with a store other than the default:
mutation{
  generateCustomerTokenAsAdmin(input: {
    customer_email: "test@test.com"
  }){
    customer_token
  }
}	
2. Run the above mutation. 


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35084: Fix GraphQL login as customer token not working for multi stores