### PR TITLE
Fix for #36509 incorrect use of storeId as websiteId in CountryWithWebsites option source

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/CountryWithWebsites.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Address/Attribute/Source/CountryWithWebsites.php
@@ -120,16 +120,16 @@ class CountryWithWebsites extends Table
                 $allowedCountries = array_unique(array_merge([], ...$allowedCountries));
             } else {
                 // Address can be added only for the allowed country list.
-                $storeId = null;
+                $websiteId = null;
                 $customerId = $this->request->getParam('parent_id') ?? null;
                 if ($customerId) {
                     $customer = $this->customerRepository->getById($customerId);
-                    $storeId = $customer->getStoreId();
+                    $websiteId = $customer->getWebsiteId();
                 }
 
                 $allowedCountries = $this->allowedCountriesReader->getAllowedCountries(
                     ScopeInterface::SCOPE_WEBSITE,
-                    $storeId
+                    $websiteId
                 );
             }
 


### PR DESCRIPTION
Correctly use of websiteId instead of storeId when resolving allowed country list.

### Description (*)
Use $customer->getWebsiteId() instead of $customer->getStoreId() when passing value scope=ScopeInterface::SCOPE_WEBSITE

### Fixed Issues (if relevant)
1. Fixes magento/magento2#36509

### Manual testing scenarios (*)
- Create a customer in a store with a store id that does not have a corresponding website id (for create 1 website, 3 stores and use the last store, to ensure the store id does not also exist in the website table)
- Create customer or signup as customer
- Open customer in admin area
- Switch to address tab and attempt to add address

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
