### PR TITLE
fix: sending customer emails with php 8.1

### DIFF
--- a/lib/internal/Magento/Framework/Filter/Input/MaliciousCode.php
+++ b/lib/internal/Magento/Framework/Filter/Input/MaliciousCode.php
@@ -47,7 +47,7 @@ class MaliciousCode implements \Zend_Filter_Interface
     {
         $replaced = 0;
         do {
-            $value = preg_replace($this->_expressions, '', $value, -1, $replaced);
+            $value = preg_replace($this->_expressions, '', $value ?? '', -1, $replaced);
         } while ($replaced !== 0);
         return  $value;
     }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Sending emails (tested with the order email) in an environment with php 8.1 failed with this exception: 

```
Deprecated Functionality: preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/vendor/magento/framework/Filter/Input/MaliciousCode.php on line 50
```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup Magento with php 8.1
2. Place an order as guest
3. Email should be sent properly without an error

Alternatively this can be verified using the [yiero email tester](https://packagist.org/packages/yireo/magento2-emailtester2).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35569: fix: sending customer emails with php 8.1