### PR TITLE
Set shared=false for SortOrderBuilder

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -284,6 +284,7 @@
     </type>
     <type name="Magento\Framework\Api\FilterBuilder" shared="false" />
     <type name="Magento\Framework\Api\SearchCriteriaBuilder" shared="false" />
+    <type name="Magento\Framework\Api\SortOrderBuilder" shared="false" />
     <type name="Magento\Framework\View\Layout\Builder" shared="false" />
     <type name="Magento\Framework\View\Page\Builder" shared="false" />
     <type name="Magento\Framework\Message\Manager">


### PR DESCRIPTION
Using a shared instance for this builder easily causes unwanted side effects

### Description (*)

The builders do not need to be shared as per their definition. If a builder is shared, it can causes side effects.
While the actual effect was not reproducible on a vanilla Magento instance, the bug is quite obvious.

In our case the sorting of the customer grid in the admin panel did not have any effect, because the UiComponent building process interfered with `\Magento\Customer\Model\GroupManagement::getLoggedInGroups`

### Manual testing scenarios (*)

I was not able to reproduce this on Vanilla Magento.

On our instance the repro steps were like this:

1. Click title in custom grid to sort the list
2. Does not have any effect

### Questions or comments

I hope this does not go the good old "can reproduce" loop. The issue should be clear. Please merge.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#35939: Set shared=false for SortOrderBuilder