### PR TITLE
Fix issue when cannot ship order item with 0.x quantity.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/ShipmentFactory.php
+++ b/app/code/Magento/Sales/Model/Order/ShipmentFactory.php
@@ -165,7 +165,7 @@ class ShipmentFactory
 
         // Remove from shipment items without qty or with qty=0
         if (!$orderItem->isDummy(true)
-            && (!isset($items[$orderItem->getId()]) || (int) $items[$orderItem->getId()] <= 0)
+            && (!isset($items[$orderItem->getId()]) || (float) $items[$orderItem->getId()] <= 0)
         ) {
             return false;
         }


### PR DESCRIPTION
As part of this commit: https://github.com/magento/magento2/commit/a209d188495866b63b48011c1309c59a82e8469c#diff-dc9d52e793660095382ff5218ccefc40be114c0b946862c7a4c83c68112b1efd a change has been introduced which forces the order item qty to INT when checking shippable items. This causes that order items with 0.x qty (e.g. 0.6) will be considered of having 0 qty and therefore never be shipped. Because of this the order containing an item like this will never be completely shipped so cannot be completed either.

### Description (*)
Previously the type cast was not added so the value (e.g. "0.6000") was handled properly and NOT recognized as zero. So this PR restores that behavior by casting to float instead of int.

### Manual testing scenarios (*)
1. Create an order with at least 2 items, where one item has a qty of e.g. 0.6 (less than 1 but above zero)
2. Try to ship all items
Expected: On the create shipment page you should see all order items
Actual: The item with the special qty is not even listed

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
