### PR TITLE
Issue #13952 - Duplicate orders with same Quote Id at same time with few time difference.

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
+++ b/app/code/Magento/CatalogUrlRewrite/Test/Unit/Observer/ProductProcessUrlRewriteSavingObserverTest.php
@@ -302,7 +302,9 @@ class ProductProcessUrlRewriteSavingObserverTest extends TestCase
      * @param array $origData
      * @param array $newData
      * @param int $expectedExecutionCount
-     * @param int $expectedStoresToAdd
+     * @param array $expectedStoresToAdd
+     * @param array $doesEntityHaveOverriddenVisibilityForStore
+     * @param array $expectedStoresToRemove
      * @throws \Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException
      * @dataProvider urlKeyDataProvider
      */
@@ -312,7 +314,7 @@ class ProductProcessUrlRewriteSavingObserverTest extends TestCase
         int $expectedExecutionCount,
         array $expectedStoresToAdd = [],
         array $doesEntityHaveOverriddenVisibilityForStore = [],
-        array $expectedStoresToRemove = [],
+        array $expectedStoresToRemove = []
     ) {
         $this->product->setData($origData);
         $this->product->setOrigData();

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -388,6 +388,8 @@ class QuoteManagement implements CartManagementInterface
     public function placeOrder($cartId, PaymentInterface $paymentMethod = null)
     {
         $quote = $this->quoteRepository->getActive($cartId);
+        $quote->setIsActive(false);
+        $this->quoteRepository->save($quote);
         $customer = $quote->getCustomer();
         $customerId = $customer ? $customer->getId() : null;
 
@@ -611,6 +613,8 @@ class QuoteManagement implements CartManagementInterface
             );
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
+            $quote->setIsActive(1);
+            $this->quoteRepository->save($quote);
             $this->rollbackAddresses($quote, $order, $e);
             throw $e;
         }

--- a/app/code/Magento/Quote/Model/QuoteManagement.php
+++ b/app/code/Magento/Quote/Model/QuoteManagement.php
@@ -388,10 +388,13 @@ class QuoteManagement implements CartManagementInterface
     public function placeOrder($cartId, PaymentInterface $paymentMethod = null)
     {
         $quote = $this->quoteRepository->getActive($cartId);
-        $quote->setIsActive(false);
-        $this->quoteRepository->save($quote);
         $customer = $quote->getCustomer();
         $customerId = $customer ? $customer->getId() : null;
+
+        if (!$quote->isEmpty()) {
+            $quote->setIsActive(false);
+            $this->quoteRepository->save($quote);
+        }
 
         if ($paymentMethod) {
             $paymentMethod->setChecks(
@@ -613,8 +616,10 @@ class QuoteManagement implements CartManagementInterface
             );
             $this->quoteRepository->save($quote);
         } catch (\Exception $e) {
-            $quote->setIsActive(1);
-            $this->quoteRepository->save($quote);
+            if (!$quote->isEmpty()) {
+                $quote->setIsActive(1);
+                $this->quoteRepository->save($quote);
+            }
             $this->rollbackAddresses($quote, $order, $e);
             throw $e;
         }


### PR DESCRIPTION
### Description (*)
Two different orders have been placed with very few seconds as time difference with same quote Id.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#13952

### Manual testing scenarios (*)
1. Login as a User
2. Add items to cart and proceed through checkout.
3. Select Any payment method. Not click on place order button
4. Now login to the same account in another system.
5. And proceed to checkout with the same items. Not click on place order button.
6. Now you have to click on place order at the same time with both the systems.
7. one of the screen must return failed 
![image](https://user-images.githubusercontent.com/32075735/155634792-053c5f5b-f2db-4e06-bdee-1de1c49cde69.png)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35833: Issue #13952 - Duplicate orders with same Quote Id at same time with few time difference.