### PR TITLE
Chore: Translate - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Translation/view/adminhtml/templates/translate_inline.phtml
+++ b/app/code/Magento/Translation/view/adminhtml/templates/translate_inline.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/**
- * @var \Magento\Framework\View\Element\Template $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
 ?>
 <link rel="stylesheet" type="text/css"
-      href="<?= $block->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
+      href="<?= $escaper->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
 <link rel="stylesheet" type="text/css"
-      href="<?= $block->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
+      href="<?= $escaper->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
 
 <script id="translate-inline-icon" type="text/x-magento-template">
     <img src="<%- data.img %>" height="16" width="16" class="translate-edit-icon">
@@ -58,7 +63,7 @@
 </script>
 
 <div data-role="translate-dialog"
-     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $block->escapeJs($block->escapeUrl($block->getAjaxUrl())) ?>"},
+     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $escaper->escapeJs($escaper->escapeUrl($block->getAjaxUrl())) ?>"},
      "loader":{}}'>
 </div>
 <?php $scriptString = <<<script
@@ -70,7 +75,7 @@ require([
 ], function($){
         $('body').editTrigger(
             {
-                img: '{$block->escapeJs($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))}',
+                img: '{$escaper->escapeJs($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))}',
                 alwaysShown: true,
                 singleElement: false
             }

--- a/app/code/Magento/Translation/view/frontend/templates/translate_inline.phtml
+++ b/app/code/Magento/Translation/view/frontend/templates/translate_inline.phtml
@@ -3,13 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var \Magento\Framework\View\Element\Template $block */
 ?>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('Magento_Theme::prototype/magento.css')) ?>"/>
-<link rel="stylesheet" type="text/css" href="<?= $block->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('prototype/windows/themes/default.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('Magento_Theme::prototype/magento.css')) ?>"/>
+<link rel="stylesheet" type="text/css" href="<?= $escaper->escapeUrl($block->getViewFileUrl('mage/translate-inline.css')) ?>"/>
 
 <script id="translate-inline-icon" type="text/x-magento-template">
     <img src="<%- data.img %>" height="16" width="16" class="translate-edit-icon">
@@ -55,12 +61,12 @@
 </script>
 
 <div data-role="translate-dialog"
-     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $block->escapeJs($block->escapeUrl($block->getAjaxUrl())) ?>"},"loader":{}}'></div>
+     data-mage-init='{"translateInline":{"ajaxUrl":"<?= $escaper->escapeJs($escaper->escapeUrl($block->getAjaxUrl())) ?>"},"loader":{}}'></div>
 <script type="text/x-magento-init">
     {
         "body": {
             "editTrigger": {
-                "img": "<?= $block->escapeJs($block->escapeUrl($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))) ?>",
+                "img": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getViewFileUrl('Magento_Theme::fam_book_open.png'))) ?>",
                 "alwaysShown":true,
                 "singleElement":false
             },


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Translate` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37141: Chore: Translate - Replace Block Escaping with Escaper