### PR TITLE
Fixed issue with lack of information about the size of the file for already uploaded images

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/element/file-uploader.js
@@ -175,12 +175,36 @@ define([
                 file.id = Base64.mageEncode(file.name);
             }
 
+            if ("size" in file && file.size === 0) {
+                file.size = this.getFileSize(file);
+            }
+
             this.observe.call(file, true, [
                 'previewWidth',
                 'previewHeight'
             ]);
 
             return file;
+        },
+
+        /**
+         * Get image size in bytes for the specified images.
+         *
+         * @param {Object} file
+         * @returns {Number}
+         */
+        getFileSize: function (file) {
+            if (!("url" in file) || file.url === "") {
+                return file.size
+            }
+
+            var request = new XMLHttpRequest();
+            request.open('HEAD', file.url, false);
+            request.send(null);
+
+            return request && request.getResponseHeader("Content-Length")
+                ? parseInt(request.getResponseHeader("Content-Length"))
+                : 0
         },
 
         /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fixing an issue with a lack of information about the size of the already uploaded images in the file-uploader component.

<!-- ### Related Pull Requests -->
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes [magento/magento2#36681](https://github.com/magento/magento2/issues/36681)

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Go to the admin panel
2. Log-in
3. Go and edit selected content type element (e.g., Content -> Elements -> Pages -> About Us)
4. Place the Row element into the Page Builder area
5. Place the Image element into the previously inserted Row
6. Edit the image by clicking the gear icon
7. In the edit form, select the image to upload
8. You should see the image preview along with its dimensions and size
9. Save data by clicking "Save" in the image edit form
10. Save the whole content by clicking the "Save" button in the Page edit bar
11. After when the page reloads, click the gear icon on the previously added image
12. Below the image thumbnail, you should still see the image size expressed in the proper unit of measure.

<!---### Questions or comments

	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
