### PR TITLE
Chore: Review - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Review/view/adminhtml/templates/rating/detailed.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rating/detailed.phtml
@@ -3,30 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Adminhtml\Rating\Detailed $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Adminhtml\Rating\Detailed;
 
+/** @var Escaper $escaper */
+/** @var Detailed $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->getRating() && $block->getRating()->getSize()): ?>
     <?php foreach ($block->getRating() as $_rating): ?>
     <div class="admin__field admin__field-rating">
-        <label class="admin__field-label"><span><?= $block->escapeHtml($_rating->getRatingCode()) ?></span></label>
+        <label class="admin__field-label"><span><?= $escaper->escapeHtml($_rating->getRatingCode()) ?></span></label>
         <?php $_iterator = 1; ?>
         <?php $_options = ($_rating->getRatingOptions()) ? $_rating->getRatingOptions() : $_rating->getOptions() ?>
         <div class="admin__field-control" data-widget="ratingControl">
         <?php foreach (array_reverse($_options) as $_option): ?>
             <input type="radio"
-                   name="ratings[<?= $block->escapeHtmlAttr($_rating->getVoteId() ? $_rating->getVoteId() :
+                   name="ratings[<?= $escaper->escapeHtmlAttr($_rating->getVoteId() ? $_rating->getVoteId() :
                        $_rating->getId()) ?>]"
-                   id="<?= $block->escapeHtmlAttr($_rating->getRatingCode())
-                    ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>"
-                   value="<?= $block->escapeHtmlAttr($_option->getId()) ?>"
+                   id="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode())
+                    ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>"
+                   value="<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
                    <?php if ($block->isSelected($_option, $_rating)): ?>checked="checked"<?php endif; ?> />
-            <label for="<?= $block->escapeHtmlAttr($_rating->getRatingCode())
-            ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>">&#9733;</label>
+            <label for="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode())
+            ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>">&#9733;</label>
             <?php $_iterator++ ?>
         <?php endforeach; ?>
         </div>
@@ -49,5 +52,5 @@ script;
     ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 <?php else: ?>
-    <?= $block->escapeHtml(__("Rating isn't Available")) ?>
+    <?= $escaper->escapeHtml(__("Rating isn't Available")) ?>
 <?php endif; ?>

--- a/app/code/Magento/Review/view/adminhtml/templates/rating/form.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rating/form.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Adminhtml\Rating\Edit\Tab\Form $block */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Adminhtml\Rating\Edit\Tab\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
 ?>
 <div class="messages">
     <div class="message message-notice message-in-rating-edit">
-        <div><?= $block->escapeHtml(__('Please specify a rating title for a store, or we\'ll just use the default value.')) ?></div>
+        <div><?= $escaper->escapeHtml(__('Please specify a rating title for a store, or we\'ll just use the default value.')) ?></div>
     </div>
 </div>
 

--- a/app/code/Magento/Review/view/adminhtml/templates/rating/options.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rating/options.phtml
@@ -3,25 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 // @deprecated
 ?>
 <div class="entry-edit-head">
-    <h4 class="icon-head head-edit-form fieldset-legend"><?= $block->escapeHtml(__('Assigned Options')) ?></h4>
+    <h4 class="icon-head head-edit-form fieldset-legend"><?= $escaper->escapeHtml(__('Assigned Options')) ?></h4>
 </div>
 <fieldset id="options_form">
 <?php if (!$options) : ?>
     <?php for ($_i = 1; $_i <= 5; $_i++) : ?>
         <span class="field-row">
-            <label for="option_<?= /* @noEscape */ $_i ?>"><?= $block->escapeHtml(__('Option Title:')) ?></label>
+            <label for="option_<?= /* @noEscape */ $_i ?>"><?= $escaper->escapeHtml(__('Option Title:')) ?></label>
             <input id="option_<?= /* @noEscape */ $_i ?>" name="option[<?= /* @noEscape */ $_i ?>][code]" value="<?= /* @noEscape */ $_i ?>" class="input-text" type="text" />
         </span>
     <?php endfor; ?>
 <?php elseif ($options->getSize() > 0) : ?>
     <?php foreach ($options->getItems() as $_item) : ?>
         <span class="field-row">
-            <label for="option_<?= $block->escapeHtmlAttr($_item->getId()) ?>"><?= $block->escapeHtml(__('Option Title:')) ?></label>
-            <input id="option_<?= $block->escapeHtmlAttr($_item->getId()) ?>" name="option[<?= $block->escapeHtmlAttr($_item->getId()) ?>][code]" value="<?= $block->escapeHtmlAttr($_item->getCode()) ?>" class="input-text" type="text" />
+            <label for="option_<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"><?= $escaper->escapeHtml(__('Option Title:')) ?></label>
+            <input id="option_<?= $escaper->escapeHtmlAttr($_item->getId()) ?>" name="option[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>][code]" value="<?= $escaper->escapeHtmlAttr($_item->getCode()) ?>" class="input-text" type="text" />
         </span>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/app/code/Magento/Review/view/adminhtml/templates/rating/stars/detailed.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rating/stars/detailed.phtml
@@ -3,7 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 // @deprecated
 ?>
 <?php if ($block->getRating() && $block->getRating()->getSize()) : ?>
@@ -11,7 +15,7 @@
         <?php foreach ($block->getRating() as $_rating) : ?>
             <?php if ($_rating->getPercent()) : ?>
                 <div class="ratings">
-                    <?= $block->escapeHtml($_rating->getRatingCode()) ?>
+                    <?= $escaper->escapeHtml($_rating->getRatingCode()) ?>
                     <div class="rating-box">
                         <div class="rating" style="width:<?= /* @noEscape */ ceil($_rating->getPercent()) ?>%;"></div>
                     </div>
@@ -20,5 +24,5 @@
         <?php endforeach; ?>
     </div>
 <?php else : ?>
-    <?= $block->escapeHtml(__("Rating isn't Available")) ?>
+    <?= $escaper->escapeHtml(__("Rating isn't Available")) ?>
 <?php endif; ?>

--- a/app/code/Magento/Review/view/adminhtml/templates/rating/stars/summary.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rating/stars/summary.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Adminhtml\Rating\Summary $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Adminhtml\Rating\Summary;
+
+/** @var Escaper $escaper */
+/** @var Summary $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->getRatingSummary()->getCount()): ?>
     <div class="rating-box">
@@ -19,5 +23,5 @@
         'div.rating-box div.rating'
     ) ?>
 <?php else: ?>
-    <?= $block->escapeHtml(__("Rating isn't Available")) ?>
+    <?= $escaper->escapeHtml(__("Rating isn't Available")) ?>
 <?php endif; ?>

--- a/app/code/Magento/Review/view/adminhtml/templates/rss/grid/link.phtml
+++ b/app/code/Magento/Review/view/adminhtml/templates/rss/grid/link.phtml
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Review\Block\Adminhtml\Grid\Rss\Link */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Adminhtml\Grid\Rss\Link;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) : ?>
-<a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>
+<a href="<?= $escaper->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $escaper->escapeHtml($block->getLabel()) ?></a>
 <?php endif; ?>

--- a/app/code/Magento/Review/view/frontend/templates/customer/list.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/customer/list.phtml
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Customer\ListCustomer $block
- * @var \Magento\Framework\Escaper $escaper
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Customer\ListCustomer;
+use Magento\Review\Helper\Data;
 
-/** @var \Magento\Review\Helper\Data $reviewHelper */
+/** @var ListCustomer $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Data $reviewHelper */
 $reviewHelper = $block->getData('reviewHelper');
 ?>
 <?php if ($block->getReviews() && count($block->getReviews())): ?>
@@ -44,7 +47,7 @@ $reviewHelper = $block->getData('reviewHelper');
                         <div class="rating-summary">
                             <span class="label"><span><?= $escaper->escapeHtml(__('Rating')) ?>:</span></span>
                             <div class="rating-result"
-                                 id="rating-result_<?= /* @noEscape */ $block->escapeHtml($review->getId()) ?>"
+                                 id="rating-result_<?= /* @noEscape */ $escaper->escapeHtml($review->getId()) ?>"
                                  title="<?= /* @noEscape */ ((int)$review->getSum() / (int)$review->getCount()) ?>%">
                                 <span class="rating_<?= $escaper->escapeUrl($review->getReviewId())?>">
                                     <span>

--- a/app/code/Magento/Review/view/frontend/templates/customer/view.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/customer/view.phtml
@@ -3,27 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Customer\View $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Customer\View;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var View $block */
 $product = $block->getProductData();
 ?>
 <?php if ($product->getId()): ?>
 <div class="customer-review view">
     <div class="product-details">
         <div class="product-media">
-            <a class="product-photo" href="<?= $block->escapeUrl($product->getProductUrl()) ?>">
+            <a class="product-photo" href="<?= $escaper->escapeUrl($product->getProductUrl()) ?>">
                 <?php /* customer_account_product_review_page */ ?>
                 <?= $block->getImage($block->getProductData(), 'customer_account_product_review_page')->toHtml() ?>
             </a>
         </div>
         <div class="product-info">
-            <h2 class="product-name"><?= $block->escapeHtml($product->getName()) ?></h2>
+            <h2 class="product-name"><?= $escaper->escapeHtml($product->getName()) ?></h2>
             <?php if ($block->getRating() && $block->getRating()->getSize()): ?>
-                <span class="rating-average-label"><?= $block->escapeHtml(__('Average Customer Rating:')) ?></span>
+                <span class="rating-average-label"><?= $escaper->escapeHtml(__('Average Customer Rating:')) ?></span>
                 <?= $block->getReviewsSummaryHtml($product) ?>
             <?php endif; ?>
         </div>
@@ -32,7 +35,7 @@ $product = $block->getProductData();
     <div class="review-details">
         <?php if ($block->getRating() && $block->getRating()->getSize()): ?>
             <div class="title">
-                <strong><?= $block->escapeHtml(__('Your Review')) ?></strong>
+                <strong><?= $escaper->escapeHtml(__('Your Review')) ?></strong>
             </div>
             <div class="customer-review-rating">
                 <?php foreach ($block->getRating() as $_rating): ?>
@@ -41,10 +44,10 @@ $product = $block->getProductData();
                         <?php $ratingId = $_rating->getRatingId() ?>
                         <div class="rating-summary item">
                             <span class="rating-label">
-                                <span><?= $block->escapeHtml($_rating->getRatingCode()) ?></span>
+                                <span><?= $escaper->escapeHtml($_rating->getRatingCode()) ?></span>
                             </span>
-                            <div class="rating-result <?= $block->escapeHtml($_rating->getRatingCode()) ?>"
-                                 id="rating-div-<?= $block->escapeHtml($ratingId) ?>"
+                            <div class="rating-result <?= $escaper->escapeHtml($_rating->getRatingCode()) ?>"
+                                 id="rating-div-<?= $escaper->escapeHtml($ratingId) ?>"
                                  title="<?= /* @noEscape */ $rating ?>%">
                                 <span>
                                     <span><?= /* @noEscape */ $rating ?>%</span>
@@ -62,20 +65,20 @@ $product = $block->getProductData();
             </div>
         <?php endif; ?>
 
-        <div class="review-title"><?= $block->escapeHtml($block->getReviewData()->getTitle()) ?></div>
+        <div class="review-title"><?= $escaper->escapeHtml($block->getReviewData()->getTitle()) ?></div>
         <div class="review-content">
-            <?= /* @noEscape */ nl2br($block->escapeHtml($block->getReviewData()->getDetail())) ?>
+            <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getReviewData()->getDetail())) ?>
         </div>
         <div class="review-date">
-            <?= $block->escapeHtml(__('Submitted on %1', '<time class="date">' .
+            <?= $escaper->escapeHtml(__('Submitted on %1', '<time class="date">' .
                 $block->dateFormat($block->getReviewData()->getCreatedAt()) . '</time>'), ['time']) ?>
         </div>
     </div>
 </div>
 <div class="actions-toolbar">
     <div class="secondary">
-        <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>">
-            <span><?= $block->escapeHtml(__('Back to My Reviews')) ?></span>
+        <a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>">
+            <span><?= $escaper->escapeHtml(__('Back to My Reviews')) ?></span>
         </a>
     </div>
 </div>

--- a/app/code/Magento/Review/view/frontend/templates/detailed.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/detailed.phtml
@@ -3,21 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Rating\Entity\Detailed $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Rating\Entity\Detailed;
+
+/** @var Escaper $escaper */
+/** @var Detailed $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!empty($collection) && $collection->getSize()): ?>
     <div class="table-wrapper">
         <table class="data table ratings review summary">
-            <caption class="table-caption"><?= $block->escapeHtml(__('Ratings Review Summary')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Ratings Review Summary')) ?></caption>
             <tbody>
             <?php foreach ($collection as $_rating): ?>
                 <?php if ($_rating->getSummary()): ?>
                     <tr>
-                        <th class="label" scope="row"><?= $block->escapeHtml(__($_rating->getRatingCode())) ?></th>
+                        <th class="label" scope="row"><?= $escaper->escapeHtml(__($_rating->getRatingCode())) ?></th>
                         <td class="value">
                             <div class="rating box">
                                 <div class="rating"></div>

--- a/app/code/Magento/Review/view/frontend/templates/empty.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/empty.phtml
@@ -3,7 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Rating\Entity\Detailed $block */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Rating\Entity\Detailed;
+
+/** @var Escaper $escaper */
+/** @var Detailed $block */
 ?>
-<p class="no-rating"><a href="#review-form"><?= $block->escapeHtml(__('Be the first to review this product')) ?></a></p>
+<p class="no-rating">
+    <a href="#review-form"><?= $escaper->escapeHtml(__('Be the first to review this product')) ?></a>
+</p>

--- a/app/code/Magento/Review/view/frontend/templates/form.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/form.phtml
@@ -3,45 +3,51 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Form $block */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
+
 //phpcs:disable Generic.Files.LineLength
 ?>
 <div class="block review-add">
-    <div class="block-title"><strong><?= $block->escapeHtml(__('Write Your Own Review')) ?></strong></div>
+    <div class="block-title"><strong><?= $escaper->escapeHtml(__('Write Your Own Review')) ?></strong></div>
 <div class="block-content">
 <?php if ($block->getAllowWriteReviewFlag()):?>
-<form action="<?= $block->escapeUrl($block->getAction()) ?>" class="review-form" method="post" id="review-form" data-role="product-review-form" data-bind="scope: 'review-form'">
+<form action="<?= $escaper->escapeUrl($block->getAction()) ?>" class="review-form" method="post" id="review-form" data-role="product-review-form" data-bind="scope: 'review-form'">
     <?= $block->getBlockHtml('formkey') ?>
     <?= $block->getChildHtml('form_fields_before') ?>
-    <fieldset class="fieldset review-fieldset" data-hasrequired="<?= $block->escapeHtmlAttr(__('* Required Fields')) ?>">
-        <legend class="legend review-legend"><span><?= $block->escapeHtml(__("You're reviewing:")) ?></span><strong><?= $block->escapeHtml($block->getProductInfo()->getName()) ?></strong></legend><br />
+    <fieldset class="fieldset review-fieldset" data-hasrequired="<?= $escaper->escapeHtmlAttr(__('* Required Fields')) ?>">
+        <legend class="legend review-legend"><span><?= $escaper->escapeHtml(__("You're reviewing:")) ?></span><strong><?= $escaper->escapeHtml($block->getProductInfo()->getName()) ?></strong></legend><br />
         <?php if ($block->getRatings() && $block->getRatings()->getSize()): ?>
         <span id="input-message-box"></span>
         <fieldset class="field required review-field-ratings">
-            <legend class="label"><span><?= $block->escapeHtml(__('Your Rating')) ?></span></legend><br/>
+            <legend class="label"><span><?= $escaper->escapeHtml(__('Your Rating')) ?></span></legend><br/>
             <div class="control">
                 <div class="nested" id="product-review-table">
                     <?php foreach ($block->getRatings() as $_rating): ?>
                         <div class="field choice review-field-rating">
-                            <label class="label" id="<?= $block->escapeHtml($_rating->getRatingCode()) ?>_rating_label"><span><?= $block->escapeHtml($_rating->getRatingCode()) ?></span></label>
+                            <label class="label" id="<?= $escaper->escapeHtml($_rating->getRatingCode()) ?>_rating_label"><span><?= $escaper->escapeHtml($_rating->getRatingCode()) ?></span></label>
                             <div class="control review-control-vote">
                             <?php $options = $_rating->getOptions();?>
                             <?php $iterator = 1; foreach ($options as $_option): ?>
                                 <input
                                     type="radio"
-                                    name="ratings[<?= $block->escapeHtmlAttr($_rating->getId()) ?>]"
-                                    id="<?= $block->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>"
-                                    value="<?= $block->escapeHtmlAttr($_option->getId()) ?>"
+                                    name="ratings[<?= $escaper->escapeHtmlAttr($_rating->getId()) ?>]"
+                                    id="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>"
+                                    value="<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
                                     class="radio"
                                     data-validate="{'rating-required':true}"
-                                    aria-labelledby="<?= $block->escapeHtmlAttr($_rating->getRatingCode()) ?>_rating_label <?= $block->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>_label" />
+                                    aria-labelledby="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode()) ?>_rating_label <?= $escaper->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>_label" />
                                 <label
-                                    class="rating-<?= $block->escapeHtmlAttr($iterator) ?>"
-                                    for="<?= $block->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>"
-                                    title="<?= $block->escapeHtmlAttr(__('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star'))) ?>"
-                                    id="<?= $block->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $block->escapeHtmlAttr($_option->getValue()) ?>_label">
-                                    <span><?= $block->escapeHtml(__('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star'))) ?></span>
+                                    class="rating-<?= $escaper->escapeHtmlAttr($iterator) ?>"
+                                    for="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>"
+                                    title="<?= $escaper->escapeHtmlAttr(__('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star'))) ?>"
+                                    id="<?= $escaper->escapeHtmlAttr($_rating->getRatingCode()) ?>_<?= $escaper->escapeHtmlAttr($_option->getValue()) ?>_label">
+                                    <span><?= $escaper->escapeHtml(__('%1 %2', $iterator, $iterator > 1 ? __('stars') : __('star'))) ?></span>
                                 </label>
                                 <?php $iterator++; ?>
                             <?php endforeach; ?>
@@ -54,19 +60,19 @@
         </fieldset>
     <?php endif ?>
         <div class="field review-field-nickname required">
-            <label for="nickname_field" class="label"><span><?= $block->escapeHtml(__('Nickname')) ?></span></label>
+            <label for="nickname_field" class="label"><span><?= $escaper->escapeHtml(__('Nickname')) ?></span></label>
             <div class="control">
                 <input type="text" name="nickname" id="nickname_field" class="input-text" data-validate="{required:true}" data-bind="value: nickname()" />
             </div>
         </div>
         <div class="field review-field-summary required">
-            <label for="summary_field" class="label"><span><?= $block->escapeHtml(__('Summary')) ?></span></label>
+            <label for="summary_field" class="label"><span><?= $escaper->escapeHtml(__('Summary')) ?></span></label>
             <div class="control">
                 <input type="text" name="title" id="summary_field" class="input-text" data-validate="{required:true}" data-bind="value: review().title" />
             </div>
         </div>
         <div class="field review-field-text required">
-            <label for="review_field" class="label"><span><?= $block->escapeHtml(__('Review')) ?></span></label>
+            <label for="review_field" class="label"><span><?= $escaper->escapeHtml(__('Review')) ?></span></label>
             <div class="control">
                 <textarea name="detail" id="review_field" cols="5" rows="3" data-validate="{required:true}" data-bind="value: review().detail"></textarea>
             </div>
@@ -78,7 +84,7 @@
                 <?php if ($block->getButtonLockManager()->isDisabled('review_form_submit')): ?>
                     disabled="disabled"
                 <?php endif; ?>>
-                <span><?= $block->escapeHtml(__('Submit Review')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Submit Review')) ?></span>
             </button>
         </div>
     </div>
@@ -98,7 +104,7 @@
 <?php else: ?>
     <div class="message info notlogged" id="review-form">
         <div>
-            <?= $block->escapeHtml(__('Only registered users can write reviews. Please <a href="%1">Sign in</a> or <a href="%2">create an account</a>', $block->getLoginLink(), $block->getRegisterUrl()), ['a']) ?>
+            <?= $escaper->escapeHtml(__('Only registered users can write reviews. Please <a href="%1">Sign in</a> or <a href="%2">create an account</a>', $block->getLoginLink(), $block->getRegisterUrl()), ['a']) ?>
         </div>
     </div>
 <?php endif ?>

--- a/app/code/Magento/Review/view/frontend/templates/helper/summary.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/helper/summary.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\Product\ReviewRenderer $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Product\ReviewRenderer;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var ReviewRenderer $block */
 $url = $block->getReviewsUrl() . '#reviews';
 $urlForm = $block->getReviewsUrl() . '#review-form';
 ?>
@@ -18,14 +21,14 @@ $urlForm = $block->getReviewsUrl() . '#review-form';
          itemtype="http://schema.org/AggregateRating">
         <?php if ($rating):?>
         <div class="rating-summary">
-             <span class="label"><span><?= $block->escapeHtml(__('Rating')) ?>:</span></span>
+             <span class="label"><span><?= $escaper->escapeHtml(__('Rating')) ?>:</span></span>
              <div class="rating-result"
-                  id="rating-result_<?= $block->escapeHtmlAttr($block->getProduct()->getId()) ?>"
-                  title="<?= $block->escapeHtmlAttr($rating) ?>%"
+                  id="rating-result_<?= $escaper->escapeHtmlAttr($block->getProduct()->getId()) ?>"
+                  title="<?= $escaper->escapeHtmlAttr($rating) ?>%"
              >
                  <span>
                      <span>
-                         <span itemprop="ratingValue"><?= $block->escapeHtml($rating); ?>
+                         <span itemprop="ratingValue"><?= $escaper->escapeHtml($rating); ?>
                          </span>% of <span itemprop="bestRating">100</span>
                      </span>
                  </span>
@@ -33,28 +36,28 @@ $urlForm = $block->getReviewsUrl() . '#review-form';
          </div>
             <?= /* @noEscape */
             $secureRenderer->renderStyleAsTag(
-                'width:' . $block->escapeHtmlAttr($rating) . '%',
+                'width:' . $escaper->escapeHtmlAttr($rating) . '%',
                 '#rating-result_' . $block->getProduct()->getId() . ' span'
             ) ?>
         <?php endif;?>
         <div class="reviews-actions">
             <a class="action view"
-               href="<?= $block->escapeUrl($url) ?>">
-                <span itemprop="reviewCount"><?= $block->escapeHtml($block->getReviewsCount()) ?></span>&nbsp;
-                <span><?= ($block->getReviewsCount() == 1) ? $block->escapeHtml(__('Review')) :
-                        $block->escapeHtml(__('Reviews')) ?>
+               href="<?= $escaper->escapeUrl($url) ?>">
+                <span itemprop="reviewCount"><?= $escaper->escapeHtml($block->getReviewsCount()) ?></span>&nbsp;
+                <span><?= ($block->getReviewsCount() == 1) ? $escaper->escapeHtml(__('Review')) :
+                        $escaper->escapeHtml(__('Reviews')) ?>
                 </span>
             </a>
-            <a class="action add" href="<?= $block->escapeUrl($urlForm) ?>">
-                <?= $block->escapeHtml(__('Add Your Review')) ?>
+            <a class="action add" href="<?= $escaper->escapeUrl($urlForm) ?>">
+                <?= $escaper->escapeHtml(__('Add Your Review')) ?>
             </a>
         </div>
     </div>
 <?php elseif ($block->isReviewEnabled() && $block->getDisplayIfEmpty()): ?>
     <div class="product-reviews-summary empty">
         <div class="reviews-actions">
-            <a class="action add" href="<?= $block->escapeUrl($urlForm) ?>">
-                <?= $block->escapeHtml(__('Be the first to review this product')) ?>
+            <a class="action add" href="<?= $escaper->escapeUrl($urlForm) ?>">
+                <?= $escaper->escapeHtml(__('Be the first to review this product')) ?>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Review/view/frontend/templates/helper/summary_short.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/helper/summary_short.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Product\ReviewRenderer $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\Product\ReviewRenderer;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var ReviewRenderer $block */
 $url = $block->getReviewsUrl() . '#reviews';
 $urlForm = $block->getReviewsUrl() . '#review-form';
 ?>
@@ -15,23 +20,23 @@ $urlForm = $block->getReviewsUrl() . '#review-form';
     <div class="product-reviews-summary short<?= !$rating ? ' no-rating' : '' ?>">
         <?php if ($rating):?>
         <div class="rating-summary">
-            <span class="label"><span><?= $block->escapeHtml(__('Rating')) ?>:</span></span>
+            <span class="label"><span><?= $escaper->escapeHtml(__('Rating')) ?>:</span></span>
             <div class="rating-result"
                  id="rating-result_<?= /* @noEscape */ $block->getProduct()->getId() ?>"
-                 title="<?= $block->escapeHtmlAttr($rating) ?>%">
-                <span><span><?= $block->escapeHtml($rating) ?>%</span></span>
+                 title="<?= $escaper->escapeHtmlAttr($rating) ?>%">
+                <span><span><?= $escaper->escapeHtml($rating) ?>%</span></span>
             </div>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
-                'width:' . $block->escapeHtmlAttr($rating) . '%',
+                'width:' . $escaper->escapeHtmlAttr($rating) . '%',
                 '#rating-result_' . $block->getProduct()->getId() . ' span'
             ) ?>
         </div>
         <?php endif;?>
         <div class="reviews-actions">
             <a class="action view"
-               href="<?= $block->escapeUrl($url) ?>"><?= $block->escapeHtml($block->getReviewsCount()) ?>
+               href="<?= $escaper->escapeUrl($url) ?>"><?= $escaper->escapeHtml($block->getReviewsCount()) ?>
                 &nbsp;<span><?= ($block->getReviewsCount() == 1) ?
-                        $block->escapeHtml(__('Review')) : $block->escapeHtml(__('Reviews')) ?>
+                        $escaper->escapeHtml(__('Review')) : $escaper->escapeHtml(__('Reviews')) ?>
                 </span>
             </a>
         </div>
@@ -39,8 +44,8 @@ $urlForm = $block->getReviewsUrl() . '#review-form';
 <?php elseif ($block->isReviewEnabled() && $block->getDisplayIfEmpty()): ?>
     <div class="product-reviews-summary short empty">
         <div class="reviews-actions">
-            <a class="action add" href="<?= $block->escapeUrl($urlForm) ?>">
-                <?= $block->escapeHtml(__('Be the first to review this product')) ?>
+            <a class="action add" href="<?= $escaper->escapeUrl($urlForm) ?>">
+                <?= $escaper->escapeHtml(__('Be the first to review this product')) ?>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Review/view/frontend/templates/product/view/count.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/product/view/count.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 // @deprecated
 ?>
 <?php if (!empty($count)) : ?>
-    <a href="#customer-reviews" class="nobr"><?= $block->escapeHtml(__('%1 Review(s)', $count)) ?></a>
+    <a href="#customer-reviews" class="nobr"><?= $escaper->escapeHtml(__('%1 Review(s)', $count)) ?></a>
 <?php endif;?>

--- a/app/code/Magento/Review/view/frontend/templates/product/view/other.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/product/view/other.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Product\View\Other $block */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Product\View\Other;
+
+/** @var Escaper $escaper */
+/** @var Other $block */
 ?>
 <?php $_product = $block->getProduct(); ?>
 <div class="actions">
-    <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" class="action back"><span><?= $block->escapeHtml(__('Back to Main Product Info')) ?></span></a>
+    <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" class="action back"><span><?= $escaper->escapeHtml(__('Back to Main Product Info')) ?></span></a>
 </div>

--- a/app/code/Magento/Review/view/frontend/templates/review.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/review.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Review\Block\Product\Review $block */
+use Magento\Framework\Escaper;
+use Magento\Review\Block\Product\Review;
+
+/** @var Escaper $escaper */
+/** @var Review $block */
 ?>
 <div id="product-review-container" data-role="product-review"></div>
 <?= $block->getChildHtml() ?>
@@ -13,7 +18,7 @@
     {
         "*": {
             "Magento_Review/js/process-reviews": {
-                "productReviewUrl": "<?= $block->escapeJs($block->getProductReviewUrl()) ?>",
+                "productReviewUrl": "<?= $escaper->escapeJs($block->getProductReviewUrl()) ?>",
                 "reviewsTabSelector": "#tab-label-reviews"
             }
         }

--- a/app/code/Magento/Review/view/frontend/templates/view.phtml
+++ b/app/code/Magento/Review/view/frontend/templates/view.phtml
@@ -3,45 +3,49 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Review\Block\View $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Review\Block\View;
+
+/** @var Escaper $escaper */
+/** @var View $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->getProductData()->getId()): ?>
 <div class="product-review">
     <div class="page-title-wrapper">
-        <h1><?= $block->escapeHtml(__('Review Details')) ?></h1>
+        <h1><?= $escaper->escapeHtml(__('Review Details')) ?></h1>
     </div>
     <div class="product-img-box">
-        <a href="<?= $block->escapeUrl($block->getProductData()->getProductUrl()) ?>">
+        <a href="<?= $escaper->escapeUrl($block->getProductData()->getProductUrl()) ?>">
             <?= $block->getImage($block->getProductData(), 'product_base_image', ['class' => 'product-image'])->toHtml()
             ?>
         </a>
         <?php if ($block->getRating() && $block->getRating()->getSize()): ?>
-            <p><?= $block->escapeHtml(__('Average Customer Rating')) ?>:</p>
+            <p><?= $escaper->escapeHtml(__('Average Customer Rating')) ?>:</p>
             <?= $block->getReviewsSummaryHtml($block->getProductData()) ?>
         <?php endif; ?>
     </div>
     <div class="details">
-        <h3 class="product-name"><?= $block->escapeHtml($block->getProductData()->getName()) ?></h3>
+        <h3 class="product-name"><?= $escaper->escapeHtml($block->getProductData()->getName()) ?></h3>
         <?php if ($block->getRating() && $block->getRating()->getSize()): ?>
-            <h4><?= $block->escapeHtml(__('Product Rating:')) ?></h4>
+            <h4><?= $escaper->escapeHtml(__('Product Rating:')) ?></h4>
             <div class="table-wrapper">
                 <table class="data-table review-summary-table">
-                    <caption class="table-caption"><?= $block->escapeHtml(__('Product Rating')) ?></caption>
+                    <caption class="table-caption"><?= $escaper->escapeHtml(__('Product Rating')) ?></caption>
                     <?php foreach ($block->getRating() as $_rating): ?>
                         <?php if ($_rating->getPercent()): ?>
                             <?php $rating = ceil($_rating->getPercent()) ?>
                             <tr>
                                 <td class="label" width="10%">
-                                    <?= $block->escapeHtml(__($_rating->getRatingCode())) ?>
+                                    <?= $escaper->escapeHtml(__($_rating->getRatingCode())) ?>
                                 </td>
                                 <td class="value">
                                     <?php $ratingId = $_rating->getRatingId() ?>
                                     <div class="rating-summary item"
-                                         id="rating-div-<?= $block->escapeHtml($ratingId) ?>">
+                                         id="rating-div-<?= $escaper->escapeHtml($ratingId) ?>">
                                         <div class="rating-result" title="<?= /* @noEscape */ $rating ?>%">
                                             <span>
                                                 <span><?= /* @noEscape */ $rating ?>%</span>
@@ -61,16 +65,16 @@
             </div>
         <?php endif; ?>
         <p class="date">
-            <?= $block->escapeHtml(
+            <?= $escaper->escapeHtml(
                 __('Product Review (submitted on %1):', $block->dateFormat($block->getReviewData()->getCreatedAt()))
             ) ?>
         </p>
-        <p><?= /* @noEscape */ nl2br($block->escapeHtml($block->getReviewData()->getDetail())) ?></p>
+        <p><?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getReviewData()->getDetail())) ?></p>
     </div>
     <div class="actions">
         <div class="secondary">
-            <a class="action back" href="<?= $block->escapeUrl($block->getBackUrl()) ?>">
-                <span><?= $block->escapeHtml(__('Back to Product Reviews')) ?></span>
+            <a class="action back" href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>">
+                <span><?= $escaper->escapeHtml(__('Back to Product Reviews')) ?></span>
             </a>
         </div>
     </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Review` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37133: Chore: Review - Replace Block Escaping with Escaper