### PR TITLE
Inventory: Actually Use Given Scope Id

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/StockRegistry.php
+++ b/app/code/Magento/CatalogInventory/Model/StockRegistry.php
@@ -73,7 +73,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getStock($scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         return $this->stockRegistryProvider->getStock($scopeId);
     }
 
@@ -84,7 +84,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getStockItem($productId, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         return $this->stockRegistryProvider->getStockItem($productId, $scopeId);
     }
 
@@ -96,7 +96,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getStockItemBySku($productSku, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         $productId = $this->resolveProductId($productSku);
         return $this->stockRegistryProvider->getStockItem($productId, $scopeId);
     }
@@ -108,7 +108,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getStockStatus($productId, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         return $this->stockRegistryProvider->getStockStatus($productId, $scopeId);
     }
 
@@ -120,7 +120,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getStockStatusBySku($productSku, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         $productId = $this->resolveProductId($productSku);
         return $this->getStockStatus($productId, $scopeId);
     }
@@ -133,7 +133,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getProductStockStatus($productId, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         $stockStatus = $this->getStockStatus($productId, $scopeId);
         return $stockStatus->getStockStatus();
     }
@@ -146,7 +146,7 @@ class StockRegistry implements StockRegistryInterface
      */
     public function getProductStockStatusBySku($productSku, $scopeId = null)
     {
-        $scopeId = $this->stockConfiguration->getDefaultScopeId();
+        $scopeId = $scopeId ?? $this->stockConfiguration->getDefaultScopeId();
         $productId = $this->resolveProductId($productSku);
         return $this->getProductStockStatus($productId, $scopeId);
     }


### PR DESCRIPTION
### Description (*)
At the moment, stock registry functions are always defaulting back to the default scope ID regardless of whether one is set or not.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
