### PR TITLE
Chore: MSRP - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
+++ b/app/code/Magento/Msrp/view/base/templates/product/price/msrp.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Msrp\Pricing\Render\PriceBox;
 
 /**
  * Template for displaying product price at product view page, gift registry and wish-list
  *
- * @var $block \Magento\Msrp\Pricing\Render\PriceBox
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var PriceBox $block
+ * @var SecureHtmlRenderer $secureRenderer
+ * @var Escaper $escaper
  */
 ?>
 <?php
@@ -65,7 +71,7 @@ $priceElementIdPrefix = $block->getPriceElementIdPrefix() ? $block->getPriceElem
     $data = [
         'origin'=> 'msrp',
         'popupId' => '#' . $popupId,
-        'productName' => $block->escapeJs($block->escapeHtml($product->getName())),
+        'productName' => $escaper->escapeJs($escaper->escapeHtml($product->getName())),
         'productId' => $productId,
         'productIdInput' => 'input[type="hidden"][name="product"]',
         'realPrice' => $block->getRealPriceHtml(),
@@ -86,14 +92,14 @@ $priceElementIdPrefix = $block->getPriceElementIdPrefix() ? $block->getPriceElem
         );
     }
     ?>
-    <?php $priceId = $block->escapeHtmlAttr($block->getPriceId() ? $block->getPriceId() : $priceElementId); ?>
+    <?php $priceId = $escaper->escapeHtmlAttr($block->getPriceId() ? $block->getPriceId() : $priceElementId); ?>
     <span id="s_<?= /* @noEscape*/ $priceId ?>"></span>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display:none", 'span#s_' . $priceId) ?>
     <a href="#"
        id="<?= /* @noEscape */ ($popupId) ?>"
        class="action map-show-info"
        data-mage-init='{"addToCart":<?= /* @noEscape */ $block->jsonEncode($data) ?>}'>
-        <?= $block->escapeHtml(__('Click for price')) ?>
+        <?= $escaper->escapeHtml(__('Click for price')) ?>
     </a>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
@@ -102,7 +108,7 @@ $priceElementIdPrefix = $block->getPriceElementIdPrefix() ? $block->getPriceElem
     ) ?>
 <?php else: ?>
     <span class="msrp-message">
-     <?= $block->escapeHtml($priceType->getMsrpPriceMessage()) ?>
+     <?= $escaper->escapeHtml($priceType->getMsrpPriceMessage()) ?>
     </span>
 <?php endif; ?>
 
@@ -113,9 +119,9 @@ $priceElementIdPrefix = $block->getPriceElementIdPrefix() ? $block->getPriceElem
        class="action map-show-info"
        data-mage-init='{"addToCart":{"origin": "info",
                                      "helpLinkId": "#<?= /* @noEscape */ $helpLinkId ?>",
-                                     "productName": "<?= $block->escapeJs($product->getName()) ?>",
+                                     "productName": "<?= $escaper->escapeJs($product->getName()) ?>",
                                      "closeButtonId": "#map-popup-close"}}'>
-        <span><?= $block->escapeHtml(__("What's this?")) ?></span>
+        <span><?= $escaper->escapeHtml(__("What's this?")) ?></span>
     </a>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',

--- a/app/code/Magento/Msrp/view/frontend/templates/cart/subtotal.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/cart/subtotal.phtml
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="subtotal">
     <span class="mark msrp">
-        <?= $block->escapeHtml(__('Order total will be displayed before you submit the order')) ?>
+        <?= $escaper->escapeHtml(__('Order total will be displayed before you submit the order')) ?>
     </span>
 </div>

--- a/app/code/Magento/Msrp/view/frontend/templates/cart/totals.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/cart/totals.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="cart-totals">
-    <div class="msrp totals"><?= $block->escapeHtml(__('You will see the order total before you submit the order.')) ?></div>
+    <div class="msrp totals"><?= $escaper->escapeHtml(__('You will see the order total before you submit the order.')) ?></div>
 </div>

--- a/app/code/Magento/Msrp/view/frontend/templates/popup.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/popup.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Msrp\Block\Popup $block */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Msrp\Block\Popup;
+
+/** @var Escaper $escaper */
+/** @var Popup $block */
 ?>
 <?php if ($block->isEnabled()) : ?>
     <script data-role="msrp-popup-template" type="text/x-magento-template">
@@ -17,22 +21,22 @@
             <div class="map-info-price" id="map-popup-content">
                 <div class="price-box">
                     <div class="map-msrp" id="map-popup-msrp-box">
-                        <span class="label"><?= $block->escapeHtml(__('Price')) ?></span>
+                        <span class="label"><?= $escaper->escapeHtml(__('Price')) ?></span>
                         <span class="old-price map-old-price" id="map-popup-msrp">
                             <span class="price"></span>
                         </span>
                     </div>
                     <div class="map-price" id="map-popup-price-box">
-                        <span class="label"><?= $block->escapeHtml(__('Actual Price')) ?></span>
+                        <span class="label"><?= $escaper->escapeHtml(__('Actual Price')) ?></span>
                         <span id="map-popup-price" class="actual-price"></span>
                     </div>
                 </div>
                 <form action="" method="POST" class="map-form-addtocart">
                     <input type="hidden" name="product" class="product_id" value="" />
                     <button type="button"
-                            title="<?= $block->escapeHtml(__('Add to Cart')) ?>"
+                            title="<?= $escaper->escapeHtml(__('Add to Cart')) ?>"
                             class="action tocart primary">
-                        <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                     </button>
                     <div class="additional-addtocart-box">
                         <?= $block->getChildHtml() ?>

--- a/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_item.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_item.phtml
@@ -3,17 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
+use Magento\Catalog\Block\Product\Price;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
 /**
  * Template for displaying product price at product view page, gift registry and wishlist
  *
- * @var $block \Magento\Catalog\Block\Product\Price
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var Price $block
+ * @var SecureHtmlRenderer $secureRenderer
+ * @var Escaper $escaper
  */
 ?>
-
 <?php
     //phpcs:disable
     /** @var $pricingHelper \Magento\Framework\Pricing\Helper\Data */
@@ -41,13 +44,13 @@
         <a href="#"
            id="<?= /* @noEscape */ ($popupId) ?>"
            data-mage-init='{"addToCart":{"popupId": "#<?= /* @noEscape */ ($popupId) ?>",
-                                         "productName": "<?= /* @noEscape */ $block->escapeJs($_product->getName()) ?>",
+                                         "productName": "<?= /* @noEscape */ $escaper->escapeJs($_product->getName()) ?>",
                                          "realPrice": <?= /* @noEscape */ $block->getRealPriceJs($_product) ?>,
                                          "msrpPrice": "<?= /* @noEscape */ $_msrpPrice ?>",
                                          "priceElementId":"<?= /* @noEscape */ $priceElementId ?>",
                                          "popupCartButtonId": "#map-popup-button",
                                          "cartForm": "#wishlist-view-form"}}'>
-            <?= $block->escapeHtml(__('Click for price')) ?>
+            <?= $escaper->escapeHtml(__('Click for price')) ?>
         </a>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
@@ -56,15 +59,15 @@
         ) ?>
     <?php else: ?>
         <span class="msrp-message">
-            <?= $block->escapeHtml($_catalogHelper->getMsrpPriceMessage($_product)) ?>
+            <?= $escaper->escapeHtml($_catalogHelper->getMsrpPriceMessage($_product)) ?>
         </span>
     <?php endif; ?>
     <?php $helpLinkId = 'msrp-help-' . $_id . $block->getRandomString(20); ?>
     <a href="#" id="<?= /* @noEscape */ ($helpLinkId) ?>"
        data-mage-init='{"addToCart":{"helpLinkId": "#<?= /* @noEscape */ ($helpLinkId) ?>",
-                                     "productName": "<?= /* @noEscape */$block->escapeJs($_product->getName()) ?>"}}'
+                                     "productName": "<?= /* @noEscape */$escaper->escapeJs($_product->getName()) ?>"}}'
        class="link tip">
-        <?= $block->escapeHtml(__("What's this?")) ?>
+        <?= $escaper->escapeHtml(__("What's this?")) ?>
     </a>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',

--- a/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_rss.phtml
+++ b/app/code/Magento/Msrp/view/frontend/templates/render/item/price_msrp_rss.phtml
@@ -3,20 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * Template for displaying wishlist item price at rss feeds pages
- *
- * @var $block \Magento\Catalog\Block\Product\Price
- */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Price;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Price $block */
 ?>
 <div class="price-box msrp">
     <?php //phpcs:disable ?>
     <?php if ($this->helper(\Magento\Msrp\Helper\Data::class)->canApplyMsrp($block->getProduct())) : ?>
     <?php //phpcs:enable ?>
-        <a href="<?= $block->escapeUrl($block->getProduct()->getProductUrl()) ?>">
-            <?= $block->escapeHtml(__('Click for price')) ?>
+        <a href="<?= $escaper->escapeUrl($block->getProduct()->getProductUrl()) ?>">
+            <?= $escaper->escapeHtml(__('Click for price')) ?>
         </a>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Msrp` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37125: Chore: MSRP - Replace Block Escaping with Escaper