### PR TITLE
Chore: Layered Navigation - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/state.phtml
@@ -3,44 +3,44 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\LayeredNavigation\Block\Navigation\State;
+
+/** @var Escaper $escaper */
+/** @var State $block */
+$_filters = $block->getActiveFilters();
 ?>
-<?php
-/**
- * Category layered navigation state
- *
- * @var $block \Magento\LayeredNavigation\Block\Navigation\State
- */
-?>
-<?php $_filters = $block->getActiveFilters() ?>
 <?php if (!empty($_filters)) : ?>
 <div class="filter-current">
     <strong class="block-subtitle filter-current-subtitle"
             role="heading"
             aria-level="2"
-            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $block->escapeHtml(__('Now Shopping by')) ?></strong>
+            data-count="<?= /* @noEscape */ count($_filters) ?>"><?= $escaper->escapeHtml(__('Now Shopping by')) ?></strong>
     <ol class="items">
         <?php foreach ($_filters as $_filter) : ?>
             <li class="item">
-                <span class="filter-label"><?= $block->escapeHtml(__($_filter->getName())) ?></span>
-                <span class="filter-value"><?= $block->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
+                <span class="filter-label"><?= $escaper->escapeHtml(__($_filter->getName())) ?></span>
+                <span class="filter-value"><?= $escaper->escapeHtml($block->stripTags($_filter->getLabel())) ?></span>
                 <?php
                 $clearLinkUrl = $_filter->getClearLinkUrl();
-                $currentFilterName = $block->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
+                $currentFilterName = $escaper->escapeHtmlAttr(__($_filter->getName()) . " " . $block->stripTags($_filter->getLabel()));
                 if ($clearLinkUrl) :
                     ?>
-                    <a class="action previous" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Previous')) ?>">
-                        <span><?= $block->escapeHtml(__('Previous')) ?></span>
+                    <a class="action previous" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Previous')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Previous')) ?></span>
                     </a>
                     <a class="action remove"
-                       title="<?= $block->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
-                       href="<?= $block->escapeUrl($clearLinkUrl) ?>">
-                        <span><?= $block->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
+                       title="<?= $escaper->escapeHtmlAttr($_filter->getFilter()->getClearLinkText()) ?>"
+                       href="<?= $escaper->escapeUrl($clearLinkUrl) ?>">
+                        <span><?= $escaper->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></span>
                     </a>
                 <?php else : ?>
-                    <a class="action remove" href="<?= $block->escapeUrl($_filter->getRemoveUrl()) ?>"
-                       title="<?= /* @noEscape */ $block->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
-                        <span><?= $block->escapeHtml(__('Remove This Item')) ?></span>
+                    <a class="action remove" href="<?= $escaper->escapeUrl($_filter->getRemoveUrl()) ?>"
+                       title="<?= /* @noEscape */ $escaper->escapeHtmlAttr(__('Remove')) . " " . $currentFilterName ?>">
+                        <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                     </a>
                 <?php endif; ?>
             </li>

--- a/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
+++ b/app/code/Magento/LayeredNavigation/view/frontend/templates/layer/view.phtml
@@ -3,19 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * Category layered navigation
- *
- * @var $block \Magento\LayeredNavigation\Block\Navigation
- */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\LayeredNavigation\Block\Navigation;
+
+/** @var Escaper $escaper */
+/** @var Navigation $block */
+?>
 <?php if ($block->canShowBlock()) : ?>
     <div class="block filter">
         <div class="block-title filter-title">
-            <strong><?= $block->escapeHtml(__('Shop By')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Shop By')) ?></strong>
         </div>
 
         <div class="block-content filter-content">
@@ -23,18 +22,18 @@
 
             <?php if ($block->getLayer()->getState()->getFilters()) : ?>
                 <div class="block-actions filter-actions">
-                    <a href="<?= $block->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear"><span><?= $block->escapeHtml(__('Clear All')) ?></span></a>
+                    <a href="<?= $escaper->escapeUrl($block->getClearUrl()) ?>" class="action clear filter-clear"><span><?= $escaper->escapeHtml(__('Clear All')) ?></span></a>
                 </div>
             <?php endif; ?>
             <?php $wrapOptions = false; ?>
             <?php foreach ($block->getFilters() as $filter) : ?>
                 <?php if (!$wrapOptions) : ?>
-                    <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $block->escapeHtml(__('Shopping Options')) ?></strong>
+                    <strong role="heading" aria-level="2" class="block-subtitle filter-subtitle"><?= $escaper->escapeHtml(__('Shopping Options')) ?></strong>
                     <dl class="filter-options" id="narrow-by-list">
                     <?php $wrapOptions = true;
                 endif; ?>
                     <?php if ($filter->getItemsCount()) : ?>
-                        <dt role="heading" aria-level="3" class="filter-options-title"><?= $block->escapeHtml(__($filter->getName())) ?></dt>
+                        <dt role="heading" aria-level="3" class="filter-options-title"><?= $escaper->escapeHtml(__($filter->getName())) ?></dt>
                         <dd class="filter-options-content"><?= /* @noEscape */ $block->getChildBlock('renderer')->render($filter) ?></dd>
                     <?php endif; ?>
             <?php endforeach; ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_LayeredNavigation` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37122: Chore: Layered Navigation - Replace Block Escaping with Escaper