### PR TITLE
Replace {YYYY} in the copyright line by the current year

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -93,7 +93,7 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return $this->replaceCurrentYear(__($this->_copyright));
+        return $this->replaceCurrentYear((string)__($this->_copyright));
     }
 
     /**

--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -93,7 +93,7 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE
             );
         }
-        return __($this->_copyright);
+        return $this->replaceCurrentYear(__($this->_copyright));
     }
 
     /**
@@ -132,5 +132,13 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     protected function getCacheLifetime()
     {
         return parent::getCacheLifetime() ?: 3600;
+    }
+    
+    /**
+     * Replace YYYY by the current year
+     */
+    private function replaceCurrentYear($text)
+    {
+        return str_replace('YYYY', (new \DateTime())->format('Y'), $text)   
     }
 }

--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -137,7 +137,7 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     /**
      * Replace YYYY by the current year
      */
-    private function replaceCurrentYear($text)
+    private function replaceCurrentYear(string $text): string
     {
         return str_replace('YYYY', (new \DateTime())->format('Y'), $text)   
     }

--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -135,7 +135,9 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     }
 
     /**
-     * Replace YYYY by the current year
+     * Replace YYYY with the current year
+     *
+     * @param string $text
      */
     private function replaceCurrentYear(string $text): string
     {

--- a/app/code/Magento/Theme/Block/Html/Footer.php
+++ b/app/code/Magento/Theme/Block/Html/Footer.php
@@ -133,12 +133,12 @@ class Footer extends \Magento\Framework\View\Element\Template implements \Magent
     {
         return parent::getCacheLifetime() ?: 3600;
     }
-    
+
     /**
      * Replace YYYY by the current year
      */
     private function replaceCurrentYear(string $text): string
     {
-        return str_replace('YYYY', (new \DateTime())->format('Y'), $text)   
+        return str_replace('{YYYY}', (new \DateTime())->format('Y'), $text);
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
@@ -8,9 +8,14 @@ declare(strict_types=1);
 namespace Magento\Theme\Test\Unit\Block\Html;
 
 use Magento\Cms\Model\Block;
+use Magento\Framework\App\Config;
+use Magento\Framework\Escaper;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use Magento\Theme\Block\Html\Footer;
+use Magento\Theme\Block\Html\Header;
 use PHPUnit\Framework\TestCase;
 
 class FooterTest extends TestCase
@@ -23,7 +28,23 @@ class FooterTest extends TestCase
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);
-        $this->block = $objectManager->getObject(Footer::class);
+
+        $context = $this->getMockBuilder(Context::class)
+            ->setMethods(['getScopeConfig'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->scopeConfig = $this->getMockBuilder(Config::class)
+            ->setMethods(['getValue'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->expects($this->once())->method('getScopeConfig')->willReturn($this->scopeConfig);
+
+        $this->block = $objectManager->getObject(
+            Footer::class,
+            [
+                'context' => $context,
+            ]
+        );
     }
 
     protected function tearDown(): void
@@ -31,6 +52,17 @@ class FooterTest extends TestCase
         $this->block = null;
     }
 
+    public function testGetCopyright()
+    {
+        $this->scopeConfig->expects($this->once())->method('getValue')
+            ->with('design/footer/copyright', ScopeInterface::SCOPE_STORE)
+            ->willReturn('Copyright 2013-{YYYY}');
+
+        $this->assertEquals(
+            'Copyright 2013-' . date('Y'),
+            $this->block->getCopyright()
+        );
+    }
     public function testGetIdentities()
     {
         $this->assertEquals(

--- a/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Block/Html/FooterTest.php
@@ -25,6 +25,11 @@ class FooterTest extends TestCase
      */
     protected $block;
 
+    /**
+     * @var Config
+     */
+    private $scopeConfig;
+    
     protected function setUp(): void
     {
         $objectManager = new ObjectManager($this);

--- a/app/code/Magento/Theme/i18n/en_US.csv
+++ b/app/code/Magento/Theme/i18n/en_US.csv
@@ -172,6 +172,7 @@ Header,Header
 Footer,Footer
 "This will be displayed just before the body closing tag.","This will be displayed just before the body closing tag."
 "Miscellaneous HTML","Miscellaneous HTML"
+"Use {YYYY} to insert the current year (updates on cache refresh).","Use {YYYY} to insert the current year (updates on cache refresh)."
 Copyright,Copyright
 "Default Robots","Default Robots"
 "Edit custom instruction of robots.txt File","Edit custom instruction of robots.txt File"

--- a/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
+++ b/app/code/Magento/Theme/view/adminhtml/ui_component/design_config_form.xml
@@ -242,6 +242,7 @@
                     <validation>
                         <rule name="validate-no-html-tags" xsi:type="boolean">true</rule>
                     </validation>
+                    <notice translate="true">Use {YYYY} to insert the current year (updates on cache refresh).</notice>
                     <dataType>text</dataType>
                     <label translate="true">Copyright</label>
                     <dataScope>footer_copyright</dataScope>


### PR DESCRIPTION
Follow up for #5004

### Description (*)

So many people spend time updating the copyright in their Magento installations every year. We want to save this time by introducing a simple solution - add a variable that will be automatically replaced with a current year.

### Related Pull Requests
https://github.com/magento/magento2/pull/5004

### Manual testing scenarios (*)
1. Go to Cotent >> Design >> Configuration >> Edit (Global)>> Footer and Set copyright string to Copyright 2013-{YYYY} in the design config 
2. Clear caches
3. Check the frontend
4. It displays (in this year) Copyright 2013-2023

### Questions or comments

**A note about caching**: The currrent year is evaluated when the page is rendered. As pages might be in the full page cache, the year will not immediately update in midnight Jan 01st 0:00. Mitigating this would cause a lot of problems and complicate the solution. For example we might not want to clear the full page cache automatically as this will slow down the page.

When a page is invalidated by other reasons (for example a product update), the copyright year will update as well.
So in the end of the day, the copyright year is current when a page was recently changed which is just what a copyright year is supposed to be. If a page is not updated for a long time, it's believed to be okay to have an older copyright year.

We also added a note to hint users who want a consistent up-to-date copyright year to clear the full cache.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36776: Replace {YYYY} in the copyright line by the current year