### PR TITLE
Code snippet that adjusts the image size in the image_with_borders.phtml is simply rewritten.

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -11,8 +11,8 @@
 $width = (int)$block->getWidth();
 $paddingBottom = $block->getRatio() * 100;
 ?>
-<span class="product-image-container product-image-container-<?= /* @noEscape */ $block->getProductId() ?>">
-    <span class="product-image-wrapper">
+<span class="product-image-container product-image-container-<?= /* @noEscape */ $block->getProductId() ?>" style="width: <?= $width; ?>px">
+    <span class="product-image-wrapper" style="padding-bottom: <?= $paddingBottom; ?>%">
         <img class="<?= $escaper->escapeHtmlAttr($block->getClass()) ?>"
             <?php foreach ($block->getCustomAttributes() as $name => $value): ?>
                 <?= $escaper->escapeHtmlAttr($name) ?>="<?= $escaper->escapeHtml($value) ?>"
@@ -21,31 +21,6 @@ $paddingBottom = $block->getRatio() * 100;
             loading="lazy"
             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
             height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
-            alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"/></span>
+            alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"/>
+    </span>
 </span>
-<?php
-$styles = <<<STYLE
-.product-image-container-{$block->getProductId()} {
-    width: {$width}px;
-}
-.product-image-container-{$block->getProductId()} span.product-image-wrapper {
-    padding-bottom: {$paddingBottom}%;
-}
-STYLE;
-//In case a script was using "style" attributes of these elements
-$script = <<<SCRIPT
-prodImageContainers = document.querySelectorAll(".product-image-container-{$block->getProductId()}");
-for (var i = 0; i < prodImageContainers.length; i++) {
-    prodImageContainers[i].style.width = "{$width}px";
-}
-prodImageContainersWrappers = document.querySelectorAll(
-    ".product-image-container-{$block->getProductId()}  span.product-image-wrapper"
-);
-for (var i = 0; i < prodImageContainersWrappers.length; i++) {
-    prodImageContainersWrappers[i].style.paddingBottom = "{$paddingBottom}%";
-}
-SCRIPT;
-
-?>
-<?= /* @noEscape */ $secureRenderer->renderTag('style', [], $styles, false) ?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', ['type' => 'text/javascript'], $script, false) ?>


### PR DESCRIPTION
### Description (*)
Each product in the product listing has a 20 line CSS&JS snippet that sets the product image size. I thought the code could be written more simply, so I opened this pull request.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#36953

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to pages with product lists.
2. Make sure the product image looks right.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
