### PR TITLE
Fixed #36571: fixed optional region checkout field visibility

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/region.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/region.js
@@ -72,6 +72,7 @@ define([
             this.validation['required-entry'] = isRegionRequired;
 
             registry.get(this.customName, function (input) {
+                this.hideRegion(option);
                 input.required(isRegionRequired);
                 input.validation['required-entry'] = isRegionRequired;
                 input.validation['validate-not-number-first'] = !this.options().length;


### PR DESCRIPTION
### Description (*)
this PR fix issue described in https://github.com/magento/magento2/issues/36571

### Fixed Issues (if relevant)
1. Fixes magento/magento2#36571

### Manual testing scenarios (*)
1. In General Settings configure `Allow to Choose State if It is Optional for Country` to `No`
2. Go to the storefront, add any product to the cart and go to the checkout
3. Fill the shipping info, and select the country which is differ from default and for which region field is optional 
4. Refresh page and make sure optional region field is not visible

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
