### PR TITLE
Add check for type on Newsletter GraphQL resolver

### DIFF
--- a/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscribeEmailToNewsletter.php
+++ b/app/code/Magento/NewsletterGraphQl/Model/Resolver/SubscribeEmailToNewsletter.php
@@ -90,9 +90,13 @@ class SubscribeEmailToNewsletter implements ResolverInterface
             );
         }
 
-        $currentUserId = (int)$context->getUserId();
+        $currentUserId = 0;
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         $websiteId = (int)$context->getExtensionAttributes()->getStore()->getWebsiteId();
+
+        if ((int)$context->getUserType() === UserContextInterface::USER_TYPE_CUSTOMER) {
+            $currentUserId = (int)$context->getUserId();
+        }
 
         $this->validator->execute($email, $currentUserId, $websiteId);
 


### PR DESCRIPTION
### Description (*)
Adds a check for user type so the check on customer only occurs when actually logged in as a customer.

### Related Pull Requests

### Fixed Issues (if relevant)
Fixes magento/magento2#36366

### Manual testing scenarios (*)

1.     Create an integration token
2.     Send integration token as bearer with GraphQL request to subscribe an email to the newsletter mutation ($email: String!) { subscribeEmailToNewsletter(email: $email) { status } }
3.     Get result that user is subscribed.


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
