### PR TITLE
Handles validation for numbers starting with decimal points

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -606,7 +606,7 @@ define([
         'validate-not-negative-number': [
             function (value) {
                 return utils.isEmptyNoTrim(value) || !isNaN(utils.parseNumber(value))
-                    && value >= 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(value);
+                    && value >= 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(utils.parseNumber(value));
 
             },
             $.mage.__('Please enter a number 0 or greater, without comma in this field.')
@@ -615,14 +615,14 @@ define([
         'validate-zero-or-greater': [
             function (value) {
                 return utils.isEmptyNoTrim(value) || !isNaN(utils.parseNumber(value))
-                    && value >= 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(value);
+                    && value >= 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(utils.parseNumber(value));
             },
             $.mage.__('Please enter a number 0 or greater, without comma in this field.')
         ],
         'validate-greater-than-zero': [
             function (value) {
                 return utils.isEmptyNoTrim(value) || !isNaN(utils.parseNumber(value))
-                    && value > 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(value);
+                    && value > 0 && (/^\s*-?\d+([,.]\d+)*\s*%?\s*$/).test(utils.parseNumber(value));
             },
             $.mage.__('Please enter a number greater than 0, without comma in this field.')
         ],


### PR DESCRIPTION
### Description (*)
Example:

A value of '.6' fails the /^\s*-?\d+([,.]\d+)*\s*%?\s*$/ regular expression check. utils.parseNumber() normalizes the value to '0.6' allowing the regular expression test pass.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Prior to this fix, enter a weight value of ".6" while editing a simple product in the admin UI.
2. Attempt to save the product.
3. See the validation error "Please enter a number 0 or greater, without comma in this field."
4. After the fix, the product saves normally.

### Questions or comments

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
