### PR TITLE
ReviewGraphQl rating name from correct store

### DIFF
--- a/app/code/Magento/ReviewGraphQl/Model/Resolver/ProductReviewRatingsMetadata.php
+++ b/app/code/Magento/ReviewGraphQl/Model/Resolver/ProductReviewRatingsMetadata.php
@@ -75,6 +75,7 @@ class ProductReviewRatingsMetadata implements ResolverInterface
         $ratingCollection = $this->ratingCollectionFactory->create();
         $ratingCollection->addEntityFilter(Review::ENTITY_PRODUCT_CODE)
             ->setStoreFilter($store->getId())
+            ->addRatingPerStoreName($store->getId())
             ->setActiveFilter(true)
             ->setPositionOrder()
             ->addOptionToItems();


### PR DESCRIPTION
### Description (*)

When running the `productReviewRatingsMetadata` GraphQL query you'll always get the `rating_code` / default title instead of the store specific title.

### Manual testing scenarios (*)

1. Create multiple stores
2. Fill in the review titles
3. Run the GraphQL query:
```
curl 'http://magento.test/graphql' \
  -H 'Content-Type: application/json' \
  -H 'Store: STORECODE' \
  --data-raw '{"query":"query { productReviewRatingsMetadata { items { name } } }"}';
```