### PR TITLE
Issue #31311 - Shipping Method Delimiter Conflict Fix

### DIFF
--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -27,6 +27,7 @@ use Magento\Quote\Model\Quote\TotalsCollector;
 use Magento\Quote\Model\QuoteAddressValidator;
 use Magento\Quote\Model\ShippingAssignmentFactory;
 use Magento\Quote\Model\ShippingFactory;
+use Magento\Sales\Model\Order;
 use Psr\Log\LoggerInterface as Logger;
 
 /**
@@ -184,7 +185,7 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
             $carrierCode = $addressInformation->getShippingCarrierCode();
             $address->setLimitCarrier($carrierCode);
             $methodCode = $addressInformation->getShippingMethodCode();
-            $quote = $this->prepareShippingAssignment($quote, $address, $carrierCode . '_' . $methodCode);
+            $quote = $this->prepareShippingAssignment($quote, $address, $carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode);
 
             $quote->setIsMultiShipping(false);
 

--- a/app/code/Magento/Checkout/Model/TotalsInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/TotalsInformationManagement.php
@@ -6,6 +6,7 @@
 namespace Magento\Checkout\Model;
 
 use Magento\Checkout\Api\Data\TotalsInformationInterface;
+use Magento\Sales\Model\Order;
 
 /**
  * Class for management of totals information.
@@ -54,7 +55,7 @@ class TotalsInformationManagement implements \Magento\Checkout\Api\TotalsInforma
             $quote->setShippingAddress($addressInformation->getAddress());
             if ($addressInformation->getShippingCarrierCode() && $addressInformation->getShippingMethodCode()) {
                 $shippingMethod = implode(
-                    '_',
+                    Order::DELIMITER_SHIPPING_METHOD,
                     [$addressInformation->getShippingCarrierCode(), $addressInformation->getShippingMethodCode()]
                 );
                 $quoteShippingAddress = $quote->getShippingAddress();

--- a/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
@@ -31,6 +31,7 @@ use Magento\Quote\Model\Shipping;
 use Magento\Quote\Model\ShippingAssignment;
 use Magento\Quote\Model\ShippingAssignmentFactory;
 use Magento\Quote\Model\ShippingFactory;
+use Magento\Sales\Model\Order;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\RuntimeException;
 use PHPUnit\Framework\TestCase;
@@ -359,7 +360,7 @@ class ShippingInformationManagementTest extends TestCase
             ->method('getCountryId')
             ->willReturn('USA');
 
-        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+        $this->setShippingAssignmentsMocks($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $shippingMethod);
 
         $this->quoteMock->expects($this->once())
             ->method('getItemsCount')
@@ -425,7 +426,7 @@ class ShippingInformationManagementTest extends TestCase
             ->method('getCountryId')
             ->willReturn('USA');
 
-        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+        $this->setShippingAssignmentsMocks($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $shippingMethod);
 
         $this->quoteMock->expects($this->once())
             ->method('getItemsCount')
@@ -488,7 +489,7 @@ class ShippingInformationManagementTest extends TestCase
             ->method('getCountryId')
             ->willReturn('USA');
 
-        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+        $this->setShippingAssignmentsMocks($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $shippingMethod);
 
         $this->quoteMock->expects($this->once())
             ->method('getItemsCount')
@@ -563,7 +564,7 @@ class ShippingInformationManagementTest extends TestCase
             ->method('getCountryId')
             ->willReturn('USA');
 
-        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+        $this->setShippingAssignmentsMocks($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $shippingMethod);
 
         $this->quoteMock->expects($this->once())
             ->method('getItemsCount')

--- a/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/model/checkout-data-resolver.js
@@ -137,7 +137,7 @@ define([
 
             if (!availableRate && selectedShippingRate) {
                 availableRate = _.find(ratesData, function (rate) {
-                    return rate['carrier_code'] + '_' + rate['method_code'] === selectedShippingRate;
+                    return rate['carrier_code'] + '::' + rate['method_code'] === selectedShippingRate;
                 });
             }
 

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-rates.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/cart/shipping-rates.js
@@ -25,7 +25,7 @@ define([
         shippingRateGroups: ko.observableArray([]),
         selectedShippingMethod: ko.computed(function () {
             return quote.shippingMethod() ?
-                quote.shippingMethod()['carrier_code'] + '_' + quote.shippingMethod()['method_code'] :
+                quote.shippingMethod()['carrier_code'] + '::' + quote.shippingMethod()['method_code'] :
                 null;
         }),
 
@@ -76,7 +76,7 @@ define([
          */
         selectShippingMethod: function (methodData) {
             selectShippingMethodAction(methodData);
-            checkoutData.setSelectedShippingRate(methodData['carrier_code'] + '_' + methodData['method_code']);
+            checkoutData.setSelectedShippingRate(methodData['carrier_code'] + '::' + methodData['method_code']);
 
             return true;
         }

--- a/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/shipping.js
@@ -260,7 +260,7 @@ define([
         isLoading: shippingService.isLoading,
         isSelected: ko.computed(function () {
             return quote.shippingMethod() ?
-                quote.shippingMethod()['carrier_code'] + '_' + quote.shippingMethod()['method_code'] :
+                quote.shippingMethod()['carrier_code'] + '::' + quote.shippingMethod()['method_code'] :
                 null;
         }),
 
@@ -270,7 +270,7 @@ define([
          */
         selectShippingMethod: function (shippingMethod) {
             selectShippingMethodAction(shippingMethod);
-            checkoutData.setSelectedShippingRate(shippingMethod['carrier_code'] + '_' + shippingMethod['method_code']);
+            checkoutData.setSelectedShippingRate(shippingMethod['carrier_code'] + '::' + shippingMethod['method_code']);
 
             return true;
         },

--- a/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/cart/shipping-rates.html
@@ -23,12 +23,12 @@
                                 click: $parents[1].selectShippingMethod,
                                 checked: $parents[1].selectedShippingMethod,
                                 attr: {
-                                        value: carrier_code + '_' + method_code,
-                                        id: 's_method_' + carrier_code + '_' + method_code,
+                                        value: carrier_code + '::' + method_code,
+                                        id: 's_method_' + carrier_code + '::' + method_code,
                                         disabled: false
                                         }
                                 "/>
-                    <label class="label" data-bind="attr: {for: 's_method_' + carrier_code + '_' + method_code}">
+                    <label class="label" data-bind="attr: {for: 's_method_' + carrier_code + '::' + method_code}">
                         <!-- ko text: $data.method_title --><!-- /ko -->
                         <each args="element.getRegion('price')" render=""></each>
                     </label>

--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/shipping-method-item.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/shipping-method-item.html
@@ -11,8 +11,8 @@
                class="radio"
                ifnot="method.error_message"
                ko-checked="element.isSelected"
-               ko-value="method.carrier_code + '_' + method.method_code"
-               attr="'aria-labelledby': 'label_method_' + method.method_code + '_' + method.carrier_code + ' ' + 'label_carrier_' + method.method_code + '_' + method.carrier_code,
+               ko-value="method.carrier_code + '::' + method.method_code"
+               attr="'aria-labelledby': 'label_method_' + method.method_code + '::' + method.carrier_code + ' ' + 'label_carrier_' + method.method_code + '::' + method.carrier_code,
                     'checked': element.rates().length == 1 || element.isSelected" />
     </td>
     <!-- ko ifnot: (method.error_message) -->
@@ -21,10 +21,10 @@
     </td>
     <!-- /ko -->
     <td class="col col-method"
-        attr="'id': 'label_method_' + method.method_code + '_' + method.carrier_code"
+        attr="'id': 'label_method_' + method.method_code + '::' + method.carrier_code"
         text="method.method_title"></td>
     <td class="col col-carrier"
-        attr="'id': 'label_carrier_' + method.method_code + '_' + method.carrier_code"
+        attr="'id': 'label_carrier_' + method.method_code + '::' + method.carrier_code"
         text="method.carrier_title"></td>
 </tr>
 <tr class="row row-error"

--- a/app/code/Magento/Quote/Model/Quote/Address/Rate.php
+++ b/app/code/Magento/Quote/Model/Quote/Address/Rate.php
@@ -6,6 +6,7 @@
 namespace Magento\Quote\Model\Quote\Address;
 
 use Magento\Framework\Model\AbstractModel;
+use Magento\Sales\Model\Order;
 
 /**
  * @api
@@ -98,7 +99,7 @@ class Rate extends AbstractModel
             );
         } elseif ($rate instanceof \Magento\Quote\Model\Quote\Address\RateResult\Method) {
             $this->setCode(
-                $rate->getCarrier() . '_' . $rate->getMethod()
+                $rate->getCarrier() . Order::DELIMITER_SHIPPING_METHOD . $rate->getMethod()
             )->setCarrier(
                 $rate->getCarrier()
             )->setCarrierTitle(

--- a/app/code/Magento/Quote/Model/Quote/ShippingAssignment/ShippingProcessor.php
+++ b/app/code/Magento/Quote/Model/Quote/ShippingAssignment/ShippingProcessor.php
@@ -10,6 +10,7 @@ use Magento\Quote\Api\Data\ShippingInterface;
 use Magento\Quote\Model\ShippingFactory;
 use Magento\Quote\Model\ShippingAddressManagement;
 use Magento\Quote\Model\ShippingMethodManagement;
+use Magento\Sales\Model\Order;
 
 class ShippingProcessor
 {
@@ -65,10 +66,9 @@ class ShippingProcessor
     {
         $this->shippingAddressManagement->assign($quote->getId(), $shipping->getAddress());
         if (!empty($shipping->getMethod()) && $quote->getItemsCount() > 0) {
-            $nameComponents = explode('_', $shipping->getMethod());
-            $carrierCode = array_shift($nameComponents);
-            // carrier method code can contains more one name component
-            $methodCode = implode('_', $nameComponents);
+            $nameComponents = explode(Order::DELIMITER_SHIPPING_METHOD, $shipping->getMethod());
+            $carrierCode = $nameComponents[0];
+            $methodCode = $nameComponents[1];
             $this->shippingMethodManagement->apply($quote->getId(), $carrierCode, $methodCode);
         }
     }

--- a/app/code/Magento/Quote/Model/ShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingMethodManagement.php
@@ -25,6 +25,7 @@ use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Rate;
 use Magento\Quote\Model\Quote\TotalsCollector;
 use Magento\Quote\Model\ResourceModel\Quote\Address as QuoteAddressResource;
+use Magento\Sales\Model\Order;
 
 /**
  * Shipping method read service
@@ -224,7 +225,7 @@ class ShippingMethodManagement implements
             $this->quoteAddressResource->delete($shippingAddress);
             throw new StateException(__('The shipping address is missing. Set the address and try again.'));
         }
-        $shippingMethod = $carrierCode . '_' . $methodCode;
+        $shippingMethod = $carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode;
         $shippingAddress->setShippingMethod($shippingMethod);
         $shippingAssignments = $quote->getExtensionAttributes()->getShippingAssignments();
         if (!empty($shippingAssignments)) {

--- a/app/code/Magento/Quote/Test/Unit/Model/ShippingMethodManagementTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/ShippingMethodManagementTest.php
@@ -456,7 +456,7 @@ class ShippingMethodManagementTest extends TestCase
             ->willReturn($countryId);
         $this->shippingAddress->expects($this->once())
             ->method('setShippingMethod')
-            ->with($carrierCode . '_' . $methodCode);
+            ->with($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode);
         $this->quote->expects($this->once())
             ->method('getExtensionAttributes')
             ->willReturn($this->extensionAttributesMock);
@@ -469,7 +469,7 @@ class ShippingMethodManagementTest extends TestCase
 
         $this->shippingMock->expects($this->once())
             ->method('setMethod')
-            ->with($carrierCode . '_' . $methodCode);
+            ->with($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode);
 
         $this->shippingAssignmentBuilder->expects($this->once())
             ->method('setShipping')
@@ -527,7 +527,7 @@ class ShippingMethodManagementTest extends TestCase
         $this->shippingAddress->expects($this->once())
             ->method('getCountryId')->willReturn($countryId);
         $this->shippingAddress->expects($this->once())
-            ->method('setShippingMethod')->with($carrierCode . '_' . $methodCode);
+            ->method('setShippingMethod')->with($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode);
         $this->quote->expects($this->once())
             ->method('getExtensionAttributes')
             ->willReturn($this->extensionAttributesMock);
@@ -540,7 +540,7 @@ class ShippingMethodManagementTest extends TestCase
 
         $this->shippingMock->expects($this->once())
             ->method('setMethod')
-            ->with($carrierCode . '_' . $methodCode);
+            ->with($carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode);
 
         $this->shippingAssignmentBuilder->expects($this->once())
             ->method('setShipping')

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1372,7 +1372,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         if (!$asObject || !$shippingMethod) {
             return $shippingMethod;
         } else {
-            list($carrierCode, $method) = explode('_', $shippingMethod, 2);
+            list($carrierCode, $method) = preg_split("/::/", $shippingMethod, 2);
             return new \Magento\Framework\DataObject(['carrier_code' => $carrierCode, 'method' => $method]);
         }
     }

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -118,6 +118,11 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     public const REPORT_DATE_TYPE_CREATED = 'created';
 
     public const REPORT_DATE_TYPE_UPDATED = 'updated';
+    
+    /**
+     * Delimiters
+     */
+    public const DELIMITER_SHIPPING_METHOD = '::';
 
     /**
      * @var string
@@ -1372,7 +1377,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         if (!$asObject || !$shippingMethod) {
             return $shippingMethod;
         } else {
-            list($carrierCode, $method) = preg_split("/::/", $shippingMethod, 2);
+            list($carrierCode, $method) = preg_split("/".self::DELIMITER_SHIPPING_METHOD."/", $shippingMethod, 2);
             return new \Magento\Framework\DataObject(['carrier_code' => $carrierCode, 'method' => $method]);
         }
     }

--- a/app/code/Magento/Sales/Model/Service/PaymentFailuresService.php
+++ b/app/code/Magento/Sales/Model/Service/PaymentFailuresService.php
@@ -16,6 +16,7 @@ use Magento\Framework\Translate\Inline\StateInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface as Quote;
 use Magento\Sales\Api\PaymentFailuresInterface;
+use Magento\Sales\Model\Order;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Psr\Log\LoggerInterface;
@@ -215,7 +216,7 @@ class PaymentFailuresService implements PaymentFailuresInterface
         $shippingInfo = $quote->getShippingAddress()->getShippingMethod();
 
         if ($shippingInfo) {
-            $data = explode('_', $shippingInfo);
+            $data = preg_split("/".Order::DELIMITER_SHIPPING_METHOD."/", $shippingInfo);
             $shippingMethod = $data[0];
         }
 

--- a/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
+++ b/app/code/Magento/Shipping/Model/Config/Source/Allmethods.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Shipping\Model\Config\Source;
 
+use Magento\Sales\Model\Order;
+
 /**
  * @inheritdoc
  */
@@ -66,7 +68,7 @@ class Allmethods implements \Magento\Framework\Option\ArrayInterface
                      continue;
                 }
                 $methods[$carrierCode]['value'][] = [
-                    'value' => $carrierCode . '_' . $methodCode,
+                    'value' => $carrierCode . Order::DELIMITER_SHIPPING_METHOD . $methodCode,
                     'label' => '[' . $carrierCode . '] ' . $methodTitle,
                 ];
             }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixes issues related to shipping modules having an underscore in their carrier code, which conflicts with the delimiter "_" used when concatenating the carrier code with the method code to identify a unique shipping method `<carriercode>_<methodcode>`. Replacing the delimiter with "::" allows for more flexibility for both the carrier codes and the method codes, while preventing conflicts.

### Related Pull Requests
<!-- related pull request placeholder -->
https://github.com/magento/magento2/pull/21340

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#31311

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new shipping module having an underscore in its carrier code.
2. Use the Magento\Sales\Model\Order::getShippingMethod() to obtain both the carrier code and method code within an object.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
1. It is important to allow the use of underscores in the carrier code to prevent conflicts between vendors. For example, a merchant may use modules from different vendors to connect to the very same carrier, a situation possibly resulting in a conflict if none of these vendors are using a "vendor_" prefix.
2. Although a possible solution could have been to store the carrier code and method code values in different columns, keeping both values concatenated remains useful to find a specific method using a unique identifier.

### Important
1. **A data patch should be developed** to iterate over all entries present in the `shipping_method` columns of the` sales_order` and `quote_address` tables and the `code` column of the `quote_shipping_rate` table to convert the previous `<carriercode>_<methodcode>` format to the new `<carriercode>::<methodcode>` format by comparing each entry to all available `<carriercode>_<methodcode>` combinations until a match is found. As old entries from uninstalled modules may still exist, the data patch should replace the **last** underscore "_" of each remaining entries, by filtering any entries already containing the new delimiter "::".
2. **A warning should be issued** before releasing this fix as several modules handling `shipping_method` string separation directly could be affected or even break. The fix is rather simple as replacing the affected `explode('_', $shippingMethod);` statement by `preg_split('/' . Order::DELIMITER_SHIPPING_METHOD . '/', $shippingMethod);` should suffice to make any module compatible.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages _(self-explanatory)_
 - [X] All new or changed code is covered with unit/integration tests _(applicable unit tests have been updated)_
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
