### PR TITLE
Correct mime type typo

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Gallery/Upload.php
@@ -33,8 +33,8 @@ class Upload extends \Magento\Backend\App\Action implements HttpPostActionInterf
     private $allowedMimeTypes = [
         'jpg' => 'image/jpg',
         'jpeg' => 'image/jpeg',
-        'gif' => 'image/png',
-        'png' => 'image/gif'
+        'gif' => 'image/gif',
+        'png' => 'image/png'
     ];
 
     /**


### PR DESCRIPTION
This PR fixes a typo in the mime types in `module-catalog/Controller/Adminhtml/Product/Gallery/Upload.php`
