### PR TITLE
Fix incorrect `@var` docblocks

### DIFF
--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/admin/note.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/admin/note.phtml
@@ -5,8 +5,8 @@
  */
 
 /**
- * @var $block \Magento\Backend\Block\Template
- * @var $escaper \Magento\Framework\Escaper
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
  */
 ?>
 <div class="adobe-ims-note spectrum-Body spectrum-Body--sizeL">

--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/admin/sign_in.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/admin/sign_in.phtml
@@ -5,9 +5,9 @@
  */
 
 /**
- * @var $block \Magento\Backend\Block\Template
- * @var $escaper \Magento\Framework\Escaper
- * @var $viewModel \Magento\AdminAdobeIms\ViewModel\LinkViewModel
+ * @var \Magento\Backend\Block\Template $block
+ * @var \Magento\Framework\Escaper $escaper
+ * @var \Magento\AdminAdobeIms\ViewModel\LinkViewModel $viewModel
  */
 $viewModel = $block->getLinkViewModel();
 ?>

--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/load_icons.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/load_icons.phtml
@@ -9,8 +9,8 @@ use Magento\Framework\View\Element\Messages;
 use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /**
- * @var $block Messages
- * @var $escaper Escaper
+ * @var Messages $block
+ * @var Escaper $escaper
  * @var SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/messages/admin_adobe_ims_messages.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/messages/admin_adobe_ims_messages.phtml
@@ -8,8 +8,8 @@ use Magento\Backend\Block\Template;
 use Magento\Framework\Escaper;
 
 /**
- * @var $block Template
- * @var $escaper Escaper
+ * @var Template $block
+ * @var Escaper $escaper
  */
 ?>
 <div class="spectrum-InLineAlert spectrum-InLineAlert--error admin-adobe-ims-message-container">

--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/messages/wrapper.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/messages/wrapper.phtml
@@ -5,8 +5,8 @@
  */
 
 /**
- * @var $block \Magento\Framework\View\Element\Messages
- * @var $viewModel \Magento\AdminAdobeIms\ViewModel\MessageViewModel
+ * @var \Magento\Framework\View\Element\Messages $block
+ * @var \Magento\AdminAdobeIms\ViewModel\MessageViewModel $viewModel
  */
 $viewModel = $block->getMessageViewModel();
 ?>

--- a/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/user/reauth.phtml
+++ b/app/code/Magento/AdminAdobeIms/view/adminhtml/templates/user/reauth.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\AdminAdobeIms\Block\Adminhtml\ImsReAuth
+ * @var \Magento\AdminAdobeIms\Block\Adminhtml\ImsReAuth $block
  */
 ?>
 

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\AdminNotification\Block\System\Messages */
+/** @var \Magento\AdminNotification\Block\System\Messages $block */
 ?>
 
 <?php $lastCritical = $block->getLastCritical();?>

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages/popup.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages/popup.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\AdminNotification\Block\System\Messages\UnreadMessagePopup */
+/** @var \Magento\AdminNotification\Block\System\Messages\UnreadMessagePopup $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/toolbar_entry.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/toolbar_entry.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 // phpcs:disable Generic.Files.LineLength
-/** @var $block \Magento\AdminNotification\Block\ToolbarEntry */
+/** @var \Magento\AdminNotification\Block\ToolbarEntry $block */
     $notificationCount = $block->getUnreadNotificationCount();
     $notificationCounterMax = $block->getNotificationCounterMax();
 ?>
@@ -27,7 +27,7 @@
             class="admin__action-dropdown-menu"
             data-mark-as-read-url="<?= $block->escapeUrl($block->getUrl('adminhtml/notification/ajaxMarkAsRead')) ?>">
             <?php foreach ($block->getLatestUnreadNotifications() as $notification): ?>
-                <?php /** @var $notification \Magento\AdminNotification\Model\Inbox */ ?>
+                <?php /** @var \Magento\AdminNotification\Model\Inbox $notification */ ?>
                 <li class="notifications-entry<?php if ($notification->getSeverity() == 1): ?> notifications-critical<?php endif; ?>"
                     data-notification-id="<?= $block->escapeHtmlAttr($notification->getId()) ?>"
                     data-notification-severity="<?php if ($notification->getSeverity() == 1): ?>1<?php endif; ?>">

--- a/app/code/Magento/AdobeIms/view/adminhtml/templates/signIn.phtml
+++ b/app/code/Magento/AdobeIms/view/adminhtml/templates/signIn.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\AdobeIms\Block\Adminhtml\SignIn
+ * @var \Magento\AdobeIms\Block\Adminhtml\SignIn $block
  */
 ?>
 <div data-bind="scope: 'adobe-login'" class="adobe-login-container">

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/page.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/page.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Backend\Block\Page */ ?>
+<?php /** @var \Magento\Backend\Block\Page $block */ ?>
 <!doctype html>
 <html lang="<?= $block->escapeHtmlAttr($block->getLang()) ?>" class="no-js">
 

--- a/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Backend\Block\Media\Uploader */
+/** @var \Magento\Backend\Block\Media\Uploader $block */
 ?>
 
 <div id="<?= $block->getHtmlId() ?>" class="uploader"

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Page\Header */
+/** @var \Magento\Backend\Block\Page\Header $block */
 $part = $block->getShowPart();
 ?>
 <?php if ($part === 'logo') : ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/js/components.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/js/components.phtml
@@ -11,5 +11,5 @@
  */
 ?>
 
-<?php /** @var $block \Magento\Framework\View\Element\Js\Components */ ?>
+<?php /** @var \Magento\Framework\View\Element\Js\Components $block */ ?>
 <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Backend\Block\Store\Switcher */
+/* @var \Magento\Backend\Block\Store\Switcher $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($websites = $block->getWebsites()): ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher/form/renderer/fieldset/element.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/* @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element */
+/* @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element $block */
 $element = $block->getElement();
 $note = $element->getNote() ? '<div class="note">' . $element->getNote() . '</div>' : '';
 $elementBeforeLabel = $element->getExtType() == 'checkbox' || $element->getExtType() == 'radio';

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/search.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/search.phtml
@@ -9,7 +9,7 @@
 use Magento\Backend\Block\GlobalSearch;
 use Magento\Framework\Json\Helper\Data;
 
-/** @var $block GlobalSearch */
+/** @var GlobalSearch $block */
 /** @var Data $helper */
 $helper = $this->helper(Data::class);
 

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/button.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/button.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Backend\Block\Widget\Button
+ * @var \Magento\Backend\Block\Widget\Button $block
  */
 ?>
 <?= $block->getBeforeHtml() ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/button/split.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/button/split.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Backend\Block\Widget\Button\SplitButton */
+/** @var \Magento\Backend\Block\Widget\Button\SplitButton $block */
 ?>
 
 <div <?= $block->getAttributesHtml() ?>>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Widget\Form */
+/** @var \Magento\Backend\Block\Widget\Form $block */
 ?>
 <?php /* @todo replace .form-inline with better class name */?>
 <?php /* ToDo UI: check if we need this wrapper in the process of global forms refactoring */ ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/container.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/container.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Widget\Form\Container */
+/** @var \Magento\Backend\Block\Widget\Form\Container $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?= /* @noEscape */ $block->getFormInitScripts() ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/** @var $element \Magento\Framework\Data\Form\Element\Fieldset */
+/** @var \Magento\Framework\Data\Form\Element\Fieldset $element */
 $element = $block->getElement();
 $containerId = $element->getFieldsetContainerId();
 $id = $element->getHtmlId();

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset/element.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/* @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element */
+/* @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element $block */
 $element = $block->getElement();
 $note = $element->getNote() ? '<div class="note admin__field-note" id="' . $element->getId() . '-note">' . $element->getNote() . '</div>' : '';
 $elementBeforeLabel = $element->getExtType() == 'checkbox admin__control-checkbox' || $element->getExtType() == 'radio admin__control-radio';

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid.phtml
@@ -16,7 +16,7 @@
  *  getVarNamePage()
  *
  */
-/* @var $block \Magento\Backend\Block\Widget\Grid */
+/* @var \Magento\Backend\Block\Widget\Grid $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/column_set.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/column_set.phtml
@@ -7,7 +7,7 @@
 <?php
 /**
  * Template for \Magento\Backend\Block\Widget\Grid\ColumnSet
- * @var $block \Magento\Backend\Block\Widget\Grid\ColumnSet
+ * @var \Magento\Backend\Block\Widget\Grid\ColumnSet $block
  */
 $numColumns = count($block->getColumns());
 ?>
@@ -22,7 +22,7 @@ $numColumns = count($block->getColumns());
             <?php if ($block->isHeaderVisible() || $block->getFilterVisibility()) : ?>
                 <tr>
                 <?php foreach ($block->getColumns() as $_column) : ?>
-                    <?php /* @var $_column \Magento\Backend\Block\Widget\Grid\Column */ ?>
+                    <?php /* @var \Magento\Backend\Block\Widget\Grid\Column $_column */ ?>
                     <?php if ($_column->getHeaderHtml() == '&nbsp;') :?>
                         <th class="data-grid-th" data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
                             <?= $_column->getHeaderHtmlProperty() ?>>&nbsp;</th>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/serializer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/serializer.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Backend\Block\Widget\Grid\Serializer
+ * @var \Magento\Backend\Block\Widget\Grid\Serializer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Widget\Tabs */
+/** @var \Magento\Backend\Block\Widget\Tabs $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!empty($tabs)): ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/catalog/product/edit/tab/attributes/extend.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/catalog/product/edit/tab/attributes/extend.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Attributes\Extend */
+/** @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Attributes\Extend $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $elementHtml = $block->getParentElementHtml();
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/bundle.phtml
@@ -6,7 +6,7 @@
 ?>
 
 <?php
-/* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle */
+/* @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Checkbox */ ?>
+<?php /* @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Checkbox $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections = $_option->getSelections(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Multi */ ?>
+<?php /* @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Multi $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections = $_option->getSelections(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Radio */ ?>
+<?php /* @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Radio $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default = $_option->getDefaultSelection(); ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Select */ ?>
+<?php /* @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Select $block */ ?>
 <?php $_option      = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle */
+/** @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option */
+/** @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <script id="bundle-option-template" type="text/x-magento-template">
@@ -309,11 +309,11 @@ bOption = new Bundle.Option(optionTemplate);
 script;
 
 foreach ($block->getOptions() as $_option) {
-    /** @var $_option \Magento\Bundle\Model\Option */
+    /** @var \Magento\Bundle\Model\Option $_option */
     $scriptString .= /* @noEscape */ 'optionIndex = bOption.add('. $_option->toJson() . ');' . PHP_EOL;
     if ($_option->getSelections()) {
         foreach ($_option->getSelections() as $_selection) {
-            /** @var $_selection \Magento\Catalog\Model\Product */
+            /** @var \Magento\Catalog\Model\Product $_selection */
             $_selection->setName($block->escapeHtml($_selection->getName()));
             $scriptString .= /* @noEscape */ 'bSelection.addRow(optionIndex,' . $_selection->toJson() . ');' . PHP_EOL;
         }

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/search.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/search.phtml
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Search */
+/** @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Search $block */
 ?>
 <?= $block->getChildHtml();

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/selection.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/selection.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Selection */
+/** @var \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Selection $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <script id="bundle-option-selection-box-template" type="text/x-magento-template">

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
@@ -7,7 +7,7 @@
 /**
  * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
  */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
@@ -7,7 +7,7 @@
 /**
  * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
  */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
@@ -7,7 +7,7 @@
 /**
  * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
  */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
@@ -7,7 +7,7 @@
 /**
  * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
  */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
@@ -7,7 +7,7 @@
 /**
  * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer
  */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
+/** @var \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle */
+/* @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle $block */
 ?>
 <?php $_product = $block->getProduct() ?>
 <?php if ($block->displayProductStockStatus()) : ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Checkbox */ ?>
+<?php /* @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Checkbox $block */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_selections = $_option->getSelections() ?>
 <?php $inputClass = 'checkbox product bundle option bundle-option-' . $block->escapeHtmlAttr($_option->getId()) ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Multi */ ?>
+<?php /* @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Multi $block */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_selections = $_option->getSelections() ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
@@ -5,7 +5,7 @@
  */
 use Magento\Bundle\ViewModel\ValidateQuantity;
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Radio */ ?>
+<?php /* @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Radio $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
@@ -5,7 +5,7 @@
  */
 use Magento\Bundle\ViewModel\ValidateQuantity;
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Select */ ?>
+<?php /* @var \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Select $block */ ?>
 <?php $_option      = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/options.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/options.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block Magento\Bundle\Block\Catalog\Product\View\Type\Bundle */ ?>
+<?php /** @var Magento\Bundle\Block\Catalog\Product\View\Type\Bundle $block */ ?>
 <?php
 $product = $block->getProduct();
 $helper = $this->helper(Magento\Catalog\Helper\Output::class);

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/creditmemo/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/creditmemo/default.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
+<?php /** @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block */ ?>
 <?php $parentItem = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/invoice/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/invoice/default.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
+<?php /** @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block */ ?>
 
 <?php $parentItem = $block->getItem() ?>
 <?php $items = $block->getChildren($parentItem) ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/order/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/order/default.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
+<?php /** @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getOrder() ?>
 

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/shipment/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/shipment/default.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
+<?php /** @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block */ ?>
 
 <?php $parentItem = $block->getItem() ?>
 

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable Generic.Files.LineLength
 /** @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter */
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
+<?php /** @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block */ ?>
 <?php $parentItem = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/checkboxes/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/checkboxes/tree.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Catalog\Block\Adminhtml\Category\Tree
+ * @var \Magento\Catalog\Block\Adminhtml\Category\Tree $block
  */
 ?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Catalog\Block\Adminhtml\Category\Edit
+ * @var \Magento\Catalog\Block\Adminhtml\Category\Edit $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Category\Tree */
+/** @var \Magento\Catalog\Block\Adminhtml\Category\Tree $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="categories-side-col">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/form/renderer/fieldset/element.phtml
@@ -5,11 +5,11 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Catalog\Block\Adminhtml\Form\Renderer\Fieldset\Element */
+/** @var \Magento\Catalog\Block\Adminhtml\Form\Renderer\Fieldset\Element $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php
-/* @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element */
+/* @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element $block */
 $element = $block->getElement();
 $note = $element->getNote() ?
     '<div class="note admin__field-note">' . $block->escapeHtml($element->getNote()) . '</div>' : '';

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml
@@ -7,7 +7,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Backend\Block\Widget\Form\Container
+ * @var \Magento\Backend\Block\Widget\Form\Container $block
  */
 ?>
 <?= /* @noEscape */ $block->getFormInitScripts() ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/labels.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/labels.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels  */
+/** @var \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels $block  */
 ?>
 
 <div class="fieldset-wrapper admin__collapsible-block-wrapper opened" id="manage-titles-wrapper">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options */
+/** @var \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options $block */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main */
+/** @var Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="attribute-set">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options */ ?>
+<?php /* @var \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options $block */ ?>
 <?php $options = $block->decorateArray($block->getOptions()); ?>
 <?php if (count($options)) :?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */
+/* @var \Magento\Catalog\Block\Product\View\Options\Type\Date $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options */ ?>
+<?php /* @var \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options $block */ ?>
 <?php $option = $block->getOption(); ?>
 <div class="admin__field field">
     <label class="admin__field-label label">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */
+/* @var \Magento\Catalog\Block\Product\View\Options\Type\File $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_option = $block->getOption(); ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select */ ?>
+<?php /* @var \Magento\Catalog\Block\Product\View\Options\Type\Select $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <div class="admin__field field<?= $_option->getIsRequire() ? ' _required' : '' ?>">
     <label class="label admin__field-label">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
+<?php /* @var \Magento\Catalog\Block\Product\View\Options\Type\Text $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <div class="field admin__field<?= $_option->getIsRequire() ? ' required _required' : '' ?>">
     <label class="admin__field-label label">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/qty.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/qty.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty */ ?>
+<?php /* @var \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty $block */ ?>
 
 <fieldset id="product_composite_configure_fields_qty"
           class="fieldset product-composite-qty-block admin__fieldset <?= $block->getIsLastFieldset() ? 'last-fieldset' : '' ?>">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit
+ * @var \Magento\Catalog\Block\Adminhtml\Product\Edit $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute */
+/** @var Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute $block */
 ?>
 
 <form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>"

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/websites.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/websites.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites */
+/** @var Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/attribute_set.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/attribute_set.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 
-/* @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\AttributeSet */
+/* @var \Magento\Catalog\Block\Adminhtml\Product\Edit\AttributeSet $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <script id="product-template-selector-template" type="text/x-magento-template">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/category/new/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/category/new/form.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/* @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\NewCategory */
+/* @var \Magento\Catalog\Block\Adminhtml\Product\Edit\NewCategory $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/option.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/option.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getTemplatesHtml() ?>
@@ -143,7 +143,7 @@ jQuery(function ($) {
     fieldSet.customOptions({$customOptions});
     //adding data to templates
 script;
-/** @var $_value \Magento\Framework\DataObject */
+/** @var \Magento\Framework\DataObject $_value */
 foreach ($block->getOptionValues() as $_value):
     $scriptString .= " fieldSet.customOptions('addOption', " . /* @noEscape */ $_value->toJson() . ');' . PHP_EOL;
 endforeach;

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/date.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Date */ ?>
+<?php /** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Date $block */ ?>
 <script id="custom-option-date-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/file.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\File */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\File $block */
 ?>
 <script id="custom-option-file-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/select.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Select */ ?>
+<?php /** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Select $block */ ?>
 <script id="custom-option-select-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/text.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Text */ ?>
+<?php /** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Text $block */ ?>
 <script id="custom-option-text-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/price/tier.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/price/tier.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 
-/* @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Price\Tier */
+/* @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Price\Tier $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $element = $block->getElement();
 ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/serializer.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/serializer.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax\Serializer */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax\Serializer $block */
 ?>
 
 // phpcs:disable Magento2.Security.InsecureFunction.DiscouragedWithAlternative

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/websites.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/websites.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Websites */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Websites $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset id="grop_fields" class="fieldset">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $elementName = $block->getElement()->getName() . '[images]';
 $formName = $block->getFormName();

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->isReadonly()):?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/attribute/search.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/attribute/search.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes\Search */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes\Search $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="product-attribute-search-container" class="suggest-expandable attribute-selector">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs $block */
 ?>
 <?php if (!empty($tabs)) :?>
     <?php $tabGroups = [
@@ -55,7 +55,7 @@
 
                 <ul <?= /* @noEscape */ $block->getUiId('tab', $tabGroupId) ?> class="tabs admin__page-nav-items" data-role="content">
                     <?php foreach ($tabs as $_tab) :?>
-                        <?php /** @var $_tab \Magento\Backend\Block\Widget\Tab\TabInterface */ ?>
+                        <?php /** @var \Magento\Backend\Block\Widget\Tab\TabInterface $_tab */ ?>
                         <?php if (!$block->canShowTab($_tab) || $_tab->getParentTab()
                             || ($_tab->getGroupCode() && $_tab->getGroupCode() != $tabGroupCode)
                             || (!$_tab->getGroupCode() && $isBasic)) : continue;

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs/child_tab.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs/child_tab.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\ChildTab */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\ChildTab $block */
 ?>
 <div class="fieldset-wrapper admin__collapsible-block-wrapper" data-tab="<?= /* @noEscape */ $block->getTabId() ?>"
      id="<?= /* @noEscape */ $block->getTabId() ?>-wrapper" data-mage-init='{"collapsible":{

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Grid */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Grid $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="<?= $block->getHtmlId() ?>" class="admin__grid-massaction">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/url_filter_applier.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/url_filter_applier.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Template */
+/** @var \Magento\Backend\Block\Template $block */
 ?>
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Catalog/view/adminhtml/templates/rss/grid/link.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/rss/grid/link.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Rss\Grid\Link */
+/** @var \Magento\Catalog\Block\Adminhtml\Rss\Grid\Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) :?>
 <a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>

--- a/app/code/Magento/Catalog/view/base/templates/product/composite/fieldset/options/view/checkable.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/composite/fieldset/options/view/checkable.phtml
@@ -7,7 +7,7 @@
 use Magento\Catalog\Model\Product\Option;
 
 /**
- * @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select\Checkable
+ * @var \Magento\Catalog\Block\Product\View\Options\Type\Select\Checkable $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $option = $block->getOption();

--- a/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 
-<?php /** @var $block \Magento\Framework\Pricing\Render\Amount */ ?>
+<?php /** @var \Magento\Framework\Pricing\Render\Amount $block */ ?>
 
 <span class="price-container <?= $block->escapeHtmlAttr($block->getAdjustmentCssClasses()) ?>"
         <?= $block->getSchema() ? ' itemprop="offers" itemscope itemtype="http://schema.org/Offer"' : '' ?>>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/cms.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/cms.phtml
@@ -8,7 +8,7 @@
 /**
  * Category view template
  *
- * @var $block \Magento\Catalog\Block\Category\View
+ * @var \Magento\Catalog\Block\Category\View $block
  */
 ?>
 <?php if ($block->isContentMode() || $block->isMixedMode()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/description.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/description.phtml
@@ -10,7 +10,7 @@
 /**
  * Category view template
  *
- * @var $block \Magento\Catalog\Block\Category\View
+ * @var \Magento\Catalog\Block\Category\View $block
  */
 ?>
 <?php if ($_description = $block->getCurrentCategory()->getDescription()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/image.phtml
@@ -8,7 +8,7 @@
 /**
  * Category view template
  *
- * @var $block \Magento\Catalog\Block\Category\View
+ * @var \Magento\Catalog\Block\Category\View $block
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis

--- a/app/code/Magento/Catalog/view/frontend/templates/category/products.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/products.phtml
@@ -8,7 +8,7 @@
 /**
  * Category view template
  *
- * @var $block \Magento\Catalog\Block\Category\View
+ * @var \Magento\Catalog\Block\Category\View $block
  */
 ?>
 <?php if (!$block->isContentMode() || $block->isMixedMode()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/rss.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/rss.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Category\Rss\Link */
+/** @var \Magento\Catalog\Block\Category\Rss\Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink() && $block->isTopCategory()) :?>
     <a href="<?= $block->escapeUrl($block->getLink()) ?>"

--- a/app/code/Magento/Catalog/view/frontend/templates/frontend_storage_manager.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/frontend_storage_manager.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\FrontendStorageManager */
+/** @var Magento\Catalog\Block\FrontendStorageManager $block */
 ?>
 <script type="text/x-magento-init">
         {

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/link.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/link.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Framework\View\Element\Template */
+/** @var Magento\Framework\View\Element\Template $block */
 ?>
 <li class="item link compare" data-bind="scope: 'compareProducts'" data-role="compare-products-link">
     <a class="action compare no-display" title="<?= $block->escapeHtmlAttr(__('Compare Products')) ?>"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -8,7 +8,7 @@
 // phpcs:disable PSR2.ControlStructures.SwitchDeclaration
 // phpcs:disable Generic.WhiteSpace.ScopeIndent
 
-/* @var $block \Magento\Catalog\Block\Product\Compare\ListCompare */
+/* @var \Magento\Catalog\Block\Product\Compare\ListCompare $block */
 ?>
 <?php $total = $block->getItems()->getSize() ?>
 <?php if ($total) :?>
@@ -45,7 +45,7 @@
                 <tr>
                     <?php $index = 0; ?>
                     <?php $helper = $this->helper(Magento\Catalog\Helper\Output::class); ?>
-                    <?php /** @var $item \Magento\Catalog\Model\Product */ ?>
+                    <?php /** @var \Magento\Catalog\Model\Product $item */ ?>
                     <?php foreach ($block->getItems() as $item) :?>
                         <?php if ($index++ == 0) :?>
                             <th scope="row" class="cell label product">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/sidebar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/sidebar.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 
-/* @var $block \Magento\Framework\View\Element\Template */
+/* @var \Magento\Framework\View\Element\Template $block */
 ?>
 <div class="block block-compare" data-bind="scope: 'compareProducts'" data-role="compare-products-sidebar">
     <div class="block-title">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image.phtml
@@ -5,8 +5,8 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Catalog\Block\Product\Image */
-/** @var $escaper \Magento\Framework\Escaper */
+/** @var \Magento\Catalog\Block\Product\Image $block */
+/** @var \Magento\Framework\Escaper $escaper */
 ?>
 <!--deprecated template as image_with_borders is a primary one-->
 <img class="photo image <?= $escaper->escapeHtmlAttr($block->getClass()) ?>"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -5,8 +5,8 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Catalog\Block\Product\Image */
-/** @var $escaper \Magento\Framework\Escaper */
+/** @var \Magento\Catalog\Block\Product\Image $block */
+/** @var \Magento\Framework\Escaper $escaper */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $width = (int)$block->getWidth();
 $paddingBottom = $block->getRatio() * 100;

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml
@@ -10,7 +10,7 @@ use Magento\Framework\App\Action\Action;
 /**
  * Product list template
  *
- * @var $block \Magento\Catalog\Block\Product\ListProduct
+ * @var \Magento\Catalog\Block\Product\ListProduct $block
  * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
@@ -46,7 +46,7 @@ $_helper = $block->getData('outputHelper');
     ?>
     <div class="products wrapper <?= /* @noEscape */ $viewMode ?> products-<?= /* @noEscape */ $viewMode ?>">
         <ol class="products list items product-items">
-            <?php /** @var $_product \Magento\Catalog\Model\Product */ ?>
+            <?php /** @var \Magento\Catalog\Model\Product $_product */ ?>
             <?php foreach ($_productCollection as $_product): ?>
             <li class="item product product-item">
                 <div class="product-item-info"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/addto/compare.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/addto/compare.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare */
+/** @var Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare $block */
 ?>
 <a href="#"
    class="action tocompare"

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -7,7 +7,7 @@
 use Magento\Catalog\ViewModel\Product\Listing\PreparePostData;
 use Magento\Framework\App\ActionInterface;
 
-/* @var $block \Magento\Catalog\Block\Product\AbstractProduct */
+/* @var \Magento\Catalog\Block\Product\AbstractProduct $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 
@@ -261,7 +261,7 @@ $_item = null;
                                                         </button>
                                                     <?php else :?>
                                                         <?php
-                                                        /** @var $viewModel PreparePostData */
+                                                        /** @var PreparePostData $viewModel */
                                                         $viewModel = $block->getViewModel();
                                                         $postArray = $viewModel->getPostData(
                                                             $block->escapeUrl($block->getAddToCartUrl($_item)),

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar.phtml
@@ -8,7 +8,7 @@
 /**
  * Product list toolbar
  *
- * @var $block \Magento\Catalog\Block\Product\ProductList\Toolbar
+ * @var \Magento\Catalog\Block\Product\ProductList\Toolbar $block
  */
 ?>
 <?php if ($block->getCollection()->getSize()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/sorter.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/sorter.phtml
@@ -8,7 +8,7 @@
 /**
  * Product list toolbar
  *
- * @var $block \Magento\Catalog\Block\Product\ProductList\Toolbar
+ * @var \Magento\Catalog\Block\Product\ProductList\Toolbar $block
  */
 ?>
 <div class="toolbar-sorter sorter">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/viewmode.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/viewmode.phtml
@@ -8,7 +8,7 @@
 /**
  * Product list toolbar
  *
- * @var $block \Magento\Catalog\Block\Product\ProductList\Toolbar
+ * @var \Magento\Catalog\Block\Product\ProductList\Toolbar $block
  */
 ?>
 <?php if ($block->isEnabledViewSwitcher()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/listing.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/listing.phtml
@@ -12,7 +12,7 @@
 /**
  * Product list template
  *
- * @var $block \Magento\Catalog\Block\Product\ListProduct
+ * @var \Magento\Catalog\Block\Product\ListProduct $block
  */
 ?>
 <?php

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/additional.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/additional.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View\Additional */
+/** @var \Magento\Catalog\Block\Product\View\Additional $block */
 ?>
 <?php foreach ($block->getChildHtmlList() as $_html) :?>
     <?= /* @noEscape */ $_html ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addto.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addto.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View*/
+/** @var \Magento\Catalog\Block\Product\View $block*/
 ?>
 <div class="product-addto-links" data-role="add-to-links">
     <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View\Addto\Compare */
+/** @var \Magento\Catalog\Block\Product\View\Addto\Compare $block */
 ?>
 
 <?php $viewModel = $block->getData('addToCompareViewModel'); ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+/** @var \Magento\Catalog\Block\Product\View $block */
 ?>
 <?php $_product = $block->getProduct(); ?>
 <?php $buttonTitle = __('Add to Cart'); ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -9,7 +9,7 @@
 /**
  * Product view template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Description
+ * @var \Magento\Catalog\Block\Product\View\Description $block
  */
 ?>
 <?php

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
@@ -9,7 +9,7 @@
 /**
  * Product additional attributes template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Attributes
+ * @var \Magento\Catalog\Block\Product\View\Attributes $block
  */
 ?>
 <?php

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/counter.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/counter.phtml
@@ -6,7 +6,7 @@
 /**
  * Product viewed counter template
  *
- * @var $block \Magento\Catalog\Block\Ui\ProductViewCounter
+ * @var \Magento\Catalog\Block\Ui\ProductViewCounter $block
  */
 ?>
 <script type="text/x-magento-init">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/description.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/description.phtml
@@ -9,7 +9,7 @@
 /**
  * Product description template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Description
+ * @var \Magento\Catalog\Block\Product\View\Description $block
  */
 ?>
 <?= /* @noEscape */ $this->helper(Magento\Catalog\Helper\Output::class)->productAttribute(

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
@@ -9,7 +9,7 @@
 /**
  * Product view template
  *
- * @var $block \Magento\Catalog\Block\Product\View
+ * @var \Magento\Catalog\Block\Product\View $block
  */
 ?>
 <?php $_helper = $this->helper(Magento\Catalog\Helper\Output::class); ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/gallery.phtml
@@ -7,7 +7,7 @@
 /**
  * Product media data template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Gallery
+ * @var \Magento\Catalog\Block\Product\View\Gallery $block
  */
 ?>
 

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/currency.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/currency.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Directory\Block\Currency */
+/** @var \Magento\Directory\Block\Currency $block */
 ?>
 <meta property="product:price:currency"
       content="<?= /* @noEscape */ $block->stripTags($block->getCurrentCurrencyCode()) ?>"/>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+/** @var \Magento\Catalog\Block\Product\View $block */
 ?>
 
 <meta property="og:type" content="product" />

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options */
+/* @var \Magento\Catalog\Block\Product\View\Options $block */
 ?>
 
 <?php $_options = $block->decorateArray($block->getOptions()) ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */ ?>
+<?php /* @var \Magento\Catalog\Block\Product\View\Options\Type\Date $block */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_optionId = $block->escapeHtmlAttr($_option->getId()) ?>
 <?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */
+/* @var \Magento\Catalog\Block\Product\View\Options\Type\File $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_option = $block->getOption(); ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select */ ?>
+<?php /* @var \Magento\Catalog\Block\Product\View\Options\Type\Select $block */ ?>
 <?php
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
+<?php /* @var \Magento\Catalog\Block\Product\View\Options\Type\Text $block */ ?>
 <?php
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/wrapper.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/wrapper.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Catalog\Block\Product\View */
+/** @var Magento\Catalog\Block\Product\View $block */
 ?>
 <?php
 $required = '';

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/review.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/review.phtml
@@ -4,5 +4,5 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Product\AbstractProduct */ ?>
+<?php /** @var \Magento\Catalog\Block\Product\AbstractProduct $block */ ?>
 <?= $block->getReviewsSummaryHtml($block->getProduct(), false, true) ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/type/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\AbstractView */?>
+<?php /* @var \Magento\Catalog\Block\Product\View\AbstractView $block */?>
 <?php $_product = $block->getProduct() ?>
 
 <?php if ($block->displayProductStockStatus()) :?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/grid.phtml
@@ -7,7 +7,7 @@
 <?php
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp(

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/list.phtml
@@ -7,7 +7,7 @@
 <?php
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp(

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/sidebar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/compared/sidebar.phtml
@@ -7,7 +7,7 @@
 <?php
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp(

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -8,7 +8,7 @@
 /**
  * Template for displaying new products widget
  *
- * @var $block \Magento\Catalog\Block\Product\Widget\NewWidget
+ * @var \Magento\Catalog\Block\Product\Widget\NewWidget $block
  */
 
 // phpcs:disable Magento2.Files.LineLength.MaxExceeded

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
@@ -12,7 +12,7 @@
 /**
  * Template for displaying new products widget
  *
- * @var $block \Magento\Catalog\Block\Product\Widget\NewWidget
+ * @var \Magento\Catalog\Block\Product\Widget\NewWidget $block
  */
 if ($exist = ($block->getProductCollection() && $block->getProductCollection()->getSize())) {
     $type = 'widget-new-list';

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/grid.phtml
@@ -8,7 +8,7 @@
 // phpcs:disable Magento2.Security.LanguageConstruct.DirectOutput
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp([

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/list.phtml
@@ -8,7 +8,7 @@
 // phpcs:disable Magento2.Security.LanguageConstruct.DirectOutput
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp([

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/sidebar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/viewed/sidebar.phtml
@@ -7,7 +7,7 @@
 <?php
 // phpcs:disable Magento2.PHP.ShortEchoSyntax.ShortEchoTag
 
-/** @var $block \Magento\Ui\Block\Wrapper */
+/** @var \Magento\Ui\Block\Wrapper $block */
 ?>
 
 <?php /* @noEscape */ echo $block->renderApp(

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CatalogInventory\Block\Qtyincrements
+ * @var \Magento\CatalogInventory\Block\Qtyincrements $block
  */
 ?>
 <?php if ($block->getProductQtyIncrements()) : ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CatalogInventory\Block\Stockqty\Composite
+ * @var \Magento\CatalogInventory\Block\Stockqty\Composite $block
  */
 ?>
 <?php if ($block->isMsgVisible()) : ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty
+ * @var \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty $block
  */
 ?>
 <?php if ($block->isMsgVisible()) : ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
@@ -7,7 +7,7 @@
 /**
  * Catalog advanced search form
  *
- * @var $block \Magento\CatalogSearch\Block\Advanced\Form
+ * @var \Magento\CatalogSearch\Block\Advanced\Form $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\CatalogSearch\Block\Advanced\Result
+ * @var \Magento\CatalogSearch\Block\Advanced\Result $block
  */
 /** this changes need for valid apply filters and configuration before search process is started */
 $productList = $block->getProductListHtml();

--- a/app/code/Magento/Checkout/view/frontend/templates/button.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/button.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Onepage\Success */ ?>
+<?php /** @var \Magento\Checkout\Block\Onepage\Success $block */ ?>
 
 <?php if ($block->getCanViewOrder() && $block->getCanPrintOrder()) :?>
     <a href="<?= $block->escapeUrl($block->getPrintUrl()) ?>"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart.phtml
@@ -8,7 +8,7 @@
 /**
  * Shopping cart template
  *
- * @var $block \Magento\Checkout\Block\Cart
+ * @var \Magento\Checkout\Block\Cart $block
  */
 
 if ($block->getItemsCount()) {

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/additional/info.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/additional/info.phtml
@@ -8,7 +8,7 @@
 <?php
 /**
  * Shopping cart additional info
- * @var $block \Magento\Framework\View\Element\Template
+ * @var \Magento\Framework\View\Element\Template $block
  */
 ?>
 <?php

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/**  @var $block \Magento\Checkout\Block\Cart\Grid */
+/**  @var \Magento\Checkout\Block\Cart\Grid $block */
 ?>
 <?php $mergedCells = ($this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices() ? 2 : 1); ?>
 <?= $block->getChildHtml('form_before') ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+/** @var \Magento\Catalog\Block\Product\View $block */
 ?>
 <?php $_product = $block->getProduct(); ?>
 <?php $buttonTitle = __('Update Cart'); ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.Files.LineLength
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer */
+/** @var \Magento\Checkout\Block\Cart\Item\Renderer $block */
 
 $_item = $block->getItem();
 $product = $_item->getProduct();

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/price/sidebar.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 ?>
 <?php $_item = $block->getItem() ?>
 <div class="price-container">

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit */
+/** @var \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit $block */
 ?>
 <?php if ($block->isProductVisibleInSiteVisibility()) :?>
     <a class="action action-edit"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/remove.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/remove.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove */
+/** @var \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove $block */
 ?>
 <a href="#"
    title="<?= $block->escapeHtml(__('Remove item')) ?>"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/methods.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/methods.phtml
@@ -6,7 +6,7 @@
 
 ?>
 <?php
-/** @var $block \Magento\Checkout\Block\Cart */
+/** @var \Magento\Checkout\Block\Cart $block */
 ?>
 <?php if (!$block->hasError()) :?>
     <?php $methods = $block->getMethods('methods') ?: $block->getMethods('top_methods') ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Cart\Sidebar */
+/** @var \Magento\Checkout\Block\Cart\Sidebar $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/noItems.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/noItems.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/**  @var $block \Magento\Checkout\Block\Cart */
+/**  @var \Magento\Checkout\Block\Cart $block */
 ?>
 <div class="cart-empty">
     <?= $block->getChildHtml('checkout_cart_empty_widget') ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
@@ -5,7 +5,7 @@
  */
 
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Cart\Shipping */ ?>
+<?php /** @var \Magento\Checkout\Block\Cart\Shipping $block */ ?>
 <?php /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */ ?>
 <div id="block-shipping"
      class="block shipping"

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/totals.phtml
@@ -7,7 +7,7 @@
 <?php
 /**
  * Shopping cart totals template
- * @var $block \Magento\Checkout\Block\Cart\Totals
+ * @var \Magento\Checkout\Block\Cart\Totals $block
  */
 ?>
 <div id="cart-totals" class="cart-totals" data-bind="scope:'block-totals'">

--- a/app/code/Magento/Checkout/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/item/price/row.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/item/price/unit.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Onepage */
+/** @var \Magento\Checkout\Block\Onepage $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/failure.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/failure.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Onepage\Failure */
+/** @var \Magento\Checkout\Block\Onepage\Failure $block */
 ?>
 <?php if ($block->getRealOrderId()) :?>
     <p><?= $block->escapeHtml(__('Order #') . $block->getRealOrderId()) ?></p>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block Magento\Checkout\Block\Cart\Item\Renderer */
+/** @var Magento\Checkout\Block\Cart\Item\Renderer $block */
 
 $_item = $block->getItem();
 $taxDataHelper = $this->helper(Magento\Tax\Helper\Data::class);

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_excl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_excl_tax.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_incl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_incl_tax.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_excl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_excl_tax.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_incl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_incl_tax.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
+/** @var \Magento\Checkout\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/registration.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/registration.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Registration */
+/** @var \Magento\Checkout\Block\Registration $block */
 ?>
 <div id="registration" data-bind="scope:'registration'">
     <br />

--- a/app/code/Magento/Checkout/view/frontend/templates/shipping/price.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/shipping/price.phtml
@@ -5,7 +5,7 @@
  */
 
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Shipping\Price */ ?>
+<?php /** @var \Magento\Checkout\Block\Shipping\Price $block */ ?>
 
 <?php $shippingPrice = $block->getShippingPrice(); ?>
 <?= $block->escapeHtml($shippingPrice) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/success.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/success.phtml
@@ -5,7 +5,7 @@
  */
 
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Onepage\Success */ ?>
+<?php /** @var \Magento\Checkout\Block\Onepage\Success $block */ ?>
 <div class="checkout-success">
     <?php if ($block->getOrderId()) :?>
         <?php if ($block->getCanViewOrder()) :?>

--- a/app/code/Magento/Checkout/view/frontend/templates/total/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/total/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Checkout\Block\Total\DefaultTotal */
+/** @var \Magento\Checkout\Block\Total\DefaultTotal $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/additional_agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/additional_agreements.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
  */
 if (!$block->getAgreements()) {
     return;

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
@@ -8,7 +8,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
 ?>
 <?php
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
  */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
@@ -8,7 +8,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
 ?>
 <?php
 /**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
+ * @var \Magento\CheckoutAgreements\Block\Agreements $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
- /** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content */
+ /** @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content $block */
 ?>
 
 <div class="media-gallery-modal" data-mage-init='{"mediabrowser": <?= $block->escapeHtml($block->getFilebrowserSetupObject()) ?>}'>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files */
+/** @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files $block */
 
 $_width  = $block->getImagesWidth();
 

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader */
+/** @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader $block */
 
 $blockHtmlId = $block->getHtmlId();
 ?>

--- a/app/code/Magento/Cms/view/adminhtml/templates/url_filter_applier.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/url_filter_applier.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Template */
+/** @var \Magento\Backend\Block\Template $block */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
 <script type="text/x-magento-init">

--- a/app/code/Magento/Cms/view/frontend/templates/widget/static_block/default.phtml
+++ b/app/code/Magento/Cms/view/frontend/templates/widget/static_block/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Cms\Block\Widget\Block */
+/* @var \Magento\Cms\Block\Widget\Block $block */
 
 ?>
 <div class="widget block block-static-block">

--- a/app/code/Magento/Config/view/adminhtml/templates/page/system/config/robots/reset.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/page/system/config/robots/reset.phtml
@@ -6,7 +6,7 @@
 
 /**
  * @deprecated
- * @var $block \Magento\Backend\Block\Page\System\Config\Robots\Reset
+ * @var \Magento\Backend\Block\Page\System\Config\Robots\Reset $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/switcher.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/switcher.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Backend\Block\Template */
+/* @var \Magento\Backend\Block\Template $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="field field-store-switcher">

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/tabs.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/tabs.phtml
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Config\Block\System\Config\Tabs */
+/** @var \Magento\Config\Block\System\Config\Tabs $block */
 ?>
 
 <?php if ($block->getTabs()) : ?>
     <div id="<?= $block->escapeHtmlAttr($block->getId()) ?>" class="config-nav">
         <?php
-        /** @var $_tab \Magento\Config\Model\Config\Structure\Element\Tab */
+        /** @var \Magento\Config\Model\Config\Structure\Element\Tab $_tab */
         foreach ($block->getTabs() as $_tab) :
             $activeCollapsible = false;
             foreach ($_tab->getChildren() as $_section) {
@@ -35,7 +35,7 @@
                 <ul class="admin__page-nav-items items" data-role="content">
                     <?php $_iterator = 1; ?>
                     <?php
-                    /** @var $_section \Magento\Config\Model\Config\Structure\Element\Section */
+                    /** @var \Magento\Config\Model\Config\Structure\Element\Section $_section */
                     foreach ($_tab->getChildren() as $_section) : ?>
                         <li class="admin__page-nav-item item
                             <?= $block->escapeHtml($_section->getClass()) ?>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/attribute/new/created.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/attribute/new/created.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Attribute\NewAttribute\Product\Created */
+/** @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Attribute\NewAttribute\Product\Created $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $attributes = /* @noEscape */ $block->getAttributesBlockJson();

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_product = $block->getProduct(); ?>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues $block */
 $isAllowedToManageAttributes = $block->getPermissions()->isAllowedToManageAttributes();
 $attributesUrl = $block->getUrl('catalog/product_attribute/getAttributes');
 $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/select_attributes.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/select_attributes.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\SelectAttributes */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\SelectAttributes $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="select-attributes-block <?= /* @noEscape */ $block->getData('config/dataScope') ?>"

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/summary.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/summary.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Summary */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Summary $block */
 
 ?>
 <div data-bind="scope: '<?= /* @noEscape */  $block->getComponentName() ?>'">

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/config.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/config.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config */
+/** @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config $block */
 ?>
 <div class="entry-edit form-inline" id="<?= $block->escapeHtmlAttr($block->getId()) ?>" data-panel="product-variations">
     <div data-bind="scope: 'variation-steps-wizard'" class="product-create-configuration">

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/matrix.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/matrix.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix */
+/** @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard-ajax.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard-ajax.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix */
+/** @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $productMatrix = $block->getProductMatrix();

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix */
+/** @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/form.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/form.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Framework\View\Element\Template */
+/* @var \Magento\Framework\View\Element\Template $block */
 ?>
 <div data-role="affected-attribute-set-selector" class="no-display affected-attribute-set">
     <?= $block->getChildHtml('affected-attribute-set-form') ?>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector */
+/* @var \Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/attribute-selector/js.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/attribute-selector/js.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector */
+/** @var \Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/ConfigurableProduct/view/frontend/templates/product/view/type/options/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/templates/product/view/type/options/configurable.phtml
@@ -6,7 +6,7 @@
 ?>
 
 <?php
-/** @var $block \Magento\ConfigurableProduct\Block\Product\View\Type\Configurable*/
+/** @var \Magento\ConfigurableProduct\Block\Product\View\Type\Configurable $block*/
 $_product    = $block->getProduct();
 $_attributes = $block->decorateArray($block->getAllowAttributes());
 ?>

--- a/app/code/Magento/Cookie/view/base/templates/html/cookie.phtml
+++ b/app/code/Magento/Cookie/view/base/templates/html/cookie.phtml
@@ -7,7 +7,7 @@
 /**
  * Cookie settings initialization script
  *
- * @var $block \Magento\Framework\View\Element\Js\Cookie
+ * @var \Magento\Framework\View\Element\Js\Cookie $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $isCookieSecure = $block->getSessionConfig()->getCookieSecure() ? 'true' : 'false';

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol
+ * @var \Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/matrix.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/matrix.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Matrix
+ * @var \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Matrix $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/services.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/services.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Services
+ * @var \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Services $block
  */
 ?>
 <div class="admin__field">

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rates.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rates.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency
+ * @var \Magento\CurrencySymbol\Block\Adminhtml\System\Currency $block
  */
 ?>
 

--- a/app/code/Magento/Customer/view/adminhtml/templates/tab/cart_website_filter_form.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/tab/cart_website_filter_form.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Widget\Form */
+/** @var \Magento\Backend\Block\Widget\Form $block */
 ?>
 <?= $block->getFormHtml() ?>
 <?= $block->getChildHtml('form_after') ?>

--- a/app/code/Magento/Customer/view/adminhtml/templates/tab/view.phtml
+++ b/app/code/Magento/Customer/view/adminhtml/templates/tab/view.phtml
@@ -8,6 +8,6 @@
  * Template for block \Magento\Customer\Block\Adminhtml\Edit\Tab\View
  */
 
-/** @var $block \Magento\Customer\Block\Adminhtml\Edit\Tab\View */
+/** @var \Magento\Customer\Block\Adminhtml\Edit\Tab\View $block */
 ?>
 <?= $block->getChildHtml();

--- a/app/code/Magento/Customer/view/frontend/templates/account/navigation.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/account/navigation.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Html\Links */
+/** @var \Magento\Framework\View\Element\Html\Links $block */
 ?>
 <div class="block account-nav">
     <div class="title">

--- a/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/forgotpassword.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  *
- * @var $block \Magento\Customer\Block\Account\Forgotpassword
+ * @var \Magento\Customer\Block\Account\Forgotpassword $block
  */
 
 // phpcs:disable Generic.Files.LineLength.TooLong

--- a/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/js/customer-data/invalidation-rules.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Customer\Block\CustomerScopeData */
+/* @var \Magento\Customer\Block\CustomerScopeData $block */
 ?>
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/composite/fieldset/downloadable.phtml
@@ -6,7 +6,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // @deprecated
 ?>
-<?php /* @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable */ ?>
+<?php /* @var \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Downloadable $block */ ?>
 <?php $_linksPurchasedSeparately = $block->getLinksPurchasedSeparately(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
 <?php if (($block->getProduct()->isSaleable() || $_skipSaleableCheck) && $block->hasLinks()) :?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable.phtml
@@ -10,7 +10,7 @@
 
 <?php
 /**
- * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable
+ * @var \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable $block
  */
 ?>
 <script>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/links.phtml
@@ -8,7 +8,7 @@
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 
 /**
- * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links
+ * @var \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links $block
  */
 ?>
 <?php $_product = $block->getProduct()?>

--- a/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
+++ b/app/code/Magento/Downloadable/view/adminhtml/templates/product/edit/downloadable/samples.phtml
@@ -8,7 +8,7 @@
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 
 /**
- * @var $block \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links
+ * @var \Magento\Downloadable\Block\Adminhtml\Catalog\Product\Edit\Tab\Downloadable\Links $block
  */
 
 $_product = $block->getProduct();

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/links.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/links.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Downloadable\Block\Catalog\Product\Links */ ?>
+<?php /* @var \Magento\Downloadable\Block\Catalog\Product\Links $block */ ?>
 <?php $_linksPurchasedSeparately = $block->getLinksPurchasedSeparately(); ?>
 <?php if ($block->getProduct()->isSaleable() && $block->hasLinks()) :?>
     <?php $_links = $block->getLinks(); ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/samples.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/samples.phtml
@@ -7,7 +7,7 @@
 /**
  * Downloadable product links
  *
- * @var $block \Magento\Downloadable\Block\Catalog\Product\Samples
+ * @var \Magento\Downloadable\Block\Catalog\Product\Samples $block
  */
 ?>
 

--- a/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/type.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/catalog/product/type.phtml
@@ -7,7 +7,7 @@
 /**
  * Downloadable product type
  *
- * @var $block \Magento\Downloadable\Block\Catalog\Product\View\Type
+ * @var \Magento\Downloadable\Block\Catalog\Product\View\Type $block
  */
 ?>
 <?php $_product = $block->getProduct() ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/customer/products/list.phtml
@@ -7,7 +7,7 @@
 use Magento\Downloadable\Model\Link\Purchased\Item;
 
 /**
- * @var $block \Magento\Downloadable\Block\Customer\Products\ListProducts
+ * @var \Magento\Downloadable\Block\Customer\Products\ListProducts $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/creditmemo/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/creditmemo/downloadable.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable */ ?>
+<?php /** @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 <tr>

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/invoice/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/invoice/downloadable.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable */ ?>
+<?php /** @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Downloadable $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder() ?>
 <tr>

--- a/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/order/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/email/order/items/order/downloadable.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable */ ?>
+<?php /** @var \Magento\Downloadable\Block\Sales\Order\Email\Items\Order\Downloadable $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder() ?>
 <tr>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/creditmemo/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/creditmemo/items/renderer/downloadable.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/** @var \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable $block */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/invoice/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/invoice/items/renderer/downloadable.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/** @var \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable $block */
 ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>

--- a/app/code/Magento/Downloadable/view/frontend/templates/sales/order/items/renderer/downloadable.phtml
+++ b/app/code/Magento/Downloadable/view/frontend/templates/sales/order/items/renderer/downloadable.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Generic.Files.LineLength
 
-/** @var $block \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable */
+/** @var \Magento\Downloadable\Block\Sales\Order\Item\Renderer\Downloadable $block */
 /** @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter */
 ?>
 <?php $_item = $block->getItem() ?>

--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -8,7 +8,7 @@ use Magento\Framework\App\TemplateTypesInterface;
 
 // phpcs:disable Generic.Files.LineLength.TooLong
 
-/** @var $block \Magento\Email\Block\Adminhtml\Template\Edit */
+/** @var \Magento\Email\Block\Adminhtml\Template\Edit $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!$block->getEditMode()): ?>

--- a/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Email\Block\Adminhtml\Template\Preview */
+/* @var \Magento\Email\Block\Adminhtml\Template\Preview $block */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">

--- a/app/code/Magento/GiftMessage/view/frontend/templates/cart/item/renderer/actions/gift_options.phtml
+++ b/app/code/Magento/GiftMessage/view/frontend/templates/cart/item/renderer/actions/gift_options.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions */
+/** @var \Magento\GiftMessage\Block\Cart\Item\Renderer\Actions\GiftOptions $block */
 ?>
 <?php if (!$block->isVirtual()) : ?>
     <div id="gift-options-cart-item-<?= (int) $block->getItem()->getId() ?>"

--- a/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
+++ b/app/code/Magento/GoogleAdwords/view/frontend/templates/code.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\GoogleAdwords\Block\Code
+ * @var \Magento\GoogleAdwords\Block\Code $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/GoogleAnalytics/view/frontend/templates/ga.phtml
+++ b/app/code/Magento/GoogleAnalytics/view/frontend/templates/ga.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\GoogleAnalytics\Block\Ga */ ?>
+<?php /** @var \Magento\GoogleAnalytics\Block\Ga $block */ ?>
 <?php $accountId = $block->getConfig(\Magento\GoogleAnalytics\Helper\Data::XML_PATH_ACCOUNT) ?>
 <!-- BEGIN GOOGLE ANALYTICS CODE -->
 <script type="text/x-magento-init">

--- a/app/code/Magento/GoogleGtag/view/frontend/templates/ga.phtml
+++ b/app/code/Magento/GoogleGtag/view/frontend/templates/ga.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\GoogleGtag\Block\Ga */
+/** @var \Magento\GoogleGtag\Block\Ga $block */
 /** @var \Magento\Framework\Escaper $escaper */
 
 $analyticsData = $block->getAnalyticsData();

--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/catalog/product/composite/fieldset/grouped.phtml
@@ -6,7 +6,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
 
-<?php /* @var $block \Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped */ ?>
+<?php /* @var \Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped $block */ ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
 <div id="catalog_product_composite_configure_fields_grouped" class="<?= $block->getIsLastFieldset() ? 'last-fieldset' : '' ?>">
     <h4><?= $block->escapeHtml(__('Associated Products')) ?></h4>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/grouped.phtml
@@ -4,9 +4,9 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var \Magento\Framework\View\Element\Template $block */
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var \Magento\Framework\View\Element\Template $block */
 $_gridPopupBlock = $block->getChildBlock('catalog.product.group.grid.popup.container')->getChildBlock('grid');
 $_gridPopupBlock->setRowClickCallback('function(){}');
 ?>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/list.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/list.phtml
@@ -5,7 +5,7 @@
  */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/* @var $block \Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts */
+/* @var \Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts $block */
 ?>
 <script type="text/x-magento-template" id="group-product-template">
 <tr title="#" class="pointer" data-role="row">

--- a/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/default.phtml
+++ b/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\AbstractView */?>
+<?php /* @var \Magento\Catalog\Block\Product\View\AbstractView $block */?>
 <?php $_product = $block->getProduct() ?>
 
 <?php $_associatedProducts = $block->getAssociatedProducts(); ?>

--- a/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/grouped.phtml
@@ -7,8 +7,8 @@
 /**
  * Grouped product data template
  *
- * @var $block \Magento\Catalog\Block\Product\View\BaseImage
- * @var $block \Magento\GroupedProduct\Block\Product\View\Type\Grouped
+ * @var \Magento\Catalog\Block\Product\View\BaseImage $block
+ * @var \Magento\GroupedProduct\Block\Product\View\Type\Grouped $block
  */
 ?>
 <?php $block->setPreconfiguredValue(); ?>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/** @var $block \Magento\ImportExport\Block\Adminhtml\Import\Edit\Before */
+/** @var \Magento\ImportExport\Block\Adminhtml\Import\Edit\Before $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 $fieldNameSourceFile = \Magento\ImportExport\Model\Import::FIELD_NAME_SOURCE_FILE;
 $uploaderErrorMessage = $block->escapeHtml(

--- a/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi */
+/** @var \Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
@@ -8,7 +8,7 @@
 /**
  * Category layered navigation state
  *
- * @var $block \Magento\LayeredNavigation\Block\Navigation\State
+ * @var \Magento\LayeredNavigation\Block\Navigation\State $block
  */
 ?>
 <?php $_filters = $block->getActiveFilters() ?>

--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
@@ -8,7 +8,7 @@
 /**
  * Category layered navigation
  *
- * @var $block \Magento\LayeredNavigation\Block\Navigation
+ * @var \Magento\LayeredNavigation\Block\Navigation $block
  */
 ?>
 

--- a/app/code/Magento/MediaGalleryCatalogUi/view/adminhtml/templates/url_filter_applier.phtml
+++ b/app/code/Magento/MediaGalleryCatalogUi/view/adminhtml/templates/url_filter_applier.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Backend\Block\Template */
+/** @var \Magento\Backend\Block\Template $block */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>
 <script type="text/x-magento-init">

--- a/app/code/Magento/MediaStorage/view/adminhtml/templates/system/config/system/storage/media/synchronize.phtml
+++ b/app/code/Magento/MediaStorage/view/adminhtml/templates/system/config/system/storage/media/synchronize.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize
+ * @var \Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
+++ b/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
@@ -7,7 +7,7 @@
 /**
  * Template for displaying product price at product view page, gift registry and wish-list
  *
- * @var $block \Magento\Msrp\Pricing\Render\PriceBox
+ * @var \Magento\Msrp\Pricing\Render\PriceBox $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
@@ -16,7 +16,7 @@
 /** @var Magento\Msrp\Pricing\Price\MsrpPriceInterface $priceType */
 $priceType = $block->getPrice();
 
-/** @var $product \Magento\Catalog\Model\Product */
+/** @var \Magento\Catalog\Model\Product $product */
 $product = $block->getSaleableItem();
 $productId = $product->getId();
 

--- a/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_item.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_item.phtml
@@ -9,20 +9,20 @@
 /**
  * Template for displaying product price at product view page, gift registry and wishlist
  *
- * @var $block \Magento\Catalog\Block\Product\Price
+ * @var \Magento\Catalog\Block\Product\Price $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>
 
 <?php
     //phpcs:disable
-    /** @var $pricingHelper \Magento\Framework\Pricing\Helper\Data */
+    /** @var \Magento\Framework\Pricing\Helper\Data $pricingHelper */
     $pricingHelper = $this->helper(\Magento\Framework\Pricing\Helper\Data::class);
-    /** @var $_catalogHelper \Magento\Catalog\Helper\Data */
+    /** @var \Magento\Catalog\Helper\Data $_catalogHelper */
     $_catalogHelper = $this->helper(\Magento\Catalog\Helper\Data::class);
     //phpcs:enable
 
-    /** @var $_product \Magento\Catalog\Model\Product */
+    /** @var \Magento\Catalog\Model\Product $_product */
     $_product = $block->getProduct();
     $_id = $_product->getId();
     $_msrpPrice = '';

--- a/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_rss.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_rss.phtml
@@ -8,7 +8,7 @@
 /**
  * Template for displaying wishlist item price at rss feeds pages
  *
- * @var $block \Magento\Catalog\Block\Product\Price
+ * @var \Magento\Catalog\Block\Product\Price $block
  */
 ?>
 <div class="price-box msrp">

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
@@ -11,7 +11,7 @@
 /**
  * Ship to multiple address template
  *
- * @var $block \Magento\Multishipping\Block\Checkout\Addresses
+ * @var \Magento\Multishipping\Block\Checkout\Addresses $block
  */
 ?>
 <form id="checkout_multishipping_form"

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/billing.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/billing.phtml
@@ -7,8 +7,8 @@
 /**
  * Multishipping checkout billing information
  *
- * @var $block \Magento\Multishipping\Block\Checkout\Billing
- * @var $escaper \Magento\Framework\Escaper
+ * @var \Magento\Multishipping\Block\Checkout\Billing $block
+ * @var \Magento\Framework\Escaper $escaper
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview/item.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview/item.phtml
@@ -14,7 +14,7 @@
  * @see \Magento\Checkout\Block\Cart\Item\Renderer
  */
 ?>
-<?php /** @var $block Magento\Checkout\Block\Cart\Item\Renderer */ ?>
+<?php /** @var Magento\Checkout\Block\Cart\Item\Renderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <tr>
     <td class="col item" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/shipping.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/shipping.phtml
@@ -11,7 +11,7 @@
 /**
  * Multishipping checkout shipping template
  *
- * @var $block \Magento\Multishipping\Block\Checkout\Shipping
+ * @var \Magento\Multishipping\Block\Checkout\Shipping $block
  */
 ?>
 <form action="<?= $block->escapeUrl($block->getPostActionUrl()) ?>" method="post" id="shipping_method_form" class="form multicheckout shipping">

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Queue\Edit */
+/* @var \Magento\Newsletter\Block\Adminhtml\Queue\Edit $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
@@ -6,7 +6,7 @@
 
 use Magento\Framework\App\TemplateTypesInterface;
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Template\Edit */
+/* @var \Magento\Newsletter\Block\Adminhtml\Template\Edit $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/banktransfer.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/banktransfer.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Banktransfer
+ * @var \Magento\OfflinePayments\Block\Form\Banktransfer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $instructions = $block->getInstructions();

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/cashondelivery.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/cashondelivery.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Cashondelivery
+ * @var \Magento\OfflinePayments\Block\Form\Cashondelivery $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $instructions = $block->getInstructions();

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Checkmo
+ * @var \Magento\OfflinePayments\Block\Form\Checkmo $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/purchaseorder.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Form\Purchaseorder $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
+ * @var \Magento\OfflinePayments\Block\Info\Checkmo $block
  */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
+ * @var \Magento\OfflinePayments\Block\Info\Checkmo $block
  */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/purchaseorder.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Info\Purchaseorder $block
  */
 ?>
 <?= $block->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/purchaseorder.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Info\Purchaseorder $block
  */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>

--- a/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
+ * @var \Magento\OfflinePayments\Block\Info\Checkmo $block
  */
 ?>
 <?= $block->escapeHtml($block->getMethod()->getTitle()) ?>

--- a/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/purchaseorder.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Info\Purchaseorder $block
  */
 ?>
 <?= $block->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/banktransfer.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/banktransfer.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Banktransfer
+ * @var \Magento\OfflinePayments\Block\Form\Banktransfer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $instructions = $block->getInstructions();

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/cashondelivery.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/cashondelivery.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Cashondelivery
+ * @var \Magento\OfflinePayments\Block\Form\Cashondelivery $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $instructions = $block->getInstructions();

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Checkmo
+ * @var \Magento\OfflinePayments\Block\Form\Checkmo $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/purchaseorder.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Form\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Form\Purchaseorder $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $methodCode = $block->escapeHtml($block->getMethodCode());

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/info/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/info/checkmo.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
+ * @var \Magento\OfflinePayments\Block\Info\Checkmo $block
  */
 ?>
 <dl class="payment-method checkmemo">

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/info/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/info/purchaseorder.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
+ * @var \Magento\OfflinePayments\Block\Info\Purchaseorder $block
  */
 ?>
 <dl class="payment-method purchase order">

--- a/app/code/Magento/Paypal/view/adminhtml/templates/payment/form/billing/agreement.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/payment/form/billing/agreement.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Paypal\Block\Payment\Form\Billing\Agreement
+ * @var \Magento\Paypal\Block\Payment\Form\Billing\Agreement $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
@@ -5,7 +5,7 @@
  */
 
 /*
- * @var $block \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Advanced
+ * @var \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Advanced $block
  */
 ?>
 <div class="payflow-settings-notice">

--- a/app/code/Magento/Paypal/view/frontend/templates/express/review/shipping/method.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/review/shipping/method.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Paypal\Block\Express\Review
+ * @var \Magento\Paypal\Block\Express\Review $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Paypal/view/frontend/templates/express/shortcut/container.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/shortcut/container.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block Magento\Paypal\Block\Express\Shortcut
+ * @var Magento\Paypal\Block\Express\Shortcut $block
  */
 ?>
 <?php if ($block->getIsInCatalogProduct()) : ?>

--- a/app/code/Magento/Paypal/view/frontend/templates/paylater/banner.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/paylater/banner.phtml
@@ -3,8 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/** @var $block \Magento\Paypal\Block\PayLater\Banner */
-/** @var $cartBlock Magento\Checkout\Block\Cart */
+/** @var \Magento\Paypal\Block\PayLater\Banner $block */
+/** @var Magento\Checkout\Block\Cart $cartBlock */
 ?>
 <?php $cartBlock = $block->getLayout()->getBlock('checkout.cart'); ?>
 <?php if ($block->getData('placement') !== 'cart' || is_object($cartBlock) && $cartBlock->getItemsCount()): ?>

--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/email.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/email.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block Magento\Framework\View\Element\Template */
+/** @var Magento\Framework\View\Element\Template $block */
 ?>
 
 <form action="<?= $block->escapeUrl($block->getUrl('productalert/unsubscribe/stock')) ?>"

--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/price.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/price.phtml
@@ -4,12 +4,12 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ProductAlert\Block\Email\Price */
+/** @var \Magento\ProductAlert\Block\Email\Price $block */
 ?>
 <?php if ($_products = $block->getProducts()) : ?>
     <p><?= $block->escapeHtml(__('Price change alert! We wanted you to know that prices have changed for these products:')) ?></p>
     <table>
-    <?php /** @var $_product \Magento\Catalog\Model\Product */ ?>
+    <?php /** @var \Magento\Catalog\Model\Product $_product */ ?>
     <?php foreach ($_products as $_product) : ?>
         <tr>
             <td class="col photo">

--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/stock.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/stock.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\ProductAlert\Block\Email\Stock */
+/** @var \Magento\ProductAlert\Block\Email\Stock $block */
 ?>
 <?php if ($_products = $block->getProducts()) : ?>
     <p><?= $block->escapeHtml(__('In stock alert! We wanted you to know that these products are now available:')) ?></p>

--- a/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /* @var $block \Magento\ProductAlert\Block\Product\View */?>
+<?php /* @var \Magento\ProductAlert\Block\Product\View $block */?>
 <div class="product alert <?= $block->getHtmlClass() ?>">
     <a href="<?= $block->escapeUrl($block->getSignupUrl()) ?>"
        title="<?= $block->escapeHtml(__($block->getSignupLabel())) ?>" class="action alert">

--- a/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
+++ b/app/code/Magento/ProductVideo/view/adminhtml/templates/helper/gallery.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 /**
- * @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content
+ * @var \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 $elementNameEscaped = $block->escapeHtmlAttr($block->getElement()->getName()) . '[images]';
@@ -30,7 +30,7 @@ $jsonHelper = $block->getData('jsonHelper');
 </div>
 
 <?php
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content */
+/** @var \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content $block */
 $element = $block->getElement();
 $elementToggleCode = $element->getToggleCode() ? $element->getToggleCode():
     'toggleValueElements(this, this.parentNode.parentNode.parentNode)';

--- a/app/code/Magento/ProductVideo/view/frontend/templates/product/view/gallery.phtml
+++ b/app/code/Magento/ProductVideo/view/frontend/templates/product/view/gallery.phtml
@@ -7,7 +7,7 @@
 /**
  * Product media data template
  *
- * @var $block \Magento\ProductVideo\Block\Product\View\Gallery
+ * @var \Magento\ProductVideo\Block\Product\View\Gallery $block
  */
 ?>
 <script type="text/x-magento-init">

--- a/app/code/Magento/Reports/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/grid.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Reports\Block\Adminhtml\Grid
+ * @var \Magento\Reports\Block\Adminhtml\Grid $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
@@ -13,7 +13,7 @@
  */
 
 /**
- * @var $block \Magento\Backend\Block\Store\Switcher
+ * @var \Magento\Backend\Block\Store\Switcher $block
  */
 ?>
 

--- a/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed.phtml
@@ -8,7 +8,7 @@
  * @deprecated
  */
 
-/* @var $block \Magento\Reports\Block\Product\Widget\Viewed */
+/* @var \Magento\Reports\Block\Product\Widget\Viewed $block */
 ?>
 
 <?php

--- a/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed/item.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed/item.phtml
@@ -8,7 +8,7 @@
  * @deprecated
  */
 
-/* @var $block \Magento\Reports\Block\Product\Widget\Viewed\Item */
+/* @var \Magento\Reports\Block\Product\Widget\Viewed\Item $block */
 
 $type = $block->getType() . '-' . $block->getViewMode();
 

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_default_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_default_list.phtml
@@ -9,7 +9,7 @@
  */
 
 /**
- * @var $block \Magento\Reports\Block\Product\Viewed
+ * @var \Magento\Reports\Block\Product\Viewed $block
  */
 ?>
 <?php

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_images_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_images_list.phtml
@@ -9,7 +9,7 @@
  */
 
 /**
- * @var $block \Magento\Reports\Block\Product\Viewed
+ * @var \Magento\Reports\Block\Product\Viewed $block
  */
 ?>
 <?php

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_names_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_names_list.phtml
@@ -9,7 +9,7 @@
  */
 
 /**
- * @var $block \Magento\Reports\Block\Product\Viewed
+ * @var \Magento\Reports\Block\Product\Viewed $block
  */
 ?>
 <?php if (($_products = $block->getRecentlyViewedProducts()) && $_products->getSize()) : ?>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_grid.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_grid.phtml
@@ -9,7 +9,7 @@
  */
 
 /**
- * @var $block \Magento\Reports\Block\Product\Viewed
+ * @var \Magento\Reports\Block\Product\Viewed $block
  */
 ?>
 <?php

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_list.phtml
@@ -9,7 +9,7 @@
  */
 
 /**
- * @var $block \Magento\Reports\Block\Product\Viewed
+ * @var \Magento\Reports\Block\Product\Viewed $block
  */
 ?>
 <?php

--- a/app/code/Magento/Review/view/adminhtml/templates/rss/grid/link.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rss/grid/link.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Review\Block\Adminhtml\Grid\Rss\Link */
+/** @var \Magento\Review\Block\Adminhtml\Grid\Rss\Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
 <a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>

--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/name.phtml
@@ -7,7 +7,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Items\Column\Name
+ * @var \Magento\Sales\Block\Adminhtml\Items\Column\Name $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/account.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/account.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Form\Account
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Form\Account $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/items/grid.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/items/grid.phtml
@@ -7,7 +7,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Items\Grid $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/shipping/method/form.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/shipping/method/form.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Shipping\Method\Form $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/sidebar/items.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\AbstractSidebar */
+/* @var \Magento\Sales\Block\Adminhtml\Order\Create\Sidebar\AbstractSidebar $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
 $blockDataId = $block->getDataId();

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/store/select.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/store/select.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Store\Select */
+/* @var \Magento\Sales\Block\Adminhtml\Order\Create\Store\Select $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="store-scope form-inline">

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/grandtotal.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/grandtotal.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Grandtotal
+ * @var \Magento\Tax\Block\Checkout\Grandtotal $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Tax\Block\Checkout\Grandtotal
  */

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/shipping.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/shipping.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Shipping
+ * @var \Magento\Tax\Block\Checkout\Shipping $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Tax\Block\Checkout\Shipping
  */

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/subtotal.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/totals/subtotal.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Subtotal
+ * @var \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Subtotal $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  * @see \Magento\Sales\Block\Adminhtml\Order\Create\Totals\Subtotal
  */

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/create/items/renderer/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer */ ?>
+<?php /** @var \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $block->setPriceDataObject($_item); ?>
 <tr>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/creditmemo/view/items/renderer/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer */ ?>
+<?php /** @var \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_item->setStoreId($_item->getCreditMemo()->getStoreId()) ?>
 <?php $block->setPriceDataObject($_item) ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/create/items/renderer/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer */ ?>
+<?php /** @var \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $block->setPriceDataObject($_item)?>
     <td class="col-product"><?= $block->getColumnHtml($_item, 'name') ?></td>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/items/renderer/default.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/invoice/view/items/renderer/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer */ ?>
+<?php /** @var \Magento\Sales\Block\Adminhtml\Items\Renderer\DefaultRenderer $block */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_item->setStoreId($_item->getInvoice()->getStoreId()) ?>
 <?php $block->setPriceDataObject($_item) ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/totals/tax.phtml
@@ -5,11 +5,11 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\Totals\Tax
+ * @var \Magento\Sales\Block\Adminhtml\Order\Totals\Tax $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
-/** @var $_source \Magento\Sales\Model\Order\Invoice */
+/** @var \Magento\Sales\Model\Order\Invoice $_source */
 $_source    = $block->getSource();
 $_order     = $block->getOrder();
 $_fullInfo  = $block->getFullTaxInfo();

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/giftmessage.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/giftmessage.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Order\View\Giftmessage */
+/** @var \Magento\Sales\Block\Adminhtml\Order\View\Giftmessage $block */
 ?>
 <?php if ($block->canDisplayGiftmessage()) : ?>
     <?php $_required = $block->getMessage()->getMessage() != '' ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/info.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/view/tab/info.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Order\View\Tab\Info */
+/** @var \Magento\Sales\Block\Adminhtml\Order\View\Tab\Info $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_order = $block->getOrder() ?>

--- a/app/code/Magento/Sales/view/adminhtml/templates/rss/order/grid/link.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/rss/order/grid/link.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Adminhtml\Rss\Order\Grid\Link */
+/** @var \Magento\Sales\Block\Adminhtml\Rss\Order\Grid\Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
 <a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Email\Items */
+/** @var \Magento\Sales\Block\Order\Email\Items $block */
 ?>
 <?php $_order = $block->getOrder() ?>
 <?php if ($_order) : ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/order/default.phtml
@@ -6,9 +6,9 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Email\Items\DefaultItems */
+/** @var \Magento\Sales\Block\Order\Email\Items\DefaultItems $block */
 
-/** @var $_item \Magento\Sales\Model\Order\Item */
+/** @var \Magento\Sales\Model\Order\Item $_item */
 $_item = $block->getItem();
 $_order = $_item->getOrder();
 ?>

--- a/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/email/items/shipment/default.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $_item \Magento\Sales\Model\Order\Item */
+/** @var \Magento\Sales\Model\Order\Item $_item */
 $_item = $block->getItem() ?>
 <tr>
     <td class="item-info<?= ($block->getItemOptions() ? ' has-extra' : '') ?>">

--- a/app/code/Magento/Sales/view/frontend/templates/order/comments.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/comments.phtml
@@ -6,7 +6,7 @@
 ?>
 <?php
 /**
- * @var $block \Magento\Sales\Block\Order\Comments
+ * @var \Magento\Sales\Block\Order\Comments $block
  * @see \Magento\Sales\Block\Order\Comments
  */
 ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/creditmemo.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/creditmemo.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Order\Creditmemo */
+/* @var \Magento\Sales\Block\Order\Creditmemo $block */
 ?>
 <div class="order-details-items creditmemo">
     <?= $block->getChildHtml('creditmemo_items') ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/info.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Order\Info */ ?>
+<?php /** @var \Magento\Sales\Block\Order\Info $block */ ?>
 <?php $_order = $block->getOrder() ?>
 <div class="block block-order-details-view">
     <div class="block-title">

--- a/app/code/Magento/Sales/view/frontend/templates/order/info/buttons/rss.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/info/buttons/rss.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Sales\Block\Order\Info\Buttons\Rss */
+/** @var \Magento\Sales\Block\Order\Info\Buttons\Rss $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
     <a href="<?= $block->escapeHtmlAttr($block->getLink()) ?>" class="action rss">

--- a/app/code/Magento/Sales/view/frontend/templates/order/invoice.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/invoice.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Sales\Block\Order\Invoice */
+/* @var \Magento\Sales\Block\Order\Invoice $block */
 ?>
 <div class="order-details-items invoice">
     <?= $block->getChildHtml('invoice_items') ?>

--- a/app/code/Magento/Sales/view/frontend/templates/order/order_status.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/order_status.phtml
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Sales\Block\Order\Info */ ?>
+<?php /** @var \Magento\Sales\Block\Order\Info $block */ ?>
 
 <span class="order-status"><?= $block->escapeHtml($block->getOrder()->getStatusLabel()) ?></span>

--- a/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/recent.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Sales\Block\Order\Recent */
+/** @var \Magento\Sales\Block\Order\Recent $block */
 ?>
 <div class="block block-dashboard-orders">
 <?php

--- a/app/code/Magento/Sales/view/frontend/templates/order/totals.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/order/totals.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Order\Totals
+ * @var \Magento\Sales\Block\Order\Totals $block
  * @see \Magento\Sales\Block\Order\Totals
  */
 ?>

--- a/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/reorder/sidebar.phtml
@@ -7,7 +7,7 @@
 /**
  * Last ordered items sidebar
  *
- * @var $block \Magento\Sales\Block\Reorder\Sidebar
+ * @var \Magento\Sales\Block\Reorder\Sidebar $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Sales/view/frontend/templates/widget/guest/form.phtml
+++ b/app/code/Magento/Sales/view/frontend/templates/widget/guest/form.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Widget\Guest\Form
+ * @var \Magento\Sales\Block\Widget\Guest\Form $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/form.mini.phtml
@@ -6,13 +6,13 @@
 
 ?>
 <?php
-/** @var $block \Magento\Framework\View\Element\Template */
-/** @var $escaper \Magento\Framework\Escaper */
-/** @var $configProvider \Magento\Search\ViewModel\ConfigProvider */
+/** @var \Magento\Framework\View\Element\Template $block */
+/** @var \Magento\Framework\Escaper $escaper */
+/** @var \Magento\Search\ViewModel\ConfigProvider $configProvider */
 $configProvider = $block->getData('configProvider');
-/** @var $versionManager \Magento\Search\ViewModel\AdditionalSearchFormData */
+/** @var \Magento\Search\ViewModel\AdditionalSearchFormData $versionManager */
 $additionalSearchFormData = $block->getData('additionalSearchFormData');
-/** @var $helper \Magento\Search\Helper\Data */
+/** @var \Magento\Search\Helper\Data $helper */
 $helper = $configProvider->getSearchHelperData();
 $allowedSuggestion = $configProvider->isSuggestionsAllowed();
 $quickSearchUrl = $allowedSuggestion ? $escaper->escapeUrl($helper->getSuggestUrl()) : '';

--- a/app/code/Magento/Security/view/adminhtml/templates/page/activity_link.phtml
+++ b/app/code/Magento/Security/view/adminhtml/templates/page/activity_link.phtml
@@ -7,7 +7,7 @@
 /**
  * Account activity template
  *
- * @var $block \Magento\Framework\View\Element\Template
+ * @var \Magento\Framework\View\Element\Template $block
  */
 ?>
 <a class="link-account-activity"

--- a/app/code/Magento/Security/view/adminhtml/templates/session/activity.phtml
+++ b/app/code/Magento/Security/view/adminhtml/templates/session/activity.phtml
@@ -7,7 +7,7 @@
 /**
  * Account activity template
  *
- * @var $block \Magento\Security\Block\Adminhtml\Session\Activity
+ * @var \Magento\Security\Block\Adminhtml\Session\Activity $block
  */
 
 $sessionInfoCollection = $block->getSessionInfoCollection();

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/packaging/popup.phtml
@@ -7,7 +7,7 @@
 //phpcs:disable Magento2.Security.IncludeFile.FoundIncludeFile
 
 /**
- * @var $block \Magento\Shipping\Block\Adminhtml\Order\Packaging
+ * @var \Magento\Shipping\Block\Adminhtml\Order\Packaging $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 /**
- * @var $block Magento\Shipping\Block\Adminhtml\Order\Tracking
+ * @var Magento\Shipping\Block\Adminhtml\Order\Tracking $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/tracking/view.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block Magento\Shipping\Block\Adminhtml\Order\Tracking\View
+ * @var Magento\Shipping\Block\Adminhtml\Order\Tracking\View $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Shipping/view/adminhtml/templates/order/view/info.phtml
+++ b/app/code/Magento/Shipping/view/adminhtml/templates/order/view/info.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Sales\Block\Adminhtml\Order\AbstractOrder
+ * @var \Magento\Sales\Block\Adminhtml\Order\AbstractOrder $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/details.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var \Magento\Framework\View\Element\Template $block */
 //phpcs:disable Magento2.Files.LineLength.MaxExceeded
 
 $parentBlock = $block->getParentBlock();

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/link.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/link.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Shipping\Block\Tracking\Link */ ?>
+<?php /** @var \Magento\Shipping\Block\Tracking\Link $block */ ?>
 <?php $order = $block->getOrder() ?>
 <a href="#" class="action track" title="<?= $block->escapeHtmlAttr($block->getLabel()) ?>"
    data-mage-init='{"popupWindow": {

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/popup.phtml
@@ -7,7 +7,7 @@
 use Magento\Framework\View\Element\Template;
 
 /**
- * @var $block \Magento\Shipping\Block\Tracking\Popup
+ * @var \Magento\Shipping\Block\Tracking\Popup $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
+++ b/app/code/Magento/Shipping/view/frontend/templates/tracking/progress.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var \Magento\Framework\View\Element\Template $block */
 $parentBlock = $block->getParentBlock();
 $track = $block->getData('track');
 ?>

--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/text.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/text.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text */
+/** @var \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text $block */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>

--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual */
+/** @var \Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual $block */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>

--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues */
+/* @var \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues $block */
 ?>
 <div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getComponentName()) ?>'">
     <h2 class="steps-wizard-title"><?= $block->escapeHtml(__('Step 2: Attribute Values')) ?></h2>

--- a/app/code/Magento/Swatches/view/frontend/templates/product/layered/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/layered/renderer.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable PSR2.ControlStructures.SwitchDeclaration
 // phpcs:disable Generic.WhiteSpace.ScopeIndent
 
-/** @var $block \Magento\Swatches\Block\LayeredNavigation\RenderLayered */
+/** @var \Magento\Swatches\Block\LayeredNavigation\RenderLayered $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 /** @var \Magento\Framework\Escaper $escaper */
 ?>

--- a/app/code/Magento/Swatches/view/frontend/templates/product/view/renderer.phtml
+++ b/app/code/Magento/Swatches/view/frontend/templates/product/view/renderer.phtml
@@ -5,7 +5,7 @@
  */
 ?>
 <?php
-/** @var $block \Magento\Swatches\Block\Product\Renderer\Configurable */
+/** @var \Magento\Swatches\Block\Product\Renderer\Configurable $block */
 /** @var \Magento\Swatches\ViewModel\Product\Renderer\Configurable $configurableViewModel */
 $configurableViewModel = $block->getConfigurableViewModel()
 ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Adminhtml\Rule\Edit\Form */
+/** @var \Magento\Tax\Block\Adminhtml\Rule\Edit\Form $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $formElementId = /* @noEscape */ \Magento\Tax\Block\Adminhtml\Rate\Form::FORM_ELEMENT_ID;

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
@@ -3,7 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/* @var $block \Magento\Tax\Block\Adminhtml\Rate\Form */
+/* @var \Magento\Tax\Block\Adminhtml\Rate\Form $block */
 ?>
 
 <div data-role="spinner" class="grid-loading-mask">

--- a/app/code/Magento/Tax/view/base/templates/pricing/adjustment.phtml
+++ b/app/code/Magento/Tax/view/base/templates/pricing/adjustment.phtml
@@ -6,7 +6,7 @@
 ?>
 
 <?php /** @var \Magento\Tax\Pricing\Render\Adjustment $block */ ?>
-<?php /** @var $escaper \Magento\Framework\Escaper */ ?>
+<?php /** @var \Magento\Framework\Escaper $escaper */ ?>
 
 <?php if ($block->displayBothPrices()): ?>
     <span id="<?= $escaper->escapeHtmlAttr($block->buildIdWithPrefix('price-excluding-tax-')) ?>"

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/** @var \Magento\Tax\Block\Item\Price\Renderer $block */
 ?>
 <?php $_item = $block->getItem() ?>
     <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/grandtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/grandtotal.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Grandtotal
+ * @var \Magento\Tax\Block\Checkout\Grandtotal $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/shipping.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/shipping.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Shipping
+ * @var \Magento\Tax\Block\Checkout\Shipping $block
  * @see \Magento\Tax\Block\Checkout\Shipping
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/shipping/price.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/shipping/price.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 ?>
-<?php /** @var $block \Magento\Tax\Block\Checkout\Shipping\Price */ ?>
+<?php /** @var \Magento\Tax\Block\Checkout\Shipping\Price $block */ ?>
 
 <?php $_excl = $block->getShippingPriceExclTax(); ?>
 <?php $_incl = $block->getShippingPriceInclTax(); ?>

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/subtotal.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/subtotal.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Subtotal
+ * @var \Magento\Tax\Block\Checkout\Subtotal $block
  * @see \Magento\Tax\Block\Checkout\Subtotal
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */

--- a/app/code/Magento/Tax/view/frontend/templates/checkout/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/checkout/tax.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Tax\Block\Checkout\Tax
+ * @var \Magento\Tax\Block\Checkout\Tax $block
  * @see \Magento\Tax\Block\Checkout\Tax
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/** @var \Magento\Tax\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+/** @var \Magento\Tax\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
+++ b/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport */
+/** @var \Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="import-export-tax-rates">

--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content.phtml
@@ -7,7 +7,7 @@
 /**
  * Wysiwyg Images content template
  *
- * @var $block \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content
+ * @var \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content $block
  */
 ?>
 <?= $block->getChildHtml('wysiwyg_files.js') ?>

--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content/files.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files */
+/** @var \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files $block */
 ?>
 
 <?php if ($block->getFilesCount() > 0) : ?>

--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader */
+/** @var \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 

--- a/app/code/Magento/Theme/view/adminhtml/templates/design/config/edit/scope.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/design/config/edit/scope.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/* @var $block \Magento\Theme\Block\Adminhtml\Design\Config\Edit\Scope */
+/* @var \Magento\Theme\Block\Adminhtml\Design\Config\Edit\Scope $block */
 ?>
 
 <div class="store-view">

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/css.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/css.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 /**
- * @var $block \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css
+ * @var \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/fieldset/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/fieldset/js.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 /**
- * @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset
+ * @var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/js.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js
+ * @var \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Theme\Block\Html\Title
+ * @var \Magento\Theme\Block\Html\Title $block
  */
 $titleIdHtml = ($block->getTitleId()) ? ' id="' . $block->escapeHtmlAttr($block->getTitleId()) . '"' : '';
 $titleClass = ($block->getTitleClass()) ? ' ' . $block->getTitleClass() : '';

--- a/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Theme\Block\Html\Notices
+ * @var \Magento\Theme\Block\Html\Notices $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Theme\Block\Html\Title
+ * @var \Magento\Theme\Block\Html\Title $block
  */
 $cssClass = $block->getCssClass() ? ' ' . $block->getCssClass() : '';
 $titleHtml = '';

--- a/app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/topmenu.phtml
@@ -7,7 +7,7 @@
 /**
  * Top menu for store
  *
- * @var $block \Magento\Theme\Block\Html\Topmenu
+ * @var \Magento\Theme\Block\Html\Topmenu $block
  */
 
 $columnsLimit = $block->getColumnsLimit() ?: 0;

--- a/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
@@ -7,7 +7,7 @@
 /**
  * Cookie settings initialization script
  *
- * @var $block \Magento\Framework\View\Element\Js\Cookie
+ * @var \Magento\Framework\View\Element\Js\Cookie $block
  */
 ?>
 

--- a/app/code/Magento/Theme/view/frontend/templates/link.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/link.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Framework\View\Element\Html\Link
+ * @var \Magento\Framework\View\Element\Html\Link $block
  */
 ?>
 <?php if (!$block->getIsDisabled()) : ?>

--- a/app/code/Magento/Theme/view/frontend/templates/template.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/template.phtml
@@ -4,6 +4,6 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var \Magento\Framework\View\Element\Template $block */
 ?>
 <?= $block->getChildHtml('', false);

--- a/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Ui\Component\Control\Button
+ * @var \Magento\Ui\Component\Control\Button $block
  */
 ?>
 <?= $block->getBeforeHtml() ?>

--- a/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Ui\Component\Control\SplitButton */
+/** @var \Magento\Ui\Component\Control\SplitButton $block */
 ?>
 
 <div <?= $block->getAttributesHtml() ?>>

--- a/app/code/Magento/Ui/view/base/templates/logger.phtml
+++ b/app/code/Magento/Ui/view/base/templates/logger.phtml
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 
-/** @var $block \Magento\Ui\Block\Logger */
+/** @var \Magento\Ui\Block\Logger $block */
 /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->isLoggingEnabled()): ?>

--- a/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
+++ b/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
@@ -5,7 +5,7 @@
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-/** @var $block \Magento\Ui\Block\Component\StepsWizard */
+/** @var \Magento\Ui\Block\Component\StepsWizard $block */
 ?>
 <div data-role="steps-wizard-main"
      class="steps-wizard <?= /* @noEscape */ $block->getData('config/dataScope') ?>"

--- a/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
+++ b/app/code/Magento/User/view/adminhtml/templates/role/edit.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\User\Block\Role\Tab\Edit
+ * @var \Magento\User\Block\Role\Tab\Edit $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/items/price/row.phtml
@@ -9,7 +9,7 @@
 <?php
 /** @var \Magento\Weee\Block\Adminhtml\Items\Price\Renderer $block */
 
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+/** @var \Magento\Weee\Helper\Data $_weeeHelper */
 $_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
 
 $_item = $block->getItem();

--- a/app/code/Magento/Weee/view/adminhtml/templates/items/price/unit.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/items/price/unit.phtml
@@ -9,7 +9,7 @@
 <?php
 /** @var \Magento\Weee\Block\Adminhtml\Items\Price\Renderer $block */
 
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+/** @var \Magento\Weee\Helper\Data $_weeeHelper */
 $_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
 
 $_item = $block->getItem();

--- a/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/row.phtml
@@ -7,7 +7,7 @@
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 <?php
-/** @var $block \Magento\Weee\Block\Item\Price\Renderer */
+/** @var \Magento\Weee\Block\Item\Price\Renderer $block */
 
 $_item = $block->getItem();
 ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/renderer/tax.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/renderer/tax.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 /**
- * @var $block \Magento\Weee\Block\Renderer\Weee\Tax
+ * @var \Magento\Weee\Block\Renderer\Weee\Tax $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
@@ -6,7 +6,7 @@
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 
-/** @var $block \Magento\Weee\Block\Item\Price\Renderer */
+/** @var \Magento\Weee\Block\Item\Price\Renderer $block */
 
 $item = $block->getItem();
 

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_excl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_excl_tax.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_incl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_incl_tax.phtml
@@ -5,12 +5,12 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
 $_item = $block->getItem();
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+/** @var \Magento\Weee\Helper\Data $_weeeHelper */
 $_weeeHelper = $block->getData('weeeHelper');
 ?>
 <?php $_incl = $_item->getRowTotalInclTax(); ?>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_excl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_excl_tax.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_incl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_incl_tax.phtml
@@ -5,12 +5,12 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 
 $_item = $block->getItem();
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+/** @var \Magento\Weee\Helper\Data $_weeeHelper */
 $_weeeHelper = $block->getData('weeeHelper');
 ?>
 <?php $_incl = $_item->getPriceInclTax(); ?>

--- a/app/code/Magento/Weee/view/frontend/templates/email/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/email/items/price/row.phtml
@@ -9,7 +9,7 @@
 <?php
 /** @var \Magento\Weee\Block\Item\Price\Renderer $block */
 
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+/** @var \Magento\Weee\Helper\Data $_weeeHelper */
 $_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
 
 $_item = $block->getItem();

--- a/app/code/Magento/Weee/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/item/price/row.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/code/Magento/Weee/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/item/price/unit.phtml
@@ -5,7 +5,7 @@
  */
 
 /**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
+ * @var \Magento\Weee\Block\Item\Price\Renderer $block
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
 

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/state.phtml
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/state.phtml
@@ -10,7 +10,7 @@
 /**
  * Category layered navigation state
  *
- * @var $block \Magento\LayeredNavigation\Block\Navigation\State
+ * @var \Magento\LayeredNavigation\Block\Navigation\State $block
  */
 ?>
 <?php $_filters = $block->getActiveFilters() ?>

--- a/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/view.phtml
+++ b/app/design/frontend/Magento/luma/Magento_LayeredNavigation/templates/layer/view.phtml
@@ -8,7 +8,7 @@
 /**
  * Category layered navigation
  *
- * @var $block \Magento\LayeredNavigation\Block\Navigation
+ * @var \Magento\LayeredNavigation\Block\Navigation $block
  */
 ?>
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Many of the `@var` docblock statements are not written in a style described by [phpDocumentor](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/var.html#var) which is recommended by [Magento DocBlock Standard](https://developer.adobe.com/commerce/php/coding-standards/docblock/)

It comes to the point where some templates have both styles of `@var` docblocks next to each other. https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml#L13

### Fixed Issues (if relevant)
Didn't create an issue. Is it needed?

### Manual testing scenarios (*)
I don't think they're needed as changes are not in code itself, but comments

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [X] All automated tests passed successfully (all builds are green)
