### PR TITLE
[.slider is not a function] slider should be slider

### DIFF
--- a/app/code/Magento/Theme/view/base/requirejs-config.js
+++ b/app/code/Magento/Theme/view/base/requirejs-config.js
@@ -39,7 +39,7 @@ var config = {
             'jquery-ui-modules/progressbar': 'jquery/ui-modules/widgets/progressbar',
             'jquery-ui-modules/resizable': 'jquery/ui-modules/widgets/resizable',
             'jquery-ui-modules/selectable': 'jquery/ui-modules/widgets/selectable',
-            'jquery-ui-modules/slider': 'jquery/ui-modules/widgets/selectmenu',
+            'jquery-ui-modules/slider': 'jquery/ui-modules/widgets/slider',
             'jquery-ui-modules/sortable': 'jquery/ui-modules/widgets/sortable',
             'jquery-ui-modules/spinner': 'jquery/ui-modules/widgets/spinner',
             'jquery-ui-modules/tabs': 'jquery/ui-modules/widgets/tabs',


### PR DESCRIPTION
fix slider wrong mapping causing $('....').slider() -> .slider is not a function, while importing jquery-ui-modules/slider