### PR TITLE
Let ES exceptions surface instead of showing no products

### DIFF
--- a/app/code/Magento/Elasticsearch7/SearchAdapter/Adapter.php
+++ b/app/code/Magento/Elasticsearch7/SearchAdapter/Adapter.php
@@ -113,13 +113,7 @@ class Adapter implements AdapterInterface
         $query = $this->mapper->buildQuery($request);
         $aggregationBuilder->setQuery($this->queryContainerFactory->create(['query' => $query]));
 
-        try {
-            $rawResponse = $client->query($query);
-        } catch (\Exception $e) {
-            $this->logger->critical($e);
-            // return empty search result in case an exception is thrown from Elasticsearch
-            $rawResponse = self::$emptyRawResponse;
-        }
+        $rawResponse = $client->query($query);
 
         $rawDocuments = $rawResponse['hits']['hits'] ?? [];
         $queryResponse = $this->responseFactory->create(


### PR DESCRIPTION
### Description (*)
If an ES query fails, Magento will show no products on the frontend just like everything is fine. This is terrible and we should let the exception fly so it becomes easily visible instead of having an empty catalog.

### Manual testing scenarios (*)
1. Just put in a wrong hostname for your ES server and your catalog will be empty and without error on the frontend

### Questions or comments
Why is Magento suppressing these critical issues? OK, the message is logged, but the shopkeeper would be better served with an error and Google will also know there is an error instead of indexing an empty page!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
