### PR TITLE
Chore: Media Storage - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/MediaStorage/view/adminhtml/templates/system/config/system/storage/media/synchronize.phtml
+++ b/app/code/Magento/MediaStorage/view/adminhtml/templates/system/config/system/storage/media/synchronize.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\MediaStorage\Block\System\Config\System\Storage\Media\Synchronize;
+
+/** @var Escaper $escaper */
+/** @var Synchronize $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php
@@ -39,8 +43,8 @@ require([
         $('system_media_storage_configuration_media_database').value
     );
 
-    addAllowedStorage({$block->escapeJs($syncStorageParams['storage_type'])},
-     '{$block->escapeJs($syncStorageParams['connection_name'])}');
+    addAllowedStorage({$escaper->escapeJs($syncStorageParams['storage_type'])},
+     '{$escaper->escapeJs($syncStorageParams['connection_name'])}');
 
     defaultValues   = [];
     defaultValues['system_media_storage_configuration_media_storage']   =
@@ -100,7 +104,7 @@ require([
     }
 
     var checkStatus = function() {
-        u = new Ajax.PeriodicalUpdater('', '{$block->escapeJs($block->getAjaxStatusUpdateUrl())}', {
+        u = new Ajax.PeriodicalUpdater('', '{$escaper->escapeJs($block->getAjaxStatusUpdateUrl())}', {
             method:     'get',
             frequency:  5,
             loaderArea: false,
@@ -162,7 +166,7 @@ require([
             connection: $('system_media_storage_configuration_media_database').value
         };
 
-        new Ajax.Request('{$block->escapeJs($block->getAjaxSyncUrl())}', {
+        new Ajax.Request('{$escaper->escapeJs($block->getAjaxSyncUrl())}', {
             parameters:     params,
             loaderArea:     false,
             asynchronous:   true
@@ -188,7 +192,7 @@ script;
 
 <?= $block->getButtonHtml() ?>
 <span class="sync-indicator no-display" id="sync_span">
-    <img alt="Synchronize" src="<?= $block->escapeUrl($block->getViewFileUrl('images/process_spinner.gif')) ?>"/>
+    <img alt="Synchronize" src="<?= $escaper->escapeUrl($block->getViewFileUrl('images/process_spinner.gif')) ?>"/>
     <span id="sync_message_span"></span>
 </span>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("margin:0 5px", '#sync_span img') ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_MediaStorage` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37124: Chore: Media Storage - Replace Block Escaping with Escaper