### PR TITLE
Sort category tree by position in product edit view

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Categories.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/Categories.php
@@ -442,7 +442,8 @@ class Categories extends AbstractModifier
 
         $collection->addAttributeToFilter('entity_id', ['in' => array_keys($shownCategoriesIds)])
             ->addAttributeToSelect(['name', 'is_active', 'parent_id'])
-            ->setStoreId($storeId);
+            ->setStoreId($storeId)
+            ->addAttributeToSort('position', 'ASC');
 
         $categoryById = [
             CategoryModel::TREE_ROOT_ID => [


### PR DESCRIPTION
### Description (*)
The category tree is not sorted in the product edit view. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->


### Manual testing scenarios (*)
1. Change the order of a category in the tree inside the magento backend
2. open a product in the edit view inside the backend. The category select sholuld not relflect the new order
3. with the applied PR the position should be correct

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
