### PR TITLE
Issue #35612 Magento\SalesGraphQl\Model\OrderItem\DataProvider uses non-contract methods on OrderItemInterface

### DIFF
--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -805,7 +805,7 @@ abstract class AbstractEntity
                     if (!$this->isAttributeParticular($columnName)) {
                         if (trim($columnName ?? '') == '') {
                             $emptyHeaderColumns[] = $columnNumber;
-                        } elseif (!$columnName || !preg_match('/^[\w\d_]*$/', $columnName)) {
+                        } elseif (!$columnName || !preg_match('/^[a-z][a-z0-9_]*$/', $columnName)) {
                             $invalidColumns[] = $columnName;
                         } elseif ($this->needColumnCheck && !in_array($columnName, $this->getValidColumnNames())) {
                             $invalidAttributes[] = $columnName;

--- a/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Import/Entity/AbstractEntity.php
@@ -805,7 +805,7 @@ abstract class AbstractEntity
                     if (!$this->isAttributeParticular($columnName)) {
                         if (trim($columnName ?? '') == '') {
                             $emptyHeaderColumns[] = $columnNumber;
-                        } elseif (!$columnName || !preg_match('/^[a-z][a-z0-9_]*$/', $columnName)) {
+                        } elseif (!$columnName || !preg_match('/^[\w\d_]*$/', $columnName)) {
                             $invalidColumns[] = $columnName;
                         } elseif ($this->needColumnCheck && !in_array($columnName, $this->getValidColumnNames())) {
                             $invalidAttributes[] = $columnName;

--- a/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
+++ b/app/code/Magento/Sales/Api/Data/OrderItemInterface.php
@@ -948,6 +948,13 @@ interface OrderItemInterface extends \Magento\Framework\Api\ExtensibleDataInterf
     public function getRowWeight();
 
     /**
+     * Gets the status for the order item.
+     *
+     * @return string status.
+     */
+    public function getStatus();
+
+    /**
      * Gets the SKU for the order item.
      *
      * @return string SKU.


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
I have added getStatus method to the Magento\Sales\Api\Data\OrderItemInterface . 
Open vendor/magento/module-sales-graph-ql/Model/OrderItem/DataProvider.php and goto line 140. Here a implementation specific method (getStatus) is called on an interface. This method does not exists in the interface.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35612

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Update the module-sales-graph-ql\Model\Resolver\OrderItems.php:55 with the following code: 

```
        $orderId = 10;
        $objectManager = Bootstrap::create(BP, $_SERVER)->getObjectManager();
        /** @var \Magento\Sales\Api\OrderRepositoryInterface $orderRepository */
        $orderRepository = $objectManager->get(\Magento\Sales\Api\OrderRepositoryInterface::class);
        $value['model'] = $orderRepository->get($orderId);
```



2. Use the following GraphQl query to retrieve the order items:  
```
{
  customerOrders {    
    items {
      increment_id
      status         
      order_number
      id      
      created_at
      items {
          id
          status
      }     
    }
  }
}
```

3. Ensure there is no issues occurring with $orderItem->getStatus() method in module-sales-graph-ql\Model\OrderItem\DataProvider.php 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
