### PR TITLE
Chore: Google Gtag - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/GoogleGtag/view/frontend/templates/code.phtml
+++ b/app/code/Magento/GoogleGtag/view/frontend/templates/code.phtml
@@ -3,27 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Framework\View\Element\Template $block */
-/** @var \Magento\Framework\Escaper $escaper */
-/** @var \Magento\GoogleGtag\ViewModel\Adwords $adsViewModel */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\GoogleGtag\ViewModel\Adwords;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var Adwords $adsViewModel */
 $adsViewModel = $block->getViewModel();
 ?>
-
 <?php if ($adsViewModel->isGoogleAdwordsConfigurable() && $adsViewModel->isGoogleAdwordsActive()): ?>
-    <?php $conversionId = $block->escapeHtml($adsViewModel->getConversionId()); ?>
-    <?php $conversionLabel = $block->escapeHtml($adsViewModel->getConversionLabel()); ?>
+    <?php $conversionId = $escaper->escapeHtml($adsViewModel->getConversionId()); ?>
+    <?php $conversionLabel = $escaper->escapeHtml($adsViewModel->getConversionLabel()); ?>
     <?php $gtagSiteSrc = $adsViewModel->getConversionGtagGlobalSiteTagSrc(); ?>
     <!-- BEGIN GOOGLE ADWORDS CODE -->
     <script type="text/x-magento-init">
     {
         "*": {
             "Magento_GoogleGtag/js/google-adwords": {
-                "conversionId": "<?= $block->escapeHtml($conversionId);  ?>",
-                "gtagSiteSrc": "<?= $block->escapeHtml($gtagSiteSrc);  ?>",
-                "conversionLabel": "<?= $block->escapeHtml($conversionLabel);  ?>"
+                "conversionId": "<?= $escaper->escapeHtml($conversionId);  ?>",
+                "gtagSiteSrc": "<?= $escaper->escapeHtml($gtagSiteSrc);  ?>",
+                "conversionLabel": "<?= $escaper->escapeHtml($conversionLabel);  ?>"
             }
         }
     }

--- a/app/code/Magento/GoogleGtag/view/frontend/templates/head.phtml
+++ b/app/code/Magento/GoogleGtag/view/frontend/templates/head.phtml
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Framework\View\Element\Template $block */
-/** @var \Magento\Framework\Escaper $escaper */
-/** @var \Magento\GoogleGtag\ViewModel\Adwords $adsViewModel */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\GoogleGtag\ViewModel\Adwords;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var Adwords $adsViewModel */
 $adsViewModel = $block->getViewModel();
 ?>
-
 <?php if ($adsViewModel->isGoogleAdwordsConfigurable() && $adsViewModel->isGoogleAdwordsActive()): ?>
     <?php $conversionId = $adsViewModel->getConversionId(); ?>
     <?php $gtagSiteSrc = $adsViewModel->getConversionGtagGlobalSiteTagSrc(); ?>
@@ -19,8 +22,8 @@ $adsViewModel = $block->getViewModel();
     {
         "*": {
             "Magento_GoogleGtag/js/google-adwords": {
-                "conversionId": "<?= $block->escapeHtml($conversionId);  ?>",
-                "gtagSiteSrc": "<?= $block->escapeHtml($gtagSiteSrc);  ?>"
+                "conversionId": "<?= $escaper->escapeHtml($conversionId);  ?>",
+                "gtagSiteSrc": "<?= $escaper->escapeHtml($gtagSiteSrc);  ?>"
             }
         }
     }


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_GoogleGtag` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37119: Chore: Google Gtag - Replace Block Escaping with Escaper