### PR TITLE
Fix Magento Bulk API fpr PUT / DELETE requests

### DIFF
--- a/app/code/Magento/WebapiAsync/Controller/Rest/Asynchronous/InputParamsResolver.php
+++ b/app/code/Magento/WebapiAsync/Controller/Rest/Asynchronous/InputParamsResolver.php
@@ -113,12 +113,13 @@ class InputParamsResolver
 
         $this->requestValidator->validate();
         $webapiResolvedParams = [];
+        $inputData = $this->getInputData();
         $route = $this->getRoute();
         $routeServiceClass = $route->getServiceClass();
         $routeServiceMethod = $route->getServiceMethod();
         $this->inputArraySizeLimitValue->set($route->getInputArraySizeLimit());
 
-        foreach ($this->getInputData() as $key => $singleEntityParams) {
+        foreach ($inputData as $key => $singleEntityParams) {
             $webapiResolvedParams[$key] = $this->resolveBulkItemParams(
                 $singleEntityParams,
                 $routeServiceClass,


### PR DESCRIPTION
### Description (*)
Since Magento 2.4.4 and 2.4.3-p2 releases, whole processing of BULK API requests for PUT and DETELE is not possible anymore.

This Pull requests fixes this issue.

### Fixed Issues (if relevant)
Issue is the following: 
If you will try to execute any Bulk API requests by using PUT or DELETE methods, for endpoints which contain parameter in URL's. Example: 

`{{URL}}rest/async/bulk/V1/products/bySku`

Then request will throw an error: 

```
[2022-04-20 05:56:43] report.CRITICAL: TypeError: Argument 1 passed to Magento\WebapiAsync\Controller\Rest\Asynchronous\InputParamsResolver::resolveBulkItemParams() must be of the type array, string given, called in /app/anpwi2ppmb6vw/vendor/magento/module-webapi-async/Controller/Rest/Asynchronous/InputParamsResolver.php on line 128 and defined in /app/anpwi2ppmb6vw/vendor/magento/module-webapi-async/Controller/Rest/Asynchronous/InputParamsResolver.php:182
```

### Manual testing scenarios (*)
1. Execute any Rest Api Buld request. For example for endpoint: `{{URL}}rest/async/bulk/V1/products/bySku`.
2. You have to receive 200 code back.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35370: Fix Magento Bulk API fpr PUT / DELETE requests