### PR TITLE
mis hanlding the data variable make the magnifier not working in 2.4.5-p1

### DIFF
--- a/lib/web/magnifier/magnifier.js
+++ b/lib/web/magnifier/magnifier.js
@@ -541,7 +541,7 @@
 
             showWrapper = false;
             $(thumbObj).on('load', function () {
-                if (data.length > 0) {
+                if (data) {
                     data[idx].status = 1;
 
                     $(largeObj).on('load', function () {

--- a/lib/web/magnifier/magnifier.js
+++ b/lib/web/magnifier/magnifier.js
@@ -541,7 +541,7 @@
 
             showWrapper = false;
             $(thumbObj).on('load', function () {
-                if (data) {
+                if (Object.keys(data).length > 0) {
                     data[idx].status = 1;
 
                     $(largeObj).on('load', function () {


### PR DESCRIPTION

### Description (*)
In Magento 2.4.5-p1 the magnifier stop to work and the reason behind that was: data variable in line 544 was mis handling and consider as array instead of object as been defined in line 521 from magnifier.js file.


### Manual testing scenarios (*)
1. After installing the Magento 2.4.5-p1.
2. open the Magento admin page.
3. navigate to the product page.
4. add some images to the product.
5. activite magnifier from the theme view.xml and fullscreen should be disabled in this case. 
6. navigate to the product page from frontend. 
7. try to hover on the product image, which is not gonna zoom or magnifing the page by the provided value in the theme view.xml file. 

### Questions or comments
solution been added to the magnifier.js by using the data variable as object instead of array.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
