### PR TITLE
Chore: Search - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Search/view/frontend/templates/term.phtml
+++ b/app/code/Magento/Search/view/frontend/templates/term.phtml
@@ -3,18 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Search\Block\Term $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Search\Block\Term;
+
+/** @var Escaper $escaper */
+/** @var Term $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (count($block->getTerms()) > 0): ?>
     <ul class="search-terms">
         <?php foreach ($block->getTerms() as $_term): ?>
             <li id="term-<?= /* @noEscape */ $_term->getId() ?>" class="item">
-                <a href="<?= $block->escapeUrl($block->getSearchUrl($_term)) ?>">
-                    <?= $block->escapeHtml($_term->getQueryText()) ?>
+                <a href="<?= $escaper->escapeUrl($block->getSearchUrl($_term)) ?>">
+                    <?= $escaper->escapeHtml($_term->getQueryText()) ?>
                 </a>
             </li>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -25,6 +29,6 @@
     </ul>
 <?php else: ?>
     <div class="message notice">
-        <div><?= $block->escapeHtml(__('There are no search terms available.')) ?></div>
+        <div><?= $escaper->escapeHtml(__('There are no search terms available.')) ?></div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Search` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37135: Chore: Search - Replace Block Escaping with Escaper