### PR TITLE
Issue 36652: Add some class cache to StatusLabel

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Status.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Status.php
@@ -6,12 +6,7 @@
 
 namespace Magento\Sales\Model\ResourceModel\Order;
 
-use Magento\Framework\App\ResourceConnection;
-use Psr\Log\LoggerInterface as LogWriter;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\SalesSequence\Model\Manager;
-use \Magento\Sales\Model\ResourceModel\EntityAbstract;
-use \Magento\Framework\Model\ResourceModel\Db\VersionControl\Snapshot;
 
 /**
  * Order status resource model
@@ -33,6 +28,11 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @var string
      */
     protected $stateTable;
+
+    /**
+     * @var array
+     */
+    private $storeLabels = [];
 
     /**
      * Internal constructor
@@ -87,14 +87,18 @@ class Status extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      */
     public function getStoreLabels(\Magento\Sales\Model\Order\Status $status)
     {
-        $select = $this->getConnection()->select()
-            ->from(['ssl' => $this->labelsTable], [])
-            ->where('status = ?', $status->getStatus())
-            ->columns([
-                'store_id',
-                'label',
-            ]);
-        return $this->getConnection()->fetchPairs($select);
+        $orderStatus = $status->getStatus();
+        if (!isset($this->storeLabels[$orderStatus])) {
+            $select = $this->getConnection()->select()
+                ->from(['ssl' => $this->labelsTable], [])
+                ->where('status = ?', $orderStatus)
+                ->columns([
+                    'store_id',
+                    'label',
+                ]);
+            $this->storeLabels[$orderStatus] = $this->getConnection()->fetchPairs($select);
+        }
+        return $this->storeLabels[$orderStatus];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36652

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
