### PR TITLE
Chore: Offline Payments - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/banktransfer.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/banktransfer.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Banktransfer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Banktransfer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Banktransfer $block */
 $instructions = $block->getInstructions();
 ?>
 <?php if ($instructions): ?>
-    <?php $methodCode = $block->escapeHtml($block->getMethodCode());?>
+    <?php $methodCode = $escaper->escapeHtml($block->getMethodCode());?>
     <ul class="form-list checkout-agreements" id="payment_form_<?= /* @noEscape */ $methodCode ?>">
         <li>
             <div class="<?= /* @noEscape */ $methodCode ?>-instructions-content checkout-agreement-item-content">
-                <?= /* @noEscape */ nl2br($block->escapeHtml($instructions)) ?>
+                <?= /* @noEscape */ nl2br($escaper->escapeHtml($instructions)) ?>
             </div>
         </li>
     </ul>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/cashondelivery.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/cashondelivery.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Cashondelivery
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Cashondelivery;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Cashondelivery $block */
 $instructions = $block->getInstructions();
 ?>
 <?php if ($instructions): ?>
-    <?php $methodCode = $block->escapeHtml($block->getMethodCode());?>
+    <?php $methodCode = $escaper->escapeHtml($block->getMethodCode());?>
     <ul class="form-list checkout-agreements" id="payment_form_<?= /* @noEscape */ $methodCode ?>">
         <li>
             <div class="<?= /* @noEscape */ $methodCode ?>-instructions-content checkout-agreement-item-content">
-                <?= /* @noEscape */ nl2br($block->escapeHtml($instructions)) ?>
+                <?= /* @noEscape */ nl2br($escaper->escapeHtml($instructions)) ?>
             </div>
         </li>
     </ul>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/checkmo.phtml
@@ -3,27 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Checkmo
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<fieldset class="admin__fieldset payment-method" id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>" >
+<fieldset class="admin__fieldset payment-method" id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>" >
     <?php if ($block->getMethod()->getPayableTo()): ?>
-        <label class="label"><span><?= $block->escapeHtml(__('Make Check payable to:')) ?></span></label>
-        <?= $block->escapeHtml($block->getMethod()->getPayableTo()) ?>
+        <label class="label"><span><?= $escaper->escapeHtml(__('Make Check payable to:')) ?></span></label>
+        <?= $escaper->escapeHtml($block->getMethod()->getPayableTo()) ?>
     <?php endif; ?>
     <?php if ($block->getMethod()->getMailingAddress()): ?>
         <div class="admin__field">
-            <label class="admin__field-label"><span><?= $block->escapeHtml(__('Send Check to:')) ?></span></label>
+            <label class="admin__field-label"><span><?= $escaper->escapeHtml(__('Send Check to:')) ?></span></label>
             <div class="admin__field-control checkmo-mailing-address">
-                <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMethod()->getMailingAddress())) ?>
+                <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMethod()->getMailingAddress())) ?>
             </div>
         </div>
     <?php endif; ?>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display:none",
-    'fieldset#payment_form_' . $block->escapeJs($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeJs($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/form/purchaseorder.phtml
@@ -3,20 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Purchaseorder
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var Purchaseorder $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<fieldset class="admin__fieldset payment-method" id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>">
+<fieldset class="admin__fieldset payment-method" id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>">
     <div class="admin__field _required">
         <label for="po_number" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Purchase Order Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Purchase Order Number')) ?></span>
         </label>
         <div class="admin__field-control">
             <input type="text" id="po_number" name="payment[po_number]"
-                   title="<?= $block->escapeHtml(__("Purchase Order Number")) ?>"
+                   title="<?= $escaper->escapeHtml(__("Purchase Order Number")) ?>"
                    class="required-entry admin__control-text"
                    value="<?= /* @noEscape */ $block->getInfoData('po_number') ?>"/>
         </div>
@@ -24,5 +28,5 @@
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display:none",
-    'fieldset#payment_form_' . $block->escapeJs($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeJs($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/checkmo.phtml
@@ -3,21 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
- */
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>
-<?= $block->escapeHtml($paymentTitle) ?>
+<?= $escaper->escapeHtml($paymentTitle) ?>
 <?php if ($block->getInfo()->getAdditionalInformation()) : ?>
     <?php if ($block->getPayableTo()) : ?>
-        <br /><?= $block->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
+        <br /><?= $escaper->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
     <?php endif; ?>
     <?php if ($block->getMailingAddress()) : ?>
-        <label><?= $block->escapeHtml(__('Send Check to:')) ?></label>
+        <label><?= $escaper->escapeHtml(__('Send Check to:')) ?></label>
         <div class="checkmo-mailing-address">
-            <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMailingAddress())) ?>
+            <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMailingAddress())) ?>
         </div>
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/checkmo.phtml
@@ -3,24 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
- */
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>
-<?= $block->escapeHtml($paymentTitle) ?>
+<?= $escaper->escapeHtml($paymentTitle) ?>
     {{pdf_row_separator}}
 <?php if ($block->getInfo()->getAdditionalInformation()) : ?>
     {{pdf_row_separator}}
     <?php if ($block->getPayableTo()) : ?>
-        <?= $block->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
+        <?= $escaper->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
         {{pdf_row_separator}}
     <?php endif; ?>
     <?php if ($block->getMailingAddress()) : ?>
-        <?= $block->escapeHtml(__('Send Check to:')) ?>
+        <?= $escaper->escapeHtml(__('Send Check to:')) ?>
         {{pdf_row_separator}}
-        <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMailingAddress())) ?>
+        <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMailingAddress())) ?>
         {{pdf_row_separator}}
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/pdf/purchaseorder.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var Purchaseorder $block */
 ?>
-<?= $block->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>
+<?= $escaper->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>
     {{pdf_row_separator}}

--- a/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/adminhtml/templates/info/purchaseorder.phtml
@@ -3,15 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var Purchaseorder $block */
 $paymentTitle = $block->getMethod()->getConfigData('title', $block->getInfo()->getOrder()->getStoreId());
 ?>
-<div class="order-payment-method-name"><?= $block->escapeHtml($paymentTitle) ?></div>
+<div class="order-payment-method-name"><?= $escaper->escapeHtml($paymentTitle) ?></div>
 <table class="data-table admin__table-secondary">
     <tr>
-        <th><?= $block->escapeHtml(__('Purchase Order Number')) ?>:</th>
-        <td><?= $block->escapeHtml($block->getInfo()->getPoNumber()) ?></td>
+        <th><?= $escaper->escapeHtml(__('Purchase Order Number')) ?>:</th>
+        <td><?= $escaper->escapeHtml($block->getInfo()->getPoNumber()) ?></td>
     </tr>
 </table>

--- a/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/checkmo.phtml
@@ -3,23 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
- */
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
 ?>
-<?= $block->escapeHtml($block->getMethod()->getTitle()) ?>
+<?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?>
     {{pdf_row_separator}}
 <?php if ($block->getInfo()->getAdditionalInformation()) : ?>
     {{pdf_row_separator}}
     <?php if ($block->getPayableTo()) : ?>
-        <?= $block->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
+        <?= $escaper->escapeHtml(__('Make Check payable to: %1', $block->getPayableTo())) ?>
         {{pdf_row_separator}}
     <?php endif; ?>
     <?php if ($block->getMailingAddress()) : ?>
-        <?= $block->escapeHtml(__('Send Check to:')) ?>
+        <?= $escaper->escapeHtml(__('Send Check to:')) ?>
         {{pdf_row_separator}}
-        <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMailingAddress())) ?>
+        <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMailingAddress())) ?>
         {{pdf_row_separator}}
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/base/templates/info/pdf/purchaseorder.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var Purchaseorder $block */
 ?>
-<?= $block->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>
+<?= $escaper->escapeHtml(__('Purchase Order Number: %1', $block->getInfo()->getPoNumber())) ?>
     {{pdf_row_separator}}

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/banktransfer.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/banktransfer.phtml
@@ -3,18 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Banktransfer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Banktransfer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Banktransfer $block */
 $instructions = $block->getInstructions();
 ?>
 <?php if ($instructions): ?>
-    <?php $methodCode = $block->escapeHtml($block->getMethodCode());?>
+    <?php $methodCode = $escaper->escapeHtml($block->getMethodCode());?>
     <div class="items <?= /* @noEscape */ $methodCode ?> instructions agreement checkout-agreement-item-content"
          id="payment_form_<?= /* @noEscape */ $methodCode ?>">
-        <?= /* @noEscape */ nl2br($block->escapeHtml($instructions)) ?>
+        <?= /* @noEscape */ nl2br($escaper->escapeHtml($instructions)) ?>
     </div>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "display:none",

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/cashondelivery.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/cashondelivery.phtml
@@ -3,18 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Cashondelivery
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Cashondelivery;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Cashondelivery $block */
 $instructions = $block->getInstructions();
 ?>
 <?php if ($instructions): ?>
-    <?php $methodCode = $block->escapeHtml($block->getMethodCode());?>
+    <?php $methodCode = $escaper->escapeHtml($block->getMethodCode());?>
     <div class="items <?= /* @noEscape */ $methodCode ?> instructions agreement"
          id="payment_form_<?= /* @noEscape */ $methodCode ?>">
-        <?= /* @noEscape */ nl2br($block->escapeHtml($instructions)) ?>
+        <?= /* @noEscape */ nl2br($escaper->escapeHtml($instructions)) ?>
     </div>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "display:none",

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/checkmo.phtml
@@ -3,29 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Checkmo
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->getMethod()->getMailingAddress() || $block->getMethod()->getPayableTo()): ?>
-    <dl class="items check payable" id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>">
+    <dl class="items check payable" id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>">
         <?php if ($block->getMethod()->getPayableTo()): ?>
-            <dt class="title"><?= $block->escapeHtml(__('Make Check payable to:')) ?></dt>
-            <dd class="content"><?= $block->escapeHtml($block->getMethod()->getPayableTo()) ?></dd>
+            <dt class="title"><?= $escaper->escapeHtml(__('Make Check payable to:')) ?></dt>
+            <dd class="content"><?= $escaper->escapeHtml($block->getMethod()->getPayableTo()) ?></dd>
         <?php endif; ?>
         <?php if ($block->getMethod()->getMailingAddress()): ?>
-            <dt class="title"><?= $block->escapeHtml(__('Send Check to:')) ?></dt>
+            <dt class="title"><?= $escaper->escapeHtml(__('Send Check to:')) ?></dt>
             <dd class="content">
                 <address class="checkmo mailing address">
-                    <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMethod()->getMailingAddress())) ?>
+                    <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMethod()->getMailingAddress())) ?>
                 </address>
             </dd>
         <?php endif; ?>
     </dl>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
         "display:none",
-        'dl#payment_form_' . $block->escapeJs($block->getMethodCode())
+        'dl#payment_form_' . $escaper->escapeJs($block->getMethodCode())
     ) ?>
 <?php endif; ?>

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/form/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/form/purchaseorder.phtml
@@ -3,22 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Form\Purchaseorder
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-$methodCode = $block->escapeHtml($block->getMethodCode());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\OfflinePayments\Block\Form\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Purchaseorder $block */
+$methodCode = $escaper->escapeHtml($block->getMethodCode());
 ?>
 <fieldset class="fieldset items <?= /* @noEscape */ $methodCode ?>"
           id="payment_form_<?= /* @noEscape */ $methodCode ?>">
     <div class="field number required">
-        <label for="po_number" class="label"><span><?= $block->escapeHtml(__('Purchase Order Number')) ?></span></label>
+        <label for="po_number" class="label"><span><?= $escaper->escapeHtml(__('Purchase Order Number')) ?></span></label>
         <div class="control">
             <input type="text" id="po_number" name="payment[po_number]"
-                   title="<?= $block->escapeHtml(__('Purchase Order Number')) ?>"
+                   title="<?= $escaper->escapeHtml(__('Purchase Order Number')) ?>"
                    class="input-text required-entry"
-                   value="<?= $block->escapeHtml($block->getInfoData('po_number')) ?>" />
+                   value="<?= $escaper->escapeHtml($block->getInfoData('po_number')) ?>" />
         </div>
     </div>
 </fieldset>

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/info/checkmo.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/info/checkmo.phtml
@@ -3,25 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Checkmo
- */
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Checkmo;
+
+/** @var Escaper $escaper */
+/** @var Checkmo $block */
 ?>
 <dl class="payment-method checkmemo">
-    <dt class="title"><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
+    <dt class="title"><?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?></dt>
     <?php if ($block->getInfo()->getAdditionalInformation()) : ?>
         <?php if ($block->getPayableTo()) : ?>
             <dd class="content">
-                <strong><?= $block->escapeHtml(__('Make Check payable to')) ?></strong>
-                <?= $block->escapeHtml($block->getPayableTo()) ?>
+                <strong><?= $escaper->escapeHtml(__('Make Check payable to')) ?></strong>
+                <?= $escaper->escapeHtml($block->getPayableTo()) ?>
             </dd>
         <?php endif; ?>
         <?php if ($block->getMailingAddress()) : ?>
             <dd class="content">
-                <strong><?= $block->escapeHtml(__('Send Check to')) ?></strong>
+                <strong><?= $escaper->escapeHtml(__('Send Check to')) ?></strong>
                 <address class="checkmo mailing address">
-                    <?= /* @noEscape */ nl2br($block->escapeHtml($block->getMailingAddress())) ?>
+                    <?= /* @noEscape */ nl2br($escaper->escapeHtml($block->getMailingAddress())) ?>
                 </address>
             </dd>
         <?php endif; ?>

--- a/app/code/Magento/OfflinePayments/view/frontend/templates/info/purchaseorder.phtml
+++ b/app/code/Magento/OfflinePayments/view/frontend/templates/info/purchaseorder.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var $block \Magento\OfflinePayments\Block\Info\Purchaseorder
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\OfflinePayments\Block\Info\Purchaseorder;
+
+/** @var Escaper $escaper */
+/** @var Purchaseorder $block */
 ?>
 <dl class="payment-method purchase order">
-    <dt class="title"><?= $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
+    <dt class="title"><?= $escaper->escapeHtml($block->getMethod()->getTitle()) ?></dt>
     <dd class="content">
-        <strong><?= $block->escapeHtml(__('Purchase Order Number')) ?></strong>
-        <span class="number"><?= $block->escapeHtml($block->getInfo()->getPoNumber()) ?></span>
+        <strong><?= $escaper->escapeHtml(__('Purchase Order Number')) ?></strong>
+        <span class="number"><?= $escaper->escapeHtml($block->getInfo()->getPoNumber()) ?></span>
     </dd>
 </dl>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_OfflinePayments` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37127: Chore: Offline Payments - Replace Block Escaping with Escaper