### PR TITLE
Fix #36576 incorrect catalog rule SKU is filter

### DIFF
--- a/app/code/Magento/CatalogRule/Model/Indexer/ReindexRuleProduct.php
+++ b/app/code/Magento/CatalogRule/Model/Indexer/ReindexRuleProduct.php
@@ -124,7 +124,8 @@ class ReindexRuleProduct
                 : $toTimeInAdminTz;
 
             foreach ($productIds as $productId => $validationByWebsite) {
-                if (!isset($validationByWebsite[$websiteId]) || $validationByWebsite[$websiteId] === null) {
+                if (!isset($validationByWebsite[$websiteId]) || $validationByWebsite[$websiteId] === null
+                        || $validationByWebsite[$websiteId] === false) {
                     continue;
                 }
 


### PR DESCRIPTION
Caused by ACP2E-673 commit 19fa878576e044ac190576d3306eff0e8baed5d6

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Recent changes in ReindexRuleProduct caused incorrect catalog rule conditions behavior 

### Related Pull Requests
https://github.com/magento/magento2/issues/7473

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36576

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Navigate to Marketing -> Catalog Price Rule -> Add New Rule
2. Apply condition with SKU IS 2 filter
3. Catalog Rule will be applied only to single product with given SKU not all products starting with it.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [X] All automated tests passed successfully (all builds are green)
