### PR TITLE
Process trans Directives Nested in depend / if Directives

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/expectedPhrases.csv
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/expectedPhrases.csv
@@ -18,4 +18,7 @@
 "string with escaped ""double quotes""","string with escaped ""double quotes"""
 "string with placeholder in escaped double quotes ""%1""","string with placeholder in escaped double quotes ""%1"""
 "string that's got an unclosed single quote in it","string that's got an unclosed single quote in it"
+"Thank you for your order from %store_name.","Thank you for your order from %store_name."
+"Our hours are <span class=""no-link"">%store_hours</span>.","Our hours are <span class=""no-link"">%store_hours</span>."
+"Translation inside if directive","Translation inside if directive"
 "Test di text","Test di text"

--- a/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/phrases/test_mail_template.html
+++ b/dev/tests/integration/testsuite/Magento/Setup/Console/Command/_files/phrases/test_mail_template.html
@@ -1,0 +1,28 @@
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+
+{{template config_path="design/email/header_template"}}
+
+<table>
+    <tr class="email-intro">
+        <td>
+            <p>
+                {{trans "Thank you for your order from %store_name." store_name=$store.frontend_name}}
+            </p>
+            <p>
+                {{depend store_hours}}
+                    {{trans 'Our hours are <span class="no-link">%store_hours</span>.' store_hours=$store_hours |raw}}
+                {{/depend}}
+            </p>
+            {{if something}}
+                <p>{{trans 'Translation inside if directive'}}</p>
+            {{/if}}
+        </td>
+    </tr>
+</table>
+
+{{template config_path="design/email/footer_template"}}

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -50,6 +50,14 @@ class Html extends AbstractAdapter
             throw new Exception('Failed to load file from disk.');
         }
 
+        $this->extractPhrasesFromTransDirective($data);
+        $this->extractPhrases(self::REGEX_I18N_BINDING, $data, 2, 1);
+        $this->extractPhrases(self::REGEX_TRANSLATE_TAG_OR_ATTR, $data, 3, 2);
+        $this->extractPhrases(Js::REGEX_TRANSLATE_FUNCTION, $data, 3, 2);
+    }
+
+    private function extractPhrasesFromTransDirective(string $data): void
+    {
         $results = [];
         preg_match_all(Filter::CONSTRUCTION_PATTERN, $data, $results, PREG_SET_ORDER);
         for ($i = 0, $count = count($results); $i < $count; $i++) {
@@ -61,12 +69,11 @@ class Html extends AbstractAdapter
 
                 $quote = $directive[1];
                 $this->_addPhrase($quote . $directive[2] . $quote);
+            } elseif (in_array($results[$i][1], ['depend', 'if'], true) && isset($results[$i][3])) {
+                // make sure to process trans directives nested inside depend / if directives
+                $this->extractPhrasesFromTransDirective($results[$i][3]);
             }
         }
-
-        $this->extractPhrases(self::REGEX_I18N_BINDING, $data, 2, 1);
-        $this->extractPhrases(self::REGEX_TRANSLATE_TAG_OR_ATTR, $data, 3, 2);
-        $this->extractPhrases(Js::REGEX_TRANSLATE_FUNCTION, $data, 3, 2);
     }
 
     /**

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -22,7 +22,7 @@ class Html extends AbstractAdapter
      * @deprecated Not used anymore because of newly introduced constants
      * @see self::REGEX_I18N_BINDING and self::REGEX_TRANSLATE_TAG_OR_ATTR
      */
-    const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/";
+    public const HTML_FILTER = "/i18n:\s?'(?<value>[^'\\\\]*(?:\\\\.[^'\\\\]*)*)'/";
 
     /**
      * Covers

--- a/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
+++ b/setup/src/Magento/Setup/Module/I18n/Parser/Adapter/Html.php
@@ -56,6 +56,13 @@ class Html extends AbstractAdapter
         $this->extractPhrases(Js::REGEX_TRANSLATE_FUNCTION, $data, 3, 2);
     }
 
+    /**
+     * Extracts all phrases from trans directives in the given string.
+     *
+     * @param string $data
+     *
+     * @return void
+     */
     private function extractPhrasesFromTransDirective(string $data): void
     {
         $results = [];
@@ -77,6 +84,8 @@ class Html extends AbstractAdapter
     }
 
     /**
+     * Extracts all phrases with the given regex in the given string.
+     *
      * @param string $regex
      * @param string $data
      * @param int $expectedGroupsCount


### PR DESCRIPTION
### Description (*)
This PR makes sure that `trans` directives, which are nested in `depend` or `if` directives are handled correctly. Currently, the `i18n:collect-phrases` command would not catch the phrases, so that they are not added to the translation file.

### Related Pull Requests
n/a

### Fixed Issues (if relevant)
1. Fixes magento/magento2#35449

### Manual testing scenarios (*)
See fixed issue magento/magento2#35449.

### Questions or comments
n/a

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
