### PR TITLE
magento/community-features#173: Add categories column and filter in the product grid

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/AddCategoriesFieldToCollection.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/AddCategoriesFieldToCollection.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Ui\DataProvider\Product;
+
+use Magento\Framework\Data\Collection;
+use Magento\Ui\DataProvider\AddFieldToCollectionInterface;
+use Magento\Ui\DataProvider\AddFilterToCollectionInterface;
+
+/**
+ * Adds categories name separated by commas to the product grid.
+ *
+ * @api
+ */
+class AddCategoriesFieldToCollection implements AddFieldToCollectionInterface, AddFilterToCollectionInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function addField(Collection $collection, $field, $alias = null)
+    {
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
+        $collection->addCategoryNamesToResult();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addFilter(Collection $collection, $field, $condition = null)
+    {
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
+        $collection->addCategoriesFilter($condition);
+    }
+}

--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -87,9 +87,11 @@
         <arguments>
             <argument name="addFieldStrategies" xsi:type="array">
                 <item name="websites" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\AddWebsitesFieldToCollection</item>
+                <item name="categories" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\AddCategoriesFieldToCollection</item>
             </argument>
             <argument name="addFilterStrategies" xsi:type="array">
                 <item name="store_id" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\AddStoreFieldToCollection</item>
+                <item name="category_id" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\AddCategoriesFieldToCollection</item>
             </argument>
             <argument name="collectionFactory" xsi:type="object">\Magento\Catalog\Ui\DataProvider\Product\ProductCollectionFactory</argument>
             <argument name="modifiersPool" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\Listing\Modifier\Pool</argument>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_listing.xml
@@ -47,6 +47,26 @@
                     <dataScope>store_id</dataScope>
                 </settings>
             </filterSelect>
+            <filterSelect name="category_id"
+                          provider="${ $.parentName }"
+                          component="Magento_Ui/js/form/element/ui-select"
+                          template="ui/grid/filters/elements/ui-select">
+                <argument name="data" xsi:type="array">
+                    <item name="config" xsi:type="array">
+                        <item name="filterOptions" xsi:type="boolean">true</item>
+                        <item name="levelsVisibility" xsi:type="number">1</item>
+                    </item>
+                </argument>
+                <settings>
+                    <options class="Magento\Catalog\Ui\Component\Product\Form\Categories\Options"/>
+                    <caption translate="true">Select...</caption>
+                    <label translate="true">Categories</label>
+                    <dataScope>category_id</dataScope>
+                    <imports>
+                        <link name="visible">componentType = column, index = ${ $.index }:visible</link>
+                    </imports>
+                </settings>
+            </filterSelect>
         </filters>
         <massaction name="listing_massaction"
                     component="Magento_Ui/js/grid/tree-massactions"
@@ -190,6 +210,14 @@
                 <options class="Magento\Store\Model\ResourceModel\Website\Collection"/>
                 <dataType>text</dataType>
                 <label translate="true">Websites</label>
+            </settings>
+        </column>
+        <column name="categories" class="Magento\Ui\Component\Listing\Columns\Column" sortOrder="110">
+            <settings>
+                <addField>true</addField>
+                <dataType>text</dataType>
+                <label translate="true">Categories</label>
+                <sortable>false</sortable>
             </settings>
         </column>
         <column name="updated_at"

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CollectionTest.php
@@ -385,4 +385,16 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
             'condition is null' => [null]
         ];
     }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_with_category.php
+     *
+     * @return void
+     */
+    public function testAddCategoryNamesToResult(): void
+    {
+        $product = $this->collection->addCategoryNamesToResult()->getFirstItem();
+
+        $this->assertEquals('Category 1', $product->getData('categories'));
+    }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Add a categories column and filter to the products grid in the admin.

The filter allows for searching and selection of multiple categories. This increases productivity of merchant who have to focus on products of specific categories. It also makes it easier to find such products by any admin user.

Thanks to @dcabrejas for the community suggestion.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Implements [magento/community-features#173](https://github.com/magento/community-features/issues/173)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

Categories column:
1. Log in to the admin
2. Click on Catalog > Product from the menu
3. Click on the Columns button and check the new "Categories" column if not already checked
4. You should see Categories appearing for all products that have categories assigned to them. The category names are separated by a comma.

Categories filter:
1. Log in to the admin
2. Click on Catalog > Product from the menu
3. Click on the Filters button
4. You should see the new "Categories" filter.
5. You can open the dropdown and select one or more category to filter
6. Click on Apply filters button
7. You should see the product grid being filtered by the category you've selected.

### Questions or comments
_2022-10-22_ Currently I have a small concern regarding the interoperability between Magento Open Source and Adobe Commerce editions. If anyone have ideas on how to fix the hardcoded entity_id jointure, I'm all ears.

_2022-10-29_ I found a solution to my concern as I remembered the entityFieldId() method in EAV.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
