### PR TITLE
github issue 36908, fixed null quote in quote observers

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -591,8 +591,8 @@ class Cart extends DataObject implements CartInterface
 
         $this->getQuote()->getBillingAddress();
         $this->getQuote()->getShippingAddress()->setCollectShippingRates(true);
-        $this->getQuote()->collectTotals();
         $this->quoteRepository->save($this->getQuote());
+        $this->getQuote()->collectTotals();
         $this->_checkoutSession->setQuoteId($this->getQuote()->getId());
         /**
          * Cart save usually called after changes with cart items.

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -2014,9 +2014,11 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
      */
     public function collectTotals()
     {
+        /* To fix null quote in observers
         if ($this->getTotalsCollectedFlag()) {
             return $this;
         }
+        */
 
         $total = $this->totalsCollector->collect($this);
         $this->addData($total->getData());

--- a/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
@@ -119,7 +119,7 @@ class SaveHandler
 
         $this->processShippingAssignment($quote);
         $quote = $quote->collectTotals();
-        $quote = $this->quoteResourceModel->save($quote);
+        $this->quoteResourceModel->save($quote);
 
         return $quote;
     }

--- a/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
@@ -118,7 +118,9 @@ class SaveHandler
         }
 
         $this->processShippingAssignment($quote);
-        $this->quoteResourceModel->save($quote->collectTotals());
+        $this->quoteResourceModel->save($quote);
+        $quote = $quote->collectTotals();
+        $this->quoteResourceModel->save($quote);
 
         return $quote;
     }

--- a/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
+++ b/app/code/Magento/Quote/Model/QuoteRepository/SaveHandler.php
@@ -118,9 +118,8 @@ class SaveHandler
         }
 
         $this->processShippingAssignment($quote);
-        $this->quoteResourceModel->save($quote);
         $quote = $quote->collectTotals();
-        $this->quoteResourceModel->save($quote);
+        $quote = $this->quoteResourceModel->save($quote);
 
         return $quote;
     }


### PR DESCRIPTION
### Description (*)
Modified Cart model and QuoteRepository SaveHandler to collectTotals AFTER the quote has been saved to the database. At present collectTotals is called before a quote entity is created so when the quote observers are fired the event contains a null quote.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes magento/magento2#36908  (if I am not wrong, issue # is the github issue #)

### Manual testing scenarios (*)
1. Use the attached module to test the quote observer being fired
2. Make sure there's no active quote
3. Add a product to the cart - you should see a valid quote id in var/log/system.log. Without the fix you will notice quote id will be null - when adding the first product to the cart.

[Xtreme_Totals.zip](https://github.com/magento/magento2/files/10825977/Xtreme_Totals.zip)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
