### PR TITLE
Remove mage.validation override from catalog validation

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/validate-product.js
@@ -24,7 +24,7 @@ define([
         _create: function () {
             var bindSubmit = this.options.bindSubmit;
 
-            this.element.validation({
+            this.element.catalogProductViewValidation({
                 radioCheckboxClosest: this.options.radioCheckboxClosest,
 
                 /**

--- a/app/code/Magento/Catalog/view/frontend/web/product/view/validation.js
+++ b/app/code/Magento/Catalog/view/frontend/web/product/view/validation.js
@@ -10,7 +10,7 @@ define([
 ], function ($) {
     'use strict';
 
-    $.widget('mage.validation', $.mage.validation, {
+    $.widget('mage.catalogProductViewValidation', $.mage.validation, {
         options: {
             radioCheckboxClosest: 'ul, ol',
 
@@ -88,5 +88,5 @@ define([
         }
     });
 
-    return $.mage.validation;
+    return $.mage.catalogProductViewValidation;
 });


### PR DESCRIPTION
### Description (*)

During the use of the normal and configurable product, the form validation is been overridden by the mage.validation in the catalog validation.js 
The `ul` and `ol` elements are not validated, only the input types are validated. 

### Manual testing scenarios (*)
1. Create a new product from the admin panel.
2. Show the product details in the pop-up form.
3. Make sure that the form you use has validation. 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
