### PR TITLE
fix: setup:di:compile create interceptors without methods handled by …

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
@@ -60,6 +60,7 @@ class InterceptionConfigurationBuilder
      * @param Type $typeReader
      * @param Manager $cacheManager
      * @param InterceptableValidator $interceptableValidator
+     * @param ConfigInterface $omConfig
      */
     public function __construct(
         InterceptionConfig $interceptionConfig,
@@ -206,16 +207,25 @@ class InterceptionConfigurationBuilder
      */
     private function getInterceptedMethods($interceptionConfiguration)
     {
-        $pluginDefinitionList = new \Magento\Framework\Interception\Definition\Runtime();
         foreach ($interceptionConfiguration as &$plugins) {
-            $pluginsMethods = [];
-            foreach ($plugins as $plugin) {
-                $pluginsMethods = array_unique(
-                    array_merge($pluginsMethods, array_keys($pluginDefinitionList->getMethodList($plugin)))
-                );
-            }
-            $plugins = $pluginsMethods;
+            $plugins = $this->getPluginsMethods($plugins);
         }
         return $interceptionConfiguration;
+    }
+
+    /**
+     * Returns plugins methods
+     *
+     * @param array $plugins
+     * @return array
+     */
+    private function getPluginsMethods(array $plugins)
+    {
+        $pluginDefinitionList = new \Magento\Framework\Interception\Definition\Runtime();
+        $pluginsMethodsToMerge = [];
+        foreach ($plugins as $plugin) {
+            $pluginsMethodsToMerge[] = array_keys($pluginDefinitionList->getMethodList($plugin));
+        }
+        return array_unique(array_merge(...$pluginsMethodsToMerge));
     }
 }

--- a/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Generator/InterceptionConfigurationBuilder.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\App\Cache\Manager;
 use Magento\Framework\App\Interception\Cache\CompiledConfig;
 use Magento\Framework\Interception\Config\Config as InterceptionConfig;
+use Magento\Framework\Interception\ObjectManager\ConfigInterface;
 use Magento\Setup\Module\Di\Code\Reader\Type;
 use Magento\Framework\ObjectManager\InterceptableValidator;
 
@@ -49,6 +50,11 @@ class InterceptionConfigurationBuilder
     private $interceptableValidator;
 
     /**
+     * @var ConfigInterface
+     */
+    private $omConfig;
+
+    /**
      * @param InterceptionConfig $interceptionConfig
      * @param PluginList $pluginList
      * @param Type $typeReader
@@ -60,13 +66,15 @@ class InterceptionConfigurationBuilder
         PluginList $pluginList,
         Type $typeReader,
         Manager $cacheManager,
-        InterceptableValidator $interceptableValidator
+        InterceptableValidator $interceptableValidator,
+        ConfigInterface $omConfig
     ) {
         $this->interceptionConfig = $interceptionConfig;
         $this->pluginList = $pluginList;
         $this->typeReader = $typeReader;
         $this->cacheManager = $cacheManager;
         $this->interceptableValidator = $interceptableValidator;
+        $this->omConfig = $omConfig;
     }
 
     /**
@@ -159,10 +167,11 @@ class InterceptionConfigurationBuilder
 
             $pluginInstances = [];
             foreach ($plugins as $plugin) {
-                if (in_array($plugin['instance'], $pluginInstances)) {
+                $pluginInstance = $this->omConfig->getOriginalInstanceType($plugin['instance']);
+                if (in_array($pluginInstance, $pluginInstances, true)) {
                     continue;
                 }
-                $pluginInstances[] = $plugin['instance'];
+                $pluginInstances[] = $pluginInstance;
             }
             $filteredData[$instance] = $pluginInstances;
         }

--- a/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Generator/InterceptionConfigurationBuilderTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Module/Di/Code/Generator/InterceptionConfigurationBuilderTest.php
@@ -10,6 +10,7 @@ namespace Magento\Setup\Test\Unit\Module\Di\Code\Generator;
 use Magento\Framework\App\Cache\Manager;
 use Magento\Framework\App\Interception\Cache\CompiledConfig;
 use Magento\Framework\Interception\Config\Config;
+use Magento\Framework\Interception\ObjectManager\ConfigInterface;
 use Magento\Framework\ObjectManager\InterceptableValidator;
 use Magento\Setup\Module\Di\Code\Generator\InterceptionConfigurationBuilder;
 use Magento\Setup\Module\Di\Code\Generator\PluginList;
@@ -50,6 +51,11 @@ class InterceptionConfigurationBuilderTest extends TestCase
      */
     private $interceptableValidator;
 
+    /**
+     * @var MockObject
+     */
+    private $omConfig;
+
     protected function setUp(): void
     {
         $this->interceptionConfig =
@@ -61,6 +67,7 @@ class InterceptionConfigurationBuilderTest extends TestCase
         $this->cacheManager = $this->createMock(Manager::class);
         $this->interceptableValidator =
             $this->createMock(InterceptableValidator::class);
+        $this->omConfig = $this->getMockForAbstractClass(ConfigInterface::class);
 
         $this->typeReader = $this->createPartialMock(Type::class, ['isConcrete']);
         $this->model = new InterceptionConfigurationBuilder(
@@ -68,7 +75,8 @@ class InterceptionConfigurationBuilderTest extends TestCase
             $this->pluginList,
             $this->typeReader,
             $this->cacheManager,
-            $this->interceptableValidator
+            $this->interceptableValidator,
+            $this->omConfig
         );
     }
 
@@ -105,6 +113,10 @@ class InterceptionConfigurationBuilderTest extends TestCase
         $this->pluginList->expects($this->once())
             ->method('getPluginsConfig')
             ->willReturn(['instance' => $plugins]);
+
+        $this->omConfig->expects($this->any())
+            ->method('getOriginalInstanceType')
+            ->willReturnArgument(0);
 
         $this->model->addAreaCode('areaCode');
         $this->model->getInterceptionConfiguration($definedClasses);


### PR DESCRIPTION
…plugins defined as virtual type

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
After use `setup:di:compile` command interceptors are created without methods handled by plugins defined as virtual type.

<!-- ### Related Pull Requests -->
<!-- related pull request placeholder -->

<!-- ### Fixed Issues (if relevant) -->
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
<!-- 1. Fixes magento/magento2#<issue_number> -->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Switch Magento to Developer mode
2. Clear all content of `generated` directory
3. Add plugin to any class (ex. admin dashboard controller)
3. Define plugin as virtual type
4. Trigger the code where your plugin should be used (ex. open admin dashboard)
5. Check code of generated interceptor of class handled by your virtual plugin. 
Your should see all public method of base class.
7. Use `setup:di:compile` command to generate interceptors
8. Check again code of generated interceptor of class handled by your virtual plugin.
You should see public methods handled by plugins only. But methods handled by plugins defined as virtual type are ignored.

<!-- ### Questions or comments -->
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
