### PR TITLE
Error on PLP if prefix exist on tables

### DIFF
--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -243,19 +243,21 @@ class SearchResultApplier implements SearchResultApplierInterface
                 $entityTypeId = $this->collection->getEntity()->getTypeId();
                 $entityMetadata = $this->metadataPool->getMetadata(ProductInterface::class);
                 $linkField = $entityMetadata->getLinkField();
+                $eavAttrTable = $this->collection->getTable('eav_attribute');
                 $query->joinLeft(
                     ['product_var' => $this->collection->getTable('catalog_product_entity_varchar')],
                     "product_var.{$linkField} = e.{$linkField} AND product_var.attribute_id =
-                    (SELECT attribute_id FROM eav_attribute WHERE entity_type_id={$entityTypeId}
+                    (SELECT attribute_id FROM {$eavAttrTable} WHERE entity_type_id={$entityTypeId}
                     AND attribute_code='name')",
                     ['product_var.value AS name']
                 );
             } elseif ($field === 'price') {
+                $storeTable = $this->collection->getTable('store');
                 $query->joinLeft(
                     ['price_index' => $this->collection->getTable('catalog_product_index_price')],
                     'price_index.entity_id = e.entity_id'
                     . ' AND price_index.customer_group_id = 0'
-                    . ' AND price_index.website_id = (Select website_id FROM store WHERE store_id = '
+                    . ' AND price_index.website_id = (Select website_id FROM '.$storeTable.' WHERE store_id = '
                     . $storeId . ')',
                     ['price_index.max_price AS price']
                 );


### PR DESCRIPTION
### Description (*)
**ISSUE:**
getting an error on PLP if the table prefix is enabled. Checked on Magento 2.4.5-p1. https://prnt.sc/1NAMyZ2BLG4Z

**STEPS TO REPRODUCE:**
Install the Magento with the prefix of the table.
Enable the developer mode and make Magento to be able to display_errors. Create some categories and products and check the PLP page 

**EXPECTED RESULTS:**
To show the product listing

**ACTUAL RESULTS:**
Showing a fatal error, attached screenshot link: https://prnt.sc/1NAMyZ2BLG4Z

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
 
