### PR TITLE
Correct typos and grammar in menu.xsd file.

### DIFF
--- a/app/code/Magento/Backend/etc/menu.xsd
+++ b/app/code/Magento/Backend/etc/menu.xsd
@@ -85,7 +85,7 @@
     <xs:simpleType name="typeId">
         <xs:annotation>
             <xs:documentation>
-                Item id attribute can has only [a-z0-9/_]. Minimal length 3 symbol. Case insensitive.
+                Item id attribute can have only [a-z0-9/_]. Minimal length 3 characters. Case insensitive.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -96,7 +96,7 @@
     <xs:simpleType name="typeAction">
         <xs:annotation>
             <xs:documentation>
-                Item action attribute can has only [a-zA-Z0-9/_]. Minimal length 3 symbol
+                Item action attribute can have only [a-zA-Z0-9/_]. Minimal length 3 characters.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -107,7 +107,7 @@
     <xs:simpleType name="typeTitle">
         <xs:annotation>
             <xs:documentation>
-                Item title attribute minimal length 3 symbol
+                Item title attribute minimal length 3 characters.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -119,7 +119,7 @@
     <xs:simpleType name="typeModule">
         <xs:annotation>
             <xs:documentation>
-                Item module attribute can has only [a-z0-9_]. Minimal length 3 symbol. Case insensitive.
+                Item module attribute can have only [a-z0-9_]. Minimal length 3 characters. Case insensitive.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -130,7 +130,7 @@
     <xs:simpleType name="typeResource">
         <xs:annotation>
             <xs:documentation>
-                Item resource attribute can has only [a-z0-9_]. Minimal length 3 symbol. Case insensitive.
+                Item resource attribute can have only [a-z0-9_]. Minimal length 3 characters. Case insensitive.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
@@ -141,7 +141,7 @@
     <xs:simpleType name="typeDependsConfig">
         <xs:annotation>
             <xs:documentation>
-                Item dependsOnConfig attribute can has only [a-z0-9_]. Minimal length 3 symbol. Case insensitive.
+                Item dependsOnConfig attribute can have only [a-z0-9_]. Minimal length 3 characters. Case insensitive.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">

--- a/app/code/Magento/Backend/etc/menu.xsd
+++ b/app/code/Magento/Backend/etc/menu.xsd
@@ -141,7 +141,7 @@
     <xs:simpleType name="typeDependsConfig">
         <xs:annotation>
             <xs:documentation>
-                Item resource attribute can has only [a-z0-9_]. Minimal length 3 symbol. Case insensitive.
+                Item dependsOnConfig attribute can has only [a-z0-9_]. Minimal length 3 symbol. Case insensitive.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">


### PR DESCRIPTION
### Description (*)

This pull request corrects typos and incorrect grammar in the `app/code/Magento/Backend/etc/menu.xsd` file.

### Manual testing scenarios (*)

This pull request changes only documentation strings and does not alter Magento behaviour. Therefore there is no special testing is required other than confirming that the previous grammar was wrong, and the current grammar is correct.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [X] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36649: Correct typos and grammar in menu.xsd file.