### PR TITLE
Chore: Tax Import Export - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
+++ b/app/code/Magento/TaxImportExport/view/adminhtml/templates/importExport.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\TaxImportExport\Block\Adminhtml\Rate\ImportExport;
+
+/** @var Escaper $escaper */
+/** @var ImportExport $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="import-export-tax-rates">
     <?php if (!$block->getIsReadonly()):?>
@@ -13,14 +19,14 @@
         <?php if ($block->getUseContainer()):?>
         <form id="import-form"
               class="admin__fieldset"
-              action="<?= $block->escapeUrl($block->getUrl('tax/rate/importPost')) ?>"
+              action="<?= $escaper->escapeUrl($block->getUrl('tax/rate/importPost')) ?>"
               method="post"
               enctype="multipart/form-data">
         <?php endif; ?>
             <?= $block->getBlockHtml('formkey') ?>
             <div class="fieldset admin__field">
                 <label for="import_rates_file" class="admin__field-label">
-                    <span><?= $block->escapeHtml(__('Import Tax Rates')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Import Tax Rates')) ?></span>
                 </label>
                 <div class="admin__field-control">
                     <input type="file"
@@ -66,13 +72,13 @@ script;
         <?php if ($block->getUseContainer()):?>
         <form id="export_form"
               class="admin__fieldset"
-              action="<?= $block->escapeUrl($block->getUrl('tax/rate/exportPost')) ?>"
+              action="<?= $escaper->escapeUrl($block->getUrl('tax/rate/exportPost')) ?>"
               method="post"
               enctype="multipart/form-data">
         <?php endif; ?>
             <?= $block->getBlockHtml('formkey') ?>
             <div class="fieldset admin__field">
-                <span class="admin__field-label"><span><?= $block->escapeHtml(__('Export Tax Rates')) ?></span></span>
+                <span class="admin__field-label"><span><?= $escaper->escapeHtml(__('Export Tax Rates')) ?></span></span>
                 <div class="admin__field-control">
                     <?= $block->getButtonHtml(__('Export Tax Rates'), "export_form.submit()") ?>
                 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_TaxImportExport` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37140: Chore: Tax Import Export - Replace Block Escaping with Escaper