### PR TITLE
Save quote_payment_id value into sales_order_payment table

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Payment/ToOrderPayment.php
+++ b/app/code/Magento/Quote/Model/Quote/Payment/ToOrderPayment.php
@@ -75,6 +75,7 @@ class ToOrderPayment
         // set directly on the model
         $orderPayment->setCcNumber($object->getCcNumber());
         $orderPayment->setCcCid($object->getCcCid());
+        $orderPayment->setQuotePaymentId($object->getId());
 
         return $orderPayment;
     }

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/Payment/ToOrderPaymentTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/Payment/ToOrderPaymentTest.php
@@ -50,7 +50,7 @@ class ToOrderPaymentTest extends TestCase
     {
         $this->paymentMock = $this->getMockBuilder(Payment::class)
             ->addMethods(['getCcNumber', 'getCcCid'])
-            ->onlyMethods(['getMethodInstance', 'getAdditionalInformation'])
+            ->onlyMethods(['getMethodInstance', 'getAdditionalInformation', 'getId'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->objectCopyMock = $this->createMock(Copy::class);
@@ -98,12 +98,16 @@ class ToOrderPaymentTest extends TestCase
             ->willReturn($additionalInfo);
         $ccNumber = 123456798;
         $ccCid = 1234;
+        $paymentId = 1;
         $this->paymentMock->expects($this->once())
             ->method('getCcNumber')
             ->willReturn($ccNumber);
         $this->paymentMock->expects($this->once())
             ->method('getCcCid')
             ->willReturn($ccCid);
+        $this->paymentMock->expects($this->once())
+            ->method('getId')
+            ->willReturn($paymentId);
 
         $orderPayment = $this->getMockForAbstractClass(
             OrderPaymentInterface::class,
@@ -112,7 +116,7 @@ class ToOrderPaymentTest extends TestCase
             false,
             true,
             true,
-            ['setCcNumber', 'setCcCid', 'setAdditionalInformation']
+            ['setCcNumber', 'setCcCid', 'setAdditionalInformation', 'setQuotePaymentId']
         );
         $orderPayment->expects($this->once())
             ->method('setAdditionalInformation')
@@ -123,6 +127,9 @@ class ToOrderPaymentTest extends TestCase
             ->willReturnSelf();
         $orderPayment->expects($this->once())
             ->method('setCcCid')
+            ->willReturnSelf();
+        $orderPayment->expects($this->once())
+            ->method('setQuotePaymentId')
             ->willReturnSelf();
 
         $this->orderPaymentRepositoryMock->expects($this->once())->method('create')->willReturn($orderPayment);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Currently sales_order_payment table always contains empty quote_payment_id so I have provided the following code:
$orderPayment->setQuotePaymentId($object->getId()); in app/code/Magento/Quote/Model/Quote/Payment/ToOrderPayment.php to set the payment Id 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Place an Order
2. Observe the value for quote_payment_id  in sales_order_payment table it should not be NULL

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
