### PR TITLE
Chore: Persistent - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Persistent/view/frontend/templates/remember_me.phtml
+++ b/app/code/Magento/Persistent/view/frontend/templates/remember_me.phtml
@@ -1,23 +1,26 @@
 <?php
-
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Persistent\Block\Form\Remember;
+
+/** @var Escaper $escaper */
+/** @var Remember $block */
 
 /**
  * Customer "Remember Me" template
  */
-
-/** @var \Magento\Persistent\Block\Form\Remember $block */
-
 ?>
 <div id="remember-me-box" class="field choice persistent">
     <?php $rememberMeId = 'remember_me' . $block->getRandomString(10); ?>
-    <input type="checkbox" name="persistent_remember_me" class="checkbox" id="<?= $block->escapeHtmlAttr($rememberMeId) ?>" <?php if ($block->isRememberMeChecked()) : ?> checked="checked" <?php endif; ?> title="<?= $block->escapeHtmlAttr(__('Remember Me')) ?>" />
-    <label for="<?= $block->escapeHtmlAttr($rememberMeId) ?>" class="label"><span><?= $block->escapeHtml(__('Remember Me')) ?></span></label>
+    <input type="checkbox" name="persistent_remember_me" class="checkbox" id="<?= $escaper->escapeHtmlAttr($rememberMeId) ?>" <?php if ($block->isRememberMeChecked()) : ?> checked="checked" <?php endif; ?> title="<?= $escaper->escapeHtmlAttr(__('Remember Me')) ?>" />
+    <label for="<?= $escaper->escapeHtmlAttr($rememberMeId) ?>" class="label"><span><?= $escaper->escapeHtml(__('Remember Me')) ?></span></label>
     <span class="tooltip wrapper">
-        <strong class="tooltip toggle"> <?= $block->escapeHtml(__('What\'s this?')) ?></strong>
-        <span class="tooltip content"> <?= $block->escapeHtml(__('Check &quot;Remember Me&quot; to access your shopping cart on this computer even if you are not signed in.')) ?></span>
+        <strong class="tooltip toggle"> <?= $escaper->escapeHtml(__('What\'s this?')) ?></strong>
+        <span class="tooltip content"> <?= $escaper->escapeHtml(__('Check &quot;Remember Me&quot; to access your shopping cart on this computer even if you are not signed in.')) ?></span>
     </span>
 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Persistent` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37129: Chore: Persistent - Replace Block Escaping with Escaper