### PR TITLE
Wrong method used to get attribute code in product comparison attribute list

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -120,7 +120,7 @@
                                                 <?=
                                                 /* @noEscape */ $block->getProductPrice(
                                                     $item,
-                                                    '-compare-list-' . $attribute->getCode()
+                                                    '-compare-list-' . $attribute->getAttributeCode()
                                                 )
                                                 ?>
                                                 <?php break;


### PR DESCRIPTION
### Description (*)
Wrong method used to get attribute code in product comparison attribute list.

### Related Pull Requests

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Add product to comparison list
2. Go to comparison list
3. Inspect price line in attribute list
4. Element ID of price is now correct (product-price-1234-compare-list-price instead of product-price-1234-compare-list-)

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#36933: Wrong method used to get attribute code in product comparison attribute list