### PR TITLE
Disable autocomplete for browser saved password

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -255,7 +255,7 @@ $createAccountButtonViewModel = $block->getData('create_account_button_view_mode
                        data-password-min-character-sets="<?=
                         $escaper->escapeHtmlAttr($block->getRequiredCharacterClassesNumber()) ?>"
                        data-validate="{required:true, 'validate-customer-password':true}"
-                       autocomplete="off">
+                       autocomplete="new-password">
                 <div id="password-strength-meter-container" data-role="password-strength-meter" aria-live="polite">
                     <div id="password-strength-meter" class="password-strength-meter">
                         <?= $escaper->escapeHtml(__('Password Strength')) ?>:
@@ -278,7 +278,7 @@ $createAccountButtonViewModel = $block->getData('create_account_button_view_mode
                        id="password-confirmation"
                        class="input-text"
                        data-validate="{required:true, equalTo:'#password'}"
-                       autocomplete="off">
+                       autocomplete="new-password">
             </div>
         </div>
         <div class="field choice" data-bind="scope: 'showPassword'">


### PR DESCRIPTION
Here there is a validation error if a password is stored and the register block is integrated as a modal.

Error:
```
jquery.validate.js:164 Uncaught TypeError: Cannot read properties of undefined (reading 'settings')
    at jQuery.fn.init.rules (jquery.validate.js:164:63)
    at $.<computed>.<computed>._calculateStrength (password-strength-indicator.js:75:42)
    at $.<computed>.<computed>._calculateStrength (widget.js:132:25)
    at HTMLInputElement.handlerProxy (widget.js:611:7)
    at HTMLInputElement.dispatch (jquery.js:5430:49)
    at elemData.handle (jquery.js:5234:47)
```
![Vali](https://user-images.githubusercontent.com/16542619/176638241-0d5a7821-790b-4b80-b8ad-a7e5051c9ceb.PNG)


Code Reference:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#browser_compatibility

1. Create an account and save the password in Chrome/Mozilla
2. Then the registry page will show the password which is already filled

After the change this is no longer the case, a registration page should always use a new password.