### PR TITLE
fix: prevent successive comma on address preview

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/shipping-address/address-renderer/default.html
@@ -10,7 +10,7 @@
     <if args="address().company">
         <text args="address().company"></text><br>
     </if>
-    <text args="_.values(address().street).join(', ')"></text><br>
+    <text args="_.values(address().street).filter(value => !!value).join(', ')"></text><br>
     <text args="address().city "></text>, <span text="address().region"></span> <text args="address().postcode"></text><br>
     <text args="getCountryName(address().countryId)"></text><br>
     <a if="address().telephone" attr="'href': 'tel:' + address().telephone" text="address().telephone"></a><br>


### PR DESCRIPTION
### Description (*)
In stores with multiple optional address line(s), sometimes one of them can be empty when the customer reaches the checkout. In such scenarios, the shipping address preview box is showing successive commas as seen below:

![image](https://user-images.githubusercontent.com/4603111/165323382-d809d77d-cca8-4303-9203-398b3c004160.png)

This PRs prevents this:
![image](https://user-images.githubusercontent.com/4603111/165323412-50b8f2f4-d8f7-4dd5-acf7-a9477b636510.png)

### Manual testing scenarios (*)
1. enable multi-line address `bin/magento config:set -n --lock-env customer/address/street_lines 4`
2. create a dummy customer;
3. create a new address (through admin or my account) and let one of the address lines empty;
4. add any product to cart and proceeds to checkout;
5. observe the shipping address preview;

After the fix:
1. repeated the steps above an notice that the successive commas are gone.

Tested on a Magento 2.4.3-p1 store with a custom checkout on the Luma one (clean 2.4.4 Luma install validation pending), in both Chrome (v100) and Firefox (v99);

### Questions or comments
Maybe there's a reason for this not have been implemented yet?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] ~~All new or changed code is covered with unit/integration tests (if applicable)~~
 - [ ] ~~README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update~~
 - [ ] All automated tests passed successfully (all builds are green) - pending
