### PR TITLE
Use Correct Verb in Table Schema Definition Docs

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/schema.xsd
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/etc/schema.xsd
@@ -78,7 +78,7 @@
     <xs:complexType name="table">
         <xs:annotation>
             <xs:documentation>
-                Table definition. Here we can found column, constraints and indexes
+                Table definition. Here we can find column, constraints and indexes
             </xs:documentation>
         </xs:annotation>
         <xs:choice minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
# Description
Updates `db_schema.xml` table definition documentation to use the correct verb: `found` -> `find`. 

# Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] `README.md` files for modified modules are updated and included in the pull request if any [`README.md` predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35505: Use Correct Verb in Table Schema Definition Docs