### PR TITLE
Chore: WEEE - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Weee/view/adminhtml/templates/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/items/price/row.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Weee\Block\Adminhtml\Items\Price\Renderer;
+use Magento\Weee\Helper\Data;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Weee\Block\Adminhtml\Items\Price\Renderer $block */
 
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
-$_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
+/** @var $_weeeHelper Data */
+$_weeeHelper = $this->helper(Data::class);
 
 $_item = $block->getItem();
 ?>
@@ -18,23 +23,23 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
 
         <?= $block->getRowPriceExclTaxHtml() ?>
 
-        <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+        <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
             <?php if ($block->displayPriceWithWeeeDetails()) : ?>
                 <small>
-                    <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                        <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_row_amount'], $tax['row_amount']) ?></span>
+                    <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                        <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_row_amount'], $tax['row_amount']) ?></span>
                     <?php endforeach; ?>
                 </small>
             <?php endif; ?>
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <br />
-                <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+                <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                     <?= $block->getFinalRowPriceExclTaxHtml() ?>
                 </span>
             <?php endif; ?>
@@ -44,23 +49,23 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?= $block->getRowPriceInclTaxHtml() ?>
 
-        <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+        <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
             <br />
             <?php if ($block->displayPriceWithWeeeDetails()) : ?>
                 <small>
-                    <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                        <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_row_amount_incl_tax'], $tax['row_amount_incl_tax']) ?></span>
+                    <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                        <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_row_amount_incl_tax'], $tax['row_amount_incl_tax']) ?></span>
                     <?php endforeach; ?>
                 </small>
             <?php endif; ?>
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <br />
-                <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+                <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                     <?= $block->getFinalRowPriceInclTaxHtml() ?>
                 </span>
             <?php endif; ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/items/price/unit.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/items/price/unit.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Weee\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Weee\Block\Adminhtml\Items\Price\Renderer $block */
 
 /** @var $_weeeHelper \Magento\Weee\Helper\Data */
 $_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
@@ -18,7 +22,7 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
 
         <?= $block->getUnitPriceExclTaxHtml() ?>
@@ -28,14 +32,14 @@ $_item = $block->getItem();
             <?php if ($block->displayPriceWithWeeeDetails()) : ?>
                 <small>
                     <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                        <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_amount'], $tax['amount']) ?></span>
+                        <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_amount'], $tax['amount']) ?></span>
                     <?php endforeach; ?>
                 </small>
             <?php endif; ?>
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <br />
-                <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+                <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                     <?= $block->getFinalUnitPriceExclTaxHtml() ?>
                 </span>
             <?php endif; ?>
@@ -45,7 +49,7 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?= $block->getUnitPriceInclTaxHtml() ?>
 
@@ -54,14 +58,14 @@ $_item = $block->getItem();
             <?php if ($block->displayPriceWithWeeeDetails()) : ?>
                 <small>
                     <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                        <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_amount_incl_tax'], $tax['amount_incl_tax']) ?></span>
+                        <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->displayPrices($tax['base_amount_incl_tax'], $tax['amount_incl_tax']) ?></span>
                     <?php endforeach; ?>
                 </small>
             <?php endif; ?>
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <br />
-                <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+                <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                     <?= $block->getFinalUnitPriceInclTaxHtml() ?>
                 </span>
             <?php endif; ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/row.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Weee\Block\Item\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var $block Renderer */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var $block \Magento\Weee\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($block->getRowDisplayPriceExclTax()) ?>
 
@@ -24,14 +27,14 @@ $_item = $block->getItem();
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
                 <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?></span><br />
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
             <br />
-            <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceExclTax()) ?>
             </span>
         <?php endif; ?>
@@ -40,7 +43,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($block->getRowDisplayPriceInclTax()) ?>
     <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
@@ -48,13 +51,13 @@ $_item = $block->getItem();
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
                 <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
-            <span class="nobr"><?= $block->escapeHtml(__('Total Incl. Tax')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total Incl. Tax')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceInclTax()) ?>
             </span>
         <?php endif; ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/total.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/total.phtml
@@ -3,36 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Weee\Block\Item\Price\Renderer $block */
-$_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
+
+$_weeeHelper = $this->helper(Data::class);
 $_item = $block->getItem();
 ?>
-
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php $_rowTotalWithoutDiscount = $block->getRowDisplayPriceExclTax() - $_item->getTotalDiscountAmount(); ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice(max(0, $_rowTotalWithoutDiscount)) ?>
 
 
-    <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+    <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
         <br />
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
-                <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?></span><br />
+                <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
             <br />
-            <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceExclTax() - $_item->getTotalDiscountAmount()) ?>
             </span>
         <?php endif; ?>
@@ -42,22 +47,22 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $block->getTotalAmount($_item); ?>
     <?= /* @noEscape */ $block->formatPrice(max(0, $_incl)) ?>
-    <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+    <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
         <br />
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
-                <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
+                <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
-            <span class="nobr"><?= $block->escapeHtml(__('Total Incl. Tax')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total Incl. Tax')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceInclTax() - $_item->getTotalDiscountAmount()) ?>
             </span>
         <?php endif; ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/unit.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/order/create/items/price/unit.phtml
@@ -3,18 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Weee\Block\Item\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
-<?php
-/** @var \Magento\Weee\Block\Item\Price\Renderer $block */
-
-$_item = $block->getItem();
-?>
-
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($block->getUnitDisplayPriceExclTax()) ?>
 
@@ -23,14 +25,14 @@ $_item = $block->getItem();
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
                 <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['amount'], true, true) ?></span><br />
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['amount'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
             <br />
-            <span class="nobr"><?= $block->escapeHtml(__('Total')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceExclTax()) ?>
             </span>
         <?php endif; ?>
@@ -40,7 +42,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($block->getUnitDisplayPriceInclTax()) ?>
 
@@ -49,13 +51,13 @@ $_item = $block->getItem();
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
                 <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?= $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['amount_incl_tax'], true, true) ?></span><br />
+                    <span class="nobr"><?= $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */ $block->formatPrice($tax['amount_incl_tax'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
-            <span class="nobr"><?= $block->escapeHtml(__('Total Incl. Tax')) ?>:<br />
+            <span class="nobr"><?= $escaper->escapeHtml(__('Total Incl. Tax')) ?>:<br />
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceInclTax()) ?>
             </span>
         <?php endif; ?>

--- a/app/code/Magento/Weee/view/adminhtml/templates/renderer/tax.phtml
+++ b/app/code/Magento/Weee/view/adminhtml/templates/renderer/tax.phtml
@@ -3,15 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/**
- * @var $block \Magento\Weee\Block\Renderer\Weee\Tax
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Renderer\Weee\Tax;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Tax $block */
 /** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
+
 /** @var \Magento\Directory\Helper\Data $directoryHelper */
 $directoryHelper = $block->getData('directoryHelper');
 
@@ -20,23 +23,25 @@ $data = ['fptAttribute' => [
     'itemsData' => $block->getValues(),
     'bundlePriceType' => '#price_type',
 ]];
+
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
 <div id="attribute-<?= /* @noEscape */ $block->getElement()->getHtmlId() ?>-container" class="field"
      data-attribute-code="<?= /* @noEscape */ $block->getElement()->getHtmlId() ?>"
      data-mage-init="<?= /* @noEscape */ $jsonHelper->jsonEncode($data) ?>">
-    <label class="label"><span><?= $block->escapeHtml($block->getElement()->getLabel()) ?></span></label>
+    <label class="label"><span><?= $escaper->escapeHtml($block->getElement()->getLabel()) ?></span></label>
 
     <div class="control">
         <table class="data-table">
             <thead>
                 <tr>
-                    <th class="col-website"><?= $block->escapeHtml(__('Website')) ?></th>
+                    <th class="col-website"><?= $escaper->escapeHtml(__('Website')) ?></th>
                     <?php if (!$block->isMultiWebsites()): ?>
                         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display: none;', 'th.col-website') ?>
                     <?php endif; ?>
-                    <th class="col-country required"><?= $block->escapeHtml(__('Country/State')) ?></th>
-                    <th class="col-tax required"><?= $block->escapeHtml(__('Tax')) ?></th>
-                    <th class="col-action"><?= $block->escapeHtml(__('Action')) ?></th>
+                    <th class="col-country required"><?= $escaper->escapeHtml(__('Country/State')) ?></th>
+                    <th class="col-tax required"><?= $escaper->escapeHtml(__('Tax')) ?></th>
+                    <th class="col-action"><?= $escaper->escapeHtml(__('Action')) ?></th>
                 </tr>
             </thead>
             <tfoot>
@@ -57,8 +62,8 @@ $data = ['fptAttribute' => [
 
     <script data-role="row-template" type="text/x-magento-template">
         <?php
-            $elementName = $block->escapeHtmlAttr($block->getElement()->getName());
-            $elementClass = $block->escapeHtmlAttr($block->getElement()->getClass());
+            $elementName = $escaper->escapeHtmlAttr($block->getElement()->getName());
+            $elementClass = $escaper->escapeHtmlAttr($block->getElement()->getClass());
         ?>
         <tr id="<?= /* @noEscape */ $block->getElement()->getHtmlId() ?>_weee_tax_row_<%- data.index %>"
             data-role="fpt-item-row">
@@ -67,7 +72,7 @@ $data = ['fptAttribute' => [
                         name="<?= /* @noEscape */ $elementName ?>[<%- data.index %>][website_id]"
                         class="<?= /* @noEscape */ $elementClass ?> website required-entry" data-role="select-website">
                     <?php foreach ($block->getWebsites() as $_websiteId => $_info): ?>
-                    <option value="<?= /* @noEscape */ $_websiteId ?>"><?= $block->escapeHtml($_info['name']) ?>
+                    <option value="<?= /* @noEscape */ $_websiteId ?>"><?= $escaper->escapeHtml($_info['name']) ?>
                         <?php if (!empty($_info['currency'])): ?>
                             [<?= /* @noEscape */ $_info['currency'] ?>]
                         <?php endif; ?>
@@ -83,8 +88,8 @@ $data = ['fptAttribute' => [
                         name="<?= /* @noEscape */ $elementName ?>[<%- data.index %>][country]"
                         class="<?= /* @noEscape */ $elementClass ?> country required-entry" data-role="select-country">
                     <?php foreach ($block->getCountries() as $_country): ?>
-                    <option value="<?= $block->escapeHtmlAttr($_country['value']) ?>">
-                        <?= $block->escapeHtml($_country['label']) ?>
+                    <option value="<?= $escaper->escapeHtmlAttr($_country['value']) ?>">
+                        <?= $escaper->escapeHtml($_country['label']) ?>
                     </option>
                     <?php endforeach ?>
                 </select>

--- a/app/code/Magento/Weee/view/base/templates/pricing/adjustment.phtml
+++ b/app/code/Magento/Weee/view/base/templates/pricing/adjustment.phtml
@@ -3,10 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
-/** @var \Magento\Weee\Pricing\Render\Adjustment $block */
+use Magento\Framework\Escaper;
+use Magento\Weee\Pricing\Render\Adjustment;
+
+/** @var Escaper $escaper */
+/** @var Adjustment $block */
 
 $weeeSeparator = $openBrace = $closeBrace = '';
 $openBrace = '(';
@@ -18,7 +21,7 @@ $priceDisplay = $block->isPriceIncludesTax();
 <?php if ($block->showInclDescr() || $block->showExclDescrIncl()) : // incl. + weee ||  excl. + weee + final ?>
     <?php foreach ($block->getWeeeTaxAttributes() as $weeeTaxAttribute) : ?>
         <?php
-            $attributeName = $block->escapeHtmlAttr($block->renderWeeeTaxAttributeName($weeeTaxAttribute));
+            $attributeName = $escaper->escapeHtmlAttr($block->renderWeeeTaxAttributeName($weeeTaxAttribute));
         ?>
         <?php if ($taxDisplay == Magento\Tax\Model\Config::DISPLAY_TYPE_INCLUDING_TAX) : ?>
             <span class="weee"
@@ -33,11 +36,11 @@ $priceDisplay = $block->isPriceIncludesTax();
         <?php elseif ($taxDisplay == Magento\Tax\Model\Config::DISPLAY_TYPE_BOTH) : ?>
             <span class="weee"
                   data-price-type="weee"
-                  data-label="<?= /* @noEscape */ $attributeName . ' ' . $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+                  data-label="<?= /* @noEscape */ $attributeName . ' ' . $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
                             <?= /* @noEscape */ $block->renderWeeeTaxAttributeWithTax($weeeTaxAttribute) ?></span>
             <span class="weee"
                   data-price-type="weee"
-                  data-label="<?= /* @noEscape */ $attributeName . ' ' . $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+                  data-label="<?= /* @noEscape */ $attributeName . ' ' . $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
                             <?= /* @noEscape */ $block->renderWeeeTaxAttributeWithoutTax($weeeTaxAttribute) ?></span>
         <?php endif; ?>
     <?php endforeach; ?>
@@ -47,5 +50,5 @@ $priceDisplay = $block->isPriceIncludesTax();
     <span class="price-final price-final_price"
           data-price-type="weeePrice"
           data-price-amount="<?= /* @noEscape */ $block->getRawFinalAmount() ?>"
-          data-label="<?= $block->escapeHtmlAttr(__('Final Price')) ?>"><?= /* @noEscape */ $block->getFinalAmount() ?></span>
+          data-label="<?= $escaper->escapeHtmlAttr(__('Final Price')) ?>"><?= /* @noEscape */ $block->getFinalAmount() ?></span>
 <?php endif; ?>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/cart/item/price/sidebar.phtml
@@ -3,20 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable Magento2.Templates.ThisInTemplate
+use Magento\Framework\Escaper;
+use Magento\Framework\Pricing\Render;
+use Magento\Weee\Block\Item\Price\Renderer;
 
-/** @var $block \Magento\Weee\Block\Item\Price\Renderer */
-
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 $item = $block->getItem();
 
 // ensure we use the zone for the shopping cart / minicart
 $originalZone = $block->getZone();
-$block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
+$block->setZone(Render::ZONE_CART);
+
+// phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
     <?php if ($block->displayPriceWithWeeeDetails()) : ?>
         <span class="minicart-tax-total">
     <?php else : ?>
@@ -29,7 +34,7 @@ $block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
         <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($item)) : ?>
             <span class="minicart-tax-info">
             <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($item) as $tax) : ?>
-                <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                     <?= /* @noEscape */ $block->formatPrice($tax['amount_incl_tax'], true, true) ?>
                 </span>
             <?php endforeach; ?>
@@ -37,7 +42,7 @@ $block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <span class="minicart-tax-total">
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceInclTax()) ?>
                     </span>
                 </span>
@@ -48,7 +53,7 @@ $block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
 <?php endif; ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
     <?php if ($block->displayPriceWithWeeeDetails()) : ?>
         <span class="minicart-tax-total">
     <?php else : ?>
@@ -61,7 +66,7 @@ $block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
         <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($item)) : ?>
             <span class="minicart-tax-info">
             <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($item) as $tax) : ?>
-                <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                     <?= /* @noEscape */ $block->formatPrice($tax['amount'], true, true) ?>
                 </span>
             <?php endforeach; ?>
@@ -69,7 +74,7 @@ $block->setZone(\Magento\Framework\Pricing\Render::ZONE_CART);
 
             <?php if ($block->displayFinalPrice()) : ?>
                 <span class="minicart-tax-total">
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceExclTax()) ?>
                     </span>
                 </span>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_excl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_excl_tax.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
-/** @var \Magento\Weee\Helper\Data $weeeHelper */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
+/** @var Data $weeeHelper */
 $weeeHelper = $block->getData('weeeHelper');
 
 $_item = $block->getItem();
@@ -27,7 +31,7 @@ $_item = $block->getItem();
     <span class="cart-tax-info no-display" id="esubtotal-item-tax-details<?= (int) $_item->getId() ?>">
     <?php if ($block->displayPriceWithWeeeDetails()): ?>
         <?php foreach ($weeeHelper->getApplied($_item) as $tax): ?>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                 <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?>
             </span>
         <?php endforeach; ?>
@@ -37,7 +41,7 @@ $_item = $block->getItem();
     <?php if ($block->displayFinalPrice()): ?>
         <span class="cart-tax-total"
               data-mage-init='{"taxToggle": {"itemTaxId" : "#esubtotal-item-tax-details<?= (int) $_item->getId() ?>"}}'>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total')) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total')) ?>">
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceExclTax()) ?>
             </span>
         </span>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_incl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/row_incl_tax.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
 $_item = $block->getItem();
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+
+/** @var $_weeeHelper Data */
 $_weeeHelper = $block->getData('weeeHelper');
 ?>
 <?php $_incl = $_item->getRowTotalInclTax(); ?>
@@ -27,7 +32,7 @@ $_weeeHelper = $block->getData('weeeHelper');
     <span class="cart-tax-info no-display" id="subtotal-item-tax-details<?= (int) $_item->getId() ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <?php foreach ($_weeeHelper->getApplied($_item) as $tax): ?>
-                <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                     <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?>
                 </span>
             <?php endforeach; ?>
@@ -37,7 +42,7 @@ $_weeeHelper = $block->getData('weeeHelper');
     <?php if ($block->displayFinalPrice()): ?>
         <span class="cart-tax-total"
               data-mage-init='{"taxToggle": {"itemTaxId" : "#subtotal-item-tax-details<?= (int) $_item->getId() ?>"}}'>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceInclTax()) ?>
             </span>
         </span>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_excl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_excl_tax.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
-/** @var \Magento\Weee\Helper\Data $weeeHelper */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
+/** @var Data $weeeHelper */
 $weeeHelper = $block->getData('weeeHelper');
 
 $_item = $block->getItem();
@@ -27,7 +31,7 @@ $_item = $block->getItem();
     <span class="cart-tax-info no-display" id="eunit-item-tax-details<?= (int) $_item->getId() ?>">
     <?php if ($block->displayPriceWithWeeeDetails()): ?>
         <?php foreach ($weeeHelper->getApplied($_item) as $tax): ?>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                 <?= /* @noEscape */ $block->formatPrice($tax['amount'], true, true) ?>
             </span>
         <?php endforeach; ?>
@@ -37,7 +41,7 @@ $_item = $block->getItem();
     <?php if ($block->displayFinalPrice()): ?>
         <span class="cart-tax-total"
               data-mage-init='{"taxToggle": {"itemTaxId" : "#eunit-item-tax-details<?= (int) $_item->getId() ?>"}}'>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total')) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total')) ?>">
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceExclTax()) ?>
             </span>
         </span>

--- a/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_incl_tax.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/checkout/onepage/review/item/price/unit_incl_tax.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
 $_item = $block->getItem();
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
+
+/** @var $_weeeHelper Data */
 $_weeeHelper = $block->getData('weeeHelper');
 ?>
 <?php $_incl = $_item->getPriceInclTax(); ?>
@@ -28,7 +33,7 @@ $_weeeHelper = $block->getData('weeeHelper');
     <span class="cart-tax-info no-display" id="unit-item-tax-details<?= (int) $_item->getId() ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <?php foreach ($_weeeHelper->getApplied($_item) as $tax): ?>
-                <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                     <?= /* @noEscape */ $block->formatPrice($tax['amount_incl_tax'], true, true) ?>
                 </span>
             <?php endforeach; ?>
@@ -38,7 +43,7 @@ $_weeeHelper = $block->getData('weeeHelper');
     <?php if ($block->displayFinalPrice()): ?>
         <span class="cart-tax-total"
               data-mage-init='{"taxToggle": {"itemTaxId" : "#unit-item-tax-details<?= (int) $_item->getId() ?>"}}'>
-            <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
+            <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
                 <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceInclTax()) ?>
             </span>
         </span>

--- a/app/code/Magento/Weee/view/frontend/templates/email/items/price/row.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/email/items/price/row.phtml
@@ -4,38 +4,45 @@
  * See COPYING.txt for license details.
  */
 
-// phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Weee\Block\Item\Price\Renderer $block */
+declare(strict_types=1);
 
-/** @var $_weeeHelper \Magento\Weee\Helper\Data */
-$_weeeHelper = $this->helper(\Magento\Weee\Helper\Data::class);
+use Magento\Framework\Escaper;
+use Magento\Sales\Model\Order;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+
+// phpcs:disable Magento2.Templates.ThisInTemplate
+
+/** @var $_weeeHelper Data */
+$_weeeHelper = $this->helper(Data::class);
 
 $_item = $block->getItem();
-/** @var \Magento\Sales\Model\Order $_order */
+
+/** @var Order $_order */
 $_order = $_item->getOrder();
 ?>
-
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?=  $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?=  $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */  $_order->formatPrice($block->getRowDisplayPriceExclTax()) ?>
 
-    <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+    <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
         <br />
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
-                <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?=  $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */  $_order->formatPrice($tax['row_amount'], true, true) ?></span><br />
+                <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                    <span class="nobr"><?=  $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */  $_order->formatPrice($tax['row_amount'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
             <br />
-            <span class="nobr"><?=  $block->escapeHtml(__('Total')) ?>:<br /> <?= /* @noEscape */  $_order->formatPrice($block->getFinalRowDisplayPriceExclTax()) ?></span>
+            <span class="nobr"><?=  $escaper->escapeHtml(__('Total')) ?>:<br /> <?= /* @noEscape */  $_order->formatPrice($block->getFinalRowDisplayPriceExclTax()) ?></span>
         <?php endif; ?>
     <?php endif; ?>
 <?php endif; ?>
@@ -43,21 +50,21 @@ $_order = $_item->getOrder();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?=  $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?=  $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */  $_order->formatPrice($block->getRowDisplayPriceInclTax()) ?>
-    <?php if ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item)) : ?>
+    <?php if ($this->helper(Data::class)->getApplied($_item)) : ?>
         <br />
         <?php if ($block->displayPriceWithWeeeDetails()) : ?>
             <small>
-                <?php foreach ($this->helper(\Magento\Weee\Helper\Data::class)->getApplied($_item) as $tax) : ?>
-                    <span class="nobr"><?=  $block->escapeHtml($tax['title']) ?>: <?= /* @noEscape */  $_order->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
+                <?php foreach ($this->helper(Data::class)->getApplied($_item) as $tax) : ?>
+                    <span class="nobr"><?=  $escaper->escapeHtml($tax['title']) ?>: <?= /* @noEscape */  $_order->formatPrice($tax['row_amount_incl_tax'], true, true) ?></span><br />
                 <?php endforeach; ?>
             </small>
         <?php endif; ?>
 
         <?php if ($block->displayFinalPrice()) : ?>
-            <span class="nobr"><?=  $block->escapeHtml(__('Total Incl. Tax')) ?>:<br /> <?= /* @noEscape */  $_order->formatPrice($block->getFinalRowDisplayPriceInclTax()) ?></span>
+            <span class="nobr"><?=  $escaper->escapeHtml(__('Total Incl. Tax')) ?>:<br /> <?= /* @noEscape */  $_order->formatPrice($block->getFinalRowDisplayPriceInclTax()) ?></span>
         <?php endif; ?>
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/Weee/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/item/price/row.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
-/** @var \Magento\Weee\Helper\Data $weeeHelper */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
+/** @var Data $weeeHelper */
 $weeeHelper = $block->getData('weeeHelper');
 
 $item = $block->getItem();
 ?>
 <?php if (($block->displayPriceInclTax() || $block->displayBothPrices()) && !$item->getNoSubtotal()): ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <span class="cart-tax-total"
                 data-mage-init='{"taxToggle": {"itemTaxId" : "#subtotal-item-tax-details<?= (int) $item->getId() ?>"}}'>
@@ -28,7 +32,7 @@ $item = $block->getItem();
         <?php if ($weeeHelper->getApplied($item)): ?>
             <div class="cart-tax-info no-display" id="subtotal-item-tax-details<?= (int) $item->getId() ?>">
                 <?php foreach ($weeeHelper->getApplied($item) as $tax): ?>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                         <?= /* @noEscape */ $block->formatPrice($tax['row_amount_incl_tax'], true, true) ?>
                     </span>
                 <?php endforeach; ?>
@@ -38,7 +42,7 @@ $item = $block->getItem();
                 <span class="cart-tax-total"
                     data-mage-init='{"taxToggle": {"itemTaxId" : "#subtotal-item-tax-details<?= (int) $item->getId()
                     ?>"}}'>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceInclTax()) ?>
                     </span>
                 </span>
@@ -48,7 +52,7 @@ $item = $block->getItem();
 <?php endif; ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()): ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <span class="cart-tax-total"
                 data-mage-init='{"taxToggle": {"itemTaxId" : "#esubtotal-item-tax-details<?= (int) $item->getId()?>"}}'>
@@ -61,7 +65,7 @@ $item = $block->getItem();
         <?php if ($weeeHelper->getApplied($item)): ?>
             <span class="cart-tax-info no-display" id="esubtotal-item-tax-details<?= (int) $item->getId() ?>">
                 <?php foreach ($weeeHelper->getApplied($item) as $tax): ?>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                         <?= /* @noEscape */ $block->formatPrice($tax['row_amount'], true, true) ?>
                     </span>
                 <?php endforeach; ?>
@@ -71,7 +75,7 @@ $item = $block->getItem();
                 <span class="cart-tax-total"
                       data-mage-init='{"taxToggle": {"itemTaxId" : "#esubtotal-item-tax-details<?= (int)$item->getId()
                         ?>"}}'>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalRowDisplayPriceExclTax()) ?>
                     </span>
                 </span>

--- a/app/code/Magento/Weee/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Weee/view/frontend/templates/item/price/unit.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Weee\Block\Item\Price\Renderer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Weee\Block\Item\Price\Renderer;
+use Magento\Weee\Helper\Data;
 
-/** @var \Magento\Weee\Helper\Data $weeeHelper */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Renderer $block */
+/** @var Data $weeeHelper */
 $weeeHelper = $block->getData('weeeHelper');
 
 $item = $block->getItem();
 ?>
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()): ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <span class="cart-tax-total"
                 data-mage-init='{"taxToggle": {"itemTaxId" : "#unit-item-tax-details<?= (int) $item->getId() ?>"}}'>
@@ -28,7 +32,7 @@ $item = $block->getItem();
         <?php if ($weeeHelper->getApplied($item)): ?>
             <span class="cart-tax-info no-display" id="unit-item-tax-details<?= (int) $item->getId() ?>">
                 <?php foreach ($weeeHelper->getApplied($item) as $tax): ?>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                         <?= /* @noEscape */ $block->formatPrice($tax['amount_incl_tax'], true, true) ?>
                     </span>
                 <?php endforeach; ?>
@@ -37,7 +41,7 @@ $item = $block->getItem();
             <?php if ($block->displayFinalPrice()): ?>
                 <span class="cart-tax-total"
                     data-mage-init='{"taxToggle": {"itemTaxId" : "#unit-item-tax-details<?= (int) $item->getId() ?>"}}'>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total Incl. Tax')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceInclTax()) ?>
                     </span>
                 </span>
@@ -47,7 +51,7 @@ $item = $block->getItem();
 <?php endif; ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()): ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <?php if ($block->displayPriceWithWeeeDetails()): ?>
             <span class="cart-tax-total"
                 data-mage-init='{"taxToggle": {"itemTaxId" : "#eunit-item-tax-details<?= (int) $item->getId() ?>"}}'>
@@ -60,7 +64,7 @@ $item = $block->getItem();
         <?php if ($weeeHelper->getApplied($item)): ?>
             <span class="cart-tax-info no-display" id="eunit-item-tax-details<?= (int) $item->getId() ?>">
                 <?php foreach ($weeeHelper->getApplied($item) as $tax): ?>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr($tax['title']) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr($tax['title']) ?>">
                         <?= /* @noEscape */ $block->formatPrice($tax['amount'], true, true) ?>
                     </span>
                 <?php endforeach; ?>
@@ -68,7 +72,7 @@ $item = $block->getItem();
             <?php if ($block->displayFinalPrice()): ?>
                 <span class="cart-tax-total"
                       data-mage-init='{"taxToggle": {"itemTaxId" : "#eunit-item-tax-details<?=(int)$item->getId()?>"}}'>
-                    <span class="weee" data-label="<?= $block->escapeHtmlAttr(__('Total')) ?>">
+                    <span class="weee" data-label="<?= $escaper->escapeHtmlAttr(__('Total')) ?>">
                         <?= /* @noEscape */ $block->formatPrice($block->getFinalUnitDisplayPriceExclTax()) ?>
                     </span>
                 </span>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Weee` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37145: Chore: WEEE - Replace Block Escaping with Escaper