### PR TITLE
Chore: Gift Message - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/giftoptionsform.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/giftoptionsform.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 
 <?php if ($block->canDisplayGiftmessageForm()) : ?>
 <div id="gift_options_giftmessage" class="giftcard-form giftcard-send-form fieldset admin__fieldset">
     <div class="field admin__field">
-        <label class="admin__field-label" for="current_item_giftmessage_sender"><?= $block->escapeHtml(__('From')) ?></label>
+        <label class="admin__field-label" for="current_item_giftmessage_sender"><?= $escaper->escapeHtml(__('From')) ?></label>
         <div class="control admin__field-control">
             <input type="text" class="input-text admin__control-text"
                    name="current_item_giftmessage_sender"
@@ -16,7 +21,7 @@
         </div>
     </div>
     <div class="field admin__field">
-        <label class="admin__field-label" for="current_item_giftmessage_recipient"><?= $block->escapeHtml(__('To')) ?></label>
+        <label class="admin__field-label" for="current_item_giftmessage_recipient"><?= $escaper->escapeHtml(__('To')) ?></label>
         <div class="control admin__field-control">
             <input type="text"
                    class="input-text admin__control-text"
@@ -25,7 +30,7 @@
         </div>
     </div>
     <div class="field admin__field">
-        <label class="admin__field-label" for="current_item_giftmessage_message"><?= $block->escapeHtml(__('Message')) ?></label>
+        <label class="admin__field-label" for="current_item_giftmessage_message"><?= $escaper->escapeHtml(__('Message')) ?></label>
         <div class="control admin__field-control">
             <textarea class="textarea admin__control-textarea"
                       cols="15"

--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/popup.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/popup.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php if ($block->getChildHtml()):?>
@@ -15,10 +20,10 @@
         </div>
         <div class="ui-dialog-buttonset">
             <button type="button" class="action-close" id="gift_options_cancel_button">
-                <span><?= $block->escapeHtml(__('Cancel')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Cancel')) ?></span>
             </button>
             <button type="button" class="action-primary" id="gift_options_ok_button">
-                <span><?= $block->escapeHtml(__('OK')) ?></span>
+                <span><?= $escaper->escapeHtml(__('OK')) ?></span>
             </button>
         </div>
     </div>

--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/create/giftoptions.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/create/giftoptions.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -14,7 +19,7 @@
         <tr class="row-gift-options">
             <td colspan="7">
                 <a class="action-link" href="#" id="gift_options_link_<?= (int) $_item->getId() ?>">
-                    <?= $block->escapeHtml(__('Gift Options')) ?>
+                    <?= $escaper->escapeHtml(__('Gift Options')) ?>
                 </a>
                 <?php $itemId = (int) ($_item->getId());
                 $scriptString = <<<script

--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/create/items.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/create/items.phtml
@@ -3,8 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+?>
 <?php if ($block->canDisplayGiftMessage()) : ?>
     <div class="no-display">
         <div id="gift-message-form-data-<?= (int) $block->getItem()->getId() ?>">
@@ -13,7 +17,7 @@
 
         <?php if ($block->getMessageText()) : ?>
         <div class="gift-options-tooltip-content">
-            <div><strong><?= $block->escapeHtml(__('Gift Message')) ?></strong>:</div>
+            <div><strong><?= $escaper->escapeHtml(__('Gift Message')) ?></strong>:</div>
             <div><?= /* @noEscape */ $block->getMessageText() ?></div>
         </div>
         <?php endif; ?>

--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/view/giftoptions.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/view/giftoptions.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_childHtml = trim($block->getChildHtml('', false)); ?>
@@ -13,7 +18,7 @@
     <tr>
         <td colspan="10" class="last">
             <a class="action-link" href="#" id="gift_options_link_<?= (int) $_item->getId() ?>">
-                <?= $block->escapeHtml(__('Gift Options')) ?>
+                <?= $escaper->escapeHtml(__('Gift Options')) ?>
             </a>
             <?php $itemId = (int) ($_item->getId());
             $scriptString = <<<script

--- a/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/view/items.phtml
+++ b/app/code/Magento/GiftMessage/view/adminhtml/templates/sales/order/view/items.phtml
@@ -3,33 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 
 <?php if ($block->canDisplayGiftmessage()) : ?>
 <div id="gift-message-form-data-<?= (int) $block->getItem()->getId() ?>" class="no-display">
-    <form id="<?= $block->escapeHtmlAttr($block->getFieldId('form')) ?>"
-          action="<?= $block->escapeUrl($block->getSaveUrl()) ?>">
+    <form id="<?= $escaper->escapeHtmlAttr($block->getFieldId('form')) ?>"
+          action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>">
         <input type="hidden"
-               id="<?= $block->escapeHtmlAttr($block->getFieldId('type')) ?>"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName('type')) ?>"
+               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('type')) ?>"
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('type')) ?>"
                value="order_item" />
         <input type="hidden"
-               id="<?= $block->escapeHtmlAttr($block->getFieldId('sender')) ?>"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName('sender')) ?>"
-               value="<?= $block->escapeHtmlAttr($block->getSender()) ?>" />
+               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('sender')) ?>"
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('sender')) ?>"
+               value="<?= $escaper->escapeHtmlAttr($block->getSender()) ?>" />
         <input type="hidden"
-               id="<?= $block->escapeHtmlAttr($block->getFieldId('recipient')) ?>"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName('recipient')) ?>"
-               value="<?= $block->escapeHtmlAttr($block->getRecipient()) ?>" />
+               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('recipient')) ?>"
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('recipient')) ?>"
+               value="<?= $escaper->escapeHtmlAttr($block->getRecipient()) ?>" />
         <input type="hidden"
-               id="<?= $block->escapeHtmlAttr($block->getFieldId('message')) ?>"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName('message')) ?>"
-               value="<?= $block->escapeHtmlAttr($block->getMessageText()) ?>" />
+               id="<?= $escaper->escapeHtmlAttr($block->getFieldId('message')) ?>"
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName('message')) ?>"
+               value="<?= $escaper->escapeHtmlAttr($block->getMessageText()) ?>" />
     </form>
 
     <?php if ($block->getMessageText()) : ?>
     <div class="gift-options-tooltip-content">
-        <div><strong><?= $block->escapeHtml(__('Gift Message')) ?></strong>: </div>
+        <div><strong><?= $escaper->escapeHtml(__('Gift Message')) ?></strong>: </div>
         <div><?= /* @noEscape */ $block->getMessageText() ?></div>
     </div>
     <?php endif; ?>

--- a/app/code/Magento/GiftMessage/view/frontend/templates/inline.phtml
+++ b/app/code/Magento/GiftMessage/view/frontend/templates/inline.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable Magento2.Files.LineLength, Generic.Files.LineLength
-
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-/** @var Magento\Framework\Escaper $escaper */
 ?>
 <?php $_giftMessage = false;
 switch ($block->getCheckoutType()):
@@ -15,7 +19,7 @@ switch ($block->getCheckoutType()):
         ?>
     <fieldset class="fieldset gift-message">
         <legend class="legend">
-            <span><?= $block->escapeHtml(__('Do you have any gift items in your order?')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Do you have any gift items in your order?')) ?></span>
         </legend><br>
 
         <div class="field choice" id="add-gift-options-<?= (int) $block->getEntity()->getId() ?>">
@@ -24,7 +28,7 @@ switch ($block->getCheckoutType()):
                 <?php if ($block->getItemsHasMesssages() || $block->getEntityHasMessage()):?>
                     checked="checked"<?php endif; ?> class="checkbox" />
             <label for="allow_gift_options" class="label">
-                <span><?= $block->escapeHtml(__('Add Gift Options')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Add Gift Options')) ?></span>
             </label>
         </div>
 
@@ -38,7 +42,7 @@ switch ($block->getCheckoutType()):
                         <?php if ($block->getEntityHasMessage()): ?> checked="checked"<?php endif; ?>
                            class="checkbox" />
                     <label for="allow_gift_options_for_order" class="label">
-                        <span><?= $block->escapeHtml(__('Gift Options for the Entire Order')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Gift Options for the Entire Order')) ?></span>
                     </label>
                 </div>
             </dt>
@@ -49,45 +53,45 @@ switch ($block->getCheckoutType()):
                     <button class="action action-gift"
                             data-mage-init='{"toggleAdvanced": {"selectorsToggleClass":"hidden",
                              "toggleContainers":"#allow-gift-messages-for-order-container"}}'>
-                        <span><?= $block->escapeHtml(__('Gift Message')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Gift Message')) ?></span>
                     </button>
                     <div id="allow-gift-messages-for-order-container" class="gift-messages-order hidden">
                         <fieldset class="fieldset">
-                            <p><?= $block->escapeHtml(__(
+                            <p><?= $escaper->escapeHtml(__(
                                 'Leave this box blank if you don\'t want to leave a gift message for the entire order.'
                             )) ?></p>
                             <div class="field from">
                                 <label for="gift-message-whole-from" class="label">
-                                    <span><?= $block->escapeHtml(__('From')) ?></span></label>
+                                    <span><?= $escaper->escapeHtml(__('From')) ?></span></label>
                                 <div class="control">
                                     <input type="text"
                                            name="giftmessage[quote][<?= (int) $block->getEntity()->getId() ?>][from]"
                                            id="gift-message-whole-from"
-                                           title="<?= $block->escapeHtmlAttr(__('From')) ?>"
+                                           title="<?= $escaper->escapeHtmlAttr(__('From')) ?>"
                                            value="<?= /* @noEscape */ $block->getEscaped($block->getMessage()->getSender(), $block->getDefaultFrom()) ?>"
                                            class="input-text">
                                 </div>
                             </div>
                             <div class="field to">
                                 <label for="gift-message-whole-to" class="label">
-                                    <span><?= $block->escapeHtml(__('To')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('To')) ?></span>
                                 </label>
                                 <div class="control">
                                     <input type="text"
                                            name="giftmessage[quote][<?= (int) $block->getEntity()->getId() ?>][to]"
-                                           id="gift-message-whole-to" title="<?= $block->escapeHtmlAttr(__('To')) ?>"
+                                           id="gift-message-whole-to" title="<?= $escaper->escapeHtmlAttr(__('To')) ?>"
                                            value="<?= /* @noEscape */ $block->getEscaped($block->getMessage()->getRecipient(), $block->getDefaultTo()) ?>"
                                            class="input-text">
                                 </div>
                             </div>
                             <div class="field text">
                                 <label for="gift-message-whole-message" class="label">
-                                    <span><?= $block->escapeHtml(__('Message')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Message')) ?></span>
                                 </label>
                                 <div class="control">
                                     <textarea id="gift-message-whole-message" class="input-text"
                                               name="giftmessage[quote][<?=(int)$block->getEntity()->getId()?>][message]"
-                                              title="<?= $block->escapeHtmlAttr(__('Message')) ?>" rows="5" cols="10"><?= $escaper->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
+                                              title="<?= $escaper->escapeHtmlAttr(__('Message')) ?>" rows="5" cols="10"><?= $escaper->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
                                 </div>
                             </div>
                         </fieldset>
@@ -113,7 +117,7 @@ script;
                         <?php if ($block->getItemsHasMesssages()): ?> checked="checked"<?php endif; ?>
                            class="checkbox" />
                     <label for="allow_gift_options_for_items" class="label">
-                        <span><?= $block->escapeHtml(__('Gift Options for Individual Items')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Gift Options for Individual Items')) ?></span>
                     </label>
                 </div>
             </dt>
@@ -125,7 +129,7 @@ script;
                     <li class="item">
                          <div class="product">
                              <div class="number">
-                                 <?= $block->escapeHtml(__(
+                                 <?= $escaper->escapeHtml(__(
                                      '<span>Item %1</span> of %2',
                                      $_index+1,
                                      $block->countItems()
@@ -134,7 +138,7 @@ script;
                              <div class="img photo container">
                                  <?= $block->getImage($_product, 'gift_messages_checkout_thumbnail')->toHtml() ?>
                              </div>
-                             <strong class="product name"><?= $block->escapeHtml($_product->getName()) ?></strong>
+                             <strong class="product name"><?= $escaper->escapeHtml($_product->getName()) ?></strong>
                          </div>
                          <div class="options">
                              <div class="options-items-container"
@@ -145,23 +149,23 @@ script;
                                      data-mage-init='{"toggleAdvanced": {"selectorsToggleClass":"hidden",
                                       "toggleContainers":"#gift-messages-for-item-container-<?= (int) $_item->getId()
                                         ?>"}}'>
-                                 <span><?= $block->escapeHtml(__('Gift Message')) ?></span>
+                                 <span><?= $escaper->escapeHtml(__('Gift Message')) ?></span>
                              </button>
                              <div id="gift-messages-for-item-container-<?= (int) $_item->getId() ?>"
                                   class="block message hidden">
                                  <fieldset class="fieldset">
-                                     <p><?= $block->escapeHtml(__(
+                                     <p><?= $escaper->escapeHtml(__(
                                          'Leave a box blank if you don\'t want to add a gift message for that item.'
                                      )) ?></p>
                                      <div class="field from">
                                          <label for="gift-message-<?= (int) $_item->getId() ?>-from" class="label">
-                                             <span><?= $block->escapeHtml(__('From')) ?></span>
+                                             <span><?= $escaper->escapeHtml(__('From')) ?></span>
                                          </label>
                                          <div class="control">
                                              <input type="text"
                                                     name="giftmessage[quote_item][<?= (int) $_item->getId() ?>][from]"
                                                     id="gift-message-<?= (int) $_item->getId() ?>-from"
-                                                    title="<?= $block->escapeHtmlAttr(__('From')) ?>"
+                                                    title="<?= $escaper->escapeHtmlAttr(__('From')) ?>"
                                                     value=
                                                     "<?= /* @noEscape */
                                                      $block->getEscaped(
@@ -172,27 +176,27 @@ script;
                                      </div>
                                      <div class="field to">
                                         <label for="gift-message-<?= (int) $_item->getId() ?>-to" class="label">
-                                            <span><?= $block->escapeHtmlAttr(__('To')) ?></span>
+                                            <span><?= $escaper->escapeHtmlAttr(__('To')) ?></span>
                                         </label>
                                         <div class="control">
                                             <input type="text"
                                                    name="giftmessage[quote_item][<?= (int) $_item->getId() ?>][to]"
                                                    id="gift-message-<?= (int) $_item->getId() ?>-to"
-                                                   title="<?= $block->escapeHtmlAttr(__('To')) ?>"
+                                                   title="<?= $escaper->escapeHtmlAttr(__('To')) ?>"
                                                    value="<?= /* @noEscape */ $block->getEscaped($block->getMessage($_item)->getRecipient(), $block->getDefaultTo()) ?>"
                                                    class="input-text">
                                         </div>
                                      </div>
                                      <div class="field text">
                                          <label for="gift-message-<?= (int) $_item->getId() ?>-message" class="label">
-                                             <span><?= $block->escapeHtml(__('Message')) ?></span>
+                                             <span><?= $escaper->escapeHtml(__('Message')) ?></span>
                                          </label>
                                          <div class="control">
                                             <textarea id="gift-message-<?= (int) $_item->getId() ?>-message"
                                                       class="input-text giftmessage-area"
                                                       name="giftmessage[quote_item][<?= (int) $_item->getId()
                                                         ?>][message]"
-                                                      title="<?= $block->escapeHtmlAttr(__('Message')) ?>"
+                                                      title="<?= $escaper->escapeHtmlAttr(__('Message')) ?>"
                                                       rows="5" cols="40"><?= $escaper->escapeHtml($block->getMessage($_item)->getMessage()) ?></textarea>
                                          </div>
                                      </div>
@@ -234,7 +238,7 @@ script;
         ?>
     <fieldset id="add-gift-options-<?= (int) $block->getEntity()->getId() ?>" class="fieldset gift-message">
         <legend class="legend">
-            <span><?= $block->escapeHtml(__('Do you have any gift items in your order?')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Do you have any gift items in your order?')) ?></span>
         </legend><br>
 
         <div class="field choice" id="add-gift-options-<?= (int) $block->getEntity()->getId() ?>">
@@ -245,7 +249,7 @@ script;
                 <?php if ($block->getItemsHasMesssages() || $block->getEntityHasMessage()):?> checked="checked"
                 <?php endif; ?> class="checkbox" />
             <label for="allow_gift_options_<?= (int) $block->getEntity()->getId() ?>" class="label">
-                <span><?= $block->escapeHtml(__('Add Gift Options')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Add Gift Options')) ?></span>
             </label>
         </div>
 
@@ -260,7 +264,7 @@ script;
                                ->getId() ?>"}'
                         <?php if ($block->getEntityHasMessage()): ?> checked="checked"<?php endif; ?> class="checkbox"/>
                     <label for="allow_gift_options_for_order_<?= (int) $block->getEntity()->getId() ?>" class="label">
-                        <span><?= $block->escapeHtml(__('Add Gift Options for the Entire Order')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Add Gift Options for the Entire Order')) ?></span>
                     </label>
                 </div>
             </dt>
@@ -275,48 +279,48 @@ script;
                             data-mage-init='{"toggleAdvanced": {"selectorsToggleClass":"hidden",
                              "toggleContainers":"#gift-messages-for-order-container-<?= (int) $block->getEntity()
                                 ->getId() ?>"}}'>
-                        <span><?= $block->escapeHtml(__('Gift Message')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Gift Message')) ?></span>
                     </button>
                     <div id="gift-messages-for-order-container-<?= (int) $block->getEntity()->getId() ?>"
                          class="gift-messages-order hidden">
                         <fieldset class="fieldset">
-                            <p><?= $block->escapeHtml(__('You can leave this box blank if you don\'t want to add a ' .
+                            <p><?= $escaper->escapeHtml(__('You can leave this box blank if you don\'t want to add a ' .
                                     'gift message for this address.')) ?></p>
                             <div class="field from">
                                 <label for="gift-message-<?= (int) $block->getEntity()->getId() ?>-from"
-                                       class="label"><span><?= $block->escapeHtml(__('From')) ?></span>
+                                       class="label"><span><?= $escaper->escapeHtml(__('From')) ?></span>
                                 </label>
                                 <div class="control">
                                     <input type="text" name="giftmessage[quote_address][<?= (int) $block->getEntity()
                                         ->getId() ?>][from]"
                                            id="gift-message-<?= (int) $block->getEntity()->getId() ?>-from"
-                                           title="<?= $block->escapeHtmlAttr(__('From')) ?>"
+                                           title="<?= $escaper->escapeHtmlAttr(__('From')) ?>"
                                            value="<?= /* @noEscape */ $block->getEscaped($block->getMessage()->getSender(), $block->getDefaultFrom()) ?>"
                                            class="input-text">
                                 </div>
                             </div>
                             <div class="field to">
                                 <label for="gift-message-<?= (int) $block->getEntity()->getId() ?>-to"
-                                       class="label"><span><?= $block->escapeHtml(__('To')) ?></span>
+                                       class="label"><span><?= $escaper->escapeHtml(__('To')) ?></span>
                                 </label>
                                 <div class="control">
                                     <input type="text" name="giftmessage[quote_address][<?= (int) $block->getEntity()
                                         ->getId() ?>][to]"
                                            id="gift-message-<?= (int) $block->getEntity()->getId() ?>-to"
-                                           title="<?= $block->escapeHtmlAttr(__('To')) ?>"
+                                           title="<?= $escaper->escapeHtmlAttr(__('To')) ?>"
                                            value="<?= /* @noEscape */ $block->getEscaped($block->getMessage()->getRecipient(), $block->getDefaultTo()) ?>"
                                            class="input-text">
                                 </div>
                             </div>
                             <div class="field text">
                                 <label for="gift-message-<?= (int) $block->getEntity()->getId() ?>-message"
-                                       class="label"><span><?= $block->escapeHtml(__('Message')) ?></span>
+                                       class="label"><span><?= $escaper->escapeHtml(__('Message')) ?></span>
                                 </label>
                                 <div class="control">
                                     <textarea id="gift-message-<?= (int) $block->getEntity()->getId() ?>-message"
                                               class="input-text" name="giftmessage[quote_address][<?= (int) $block
                                                 ->getEntity()->getId() ?>][message]"
-                                              title="<?= $block->escapeHtmlAttr(__('Message')) ?>" rows="5" cols="40"><?= $escaper->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
+                                              title="<?= $escaper->escapeHtmlAttr(__('Message')) ?>" rows="5" cols="40"><?= $escaper->escapeHtml($block->getMessage()->getMessage()) ?></textarea>
                                 </div>
                             </div>
                         </fieldset>
@@ -335,7 +339,7 @@ script;
                         <?php if ($block->getItemsHasMesssages()): ?> checked="checked"<?php endif; ?>
                            class="checkbox" />
                     <label for="allow_gift_options_for_items_<?= (int) $block->getEntity()->getId() ?>" class="label">
-                        <span><?= $block->escapeHtml(__('Add Gift Options for Individual Items')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Add Gift Options for Individual Items')) ?></span>
                     </label>
                 </div>
             </dt>
@@ -348,14 +352,14 @@ script;
                     <li class="item">
                         <div class="product">
                             <div class="number">
-                                <?= $block->escapeHtml(
+                                <?= $escaper->escapeHtml(
                                     __('<span>Item %1</span> of %2', $_index+1, $block->countItems()),
                                     ['span']
                                 ) ?></div>
                             <div class="img photo container">
                              <?= $block->getImage($_product, 'gift_messages_checkout_thumbnail')->toHtml() ?>
                             </div>
-                            <strong class="product-name"><?= $block->escapeHtml($_product->getName()) ?></strong>
+                            <strong class="product-name"><?= $escaper->escapeHtml($_product->getName()) ?></strong>
                         </div>
                         <div class="options">
                             <div class="options-items-container"
@@ -371,12 +375,12 @@ script;
                                      data-mage-init='{"toggleAdvanced": {"selectorsToggleClass":"hidden",
                                       "toggleContainers":"#gift-messages-for-item-container-<?= (int) $_item->getId()
                                         ?>"}}'>
-                                    <span><?= $block->escapeHtml(__('Gift Message')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Gift Message')) ?></span>
                                 </button>
                                 <div id="gift-messages-for-item-container-<?= (int) $_item->getId() ?>"
                                      class="block message hidden">
                                     <fieldset class="fieldset">
-                                        <p><?= $block->escapeHtml(__(
+                                        <p><?= $escaper->escapeHtml(__(
                                             'You can leave this box blank if you don\'t want to add a gift message ' .
                                             'for the item.'
                                         )) ?></p>
@@ -384,40 +388,40 @@ script;
                                             ->getId() ?>][address]" value="<?= (int) $block->getEntity()->getId() ?>" />
                                         <div class="field from">
                                             <label for="gift-message-<?= (int) $_item->getId() ?>-from" class="label">
-                                                <span><?= $block->escapeHtml(__('From')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('From')) ?></span>
                                             </label>
                                             <div class="control">
                                                 <input type="text"
                                                        name="giftmessage[quote_address_item][<?= (int) $_item->getId()
                                                         ?>][from]" id="gift-message-<?= (int) $_item->getId() ?>-from"
-                                                       title="<?= $block->escapeHtmlAttr(__('From')) ?>"
+                                                       title="<?= $escaper->escapeHtmlAttr(__('From')) ?>"
                                                        value="<?= /* @noEscape */ $block->getEscaped($block->getMessage($_item)->getSender(), $block->getDefaultFrom()) ?>"
                                                        class="input-text">
                                             </div>
                                         </div>
                                         <div class="field to">
                                             <label for="gift-message-<?= (int) $_item->getId() ?>-to" class="label">
-                                                <span><?= $block->escapeHtml(__('To')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('To')) ?></span>
                                             </label>
                                             <div class="control">
                                                 <input type="text"
                                                        name="giftmessage[quote_address_item][<?= (int) $_item->getId()
                                                         ?>][to]" id="gift-message-<?= (int) $_item->getId() ?>-to"
-                                                       title="<?= $block->escapeHtmlAttr(__('To')) ?>"
+                                                       title="<?= $escaper->escapeHtmlAttr(__('To')) ?>"
                                                        value="<?= /* @noEscape */ $block->getEscaped($block->getMessage($_item)->getRecipient(), $block->getDefaultTo()) ?>"
                                                        class="input-text">
                                             </div>
                                         </div>
                                         <div class="field text">
                                             <label for="gift-message-<?= (int) $_item->getId()?>-message" class="label">
-                                                <span><?= $block->escapeHtml(__('Message')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Message')) ?></span>
                                             </label>
                                             <div class="control">
                                                 <textarea id="gift-message-<?= (int) $_item->getId() ?>-message"
                                                           class="input-text giftmessage-area"
                                                           name="giftmessage[quote_address_item][<?= (int) $_item
                                                               ->getId() ?>][message]"
-                                                          title="<?= $block->escapeHtmlAttr(__('Message')) ?>" rows="5"
+                                                          title="<?= $escaper->escapeHtmlAttr(__('Message')) ?>" rows="5"
                                                           cols="10"><?= $escaper->escapeHtml($block->getMessage($_item)->getMessage()) ?></textarea>
                                             </div>
                                         </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_GiftMessage` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37118: Chore: Gift Message - Replace Block Escaping with Escaper