### PR TITLE
Fixes type error in curl adapter in case the curl execution failed.

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php
@@ -211,6 +211,9 @@ class Curl implements \Zend_Http_Client_Adapter_Interface
     public function read()
     {
         $response = curl_exec($this->_getResource());
+        if ($response === false) {
+            return '';
+        }
 
         // Remove 100 and 101 responses headers
         while (\Zend_Http_Response::extractCode($response) == 100

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Adapter/CurlTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Adapter/CurlTest.php
@@ -41,6 +41,17 @@ class CurlTest extends TestCase
     }
 
     /**
+     * @param string $response
+     */
+    public function testReadFailure()
+    {
+        self::$curlExectClosure = function () {
+            return false;
+        };
+        $this->assertEquals('', $this->model->read());
+    }
+
+    /**
      * @return array
      */
     public function readDataProvider()


### PR DESCRIPTION
### Description (*)
When `curl_exec` fails, it will return `false`.
This result can be [passed on](https://github.com/magento/magento2/blob/608507e1191ecfef363390bec1cc3f848199595a/lib/internal/Magento/Framework/HTTP/Adapter/Curl.php#L213-L224) to `preg_replace` in an argument that [expects](https://www.php.net/manual/en/function.preg-replace.php) either an `array` or a `string`. In this case it will be a string, because `curl_exec` either returns a `bool` or a `string`.
Since PHP 8, internal php functions are throwing TypeErrors when you pass the wrong type of an argument and when `declare(strict_types=1);` is set.
So this code can start throwing errors now. This PR fixes that.



### Related Pull Requests

### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios (*)
1. Setup clean Magento on PHP 8.1
2. Make sure it uses https in both the secure and unsecure base url. And that this https certificate is a selfsigned certificate that's not trusted by your operating system or php
3. Open the backoffice of Magento, you'll see this error in the top left corner: `TypeError: preg_replace(): Argument #3 ($subject) must be of type array|string, bool given`:
![Screenshot 2022-05-02 at 17 44 14](https://user-images.githubusercontent.com/85479/166265029-a0679322-5a38-43b7-8e79-513e79c693de.png)

You'll also find the following stacktrace in your `var/log/system.log` file:
```
main.CRITICAL: TypeError: preg_replace(): Argument #3 ($subject) must be of type array|string, bool given in lib/internal/Magento/Framework/HTTP/Adapter/Curl.php:224
Stack trace:
#0 lib/internal/Magento/Framework/HTTP/Adapter/Curl.php(224): preg_replace('/Transfer-Encod...', '', false)
#1 app/code/Magento/AdminNotification/Model/System/Message/Security.php(107): Magento\Framework\HTTP\Adapter\Curl->read()
#2 app/code/Magento/AdminNotification/Model/System/Message/Security.php(85): Magento\AdminNotification\Model\System\Message\Security->_isFileAccessible()
#3 app/code/Magento/AdminNotification/Model/System/Message/Security.php(131): Magento\AdminNotification\Model\System\Message\Security->_canShowNotification()
#4 app/code/Magento/AdminNotification/Model/ResourceModel/System/Message/Collection/Synchronized.php(32): Magento\AdminNotification\Model\System\Message\Security->isDisplayed()
#5 generated/code/Magento/AdminNotification/Model/ResourceModel/System/Message/Collection/Synchronized/Interceptor.php(23): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized->_afterLoad()
#6 lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(594): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized\Interceptor->_afterLoad()
#7 generated/code/Magento/AdminNotification/Model/ResourceModel/System/Message/Collection/Synchronized/Interceptor.php(338): Magento\Framework\Data\Collection\AbstractDb->loadWithFilter(false, false)
#8 lib/internal/Magento/Framework/Data/Collection/AbstractDb.php(565): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized\Interceptor->loadWithFilter(false, false)
#9 generated/code/Magento/AdminNotification/Model/ResourceModel/System/Message/Collection/Synchronized/Interceptor.php(329): Magento\Framework\Data\Collection\AbstractDb->load(false, false)
#10 lib/internal/Magento/Framework/Data/Collection.php(840): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized\Interceptor->load()
#11 generated/code/Magento/AdminNotification/Model/ResourceModel/System/Message/Collection/Synchronized/Interceptor.php(671): Magento\Framework\Data\Collection->getIterator()
#12 lib/internal/Magento/Framework/Data/Collection.php(741): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized\Interceptor->getIterator()
#13 lib/internal/Magento/Framework/Interception/Interceptor.php(58): Magento\Framework\Data\Collection->toArray()
#14 lib/internal/Magento/Framework/Interception/Interceptor.php(138): Magento\AdminNotification\Model\ResourceModel\System\Message\Collection\Synchronized\Interceptor->___callParent('toArray', Array)

...
```
4. Apply the changes from this commit
5. **Flush your cache** (make sure to always flush the Magento cache in between tries, because in case there is no error, it gets cached, so when you want to re-trigger the error, make sure to flush the cache)
6. Open the backoffice again, and no more errors

### Questions or comments
I saw this being triggered on my local because Magento checks in the backoffice if the file `app/etc/config.php` is readable over http, and it uses the curl adapter for it, that happens [over here](https://github.com/magento/magento2/blob/44d8a9301f7b531b2ede76fbc2f11bfef6b121af/app/code/Magento/AdminNotification/Model/System/Message/Security.php#L99-L112), and since I'm using a self signed https certificate on my local, I started noticing this error all over the backoffice of Magento.

I've chosen to fix it by just returning an empty string because that's how it worked on PHP 7.4: https://3v4l.org/ApSpT
It's probably better to throw an Exception, but that would be backwards incompatible most likely.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35411: Fixes type error in curl adapter in case the curl execution failed.