### PR TITLE
Skip empty options even when the SkipCheckRequiredOption flag is true

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
+++ b/app/code/Magento/Catalog/Model/Product/Type/AbstractType.php
@@ -591,7 +591,10 @@ abstract class AbstractType
 
                     if ($product->getSkipCheckRequiredOption() !== true) {
                         $group->validateUserValue($optionsFromRequest);
-                    } elseif ($optionsFromRequest !== null && isset($optionsFromRequest[$option->getId()])) {
+                    } elseif ($optionsFromRequest !== null
+                        && isset($optionsFromRequest[$option->getId()])
+                        && $optionsFromRequest[$option->getId()] !== ''
+                    ) {
                         if (is_array($optionsFromRequest[$option->getId()])) {
                             $group->validateUserValue($optionsFromRequest);
                         } else {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
A conditional is added to skip empty string options so that they are not included when adding a product to a quote.

Including empty string values will add an error to the quote item because `\Magento\Catalog\Model\Product\Option::getValueById` is unable to find a value for an empty string and therefore returns null, causing the else statement to be run in `\Magento\Catalog\Model\Product\Option\Type\Select::getOptionSku` which adds an error to the listener:
`$this->getListener()->setHasError(true)->setMessage($this->_getWrongConfigurationMessage());`.

This adds the `Some of the selected options are not currently available.` error in `\Magento\Quote\Model\Quote\Item\AbstractItem::checkData` to itself.

<!-- ### Related Pull Requests -->
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35409

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new product.
2. Add a custom dropdown option to the new product and uncheck 'Required' checkbox.
3. Order the product through the frontend without any custom options selected.
4. Reorder from the admin view (Sales -> Order -> View Order -> Reorder).

**Before the change:**
An error message is shown `Some of the selected options are not currently available.`, forcing the user to use a workaround.
The Submit Order button redirects the user to the same page with the error message, no order is created.

**After the change:**
No error message is displayed, order can be created as usual. 


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
My first PR here. I still need to figure out how tests work and whether I need to do any tests.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
