### PR TITLE
Changed addData to setData to improve performance

### DIFF
--- a/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/Summary/CollectionTest.php
+++ b/app/code/Magento/Review/Test/Unit/Model/ResourceModel/Review/Summary/CollectionTest.php
@@ -151,9 +151,9 @@ class CollectionTest extends TestCase
             ->with($this->selectMock, [])
             ->willReturn([$data]);
 
-        $objectMock = $this->createPartialMock(DataObject::class, ['addData']);
+        $objectMock = $this->createPartialMock(DataObject::class, ['setData']);
         $objectMock->expects($this->once())
-            ->method('addData')
+            ->method('setData')
             ->with($data);
         $this->entityFactoryMock->expects($this->once())
             ->method('create')

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Status/History/CollectionTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Status/History/CollectionTest.php
@@ -80,7 +80,7 @@ class CollectionTest extends TestCase
         $this->selectMock = $this->createMock(Select::class);
         $this->historyItemMock = $this->createPartialMock(
             History::class,
-            ['addData']
+            ['setData']
         );
         $this->resourceMock = $this->getMockForAbstractClass(
             EntityAbstract::class,
@@ -111,7 +111,7 @@ class CollectionTest extends TestCase
 
         $data = [['data']];
         $this->historyItemMock->expects($this->once())
-            ->method('addData')
+            ->method('setData')
             ->with($data[0])
             ->willReturn($this->historyItemMock);
 
@@ -152,13 +152,13 @@ class CollectionTest extends TestCase
         $this->connectionMock->expects($this->exactly(3))
             ->method('prepareSqlCondition')
             ->willReturnMap(
-                
+
                     [
                         ['entity_name', $entityType, 'sql-string'],
                         ['is_customer_notified', 0, 'sql-string'],
                         ['parent_id', $orderId, 'sql-string'],
                     ]
-                
+
             );
         $result = $this->collection->getUnnotifiedForInstance($order);
         $this->assertEquals($this->historyItemMock, $result);

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -585,7 +585,7 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
                 if ($this->getIdFieldName()) {
                     $item->setIdFieldName($this->getIdFieldName());
                 }
-                $item->addData($row);
+                $item->setData($row);
                 $this->beforeAddLoadedItem($item);
                 $this->addItem($item);
             }

--- a/lib/internal/Magento/Framework/Data/Test/Unit/Collection/DbTest.php
+++ b/lib/internal/Magento/Framework/Data/Test/Unit/Collection/DbTest.php
@@ -581,11 +581,11 @@ class DbTest extends TestCase
 
         $objectMock = $this->getMockBuilder(DataObject::class)
             ->addMethods(['setIdFieldName'])
-            ->onlyMethods(['addData', 'getData'])
+            ->onlyMethods(['setData', 'getData'])
             ->disableOriginalConstructor()
             ->getMock();
         $objectMock->expects($this->once())
-            ->method('addData')
+            ->method('setData')
             ->with($data);
         $objectMock->expects($this->any())
             ->method('getData')


### PR DESCRIPTION
Replace the iterations over datasets from records loaded from the database through the loadWithFilter mechanic, by just setting the data with setData instead of addData. This will improve performance by a fair amount the greater the amount of records and data per record.

### Description (*)
The AbstractDb class seems to be calling addData in the loadWithFilter to hydrate data to new empty items. The addData method is then iterating over all the data records which can quickly create a large amount of iterations for setting a simple value.

On our homepage this will do 60 (eav attribute fields) * 50 iterations for loading products and eav data, setting a value in an associative array = ~3000 unnecessary small iterations. But this mechanic is used for a lot of smaller things as well, which in the end does have a penalty on transaction performance. Categories are even worse...

### Manual testing scenarios (*)
Test if all page types are still working as expected.

### Questions or comments
Why is the addData method used in this logic? It seems to me it is not needed and only adds overhead.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
