### PR TITLE
Chore: Widget - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Widget/view/adminhtml/templates/catalog/category/widget/tree.phtml
+++ b/app/code/Magento/Widget/view/adminhtml/templates/catalog/category/widget/tree.phtml
@@ -3,13 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Catalog\Block\Adminhtml\Category\Widget\Chooser $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Category\Widget\Chooser;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Chooser $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_divId = 'tree' . $block->getId() ?>
-<div id="<?= $block->escapeHtmlAttr($_divId) ?>" class="tree"></div>
+<div id="<?= $escaper->escapeHtmlAttr($_divId) ?>" class="tree"></div>
 <?php
 $useMassaction = /* @noEscape */ $block->getUseMassaction() ? 1 : 0;
 $isAnchorOnly = /* @noEscape */ $block->getIsAnchorOnly() ? 1 : 0;
@@ -24,7 +30,7 @@ $scriptString = <<<script
 
 require(['jquery', "prototype", "extjs/ext-tree-checkbox"], function(jQuery){
 
-var tree{$block->escapeJs($block->getId())};
+var tree{$escaper->escapeJs($block->getId())};
 
 var useMassaction = {$useMassaction};
 
@@ -77,7 +83,7 @@ jQuery(function()
     var emptyNodeAdded = {$withEmpltyNode};
 
     var categoryLoader = new Ext.tree.TreeLoader({
-        dataUrl: '{$block->escapeJs($block->getLoadTreeUrl())}'
+        dataUrl: '{$escaper->escapeJs($block->getLoadTreeUrl())}'
     });
 
     categoryLoader.buildCategoryTree = function(parent, config)
@@ -96,7 +102,7 @@ jQuery(function()
                 // Add empty node to reset category filter
                 if(!emptyNodeAdded) {
                     var empty = Object.clone(_node);
-                    empty.text = '{$block->escapeJs($block->escapeHtml(__('None')))}';
+                    empty.text = '{$escaper->escapeJs($escaper->escapeHtml(__('None')))}';
                     empty.children = [];
                     empty.id = 'none';
                     empty.path = '1/none';
@@ -167,11 +173,11 @@ jQuery(function()
     };
 
     categoryLoader.on("beforeload", function(treeLoader, node) {
-        $('{$block->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
+        $('{$escaper->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
         treeLoader.baseParams.id = node.attributes.id;
     });
 
-    tree{$block->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$block->escapeJs($_divId)}', {
+    tree{$escaper->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$escaper->escapeJs($_divId)}', {
         animate:          false,
         loader:           categoryLoader,
         enableDD:         false,
@@ -183,9 +189,9 @@ jQuery(function()
     });
 
     if (useMassaction) {
-        tree{$block->escapeJs($block->getId())}.on('check', function(node) {
-            $('{$block->escapeJs($_divId)}').fire('node:changed', {node:node});
-        }, tree{$block->escapeJs($block->getId())});
+        tree{$escaper->escapeJs($block->getId())}.on('check', function(node) {
+            $('{$escaper->escapeJs($_divId)}').fire('node:changed', {node:node});
+        }, tree{$escaper->escapeJs($block->getId())});
     }
 
     // set the root node
@@ -197,7 +203,7 @@ jQuery(function()
         category_id: {$categoryId}
     };
 
-    tree{$block->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$treeJson}},true);
+    tree{$escaper->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$treeJson}},true);
 
 });
 


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Widget` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37146: Chore: Widget - Replace Block Escaping with Escaper