### PR TITLE
Fix ariaLabel on nameless products

### DIFF
--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
@@ -58,7 +58,7 @@ class ProductActions extends Column
                         'catalog/product/edit',
                         ['id' => $item['entity_id'], 'store' => $storeId]
                     ),
-                    'ariaLabel' => __('Edit ') . $item['name'],
+                    'ariaLabel' => __('Edit ') . (isset($item['name']) ? $item['name'] : ''),
                     'label' => __('Edit'),
                     'hidden' => false,
                 ];

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/ProductActions.php
@@ -58,7 +58,7 @@ class ProductActions extends Column
                         'catalog/product/edit',
                         ['id' => $item['entity_id'], 'store' => $storeId]
                     ),
-                    'ariaLabel' => __('Edit ') . (isset($item['name']) ? $item['name'] : ''),
+                    'ariaLabel' => __('Edit') . ' ' . ($item['name'] ?? ''),
                     'label' => __('Edit'),
                     'hidden' => false,
                 ];


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Safely renders the ariaLabel on the product admin grid should a product not have a name set so the page stays functional

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35783

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a product without a name (aka without an entry in the catalog_product_entity_varchar on the name attribute)
2. Open the admin panel -> Catalog -> Products and make sure that product is included in the view
3. It should error/free

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
