### PR TITLE
Chore: RSS - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Rss/view/frontend/templates/feeds.phtml
+++ b/app/code/Magento/Rss/view/frontend/templates/feeds.phtml
@@ -3,29 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Rss\Block\Feeds $block */
+use Magento\Framework\Escaper;
+use Magento\Rss\Block\Feeds;
 
+/** @var Escaper $escaper */
+/** @var Feeds $block */
 ?>
 <table class="data table rss">
-    <caption class="table-caption"><?= $block->escapeHtml(__('Feed')) ?></caption>
+    <caption class="table-caption"><?= $escaper->escapeHtml(__('Feed')) ?></caption>
     <tbody>
-        <th colspan="2" scope="col"><?= $block->escapeHtml(__('Miscellaneous Feeds')) ?></th>
+        <th colspan="2" scope="col"><?= $escaper->escapeHtml(__('Miscellaneous Feeds')) ?></th>
     <?php foreach ($block->getFeeds() as $feed) : ?>
         <?php if (!isset($feed['group'])) : ?>
         <tr>
-            <td class="col feed"><?= $block->escapeHtml($feed['label']) ?></td>
+            <td class="col feed"><?= $escaper->escapeHtml($feed['label']) ?></td>
             <td class="col action">
-                <a href="<?= $block->escapeUrl($feed['link']) ?>" class="action get"><span><?= $block->escapeHtml(__('Get Feed')) ?></span></a>
+                <a href="<?= $escaper->escapeUrl($feed['link']) ?>" class="action get"><span><?= $escaper->escapeHtml(__('Get Feed')) ?></span></a>
             </td>
         </tr>
         <?php else : ?>
-            <th colspan="2" scope="col"><?= $block->escapeHtml($feed['group']) ?></th>
+            <th colspan="2" scope="col"><?= $escaper->escapeHtml($feed['group']) ?></th>
             <?php foreach ($feed['feeds'] as $item) :?>
                 <tr>
-                    <td class="col feed"><?= $block->escapeHtml($item['label']) ?></td>
+                    <td class="col feed"><?= $escaper->escapeHtml($item['label']) ?></td>
                     <td class="col action">
-                        <a href="<?= $block->escapeUrl($item['link']) ?>" class="action get"><span><?= $block->escapeHtml(__('Get Feed')) ?></span></a>
+                        <a href="<?= $escaper->escapeUrl($item['link']) ?>" class="action get"><span><?= $escaper->escapeHtml(__('Get Feed')) ?></span></a>
                     </td>
                 </tr>
             <?php endforeach; ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Rss` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37134: Chore: RSS - Replace Block Escaping with Escaper