### PR TITLE
Use info data object in checkout flow

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -522,7 +522,7 @@ class Cart extends DataObject implements CartInterface
         );
 
         $qtyRecalculatedFlag = false;
-        foreach ($data as $itemId => $itemInfo) {
+        foreach ($infoDataObject->getData() as $itemId => $itemInfo) {
             $item = $this->getQuote()->getItemById($itemId);
             if (!$item) {
                 continue;


### PR DESCRIPTION
### Description (*)
Using the infoDataObject enables us to modify the items that will be updated in the checkout_cart_update_items_before event.

### Manual testing scenarios (*)
1. Create an event listener for the checkout_cart_update_items_before event
2. Modify the info object e.g. ` $observer->getInfo()->unsetData($key);`
3. The item with the key should not be changed when updating the cart

### Contribution checklist (*)
 - [x ] Pull request has a meaningful description of its purpose
 - [x ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36897: Use info data object in checkout flow