### PR TITLE
Fix comment typo in getSearchResultApplier method

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection.php
@@ -548,7 +548,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
             [
                 'collection' => $this,
                 'searchResult' => $searchResult,
-                /** This variable sets by serOrder method, but doesn't have a getter method. */
+                /** This variable sets by setOrder method, but doesn't have a getter method. */
                 'orders' => $this->_orders,
                 'size' => $this->getPageSize(),
                 'currentPage' => (int)$this->_curPage,


### PR DESCRIPTION
### Description (*)
This commit fix a comment typo inside getSearchResultApplier method


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
