### PR TITLE
fix: InvalidArgumentException when block content is null

### DIFF
--- a/app/code/Magento/Cms/Block/Block.php
+++ b/app/code/Magento/Cms/Block/Block.php
@@ -75,7 +75,7 @@ class Block extends AbstractBlock implements \Magento\Framework\DataObject\Ident
             /** @var \Magento\Cms\Model\Block $block */
             $block = $this->_blockFactory->create();
             $block->setStoreId($storeId)->load($blockId);
-            if ($block->isActive()) {
+            if ($block->isActive() && $block->getContent() !== null) {
                 $html = $this->_filterProvider->getBlockFilter()->setStoreId($storeId)->filter($block->getContent());
             }
         }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->
### Description (*)

If the content of the cms block is `null` rendering it in a phtml template resulted in an `InvalidArgumentException` exception and rendered the error message of the exception instead.

### Testing scenarios (*)

1. Create a CMS Block with `null` as its content (not an empty string, it has to be `null` in the database). We did that with a data patch but for the purpose of testing this and update of the CMS block in the db should work fine too (`update cms_block set content = null where block_id = ...`).
2. Inject the CMS block via xml in a block with a phtml template:
```xml
<block class="Magento\Framework\View\Element\Template" name="product.note.additional.wrap"
    template="MyVendor_MyModule::product_note_additional_wrap.phtml">
    <block class="Magento\Cms\Block\Block" name="product.note.additional.content" as="additional.note.content">
        <arguments>
            <argument name="block_id" xsi:type="string">my_cms_block_name</argument>
        </arguments>
    </block>
</block>
```
3. In the phtml template, try to render the block like this:
```phtml
<?php
/** @var \Magento\Framework\View\Element\Template $block */

$content = $block->getChildBlock('additional.note.content')->toHtml();

if ($content): ?>
    <div class="w-full bg-gray-200 p-4 flex mb-4 text-sm print:hidden">
        <?= $content ?>
    </div>
<?php
endif;
```

**Expected Result:** No content should be rendered as the CMS block is empty (`null` in the db).

**Actual Result before this PR:** The following exception occured:

```
[2022-05-23T10:34:11.391976+00:00] .CRITICAL: InvalidArgumentException: Argument 'value' must be type of string, NULL given. in vendor/magento/framework/Filter/Template.php:177
Stack trace:
#0 vendor/magento/module-email/Model/Template/Filter.php(1106): Magento\Framework\Filter\Template->filter()
#1 vendor/magento/framework/Interception/Interceptor.php(58): Magento\Email\Model\Template\Filter->filter()
#2 vendor/magento/framework/Interception/Interceptor.php(138): Magento\Widget\Model\Template\Filter\Interceptor->___callParent()
#3 vendor/magento/framework/Interception/Interceptor.php(153): Magento\Widget\Model\Template\Filter\Interceptor->Magento\Framework\Interception\{closure}()
#4 generated/code/Magento/Widget/Model/Template/Filter/Interceptor.php(284): Magento\Widget\Model\Template\Filter\Interceptor->___callPlugins()
#5 vendor/magento/module-cms/Block/Block.php(79): Magento\Widget\Model\Template\Filter\Interceptor->filter()
#6 vendor/magento/framework/View/Element/AbstractBlock.php(1095): Magento\Cms\Block\Block->_toHtml()
#7 vendor/magento/framework/View/Element/AbstractBlock.php(1099): Magento\Framework\View\Element\AbstractBlock->Magento\Framework\View\Element\{closure}()
#8 vendor/magento/framework/View/Element/AbstractBlock.php(660): Magento\Framework\View\Element\AbstractBlock->_loadCache()
#9 app/design/frontend/MyVendor/MyTheme/MyVendor_MyModule/templates/product_note_additional_wrap.phtml(6): Magento\Framework\View\Element\AbstractBlock->toHtml()
```

The text `InvalidArgumentException: Argument 'value' must be type of string, NULL given.` was rendered instead of the CMS block's content.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
