### PR TITLE
Prevent consecutive logins due to spamming enter key on one-page checkout

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/action/login.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/action/login.js
@@ -24,6 +24,8 @@ define([
             messageContainer = messageContainer || globalMessageList;
             let customerLoginUrl = 'customer/ajax/login';
 
+            $('input:focus').blur();
+
             if (loginData.customerLoginUrl) {
                 customerLoginUrl = loginData.customerLoginUrl;
                 delete loginData.customerLoginUrl;


### PR DESCRIPTION
Preventing consecutive login events by blurring the input fields on submit.

### Description (*)
When using the one-page checkout the user will get the option to logon to the site if the email address is already known.
When typing the username / password, users can repeatedly press enter and multiple login events get fired.

The big issue is that when doing this while te page is reloaded, the login event is cancelled and the user is logged out.
This results in a redirect to an "empty cart" page and probably a loss of sale.

This PR will prevent that by removing focus from all input fields and thus any [enter] press will not trigger extra submits.

### Manual testing scenarios (*)

1. Enable one page checkout
2. create a user account, but log out
3. Order an item
4. In the checkout when asked for a password hit [enter] multiple times. Especially just before/during the page reload that gets triggerd.
5. See how you will get logged out.

