### PR TITLE
Update Currency.php

### DIFF
--- a/app/code/Magento/Directory/Model/Currency.php
+++ b/app/code/Magento/Directory/Model/Currency.php
@@ -434,6 +434,7 @@ class Currency extends \Magento\Framework\Model\AbstractModel
 
         if ((array_key_exists(LocaleCurrency::CURRENCY_OPTION_DISPLAY, $options)
             && $options[LocaleCurrency::CURRENCY_OPTION_DISPLAY] === \Magento\Framework\Currency::NO_SYMBOL)) {
+            $formattedCurrency = str_replace($this->numberFormatter->getSymbol(\NumberFormatter::CURRENCY_SYMBOL), '', $formattedCurrency);
             $formattedCurrency = str_replace(' ', '', $formattedCurrency);
         }
 
@@ -475,10 +476,6 @@ class Currency extends \Magento\Framework\Model\AbstractModel
                 \NumberFormatter::CURRENCY_SYMBOL,
                 $options[LocaleCurrency::CURRENCY_OPTION_SYMBOL]
             );
-        }
-        if (array_key_exists(LocaleCurrency::CURRENCY_OPTION_DISPLAY, $options)
-            && $options[LocaleCurrency::CURRENCY_OPTION_DISPLAY] === \Magento\Framework\Currency::NO_SYMBOL) {
-            $this->numberFormatter->setSymbol(\NumberFormatter::CURRENCY_SYMBOL, '');
         }
         if (array_key_exists('precision', $options)) {
             $this->numberFormatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $options['precision']);


### PR DESCRIPTION
Addresses issue #36343 and takes into account the non-working code according to comments at https://www.php.net/manual/de/numberformatter.setsymbol.php


Fixes https://github.com/magento/magento2/issues/36343