### PR TITLE
Remove forbidden `@author` tag from import/export modules

### DIFF
--- a/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
@@ -14,7 +14,6 @@ use Magento\Store\Model\Store;
 /**
  * Export Advanced Pricing
  *
- * @author      Magento Core Team <core@magentocommerce.com>
  * @SuppressWarnings(PHPMD.TooManyFields)
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)

--- a/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
+++ b/app/code/Magento/AdvancedPricingImportExport/Model/Export/AdvancedPricing.php
@@ -20,7 +20,7 @@ use Magento\Store\Model\Store;
  */
 class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
 {
-    const ENTITY_ADVANCED_PRICING = 'advanced_pricing';
+    public const ENTITY_ADVANCED_PRICING = 'advanced_pricing';
 
     /**
      * @var \Magento\CatalogImportExport\Model\Import\Product\StoreResolver
@@ -567,10 +567,10 @@ class AdvancedPricing extends \Magento\CatalogImportExport\Model\Export\Product
                 if (isset($price[0]) && !empty($price[0]) || isset($price[1]) && !empty($price[1])) {
                     $select->orWhere('ap.percentage_value IS NOT NULL');
                 }
-                if (isset($updatedAtFrom) && !empty($updatedAtFrom)) {
+                if (isset($updatedAtFrom)) {
                     $select->where('cpe.updated_at >= ?', $updatedAtFrom);
                 }
-                if (isset($updatedAtTo) && !empty($updatedAtTo)) {
+                if (isset($updatedAtTo)) {
                     $select->where('cpe.updated_at <= ?', $updatedAtTo);
                 }
                 $exportData = $this->_connection->fetchAll($select);

--- a/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product.php
@@ -6,8 +6,6 @@
 
 /**
  * Import proxy product model
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\CatalogImportExport\Model\Import\Proxy;
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product.php
@@ -15,6 +15,7 @@ class Product extends \Magento\Catalog\Model\Product
      * DO NOT Initialize resources.
      *
      * @return void
+     * @phpcs:disable Magento2.CodeAnalysis.EmptyBlock.DetectedFunction
      */
     protected function _construct()
     {

--- a/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product/ResourceModel.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Proxy/Product/ResourceModel.php
@@ -6,8 +6,6 @@
 
 /**
  * Import proxy product resource
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\CatalogImportExport\Model\Import\Proxy\Product;
 

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit.php
@@ -6,8 +6,6 @@
 
 /**
  * Export edit block
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\ImportExport\Block\Adminhtml\Export;
 

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Export/Edit/Form.php
@@ -6,8 +6,6 @@
 
 /**
  * Export edit form block
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\ImportExport\Block\Adminhtml\Export\Edit;
 

--- a/app/code/Magento/ImportExport/Block/Adminhtml/History.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/History.php
@@ -9,7 +9,6 @@ namespace Magento\ImportExport\Block\Adminhtml;
  * Adminhtml import history page content block
  *
  * @api
- * @author      Magento Core Team <core@magentocommerce.com>
  * @since 100.0.2
  */
 class History extends \Magento\Backend\Block\Widget\Grid\Container

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit.php
@@ -6,8 +6,6 @@
 
 /**
  * Import edit block
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\ImportExport\Block\Adminhtml\Import;
 

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Before.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Before.php
@@ -6,8 +6,6 @@
 
 /**
  * Block before edit form
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\ImportExport\Block\Adminhtml\Import\Edit;
 

--- a/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
+++ b/app/code/Magento/ImportExport/Block/Adminhtml/Import/Edit/Form.php
@@ -11,8 +11,6 @@ use Magento\ImportExport\Model\Import\ErrorProcessing\ProcessingErrorAggregatorI
 
 /**
  * Import edit form block
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 class Form extends \Magento\Backend\Block\Widget\Form\Generic
 {

--- a/app/code/Magento/ImportExport/Model/AbstractModel.php
+++ b/app/code/Magento/ImportExport/Model/AbstractModel.php
@@ -60,9 +60,11 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
 
     /**
      * Log debug data to file.
+     *
      * Log file dir: var/log/import_export/%Y/%m/%d/%time%_%operation_type%_%entity_type%.log
      *
      * @param mixed $debugData
+     *
      * @return $this
      */
     public function addLogComment($debugData)
@@ -89,9 +91,11 @@ abstract class AbstractModel extends \Magento\Framework\DataObject
     {
         $trace = '';
         $lineNumber = 1;
+
         foreach ($this->_logTrace as &$info) {
-            $trace .= $lineNumber++ . ': ' . $info . "\n";
+            $trace .= ($lineNumber++) . ': ' . $info . "\n";
         }
+
         return $trace;
     }
 }

--- a/app/code/Magento/ImportExport/Model/AbstractModel.php
+++ b/app/code/Magento/ImportExport/Model/AbstractModel.php
@@ -9,8 +9,6 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 
 /**
  * Operation abstract class
- *
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 abstract class AbstractModel extends \Magento\Framework\DataObject
 {

--- a/app/code/Magento/ImportExport/Model/Import/Adapter.php
+++ b/app/code/Magento/ImportExport/Model/Import/Adapter.php
@@ -12,7 +12,6 @@ use Magento\ImportExport\Model\Import\Source\Factory;
  * Import adapter model
  * @Deprecated
  * @see \Magento\ImportExport\Model\Import\Source\Factory
- * @author      Magento Core Team <core@magentocommerce.com>
  */
 class Adapter
 {

--- a/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/Grid/Renderer/Country.php
+++ b/app/code/Magento/TaxImportExport/Block/Adminhtml/Rate/Grid/Renderer/Country.php
@@ -6,8 +6,6 @@
 
 /**
  * Adminhtml tax rates grid item renderer country
- *
- * @author     Magento Core Team <core@magentocommerce.com>
  */
 namespace Magento\TaxImportExport\Block\Adminhtml\Rate\Grid\Renderer;
 


### PR DESCRIPTION
### Description
According to https://devdocs.magento.com/guides/v2.4/coding-standards/docblock-standard-general.html#documentation-space, the `@author` tag is not permitted in Magento. This pull request removes this tag from some modules. Given there are so many instances of this tag, I've opened a small pull request to get the process started. I expect that the linter will force me to fix several other coding standards violations on the way, so having a smaller pull request means that task is easier to manage. I plan to open more pull requests to tackle the other instances of this tag.

See also https://github.com/magento/magento-coding-standard/pull/382 and https://github.com/magento/magento-coding-standard/issues/167

### Manual testing scenarios
There are not code changes in this pull request. This pull request only removes forbidden comments.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36338: Remove forbidden `@author` tag from import/export modules