### PR TITLE
Format category url_key and url_path attributes to the correct pattern on rest api

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Plugin/Webapi/Model/FormatUrlKeyAndPath.php
+++ b/app/code/Magento/CatalogUrlRewrite/Plugin/Webapi/Model/FormatUrlKeyAndPath.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+namespace Magento\CatalogUrlRewrite\Plugin\Webapi\Model;
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Model\CategoryRepository;
+
+/**
+ * Plugin for category repository
+ *
+ * Format url_keys and url_paths before saving the entity.
+ */
+class FormatUrlKeyAndPath
+{
+    private const ATTRIBUTES_TO_PROCESS = [
+        'url_key',
+        'url_path'
+    ];
+
+    /**
+     * Formats category url key and path using the default formatter.
+     *
+     * @param CategoryRepository $subject
+     * @param CategoryInterface $category
+     * @return array
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeSave(CategoryRepository $subject, CategoryInterface $category): array
+    {
+        foreach (self::ATTRIBUTES_TO_PROCESS as $attributeKey) {
+            if ($attribute = $category->getCustomAttribute($attributeKey)) {
+                $attribute->setValue($category->formatUrlKey(
+                    $category->getData($attributeKey)
+                ));
+            }
+        }
+        return [$category];
+    }
+}

--- a/app/code/Magento/CatalogUrlRewrite/etc/webapi_rest/di.xml
+++ b/app/code/Magento/CatalogUrlRewrite/etc/webapi_rest/di.xml
@@ -12,4 +12,9 @@
     <type name="Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator">
         <plugin name="category_set_save_rewrites_history_rest_plugin" type="Magento\CatalogUrlRewrite\Plugin\Model\CategorySetSaveRewriteHistory" disabled="false" />
     </type>
+    <type name="Magento\Catalog\Model\CategoryRepository">
+        <plugin name="format_url_key_and_path"
+                type="Magento\CatalogUrlRewrite\Plugin\Webapi\Model\FormatUrlKeyAndPath"
+                sortOrder="99"/>
+    </type>
 </config>


### PR DESCRIPTION
### Description (*)
Added code to format url key and path when creating a category via rest api.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35577

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Call the REST API Endpoint to create a new Category: (with a valid authorization)
POST https://{shop-url}/rest/V1/categories
````
{
	"category": {
		"parent_id": 2,
		"name": "NewTest Cat (100)",
		"is_active": true,
		"include_in_menu": true,
		"custom_attributes": [
			{
				"attribute_code": "url_key",
				"value": "new test Cat (100)!"
			}
		]
	}
}
````
2. The response should contain the url_key with no special characters and a normalized the string:
````
 {
            "attribute_code": "url_key",
            "value": "new-test-cat-100"
        },
        {
            "attribute_code": "url_path",
            "value": "new-test-cat-100"
        }
````

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
