### PR TITLE
Improve AdvancedPricingImportExport saving of bunch data

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Import/AdvancedPricing.php
@@ -397,6 +397,7 @@ class AdvancedPricing extends \Magento\ImportExport\Model\Import\Entity\Abstract
         $listSku = [];
         $tierPrices = [];
         while ($bunch = $this->_dataSourceModel->getNextBunch()) {
+            $bunchTierPrices = [];
             foreach ($bunch as $rowNum => $rowData) {
                 if (!$this->validateRow($rowData, $rowNum)) {
                     $this->addRowError(ValidatorInterface::ERROR_SKU_IS_EMPTY, $rowNum);
@@ -410,7 +411,7 @@ class AdvancedPricing extends \Magento\ImportExport\Model\Import\Entity\Abstract
                 $rowSku = $rowData[self::COL_SKU];
                 $listSku[] = $rowSku;
                 if (!empty($rowData[self::COL_TIER_PRICE_WEBSITE])) {
-                    $tierPrices[$rowSku][] = [
+                    $tierPrice = [
                         'all_groups' => $rowData[self::COL_TIER_PRICE_CUSTOMER_GROUP] == self::VALUE_ALL_GROUPS,
                         'customer_group_id' => $this->getCustomerGroupId(
                             $rowData[self::COL_TIER_PRICE_CUSTOMER_GROUP]
@@ -422,17 +423,26 @@ class AdvancedPricing extends \Magento\ImportExport\Model\Import\Entity\Abstract
                             ? $rowData[self::COL_TIER_PRICE] : null,
                         'website_id' => $this->getWebSiteId($rowData[self::COL_TIER_PRICE_WEBSITE])
                     ];
+                    if (\Magento\ImportExport\Model\Import::BEHAVIOR_APPEND == $behavior) {
+                         $bunchTierPrices[$rowSku][] = $tierPrice;
+                    }
+                    if (\Magento\ImportExport\Model\Import::BEHAVIOR_REPLACE == $behavior) {
+                        $tierPrices[$rowSku][] = $tierPrice;
+                    }
                 }
             }
 
             if (\Magento\ImportExport\Model\Import::BEHAVIOR_APPEND == $behavior) {
-                $this->processCountExistingPrices($tierPrices, self::TABLE_TIER_PRICE)
-                    ->processCountNewPrices($tierPrices);
+                $this->processCountExistingPrices($bunchTierPrices, self::TABLE_TIER_PRICE)
+                    ->processCountNewPrices($bunchTierPrices);
 
-                $this->saveProductPrices($tierPrices, self::TABLE_TIER_PRICE);
-                if ($listSku) {
-                    $this->setUpdatedAt($listSku);
-                }
+                $this->saveProductPrices($bunchTierPrices, self::TABLE_TIER_PRICE);
+            }
+        }
+
+        if (\Magento\ImportExport\Model\Import::BEHAVIOR_APPEND == $behavior) {
+            if ($listSku) {
+                $this->setUpdatedAt($listSku);
             }
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Current implementation inserts the same data from previous bunches again and again until the import finishes. This is because `$tierPrices` is defined outside of the while loop and filled for each bunch keeping data from previous bunches.

This might work in most cases because the insert checks for duplicates but causes problems for imports that do some pre-processing on the data before running the insert. This changes also significantly improves import performance.

### Related Pull Requests

none.

### Fixed Issues (if relevant)

none.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - ~~[ ] All new or changed code is covered with unit/integration tests (if applicable)~~
 - ~~[ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update~~
 - [ ] All automated tests passed successfully (all builds are green)
