### PR TITLE
Add Possibility to use Table Prefixes in magento/module-elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php.

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -64,13 +64,13 @@ class SearchResultApplier implements SearchResultApplierInterface
     private $stockStatusApplier;
 
     /**
-     * @param Collection $collection
-     * @param SearchResultInterface $searchResult
-     * @param int $size
-     * @param int $currentPage
-     * @param ScopeConfigInterface|null $scopeConfig
-     * @param MetadataPool|null $metadataPool
-     * @param StockStatusFilterInterface|null $stockStatusFilter
+     * @param Collection                       $collection
+     * @param SearchResultInterface            $searchResult
+     * @param int                              $size
+     * @param int                              $currentPage
+     * @param ScopeConfigInterface|null        $scopeConfig
+     * @param MetadataPool|null                $metadataPool
+     * @param StockStatusFilterInterface|null  $stockStatusFilter
      * @param StockStatusApplierInterface|null $stockStatusApplier
      */
     public function __construct(
@@ -82,8 +82,7 @@ class SearchResultApplier implements SearchResultApplierInterface
         ?MetadataPool                $metadataPool = null,
         ?StockStatusFilterInterface  $stockStatusFilter = null,
         ?StockStatusApplierInterface $stockStatusApplier = null
-    )
-    {
+    ) {
         $this->collection = $collection;
         $this->searchResult = $searchResult;
         $this->size = $size;
@@ -124,9 +123,9 @@ class SearchResultApplier implements SearchResultApplierInterface
     /**
      * Slice current items
      *
-     * @param array $items
-     * @param int $size
-     * @param int $currentPage
+     * @param  array $items
+     * @param  int   $size
+     * @param  int   $currentPage
      * @return array
      */
     private function sliceItems(array $items, int $size, int $currentPage): array
@@ -153,8 +152,8 @@ class SearchResultApplier implements SearchResultApplierInterface
     /**
      * Get offset for given page.
      *
-     * @param int $pageNumber
-     * @param int $pageSize
+     * @param  int $pageNumber
+     * @param  int $pageSize
      * @return int
      */
     private function getOffset(int $pageNumber, int $pageSize): int
@@ -176,7 +175,8 @@ class SearchResultApplier implements SearchResultApplierInterface
         }
 
         if ($this->collection->getFlag('has_stock_status_filter')
-            || $this->collection->getFlag('has_category_filter')) {
+            || $this->collection->getFlag('has_category_filter')
+        ) {
             $categoryId = null;
             $searchCriteria = $this->searchResult->getSearchCriteria();
             foreach ($searchCriteria->getFilterGroups() as $filterGroup) {
@@ -202,7 +202,7 @@ class SearchResultApplier implements SearchResultApplierInterface
     /**
      * Fetch product resultset by custom sort orders
      *
-     * @param int $categoryId
+     * @param  int $categoryId
      * @return array
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Exception

--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -239,7 +239,7 @@ class SearchResultApplier implements SearchResultApplierInterface
                 $query->joinLeft(
                     ['product_var' => $this->collection->getTable('catalog_product_entity_varchar')],
                     "product_var.{$linkField} = e.{$linkField} AND product_var.attribute_id =
-                    (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId}
+                    (SELECT attribute_id FROM {$this->collection->getTable('eav_attribute')} WHERE entity_type_id={$entityTypeId}
                     AND attribute_code='name')",
                     ['product_var.value AS name']
                 );
@@ -248,7 +248,7 @@ class SearchResultApplier implements SearchResultApplierInterface
                     ['price_index' => $this->collection->getTable('catalog_product_index_price')],
                     'price_index.entity_id = e.entity_id'
                     . ' AND price_index.customer_group_id = 0'
-                    . ' AND price_index.website_id = (Select website_id FROM store WHERE store_id = '
+                    . " AND price_index.website_id = (Select website_id FROM  {$this->collection->getTable('store')} WHERE store_id = "
                     . $storeId . ')',
                     ['price_index.max_price AS price']
                 );

--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -74,15 +74,16 @@ class SearchResultApplier implements SearchResultApplierInterface
      * @param StockStatusApplierInterface|null $stockStatusApplier
      */
     public function __construct(
-        Collection $collection,
-        SearchResultInterface $searchResult,
-        int $size,
-        int $currentPage,
-        ?ScopeConfigInterface $scopeConfig = null,
-        ?MetadataPool $metadataPool = null,
-        ?StockStatusFilterInterface $stockStatusFilter = null,
+        Collection                   $collection,
+        SearchResultInterface        $searchResult,
+        int                          $size,
+        int                          $currentPage,
+        ?ScopeConfigInterface        $scopeConfig = null,
+        ?MetadataPool                $metadataPool = null,
+        ?StockStatusFilterInterface  $stockStatusFilter = null,
         ?StockStatusApplierInterface $stockStatusApplier = null
-    ) {
+    )
+    {
         $this->collection = $collection;
         $this->searchResult = $searchResult;
         $this->size = $size;
@@ -134,7 +135,7 @@ class SearchResultApplier implements SearchResultApplierInterface
             // Check that current page is in a range of allowed page numbers, based on items count and items per page,
             // than calculate offset for slicing items array.
             $itemsCount = count($items);
-            $maxAllowedPageNumber = ceil($itemsCount/$size);
+            $maxAllowedPageNumber = ceil($itemsCount / $size);
             if ($currentPage < 1) {
                 $currentPage = 1;
             }
@@ -160,6 +161,7 @@ class SearchResultApplier implements SearchResultApplierInterface
     {
         return ($pageNumber - 1) * $pageSize;
     }
+
     /**
      * Fetch filtered product ids sorted by the saleability and other applied sort orders
      *
@@ -239,7 +241,9 @@ class SearchResultApplier implements SearchResultApplierInterface
                 $query->joinLeft(
                     ['product_var' => $this->collection->getTable('catalog_product_entity_varchar')],
                     "product_var.{$linkField} = e.{$linkField} AND product_var.attribute_id =
-                    (SELECT attribute_id FROM {$this->collection->getTable('eav_attribute')} WHERE entity_type_id={$entityTypeId}
+		            (SELECT attribute_id FROM
+	                {$this->collection->getTable('eav_attribute')}
+		            WHERE entity_type_id={$entityTypeId}
                     AND attribute_code='name')",
                     ['product_var.value AS name']
                 );
@@ -248,7 +252,9 @@ class SearchResultApplier implements SearchResultApplierInterface
                     ['price_index' => $this->collection->getTable('catalog_product_index_price')],
                     'price_index.entity_id = e.entity_id'
                     . ' AND price_index.customer_group_id = 0'
-                    . " AND price_index.website_id = (Select website_id FROM  {$this->collection->getTable('store')} WHERE store_id = "
+                    . " AND price_index.website_id = (Select website_id FROM
+	                {$this->collection->getTable('store')}
+		            WHERE store_id = "
                     . $storeId . ')',
                     ['price_index.max_price AS price']
                 );
@@ -278,7 +284,7 @@ class SearchResultApplier implements SearchResultApplierInterface
      */
     private function hasShowOutOfStockStatus(): bool
     {
-        return (bool) $this->scopeConfig->getValue(
+        return (bool)$this->scopeConfig->getValue(
             \Magento\CatalogInventory\Model\Configuration::XML_PATH_SHOW_OUT_OF_STOCK,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );


### PR DESCRIPTION
First commit to Magento Repository.


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
- When using database prefixes for tables, the sort by name and sort by price function on the category page is not working anymore
- Instead of using hard-coded table names, get the correct table name.
- This should work for both tables with prefixes and without them.
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Sort by name on category page
- Added a database prefix in env.php. 
- Change table names to include prefix. 
- Go to a category page
- Sort by name
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
