### PR TITLE
Remove short description reset from product review block

### DIFF
--- a/app/code/Magento/Review/Block/Product/View.php
+++ b/app/code/Magento/Review/Block/Product/View.php
@@ -3,6 +3,9 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
 namespace Magento\Review\Block\Product;
 
 use Magento\Catalog\Api\ProductRepositoryInterface;
@@ -21,14 +24,14 @@ class View extends \Magento\Catalog\Block\Product\View
      *
      * @var ReviewCollection
      */
-    protected $_reviewsCollection;
+    protected ReviewCollection $_reviewsCollection;
 
     /**
      * Review resource model
      *
      * @var \Magento\Review\Model\ResourceModel\Review\CollectionFactory
      */
-    protected $_reviewsColFactory;
+    protected \Magento\Review\Model\ResourceModel\Review\CollectionFactory $_reviewsColFactory;
 
     /**
      * @param \Magento\Catalog\Block\Product\Context $context
@@ -101,12 +104,13 @@ class View extends \Magento\Catalog\Block\Product\View
      * @param bool $displayIfNoReviews
      * @return string
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function getReviewsSummaryHtml(
         \Magento\Catalog\Model\Product $product,
         $templateType = false,
         $displayIfNoReviews = false
-    ) {
+    ): string {
         return $this->getLayout()->createBlock(
             \Magento\Review\Block\Rating\Entity\Detailed::class
         )->setEntityId(
@@ -123,8 +127,9 @@ class View extends \Magento\Catalog\Block\Product\View
      * Get collection of reviews
      *
      * @return ReviewCollection
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function getReviewsCollection()
+    public function getReviewsCollection(): ReviewCollection
     {
         if (null === $this->_reviewsCollection) {
             $this->_reviewsCollection = $this->_reviewsColFactory->create()->addStoreFilter(
@@ -144,7 +149,7 @@ class View extends \Magento\Catalog\Block\Product\View
      *
      * @return bool
      */
-    public function hasOptions()
+    public function hasOptions(): bool
     {
         return false;
     }

--- a/app/code/Magento/Review/Block/Product/View.php
+++ b/app/code/Magento/Review/Block/Product/View.php
@@ -88,8 +88,6 @@ class View extends \Magento\Catalog\Block\Product\View
             return '';
         }
 
-        $product->setShortDescription(null);
-
         return parent::_toHtml();
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

For unknown reasons, the product review block resets the short description in product data. This PR removes the code that causes the product short description to be reset whenever reviews are rendered.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a product that has a short description. 
2. Via layout XML, move the `reviews.tab` block to the beginning of the `content` container for the `catalog_product_view` handle. This is done to create a testing scenario where the product reviews block is rendered before the short description block `product.info.overview` on the product page.
3. Go to the product page. Observe that that the short description is not displayed, even though it should. This is because `\Magento\Review\Block\Product\View::_toHtml` resets the product's short description.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

I could not find any reason why this code exists. It seems to have been an issue all the way in Magento 1.9 ([example issue from StackOverflow](https://magento.stackexchange.com/questions/99616/adding-a-reviews-tab-to-the-product-view-page-removes-short-description/211903)). The code in question has been present in the Magento 2 code base for a long time, having been migrated from Magento 1  ([link to commit](https://github.com/magento/magento2/blame/a15ecb31976feb4ecb62f85257ff6b606fbdbc00/app/code/Mage/Review/Block/Product/View.php)).

This seems to be a legacy workaround all the way from Magento 1, hopefully no longer necessary. I would love to know if anyone has any additional information.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
