### PR TITLE
Chore: Reports - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Reports/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/grid.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\Reports\Block\Adminhtml\Grid
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Reports\Block\Adminhtml\Grid;
+
+/** @var Escaper $escaper */
+/** @var Grid $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->getCollection()): ?>
     <?php if ($block->canDisplayContainer()): ?>
-    <div id="<?= $block->escapeHtmlAttr($block->getId()) ?>">
+    <div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>">
         <?php else: ?>
             <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
         <?php endif; ?>
@@ -21,47 +24,47 @@
                 <div class="admin__data-grid-header-row">
                     <?php if ($block->getDateFilterVisibility()): ?>
                         <div class="admin__filter-actions" data-role="filter-form"
-                             id="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_range')) ?>">
+                             id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_range')) ?>">
                             <span class="field-row">
-                                <label for="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_from')) ?>"
+                                <label for="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_from')) ?>"
                                        class="admin__control-support-text">
-                                    <span><?= $block->escapeHtml(__('From')) ?>:</span>
+                                    <span><?= $escaper->escapeHtml(__('From')) ?>:</span>
                                 </label>
                                 <input class="input-text no-changes required-entry admin__control-text"
                                        type="text"
-                                       id="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_from')) ?>"
+                                       id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_from')) ?>"
                                        name="report_from"
-                                       value="<?= $block->escapeHtmlAttr($block->getFilter('report_from')) ?>">
-                                <span id="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_from_advice'))?>">
+                                       value="<?= $escaper->escapeHtmlAttr($block->getFilter('report_from')) ?>">
+                                <span id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_from_advice'))?>">
                                 </span>
                             </span>
 
                             <span class="field-row">
-                                <label for="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_to')) ?>"
+                                <label for="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_to')) ?>"
                                        class="admin__control-support-text">
-                                    <span><?= $block->escapeHtml(__('To')) ?>:</span>
+                                    <span><?= $escaper->escapeHtml(__('To')) ?>:</span>
                                 </label>
                                 <input class="input-text no-changes required-entry admin__control-text"
                                        type="text"
-                                       id="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_to')) ?>"
+                                       id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_to')) ?>"
                                        name="report_to"
-                                       value="<?= $block->escapeHtmlAttr($block->getFilter('report_to')) ?>"/>
-                                <span id="<?= $block->escapeHtmlAttr($block->getSuffixId('period_date_to_advice')) ?>">
+                                       value="<?= $escaper->escapeHtmlAttr($block->getFilter('report_to')) ?>"/>
+                                <span id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('period_date_to_advice')) ?>">
                                 </span>
                             </span>
 
                             <span class="field-row admin__control-filter">
-                                 <label for="<?= $block->escapeHtmlAttr($block->getSuffixId('report_period')) ?>"
+                                 <label for="<?= $escaper->escapeHtmlAttr($block->getSuffixId('report_period')) ?>"
                                         class="admin__control-support-text">
-                                     <span><?= $block->escapeHtml(__('Show By')) ?>:</span>
+                                     <span><?= $escaper->escapeHtml(__('Show By')) ?>:</span>
                                  </label>
                                 <select name="report_period"
-                                        id="<?= $block->escapeHtmlAttr($block->getSuffixId('report_period')) ?>"
+                                        id="<?= $escaper->escapeHtmlAttr($block->getSuffixId('report_period')) ?>"
                                         class="admin__control-select">
                                     <?php foreach ($block->getPeriods() as $_value => $_label): ?>
-                                        <option value="<?= $block->escapeHtmlAttr($_value) ?>"
+                                        <option value="<?= $escaper->escapeHtmlAttr($_value) ?>"
                                             <?php if ($block->getFilter('report_period') == $_value):
-                                                ?> selected<?php endif; ?>><?= $block->escapeHtml($_label) ?>
+                                                ?> selected<?php endif; ?>><?= $escaper->escapeHtml($_label) ?>
                                         </option>
                                     <?php endforeach; ?>
                                 </select>
@@ -74,14 +77,14 @@
                                     "mage/calendar"
                                 ], function($){
 
-                                    $("#{$block->escapeJs($block->getSuffixId('period_date_range'))}").dateRange({
-                                        dateFormat:"{$block->escapeJs($block->getDateFormat())}",
+                                    $("#{$escaper->escapeJs($block->getSuffixId('period_date_range'))}").dateRange({
+                                        dateFormat:"{$escaper->escapeJs($block->getDateFormat())}",
                                         buttonText:"",
                                         from:{
-                                            id:"{$block->escapeJs($block->getSuffixId('period_date_from'))}"
+                                            id:"{$escaper->escapeJs($block->getSuffixId('period_date_from'))}"
                                         },
                                         to:{
-                                            id:"{$block->escapeJs($block->getSuffixId('period_date_to'))}"
+                                            id:"{$escaper->escapeJs($block->getSuffixId('period_date_to'))}"
                                         }
                                     });
                                 });
@@ -98,7 +101,7 @@ script;
             </div>
         <?php endif; ?>
         <div class="admin__data-grid-wrap admin__data-grid-wrap-static">
-            <table class="data-grid" id="<?= $block->escapeHtmlAttr($block->getId()) ?>_table">
+            <table class="data-grid" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_table">
                 <?= $block->getChildHtml('grid.columnSet') ?>
             </table>
         </div>
@@ -106,7 +109,7 @@ script;
     <?php if ($block->canDisplayContainer()): ?>
         <?php $useAjax = '';
         if ($block->getUseAjax()):
-            $useAjax = $block->escapeJs($block->getUseAjax());
+            $useAjax = $escaper->escapeJs($block->getUseAjax());
         endif;
         $scriptString = <<<script
 
@@ -118,24 +121,24 @@ script;
             ], function(jQuery){
 
                 //<![CDATA[
-                {$block->escapeJs($block->getJsObjectName())} = new varienGrid('{$block->escapeJs($block->getId())}',
-                 '{$block->escapeJs($block->getGridUrl())}', '{$block->escapeJs($block->getVarNamePage())}',
-                 '{$block->escapeJs($block->getVarNameSort())}', '{$block->escapeJs($block->getVarNameDir())}',
-                 '{$block->escapeJs($block->getVarNameFilter())}');
-                {$block->escapeJs($block->getJsObjectName())}.useAjax = '{$useAjax}';
+                {$escaper->escapeJs($block->getJsObjectName())} = new varienGrid('{$escaper->escapeJs($block->getId())}',
+                 '{$escaper->escapeJs($block->getGridUrl())}', '{$escaper->escapeJs($block->getVarNamePage())}',
+                 '{$escaper->escapeJs($block->getVarNameSort())}', '{$escaper->escapeJs($block->getVarNameDir())}',
+                 '{$escaper->escapeJs($block->getVarNameFilter())}');
+                {$escaper->escapeJs($block->getJsObjectName())}.useAjax = '{$useAjax}';
 
 script;
         ?>
                 <?php if ($block->getDateFilterVisibility()): ?>
                     <?php $scriptString .= <<<script
 
-                    {$block->escapeJs($block->getJsObjectName())}.doFilterCallback = validateFilterDate;
-                    var period_date_from = $('{$block->escapeJs($block->getSuffixId('period_date_from'))}');
-                    var period_date_to = $('{$block->escapeJs($block->getSuffixId('period_date_to'))}');
+                    {$escaper->escapeJs($block->getJsObjectName())}.doFilterCallback = validateFilterDate;
+                    var period_date_from = $('{$escaper->escapeJs($block->getSuffixId('period_date_from'))}');
+                    var period_date_to = $('{$escaper->escapeJs($block->getSuffixId('period_date_to'))}');
                     period_date_from.adviceContainer =
-                     $('{$block->escapeJs($block->getSuffixId('period_date_from_advice'))}');
+                     $('{$escaper->escapeJs($block->getSuffixId('period_date_from_advice'))}');
                     period_date_to.adviceContainer =
-                     $('{$block->escapeJs($block->getSuffixId('period_date_to_advice'))}');
+                     $('{$escaper->escapeJs($block->getSuffixId('period_date_to_advice'))}');
 
                     var validateFilterDate = function() {
                         if (period_date_from && period_date_to) {
@@ -169,11 +172,11 @@ script;
                     if (obj.switchParams) {
                         storeParam += obj.switchParams;
                     }
-                    var formParam = new Array('{$block->escapeJs($block->getSuffixId('period_date_from'))}',
-                     '{$block->escapeJs($block->getSuffixId('period_date_to'))}',
-                     '{$block->escapeJs($block->getSuffixId('report_period'))}');
+                    var formParam = new Array('{$escaper->escapeJs($block->getSuffixId('period_date_from'))}',
+                     '{$escaper->escapeJs($block->getSuffixId('period_date_to'))}',
+                     '{$escaper->escapeJs($block->getSuffixId('report_period'))}');
                     var paramURL = '';
-                    var switchURL = '{$block->escapeJs($block->getAbsoluteGridUrl(['_current' => false]))}'
+                    var switchURL = '{$escaper->escapeJs($block->getAbsoluteGridUrl(['_current' => false]))}'
                     .replace(/(store|group|website)\/\d+\//, '');
 
                     for (var i = 0; i < formParam.length; i++) {

--- a/app/code/Magento/Reports/view/adminhtml/templates/report/grid/container.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/report/grid/container.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <div class="reports-content">
@@ -34,7 +39,7 @@ require([
         }
 
         if (jQuery('#filter_form').valid()) {
-            setLocation('{$block->escapeJs($block->getFilterUrl())}filter/'+
+            setLocation('{$escaper->escapeJs($block->getFilterUrl())}filter/'+
                 Base64.encode(Form.serializeElements(elements))+'/'
             );
         }

--- a/app/code/Magento/Reports/view/adminhtml/templates/report/wishlist.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/report/wishlist.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 /**
  * @deprecated
@@ -11,13 +16,13 @@
 <?= $block->getChildHtml('grid') ?>
 
 <div class="switcher f-left" style="margin: 10px 10px 10px 0px; padding:15px;">
-<?= $block->escapeHtml(__('Customers that have Wish List: %1', $block->getCustomerWithWishlist())) ?>
+<?= $escaper->escapeHtml(__('Customers that have Wish List: %1', $block->getCustomerWithWishlist())) ?>
 </div>
 
 <div class="switcher" style="float: right; margin: 10px 0px 10px 10px; padding:15px;">
-    <?= $block->escapeHtml(__('Number of Wish Lists: %1', $block->getWishlistsCount())) ?><br />
-    <?= $block->escapeHtml(__('Number of items bought from a Wish List: %1', $block->getItemsBought())) ?><br />
-    <?= $block->escapeHtml(__('Number of times Wish Lists have been shared (emailed): %1', $block->getSharedCount())) ?><br />
-    <?= $block->escapeHtml(__('Number of Wish List referrals: %1', $block->getReferralsCount())) ?><br />
-    <?= $block->escapeHtml(__('Number of Wish List conversions: %1', $block->getConversionsCount())) ?><br />
+    <?= $escaper->escapeHtml(__('Number of Wish Lists: %1', $block->getWishlistsCount())) ?><br />
+    <?= $escaper->escapeHtml(__('Number of items bought from a Wish List: %1', $block->getItemsBought())) ?><br />
+    <?= $escaper->escapeHtml(__('Number of times Wish Lists have been shared (emailed): %1', $block->getSharedCount())) ?><br />
+    <?= $escaper->escapeHtml(__('Number of Wish List referrals: %1', $block->getReferralsCount())) ?><br />
+    <?= $escaper->escapeHtml(__('Number of Wish List conversions: %1', $block->getConversionsCount())) ?><br />
 </div>

--- a/app/code/Magento/Reports/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/store/switcher.phtml
@@ -3,25 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Store\Switcher;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Switcher $block */
 
 /**
  * @deprecated
  */
-
-/**
- * @see \Magento\Backend\Block\Store\Switcher
- */
 ?>
 <?php if ($block->isShow()) : ?>
 <div class="field field-store-switcher">
-    <label class="label" for="store_switcher"><?= $block->escapeHtml(__('Show Report For:')) ?></label>
+    <label class="label" for="store_switcher"><?= $escaper->escapeHtml(__('Show Report For:')) ?></label>
     <div class="control">
-        <select 
+        <select
             id="store_switcher"
             class="admin__control-select"
             name="store_switcher"
             onchange="return switchStore(this);">
-            <option value=""><?= $block->escapeHtml(__('All Websites')) ?></option>
+            <option value=""><?= $escaper->escapeHtml(__('All Websites')) ?></option>
             <?php foreach ($block->getWebsiteCollection() as $_website) : ?>
                 <?php $showWebsite = false; ?>
                 <?php foreach ($block->getGroupCollection($_website) as $_group) : ?>
@@ -29,15 +32,15 @@
                     <?php foreach ($block->getStoreCollection($_group) as $_store) : ?>
                         <?php if ($showWebsite == false) : ?>
                             <?php $showWebsite = true; ?>
-                                <option website="true" value="<?= $block->escapeHtmlAttr($_website->getId()) ?>"<?php if ($block->getRequest()->getParam('website') == $_website->getId()) : ?> selected<?php endif; ?>>
-                                    <?= $block->escapeHtml($_website->getName()) ?>
+                                <option website="true" value="<?= $escaper->escapeHtmlAttr($_website->getId()) ?>"<?php if ($block->getRequest()->getParam('website') == $_website->getId()) : ?> selected<?php endif; ?>>
+                                    <?= $escaper->escapeHtml($_website->getName()) ?>
                                 </option>
                         <?php endif; ?>
                         <?php if ($showGroup == false) : ?>
                             <?php $showGroup = true; ?>
-                            <option group="true" value="<?= $block->escapeHtmlAttr($_group->getId()) ?>"<?php if ($block->getRequest()->getParam('group') == $_group->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_group->getName()) ?></option>
+                            <option group="true" value="<?= $escaper->escapeHtmlAttr($_group->getId()) ?>"<?php if ($block->getRequest()->getParam('group') == $_group->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($_group->getName()) ?></option>
                         <?php endif; ?>
-                        <option value="<?= $block->escapeHtmlAttr($_store->getId()) ?>"<?php if ($block->getStoreId() == $_store->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_store->getName()) ?></option>
+                        <option value="<?= $escaper->escapeHtmlAttr($_store->getId()) ?>"<?php if ($block->getStoreId() == $_store->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($_store->getName()) ?></option>
                     <?php endforeach; ?>
                 <?php endforeach; ?>
             <?php endforeach; ?>
@@ -60,7 +63,7 @@ require(['prototype'], function(){
         if(obj.switchParams){
             storeParam+= obj.switchParams;
         }
-        setLocation('<?= $block->escapeUrl($block->getSwitchUrl()) ?>'+storeParam);
+        setLocation('<?= $escaper->escapeUrl($block->getSwitchUrl()) ?>'+storeParam);
     }
 
 });

--- a/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
@@ -13,6 +13,8 @@ use Magento\Framework\Escaper;
 
 /**
  * @deprecated
+ *
+ * @see \Magento\Backend\Block\Store\Switcher
  */
 ?>
 

--- a/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
+++ b/app/code/Magento/Reports/view/adminhtml/templates/store/switcher/enhanced.phtml
@@ -3,30 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Store\Switcher;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Switcher $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @see \Magento\Backend\Block\Store\Switcher
- */
-
-/**
- * @var $block \Magento\Backend\Block\Store\Switcher
  */
 ?>
 
 <?php if ($block->isShow()) : ?>
 <div class="field field-store-switcher">
-    <label class="label" for="store_switcher"><?= $block->escapeHtml(__('Show Report For:')) ?></label>
+    <label class="label" for="store_switcher"><?= $escaper->escapeHtml(__('Show Report For:')) ?></label>
     <div class="control">
-        <select 
+        <select
             id="store_switcher"
             class="admin__control-select"
             name="store_switcher"
             onchange="return switchStore(this);">
-            <option value=""><?= $block->escapeHtml(__('All Websites')) ?></option>
+            <option value=""><?= $escaper->escapeHtml(__('All Websites')) ?></option>
             <?php foreach ($block->getWebsiteCollection() as $_website) : ?>
                 <?php $showWebsite = false; ?>
                 <?php foreach ($block->getGroupCollection($_website) as $_group) : ?>
@@ -34,13 +33,13 @@
                     <?php foreach ($block->getStoreCollection($_group) as $_store) : ?>
                         <?php if ($showWebsite == false) : ?>
                             <?php $showWebsite = true; ?>
-                            <option website="true" value="<?= $block->escapeHtmlAttr(implode(',', $_website->getStoreIds())) ?>"<?php if ($block->getRequest()->getParam('store_ids') == implode(',', $_website->getStoreIds())) : ?> selected<?php endif; ?>><?= $block->escapeHtml($_website->getName()) ?></option>
+                            <option website="true" value="<?= $escaper->escapeHtmlAttr(implode(',', $_website->getStoreIds())) ?>"<?php if ($block->getRequest()->getParam('store_ids') == implode(',', $_website->getStoreIds())) : ?> selected<?php endif; ?>><?= $escaper->escapeHtml($_website->getName()) ?></option>
                         <?php endif; ?>
                         <?php if ($showGroup == false) : ?>
                             <?php $showGroup = true; ?>
-                            <option group="true" value="<?= $block->escapeHtmlAttr(implode(',', $_group->getStoreIds())) ?>"<?php if ($block->getRequest()->getParam('store_ids') == implode(',', $_group->getStoreIds())) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_group->getName()) ?></option>
+                            <option group="true" value="<?= $escaper->escapeHtmlAttr(implode(',', $_group->getStoreIds())) ?>"<?php if ($block->getRequest()->getParam('store_ids') == implode(',', $_group->getStoreIds())) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($_group->getName()) ?></option>
                         <?php endif; ?>
-                        <option value="<?= $block->escapeHtmlAttr($_store->getId()) ?>"<?php if ($block->getStoreId() == $_store->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_store->getName()) ?></option>
+                        <option value="<?= $escaper->escapeHtmlAttr($_store->getId()) ?>"<?php if ($block->getStoreId() == $_store->getId()) : ?> selected<?php endif; ?>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($_store->getName()) ?></option>
                     <?php endforeach; ?>
                     <?php if ($showGroup) : ?>
                         </optgroup>
@@ -59,7 +58,7 @@ require(['prototype'], function(){
         if(obj.switchParams){
             storeParam+= obj.switchParams;
         }
-        setLocation('<?= $block->escapeUrl($block->getSwitchUrl()) ?>'+storeParam);
+        setLocation('<?= $escaper->escapeUrl($block->getSwitchUrl()) ?>'+storeParam);
     }
 
 });

--- a/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Widget\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
  */
-
-/* @var $block \Magento\Reports\Block\Product\Widget\Viewed */
 ?>
 
 <?php
@@ -17,12 +22,12 @@ $type = $block->getType() . '-' . $mode;
 $class = 'widget viewed' . ' ' . $mode;
 $title = __('Recently Viewed');
 ?>
-<div class="block <?= $block->escapeHtmlAttr($class) ?>" id="recently_viewed_container" data-mage-init='{"recentlyViewedProducts":{}}' data-count="<?= $block->escapeHtmlAttr($block->getCount()) ?>" style="display: none;">
+<div class="block <?= $escaper->escapeHtmlAttr($class) ?>" id="recently_viewed_container" data-mage-init='{"recentlyViewedProducts":{}}' data-count="<?= $escaper->escapeHtmlAttr($block->getCount()) ?>" style="display: none;">
     <div class="title">
-        <strong><?= $block->escapeHtml($title) ?></strong>
+        <strong><?= $escaper->escapeHtml($title) ?></strong>
     </div>
     <div class="content">
-        <ol class="products list items <?= $block->escapeHtmlAttr($type) ?>">
+        <ol class="products list items <?= $escaper->escapeHtmlAttr($type) ?>">
         </ol>
     </div>
 </div>

--- a/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed/item.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/product/widget/viewed/item.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Widget\Viewed\Item;
+
+/** @var Escaper $escaper */
+/* @var Item $block */
 
 /**
  * @deprecated
  */
-
-/* @var $block \Magento\Reports\Block\Product\Widget\Viewed\Item */
 
 $type = $block->getType() . '-' . $block->getViewMode();
 
@@ -17,16 +22,16 @@ $item = $block->getProduct();
 $image = $block->getImageType();
 $rating = 'short';
 ?>
-<div class="block" id="widget_viewed_item" data-sku="<?= $block->escapeHtmlAttr($item->getSku()) ?>" style="display: none;">
+<div class="block" id="widget_viewed_item" data-sku="<?= $escaper->escapeHtmlAttr($item->getSku()) ?>" style="display: none;">
     <li class="item product">
         <div class="product">
-            <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-            <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>" class="product photo">
+            <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+            <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>" class="product photo">
                 <?= $block->getImage($item, $image)->toHtml() ?>
             </a>
             <div class="product details">
-                <strong class="product name"><a title="<?= $block->escapeHtmlAttr($item->getName()) ?>" href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>">
-                    <?= $block->escapeHtml($item->getName()) ?></a>
+                <strong class="product name"><a title="<?= $escaper->escapeHtmlAttr($item->getName()) ?>" href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>">
+                    <?= $escaper->escapeHtml($item->getName()) ?></a>
                 </strong>
 
                 <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -46,8 +51,8 @@ $rating = 'short';
                     <div class="primary">
                         <?php if ($item->isSaleable()) : ?>
                             <?php if ($item->getTypeInstance()->hasRequiredOptions($item)) : ?>
-                                <button class="action tocart" data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($item)) ?>"}}' type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                    <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                <button class="action tocart" data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($item)) ?>"}}' type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                    <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                 </button>
                             <?php else : ?>
                                 <?php $postDataHelper = $this->helper(\Magento\Framework\Data\Helper\PostHelper::class);
@@ -55,23 +60,23 @@ $rating = 'short';
                                 ?>
                                 <button class="action tocart"
                                         data-post='<?= /* @noEscape */ $postData ?>'
-                                        type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                    <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                        type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                    <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                 </button>
                             <?php endif; ?>
                         <?php else : ?>
                             <?php if ($item->isAvailable()) : ?>
-                                <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                             <?php else : ?>
-                                <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                             <?php endif; ?>
                         <?php endif; ?>
                     </div>
 
                     <div class="secondary-addto-links" data-role="add-to-links">
                         <?php if ($this->helper(\Magento\Wishlist\Helper\Data::class)->isAllow()) : ?>
-                            <a href="#" data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($item) ?>'  class="action towishlist" data-action="add-to-wishlist" title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                            <a href="#" data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($item) ?>'  class="action towishlist" data-action="add-to-wishlist" title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                             </a>
                         <?php endif; ?>
                         <?php if ($block->getAddToCompareUrl()) : ?>
@@ -81,8 +86,8 @@ $rating = 'short';
                             <a href="#" class="action tocompare"
                                data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($item) ?>'
                                data-role="add-to-links"
-                               title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                               title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                             </a>
                         <?php endif; ?>
                     </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_default_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_default_list.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 /**
  * @deprecated
@@ -27,25 +32,25 @@ if ($exist = $block->getRecentlyComparedProducts()) {
 }
 ?>
 <?php if ($exist) : ?>
-<div class="block widget block-compared-products-<?= $block->escapeHtmlAttr($mode) ?>">
+<div class="block widget block-compared-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
     <div class="block-title">
-        <strong><?= $block->escapeHtml($title) ?></strong>
+        <strong><?= $escaper->escapeHtml($title) ?></strong>
     </div>
     <div class="block-content">
         <?php $suffix = $block->getNameInLayout(); ?>
-        <ol class="product-items" id="widget-compared-<?= $block->escapeHtmlAttr($suffix) ?>">
+        <ol class="product-items" id="widget-compared-<?= $escaper->escapeHtmlAttr($suffix) ?>">
             <?php foreach ($items as $_product) : ?>
                 <li class="product-item">
                     <div class="product-item-info">
-                        <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
-                           title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
+                        <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
+                           title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
                             <?= $block->getImage($_product, $image)->toHtml() ?>
                         </a>
                         <div class="product-item-details">
                             <strong class="product-item-name">
-                                <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
-                                   title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>)">
-                                    <?= $block->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
+                                <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
+                                   title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>)">
+                                    <?= $escaper->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
                                 </a>
                             </strong>
                             <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -61,9 +66,9 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                 <div class="actions-primary">
                                 <?php if ($_product->getTypeInstance()->hasRequiredOptions($_product)) : ?>
                                     <button class="action tocart primary"
-                                            data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'
-                                            type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                            data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'
+                                            type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                     </button>
                                 <?php else : ?>
                                     <?php
@@ -72,16 +77,16 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                     ?>
                                     <button class="action tocart primary"
                                             data-post='<?= /* @noEscape */ $postData ?>'
-                                            type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                            type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                     </button>
                                 <?php endif; ?>
                                 </div>
                             <?php else : ?>
                                 <?php if ($_product->isAvailable()) : ?>
-                                    <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                    <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                 <?php else : ?>
-                                    <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                    <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                 <?php endif; ?>
                             <?php endif; ?>
                             </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_images_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_images_list.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 /**
  * @deprecated
@@ -26,14 +31,14 @@ if ($exist = $block->getRecentlyComparedProducts()) {
 <?php if ($exist) : ?>
 <div class="block widget block-compared-products-images">
     <div class="block-title">
-        <strong><?= $block->escapeHtml($title) ?></strong>
+        <strong><?= $escaper->escapeHtml($title) ?></strong>
     </div>
     <div class="block-content">
-        <ol id="widget-compared-<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>" class="product-items product-items-images">
+        <ol id="widget-compared-<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>" class="product-items product-items-images">
         <?php $i = 0; foreach ($items as $_product) : ?>
             <li class="product-item">
-                <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
-                    title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
+                <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
+                    title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
                     <?= $block->getImage($_product, $image)->toHtml() ?>
                 </a>
             </li>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_names_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/compared/column/compared_names_list.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 /**
  * @deprecated
@@ -11,15 +16,15 @@
 <?php if ($_products = $block->getRecentlyComparedProducts()) : ?>
 <div class="block widget block-compared-products-names">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Recently Compared')) ?></span></strong>
+        <strong><?= $escaper->escapeHtml(__('Recently Compared')) ?></span></strong>
     </div>
     <div class="block-content">
-        <ol id="widget-compared-<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>" class="product-items product-items-names">
+        <ol id="widget-compared-<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>" class="product-items product-items-names">
         <?php $i = 0; foreach ($_products as $_product) : ?>
             <li class="product-item">
                 <strong class="product-item-name">
-                    <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" class="product-item-link">
-                        <?= $block->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
+                    <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" class="product-item-link">
+                        <?= $escaper->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
                     </a>
                 </strong>
             </li>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/compared/content/compared_grid.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/compared/content/compared_grid.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Compare\ListCompare;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var ListCompare $block */
 
 /**
  * @deprecated
  */
 
-/** @var \Magento\Catalog\Block\Product\Compare\ListCompare $block */
 if ($exist = $block->getRecentlyComparedProducts()) {
     $type = 'widget-compared';
     $mode = 'grid';
@@ -28,25 +34,25 @@ if ($exist = $block->getRecentlyComparedProducts()) {
 ?>
 
 <?php if ($exist) : ?>
-    <div class="block widget block-compared-products-<?= $block->escapeHtmlAttr($mode) ?>">
+    <div class="block widget block-compared-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
-            <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-            <div class="products-<?= $block->escapeHtmlAttr($mode) ?> <?= $block->escapeHtmlAttr($mode) ?>">
-                <ol class="product-items <?= $block->escapeHtmlAttr($type)?>">
+            <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+            <div class="products-<?= $escaper->escapeHtmlAttr($mode) ?> <?= $escaper->escapeHtmlAttr($mode) ?>">
+                <ol class="product-items <?= $escaper->escapeHtmlAttr($type)?>">
                     <?php foreach ($items as $_item) : ?>
                         <li class="product-item">
                             <div class="product-item-info">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product-item-details">
                                     <strong class="product-item-name">
-                                        <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                           href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
-                                            <?= $block->escapeHtml($_item->getName()) ?>
+                                        <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                           href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
+                                            <?= $escaper->escapeHtml($_item->getName()) ?>
                                         </a>
                                     </strong>
                                     <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -67,9 +73,9 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                     <?php if ($_item->isSaleable()) : ?>
                                                         <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)) : ?>
                                                             <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else : ?>
                                                             <?php
@@ -78,15 +84,15 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                             ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php endif; ?>
                                                     <?php else : ?>
                                                         <?php if ($_item->isAvailable()) : ?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else : ?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -99,16 +105,16 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
                                                            data-action="add-to-wishlist"
                                                            class="action towishlist"
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) : ?>
                                                         <?php $compareHelper = $this->helper(\Magento\Catalog\Helper\Product\Compare::class); ?>
                                                         <a href="#" class="action tocompare"
                                                            data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/compared/content/compared_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/compared/content/compared_list.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Compare\ListCompare;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var ListCompare $block */
 
 /**
  * @deprecated
  */
 
-/** @var \Magento\Catalog\Block\Product\Compare\ListCompare $block */
 if ($exist = $block->getRecentlyComparedProducts()) {
     $type = 'widget-compared';
     $mode = 'list';
@@ -29,25 +35,25 @@ if ($exist = $block->getRecentlyComparedProducts()) {
 ?>
 
 <?php if ($exist) : ?>
-    <div class="block widget block-compared-products-<?= $block->escapeHtmlAttr($mode) ?>">
+    <div class="block widget block-compared-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
-            <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-            <div class="products-<?= $block->escapeHtmlAttr($mode) ?> <?= $block->escapeHtmlAttr($mode) ?>">
-                <ol class="product-items <?= $block->escapeHtmlAttr($type) ?>">
+            <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+            <div class="products-<?= $escaper->escapeHtmlAttr($mode) ?> <?= $escaper->escapeHtmlAttr($mode) ?>">
+                <ol class="product-items <?= $escaper->escapeHtmlAttr($type) ?>">
                     <?php foreach ($items as $_item) : ?>
                         <li class="product-item">
                             <div class="product-item-info">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product-item-details">
                                     <strong class="product-item-name">
-                                        <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                           href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
-                                            <?= $block->escapeHtml($_item->getName()) ?>
+                                        <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                           href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
+                                            <?= $escaper->escapeHtml($_item->getName()) ?>
                                         </a>
                                     </strong>
                                     <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -68,9 +74,9 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                     <?php if ($_item->isSaleable()) : ?>
                                                         <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)) : ?>
                                                             <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeHtmlAttr($block->escapeUrl($block->getAddToCartUrl($_item))) ?>"}}'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeHtmlAttr($escaper->escapeUrl($block->getAddToCartUrl($_item))) ?>"}}'
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else : ?>
                                                             <?php
@@ -79,15 +85,15 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                             ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php endif; ?>
                                                     <?php else : ?>
                                                         <?php if ($_item->isAvailable()) : ?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else : ?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -100,16 +106,16 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
                                                            data-action="add-to-wishlist"
                                                            class="action towishlist"
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) : ?>
                                                         <?php $compareHelper = $this->helper(\Magento\Catalog\Helper\Product\Compare::class);?>
                                                         <a href="#" class="action tocompare"
                                                            data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>
@@ -118,10 +124,10 @@ if ($exist = $block->getRecentlyComparedProducts()) {
                                     <?php endif; ?>
                                     <?php if ($description) : ?>
                                         <div class="product-item-description">
-                                            <?= $block->escapeHtml($_helper->productAttribute($_item, $_item->getShortDescription(), 'short_description')) ?>
-                                            <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                               href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
-                                               class="action more"><?= $block->escapeHtml(__('Learn More')) ?></a>
+                                            <?= $escaper->escapeHtml($_helper->productAttribute($_item, $_item->getShortDescription(), 'short_description')) ?>
+                                            <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                               href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
+                                               class="action more"><?= $escaper->escapeHtml(__('Learn More')) ?></a>
                                         </div>
                                     <?php endif; ?>
                                 </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_default_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_default_list.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @var $block \Magento\Reports\Block\Product\Viewed
  */
 ?>
 <?php
@@ -31,26 +34,26 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
 }
 ?>
 <?php if ($exist) : ?>
-<div class="block widget block-viewed-products-<?= $block->escapeHtmlAttr($mode) ?>">
+<div class="block widget block-viewed-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
     <div class="block-title">
-        <strong><?= $block->escapeHtml($title) ?></strong>
+        <strong><?= $escaper->escapeHtml($title) ?></strong>
     </div>
     <div class="block-content">
         <?php $suffix = $block->getNameInLayout(); ?>
-        <ol class="product-items" id="widget-viewed-<?= $block->escapeHtmlAttr($suffix) ?>">
+        <ol class="product-items" id="widget-viewed-<?= $escaper->escapeHtmlAttr($suffix) ?>">
             <?php foreach ($items as $_product) : ?>
                 <li class="product-item">
                     <div class="product-item-info">
-                        <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
-                           title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
+                        <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
+                           title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
                             <?= $block->getImage($_product, $image)->toHtml() ?>
                         </a>
                         <div class="product-item-details">
                             <strong class="product-item-name">
-                                <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
-                                   title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>"
+                                <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
+                                   title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>"
                                    class="product-item-link">
-                                    <?= $block->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
+                                    <?= $escaper->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
                                 </a>
                             </strong>
                             <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -66,9 +69,9 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                 <div class="actions-primary">
                                     <?php if ($_product->getTypeInstance()->hasRequiredOptions($_product)) : ?>
                                         <button class="action tocart primary"
-                                                data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'
-                                                type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'
+                                                type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                         </button>
                                     <?php else : ?>
                                         <?php
@@ -76,15 +79,15 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                             $postData = $postDataHelper->getPostData($block->getAddToCartUrl($_product), ['product' => $_product->getEntityId()]);
                                         ?>
                                         <button type="button" class="action tocart primary" data-post='<?= /* @noEscape */ $postData ?>'>
-                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                         </button>
                                     <?php endif; ?>
                                 </div>
                                 <?php else : ?>
                                     <?php if ($_product->isAvailable()) : ?>
-                                        <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                        <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                     <?php else : ?>
-                                        <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                        <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                     <?php endif; ?>
                                 <?php endif; ?>
                             </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_images_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_images_list.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @var $block \Magento\Reports\Block\Product\Viewed
  */
 ?>
 <?php
@@ -30,14 +33,14 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
 <?php if ($exist) : ?>
     <div class="block widget block-viewed-products-images">
         <div class="block-title">
-            <strong><?= $block->escapeHtml($title) ?></strong>
+            <strong><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
             <?php $suffix = $block->getNameInLayout(); ?>
-            <ol id="widget-viewed-<?= $block->escapeHtmlAttr($suffix) ?>" class="product-items product-items-images">
+            <ol id="widget-viewed-<?= $escaper->escapeHtmlAttr($suffix) ?>" class="product-items product-items-images">
                 <?php foreach ($items as $_product) : ?>
                     <li class="product-item">
-                        <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" title="<?= $block->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
+                        <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" title="<?= $escaper->escapeHtmlAttr($block->stripTags($_product->getName(), null, true)) ?>">
                             <?= $block->getImage($_product, $image)->toHtml() ?>
                         </a>
                     </li>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_names_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/column/viewed_names_list.phtml
@@ -3,28 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @var $block \Magento\Reports\Block\Product\Viewed
  */
 ?>
 <?php if (($_products = $block->getRecentlyViewedProducts()) && $_products->getSize()) : ?>
 <div class="block widget block-viewed-products-names">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Recently Viewed')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Recently Viewed')) ?></strong>
     </div>
     <div class="block-content">
         <?php $suffix = $block->getNameInLayout(); ?>
-        <ol id="widget-viewed-<?= $block->escapeHtmlAttr($suffix) ?>" class="product-items product-items-names">
+        <ol id="widget-viewed-<?= $escaper->escapeHtmlAttr($suffix) ?>" class="product-items product-items-names">
         <?php foreach ($_products as $_product) : ?>
             <li class="product-item">
                 <strong class="product-item-name">
-                    <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" class="product-item-link">
-                        <?= $block->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
+                    <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" class="product-item-link">
+                        <?= $escaper->escapeHtml($this->helper(\Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name')) ?>
                     </a>
                 </strong>
             </li>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_grid.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_grid.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @var $block \Magento\Reports\Block\Product\Viewed
  */
 ?>
 <?php
@@ -31,25 +34,25 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
 }
 ?>
 <?php if ($exist) : ?>
-    <div class="block widget block-viewed-products-<?= $block->escapeHtmlAttr($mode) ?>">
+    <div class="block widget block-viewed-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
-            <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-            <div class="products-<?= $block->escapeHtmlAttr($mode) ?> <?= $block->escapeHtmlAttr($mode) ?>">
-                <ol class="product-items <?= $block->escapeHtmlAttr($type) ?>">
+            <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+            <div class="products-<?= $escaper->escapeHtmlAttr($mode) ?> <?= $escaper->escapeHtmlAttr($mode) ?>">
+                <ol class="product-items <?= $escaper->escapeHtmlAttr($type) ?>">
                     <?php foreach ($items as $_item) : ?>
                         <li class="product-item">
                             <div class="product-item-info">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product-item-details">
                                     <strong class="product-item-name">
-                                        <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                           href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
-                                            <?= $block->escapeHtml($_item->getName()) ?>
+                                        <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                           href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
+                                            <?= $escaper->escapeHtml($_item->getName()) ?>
                                         </a>
                                     </strong>
                                     <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -70,9 +73,9 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                     <?php if ($_item->isSaleable()) : ?>
                                                         <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)) : ?>
                                                             <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else : ?>
                                                             <?php
@@ -81,15 +84,15 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                             ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php endif; ?>
                                                     <?php else : ?>
                                                         <?php if ($_item->isAvailable()) : ?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else : ?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -100,16 +103,16 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                         <a href="#"
                                                            class="action towishlist" data-action="add-to-wishlist"
                                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) : ?>
                                                         <?php $compareHelper = $this->helper(\Magento\Catalog\Helper\Product\Compare::class);?>
                                                         <a href="#" class="action tocompare"
                                                            data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>

--- a/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_list.phtml
+++ b/app/code/Magento/Reports/view/frontend/templates/widget/viewed/content/viewed_list.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Reports\Block\Product\Viewed;
+
+/** @var Escaper $escaper */
+/** @var Viewed $block */
 
 /**
  * @deprecated
- */
-
-/**
- * @var $block \Magento\Reports\Block\Product\Viewed
  */
 ?>
 <?php
@@ -33,25 +36,25 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
 ?>
 
 <?php if ($exist) : ?>
-    <div class="block widget block-viewed-products-<?= $block->escapeHtmlAttr($mode) ?>">
+    <div class="block widget block-viewed-products-<?= $escaper->escapeHtmlAttr($mode) ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
-            <?= '<!-- ' . $block->escapeHtml($image) . '-->' ?>
-            <div class="products-<?= $block->escapeHtmlAttr($mode) ?> <?= $block->escapeHtmlAttr($mode) ?>">
-                <ol class="product-items <?= $block->escapeHtmlAttr($type) ?>">
+            <?= '<!-- ' . $escaper->escapeHtml($image) . '-->' ?>
+            <div class="products-<?= $escaper->escapeHtmlAttr($mode) ?> <?= $escaper->escapeHtmlAttr($mode) ?>">
+                <ol class="product-items <?= $escaper->escapeHtmlAttr($type) ?>">
                     <?php foreach ($items as $_item) : ?>
                         <li class="product-item">
                             <div class="product-item-info">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product-item-details">
                                     <strong class="product-item-name">
-                                        <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                           href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
-                                            <?= $block->escapeHtml($_item->getName()) ?>
+                                        <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                           href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>" class="product-item-link">
+                                            <?= $escaper->escapeHtml($_item->getName()) ?>
                                         </a>
                                     </strong>
                                     <?= /* @noEscape */ $block->getProductPriceHtml(
@@ -72,9 +75,9 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                     <?php if ($_item->isSaleable()) : ?>
                                                         <?php if ($_item->getTypeInstance()->hasRequiredOptions($_item)) : ?>
                                                             <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else : ?>
                                                             <?php
@@ -83,15 +86,15 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                             ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                             <?php endif; ?>
                                                     <?php else : ?>
                                                         <?php if ($_item->isAvailable()) : ?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else : ?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -103,16 +106,16 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                                         <a href="#"
                                                            class="action towishlist" data-action="add-to-wishlist"
                                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) : ?>
                                                         <?php  $compareHelper = $this->helper(\Magento\Catalog\Helper\Product\Compare::class);?>
                                                         <a href="#" class="action tocompare"
                                                            data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>
@@ -121,10 +124,10 @@ if ($exist = ($block->getRecentlyViewedProducts() && $block->getRecentlyViewedPr
                                     <?php endif; ?>
                                     <?php if ($description) : ?>
                                         <div class="product-item-description">
-                                            <?= $block->escapeHtml($_helper->productAttribute($_item, $_item->getShortDescription(), 'short_description')) ?>
-                                            <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                               href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
-                                               class="action more"><?= $block->escapeHtml(__('Learn More')) ?></a>
+                                            <?= $escaper->escapeHtml($_helper->productAttribute($_item, $_item->getShortDescription(), 'short_description')) ?>
+                                            <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                               href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
+                                               class="action more"><?= $escaper->escapeHtml(__('Learn More')) ?></a>
                                         </div>
                                     <?php endif; ?>
                                 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Reports` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37132: Chore: Reports - Replace Block Escaping with Escaper