### PR TITLE
Fixed issue #35329, open and close events were triggered at the sime time

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -431,7 +431,7 @@ define([
                  * @param {jQuery.Event} event
                  */
                 'click .ui-menu-item:has(a)': function (event) {
-                    var target;
+                    var target, submenu;
 
                     event.preventDefault();
                     target = $(event.target).closest('.ui-menu-item');
@@ -439,6 +439,12 @@ define([
 
                     if (!target.hasClass('level-top') || !target.has('.ui-menu').length) {
                         window.location.href = target.find('> a').attr('href');
+                    }
+
+                    submenu = target.find('ul.submenu').first();
+
+                    if (submenu.attr('aria-expanded') == "true") {
+                        this.collapseAll(event, true);
                     }
                 },
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I found that when clicking on a menu item to expand its submenu, **both** submenu **open** and **close events were invoked**.

In this way it is not possible to keep the submenu open and navigable.

The element selector used the _.ui-state-active_ class to determine whether the submenu was open or closed.

For some reason the check _:has(.ui-state-active)_ is always true, even if the element doesn't actually have the class.

I just thought about using the value of the aria-expanded attribute to determine if the submenu is closed or open.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35329

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. You should be able to navigate the main menu with subcategories on mobile devices.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
