### PR TITLE
catalogAddToCart moved to data-mage-init and product_sku option removed

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
@@ -86,6 +86,7 @@ $_helper = $block->getData('outputHelper');
                                         <form data-role="tocart-form"
                                               data-product-sku="<?= $escaper->escapeHtml($_product->getSku()) ?>"
                                               action="<?= $escaper->escapeUrl($postParams['action']) ?>"
+                                              data-mage-init='{"catalogAddToCart": {}}'
                                               method="post">
                                             <?php $options = $block->getData('viewModel')->getOptionsData($_product); ?>
                                             <?php foreach ($options as $optionItem): ?>
@@ -161,13 +162,4 @@ $_helper = $block->getData('outputHelper');
     </div>
     <?= $block->getChildBlock('toolbar')->setIsBottom(true)->toHtml() ?>
     <?php // phpcs:ignore Magento2.Legacy.PhtmlTemplate ?>
-    <script type="text/x-magento-init">
-    {
-        "[data-role=tocart-form], .form.map.checkout": {
-            "catalogAddToCart": {
-                "product_sku": "<?= $escaper->escapeJs($_product->getSku()) ?>"
-            }
-        }
-    }
-    </script>
 <?php endif; ?>


### PR DESCRIPTION
### Description (*)

I've implemented products infinite scroll for a project and I got a bug that `catalogAddToCart` widget doesn't work for new loaded items after repeating scripts applying.

It happens because I tried to load only items from a grid which exists only in a loop but the script tag that has to call `catalogAddToCart` inserted after the grid:
<img width="986" alt="image" src="https://user-images.githubusercontent.com/28815318/164516719-e8a24749-6241-4e7c-bac1-6a98693dd79a.png">

It can be fixed by manual widget calling after parsing html, as:
<img width="782" alt="image" src="https://user-images.githubusercontent.com/28815318/164517242-ae08a6d8-9cb0-49a1-9283-b69140cdc448.png">

But before doing that I didn't understand why the option `product_sku` added to the widget when this initialization is outside of loop:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/28815318/164517544-42f62fcb-fab6-40ae-b20a-2667f315bd3a.png">

I've investigated how it works, and I got that the option doesn't necessary, because the product SKU passed to widget from the form data attribute:
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/28815318/164517966-d820b853-9513-45aa-a9f6-af10804da59a.png">

And I've additionally investigated that elements with the selector `.form.map.checkout` don't exist on PLP:
<img width="1494" alt="image" src="https://user-images.githubusercontent.com/28815318/164518584-74ecf32a-1d88-4364-9736-b34cf00c3b7c.png">

So, we can remove it from the template.

And better solution is to move the script initialization to the loop to fix the issue when the product will be loaded after AJAX, all scripts inside the loop can be initialized by triggering the event `contentUpdated` without separated calling of `catalogAddToCart` widget:
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/28815318/164518949-8848771f-8437-4d8d-851b-9752d72d7de8.png">
<img width="833" alt="image" src="https://user-images.githubusercontent.com/28815318/164519122-423641f3-a67b-4cce-a3f5-04eac13348cf.png">


### Related Pull Requests

When the script have been added:
https://github.com/magento/magento2/commit/617d107e0347bfc330310a4e545671767551f0b7

When the property `product_sku` was added:
https://github.com/magento/magento2/commit/3494fbb0cfb4a952308bc775027017b064911865

### Manual testing scenarios (*)

1. Create a custom theme like Vendor/theme
2. Create the handle with the content:
```shell
app/design/frontend/Vendor/theme/Magento_Catalog/layout/catalog_category_view.xml
```
```xml
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <body>
        <referenceContainer name="content">
            <block template="Magento_Catalog::load-more.phtml" after="category.products"/>
        </referenceContainer>
    </body>
</page>
```
3. Create the template with the content to call a script:
```shell
app/design/frontend/Vendor/theme/Magento_Catalog/templates/load-more.phtml
```
```html
<script type="text/x-magento-init">
    {
        "*": {
            "Magento_Catalog/js/load-more": {}
        }
    }
</script>
```
4. Create the widget if IAS:
```shell
app/design/frontend/Vendor/theme/Magento_Catalog/web/js/load-more.js
```
```js
define(['jquery', 'mage/storage', 'mage/translate', 'jquery-ui-modules/widget'], ($, storage, $t) => {
    'use strict';

    $.widget('custom.loadMore', {
        _init() {
            this.appendLoadMoreButton();
        },

        appendLoadMoreButton() {
            $('.products.wrapper .product-items').after(
                $('<button/>', {
                    text: $t('Load more'),
                    click: this.getProducts.bind(this)
                })
            );
        },

        getProducts() {
            storage.get(`${window.location.pathname}/?p=2`).done(this.appendItems.bind(this));
        },

        appendItems(response) {
            const listSelector = '.products.wrapper .product-items';
            const list = $(listSelector);
            const items = $(response).find(`${listSelector} .product-item`);

            if (!items.length) return this;

            list.append(items);
            list.trigger('contentUpdated');
        }
    });

    return $.custom.loadMore;
});
```
5. Go to the page domain.tld/women/tops-women.html
6. And press the button "Load More":
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/28815318/164520249-4b3feece-0967-46c8-9a6d-61bdd270264e.png">
7. AJAX Add to Cart widget has to work for all uploaded items.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35480: catalogAddToCart moved to data-mage-init and product_sku option removed