### PR TITLE
Chore: Product Alert - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/email.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/email.phtml
@@ -3,15 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Framework\View\Element\Template */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
-
-<form action="<?= $block->escapeUrl($block->getUrl('productalert/unsubscribe/stock')) ?>"
+<form action="<?= $escaper->escapeUrl($block->getUrl('productalert/unsubscribe/stock')) ?>"
       method="post"
       data-form="unsubscription_form">
     <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
-    <input type="hidden" id="productId" name="product" value="<?= $block->escapeHtml($block->getProductId()) ?>" />
+    <input type="hidden" id="productId" name="product" value="<?= $escaper->escapeHtml($block->getProductId()) ?>" />
 </form>
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/price.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/price.phtml
@@ -3,24 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\ProductAlert\Block\Email\Price */
+use Magento\Framework\Escaper;
+use Magento\ProductAlert\Block\Email\Price;
+
+/** @var Escaper $escaper */
+/** @var Price $block */
 ?>
 <?php if ($_products = $block->getProducts()) : ?>
-    <p><?= $block->escapeHtml(__('Price change alert! We wanted you to know that prices have changed for these products:')) ?></p>
+    <p><?= $escaper->escapeHtml(__('Price change alert! We wanted you to know that prices have changed for these products:')) ?></p>
     <table>
     <?php /** @var $_product \Magento\Catalog\Model\Product */ ?>
     <?php foreach ($_products as $_product) : ?>
         <tr>
             <td class="col photo">
-                <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" title="<?= $block->escapeHtml($_product->getName()) ?>" class="product photo">
+                <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" title="<?= $escaper->escapeHtml($_product->getName()) ?>" class="product photo">
                     <?= $block->getImage($_product, 'product_thumbnail_image', ['class' => 'photo image'])->toHtml() ?>
                 </a>
             </td>
             <td class="col item">
                 <p>
                     <strong class="product name">
-                        <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"><?= $block->escapeHtml($_product->getName()) ?></a>
+                        <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"><?= $escaper->escapeHtml($_product->getName()) ?></a>
                     </strong>
                 </p>
                 <?php if ($shortDescription = $block->getFilteredContent($_product->getShortDescription())) : ?>
@@ -36,10 +41,10 @@
                     ]
                 );
                 ?>
-                <p><small><a href="<?= $block->escapeUrl($block->getProductUnsubscribeUrl($_product->getId())) ?>"><?= $block->escapeHtml(__('Click here to stop alerts for this product.')) ?></a></small></p>
+                <p><small><a href="<?= $escaper->escapeUrl($block->getProductUnsubscribeUrl($_product->getId())) ?>"><?= $escaper->escapeHtml(__('Click here to stop alerts for this product.')) ?></a></small></p>
             </td>
         </tr>
     <?php endforeach; ?>
     </table>
-    <p><a href="<?= $block->escapeUrl($block->getUnsubscribeUrl()) ?>"><?= $block->escapeHtml(__('Unsubscribe from all price alerts')) ?></a></p>
+    <p><a href="<?= $escaper->escapeUrl($block->getUnsubscribeUrl()) ?>"><?= $escaper->escapeHtml(__('Unsubscribe from all price alerts')) ?></a></p>
 <?php endif; ?>

--- a/app/code/Magento/ProductAlert/view/frontend/templates/email/stock.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/email/stock.phtml
@@ -3,23 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\ProductAlert\Block\Email\Stock */
+use Magento\Framework\Escaper;
+use Magento\ProductAlert\Block\Email\Stock;
+
+/** @var Escaper $escaper */
+/** @var Stock $block */
 ?>
 <?php if ($_products = $block->getProducts()) : ?>
-    <p><?= $block->escapeHtml(__('In stock alert! We wanted you to know that these products are now available:')) ?></p>
+    <p><?= $escaper->escapeHtml(__('In stock alert! We wanted you to know that these products are now available:')) ?></p>
     <table>
     <?php foreach ($_products as $_product) : ?>
         <tr>
             <td class="col photo">
-                <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" title="<?= $block->escapeHtml($_product->getName()) ?>" class="product photo">
+                <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" title="<?= $escaper->escapeHtml($_product->getName()) ?>" class="product photo">
                     <?= $block->getImage($_product, 'product_thumbnail_image', ['class' => 'photo image'])->toHtml() ?>
                 </a>
             </td>
             <td class="col item">
                 <p>
                     <strong class="product name">
-                        <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"><?= $block->escapeHtml($_product->getName()) ?></a>
+                        <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"><?= $escaper->escapeHtml($_product->getName()) ?></a>
                     </strong>
                 </p>
                 <?php if ($shortDescription = $block->getFilteredContent($_product->getShortDescription())) : ?>
@@ -35,10 +40,10 @@
                     ]
                 );
                 ?>
-                <p><small><a href="<?= $block->escapeUrl($block->getProductUnsubscribeUrl($_product->getId())) ?>"><?= $block->escapeHtml(__('Click here to stop alerts for this product.')) ?></a></small></p>
+                <p><small><a href="<?= $escaper->escapeUrl($block->getProductUnsubscribeUrl($_product->getId())) ?>"><?= $escaper->escapeHtml(__('Click here to stop alerts for this product.')) ?></a></small></p>
             </td>
         </tr>
     <?php endforeach; ?>
     </table>
-    <p><a href="<?= $block->escapeUrl($block->getUnsubscribeUrl()) ?>"><?= $block->escapeHtml(__('Unsubscribe from all stock alerts')) ?></a></p>
+    <p><a href="<?= $escaper->escapeUrl($block->getUnsubscribeUrl()) ?>"><?= $escaper->escapeHtml(__('Unsubscribe from all stock alerts')) ?></a></p>
 <?php endif; ?>

--- a/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
+++ b/app/code/Magento/ProductAlert/view/frontend/templates/product/view.phtml
@@ -3,11 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\ProductAlert\Block\Product\View;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 ?>
-<?php /* @var $block \Magento\ProductAlert\Block\Product\View */?>
 <div class="product alert <?= $block->getHtmlClass() ?>">
-    <a href="<?= $block->escapeUrl($block->getSignupUrl()) ?>"
-       title="<?= $block->escapeHtml(__($block->getSignupLabel())) ?>" class="action alert">
-        <?= $block->escapeHtml(__($block->getSignupLabel())) ?>
+    <a href="<?= $escaper->escapeUrl($block->getSignupUrl()) ?>"
+       title="<?= $escaper->escapeHtml(__($block->getSignupLabel())) ?>" class="action alert">
+        <?= $escaper->escapeHtml(__($block->getSignupLabel())) ?>
     </a>
 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_ProductAlert` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37130: Chore: Product Alert - Replace Block Escaping with Escaper