### PR TITLE
Replaced `CREATE TEMPORARY TABLE ... LIKE` with different approach

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -2233,10 +2233,12 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
      */
     public function createTemporaryTableLike($temporaryTableName, $originTableName, $ifNotExists = false)
     {
-        $ifNotExistsSql = ($ifNotExists ? 'IF NOT EXISTS' : '');
+        $ifNotExistsSql = ($ifNotExists ? ' IF NOT EXISTS' : '');
         $temporaryTable = $this->quoteIdentifier($this->_getTableName($temporaryTableName));
         $originTable = $this->quoteIdentifier($this->_getTableName($originTableName));
-        $sql = sprintf('CREATE TEMPORARY TABLE %s %s LIKE %s', $ifNotExistsSql, $temporaryTable, $originTable);
+        $originCreate = $this->fetchPairs(sprintf('SHOW CREATE TABLE %s', $originTable));
+        $sql = str_replace('CREATE TABLE', 'CREATE TEMPORARY TABLE' . $ifNotExistsSql, reset($originCreate));
+        $sql = str_replace($originTable, $temporaryTable, $sql);
 
         return $this->query($sql);
     }


### PR DESCRIPTION
### Description (*)
Magento's MySQL adapter uses `CREATE TEMPORARY TABLE ... LIKE` command in `\Magento\Framework\DB\Adapter\Pdo\Mysql::createTemporaryTableLike`.

Newer versions of MySQL (8+) have problems with `CREATE TEMPORARY TABLE ... LIKE`, as you can read in the official documentation (https://dev.mysql.com/doc/refman/8.0/en/create-temporary-table.html):

> You cannot use CREATE TEMPORARY TABLE ... LIKE to create an empty table based on the definition of a table that resides in the mysql tablespace, InnoDB system tablespace (innodb_system), or a general tablespace.

The documentation suggests to use `CREATE TEMPORARY TABLE ... SELECT * FROM ... LIMIT 0` instead, but such command **IS NOT** an exact equivalent. It will create temporary table with the same fields, but will not create indexes. Without indexes performance of reindexing big amount of data is absurdly slow.

I suggest to build `CREATE TEMPORARY TABLE` without `LIKE` and without `SELECT * FROM`. Here's my idea:

Firstly use `SHOW CREATE TABLE` to get query for creation of source table (including indexes creation), and then modify it with PHP: change `CREATE TABLE` to `CREATE TEMPORARY TABLE`, add `IF NOT EXISTS` if necessary, and replace source table name with temporary table name.

### Manual testing scenarios (*)
1. Install Magento 2.4 on a server with MySQL 8.
2. Apply sample data.
3. Run `bin/magento index:reindex`.
4. Check data on frontend.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
