### PR TITLE
Update the Fixer.Io api endpoint and method of submitting the api key.

### DIFF
--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -111,8 +111,8 @@ class FixerIo extends AbstractImport
 
         $currenciesStr = implode(',', $currenciesTo);
         $url = str_replace(
-            ['{{ACCESS_KEY}}', '{{CURRENCY_FROM}}', '{{CURRENCY_TO}}'],
-            [$accessKey, $currencyFrom, $currenciesStr],
+            ['{{CURRENCY_FROM}}', '{{CURRENCY_TO}}'],
+            [$currencyFrom, $currenciesStr],
             self::CURRENCY_CONVERTER_URL
         );
         // phpcs:ignore Magento2.Functions.DiscouragedFunction

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -29,7 +29,7 @@ class FixerIo extends AbstractImport
     /**
      * @var string
      */
-    public const API_KEY_CONFIG_PATH = 'currency/fixerio/api_key';
+    private const API_KEY_CONFIG_PATH = 'currency/fixerio/api_key';
 
     /**
      * @var HttpClientFactory

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -173,7 +173,7 @@ class FixerIo extends AbstractImport
             );
             $httpClient->setMethod(Request::METHOD_GET);
             
-            $httpClient->getHeaders()->addHeaders([
+            $httpClient->setHeaders([
                 'Content-Type' => 'text/plain',
                 'apikey' => $accessKey,
             ]);

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -184,6 +184,7 @@ class FixerIo extends AbstractImport
         } catch (Exception $e) {
             if ($retry == 0) {
                 $response = $this->getServiceResponse($url, 1);
+                $response = json_decode($response, true);
             }
         }
         return $response;

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -214,7 +214,8 @@ class FixerIo extends AbstractImport
             201 => __('An invalid base currency has been entered.'),
         ];
 
-        $this->_messages[] = $errorCodes[$response['error']['code']] ?? __('Currency rates can\'t be retrieved.');
+        $this->_messages[] = var_export($response, true);
+        //$this->_messages[] = $errorCodes[$response['error']['code']] ?? __('Currency rates can\'t be retrieved.');
 
         return false;
     }

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -23,7 +23,8 @@ class FixerIo extends AbstractImport
     /**
      * @var string
      */
-    public const CURRENCY_CONVERTER_URL = 'https://api.apilayer.com/fixer/latest?symbols{{CURRENCY_TO}}&base={{CURRENCY_FROM}}';
+    public const CURRENCY_CONVERTER_URL = 'https://api.apilayer.com/fixer/latest?symbols{{CURRENCY_TO}}' .
+                                          '&base={{CURRENCY_FROM}}';
     
     /**
      * @var string

--- a/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
+++ b/app/code/Magento/Directory/Model/Currency/Import/FixerIo.php
@@ -199,7 +199,11 @@ class FixerIo extends AbstractImport
      */
     private function validateResponse(array $response, string $baseCurrency): bool
     {
-        if ($response['success']) {
+        if (
+            is_array($response) && 
+            array_key_exists('success', $response) && 
+            $response['success']
+        ) {
             return true;
         }
 

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -89,18 +89,11 @@ class FixerIoTest extends TestCase
         /** @var LaminasClient|MockObject $httpClient */
         $httpClient = $this->getMockBuilder(LaminasClient::class)
             ->disableOriginalConstructor()
-            ->setMethods(array_merge(get_class_methods(LaminasClient::class), ['getHeaders']))
             ->getMock();
         /** @var DataObject|MockObject $currencyMock */
         $httpResponse = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
             ->setMethods(['getBody'])
-            ->getMock();
-            
-        /** @var DataObject|MockObject $headerMock */
-        $headerMock = $this->getMockBuilder(DataObject::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addHeaders'])
             ->getMock();
 
         $this->currencyFactory->method('create')
@@ -119,7 +112,7 @@ class FixerIoTest extends TestCase
         $httpClient->method('setMethod')
             ->willReturnSelf();
         $httpClient->method('getHeaders')
-            ->willReturn($headerMock);
+            ->willReturnSelf();
         $httpClient->method('send')
             ->willReturn($httpResponse);
         $httpResponse->method('getBody')

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -95,11 +95,6 @@ class FixerIoTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods(['getBody'])
             ->getMock();
-        /** @var DataObject|MockObject $headerMock */
-        $headerMock = $this->getMockBuilder(DataObject::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['addHeaders'])
-            ->getMock();
 
         $this->currencyFactory->method('create')
             ->willReturn($currency);
@@ -116,8 +111,6 @@ class FixerIoTest extends TestCase
             ->willReturnSelf();
         $httpClient->method('setMethod')
             ->willReturnSelf();
-        $httpClient->method('getHeaders')
-            ->willReturn($headerMock);
         $httpClient->method('send')
             ->willReturn($httpResponse);
         $httpResponse->method('getBody')

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -72,14 +72,15 @@ class FixerIoTest extends TestCase
         $responseBody = '{"success":"true","base":"USD","date":"2015-10-07","rates":{"EUR":0.9022}}';
         $expectedCurrencyRateList = ['USD' => ['EUR' => 0.9022, 'UAH' => null]];
         $message = "We can't retrieve a rate from "
-            . "http://data.fixer.io for UAH.";
+            ."https://api.apilayer.com for UAH.";
 
         $this->scopeConfig->method('getValue')
             ->withConsecutive(
                 ['currency/fixerio/api_key', 'store'],
+                ['currency/fixerio/api_key', 'store'],
                 ['currency/fixerio/timeout', 'store']
             )
-            ->willReturnOnConsecutiveCalls('api_key', 100);
+            ->willReturnOnConsecutiveCalls('api_key', 'api_key', 100);
 
         /** @var Currency|MockObject $currency */
         $currency = $this->getMockBuilder(Currency::class)
@@ -93,6 +94,11 @@ class FixerIoTest extends TestCase
         $httpResponse = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
             ->setMethods(['getBody'])
+            ->getMock();
+        /** @var DataObject|MockObject $headerMock */
+        $headerMock = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addHeaders'])
             ->getMock();
 
         $this->currencyFactory->method('create')
@@ -110,6 +116,8 @@ class FixerIoTest extends TestCase
             ->willReturnSelf();
         $httpClient->method('setMethod')
             ->willReturnSelf();
+        $httpClient->method('getHeaders')
+            ->willReturn($headerMock);
         $httpClient->method('send')
             ->willReturn($httpResponse);
         $httpResponse->method('getBody')

--- a/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
+++ b/app/code/Magento/Directory/Test/Unit/Model/Currency/Import/FixerIoTest.php
@@ -89,11 +89,18 @@ class FixerIoTest extends TestCase
         /** @var LaminasClient|MockObject $httpClient */
         $httpClient = $this->getMockBuilder(LaminasClient::class)
             ->disableOriginalConstructor()
+            ->setMethods(array_merge(get_class_methods(LaminasClient::class), ['getHeaders']))
             ->getMock();
         /** @var DataObject|MockObject $currencyMock */
         $httpResponse = $this->getMockBuilder(DataObject::class)
             ->disableOriginalConstructor()
             ->setMethods(['getBody'])
+            ->getMock();
+            
+        /** @var DataObject|MockObject $headerMock */
+        $headerMock = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addHeaders'])
             ->getMock();
 
         $this->currencyFactory->method('create')
@@ -111,6 +118,8 @@ class FixerIoTest extends TestCase
             ->willReturnSelf();
         $httpClient->method('setMethod')
             ->willReturnSelf();
+        $httpClient->method('getHeaders')
+            ->willReturn($headerMock);
         $httpClient->method('send')
             ->willReturn($httpResponse);
         $httpResponse->method('getBody')


### PR DESCRIPTION
### Description (*)
Fixer.io has changed the api endpoint and method of submitting the api key. Utilising Fixer.io to update currency rates results in an invalid api key error message. This PR updates the api endpoint and method of submitting the api key.

### Manual testing scenarios (*)
Go to Stores > Currency Rates , select Fixer.io as service and click on "Import". An error will appear.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36010


### Contribution checklist (*)
- [x]  Pull request has a meaningful description of its purpose
- [x]  All commits are accompanied by meaningful commit messages
- [x]  All new or changed code is covered with unit/integration tests (if applicable)
- [ ]  README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ]  All automated tests passed successfully (all builds are green)