### PR TITLE
magento/magento2#32464: Magento erroneously assums one category is parent of another based on category path

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryManagement.php
+++ b/app/code/Magento/Catalog/Model/CategoryManagement.php
@@ -128,7 +128,7 @@ class CategoryManagement implements \Magento\Catalog\Api\CategoryManagementInter
             $afterId = ($afterId === null || $afterId > $lastId) ? $lastId : $afterId;
         }
         $parentPath = $parentCategory->getPath() ?? '';
-        $path = $model->getPath();
+        $path = $model->getPath() . '/';
         if ($path && strpos($parentPath, $path) === 0) {
             throw new \Magento\Framework\Exception\LocalizedException(
                 __('Operation do not allow to move a parent category to any of children category')

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryManagementTest.php
@@ -201,8 +201,8 @@ class CategoryManagementTest extends TestCase
 
     public function testMove()
     {
-        $categoryId = 2;
-        $parentId = 1;
+        $categoryId = 4;
+        $parentId = 40;
         $afterId = null;
         $categoryMock = $this->getMockBuilder(Category::class)
             ->setMockClassName('categoryMock')
@@ -214,18 +214,25 @@ class CategoryManagementTest extends TestCase
             ->getMock();
 
         $this->categoryRepositoryMock
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(6))
             ->method('get')
             ->willReturnMap([
                 [$categoryId, null, $categoryMock],
                 [$parentId, null, $parentCategoryMock],
             ]);
-        $parentCategoryMock->expects($this->once())->method('hasChildren')->willReturn(true);
+        $parentCategoryMock->expects($this->exactly(3))->method('hasChildren')
+            ->willReturn(true, false, false);
         $parentCategoryMock->expects($this->once())->method('getChildren')->willReturn('5,6,7');
-        $categoryMock->expects($this->once())->method('getPath');
-        $parentCategoryMock->expects($this->once())->method('getPath');
-        $categoryMock->expects($this->once())->method('move')->with($parentId, '7');
+        $categoryMock->expects($this->exactly(3))->method('getPath')
+            ->willReturnOnConsecutiveCalls('2/4', '2/3/4', '2/3/4');
+        $parentCategoryMock->expects($this->exactly(3))->method('getPath')
+            ->willReturnOnConsecutiveCalls('2/40', '2/3/40', '2/3/44/40');
+        $categoryMock->expects($this->exactly(3))->method('move')
+            ->withConsecutive([$parentId, '7'], [$parentId, null], [$parentId, null]);
+
         $this->assertTrue($this->model->move($categoryId, $parentId, $afterId));
+        $this->assertTrue($this->model->move($categoryId, $parentId));
+        $this->assertTrue($this->model->move($categoryId, $parentId));
     }
 
     public function testMoveWithException()
@@ -251,8 +258,8 @@ class CategoryManagementTest extends TestCase
                 [$categoryId, null, $categoryMock],
                 [$parentId, null, $parentCategoryMock],
             ]);
-        $categoryMock->expects($this->once())->method('getPath')->willReturn('test');
-        $parentCategoryMock->expects($this->once())->method('getPath')->willReturn('test');
+        $categoryMock->expects($this->once())->method('getPath')->willReturn('test/2');
+        $parentCategoryMock->expects($this->once())->method('getPath')->willReturn('test/2/1');
         $this->model->move($categoryId, $parentId, $afterId);
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
According to https://github.com/magento/magento2/issues/32464 Method `\Magento\Catalog\Model\CategoryManagement::move` throws error when 1 category id starts with the category id of the other. (Like id 14 and id 146).

Changes in PR:
- Update Unit test to reproduce issue
- Fix check for parent category path


### Related Pull Requests
<!-- related pull request placeholder -->
no

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#32464

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Steps to reproduce described in fixed issue magento/magento2#32464.
Bug can't be reproduced in admin (see https://github.com/magento/magento2/issues/32464#issuecomment-865641790). Also bug affects `/V1/categories/:categoryId/move` webapi.
Manual test via swagger:
1. Setup categories in admin similar as in issue example.
2. Go to `magento/swagger` and Authorize using Admin credentials/or configured API integration key.
3. Go to `catalogCategoryManagementV1` section and `/v1/categories/{categoryId}/move` method
4. Set categoryId = 14 and parentId = 146 (or your according values). And execute.
5. Before fix response code 400 and response `"message": "Operation do not allow to move a parent category to any of children category"`
6. After fix result code 200 and response `true`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
--

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
