### PR TITLE
Fixes deprecated jquery call to focus in validation library.

### DIFF
--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1986,7 +1986,7 @@ define([
                 $('html, body').stop().animate({
                     scrollTop: firstActive.parent().offset().top - windowHeight / 2
                 });
-                firstActive.focus();
+                firstActive.trigger('focus');
             }
         }
     });


### PR DESCRIPTION
### Description (*)
The call `.focus` on a jquery element [is considered deprecated](https://github.com/jquery/jquery-migrate/blob/main/warnings.md#shorthand-deprecated-v3-jqmigrate-jqueryfnclick-event-shorthand-is-deprecated) since jquery 3.x and higher

Magento switched from jQuery 1.x to 3.x in version 2.4.4 and a bunch of deprecated usages got cleaned up, but definitely not all of them.

To make matters worse, the jquery migrate library who brings these things to the light has been removed via ticket [AC-1199](https://github.com/magento/magento2/search?q=AC-1199&type=commits), this isn't released yet but will probably be included in Magento 2.4.6 I guess.

I've only fixed one usage here, but there a probably still hundreds of them in the various frontend JS libraries used by Magento. So maybe someone should clean those up as well one day...

/cc @mrtuvn 

### Related Pull Requests

### Fixed Issues (if relevant)
None that I could find

### Manual testing scenarios (*)
1. Install clean Magento 2.4.5-p1 or 2.4-develop but with the jquery migrate library still installed (basically revert changes from ticket AC-1199 mentioned above)
2. Go to the 'Create an account' page on the frontend
3. Don't fill in any fields
4. Click on the 'Create an account button'
5. Expected is that the first invalid form field gets the focus
6. Look at the console in the inspector of your browser
7. Without this fix, it will show a warning: `jQuery.fn.focus() event shorthand is deprecated`
8. With the fix from the PR, the console will be clean

### Questions or comments
I think it's a good thing if the jquery migrate plugin is not included on the frontend. But maybe that should only happen when a shop is running in production mode and still load the jquery migrate plugin when in developer mode, so warnings of deprecations still show up so frontend devs still are aware of those.
Also, if that happens, maybe automated MFTF tests should also check for such outputs from the jquery migrate plugin on their execution so it gets more visible in automated tests that something needs fixing. Just an idea ...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36728: Fixes deprecated jquery call to focus in validation library.