### PR TITLE
Chore: Wishlist - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Wishlist/view/adminhtml/templates/customer/edit/tab/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/adminhtml/templates/customer/edit/tab/wishlist.phtml
@@ -3,11 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php $scriptString = <<<script
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
 
     require([
             "Magento_Ui/js/modal/confirm",
@@ -21,14 +27,14 @@
                     if (!urlParams) {
                         urlParams = '';
                     }
-                    var url = {$block->escapeJs($block->getJsObjectName())}.url + '?ajax=true' + urlParams;
+                    var url = {$escaper->escapeJs($block->getJsObjectName())}.url + '?ajax=true' + urlParams;
                     new Ajax.Updater(
-                        {$block->escapeJs($block->getJsObjectName())}.containerId,
+                        {$escaper->escapeJs($block->getJsObjectName())}.containerId,
                         url,
                         {
                             parameters: {form_key: FORM_KEY},
-                            onComplete: {$block->escapeJs($block->getJsObjectName())}.initGrid
-                            .bind({$block->escapeJs($block->getJsObjectName())}),
+                            onComplete: {$escaper->escapeJs($block->getJsObjectName())}.initGrid
+                            .bind({$escaper->escapeJs($block->getJsObjectName())}),
                         evalScripts:true
                 }
             );
@@ -51,7 +57,7 @@
         var self = this;
 
         confirm({
-            content: '{$block->escapeJs(__('Are you sure you want to remove this item?'))}',
+            content: '{$escaper->escapeJs(__('Are you sure you want to remove this item?'))}',
             actions: {
                 confirm: function () {
                     self.reload('&delete=' + itemId);
@@ -64,8 +70,8 @@
     productConfigure.addListType(
         'wishlist',
         {
-            urlFetch: '{$block->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/configure'))}',
-            urlConfirm: '{$block->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/update'))}'
+            urlFetch: '{$escaper->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/configure'))}',
+            urlConfirm: '{$escaper->escapeJs($block->getUrl('customer/wishlist_product_composite_wishlist/update'))}'
         }
     );
     //-->

--- a/app/code/Magento/Wishlist/view/base/templates/product/price/bundle/configured_price.phtml
+++ b/app/code/Magento/Wishlist/view/base/templates/product/price/bundle/configured_price.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Catalog\Pricing\Render\ConfiguredPriceBox $block */
+declare(strict_types=1);
+
+use Magento\Catalog\Pricing\Render\ConfiguredPriceBox;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var ConfiguredPriceBox $block */
 $schema = ($block->getZone() == 'item_view');
 $idSuffix = $block->getIdSuffix() ?: '';
 ?>
@@ -15,8 +19,8 @@ $idSuffix = $block->getIdSuffix() ?: '';
             <?= /* @noEscape */ $block->renderAmount(
                 $block->getConfiguredPrice()->getAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Special Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Special Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                     'price_type'        => 'finalPrice',
                     'include_container' => true,
                     'schema' => $schema,
@@ -27,8 +31,8 @@ $idSuffix = $block->getIdSuffix() ?: '';
             <?= /* @noEscape */ $block->renderAmount(
                 $block->getConfiguredRegularPrice()->getAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Regular Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Regular Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
                     'price_type'        => 'oldPrice',
                     'include_container' => true,
                     'skip_adjustments'  => true,
@@ -46,8 +50,8 @@ $idSuffix = $block->getIdSuffix() ?: '';
         <?= /* @noEscape */ $block->renderAmount(
             $block->getConfiguredPrice()->getAmount(),
             [
-                'display_label'     => $block->escapeHtml($priceLabel),
-                'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                'display_label'     => $escaper->escapeHtml($priceLabel),
+                'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                 'price_type'        => 'finalPrice',
                 'include_container' => true,
                 'schema' => $schema,

--- a/app/code/Magento/Wishlist/view/base/templates/product/price/configurable/configured_price.phtml
+++ b/app/code/Magento/Wishlist/view/base/templates/product/price/configurable/configured_price.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Wishlist\Pricing\Render\ConfiguredPriceBox $block */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct;
+use Magento\Wishlist\Pricing\Render\ConfiguredPriceBox;
+
+/** @var Escaper $escaper */
+/** @var ConfiguredPriceBox $block */
 $schema = ($block->getZone() == 'item_view');
 $idSuffix = $block->getIdSuffix() ?: '';
-/** @var \Magento\Wishlist\Pricing\ConfiguredPrice\ConfigurableProduct $configuredPrice */
+
+/** @var ConfigurableProduct $configuredPrice */
 $configuredPrice = $block->getPrice();
 $configuredRegularAmountValue = $configuredPrice->getConfiguredRegularAmount()->getValue();
 ?>
@@ -20,8 +26,8 @@ $configuredRegularAmountValue = $configuredPrice->getConfiguredRegularAmount()->
             <?= /* @noEscape */ $block->renderAmount(
                 $configuredPrice->getConfiguredAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Special Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Special Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                     'price_type'        => 'finalPrice',
                     'include_container' => true,
                     'schema' => $schema,
@@ -32,8 +38,8 @@ $configuredRegularAmountValue = $configuredPrice->getConfiguredRegularAmount()->
             <?= /* @noEscape */ $block->renderAmount(
                 $configuredPrice->getConfiguredRegularAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Regular Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Regular Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
                     'price_type'        => 'oldPrice',
                     'include_container' => true,
                     'skip_adjustments'  => true,
@@ -51,8 +57,8 @@ $configuredRegularAmountValue = $configuredPrice->getConfiguredRegularAmount()->
         <?= /* @noEscape */ $block->renderAmount(
             $configuredPrice->getAmount(),
             [
-                'display_label'     => $block->escapeHtml($priceLabel),
-                'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                'display_label'     => $escaper->escapeHtml($priceLabel),
+                'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                 'price_type'        => 'finalPrice',
                 'include_container' => true,
                 'schema' => $schema,

--- a/app/code/Magento/Wishlist/view/frontend/templates/button/share.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/button/share.phtml
@@ -3,11 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Button $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Button;
+
+/** @var Escaper $escaper */
+/** @var Button $block */
 ?>
 <?php if ($block->getWishlist()->getItemsCount() && $block->getWishlist()->getShared() < $block->getConfig()->getSharingEmailLimit()) : ?>
-    <button type="submit" name="save_and_share" title="<?= $block->escapeHtmlAttr(__('Share Wish List')) ?>" class="action share">
-        <span><?= $block->escapeHtml(__('Share Wish List')) ?></span>
+    <button type="submit"
+            name="save_and_share"
+            title="<?= $escaper->escapeHtmlAttr(__('Share Wish List')) ?>"
+            class="action share">
+        <span><?= $escaper->escapeHtml(__('Share Wish List')) ?></span>
     </button>
 <?php endif;?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/button/tocart.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/button/tocart.phtml
@@ -3,12 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Button $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Button;
+
+/** @var Escaper $escaper */
+/** @var Button $block */
 ?>
 
 <?php if ($block->getWishlist()->getItemsCount() && $block->getWishlist()->isSalable()) : ?>
-    <button type="button" data-role="all-tocart" title="<?= $block->escapeHtmlAttr(__('Add All to Cart')) ?>" class="action tocart">
-        <span><?= $block->escapeHtml(__('Add All to Cart')) ?></span>
+    <button type="button"
+            data-role="all-tocart"
+            title="<?= $escaper->escapeHtmlAttr(__('Add All to Cart')) ?>"
+            class="action tocart">
+        <span><?= $escaper->escapeHtml(__('Add All to Cart')) ?></span>
     </button>
 <?php endif;?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/button/update.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/button/update.phtml
@@ -3,12 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Button $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Button;
+
+/** @var Escaper $escaper */
+/** @var Button $block */
 ?>
-
 <?php if ($block->getWishlist()->getItemsCount()) : ?>
-    <button type="submit" name="do" title="<?= $block->escapeHtmlAttr(__('Update Wish List')) ?>" class="action update">
-        <span><?= $block->escapeHtml(__('Update Wish List')) ?></span>
+    <button type="submit"
+            name="do"
+            title="<?= $escaper->escapeHtmlAttr(__('Update Wish List')) ?>"
+            class="action update">
+        <span><?= $escaper->escapeHtml(__('Update Wish List')) ?></span>
     </button>
 <?php endif;?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/cart/item/renderer/actions/move_to_wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/cart/item/renderer/actions/move_to_wishlist.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Cart\Item\Renderer\Actions\MoveToWishlist;
+
+/** @var Escaper $escaper */
+/** @var MoveToWishlist $block */
 ?>
 <?php if ($block->isAllowInCart() && $block->isProductVisibleInSiteVisibility()) : ?>
     <a href="#"
        data-post='<?= /* @noEscape */ $block->getMoveFromCartParams() ?>'
        class="use-ajax action towishlist action-towishlist">
-        <span><?= $block->escapeHtml(__('Move to Wishlist')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Move to Wishlist')) ?></span>
     </a>
 <?php endif ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/catalog/product/list/addto/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/catalog/product/list/addto/wishlist.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var Magento\Wishlist\Block\Catalog\Product\ProductList\Item\AddTo\Wishlist $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Catalog\Product\ProductList\Item\AddTo\Wishlist;
+
+/** @var Escaper $escaper */
+/** @var Wishlist $block */
 ?>
 <?php if ($block->getWishlistHelper()->isAllow()) : ?>
     <a href="#"

--- a/app/code/Magento/Wishlist/view/frontend/templates/catalog/product/view/addto/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/catalog/product/view/addto/wishlist.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Catalog\Product\View\AddTo\Wishlist $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Catalog\Product\View\AddTo\Wishlist;
+
+/** @var Escaper $escaper */
+/** @var Wishlist $block */
 ?>
 <?php if ($block->isWishListAllowed()) : ?>
     <a href="#"
        class="action towishlist"
        data-post='<?= /* @noEscape */ $block->getWishlistParams() ?>'
-       data-action="add-to-wishlist"><span><?= $block->escapeHtml(__('Add to Wish List')) ?></span></a>
+       data-action="add-to-wishlist"><span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span></a>
 <?php endif; ?>
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Wishlist/view/frontend/templates/email/items.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/email/items.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Block\Share\Email\Items $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Share\Email\Items;
+
+/** @var Escaper $escaper */
+/* @var Items $block */
 ?>
 <?php $l = $block->getWishlistItemsCount() ?>
 <div>
@@ -17,26 +22,26 @@
                 <?php $_product = $item->getProduct(); ?>
                 <td class="col product">
                     <p>
-                        <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>">
+                        <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>">
                             <?php $productThumbnail = $block->getProductForThumbnail($item) ?>
                             <?= /* @noEscape */ $block->getImage($productThumbnail, 'product_small_image')->toHtml() ?>
                         </a>
                     </p>
 
                     <p>
-                        <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>">
-                            <strong><?= $block->escapeHtml($_product->getName()) ?></strong>
+                        <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>">
+                            <strong><?= $escaper->escapeHtml($_product->getName()) ?></strong>
                         </a>
                     </p>
                     <?php if ($block->hasDescription($item)): ?>
                         <p>
-                            <strong><?= $block->escapeHtml(__('Comment')) ?>:</strong>
+                            <strong><?= $escaper->escapeHtml(__('Comment')) ?>:</strong>
                             <br/><?= /* @noEscape */  $block->getEscapedDescription($item) ?>
                         </p>
                     <?php endif; ?>
                     <p>
-                        <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>">
-                            <?= $block->escapeHtml(__('View Product')) ?>
+                        <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>">
+                            <?= $escaper->escapeHtml(__('View Product')) ?>
                         </a>
                     </p>
                 </td>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/actions.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/actions.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Actions;
+
+/** @var Escaper $escaper */
+/** @var Actions $block */
 ?>
 <?php $children = $block->getChildNames(); ?>
 <?php if ($children) : ?>
-    <div class="<?= $block->escapeHtmlAttr($block->getCssClass()) ?>">
+    <div class="<?= $escaper->escapeHtmlAttr($block->getCssClass()) ?>">
         <?php foreach ($children as $childName) : ?>
             <?= /* @noEscape */ $block->getLayout()->renderElement($childName, false) ?>
         <?php endforeach;?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/cart.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/cart.phtml
@@ -3,13 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart;
+use Magento\Wishlist\Model\Item;
+use Magento\Wishlist\ViewModel\AllowedQuantity;
 
-/** @var \Magento\Wishlist\Model\Item $item */
+/** @var Escaper $escaper */
+/** @var Cart $block */
+/** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
-/** @var \Magento\Wishlist\ViewModel\AllowedQuantity $viewModel */
+
+/** @var AllowedQuantity $viewModel */
 $viewModel = $block->getData('allowedQuantityViewModel');
 $allowedQty = $viewModel->setItem($item)->getMinMaxQty();
 ?>
@@ -20,29 +27,29 @@ $allowedQty = $viewModel->setItem($item)->getMinMaxQty();
     <fieldset class="fieldset">
     <?php if ($item->canHaveQty() && $product->isVisibleInSiteVisibility()) : ?>
         <div class="field qty">
-            <label class="label" for="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]"><span><?= $block->escapeHtml(__('Qty')) ?></span></label>
+            <label class="label" for="qty[<?= $escaper->escapeHtmlAttr($item->getId()) ?>]"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></label>
             <div class="control">
-                <input type="number" data-role="qty" id="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]" class="input-text qty" data-validate="{'required-number':true,'validate-greater-than-zero':true, 'validate-item-quantity':{'minAllowed':<?= /* @noEscape */ $allowedQty['minAllowed'] ?>,'maxAllowed':<?= /* @noEscape */ $allowedQty['maxAllowed'] ?>}}"
-               name="qty[<?= $block->escapeHtmlAttr($item->getId()) ?>]" value="<?= /* @noEscape */ $block->getAddToCartQty($item) * 1 ?>" <?= $product->isSaleable() ? '' : 'disabled="disabled"' ?>>
+                <input type="number" data-role="qty" id="qty[<?= $escaper->escapeHtmlAttr($item->getId()) ?>]" class="input-text qty" data-validate="{'required-number':true,'validate-greater-than-zero':true, 'validate-item-quantity':{'minAllowed':<?= /* @noEscape */ $allowedQty['minAllowed'] ?>,'maxAllowed':<?= /* @noEscape */ $allowedQty['maxAllowed'] ?>}}"
+               name="qty[<?= $escaper->escapeHtmlAttr($item->getId()) ?>]" value="<?= /* @noEscape */ $block->getAddToCartQty($item) * 1 ?>" <?= $product->isSaleable() ? '' : 'disabled="disabled"' ?>>
             </div>
         </div>
     <?php endif; ?>
     <?php if ($product->isSaleable()) : ?>
     <div class="product-item-actions">
         <div class="actions-primary">
-            <button type="button" data-role="tocart" data-post='<?= /* @noEscape */ $block->getItemAddToCartParams($item) ?>' title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>" data-item-id="<?= $block->escapeHtmlAttr($item->getId()) ?>" class="action tocart primary">
-                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+            <button type="button" data-role="tocart" data-post='<?= /* @noEscape */ $block->getItemAddToCartParams($item) ?>' title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>" data-item-id="<?= $escaper->escapeHtmlAttr($item->getId()) ?>" class="action tocart primary">
+                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
             </button>
         </div>
     </div>
     <?php else : ?>
         <?php if ($product->getIsSalable()) : ?>
-            <p class="available stock" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                <span><?= $block->escapeHtml(__('In stock')) ?></span>
+            <p class="available stock" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
             </p>
         <?php else : ?>
-            <p class="unavailable stock" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+            <p class="unavailable stock" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
             </p>
         <?php endif; ?>
     <?php endif; ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/comment.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/comment.phtml
@@ -4,17 +4,22 @@
  * See COPYING.txt for license details.
  */
 
-/* @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Comment $block  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Model\Item $item */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Comment;
+use Magento\Wishlist\Model\Item;
+
+/** @var Escaper $escaper */
+/** @var Comment $block  */
+/** @var Item $item */
 $item = $block->getItem();
 ?>
-
 <div class="field comment-box">
-    <label class="label" for="product-item-comment-<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>">
-        <span><?= $block->escapeHtml(__('Comment')) ?></span>
+    <label class="label" for="product-item-comment-<?= $escaper->escapeHtmlAttr($item->getWishlistItemId()) ?>">
+        <span><?= $escaper->escapeHtml(__('Comment')) ?></span>
     </label>
     <div class="control">
-        <textarea id="product-item-comment-<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>" placeholder="<?= /* @noEscape */ $this->helper(\Magento\Wishlist\Helper\Data::class)->defaultCommentString() ?>" name="description[<?= $block->escapeHtmlAttr($item->getWishlistItemId()) ?>]" title="<?= $block->escapeHtmlAttr(__('Comment')) ?>" class="product-item-comment" <?= $item->getProduct()->isSaleable() ? '' : 'disabled="disabled"' ?>><?= ($block->escapeHtml($item->getDescription())) ?></textarea>
+        <textarea id="product-item-comment-<?= $escaper->escapeHtmlAttr($item->getWishlistItemId()) ?>" placeholder="<?= /* @noEscape */ $this->helper(\Magento\Wishlist\Helper\Data::class)->defaultCommentString() ?>" name="description[<?= $escaper->escapeHtmlAttr($item->getWishlistItemId()) ?>]" title="<?= $escaper->escapeHtmlAttr(__('Comment')) ?>" class="product-item-comment" <?= $item->getProduct()->isSaleable() ? '' : 'disabled="disabled"' ?>><?= ($escaper->escapeHtml($item->getDescription())) ?></textarea>
     </div>
 </div>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/edit.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/edit.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Edit $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Edit;
+use Magento\Wishlist\Model\Item;
 
-/** @var \Magento\Wishlist\Model\Item $item */
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
 ?>
-
 <?php if ($product->isVisibleInSiteVisibility()) : ?>
-    <a class="action edit" href="<?= $block->escapeUrl($block->getItemConfigureUrl($item)) ?>">
-        <span><?= $block->escapeHtml(__('Edit')) ?></span>
+    <a class="action edit" href="<?= $escaper->escapeUrl($block->getItemConfigureUrl($item)) ?>">
+        <span><?= $escaper->escapeHtml(__('Edit')) ?></span>
     </a>
 <?php endif ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/image.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/image.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Image;
+use Magento\Wishlist\Model\Item;
 
-/** @var \Magento\Wishlist\Model\Item $item */
+/** @var Escaper $escaper */
+/** @var Image $block */
+/** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
 ?>
-<a class="product-item-photo" tabindex="-1" href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>" title="<?= $block->escapeHtmlAttr($product->getName()) ?>">
+<a class="product-item-photo" tabindex="-1" href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>" title="<?= $escaper->escapeHtmlAttr($product->getName()) ?>">
     <?= $block->getImage($block->getProductForThumbnail($item), 'wishlist_thumbnail')->toHtml() ?>
 </a>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/name.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/name.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Info $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Info;
+use Magento\Wishlist\Model\Item;
 
-/** @var \Magento\Wishlist\Model\Item $item */
+/** @var Escaper $escaper */
+/** @var Info $block */
+/** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
 ?>
 <strong class="product-item-name">
-    <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>" title="<?= $block->escapeHtmlAttr($product->getName()) ?>" class="product-item-link">
-        <?= $block->escapeHtml($product->getName()) ?>
+    <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>" title="<?= $escaper->escapeHtmlAttr($product->getName()) ?>" class="product-item-link">
+        <?= $escaper->escapeHtml($product->getName()) ?>
     </a>
 </strong>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/column/remove.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/column/remove.phtml
@@ -3,10 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Remove $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Remove;
+
+/** @var Escaper $escaper */
+/* @var Remove $block */
 ?>
-
-<a href="#" data-role="remove" data-post-remove='<?= /* @noEscape */ $block->getItemRemoveParams($block->getItem()) ?>' title="<?= $block->escapeHtmlAttr(__('Remove Item')) ?>" class="btn-remove action delete">
-    <span><?= $block->escapeHtml(__('Remove item')) ?></span>
+<a href="#"
+   data-role="remove"
+   data-post-remove='<?= /* @noEscape */ $block->getItemRemoveParams($block->getItem()) ?>'
+   title="<?= $escaper->escapeHtmlAttr(__('Remove Item')) ?>"
+   class="btn-remove action delete">
+    <span><?= $escaper->escapeHtml(__('Remove item')) ?></span>
 </a>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/configure/addto.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/configure/addto.phtml
@@ -3,21 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Item\configure $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Item\configure;
+
+/** @var Escaper $escaper */
+/** @var configure $block */
 ?>
-
 <div class="product-addto-links" data-role="add-to-links">
     <?php if ($this->helper(\Magento\Wishlist\Helper\Data::class)->isAllow()) : ?>
         <a href="#" data-post='<?= /* @noEscape */ $block->getUpdateParams() ?>' class="action towishlist updated" data-action="add-to-wishlist">
-            <span><?= $block->escapeHtml(__('Update Wish List')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Update Wish List')) ?></span>
         </a>
     <?php endif; ?>
     <?php $_product = $block->getProduct(); ?>
     <?php $_compareUrl = $this->helper(\Magento\Catalog\Helper\Product\Compare::class)->getAddUrl($_product); ?>
     <?php if ($_compareUrl) : ?>
-        <a href="<?= $block->escapeUrl($_compareUrl) ?>" class="action tocompare">
-            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+        <a href="<?= $escaper->escapeUrl($_compareUrl) ?>" class="action tocompare">
+            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
         </a>
     <?php endif; ?>
 </div>

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/configure/addto/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/configure/addto/wishlist.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Item\Configure $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Item\Configure;
+
+/** @var Escaper $escaper */
+/** @var Configure $block */
 ?>
 <?php if ($this->helper(\Magento\Wishlist\Helper\Data::class)->isAllow()) : ?>
     <a href="#" data-post='<?= /* @noEscape */ $block->getUpdateParams() ?>' class="action towishlist updated" data-action="add-to-wishlist">
-        <span><?= $block->escapeHtml(__('Update Wish List')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Update Wish List')) ?></span>
     </a>
 <?php endif; ?>
 <script type="text/x-magento-init">

--- a/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/item/list.phtml
@@ -3,17 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Wishlist\Block\Customer\Wishlist\Items $block */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Items;
+
+/** @var Escaper $escaper */
+/** @var Items $block */
 $columns = $block->getColumns();
 ?>
-
 <div class="products-grid wishlist">
     <?php if (count($block->getItems())) : ?>
     <ol class="product-items">
         <?php foreach ($block->getItems() as $item) : ?>
-            <li data-row="product-item" class="product-item" id="item_<?= $block->escapeHtmlAttr($item->getId()) ?>">
+            <li data-row="product-item" class="product-item" id="item_<?= $escaper->escapeHtmlAttr($item->getId()) ?>">
                 <div class="product-item-info" data-container="product-grid">
                     <?php foreach ($columns as $column) : ?>
                         <?= $column->setItem($item)->toHtml();?>
@@ -24,7 +27,7 @@ $columns = $block->getColumns();
     </ol>
     <?php else : ?>
         <div class="message info empty">
-            <span><?= $block->escapeHtml(__('This Wish List has no Items')) ?></span>
+            <span><?= $escaper->escapeHtml(__('This Wish List has no Items')) ?></span>
         </div>
     <?php endif; ?>
 </div>

--- a/app/code/Magento/Wishlist/view/frontend/templates/link.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/link.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Block\Link $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Link;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <li class="link wishlist" data-bind="scope: 'wishlist'">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><?= $block->escapeHtml($block->getLabel()) ?>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><?= $escaper->escapeHtml($block->getLabel()) ?>
         <!-- ko if: wishlist().counter -->
         <span data-bind="text: wishlist().counter" class="counter qty"></span>
         <!-- /ko -->

--- a/app/code/Magento/Wishlist/view/frontend/templates/messages/addProductSuccessMessage.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/messages/addProductSuccessMessage.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
 
-<?= $block->escapeHtml(__('%1 has been added to your Wish List.', $block->getData('product_name'))) ?> <?= $block->escapeHtml(__('Click <a href="%1">here</a> to continue shopping.', $block->getData('referer')), ['a']);
+<?= $escaper->escapeHtml(__('%1 has been added to your Wish List.', $block->getData('product_name'))) ?> <?= $escaper->escapeHtml(__('Click <a href="%1">here</a> to continue shopping.', $block->getData('referer')), ['a']);

--- a/app/code/Magento/Wishlist/view/frontend/templates/messages/removeWishlistItemSuccessMessage.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/messages/removeWishlistItemSuccessMessage.phtml
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
 
-<?= $block->escapeHtml(__('%1 has been removed from your Wish List.', $block->getData('product_name'))); ?>
+<?= $escaper->escapeHtml(__('%1 has been removed from your Wish List.', $block->getData('product_name'))); ?>
 

--- a/app/code/Magento/Wishlist/view/frontend/templates/options_list.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/options_list.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Block\Customer\Wishlist\Item\Options $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Options;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
+$options = $block->getOptionList();
 ?>
-
-<?php $options = $block->getOptionList(); ?>
 <?php if ($options) : ?>
 <div class="tooltip wrapper product-item-tooltip">
-    <span class="action details tooltip toggle"><?= $block->escapeHtml(__('See Details')) ?></span>
+    <span class="action details tooltip toggle"><?= $escaper->escapeHtml(__('See Details')) ?></span>
     <div class="tooltip content">
-        <strong class="subtitle"><?= $block->escapeHtml(__('Options Details')) ?></strong>
+        <strong class="subtitle"><?= $escaper->escapeHtml(__('Options Details')) ?></strong>
         <dl>
             <?php foreach ($options as $option) : ?>
-            <dt class="label"><?= $block->escapeHtml($option['label']) ?></dt>
+            <dt class="label"><?= $escaper->escapeHtml($option['label']) ?></dt>
             <dd class="values">
                 <?php if (is_array($option['value'])) : ?>
                     <?= /* @noEscape */ nl2br(implode("\n", $option['value'])) ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/rss/email.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/rss/email.phtml
@@ -3,18 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var \Magento\Wishlist\Block\Rss\EmailLink $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Wishlist\Block\Rss\EmailLink;
+use Magento\Wishlist\Helper\Data;
 
-/** @var \Magento\Wishlist\Helper\Data $wishlistHelper */
+/** @var Escaper $escaper */
+/** @var EmailLink $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Data $wishlistHelper */
 $wishlistHelper = $block->getData('wishlistHelper');
 ?>
 <?php if ($block->getLink()): ?>
 <p id="wishlist-rss-email-link">
-    <?= $block->escapeHtml(__("RSS link to %1's wishlist", $wishlistHelper->getCustomerName())) ?>
+    <?= $escaper->escapeHtml(__("RSS link to %1's wishlist", $wishlistHelper->getCustomerName())) ?>
     <br />
-    <a href="<?= $block->escapeUrl($block->getLink()) ?>"><?= $block->escapeUrl($block->getLink()) ?></a>
+    <a href="<?= $escaper->escapeUrl($block->getLink()) ?>"><?= $escaper->escapeUrl($block->getLink()) ?></a>
 </p>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "font-size:12px; line-height:16px; margin:0 0 16px;",

--- a/app/code/Magento/Wishlist/view/frontend/templates/rss/wishlist.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/rss/wishlist.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Rss\Link $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Rss\Link;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink() && $this->helper(\Magento\Wishlist\Helper\Data::class)->getWishlist()->getItemsCount()) : ?>
-    <a href="<?= $block->escapeUrl($block->getLink()) ?>" class="action rss wishlist">
-        <span><?= $block->escapeHtml(__('RSS Feed')) ?></span>
+    <a href="<?= $escaper->escapeUrl($block->getLink()) ?>" class="action rss wishlist">
+        <span><?= $escaper->escapeHtml(__('RSS Feed')) ?></span>
     </a>
 <?php endif; ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/shared.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/shared.phtml
@@ -3,22 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Share\Wishlist $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Wishlist\Block\Share\Wishlist;
+
+/** @var Escaper $escaper */
+/** @var Wishlist $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <?php if ($block->hasWishlistItems()): ?>
-    <form class="form shared wishlist" action="<?= $block->escapeUrl($block->getUrl('wishlist/index/update')) ?>"
+    <form class="form shared wishlist" action="<?= $escaper->escapeUrl($block->getUrl('wishlist/index/update')) ?>"
           method="post">
         <div class="wishlist table-wrapper">
             <table class="table data wishlist" id="wishlist-table">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Wish List')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Wish List')) ?></caption>
                 <thead>
                 <tr>
-                    <th class="col product" scope="col"><?= $block->escapeHtml(__('Product')) ?></th>
-                    <th class="col comment" scope="col"><?= $block->escapeHtml(__('Comment')) ?></th>
-                    <th class="col actions" scope="col"><?= $block->escapeHtml(__('Add to Cart')) ?></th>
+                    <th class="col product" scope="col"><?= $escaper->escapeHtml(__('Product')) ?></th>
+                    <th class="col comment" scope="col"><?= $escaper->escapeHtml(__('Comment')) ?></th>
+                    <th class="col actions" scope="col"><?= $escaper->escapeHtml(__('Add to Cart')) ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -28,14 +33,14 @@
                     $isVisibleProduct = $product->isVisibleInSiteVisibility();
                     ?>
                     <tr>
-                        <td data-th="<?= $block->escapeHtmlAttr(__('Product')) ?>" class="col product">
-                            <a class="product photo" href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>"
-                               title="<?= $block->escapeHtmlAttr($product->getName()) ?>">
+                        <td data-th="<?= $escaper->escapeHtmlAttr(__('Product')) ?>" class="col product">
+                            <a class="product photo" href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>"
+                               title="<?= $escaper->escapeHtmlAttr($product->getName()) ?>">
                                 <?= $block->getImage($product, 'customer_shared_wishlist')->toHtml() ?>
                             </a>
                             <strong class="product name">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>">
-                                    <?= $block->escapeHtml($product->getName()) ?>
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>">
+                                    <?= $escaper->escapeHtml($product->getName()) ?>
                                 </a>
                             </strong>
                             <?=
@@ -48,25 +53,25 @@
                             ?>
                             <?= $block->getDetailsHtml($item) ?>
                         </td>
-                        <td data-th="<?= $block->escapeHtmlAttr(__('Comment')) ?>"
+                        <td data-th="<?= $escaper->escapeHtmlAttr(__('Comment')) ?>"
                             class="col comment"><?= /* @noEscape */ $block->getEscapedDescription($item) ?>
                         </td>
-                        <td data-th="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>" class="col actions"
+                        <td data-th="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>" class="col actions"
                             data-role="add-to-links">
                             <?php if ($product->isSaleable()): ?>
                                 <?php if ($isVisibleProduct): ?>
                                     <button type="button"
-                                            title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>"
+                                            title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>"
                                             data-post='<?= /* @noEscape */ $block->getSharedItemAddToCartUrl($item) ?>'
                                             class="action tocart">
-                                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                     </button>
                                 <?php endif ?>
                             <?php endif; ?>
                             <a href="#" data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($item) ?>'
                                id="wishlist-shared-item-<?= /* @noEscape */ $item->getId() ?>"
                                class="action towishlist" data-action="add-to-wishlist">
-                                <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                             </a>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
@@ -84,20 +89,20 @@
             <?php if ($block->isSaleable()): ?>
                 <div class="primary">
                     <button type="button"
-                            title="<?= $block->escapeHtmlAttr(__('Add All to Cart')) ?>"
-                            data-post='<?= $block->escapeUrl($block->getSharedAddAllToCartUrl()) ?>'
+                            title="<?= $escaper->escapeHtmlAttr(__('Add All to Cart')) ?>"
+                            data-post='<?= $escaper->escapeUrl($block->getSharedAddAllToCartUrl()) ?>'
                             class="action tocart primary">
-                        <span><?= $block->escapeHtml(__('Add All to Cart')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Add All to Cart')) ?></span>
                     </button>
                 </div>
             <?php endif;?>
             <div class="secondary">
-                <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                    <span><?= $block->escapeHtml(__('Back')) ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                    <span><?= $escaper->escapeHtml(__('Back')) ?></span>
                 </a>
             </div>
         </div>
     </form>
 <?php else: ?>
-    <div class="message info empty"><div><?= $block->escapeHtml(__('Wish List is empty now.')) ?></div></div>
+    <div class="message info empty"><div><?= $escaper->escapeHtml(__('Wish List is empty now.')) ?></div></div>
 <?php endif ?>

--- a/app/code/Magento/Wishlist/view/frontend/templates/sharing.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/sharing.phtml
@@ -3,36 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Sharing $block */
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Sharing;
+
+/** @var Escaper $escaper */
+/** @var Sharing $block */
 ?>
 <form class="form wishlist share"
-      action="<?= $block->escapeUrl($block->getSendUrl()) ?>"
+      action="<?= $escaper->escapeUrl($block->getSendUrl()) ?>"
       id="form-validate"
       method="post"
-      data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>"
+      data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>"
       data-mage-init='{"validation":{}}'>
     <fieldset class="fieldset">
         <?= $block->getBlockHtml('formkey') ?>
-        <legend class="legend"><span><?= $block->escapeHtml(__('Sharing Information')) ?></span></legend><br />
+        <legend class="legend"><span><?= $escaper->escapeHtml(__('Sharing Information')) ?></span></legend><br />
         <div class="field emails required">
-            <label class="label" for="email_address"><span><?= $block->escapeHtml(__('Email addresses, separated by commas')) ?></span></label>
+            <label class="label" for="email_address"><span><?= $escaper->escapeHtml(__('Email addresses, separated by commas')) ?></span></label>
             <div class="control">
                 <textarea name="emails" cols="60" rows="5" id="email_address" data-validate="{required:true,'validate-emails':true}"><?= /* @noEscape */ $block->getEnteredData('emails') ?></textarea>
             </div>
         </div>
         <div class="field text">
-            <label class="label" for="message"><span><?= $block->escapeHtml(__('Message')) ?></span></label>
+            <label class="label" for="message"><span><?= $escaper->escapeHtml(__('Message')) ?></span></label>
             <div class="control">
                 <textarea id="message" name="message" cols="60" rows="5"><?= /* @noEscape */ $block->getEnteredData('message') ?></textarea>
             </div>
         </div>
         <?php if ($this->helper(\Magento\Wishlist\Helper\Rss::class)->isRssAllow()) : ?>
             <div class="field choice rss">
-                <input type="checkbox" name="rss_url" id="rss_url" value="1" title="<?= $block->escapeHtmlAttr(__('Check here to link an RSS feed to your Wish List.')) ?>" class="checkbox">
+                <input type="checkbox" name="rss_url" id="rss_url" value="1" title="<?= $escaper->escapeHtmlAttr(__('Check here to link an RSS feed to your Wish List.')) ?>" class="checkbox">
                 <label class="label" for="rss_url">
                     <span>
-                        <?= $block->escapeHtml(__('Check here to link an RSS feed to your Wish List.')) ?>
+                        <?= $escaper->escapeHtml(__('Check here to link an RSS feed to your Wish List.')) ?>
                     </span>
                 </label>
             </div>
@@ -41,12 +46,12 @@
     <?= $block->getChildHtml('captcha'); ?>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="submit" title="<?= $block->escapeHtmlAttr(__('Share Wish List')) ?>" class="action submit primary">
-                <span><?= $block->escapeHtml(__('Share Wish List')) ?></span>
+            <button type="submit" title="<?= $escaper->escapeHtmlAttr(__('Share Wish List')) ?>" class="action submit primary">
+                <span><?= $escaper->escapeHtml(__('Share Wish List')) ?></span>
             </button>
         </div>
         <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>"><span><?= $block->escapeHtml(__('Back')) ?></span></a>
+            <a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>"><span><?= $escaper->escapeHtml(__('Back')) ?></span></a>
         </div>
     </div>
 </form>

--- a/app/code/Magento/Wishlist/view/frontend/templates/sidebar.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/sidebar.phtml
@@ -3,22 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Wishlist\Block\Customer\Sidebar $block */
-?>
-<?php
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Sidebar;
+
+/** @var Escaper $escaper */
+/** @var Sidebar $block */
 $wishlstViewModel = $block->getData('wishlistDataViewModel');
 ?>
 <?php if ($wishlstViewModel->isAllow()): ?>
     <div class="block block-wishlist" data-bind="scope: 'wishlist'">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($block->getTitle()) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($block->getTitle()) ?></strong>
             <!-- ko if: wishlist().counter -->
             <span data-bind="text: wishlist().counter" class="counter"></span>
             <!-- /ko -->
         </div>
         <div class="block-content">
-            <strong class="subtitle"><?= $block->escapeHtml(__('Last Added Items')) ?></strong>
+            <strong class="subtitle"><?= $escaper->escapeHtml(__('Last Added Items')) ?></strong>
             <!-- ko if: wishlist().counter -->
                 <ol class="product-items no-display"
                     id="wishlist-sidebar"
@@ -42,23 +45,23 @@ $wishlstViewModel = $block->getData('wishlistDataViewModel');
                                         <a href="#"
                                            data-bind="attr: {'data-post': add_to_cart_params}"
                                            class="action tocart primary">
-                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                         </a>
                                         <!-- /ko -->
                                         <!-- ko ifnot: product_has_required_options -->
                                             <button type="button"
                                                     class="action tocart primary"
                                                     data-bind="attr: {'data-post': add_to_cart_params}">
-                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                             </button>
                                         <!-- /ko -->
                                     </div>
                                     <!-- /ko -->
                                     <div class="actions-secondary">
                                         <a href="#"  data-bind="attr: {'data-post': delete_item_params}"
-                                           title="<?= $block->escapeHtmlAttr(__('Remove This Item')) ?>"
+                                           title="<?= $escaper->escapeHtmlAttr(__('Remove This Item')) ?>"
                                            class="btn-remove action delete">
-                                            <span><?= $block->escapeHtml(__('Remove This Item')) ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                                         </a>
                                     </div>
                                 </div>
@@ -69,15 +72,15 @@ $wishlstViewModel = $block->getData('wishlistDataViewModel');
                 <div class="actions-toolbar no-display" data-bind="css: {'no-display': null}">
                     <div class="primary">
                         <a class="action details"
-                           href="<?= $block->escapeUrl($wishlstViewModel->getListUrl()) ?>"
-                           title="<?= $block->escapeHtmlAttr(__('Go to Wish List')) ?>">
-                            <span><?= $block->escapeHtml(__('Go to Wish List')) ?></span>
+                           href="<?= $escaper->escapeUrl($wishlstViewModel->getListUrl()) ?>"
+                           title="<?= $escaper->escapeHtmlAttr(__('Go to Wish List')) ?>">
+                            <span><?= $escaper->escapeHtml(__('Go to Wish List')) ?></span>
                         </a>
                     </div>
                 </div>
             <!-- /ko -->
             <!-- ko ifnot: wishlist().counter -->
-                <div class="empty"><?= $block->escapeHtml(__('You have no items in your wish list.')) ?></div>
+                <div class="empty"><?= $escaper->escapeHtml(__('You have no items in your wish list.')) ?></div>
             <!-- /ko -->
         </div>
     </div>

--- a/app/code/Magento/Wishlist/view/frontend/templates/view.phtml
+++ b/app/code/Magento/Wishlist/view/frontend/templates/view.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist;
+
+/** @var Escaper $escaper */
+/** @var Wishlist $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var \Magento\Wishlist\Block\Customer\Wishlist $block */
 ?>
-
 <?php if ($this->helper(\Magento\Wishlist\Helper\Data::class)->isAllow()) : ?>
     <div class="toolbar wishlist-toolbar"><?= $block->getChildHtml('wishlist_item_pager'); ?></div>
     <?= ($block->getChildHtml('wishlist.rss.link')) ?>
@@ -16,14 +21,14 @@
           "addToCartUrl":<?= /* @noEscape */ $block->getItemAddToCartParams("%item%") ?>,
           "addAllToCartUrl":<?= /* @noEscape */ $block->getAddAllToCartParams() ?>,
           "commentString":""},
-          "validation": {}}' action="<?= $block->escapeUrl($block->getUrl('wishlist/index/update', ['wishlist_id' => $block->getWishlistInstance()->getId()])) ?>" method="post">
+          "validation": {}}' action="<?= $escaper->escapeUrl($block->getUrl('wishlist/index/update', ['wishlist_id' => $block->getWishlistInstance()->getId()])) ?>" method="post">
         <?= $block->getChildHtml('top') ?>
         <?php if ($block->hasWishlistItems()) : ?>
             <?= $block->getBlockHtml('formkey') ?>
             <?php $block->getChildBlock('items')->setItems($block->getWishlistItems()); ?>
             <?= $block->getChildHtml('items') ?>
         <?php else : ?>
-            <div class="message info empty"><span><?= $block->escapeHtml(__('You have no items in your wish list.')) ?></span></div>
+            <div class="message info empty"><span><?= $escaper->escapeHtml(__('You have no items in your wish list.')) ?></span></div>
         <?php endif ?>
         <?= $block->getChildHtml('bottom') ?>
         <div class="actions-toolbar">
@@ -31,8 +36,8 @@
                 <?= $block->getChildHtml('control_buttons') ?>
             </div>
             <div class="secondary">
-                <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                    <span><?= $block->escapeHtml(__('Back')) ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                    <span><?= $escaper->escapeHtml(__('Back')) ?></span>
                 </a>
             </div>
         </div>
@@ -42,11 +47,11 @@
           <% if (data.qty) { %>
           <input name="qty" value="<%- data.qty %>">
           <% } %>
-          
+
           <% if (data.item) { %>
           <input name="item" value="<%- data.item %>">
           <% } %>
-          
+
           <% if (data.entity) { %>
           <input name="entity" value="<%- data.entity %>">
           <% } %>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Wishlist` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37147: Chore: Wishlist - Replace Block Escaping with Escaper