### PR TITLE
Add --no-db-upgrade option to setup:upgrade 

### DIFF
--- a/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Console/Command/UpgradeCommandTest.php
@@ -105,13 +105,21 @@ class UpgradeCommandTest extends TestCase
     public function testExecute($options, $deployMode, $expectedString, $expectedOptions): void
     {
         $this->appStateMock->method('getMode')->willReturn($deployMode);
-        $this->installerMock->expects($this->once())
-            ->method('installSchema')
-            ->with($expectedOptions);
         $this->installerMock
             ->method('updateModulesSequence');
-        $this->installerMock
-        ->method('installDataFixtures');
+        if (isset($options['--no-db-upgrade']) && $options['--no-db-upgrade'] === true) {
+            $this->installerMock->expects($this->never())
+                ->method('installSchema')
+                ->with($expectedOptions);
+            $this->installerMock->expects($this->never())
+                ->method('installDataFixtures');
+        } else {
+            $this->installerMock->expects($this->once())
+                ->method('installSchema')
+                ->with($expectedOptions);
+            $this->installerMock
+                ->method('installDataFixtures');
+        }
 
         $this->assertSame(Cli::RETURN_SUCCESS, $this->commandTester->execute($options));
         $this->assertEquals($expectedString, $this->commandTester->getDisplay());
@@ -137,6 +145,7 @@ class UpgradeCommandTest extends TestCase
                     . PHP_EOL . $mediaGalleryNotice,
                 'expectedOptions' => [
                     'keep-generated' => false,
+                    'no-db-upgrade' => false,
                     'convert-old-scripts' => false,
                     'safe-mode' => false,
                     'data-restore' => false,
@@ -154,6 +163,7 @@ class UpgradeCommandTest extends TestCase
                 'expectedString' => $mediaGalleryNotice,
                 'expectedOptions' => [
                     'keep-generated' => true,
+                    'no-db-upgrade' => false,
                     'convert-old-scripts' => false,
                     'safe-mode' => false,
                     'data-restore' => false,
@@ -167,6 +177,7 @@ class UpgradeCommandTest extends TestCase
                 'expectedString' => $mediaGalleryNotice,
                 'expectedOptions' => [
                     'keep-generated' => false,
+                    'no-db-upgrade' => false,
                     'convert-old-scripts' => false,
                     'safe-mode' => false,
                     'data-restore' => false,
@@ -180,6 +191,26 @@ class UpgradeCommandTest extends TestCase
                 'expectedString' => $mediaGalleryNotice,
                 'expectedOptions' => [
                     'keep-generated' => false,
+                    'no-db-upgrade' => false,
+                    'convert-old-scripts' => false,
+                    'safe-mode' => false,
+                    'data-restore' => false,
+                    'dry-run' => false,
+                    'magento-init-params' => ''
+                ]
+            ],
+            [
+                'options' => [
+                    '--magento-init-params' => '',
+                    '--convert-old-scripts' => false,
+                    '--no-db-upgrade' => true
+                ],
+                'deployMode' => AppState::MODE_PRODUCTION,
+                'expectedString' => 'Please re-run Magento compile command. Use the command "setup:di:compile"'
+                    . PHP_EOL . $mediaGalleryNotice,
+                'expectedOptions' => [
+                    'keep-generated' => false,
+                    'no-db-upgrade' => true,
                     'convert-old-scripts' => false,
                     'safe-mode' => false,
                     'data-restore' => false,


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Maintenance mode during deployment on cloud, as well as on-premise, can be significantly shortened, by skipping schema and data install/update steps.
"Zero-Downtime Deployment" can still requires up to 5 minutes of downtime with big databases. With databases of 100+ GiB, the recurring operations in setup:upgrade can take 5 minutes, even if there is no module to update. This leads to timeouts on the frontend system, which is waiting for Adobe Commerce to respond, often no longer than 30 seconds before timing out (if the customer has not left by then).

Reducing the maintenance mode from 5 minutes to 15 seconds, can be achieved by skipping lengthy database operations, if all modules are up-to-date. But we cannot simply skip `setup:upgrade` entirely when `setup:db:status` tells us that modules are up to date. The `setup:upgrade` command contains more than just upgrade code, that can not be found in any other command. For instance the `\Magento\Setup\Model\Installer::updateModulesSequence` method and `\Magento\Setup\Model\Installer::removeUnusedTriggers`, but also `\Magento\Setup\Model\SearchConfig::validateSearchEngine` which is only found on the search config save action but not in any other deployment command.

Because of this, I would like to add the option to skip schema and data upgrades when executing `setup:upgrade`. Deployments should execute `setup:db:status` before going into maintenance mode and use the outcome of that command to determine whether to skip the schema and data upgrades.

An alternative was to include the `setup:db:status` within `setup:upgrade` and let it decide for itself whether to run DB upgrades or not, which I have created a PR for in https://github.com/magento/magento2/pull/35116/commits/ed114375d8f7714edf6c09ded69b2739e7d2b762, but this results in executing `setup:db:status` inside maintenance mode, adding 10 seconds to maintenance mode, for a command that does not need maintenance mode to be enabled.

Below diagram shows the current deployment, with maintenance mode enabled, and `setup:upgrade` taking 5 minutes of that time.

![image](https://user-images.githubusercontent.com/1489129/155520641-3c737178-4e8d-4936-93f6-615c3f69aae0.png)

The second diagram shows what it could look like, when skipping `$installer->installSchema($request)` and `$installer->installDataFixtures($request, true)` in the `setup:upgrade` command, based on the outcome of `setup:db:status`.

![image](https://user-images.githubusercontent.com/1489129/155520635-1719e15f-bc14-4166-95ef-4ad8f63b8311.png)

A 15 second delay in response time during deployment is completely acceptable. Whereas a 1 - 5 minute downtime is often not.

I have added the `--no-db-upgrade` flag to the `setup:upgrade` command in https://github.com/magento/magento2/pull/35116/files

ECE tools should run `setup:db:status` before maintenance mode, to determine whether the `--no-db-upgrade` flag should be set when using the `setup:upgrade` command. If all modules are up to date, the flag should be added to skip unnecessary code execution in maintenance mode. The request for this ECE tools update is logged in MDVA-43621.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MDVA-43621

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. `bin/magento setup:upgrade --no-db-upgrade --keep-generated`  should NOT RUN upgrades
2. `bin/magento setup:upgrade --keep-generated`  should RUN upgrades

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
