### PR TITLE
Filter category product name by store id

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -240,8 +240,16 @@ class SearchResultApplier implements SearchResultApplierInterface
                     ['product_var' => $this->collection->getTable('catalog_product_entity_varchar')],
                     "product_var.{$linkField} = e.{$linkField} AND product_var.attribute_id =
                     (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId}
-                    AND attribute_code='name')",
+                    AND attribute_code='name') AND (product_var.store_id=0 OR product_var.store_id={$storeId})",
                     ['product_var.value AS name']
+                );
+                $query->join(
+                    ['name_filter' => new \Zend_Db_Expr("(SELECT {$linkField}, MAX(store_id) as store_id
+                    from catalog_product_entity_varchar WHERE store_id IN (0,{$storeId})
+                    AND attribute_id = (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId} AND attribute_code='name')
+                    GROUP BY {$linkField})")],
+                    "product_var.{$linkField} = name_filter.{$linkField} and product_var.store_id = name_filter.store_id",
+                    [""]
                 );
             } elseif ($field === 'price') {
                 $query->joinLeft(

--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -207,11 +207,11 @@ class SearchResultApplier implements SearchResultApplierInterface
      */
     private function categoryProductByCustomSortOrder(int $categoryId): array
     {
+        $defaultStoreId = $this->collection->getDefaultStoreId();
         $storeId = $this->collection->getStoreId();
         $searchCriteria = $this->searchResult->getSearchCriteria();
         $sortOrders = $searchCriteria->getSortOrders() ?? [];
         $sortOrders = array_merge(['is_salable' => \Magento\Framework\DB\Select::SQL_DESC], $sortOrders);
-
         $connection = $this->collection->getConnection();
         $query = clone $connection->select()
             ->reset(\Magento\Framework\DB\Select::ORDER)
@@ -231,25 +231,38 @@ class SearchResultApplier implements SearchResultApplierInterface
             . ' AND cat_index.store_id = ' . $storeId,
             ['cat_index.position']
         );
+
+        $productIds = [];
+        foreach ($this->searchResult->getItems() as $item) {
+            $productIds[] = $item->getId();
+        }
+
+        $query->where('e.entity_id IN(?)', $productIds);
+
         foreach ($sortOrders as $field => $dir) {
             if ($field === 'name') {
                 $entityTypeId = $this->collection->getEntity()->getTypeId();
                 $entityMetadata = $this->metadataPool->getMetadata(ProductInterface::class);
                 $linkField = $entityMetadata->getLinkField();
+                $attribute_id = "(SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId} AND attribute_code='name')";
+
+                $product_name_by_store_id = $connection->select()
+                    ->from(['name_by_store' => $this->collection->getTable('catalog_product_entity_varchar')],
+                        [$linkField, 'MAX(store_id) AS store_id'])
+                    ->where("store_id IN ({$defaultStoreId},{$storeId}) AND attribute_id = {$attribute_id}")
+                    ->group($linkField);
+
                 $query->joinLeft(
                     ['product_var' => $this->collection->getTable('catalog_product_entity_varchar')],
-                    "product_var.{$linkField} = e.{$linkField} AND product_var.attribute_id =
-                    (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId}
-                    AND attribute_code='name') AND (product_var.store_id=0 OR product_var.store_id={$storeId})",
-                    ['product_var.value AS name']
+                    "product_var.{$linkField} = e.{$linkField}"
+                    . " AND product_var.attribute_id = {$attribute_id}",
+                    ['']
                 );
                 $query->join(
-                    ['name_filter' => new \Zend_Db_Expr("(SELECT {$linkField}, MAX(store_id) as store_id
-                    from catalog_product_entity_varchar WHERE store_id IN (0,{$storeId})
-                    AND attribute_id = (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId} AND attribute_code='name')
-                    GROUP BY {$linkField})")],
-                    "product_var.{$linkField} = name_filter.{$linkField} and product_var.store_id = name_filter.store_id",
-                    [""]
+                    ['name_filter' => $product_name_by_store_id],
+                    "product_var.{$linkField} = name_filter.{$linkField}"
+                    . ' AND product_var.store_id = name_filter.store_id',
+                    ['product_var.value AS name']
                 );
             } elseif ($field === 'price') {
                 $query->joinLeft(


### PR DESCRIPTION
**PS: I wrongly deleted the main branch when I was trying to update, so open a new PR**
 
### Description (*)
According to https://github.com/magento/magento2/issues/36076

In the category grid we can see blank/missing/out_order products when ordering by name if the product has the name defined in multiple scopes.

To prevent duplicate products in the result query I defined the store id scope if exists, if not return the default scope id.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36076

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Steps to reproduce described in fixed issue https://github.com/magento/magento2/issues/36076.
2. The above steps are missing multiple store views categories with the same products but different names
3. [EDIT] **This will happen if the out-of-stock products are enabled**
### Questions or comments

The bug can be found easier with the original select, remember to change cat_index.store_id = 1
if we have multiple attribute names associated with different scopes in catalog_product_entity_varchar the select will return with repeated products
 
SELECT product_var.store_id, entity_id , product_var.value as name FROM `catalog_product_entity` AS `e`
     INNER JOIN `cataloginventory_stock_status` AS `stockItem` ON stockItem.product_id = e.entity_id AND stockItem.website_id = 0 AND stockItem.stock_id = 1
     INNER JOIN `catalog_category_product_index_store1` AS `cat_index` ON cat_index.product_id = e.entity_id AND cat_index.category_id = 14 AND cat_index.store_id = 1
     INNER JOIN `catalog_product_entity_varchar` AS `product_var` ON product_var.row_id = e.row_id  AND product_var.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE entity_type_id=4 AND attribute_code='name')
 WHERE (e.created_in <= '1640995204') AND (e.updated_in > '1640995204')


modified to:

SELECT `e`.`entity_id`, `stockItem`.`stock_status` AS `is_salable`, `cat_index`.`position`, `product_var`.`value` AS `name` FROM `catalog_product_entity` AS `e`
 INNER JOIN `cataloginventory_stock_status` AS `stockItem` ON stockItem.product_id = e.entity_id AND stockItem.website_id = 0 AND stockItem.stock_id = 1
 INNER JOIN `catalog_category_product_index_store2` AS `cat_index` ON cat_index.product_id = e.entity_id AND cat_index.category_id = 3 AND cat_index.store_id = 2
 LEFT JOIN `catalog_product_entity_varchar` AS `product_var` ON product_var.entity_id = e.entity_id AND product_var.attribute_id = (SELECT attribute_id FROM eav_attribute WHERE entity_type_id=4 AND attribute_code='name')
 INNER JOIN (SELECT `name_by_store`.`entity_id`, MAX(store_id) AS `store_id` FROM `catalog_product_entity_varchar` AS `name_by_store` WHERE (store_id IN (0,2) AND attribute_id = (SELECT attribute_id FROM eav_attribute WHERE entity_type_id=4 AND attribute_code='name')) GROUP BY `entity_id`) AS `name_filter` ON product_var.entity_id = name_filter.entity_id AND product_var.store_id = name_filter.store_id WHERE (e.entity_id IN('2', '8', '11', '5', '4', '9', '7', '6', '10', '3', '12', '1')) ORDER BY is_salable DESC, name ASC, entity_id DESC
 LIMIT 12


**_the subselect catches the default store_id and the current store_id between these two orders by the highest and returns to the view the right name_** 

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
