### PR TITLE
Remove laminas/laminas-dependency-plugin dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "laminas/laminas-dependency-plugin": true,
             "magento/*": true
         },
         "preferred-install": "dist",
@@ -45,7 +44,6 @@
         "laminas/laminas-captcha": "^2.12",
         "laminas/laminas-code": "^4.5",
         "laminas/laminas-db": "^2.15",
-        "laminas/laminas-dependency-plugin": "^2.5",
         "laminas/laminas-di": "^3.7",
         "laminas/laminas-escaper": "^2.10",
         "laminas/laminas-eventmanager": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ad4c199ce2f8eff1b17f2a05a682c3a",
+    "content-hash": "7ff961b0e7ebdbf0884b827145413744",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2077,59 +2077,6 @@
                 }
             ],
             "time": "2022-04-11T13:26:20+00:00"
-        },
-        {
-            "name": "laminas/laminas-dependency-plugin",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-dependency-plugin.git",
-                "reference": "8f2d10199381cdc7d0843bfadad55f8485df9e38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-dependency-plugin/zipball/8f2d10199381cdc7d0843bfadad55f8485df9e38",
-                "reference": "8f2d10199381cdc7d0843bfadad55f8485df9e38",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": ">=1.1.0 <2.3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
-            },
-            "require-dev": {
-                "composer/composer": ">=1.9.0 <2.3.0",
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "roave/security-advisories": "dev-master",
-                "vimeo/psalm": "^4.5"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Laminas\\DependencyPlugin\\DependencyRewriterPluginDelegator"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\DependencyPlugin\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Replace zendframework and zfcampus packages with their Laminas Project equivalents.",
-            "support": {
-                "issues": "https://github.com/laminas/laminas-dependency-plugin/issues",
-                "source": "https://github.com/laminas/laminas-dependency-plugin/tree/2.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-10-16T14:45:47+00:00"
         },
         {
             "name": "laminas/laminas-di",
@@ -13720,5 +13667,5 @@
         "lib-libxml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Description (*)
This PR removes the `laminas/laminas-dependency-plugin` composer plugin.
The plugin was introduced in https://github.com/magento/magento2/pull/26436 and its purpose is described as follows on [their homepage](https://github.com/laminas/laminas-dependency-plugin):
> This Composer plugin, when enabled in a project, intercepts requests to install packages from the zendframework and zfcampus vendors, and will replace them with the equivalents from the Laminas Project.

Reason why I think we should get rid of this, is that I'm currently unable to use a modern version of composer to install dependencies on the `2.4-develop` branch:
```
$ composer --version
Composer version 2.4.4 2022-10-27 14:39:29

$ composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
In Laminas\DependencyPlugin\DependencyRewriterV2::onPrePoolCreate
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - laminas/laminas-dependency-plugin is locked to version 2.5.0 and an update of this package was not requested.
    - laminas/laminas-dependency-plugin 2.5.0 requires composer-plugin-api >=1.1.0 <2.3.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
```

Which was a restriction added to that plugin in https://github.com/laminas/laminas-dependency-plugin/commit/54d508ab145072c4c7e7ec07cdad1e10196ad373


I believe that after 2 years since Magento switched from Zend to Laminas, that this plugin is not really necessary anymore, most people will have gotten used to the Laminas components by now and should install those instead of the old Zend ones.

// cc @ihor-sviziev 

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
None that I know of

### Manual testing scenarios (*)
1. Use composer 2.3.x or 2.4.x
2. Try to run `composer install` without getting errors

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36515: Remove laminas/laminas-dependency-plugin dependency
2. [x] resolves magento/magento2#36516: Unable to install Magento with Composer version 2.4.4