### PR TITLE
feat: allow user to define php error_reporting levels

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -7,7 +7,6 @@
 /**
  * Environment initialization
  */
-error_reporting(E_ALL);
 if (in_array('phar', \stream_get_wrappers())) {
     stream_wrapper_unregister('phar');
 }


### PR DESCRIPTION
### Description (*)
Php 8.1 has lots of deprecations that are being reported as errors in production. As an example [colinmollenhour](https://github.com/colinmollenhour) /
[php-redis-session-abstract](https://github.com/colinmollenhour/php-redis-session-abstract/tree/v1.5.0) 

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35875


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
