### PR TITLE
Not visible individually products should not be taken into account when checking for duplicate url keys

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
+++ b/app/code/Magento/CatalogUrlRewrite/Model/Product/Validator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\CatalogUrlRewrite\Model\Product;
 
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility as ProductVisibility;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
 use Magento\UrlRewrite\Model\Exception\UrlAlreadyExistsException;
 use Magento\UrlRewrite\Model\UrlFinderInterface;
@@ -68,6 +69,11 @@ class Validator
 
         foreach ($stores as $store) {
             if (!in_array($store->getWebsiteId(), $product->getWebsiteIds())) {
+                continue;
+            }
+
+            // check if product visibility on store is not set to "Not Visible Individually"
+            if ($product->setStoreId($store->getId())->getVisibility() == ProductVisibility::VISIBILITY_NOT_VISIBLE) {
                 continue;
             }
 


### PR DESCRIPTION
### Description (*)
As in `ProductUrlRewriteGenerator::generate` the visibility is checked to ignore products with Visibility Not Visible individually, the same exception should be made when checking for duplicates before save. 

### Fixed Issues (if relevant)
1. Fixes magento/magento2#35623

### Manual testing scenarios (*)
1. Create a configurable product with URL key: 'test'
2. Try to create a simple product under this configurable product with Visibility: 'Not visible individually', status disabled and url key: 'test'
3. This product can now be created, and enabled. However, changing the visibility again would result in a Duplicate URL key error.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
