### PR TITLE
[refactor] Slight type juggling abuse to prevent increment on empty string in DataFixture

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Fixture/Parser/DataFixture.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Fixture/Parser/DataFixture.php
@@ -55,7 +55,12 @@ class DataFixture implements ParserInterface
             $args = $attribute->getArguments();
             $alias = $args['as'] ?? $args[2] ?? null;
             $count = $args['count'] ?? $args[4] ?? 1;
-            $id = $count > 1 ? 1 : '';
+            /* Use null if we are only generating one set of date.
+             * The reson is that an empty string is not a valid numeric string, and will warn if
+             * https://wiki.php.net/rfc/saner-inc-dec-operators is accepted.
+             * However, null will hapilly get cast to the empty string for concatenation and then incremented to 1 with no warnings
+             */
+            $id = $count > 1 ? 1 : null;
             do {
                 $fixtures[] = [
                     'name' => $alias !== null ? ($alias.($id++)) : null,


### PR DESCRIPTION
### Description (*)

Empty strings are not considered numeric as of PHP 8.0.
Incrementing them via ``++`` might be consistent with trying to do ``'' + 1`` (which throws a TypeError) if https://wiki.php.net/rfc/saner-inc-dec-operators is accepted.

This was found during the impact analysis for https://wiki.php.net/rfc/saner-inc-dec-operators

### Manual testing scenarios (*)
None

### Questions or comments

Not sure if you want to split those cases more explicitly, but using ``null`` here will sidestep the potential warning with minimal effort. I've also chosen this solution as the fixture already relies on some automatic type coercions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
