### PR TITLE
Fixes filtering setters from DataObject when their method contains 2 …

### DIFF
--- a/lib/internal/Magento/Framework/Api/DataObjectHelper.php
+++ b/lib/internal/Magento/Framework/Api/DataObjectHelper.php
@@ -302,11 +302,24 @@ class DataObjectHelper
                     strtolower(
                         // (0) remove all not setter
                         // (1) add _ before upper letter
-                        // (2) remove set_ in start of name
-                        // (3) add name without is_ prefix
+                        // (2) put _ in between 2 consecutive uppercase chars
+                        // (3) remove set_ in start of name
+                        // (4) add name without is_ prefix
                         preg_replace(
-                            ['/(^|,)(?!set)[^,]*/S','/(.)([A-Z])/S','/([A-Z])([A-Z])/S', '/(^|,)set_/iS', '/(^|,)is_([^,]+)/is'],
-                            ['', '$1_$2','$1_$2', '$1', '$1$2,is_$2'],
+                            [
+                                '/(^|,)(?!set)[^,]*/S',
+                                '/(.)([A-Z])/S',
+                                '/([A-Z])([A-Z])/S',
+                                '/(^|,)set_/iS',
+                                '/(^|,)is_([^,]+)/is'
+                            ],
+                            [
+                                '',
+                                '$1_$2',
+                                '$1_$2',
+                                '$1',
+                                '$1$2,is_$2'
+                            ],
                             implode(',', $dataObjectMethods)
                         )
                     )

--- a/lib/internal/Magento/Framework/Api/DataObjectHelper.php
+++ b/lib/internal/Magento/Framework/Api/DataObjectHelper.php
@@ -305,8 +305,8 @@ class DataObjectHelper
                         // (2) remove set_ in start of name
                         // (3) add name without is_ prefix
                         preg_replace(
-                            ['/(^|,)(?!set)[^,]*/S','/(.)([A-Z])/S', '/(^|,)set_/iS', '/(^|,)is_([^,]+)/is'],
-                            ['', '$1_$2', '$1', '$1$2,is_$2'],
+                            ['/(^|,)(?!set)[^,]*/S','/(.)([A-Z])/S','/([A-Z])([A-Z])/S', '/(^|,)set_/iS', '/(^|,)is_([^,]+)/is'],
+                            ['', '$1_$2','$1_$2', '$1', '$1$2,is_$2'],
                             implode(',', $dataObjectMethods)
                         )
                     )

--- a/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
+++ b/lib/internal/Magento/Framework/Api/Test/Unit/DataObjectHelperTest.php
@@ -24,7 +24,9 @@ use Magento\Framework\Reflection\DataObjectProcessor;
 use Magento\Framework\Reflection\MethodsMap;
 use Magento\Framework\Reflection\TypeProcessor;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -357,6 +359,32 @@ class DataObjectHelperTest extends TestCase
         $this->assertEquals($cc_number_enc, $orderPaymentObject->getCcNumberEnc());
         $this->assertEquals($poNumber, $orderPaymentObject->getPoNumber());
         $this->assertEquals($cc_type, $orderPaymentObject->getCcType());
+    }
+
+    /**
+     * @return void
+     */
+    public function testPopulateWithArrayWithOrderAttributes(): void
+    {
+        $xForwardedFor = '1.2.3.4';
+
+        /** @var OrderInterface $orderObject */
+        $orderObject = $this->objectManager->getObject(
+            Order::class,
+            ['dataObjectHelper' => $this->dataObjectHelper]
+        );
+
+        $data = [
+            OrderInterface::X_FORWARDED_FOR => $xForwardedFor,
+        ];
+
+        $this->dataObjectHelper->populateWithArray(
+            $orderObject,
+            $data,
+            OrderInterface::class
+        );
+
+        $this->assertEquals($xForwardedFor, $orderObject->getXForwardedFor());
     }
 
     /**


### PR DESCRIPTION
…consecutive uppercase characters, like 'setXForwardedFor'.

### Description (*)
A bunch of refactoring that happened between Magento 2.4.3 and 2.4.4 to the `Magento\Framework\Api\DataObjectHelper` class broke being able to save a value of `x_forwarded_for`. This is due to the value to start with one character immediately followed by an underscore. The new regular expressions introduced in 2.4.4, didn't account for such a case yet.

This has been fixed here.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes magento/magento2#36723: x_forwarded_for empty in order object

### Manual testing scenarios (*)
1. Setup a webserver stack (nginx/varnish combi) which runs on 127.0.0.1 to forward the real IP address of visitors to Magento using the `X-Forwarded-For` HTTP header
2. Place an order on the frontend with this setup
3. Expected is to see the IP address from the `X-Forwarded-For` header added to the `x_forwarded_for` column in the `sales_order` database table.

### Questions or comments
Big thanks to @kandy for the suggested fix!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
