### PR TITLE
Chore: Vault - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Vault/view/adminhtml/templates/form/vault.phtml
+++ b/app/code/Magento/Vault/view/adminhtml/templates/form/vault.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var Magento\Vault\Block\Form $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-$code = $block->escapeHtml($block->getMethodCode());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Vault\Block\Form;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Form $block */
+$code = $escaper->escapeHtml($block->getMethodCode());
 ?>
 <fieldset data-mage-init='{
         "Magento_Vault/js/vault": {

--- a/app/code/Magento/Vault/view/frontend/templates/cards_list.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/cards_list.phtml
@@ -3,19 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Vault\Block\Customer\CreditCards $block */
+use Magento\Framework\Escaper;
+use Magento\Vault\Block\Customer\CreditCards;
+
+/** @var Escaper $escaper */
+/** @var CreditCards $block */
 $tokens = $block->getPaymentTokens();
 ?>
 <?php if (count($tokens) !== 0) : ?>
     <div class="table-wrapper my-credit-cards">
         <table class="data table table-credit-cards" id="my-orders-table">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Stored Payment Methods')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Stored Payment Methods')) ?></caption>
             <thead>
             <tr>
-                <th scope="col" class="col card-number"><?= $block->escapeHtml(__('Card Number')) ?></th>
-                <th scope="col" class="col expire"><?= $block->escapeHtml(__('Expiration Date')) ?></th>
-                <th scope="col" class="col card-type"><?= $block->escapeHtml(__('Type')) ?></th>
+                <th scope="col" class="col card-number"><?= $escaper->escapeHtml(__('Card Number')) ?></th>
+                <th scope="col" class="col expire"><?= $escaper->escapeHtml(__('Expiration Date')) ?></th>
+                <th scope="col" class="col card-type"><?= $escaper->escapeHtml(__('Type')) ?></th>
                 <th scope="col" class="col actions">&nbsp;</th>
             </tr>
             </thead>
@@ -30,5 +35,5 @@ $tokens = $block->getPaymentTokens();
     </div>
 
 <?php elseif (!$block->isExistsCustomerTokens()) : ?>
-    <div class="message info empty"><span><?= $block->escapeHtml(__('You have no stored payment methods.')) ?></span></div>
+    <div class="message info empty"><span><?= $escaper->escapeHtml(__('You have no stored payment methods.')) ?></span></div>
 <?php endif ?>

--- a/app/code/Magento/Vault/view/frontend/templates/customer_account/credit_card.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/customer_account/credit_card.phtml
@@ -3,31 +3,35 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Block\CardRendererInterface;
 
+/** @var Escaper $escaper */
 /** @var CardRendererInterface|Template $block */
 
-$ccNumberView = $block->escapeHtml($block->getNumberLast4Digits());
+$ccNumberView = $escaper->escapeHtml($block->getNumberLast4Digits());
 ?>
 <tr>
-    <td data-th="<?= $block->escapeHtml(__('Card Number')) ?>" class="col card-number">
-        <span><?= $block->escapeHtml(__('ending')) ?></span> <?= /* @noEscape */ $ccNumberView ?>
+    <td data-th="<?= $escaper->escapeHtml(__('Card Number')) ?>" class="col card-number">
+        <span><?= $escaper->escapeHtml(__('ending')) ?></span> <?= /* @noEscape */ $ccNumberView ?>
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Expiration Date')) ?>" class="col card-expire">
-        <?= $block->escapeHtml($block->getExpDate()) ?>
+    <td data-th="<?= $escaper->escapeHtml(__('Expiration Date')) ?>" class="col card-expire">
+        <?= $escaper->escapeHtml($block->getExpDate()) ?>
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Type')) ?>" class="col card-type">
+    <td data-th="<?= $escaper->escapeHtml(__('Type')) ?>" class="col card-type">
         <img src="<?= /* @noEscape */ $block->getIconUrl() ?>"
              width="<?= /* @noEscape */ $block->getIconWidth() ?>"
              height="<?= /* @noEscape */ $block->getIconHeight() ?>"
         >
     </td>
-    <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
+    <td data-th="<?= $escaper->escapeHtml(__('Actions')) ?>" class="col actions">
         <form
             class="form"
-            action="<?= $block->escapeUrl($block->getUrl('vault/cards/deleteaction')) ?>"
+            action="<?= $escaper->escapeUrl($block->getUrl('vault/cards/deleteaction')) ?>"
             method="post"
             >
             <?= $block->getBlockHtml('formkey') ?>
@@ -42,11 +46,11 @@ $ccNumberView = $block->escapeHtml($block->getNumberLast4Digits());
                                         "type": "popup",
                                         "modalClass": "my-credit-cards-popup",
                                         "toggleEvent": "click",
-                                        "title": "<?= $block->escapeHtml(__('Delete')) ?>",
-                                        "content": "<?= $block->escapeHtml(__('Are you sure you want to delete this card: %1?', $ccNumberView)) ?>"
+                                        "title": "<?= $escaper->escapeHtml(__('Delete')) ?>",
+                                        "content": "<?= $escaper->escapeHtml(__('Are you sure you want to delete this card: %1?', $ccNumberView)) ?>"
                                     }
                                 }'>
-                <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
             </button>
         </form>
     </td>

--- a/app/code/Magento/Vault/view/frontend/templates/token_list.phtml
+++ b/app/code/Magento/Vault/view/frontend/templates/token_list.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Vault\Block\Customer\AccountTokens $block */
+use Magento\Framework\Escaper;
+use Magento\Vault\Block\Customer\AccountTokens;
+
+/** @var Escaper $escaper */
+/** @var AccountTokens $block */
 $tokens = $block->getPaymentTokens();
 ?>
 <?php if (count($tokens) !== 0) : ?>
@@ -12,7 +17,7 @@ $tokens = $block->getPaymentTokens();
         <table class="data table table-credit-cards" id="token-list-table">
             <thead>
             <tr>
-                <th scope="col" class="col"><?= $block->escapeHtml(__('PayPal Account')) ?></th>
+                <th scope="col" class="col"><?= $escaper->escapeHtml(__('PayPal Account')) ?></th>
                 <th scope="col" class="col actions">&nbsp;</th>
             </tr>
             </thead>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Vault` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37144: Chore: Vault - Replace Block Escaping with Escaper