### PR TITLE
Fix height of iframe when previewing emails

### DIFF
--- a/app/code/Magento/Email/view/adminhtml/layout/adminhtml_email_template_preview.xml
+++ b/app/code/Magento/Email/view/adminhtml/layout/adminhtml_email_template_preview.xml
@@ -12,6 +12,7 @@
         <remove src="css/styles-old.css"/>
         <remove src="css/styles.css"/>
         <remove src="jquery/jstree/themes/default/style.css"/>
+        <css src="Magento_Email::css/email-preview.css" />
     </head>
     <body>
         <attribute name="id" value="html-body"/>

--- a/app/code/Magento/Email/view/adminhtml/web/css/email-preview.less
+++ b/app/code/Magento/Email/view/adminhtml/web/css/email-preview.less
@@ -1,0 +1,13 @@
+body {
+    height: calc(100vh - 16px);
+
+    #preview {
+        height: 100%;
+
+        iframe {
+            height: 100%;
+            width: 100%;
+            border: 0;
+        }
+    }
+}


### PR DESCRIPTION
### Description (*)
When clicking preview email on Marketing->Email Templates the content is not in the right height.

### Manual testing scenarios (*)
1. enter admin panel and and go to Marketing -> Email Templates
2. Create a new Email Template
3. Click Preview

Fixes https://github.com/magento/magento2/issues/35697 
### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
