### PR TITLE
fix(eav): fetch option value from its option_id as stated by OptionValueProvider

### DIFF
--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/OptionValueProvider.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/OptionValueProvider.php
@@ -32,14 +32,14 @@ class OptionValueProvider
     /**
      * Get EAV attribute option value by option id
      *
-     * @param int $valueId
+     * @param int $optionId
      * @return string|null
      */
-    public function get(int $valueId): ?string
+    public function get(int $optionId): ?string
     {
         $select = $this->connection->select()
             ->from($this->connection->getTableName('eav_attribute_option_value'), 'value')
-            ->where('value_id = ?', $valueId);
+            ->where('option_id = ?', $optionId);
 
         $result = $this->connection->fetchOne($select);
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

This PR fixes the `OptionValueProvider` by doing what is documented in  its docblock.
Option values were fetched in DB from their `value_id` but the code used the `get()` method as stated in its docblock: by providing an `option_id`.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35910

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
This code isn't use in Magento OpenSource.
It however leads to a reproducible issue in Adobe Commerce RMA GraphQL module.

See https://github.com/magento/magento2/issues/35910#issuecomment-1238916647 for details.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
