### PR TITLE
NEW PR for #36422: Only Update Indexer Mode When Required

### DIFF
--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
@@ -24,16 +24,27 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer implem
         if (!is_array($indexerIds)) {
             $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
+            $updatedIndexersCount = 0;
+
             try {
                 foreach ($indexerIds as $indexerId) {
                     /** @var \Magento\Framework\Indexer\IndexerInterface $model */
                     $model = $this->_objectManager->get(
                         \Magento\Framework\Indexer\IndexerRegistry::class
                     )->get($indexerId);
-                    $model->setScheduled(true);
+
+                    if (!$model->isScheduled()) {
+                        $model->setScheduled(true);
+                        $updatedIndexersCount++;
+                    }
                 }
-                $this->messageManager->addSuccess(
-                    __('%1 indexer(s) are in "Update by Schedule" mode.', count($indexerIds))
+
+                $this->messageManager->addSuccessMessage(
+                    __(
+                        '%1 indexer(s) have been updated to "Update by Schedule" mode. %2 skipped because there was nothing to change.',
+                        $updatedIndexersCount,
+                        count($indexerIds) - $updatedIndexersCount
+                    )
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassChangelog.php
@@ -41,7 +41,8 @@ class MassChangelog extends \Magento\Indexer\Controller\Adminhtml\Indexer implem
 
                 $this->messageManager->addSuccessMessage(
                     __(
-                        '%1 indexer(s) have been updated to "Update by Schedule" mode. %2 skipped because there was nothing to change.',
+                        '%1 indexer(s) have been updated to "Update by Schedule" mode. 
+                        %2 skipped because there was nothing to change.',
                         $updatedIndexersCount,
                         count($indexerIds) - $updatedIndexersCount
                     )

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
@@ -24,16 +24,27 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer impleme
         if (!is_array($indexerIds)) {
             $this->messageManager->addErrorMessage(__('Please select indexers.'));
         } else {
+            $updatedIndexersCount = 0;
+
             try {
                 foreach ($indexerIds as $indexerId) {
                     /** @var \Magento\Framework\Indexer\IndexerInterface $model */
                     $model = $this->_objectManager->get(
                         \Magento\Framework\Indexer\IndexerRegistry::class
                     )->get($indexerId);
-                    $model->setScheduled(false);
+
+                    if ($model->isScheduled()) {
+                        $model->setScheduled(false);
+                        $updatedIndexersCount++;
+                    }
                 }
-                $this->messageManager->addSuccess(
-                    __('%1 indexer(s) are in "Update on Save" mode.', count($indexerIds))
+
+                $this->messageManager->addSuccessMessage(
+                    __(
+                        '%1 indexer(s) have been updated to "Update on Save" mode. %2 skipped because there was nothing to change.',
+                        $updatedIndexersCount,
+                        count($indexerIds) - $updatedIndexersCount
+                    )
                 );
             } catch (\Magento\Framework\Exception\LocalizedException $e) {
                 $this->messageManager->addErrorMessage($e->getMessage());

--- a/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
+++ b/app/code/Magento/Indexer/Controller/Adminhtml/Indexer/MassOnTheFly.php
@@ -41,7 +41,8 @@ class MassOnTheFly extends \Magento\Indexer\Controller\Adminhtml\Indexer impleme
 
                 $this->messageManager->addSuccessMessage(
                     __(
-                        '%1 indexer(s) have been updated to "Update on Save" mode. %2 skipped because there was nothing to change.',
+                        '%1 indexer(s) have been updated to "Update on Save" mode. 
+                        %2 skipped because there was nothing to change.',
                         $updatedIndexersCount,
                         count($indexerIds) - $updatedIndexersCount
                     )

--- a/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchAllIndexerToActionModeActionGroup.xml
+++ b/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchAllIndexerToActionModeActionGroup.xml
@@ -11,13 +11,15 @@
     <actionGroup name="AdminSwitchAllIndexerToActionModeActionGroup">
         <arguments>
             <argument name="action" type="string" defaultValue="Update by Schedule"/>
+            <!-- <argument name="count" type="string" defaultValue="10"/> -->
         </arguments>
         <amOnPage url="{{AdminIndexManagementPage.url}}" stepKey="onIndexManagement"/>
         <waitForPageLoad stepKey="waitForManagementPage"/>
         <selectOption userInput="selectAll" selector="{{AdminIndexManagementSection.selectMassAction}}" stepKey="checkIndexer"/>
         <selectOption userInput="{{action}}" selector="{{AdminIndexManagementSection.massActionSelect}}" stepKey="selectAction"/>
+        <grabValueFrom selector="{{AdminIndexManagementSection.massIndexSelectionCount}}" stepKey="selectCount"/>
         <click selector="{{AdminIndexManagementSection.massActionSubmit}}" stepKey="clickSubmit"/>
         <waitForPageLoad stepKey="waitForSubmit"/>
-        <see userInput="indexer(s) are in &quot;{{action}}&quot; mode." stepKey="seeMessage"/>
+        <see userInput="{$selectCount} indexer(s) have been updated to &quot;{{action}}&quot; mode. 0 skipped because there was nothing to change." stepKey="seeMessage"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchIndexerToActionModeActionGroup.xml
+++ b/app/code/Magento/Indexer/Test/Mftf/ActionGroup/AdminSwitchIndexerToActionModeActionGroup.xml
@@ -17,6 +17,6 @@
         <selectOption userInput="{{action}}" selector="{{AdminIndexManagementSection.massActionSelect}}" stepKey="selectAction"/>
         <click selector="{{AdminIndexManagementSection.massActionSubmit}}" stepKey="clickSubmit"/>
         <waitForPageLoad stepKey="waitForSubmit"/>
-        <see selector="{{AdminIndexManagementSection.successMessage}}" userInput="1 indexer(s) are in &quot;{{action}}&quot; mode." stepKey="seeMessage"/>
+        <see selector="{{AdminIndexManagementSection.successMessage}}" userInput="1 indexer(s) have been updated to &quot;{{action}}&quot; mode. 0 skipped because there was nothing to change." stepKey="seeMessage"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Indexer/Test/Mftf/Section/AdminIndexManagementSection.xml
+++ b/app/code/Magento/Indexer/Test/Mftf/Section/AdminIndexManagementSection.xml
@@ -19,5 +19,6 @@
         <element name="selectMassAction" type="select" selector="#gridIndexer_massaction-mass-select"/>
         <element name="columnScheduleStatus" type="text" selector="//th[contains(@class, 'col-indexer_schedule_status')]"/>
         <element name="indexerScheduleStatus" type="text" selector="//tr[contains(.,'{{var1}}')]//td[contains(@class,'col-indexer_schedule_status')]" parameterized="true"/>
+        <element name="massIndexSelectionCount" type="text" selector="#gridIndexer-total-count"/>
     </section>
 </sections>

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
@@ -224,6 +224,8 @@ class MassOnTheFlyTest extends TestCase
 
             if ($exception !== null) {
                 $indexerInterface->expects($this->any())
+                    ->method('isScheduled')->willReturn(true);
+                $indexerInterface->expects($this->any())
                     ->method('setScheduled')->with(false)->willThrowException($exception);
             } else {
                 $indexerInterface->expects($this->any())

--- a/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Controller/Adminhtml/Indexer/MassOnTheFlyTest.php
@@ -82,7 +82,7 @@ class MassOnTheFlyTest extends TestCase
     protected $indexReg;
 
     /**
-     * @return ResponseInterface
+     * @var ResponseInterface
      */
     protected $response;
 


### PR DESCRIPTION
As https://github.com/magento/magento2/pull/36422 contributor repo is seems to be deleted, hence created new PR with its changes.

The description from https://github.com/magento/magento2/pull/36422  is as below:

### Description (*)
Updates the indexer mode change mass actions to only change modes when required i.e. when the current index mode is different to the one being applied. This prevents unnecessary trips to the database.

Also updates the messaging displayed to the admin to inform them how many indexers were updated and how many were skipped thanks to this change.

Finally, replaces the deprecated `addSuccess()` function with the non-deprecated `addSuccessMessage()` function for the message manager class when displaying the changed messages to the admin.

### Manual testing scenarios (*)
1. Log into the admin
2. Set any number of indexers to be `Update on Schedule`
3. Observe the success message to confirm the correct number of indexers were updated versus skipped, based on their original mode

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36823: Only Update Indexer Mode When Required