### PR TITLE
fixes issue #34289: Incorrect qty to ship after few creditmemos; qty_…

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -232,7 +232,10 @@ class Item extends AbstractModel implements OrderItemInterface
      */
     public function getSimpleQtyToShip()
     {
-        $qty = $this->getQtyOrdered() - $this->getQtyShipped() - $this->getQtyRefunded() - $this->getQtyCanceled();
+        $qty = $this->getQtyOrdered();
+        $qty -= $this->getQtyShipped();
+        $qty -= $this->getQtyRefunded();
+        $qty -= $this->getQtyCanceled();
         return max(round($qty, 8), 0);
     }
 

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -232,7 +232,7 @@ class Item extends AbstractModel implements OrderItemInterface
      */
     public function getSimpleQtyToShip()
     {
-        $qty = $this->getQtyOrdered() - max($this->getQtyShipped(), $this->getQtyRefunded()) - $this->getQtyCanceled();
+        $qty = $this->getQtyOrdered() - $this->getQtyShipped() - $this->getQtyRefunded() - $this->getQtyCanceled();
         return max(round($qty, 8), 0);
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -321,7 +321,7 @@ class ItemTest extends TestCase
                     'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 5, 'qty_shipped' => 4,
                     'qty_canceled' => 0
                 ],
-                'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 0.0]
+                'expectedResult' => ['to_ship' => 3.0, 'to_invoice' => 0.0]
             ],
             'complete' => [
                 'options' => [
@@ -339,10 +339,10 @@ class ItemTest extends TestCase
             ],
             'completely_shipped_using_decimals' => [
                 'options' => [
-                    'qty_ordered' => 4.4, 'qty_invoiced' => 0.4, 'qty_refunded' => 0.4, 'qty_shipped' => 4,
+                    'qty_ordered' => 4.8, 'qty_invoiced' => 0.4, 'qty_refunded' => 0.4, 'qty_shipped' => 4,
                     'qty_canceled' => 0,
                 ],
-                'expectedResult' => ['to_ship' => 0.4, 'to_invoice' => 4.0]
+                'expectedResult' => ['to_ship' => 0.4, 'to_invoice' => 4.4]
             ],
             'completely_invoiced_using_decimals' => [
                 'options' => [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
It seems to me, that qtyToShip does not handle refunds correctly. Ship an item, which has been refunded does not make sense IMHO.

Therefore, the unit test spec seems also wrong to me. Consider this:

qty_ordered: 12
qty_refunded: 5
qty_shipped: 4

If 5 items were refunded and 4 were already shipped, there are only 3 items left, right?

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#34289

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps from issue: 

1. Create simple product with more than 10 QTY
2. Place order with 10 created simples (pay by check money order)
3. Go to order in admin and create invoice for 10 QTY
4. Ship 1 item
5. Create credit memo for 2 items
6. Create one more credit memo for 2 items
7. Ship 2 items (please note that allowed to ship is 6)
8. Click Ship again and see that allowed to ship is 6 again, but I think it should be 4 (because we have shipped 2 items one step ago)

Before change:
![Selection_2056](https://user-images.githubusercontent.com/584644/164991145-140106c0-84d0-4a1a-8938-3b3867a71904.png)
After change:
![Selection_2057](https://user-images.githubusercontent.com/584644/164991150-087e4eb8-3008-4c72-81df-785212eb712a.png)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
