### PR TITLE
Issue/33352

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/UnitBaseCalculator.php
@@ -133,6 +133,7 @@ class UnitBaseCalculator extends AbstractCalculator
         $appliedRates = $this->calculationTool->getAppliedRates($taxRateRequest);
 
         $applyTaxAfterDiscount = $this->config->applyTaxAfterDiscount($this->storeId);
+        $applyTaxRounding = $this->config->applyTaxRounding($this->storeId);
         $discountAmount = $item->getDiscountAmount();
         $discountTaxCompensationAmount = 0;
 
@@ -164,14 +165,17 @@ class UnitBaseCalculator extends AbstractCalculator
                     false,
                     false
                 );
-                $unitTaxAfterDiscount = $this->roundAmount(
-                    $unitTaxAfterDiscount,
-                    $taxId,
-                    false,
-                    self::KEY_REGULAR_DELTA_ROUNDING,
-                    $round,
-                    $item
-                );
+
+                if ($applyTaxRounding) {
+                    $unitTaxAfterDiscount = $this->roundAmount(
+                        $unitTaxAfterDiscount,
+                        $taxId,
+                        false,
+                        self::KEY_REGULAR_DELTA_ROUNDING,
+                        $round,
+                        $item
+                    );
+                }
             }
             $appliedTaxes[$taxId] = $this->getAppliedTax(
                 $unitTaxAfterDiscount * $quantity,

--- a/app/code/Magento/Tax/Model/Config.php
+++ b/app/code/Magento/Tax/Model/Config.php
@@ -43,6 +43,8 @@ class Config
 
     public const CONFIG_XML_PATH_APPLY_ON = 'tax/calculation/apply_tax_on';
 
+    public const CONFIG_XML_PATH_APPLY_TAX_ROUNDING = 'tax/calculation/apply_tax_rounding';
+
     public const CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT = 'tax/calculation/apply_after_discount';
 
     public const CONFIG_XML_PATH_DISCOUNT_TAX = 'tax/calculation/discount_tax';
@@ -205,6 +207,21 @@ class Config
     {
         return (bool)$this->_scopeConfig->getValue(
             self::CONFIG_XML_PATH_APPLY_AFTER_DISCOUNT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    /**
+     * Get configuration setting "Apply Tax Rounding" value
+     *
+     * @param   null|string|bool|int|Store $store
+     * @return  bool
+     */
+    public function applyTaxRounding($store = null)
+    {
+        return (bool) $this->_scopeConfig->getValue(
+            self::CONFIG_XML_PATH_APPLY_TAX_ROUNDING,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
@@ -182,6 +182,10 @@ class UnitBaseCalculatorTest extends TestCase
             ->method('applyTaxAfterDiscount')
             ->willReturn(true);
 
+        $this->mockConfig->expects($this->once())
+            ->method('applyTaxRounding')
+            ->willReturn(true);
+
         $this->mockCalculationTool->expects($this->once())
             ->method('getRate')
             ->with($this->addressRateRequest)

--- a/app/code/Magento/Tax/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/ConfigTest.php
@@ -134,6 +134,12 @@ class ConfigTest extends TestCase
                 true
             ],
             [
+                'applyTaxRounding',
+                Config::CONFIG_XML_PATH_APPLY_TAX_ROUNDING,
+                true,
+                true
+            ],
+            [
                 'getPriceDisplayType',
                 Config::CONFIG_XML_PATH_PRICE_DISPLAY_TYPE,
                 true,

--- a/app/code/Magento/Tax/etc/adminhtml/system.xml
+++ b/app/code/Magento/Tax/etc/adminhtml/system.xml
@@ -71,6 +71,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>When catalog price includes tax, enable this setting to fix the price no matter what the customer's tax rate.</comment>
                 </field>
+                <field id="apply_tax_rounding" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1">
+                    <label>Apply Tax Rounding</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>When catalog price includes tax, enable this setting to round tax amount.</comment>
+                </field>
             </group>
             <group id="defaults" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Default Tax Destination Calculation</label>

--- a/app/code/Magento/Tax/etc/config.xml
+++ b/app/code/Magento/Tax/etc/config.xml
@@ -21,6 +21,7 @@
                 <price_includes_tax>0</price_includes_tax>
                 <shipping_includes_tax>0</shipping_includes_tax>
                 <apply_tax_on>0</apply_tax_on>
+                <apply_tax_rounding>1</apply_tax_rounding>
             </calculation>
             <defaults>
                 <country>US</country>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)


<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Based on this [issue](https://github.com/magento/magento2/issues/33352)  I have provided an additional configuration to enable/disable tax rounding when catalog price includes tax.


### Manual testing scenarios (*)

- Login to Magento Admin
- Add New Tax Rate - 19% in Stores/Tax Zones  and Rates

![tax-1](https://user-images.githubusercontent.com/57759456/176389363-b9cfc623-8db0-4ed3-a6b7-401d0d1a8835.png)

- Apply created tax rate in Stores/Tax Rules
![tax-2](https://user-images.githubusercontent.com/57759456/176391546-89312384-eba3-4920-b411-5aa80c00b881.png)

- Set every configuration in Sales / Tax to Excluding Tax (Calucation Settings: Catalog Prices, Shipping PRices, Apply Discount on Prices, All Display Settings)
- Set "The Tax Calculation Method Based On" to "Unit Price"
- Disable "Apply Tax Rounding" setting in Sales/Tax/Calculation Settings
- Add products in high quantities to the shopping cart, e.g., 200 
- Place Order
- Observe Tax Amount
 
![tax-3](https://user-images.githubusercontent.com/57759456/176392973-684b79f8-e9a2-448d-9ed0-907fe8303bb6.png)


**Expected Result**
Tax Amount should not be rounded

Fixes https://github.com/magento/magento2/issues/33352