### PR TITLE
Chore: URL Rewrite - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/categories.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/categories.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\UrlRewrite\Block\Catalog\Category\Tree $block */
+use Magento\Framework\Escaper;
+use Magento\UrlRewrite\Block\Catalog\Category\Tree;
+
+/** @var Escaper $escaper */
+/** @var Tree $block */
 ?>
     <fieldset class="admin__fieldset" data-ui-id="category-selector">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Select Category')) ?></span></legend>
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Select Category')) ?></span></legend>
         <div class="content content-category-tree">
             <input type="hidden" name="categories" id="product_categories" value=""/>
             <?php if ($block->getRoot()) : ?>
@@ -22,7 +27,7 @@
             "categoryTree": {
                 "data": <?= /* @noEscape */
                 $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getTreeArray()); ?>,
-                "url": "<?= $block->escapeJs($block->escapeUrl($block->getLoadTreeUrl())); ?>"
+                "url": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getLoadTreeUrl())); ?>"
             }
         }
     }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/edit.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/edit.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\UrlRewrite\Block\Edit $block */
+use Magento\Framework\Escaper;
+use Magento\UrlRewrite\Block\Edit;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
 ?>
 <?= $block->getChildHtml() ?>
 <?php if ($block->getChildBlock('form')) : ?>
@@ -12,7 +17,7 @@
     {
         "#edit_form": {
             "Magento_UrlRewrite/js/url-rewrite-validation" : {
-                "url": "<?= $block->escapeUrl($block->getValidationUrl()) ?>"
+                "url": "<?= $escaper->escapeUrl($block->getValidationUrl()) ?>"
             }
         }
     }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/messages/url_duplicate_message.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/messages/url_duplicate_message.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 $urls = $block->getData('urls');
 ?>
 <h4>
-<?=$block->escapeHtml(__('The value specified in the URL Key field would generate a URL that already exists.')); ?>
+<?=$escaper->escapeHtml(__('The value specified in the URL Key field would generate a URL that already exists.')); ?>
 </h4>
 <p>
-<?=$block->escapeHtml(
+<?=$escaper->escapeHtml(
     __(
         'To resolve this conflict, you can either change the value of the URL Key field '
         . '(located in the Search Engine Optimization section) to a unique value, or change the Request Path fields'
@@ -23,7 +28,7 @@ $urls = $block->getData('urls');
 if (!empty($urls)) {
     foreach ($urls as $url => $urlTitle) {
         ?>
-        <?='<p> - <a href="' . $block->escapeHtml($url) . '">' . $block->escapeHtml($urlTitle) . '</a></p>'; ?>
+        <?='<p> - <a href="' . $escaper->escapeHtml($url) . '">' . $escaper->escapeHtml($urlTitle) . '</a></p>'; ?>
         <?php
     }
 }

--- a/app/code/Magento/UrlRewrite/view/adminhtml/templates/selector.phtml
+++ b/app/code/Magento/UrlRewrite/view/adminhtml/templates/selector.phtml
@@ -3,23 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\UrlRewrite\Block\Selector $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\UrlRewrite\Block\Selector;
+
+/** @var Escaper $escaper */
+/** @var Selector $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="form-inline">
     <fieldset class="admin__fieldset fieldset" data-container-for="entity-type-selector">
         <div class="admin__field field field-entity-type-selector">
             <label for="entity-type-selector" class="admin__field-label label">
-                <span><?= $block->escapeHtml($block->getSelectorLabel()) ?></span>
+                <span><?= $escaper->escapeHtml($block->getSelectorLabel()) ?></span>
             </label>
             <div class="admin__field-control control">
                 <select data-role="entity-type-selector" class="admin__control-select select" id="entity-type-selector">
                 <?php foreach ($block->getModes() as $mode => $label): ?>
                     <option <?= /* @noEscape */ $block->isMode($mode) ? 'selected="selected" ' : '' ?>
-                        value="<?= $block->escapeUrl($block->getModeUrl($mode)) ?>"><?= $block->escapeHtml($label) ?>
+                        value="<?= $escaper->escapeUrl($block->getModeUrl($mode)) ?>"><?= $escaper->escapeHtml($label) ?>
                     </option>
                 <?php endforeach; ?>
                 </select>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_UrlRewrite` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37142: Chore: URL Rewrite - Replace Block Escaping with Escaper