### PR TITLE
Fixes to admin serialized array configuration value (Abstract field array)

### DIFF
--- a/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
@@ -56,6 +56,13 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
     protected $_template = 'Magento_Config::system/config/form/field/array.phtml';
 
     /**
+     * Increment id for each row of a table
+     *
+     * @var int
+     */
+    protected $_incrementId = 1;
+
+    /**
      * Check if columns are defined, set template
      *
      * @return void
@@ -115,6 +122,7 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
         $this->setElement($element);
         $html = $this->_toHtml();
         $this->_arrayRowsCache = null;
+        $this->_incrementId = ++$this->_incrementId;
         // doh, the object is used as singleton!
         return $html;
     }
@@ -148,6 +156,7 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
         $element = $this->getElement();
         if ($element->getValue() && is_array($element->getValue())) {
             foreach ($element->getValue() as $rowId => $row) {
+                $row = $this->validateRow($row);
                 $rowColumnValues = [];
                 foreach ($row as $key => $value) {
                     $row[$key] = $value;
@@ -287,5 +296,34 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
     public function getAddButtonLabel()
     {
         return $this->_addButtonLabel;
+    }
+
+    /**
+     * Return row increment id
+     *
+     * @return int
+     */
+    public function getIncrementId()
+    {
+        return $this->_incrementId;
+    }
+
+    /**
+     * Make sure that the row has the required row data available for rendering.
+     *
+     * @param array<string,string> $row
+     *
+     * @return array<string,string>
+     */
+    private function validateRow(array $row): array
+    {
+        foreach ($this->_columns as $columnId => $column) {
+            // Dropdowns will have a renderer which handles the rendering correctly for any missing column.
+            if (!isset($row[$columnId]) && !$column['renderer']) {
+                $row[$columnId] = '';
+            }
+        }
+
+        return $row;
     }
 }

--- a/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
+++ b/app/code/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php
@@ -156,7 +156,6 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
         $element = $this->getElement();
         if ($element->getValue() && is_array($element->getValue())) {
             foreach ($element->getValue() as $rowId => $row) {
-                $row = $this->validateRow($row);
                 $rowColumnValues = [];
                 foreach ($row as $key => $value) {
                     $row[$key] = $value;
@@ -306,24 +305,5 @@ abstract class AbstractFieldArray extends \Magento\Config\Block\System\Config\Fo
     public function getIncrementId()
     {
         return $this->_incrementId;
-    }
-
-    /**
-     * Make sure that the row has the required row data available for rendering.
-     *
-     * @param array<string,string> $row
-     *
-     * @return array<string,string>
-     */
-    private function validateRow(array $row): array
-    {
-        foreach ($this->_columns as $columnId => $column) {
-            // Dropdowns will have a renderer which handles the rendering correctly for any missing column.
-            if (!isset($row[$columnId]) && !$column['renderer']) {
-                $row[$columnId] = '';
-            }
-        }
-
-        return $row;
     }
 }

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -8,7 +8,8 @@
 ?>
 
 <?php
-$_htmlId = $block->getHtmlId() ? $block->getHtmlId() : '_' . uniqid();
+$_htmlId = $block->getHtmlId() ? $block->getHtmlId() : uniqid();
+$_htmlId = 'table_' . $_htmlId . '_' . $block->getIncrementId();
 $_colspan = $block->isAddAfter() ? 2 : 1;
 ?>
 
@@ -108,8 +109,15 @@ script;
     endforeach;
     $scriptString .= <<<script
 
-                        _id: '_' + d.getTime() + '_' + d.getMilliseconds()
+                        _id: '{$_htmlId}_' + d.getTime() + '_' + d.getMilliseconds()
                 };
+            }
+
+            // If row data in the core_config_data-table is an array,
+            // the _id will be an array index number which won't be unique
+            // and will break the form. This makes each id unique.
+            if (Number.isInteger(templateValues['_id'])) {
+                templateValues['_id'] = '{$_htmlId}_' + templateValues['_id'];
             }
 
             // Insert new row after specified row or at the bottom


### PR DESCRIPTION
### Description (*)

Currently there are a few issues with the frontend rendering of admin config serialized array values handled by `Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArray.php` and `Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml`. This PR is aimed to fix two issues with the rendering.

**First issue:**

There are rendering problems on the configuration page with serialized arrays when the data is being stored in the database (`core_config_data`-table) as arrays instead of an objects. If there is a table that is stored as an array, the table will be rendered with invalid html ids, since the ids will be just array index numbers (0, 1, 2 ...). If there are multiple serialized array -widgets with data as arrays on the same page, this will cause duplicate html ids on the page. The duplicate ids cause javascript issues that break row deletion and row input value setting since there are multiple targets.

Deletion of rows will break (`app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml:155`):

![Screenshot from 2022-07-04 10-31-42](https://user-images.githubusercontent.com/16919059/177105279-45407413-fcf6-4c7d-b01e-e49f3527a385.png)

Input value setting done via javascript (`app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml:135`). The values won't be set for the correct tables because of the duplicate ids since the first table with the duplicate id will always be targeted with the setValue script:

![image](https://user-images.githubusercontent.com/16919059/177107478-bf441f6a-f025-4d4f-ae36-235076d13087.png)


The proposed change is to make sure that the table and table row ids will be unique by introducing an incrementId for tables in the `AbstractFieldArray.php` and modifying the `array.phtml` to have unique ids for data rows that are rendered from array-data that'd otherwise have integer as it's html ids.

**Second issue:**

If a new column is added to an already existing serialized array, without having a patch that would update the existing data, each serialized array -widget on the page would break because the row cannot be rendered with missing columns by the `Element.insert($('addRow{$block->escapeJs($_htmlId)}'), {bottom: this.template(templateValues)});` (`app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml:127`).

The proposed change is to validate the rows with the `validateRow`-function in the `AbstractFieldArray.php` before rendering, by initializing the missing column by adding an entry to the row with the column key and assigning an empty string as it's value. Columns with a renderer are skipped since these are rows that have a dropdown. The dropdown renderer will handle any missing columns automatically, and the rows will work even if the column value is missing from the database entry. 

![image](https://user-images.githubusercontent.com/16919059/177108955-b78a2d48-f0e5-4d27-8d05-87842c2c1b6d.png)


### Manual testing scenarios (*)

1. Setup a configuration page which has two fields that use the `Magento\Config\Model\Config\Backend\Serialized\ArraySerialized` backend_model.

```
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
    <system>
        <section id="test_serialized_array_test" showInDefault="1" showInWebsite="0" showInStore="0">
            <tab>test_config</tab>
            <label>Serialized Array Testing</label>
            <resource>Test_SerializedArrayTest::config</resource>
            <group id="general" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="3100">
                <label>Serialized Array Test</label>
                <field id="dogs" sortOrder="10" type="text" showInDefault="1" showInWebsite="0" showInStore="0">
                    <label>Dogs</label>
                    <frontend_model>Test\SerializedArrayTest\Block\System\Config\Form\Field\Animal</frontend_model>
                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                </field>
                <field id="cats" sortOrder="20" type="text" showInDefault="1" showInWebsite="0" showInStore="0">
                    <label>Cats</label>
                    <frontend_model>Test\SerializedArrayTest\Block\System\Config\Form\Field\Animal</frontend_model>
                    <backend_model>Magento\Config\Model\Config\Backend\Serialized\ArraySerialized</backend_model>
                </field>
            </group>
        </section>
    </system>
</config>
```

2. Prepare the columns for rendering

```
namespace Test\SerializedArrayTest\Block\System\Config\Form\Field;

use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
use Magento\Framework\Phrase;

class Animal extends AbstractFieldArray
{
    /**
     * {@inheritdoc}
     */
    protected $_addAfter = true;

    /**
     * {@inheritdoc}
     */
    protected $_addButtonLabel;

    /**
     * {@inheritdoc}
     */
    protected function _prepareToRender()
    {
        $this->addColumn('name', [
            'label' => new Phrase('Name'),
        ]);

        $this->addColumn('age', [
            'label' => new Phrase('Age'),
        ]);

        $this->addColumn('color', [
            'label' => new Phrase('Color'),
        ]);

        $this->_addAfter = false;
        $this->_addButtonLabel = (new Phrase('Add'))->render();
    }
}
```

3. Insert data for the newly added configuration values that are arrays (not objects)

```
INSERT INTO `core_config_data` (`config_id`, `scope`, `scope_id`, `path`, `value`, `updated_at`) VALUES
(1863, 'default', 0, 'test_serialized_array_test/general/dogs', '[{\"name\":\"Max\",\"age\":\"8\"},{\"name\":\"Rex\",\"age\":\"11\"}]', '2022-07-04 11:04:21'),
(1864, 'default', 0, 'test_serialized_array_test/general/cats', '[{\"name\":\"Ada\",\"age\":\"2\"},{\"name\":\"Eliza\",\"age\":\"13\"}]', '2022-07-04 11:04:32');
```

4. You should encounter both of the errors described in the PR when you go to the configuration page. The error related to duplicate ids, and error due to missing column data.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
