### PR TITLE
Added Puerto Rico as an Enum

### DIFF
--- a/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CustomerGraphQl/etc/schema.graphqls
@@ -354,6 +354,7 @@ enum CountryCodeEnum @doc(description: "The list of country codes.") {
     PN @doc(description: "Pitcairn Islands")
     PL @doc(description: "Poland")
     PT @doc(description: "Portugal")
+    PR @doc(description: "Puerto Rico")
     QA @doc(description: "Qatar")
     RE @doc(description: "Réunion")
     RO @doc(description: "Romania")


### PR DESCRIPTION
### Description (*)
Added Puerto Rico to the Enum list of countries in GraphQL. Currently there is a bug that gives the following message when you set Puerto Rico to be the shippping address country:
```Expected a value of type "CountryCodeEnum" but received: PR```

Issue: https://github.com/magento/magento2/issues/35610

### Fixed Issues (if relevant)
Puerto Rico was not an accepted Enum for GraphQL as a country

### Manual testing scenarios (*)
1. Create a cart
2. Use GraphQL to update the cart address with Puerto Rico as a country

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
