### PR TITLE
Use the new Fixer.io endpoint

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -17,7 +17,7 @@ class FixerIo extends AbstractImport
     /**
      * @var string
      */
-    const CURRENCY_CONVERTER_URL = 'http://data.fixer.io/api/latest?access_key={{ACCESS_KEY}}'
+    const CURRENCY_CONVERTER_URL = 'https://api.apilayer.com/fixer/latest?apikey={{ACCESS_KEY}}'
         . '&base={{CURRENCY_FROM}}&symbols={{CURRENCY_TO}}';
 
     /**

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -72,7 +72,7 @@ class FixerIoTest extends TestCase
         $responseBody = '{"success":"true","base":"USD","date":"2015-10-07","rates":{"EUR":0.9022}}';
         $expectedCurrencyRateList = ['USD' => ['EUR' => 0.9022, 'UAH' => null]];
         $message = "We can't retrieve a rate from "
-            . "http://data.fixer.io for UAH.";
+            . "https://api.apilayer.com/fixer for UAH.";
 
         $this->scopeConfig->method('getValue')
             ->withConsecutive(


### PR DESCRIPTION
### Description (*)
Fixer.io changes his endpoint, then Magento Fixer.io service stops to work. With this PR Magento use the new Fixer.io endpoint

### Manual testing scenarios (*)
Go to Stores > Currency Rates , select Fixer.io as service and click on "Import". An error will appear.

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [X] All automated tests passed successfully (all builds are green)
