### PR TITLE
L2 cache save operation stop working when the hash key exists on remo…

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
@@ -231,20 +231,9 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
      */
     public function save($data, $id, $tags = [], $specificLifetime = false)
     {
-        $dataToSave = $data;
-        $remHash = $this->loadRemoteDataVersion($id);
-        $isRemoteUpToDate = false;
-        if ($remHash !== false && $this->getDataVersion($data) === $remHash) {
-            $remoteData = $this->remote->load($id);
-            if ($remoteData !== false && $this->getDataVersion($data) === $this->getDataVersion($remoteData)) {
-                $isRemoteUpToDate = true;
-                $dataToSave = $remoteData;
-            }
-        }
-        if (!$isRemoteUpToDate) {
-            $this->remote->save($data, $id, $tags, $specificLifetime);
-            $this->saveRemoteDataVersion($data, $id, $tags, $specificLifetime);
-        }
+
+        $this->remote->save($data, $id, $tags, $specificLifetime);
+        $this->saveRemoteDataVersion($data, $id, $tags, $specificLifetime);
 
         if ($this->_options['use_stale_cache']) {
             $this->unlock($id);
@@ -258,7 +247,7 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
 
         // Local cache doesn't save tags intentionally since it will cause inconsistency after flushing the cache
         // in multinode environment
-        return $this->local->save($dataToSave, $id, [], $specificLifetime);
+        return $this->local->save($data, $id, [], $specificLifetime);
     }
 
     /**


### PR DESCRIPTION
Save operation stop working on L2 cache and remote cache when the hash key exists on remote server, but the data key was evicted meanwhile from remote cache.

**Later edit:** The original issue has been fixed int magento:2.4-develop branch, but this is a performance improvement implementation that should be beneficial by following argument: The concept of cache involves try loading the data from storage, generate if data doesn't exist in cache, and save it to cache.  **There is no need to check if data exist in cache in the save method.** 

### Description (*)
When save method is called on L2 cache adapter there are 3 things do be done:
- update the data on remote server (this will make sure the data exists on the remote server and the TTL is renewed)
- update the version (hash) on the remote server (this will make sure the version id (hash) exists on the remote server and the TTL is renewed) 
- update the data in the local cache (this will make sure the data exists on the local server)

The original checks of the remote version of data are preventing the save of the cache to remote and local servers in the scenario where the version id exists and is correct but the data is missing from remote server. (eg: because it was evicted by Redis) 

        $remHash = $this->loadRemoteDataVersion($id);

        if ($remHash !== false && $this->getDataVersion($data) === $remHash) {
            $dataToSave = $this->remote->load($id);
        } else {
            $this->remote->save($data, $id, $tags, $specificLifetime);
            $this->saveRemoteDataVersion($data, $id, $tags, $specificLifetime);
        }


In order to avoid unnecessary writes on the remote server for both entries from point 1 and 2, it needs to read both keys content and TTL in order to create a condition that will cover all the cases. I find this solution overkill and I think it make more sense to force write both keys on remote server. The cache lock is a different component that could perform the above purpose of reducing the writes. 

**Important note: the remote cache consistency check should be performed in the load method** 

Follow the red arrows to see the failing scenario:
![L2-cache-save-diagram](https://user-images.githubusercontent.com/6019079/199963274-44cd2874-114b-4300-a8a9-99977de0c245.jpg)

### Manual testing scenarios (*)
1. Enable the L2 cache
2. Manually remove the data key for one of the cache entries from remote server, but keep the version cache key 
3. Clear all the L2 cache entries
4. Check if the data cache key is saved to the remote server next time the code is executed

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
