### PR TITLE
Chore: Send Friend - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
+++ b/app/code/Magento/SendFriend/view/frontend/templates/send.phtml
@@ -3,45 +3,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Send to friend form
- */
-/**
- * @var \Magento\SendFriend\Block\Send $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\SendFriend\Block\Send;
+
+/** @var Escaper $escaper */
+/** @var Send $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-
 ?>
 <script id="add-recipient-tmpl" type="text/x-magento-template">
     <div class="actions-toolbar">
         <div class="secondary">
             <button type="button" id="btn-remove<%- data._index_ %>" class="action remove"
-               title="<?= $block->escapeHtmlAttr(__('Remove Recipent')) ?>">
-               <span><?= $block->escapeHtml(__('Remove')) ?></span>
+               title="<?= $escaper->escapeHtmlAttr(__('Remove Recipent')) ?>">
+               <span><?= $escaper->escapeHtml(__('Remove')) ?></span>
             </button>
         </div>
     </div>
     <fieldset class="fieldset">
         <div class="field name required">
             <label for="recipients-name<%- data._index_ %>" class="label">
-                <span><?= $block->escapeHtml(__('Name')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Name')) ?></span>
             </label>
             <div class="control">
                 <input name="recipients[name][<%- data._index_ %>]" type="text"
-                       title="<?= $block->escapeHtmlAttr(__('Name')) ?>" class="input-text"
+                       title="<?= $escaper->escapeHtmlAttr(__('Name')) ?>" class="input-text"
                        id="recipients-name<%- data._index_ %>" data-validate="{required:true}"/>
             </div>
         </div>
 
         <div class="field email required">
             <label for="recipients-email<%- data._index_ %>" class="label">
-                <span><?= $block->escapeHtml(__('Email')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Email')) ?></span>
             </label>
             <div class="control">
                 <input name="recipients[email][<%- data._index_ %>]"
-                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Email')) ?>"
                        id="recipients-email<%- data._index_ %>" type="email" class="input-text"
                        data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
@@ -50,7 +51,7 @@
     </fieldset>
 </script>
 
-<form action="<?= $block->escapeUrl($block->getSendUrl()) ?>" method="post" id="product-sendtofriend-form"
+<form action="<?= $escaper->escapeUrl($block->getSendUrl()) ?>" method="post" id="product-sendtofriend-form"
       data-mage-init='{
         "rowBuilder":{
             "rowTemplate":"#add-recipient-tmpl",
@@ -63,26 +64,26 @@
             "addRowBtn":"#add-recipient-button",
             "additionalRowClass":"additional"},
         "validation":{}}'
-      class="form send friend" data-hasRequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>">
+      class="form send friend" data-hasRequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>">
     <fieldset class="fieldset sender" id="sender_options">
         <?= $block->getBlockHtml('formkey') ?>
-        <legend class="legend"><span><?= $block->escapeHtml(__('Sender')) ?></span></legend>
+        <legend class="legend"><span><?= $escaper->escapeHtml(__('Sender')) ?></span></legend>
         <br>
         <div class="field sender required">
-            <label for="sender-name" class="label"><span><?= $block->escapeHtml(__('Name')) ?></span></label>
+            <label for="sender-name" class="label"><span><?= $escaper->escapeHtml(__('Name')) ?></span></label>
             <div class="control">
-                <input name="sender[name]" value="<?= $block->escapeHtmlAttr($block->getUserName()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Name')) ?>"
+                <input name="sender[name]" value="<?= $escaper->escapeHtmlAttr($block->getUserName()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Name')) ?>"
                        id="sender-name" type="text" class="input-text"
                        data-validate="{required:true}"/>
             </div>
         </div>
 
         <div class="field email required">
-            <label for="sender-email" class="label"><span><?= $block->escapeHtml(__('Email')) ?></span></label>
+            <label for="sender-email" class="label"><span><?= $escaper->escapeHtml(__('Email')) ?></span></label>
             <div class="control">
-                <input name="sender[email]" value="<?= $block->escapeHtmlAttr($block->getEmail()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="email"
+                <input name="sender[email]" value="<?= $escaper->escapeHtmlAttr($block->getEmail()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Email')) ?>" id="sender-email" type="email"
                        class="input-text"
                        data-mage-init='{"mage/trim-input":{}}'
                        data-validate="{required:true, 'validate-email':true}"/>
@@ -91,24 +92,24 @@
 
         <div class="field text required">
             <label for="sender-message" class="label">
-                <span><?= $block->escapeHtml(__('Message')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Message')) ?></span>
             </label>
             <div class="control">
                 <textarea name="sender[message]" class="input-text" id="sender-message" cols="3" rows="3"
-                          data-validate="{required:true}"><?= $block->escapeHtml($block->getMessage()) ?></textarea>
+                          data-validate="{required:true}"><?= $escaper->escapeHtml($block->getMessage()) ?></textarea>
             </div>
         </div>
     </fieldset>
 
     <fieldset class="fieldset recipients">
         <?= $block->getBlockHtml('formkey') ?>
-        <legend class="legend"><span><?= $block->escapeHtml(__('Invitee')) ?></span></legend>
+        <legend class="legend"><span><?= $escaper->escapeHtml(__('Invitee')) ?></span></legend>
         <br />
         <div id="recipients-options"></div>
         <?php if ($block->getMaxRecipients()): ?>
             <div id="max-recipient-message" class="message notice limit" role="alert">
                 <span>
-                    <?= $block->escapeHtml(__('Maximum %1 email addresses allowed.', $block->getMaxRecipients())) ?>
+                    <?= $escaper->escapeHtml(__('Maximum %1 email addresses allowed.', $block->getMaxRecipients())) ?>
                 </span>
             </div>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display: none;", 'div#max-recipient-message') ?>
@@ -117,7 +118,7 @@
             <div class="secondary">
             <?php if (1 < $block->getMaxRecipients()): ?>
                 <button type="button" id="add-recipient-button" class="action add">
-                    <span><?= $block->escapeHtml(__('Add Invitee')) ?></span></button>
+                    <span><?= $escaper->escapeHtml(__('Add Invitee')) ?></span></button>
             <?php endif; ?>
             </div>
         </div>
@@ -132,10 +133,10 @@
                         $block->getButtonLockManager()->isDisabled('sendfriend_form_submit')): ?>
                     disabled="disabled"
                     <?php endif ?>>
-                <span><?= $block->escapeHtml(__('Send Email')) ?></span></button>
+                <span><?= $escaper->escapeHtml(__('Send Email')) ?></span></button>
         </div>
         <div class="secondary">
-            <a class="action back" href="#" role="back"><span><?= $block->escapeHtml(__('Back')) ?></span></a>
+            <a class="action back" href="#" role="back"><span><?= $escaper->escapeHtml(__('Back')) ?></span></a>
         </div>
     </div>
 </form>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_SendFriend` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37137: Chore: Send Friend - Replace Block Escaping with Escaper