### PR TITLE
Optimize getLastPageNumber function

### DIFF
--- a/lib/internal/Magento/Framework/Data/Collection.php
+++ b/lib/internal/Magento/Framework/Data/Collection.php
@@ -257,9 +257,7 @@ class Collection implements \IteratorAggregate, \Countable, ArrayInterface, Coll
     public function getLastPageNumber()
     {
         $collectionSize = (int)$this->getSize();
-        if (0 === $collectionSize) {
-            return 1;
-        } elseif ($this->_pageSize) {
+        if ($collectionSize > 0 && $this->_pageSize) {
             return (int)ceil($collectionSize / $this->_pageSize);
         }
 


### PR DESCRIPTION
### Description (*)
We can reduce line of code of getLastPageNumber function

### Questions or comments
As $collectionSize has an integer value all time, we can reduce the line of codes.
