### PR TITLE
Correct typos in 'Choose Affected Attribute Set' dialogue

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/AttributeSet/Form.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Adminhtml/Product/Edit/AttributeSet/Form.php
@@ -75,7 +75,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             'new-affected-attribute-set',
             'radio',
             [
-                'after_element_html' => __('Add configurable attributes to the new Attribute Set based on current'),
+                'after_element_html' => __('Add configurable attributes to a new Attribute Set based on current'),
                 'name' => 'affected-attribute-set',
                 'class' => 'admin__control-radio',
                 'css_class' => 'admin__field-option',
@@ -98,7 +98,7 @@ class Form extends \Magento\Backend\Block\Widget\Form\Generic
             'existing-affected-attribute-set',
             'radio',
             [
-                'after_element_html' => __('Add configurable attributes to the existing Attribute Set'),
+                'after_element_html' => __('Add configurable attributes to an existing Attribute Set'),
                 'name' => 'affected-attribute-set',
                 'required' => true,
                 'class' => 'admin__control-radio no-display',

--- a/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurableAttributeSetHandler.php
+++ b/app/code/Magento/ConfigurableProduct/Ui/DataProvider/Product/Form/Modifier/ConfigurableAttributeSetHandler.php
@@ -92,7 +92,7 @@ class ConfigurableAttributeSetHandler extends AbstractModifier
                                         'formElement' => Form\Element\Checkbox::NAME,
                                         'prefer' => 'radio',
                                         'description' => __(
-                                            'Add configurable attributes to the new Attribute Set based on current'
+                                            'Add configurable attributes to a new Attribute Set based on current'
                                         ),
                                         'dataScope' => 'configurableAffectedAttributeSet',
                                         'valueMap' => [
@@ -115,7 +115,7 @@ class ConfigurableAttributeSetHandler extends AbstractModifier
                                         'formElement' => Form\Element\Checkbox::NAME,
                                         'prefer' => 'radio',
                                         'description' => __(
-                                            'Add configurable attributes to the existing Attribute Set'
+                                            'Add configurable attributes to an existing Attribute Set'
                                         ),
                                         'dataScope' => 'configurableAffectedAttributeSet',
                                         'valueMap' => [

--- a/app/code/Magento/ConfigurableProduct/i18n/en_US.csv
+++ b/app/code/Magento/ConfigurableProduct/i18n/en_US.csv
@@ -1,7 +1,7 @@
 "Add configurable attributes to the current Attribute Set (""%1"")","Add configurable attributes to the current Attribute Set (""%1"")"
-"Add configurable attributes to the new Attribute Set based on current","Add configurable attributes to the new Attribute Set based on current"
+"Add configurable attributes to a new Attribute Set based on current","Add configurable attributes to a new Attribute Set based on current"
 "New attribute set name","New attribute set name"
-"Add configurable attributes to the existing Attribute Set","Add configurable attributes to the existing Attribute Set"
+"Add configurable attributes to an existing Attribute Set","Add configurable attributes to an existing Attribute Set"
 "Choose existing Attribute Set","Choose existing Attribute Set"
 Save,Save
 "Save & New","Save & New"


### PR DESCRIPTION
### Description (*)

This PR corrects two instances of incorrect grammar in the 'Choose Affected Attribute Set' dialogue. There are no functional changes in this PR. Essentially, this PR is similar to PR 35277 but I think that I've made some sort of mistake with the GH interface in that PR from which I am unable to recover.

### Manual testing scenarios (*)

1. Initiate the process of adding a new Configurable Product.
2. During the process, add new Attributes.
3. At the end of the process, note the text of the "Choose Affected Attribute Set" dialogue:
Was:
```
Add configurable attributes to the current Attribute Set
Add configurable attributes to the new Attribute Set based on current
Add configurable attributes to the existing Attribute Set
```

With this PR:
```
Add configurable attributes to the current Attribute Set
Add configurable attributes to a new Attribute Set based on current
Add configurable attributes to an existing Attribute Set
```
