### PR TITLE
Fixes the active_tab param not applying on admin sections that use th…

### DIFF
--- a/lib/web/mage/backend/tabs.js
+++ b/lib/web/mage/backend/tabs.js
@@ -65,7 +65,7 @@ define([
                 this.anchors :
                 this._getList().find('> li > a[href]');
 
-            return anchors.index($('#' + id));
+            return anchors.index($('a#' + id));
         },
 
         /**


### PR DESCRIPTION
…e tabs.js script

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
On Admin sections like Sales Order Edit, Product Attribute Edit, Admin User Edit. among others, that use the `tabs.js` mage script, there exists supporting code to allow for an `active_tab` to be passed in the URL as a param, and that tab will get selected and load first on the page. This is all working up until the JS has to find the selector and its index on the page, where it is using the wrong selector, so it always gets an index of `-1`.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Login to the Admin
2. Go view an existing Order
3. Now add this extra param to the url `/active_tab/order_shipments` and go to that page
4. The Order should now load with the `Shipments` tab active
5. Do the same now with `/active_tab/order_invoices`. This should select the `Invoices` tab on load


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
