### PR TITLE
Issue 36052: Can't Create shipment for ordered qty less than 1

### DIFF
--- a/app/code/Magento/Sales/Model/Order/ShipmentFactory.php
+++ b/app/code/Magento/Sales/Model/Order/ShipmentFactory.php
@@ -3,6 +3,8 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
 namespace Magento\Sales\Model\Order;
 
 use Magento\Framework\Exception\LocalizedException;
@@ -38,7 +40,7 @@ class ShipmentFactory
     protected $instanceName;
 
     /**
-     * Serializer
+     * Json Serializer
      *
      * @var Json
      */
@@ -165,7 +167,7 @@ class ShipmentFactory
 
         // Remove from shipment items without qty or with qty=0
         if (!$orderItem->isDummy(true)
-            && (!isset($items[$orderItem->getId()]) || (int) $items[$orderItem->getId()] <= 0)
+            && (!isset($items[$orderItem->getId()]) || (float) $items[$orderItem->getId()] <= 0)
         ) {
             return false;
         }


### PR DESCRIPTION
### Description (*)
Can't Create shipment for ordered qty less than 1

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36052

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create an order with an item with decimal qty and the qty must be less than 1. (Eg:0.5)
2. Create invoice
3. Create shipment

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
