### PR TITLE
Chore: Import Export - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/ImportExport/view/adminhtml/templates/busy.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/busy.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="fieldset">
     <div class="legend">
-        <span><?= $block->escapeHtml(__('Status')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Status')) ?></span>
     </div><br>
     <div class="messages">
         <div class="message message-success success">
-            <div><?= $block->escapeHtml($block->getStatusMessage()) ?></div>
+            <div><?= $escaper->escapeHtml($block->getStatusMessage()) ?></div>
         </div>
     </div>
 </div>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/after.phtml
@@ -3,21 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\ImportExport\Block\Adminhtml\Form\After $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\ImportExport\Block\Adminhtml\Form\After;
+
+/** @var Escaper $escaper */
+/** @var After $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset class="admin__fieldset" id="export_filter_container">
     <legend class="admin__legend">
-        <span><?= $block->escapeHtml(__('Entity Attributes')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Entity Attributes')) ?></span>
     </legend>
     <br />
-    <form id="export_filter_form" action="<?= $block->escapeUrl($block->getUrl('*/*/export')) ?>" method="post">
+    <form id="export_filter_form" action="<?= $escaper->escapeUrl($block->getUrl('*/*/export')) ?>" method="post">
         <input name="form_key" type="hidden" value="<?= /* @noEscape */ $block->getFormKey() ?>" />
         <div id="export_filter_grid_container"><!-- --></div>
     </form>
     <button class="action- scalable" type="button">
-        <span><?= $block->escapeHtml(__('Continue')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Continue')) ?></span>
     </button>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("display:none;", 'fieldset#export_filter_container') ?>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/export/form/before.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Template $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Backend\Block\Template;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php $scriptString = <<<script
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
 require([
     'Magento_Ui/js/modal/alert',
     'prototype'
@@ -48,7 +53,7 @@ require([
          */
         getFilter: function() {
             if ($('entity') && \$F('entity')) {
-                var url    = "{$block->escapeJs($block->getUrl('*/*/getFilter'))}";
+                var url    = "{$escaper->escapeJs($block->getUrl('*/*/getFilter'))}";
                 var entity = \$F('entity');
                 if (entity != this.previousGridEntity) {
                     this.previousGridEntity = entity;
@@ -93,7 +98,7 @@ require([
             form.action   = oldAction;
         } else {
             alert({
-                content: '{$block->escapeHtml(__('Invalid data'))}'
+                content: '{$escaper->escapeHtml(__('Invalid data'))}'
             });
         }
     };

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/after.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\ImportExport\Block\Adminhtml\Form\After $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\ImportExport\Block\Adminhtml\Form\After;
+
+/** @var Escaper $escaper */
+/** @var After $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div class="entry-edit fieldset" id="import_validation_container">
     <div class="entry-edit-head legend">
         <span class="icon-head head-edit-form fieldset-legend"
-            id="import_validation_container_header"><?= $block->escapeHtml(__('Validation Results')) ?></span>
+            id="import_validation_container_header"><?= $escaper->escapeHtml(__('Validation Results')) ?></span>
     </div><br>
     <div id="import_validation_messages" class="fieldset"><!-- --></div>
 </div>

--- a/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
+++ b/app/code/Magento/ImportExport/view/adminhtml/templates/import/form/before.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var $block \Magento\ImportExport\Block\Adminhtml\Import\Edit\Before */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\ImportExport\Block\Adminhtml\Import\Edit\Before;
+
+/** @var Escaper $escaper */
+/** @var Before $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 $fieldNameSourceFile = \Magento\ImportExport\Model\Import::FIELD_NAME_SOURCE_FILE;
-$uploaderErrorMessage = $block->escapeHtml(
+$uploaderErrorMessage = $escaper->escapeHtml(
     __('Content of uploaded file was changed, please re-upload the file')
 );
 ?>
@@ -51,7 +56,7 @@ require([
          * Base url
          * @type {string}
          */
-        sampleFilesBaseUrl: '{$block->escapeJs($block->getUrl('*/*/download/', ['filename' => 'entity-name']))}',
+        sampleFilesBaseUrl: '{$escaper->escapeJs($block->getUrl('*/*/download/', ['filename' => 'entity-name']))}',
 
         /**
         * Loaded file last modified
@@ -258,7 +263,7 @@ require([
         postToFrameProcessResponse: function(response) {
             if ('object' != typeof(response)) {
                 alert({
-                    content: '{$block->escapeHtml(__('Invalid response'))}'
+                    content: '{$escaper->escapeHtml(__('Invalid response'))}'
                 });
 
                 return false;


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_ImportExport` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37120: Chore: Import Export - Replace Block Escaping with Escaper