### PR TITLE
Chore: Integration - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions.phtml
@@ -7,8 +7,13 @@
  *
  * @var \Magento\Backend\Block\Widget\Form\Container $block
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<div><p><?= $block->escapeHtml(__('The integration you selected asks you to approve access to the following:')) ?></p></div>
+<div><p><?= $escaper->escapeHtml(__('The integration you selected asks you to approve access to the following:')) ?></p></div>
 <div id="integration-activate-permissions-tabs">
     <?= $block->getChildHtml('tabs') ?>
 </div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions/tab/webapi.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/activate/permissions/tab/webapi.phtml
@@ -6,13 +6,19 @@
 /**
  * API permissions tab template for integration activation dialog.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Integration\Block\Adminhtml\Integration\Activate\Permissions\Tab\Webapi $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Integration\Block\Adminhtml\Integration\Activate\Permissions\Tab\Webapi;
+
+/** @var Escaper $escaper */
+/** @var Webapi $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset class="admin__fieldset form-inline entry-edit">
     <?php if ($block->isTreeEmpty()): ?>
-        <p class="empty"><?= $block->escapeHtml(__('No permissions requested')) ?></p>
+        <p class="empty"><?= $escaper->escapeHtml(__('No permissions requested')) ?></p>
     <?php else: ?>
         <div class="field" data-role="tree-resources-container">
             <div class="control">

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/popup_container.phtml
@@ -5,14 +5,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  *
- * @var \Magento\Backend\Block\Template $block
+ * @var Template $block
  */
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Template $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Backend\Block\Template;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php $scriptString = <<<script
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
     require([
         "jquery",
         'Magento_Ui/js/modal/confirm',
@@ -22,30 +27,30 @@
     ], function ($, Confirm) {
 
         window.integration = new Integration(
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/permissionsDialog',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/tokensDialog',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/tokensExchange',
                     ['id' => ':id', 'reauthorize' => ':isReauthorize', '_escape_params' => false]
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*'
                 )
             )}',
-            '{$block->escapeJs(
+            '{$escaper->escapeJs(
                 $block->getUrl(
                     '*/*/loginSuccessCallback'
                 )
@@ -59,8 +64,8 @@
             $('div#integrationGrid').on('click', 'button#delete', function (e) {
 
                 new Confirm({
-                    title: '{$block->escapeJs(__('Are you sure?'))}',
-                    content: "{$block->escapeJs(__("Are you sure you want to delete this integration? " .
+                    title: '{$escaper->escapeJs(__('Are you sure?'))}',
+                    content: "{$escaper->escapeJs(__("Are you sure you want to delete this integration? " .
                                                      "You can't undo this action."))}",
                     actions: {
                         confirm: function () {

--- a/app/code/Magento/Integration/view/adminhtml/templates/integration/tokens_exchange.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/integration/tokens_exchange.phtml
@@ -7,5 +7,10 @@
  *
  * @var \Magento\Backend\Block\Template $block
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<div><p><?= $block->escapeHtml(__("Please setup or sign in into your 3rd party account to complete setup of this integration.")) ?></p></div>
+<div><p><?= $escaper->escapeHtml(__("Please setup or sign in into your 3rd party account to complete setup of this integration.")) ?></p></div>

--- a/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
+++ b/app/code/Magento/Integration/view/adminhtml/templates/resourcetree.phtml
@@ -3,28 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Integration\Block\Adminhtml\Integration\Edit\Tab\Webapi;
+
+/** @var Escaper $escaper */
+/** @var Webapi $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?= $block->getChildHtml() ?>
 
 <fieldset class="fieldset form-inline entry-edit">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Available APIs')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Available APIs')) ?></span>
     </legend><br />
 
     <div class="field">
-        <label class="label" for="all_resources"><span><?= $block->escapeHtml(__('Resource Access')) ?></span></label>
+        <label class="label" for="all_resources"><span><?= $escaper->escapeHtml(__('Resource Access')) ?></span></label>
 
         <div class="control">
             <select id="all_resources" name="all_resources" class="select">
                 <option value="0" <?= ($block->isEverythingAllowed() ? '' : 'selected="selected"') ?>>
-                    <?= $block->escapeHtml(__('Custom')) ?>
+                    <?= $escaper->escapeHtml(__('Custom')) ?>
                 </option>
                 <option value="1" <?= ($block->isEverythingAllowed() ? 'selected="selected"' : '') ?>>
-                    <?= $block->escapeHtml(__('All')) ?>
+                    <?= $escaper->escapeHtml(__('All')) ?>
                 </option>
             </select>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
@@ -40,11 +46,11 @@
             no-display
         <?php endif ?>"
          data-role="tree-resources-container">
-        <label class="label"><span><?= $block->escapeHtml(__('Resources')) ?></span></label>
+        <label class="label"><span><?= $escaper->escapeHtml(__('Resources')) ?></span></label>
 
         <div class="control">
             <div class="tree x-tree" data-role="resource-tree" data-mage-init='<?=
-                $block->escapeHtmlAttr($block->getJsonSerializer()->serialize([
+                $escaper->escapeHtmlAttr($block->getJsonSerializer()->serialize([
                     'rolesTree' => [
                         "treeInitData" => $block->getTree(),
                         'editFormSelector' => '#edit_form'


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Integration` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37121: Chore: Integration - Replace Block Escaping with Escaper