### PR TITLE
#35437 Add order status history when order state or status changed

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -24,6 +24,7 @@ class State
     public function check(Order $order)
     {
         $currentState = $order->getState();
+        $currentStatus = $order->getStatus();
         if ($currentState == Order::STATE_NEW && $order->getIsInProcess()) {
             $order->setState(Order::STATE_PROCESSING)
                 ->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING));
@@ -47,6 +48,11 @@ class State
                 $order->setState(Order::STATE_CLOSED);
             }
         }
+
+        if ($currentState != $order->getState() || $currentStatus != $order->getStatus()) {
+            $order->addStatusHistoryComment('');
+        }
+        
         return $this;
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/ResourceModel/Order/Handler/StateTest.php
@@ -45,7 +45,8 @@ class StateTest extends TestCase
                     'getIsVirtual',
                     'getIsNotVirtual',
                     'getStatus',
-                    'getAllItems'
+                    'getAllItems',
+                    'addStatusHistoryComment'
                 ]
             )
             ->disableOriginalConstructor()


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Create order status history record when state is changed by an action (invoice, shipment, creditmemo, ..)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35437

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
See #35437
