### PR TITLE
Wrong state for virtual order

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -41,6 +41,8 @@ class State
             } elseif ($currentState === Order::STATE_PROCESSING && !$order->canShip()) {
                 $order->setState(Order::STATE_COMPLETE)
                     ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_COMPLETE));
+            } elseif ($order->getIsVirtual() && $order->getStatus() === Order::STATE_CLOSED) {
+                $order->setState(Order::STATE_CLOSED);
             }
         }
         return $this;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR sets correct state for order with virtual product while creating credit memo. 

**_Actual result_**
I see correct status after credit memo was created for order with virtual product
<img width="505" alt="Screenshot 2022-05-05 at 10 12 33" src="https://user-images.githubusercontent.com/13517181/166877350-048bd8e2-3137-4f0b-b97f-40ec5ef454f7.png">


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35283

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Steps provided in https://github.com/magento/magento2/issues/35283 
