### PR TITLE
Fix email preview template cut off

### DIFF
--- a/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -34,7 +34,7 @@ require([
         $('#preview_form').trigger('submit');
     });
 
-    $('#preview_iframe').load(function() {
+    $('#preview_iframe').on('load', function() {
         $(this).height($(this).contents().height());
     });
 });


### PR DESCRIPTION
Jquery 3.6 doesn't have .load anymore.

Resolves https://github.com/magento/magento2/issues/35697