### PR TITLE
[35302] Fixed error while running  `sales_clean_orders cron

### DIFF
--- a/app/code/Magento/SalesRule/Model/Coupon/Usage/Processor.php
+++ b/app/code/Magento/SalesRule/Model/Coupon/Usage/Processor.php
@@ -144,6 +144,11 @@ class Processor
         } elseif ($isIncrement) {
             $ruleCustomer->setCustomerId($customerId)->setRuleId($ruleId)->setTimesUsed(1);
         }
+
+        if (!$ruleCustomer->getId() && !$isIncrement) {
+            return;
+        }
+
         $ruleCustomer->save();
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR fixes  `SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (magento2.salesrule_customer, CONSTRAINT SALESRULE_CUSTOMER_RULE_ID_SALESRULE_RULE_ID FOREIGN KEY (rule_id) REFERENCES salesrule (rule_id) ON DELETE CASCADE), query was: INSERT INTO salesrule_customer () VALUES ()` error which was reported in https://github.com/magento/magento2/issues/35302 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35302


### Actual result
I don't see reported error 
<img width="570" alt="Screenshot 2022-04-13 at 18 29 17" src="https://user-images.githubusercontent.com/13517181/163216179-c64626fb-2446-4c90-bafa-7ba7f4d2c2f4.png">

