### PR TITLE
Chore: Newsletter - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Page $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Page;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Page $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="preview" class="cms-revision-preview">
     <div class="toolbar">
@@ -20,7 +26,7 @@
         id="preview_iframe"
         class="preview_iframe"
         frameborder="0"
-        title="<?= $block->escapeHtmlAttr(__('Preview')) ?>"
+        title="<?= $escaper->escapeHtmlAttr(__('Preview')) ?>"
         width="100%"
         sandbox="allow-forms allow-pointer-lock allow-same-origin"
     >

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/preview/store.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/preview/store.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php if ($websites = $block->getWebsites()): ?>
 <div class="field field-store-switcher">
-    <label class="label" for="store_switcher"><?= $block->escapeHtml(__('Choose Store View:')) ?></label>
+    <label class="label" for="store_switcher"><?= $escaper->escapeHtml(__('Choose Store View:')) ?></label>
     <div class="control">
         <select
             id="store_switcher"
@@ -22,15 +27,15 @@
                     <?php foreach ($block->getStores($group) as $store): ?>
                         <?php if ($showWebsite == false): ?>
                             <?php $showWebsite = true; ?>
-                            <optgroup label="<?= $block->escapeHtmlAttr($website->getName()) ?>"></optgroup>
+                            <optgroup label="<?= $escaper->escapeHtmlAttr($website->getName()) ?>"></optgroup>
                         <?php endif; ?>
                         <?php if ($showGroup == false): ?>
                             <?php $showGroup = true; ?>
-                            <optgroup label="&nbsp;&nbsp;&nbsp;<?= $block->escapeHtmlAttr($group->getName()) ?>">
+                            <optgroup label="&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtmlAttr($group->getName()) ?>">
                         <?php endif; ?>
-                        <option value="<?= $block->escapeHtmlAttr($store->getId()) ?>"
+                        <option value="<?= $escaper->escapeHtmlAttr($store->getId()) ?>"
                             <?php if ($block->getStoreId() == $store->getId()): ?> selected="selected"<?php endif; ?>>
-                            &nbsp;&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($store->getName()) ?>
+                            &nbsp;&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($store->getName()) ?>
                         </option>
                     <?php endforeach; ?>
                     <?php if ($showGroup): ?>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/edit.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Queue\Edit */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Newsletter\Block\Adminhtml\Queue\Edit;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
@@ -19,11 +25,11 @@
     <?php endif ?>
 </div>
 
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="queue_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="queue_edit_form">
     <?= $block->getBlockHtml('formkey') ?>
     <?= $block->getChildHtml('form') ?>
 </form>
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_queue_preview_form"
       target="_blank">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="no-display">

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/queue/preview.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/queue/preview.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Newsletter Message Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Newsletter Message Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/subscriber/list.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/subscriber/list.phtml
@@ -3,22 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Newsletter\Block\Adminhtml\Subscriber $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Newsletter\Block\Adminhtml\Subscriber;
+
+/** @var Escaper $escaper */
+/** @var Subscriber $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getChildHtml('grid') ?>
 <?php if (count($block->getQueueAsOptions())>0 && $block->getShowQueueAdd()): ?>
 <div class="form-buttons">
     <select id="queueList" name="queue">
     <?php foreach ($block->getQueueAsOptions() as $_queue): ?>
-        <option value="<?= $block->escapeHtmlAttr($_queue['value']) ?>">
-            <?= $block->escapeHtml($_queue['label']) ?> #<?= $block->escapeHtml($_queue['value']) ?>
+        <option value="<?= $escaper->escapeHtmlAttr($_queue['value']) ?>">
+            <?= $escaper->escapeHtml($_queue['label']) ?> #<?= $escaper->escapeHtml($_queue['value']) ?>
         </option>
     <?php endforeach; ?>
     </select>
     <button type="button" class="scalable" id="addToQueue">
-        <span><span><span><?= $block->escapeHtml(__('Add to Queue')) ?></span></span></span>
+        <span><span><span><?= $escaper->escapeHtml(__('Add to Queue')) ?></span></span></span>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/template/edit.phtml
@@ -3,30 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
 use Magento\Framework\App\TemplateTypesInterface;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Newsletter\Block\Adminhtml\Template\Edit;
 
-/* @var $block \Magento\Newsletter\Block\Adminhtml\Template\Edit */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="newsletter_template_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="newsletter_template_edit_form">
     <?= $block->getBlockHtml('formkey') ?>
     <div class="no-display">
         <input type="hidden" id="change_flag_element" name="_change_type_flag" value="" />
         <input type="hidden" id="save_as_flag" name="_save_as_flag"
-               value="<?= $block->escapeHtmlAttr($block->getSaveAsFlag()) ?>" />
+               value="<?= $escaper->escapeHtmlAttr($block->getSaveAsFlag()) ?>" />
     </div>
     <?= /* @noEscape */ $block->getForm() ?>
 </form>
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_template_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="newsletter_template_preview_form"
       target="_blank">
     <div class="no-display">
         <input type="hidden" id="preview_type" name="type" value="<?= /* @noEscape */ $block->isTextType() ? 1 : 2 ?>"/>
         <input type="hidden" id="preview_text" name="text" value="" />
         <input type="hidden" id="preview_styles" name="styles" value="" />
         <input type="hidden" id="preview_id" name="id" value="" />
-        <input type="hidden" name="form_key" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" >
+        <input type="hidden" name="form_key" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" >
     </div>
 </form>
 <?php $scriptString = <<<script
@@ -94,7 +98,7 @@ require([
             var self = this;
 
             confirm({
-                content: "{$block->escapeJs(__('Are you sure that you want to strip all tags?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure that you want to strip all tags?'))}",
                 actions: {
                     confirm: function () {
                         if (wysiwyg.activeEditor()) {
@@ -145,8 +149,8 @@ require([
 
             if (\$F('code').blank() || \$F('code') == templateControl.templateName) {
                 prompt({
-                    content: '{$block->escapeJs(__('Please enter a new template name.'))}',
-                    value: templateControl.templateName + '{$block->escapeJs(__(' Copy'))}',
+                    content: '{$escaper->escapeJs(__('Please enter a new template name.'))}',
+                    value: templateControl.templateName + '{$escaper->escapeJs(__(' Copy'))}',
                     actions: {
                         confirm: function (value) {
                             $('code').value = value;
@@ -177,9 +181,9 @@ require([
 
         preview: function () {
             if (this.typeChange) {
-                $('preview_type').value = {$block->escapeJs(TemplateTypesInterface::TYPE_TEXT)};
+                $('preview_type').value = {$escaper->escapeJs(TemplateTypesInterface::TYPE_TEXT)};
             } else {
-                $('preview_type').value = {$block->escapeJs($block->getTemplateType())};
+                $('preview_type').value = {$escaper->escapeJs($block->getTemplateType())};
             }
 
             if (wysiwyg.activeEditor()) {
@@ -203,10 +207,10 @@ require([
 
         deleteTemplate: function () {
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to delete this template?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to delete this template?'))}",
                 actions: {
                     confirm: function () {
-                        window.location.href = '{$block->escapeJs($block->getDeleteUrl())}';
+                        window.location.href = '{$escaper->escapeJs($block->getDeleteUrl())}';
                     }
                 }
             });
@@ -214,7 +218,7 @@ require([
     };
 
     templateControl.init();
-    templateControl.templateName = "{$block->escapeJs($block->getJsTemplateName())}";
+    templateControl.templateName = "{$escaper->escapeJs($block->getJsTemplateName())}";
 //]]>
 
 });

--- a/app/code/Magento/Newsletter/view/adminhtml/templates/template/preview.phtml
+++ b/app/code/Magento/Newsletter/view/adminhtml/templates/template/preview.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Newsletter Message Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Newsletter Message Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>

--- a/app/code/Magento/Newsletter/view/frontend/templates/messages/localizedSubscriptionErrorMessage.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/messages/localizedSubscriptionErrorMessage.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
-<?= $block->escapeHtml(__($block->getData('message')), ['a']); ?>
+<?= $escaper->escapeHtml(__($block->getData('message')), ['a']); ?>

--- a/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
+++ b/app/code/Magento/Newsletter/view/frontend/templates/subscribe.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Newsletter\Block\Subscribe $block */
+use Magento\Framework\Escaper;
+use Magento\Newsletter\Block\Subscribe;
+
+/** @var Escaper $escaper */
+/** @var Subscribe $block */
 ?>
 <div class="block newsletter">
-    <div class="title"><strong><?= $block->escapeHtml(__('Newsletter')) ?></strong></div>
+    <div class="title"><strong><?= $escaper->escapeHtml(__('Newsletter')) ?></strong></div>
     <div class="content">
         <form class="form subscribe"
             novalidate
-            action="<?= $block->escapeUrl($block->getFormActionUrl()) ?>"
+            action="<?= $escaper->escapeUrl($block->getFormActionUrl()) ?>"
             method="post"
             data-mage-init='{"validation": {"errorClass": "mage-error"}}'
             id="newsletter-validate-detail">
@@ -19,10 +24,10 @@
                 <div class="control">
                     <label for="newsletter">
                         <span class="label">
-                            <?= $block->escapeHtml(__('Sign Up for Our Newsletter:')) ?>
+                            <?= $escaper->escapeHtml(__('Sign Up for Our Newsletter:')) ?>
                         </span>
                         <input name="email" type="email" id="newsletter"
-                               placeholder="<?= $block->escapeHtml(__('Enter your email address')) ?>"
+                               placeholder="<?= $escaper->escapeHtml(__('Enter your email address')) ?>"
                                data-mage-init='{"mage/trim-input":{}}'
                                data-validate="{required:true, 'validate-email':true}"
                         />
@@ -31,13 +36,13 @@
             </div>
             <div class="actions">
                 <button class="action subscribe primary"
-                        title="<?= $block->escapeHtmlAttr(__('Subscribe')) ?>"
+                        title="<?= $escaper->escapeHtmlAttr(__('Subscribe')) ?>"
                         type="submit"
                         aria-label="Subscribe"
                     <?php if ($block->getButtonLockManager()->isDisabled('newsletter_form_submit')): ?>
                         disabled="disabled"
                     <?php endif; ?>>
-                    <span><?= $block->escapeHtml(__('Subscribe')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Subscribe')) ?></span>
                 </button>
             </div>
         </form>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Newsletter` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37126: Chore: Newsletter - Replace Block Escaping with Escaper