### PR TITLE
Chore: Email - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/preview/iframeswitcher.phtml
@@ -3,26 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Page $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Page;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Page $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="preview" class="cms-revision-preview">
     <iframe name="preview_iframe"
             id="preview_iframe"
             frameborder="0"
-            title="<?= $block->escapeHtmlAttr(__('Preview')) ?>"
+            title="<?= $escaper->escapeHtmlAttr(__('Preview')) ?>"
             width="100%"
             sandbox="allow-same-origin allow-pointer-lock"
     ></iframe>
     <form id="preview_form"
-          action="<?= $block->escapeUrl($block->getUrl('*/*/popup')) ?>"
+          action="<?= $escaper->escapeUrl($block->getUrl('*/*/popup')) ?>"
           method="post"
           target="preview_iframe"
     >
     <input type="hidden" name="form_key" value="<?= /* @noEscape */ $block->getFormKey() ?>" />
     <?php foreach ($block->getPreviewFormViewModel()->getFormFields() as $name => $value): ?>
-        <input type="hidden" name="<?= $block->escapeHtmlAttr($name) ?>" value="<?= $block->escapeHtmlAttr($value) ?>"/>
+        <input type="hidden" name="<?= $escaper->escapeHtmlAttr($name) ?>" value="<?= $escaper->escapeHtmlAttr($value) ?>"/>
     <?php endforeach; ?>
     </form>
 </div>

--- a/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/edit.phtml
@@ -3,33 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Email\Block\Adminhtml\Template\Edit;
 use Magento\Framework\App\TemplateTypesInterface;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable Generic.Files.LineLength.TooLong
-
-/** @var $block \Magento\Email\Block\Adminhtml\Template\Edit */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!$block->getEditMode()): ?>
-<form action="<?= $block->escapeUrl($block->getLoadUrl()) ?>" method="post" id="email_template_load_form">
+<form action="<?= $escaper->escapeUrl($block->getLoadUrl()) ?>" method="post" id="email_template_load_form">
     <?= $block->getBlockHtml('formkey') ?>
     <fieldset class="admin__fieldset form-inline">
-        <legend class="admin__legend"><span><?= $block->escapeHtml(__('Load Default Template')) ?></span></legend><br>
+        <legend class="admin__legend"><span><?= $escaper->escapeHtml(__('Load Default Template')) ?></span></legend><br>
         <div class="admin__field required">
             <label class="admin__field-label" for="template_select">
-                <span><?= $block->escapeHtml(__('Template')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Template')) ?></span>
             </label>
             <div class="admin__field-control">
                 <select id="template_select" name="code" class="admin__control-select required-entry">
                     <?php foreach ($block->getTemplateOptions() as $group => $options): ?>
                         <?php if ($group): ?>
-                            <optgroup label="<?= $block->escapeHtmlAttr($group) ?>">
+                            <optgroup label="<?= $escaper->escapeHtmlAttr($group) ?>">
                         <?php endif; ?>
                         <?php foreach ($options as $option): ?>
-                            <option value="<?= $block->escapeHtmlAttr($option['value']) ?>"
+                            <option value="<?= $escaper->escapeHtmlAttr($option['value']) ?>"
                                 <?= /* @noEscape */ $block->getOrigTemplateCode() == $option['value'] ?
-                                    ' selected="selected"' : '' ?>><?= $block->escapeHtml($option['label']) ?>
+                                    ' selected="selected"' : '' ?>><?= $escaper->escapeHtml($option['label']) ?>
                             </option>
                         <?php endforeach; ?>
                         <?php if ($group): ?>
@@ -49,15 +54,15 @@ use Magento\Framework\App\TemplateTypesInterface;
 </form>
 <?php endif ?>
 
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="email_template_edit_form">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" id="email_template_edit_form">
     <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
     <input type="hidden" id="change_flag_element" name="_change_type_flag" value="" />
     <input type="hidden" id="orig_template_code" name="orig_template_code"
-           value="<?= $block->escapeHtmlAttr($block->getOrigTemplateCode()) ?>" />
+           value="<?= $escaper->escapeHtmlAttr($block->getOrigTemplateCode()) ?>" />
     <?= /* @noEscape */ $block->getFormHtml() ?>
 </form>
 
-<form action="<?= $block->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="email_template_preview_form"
+<form action="<?= $escaper->escapeUrl($block->getPreviewUrl()) ?>" method="post" id="email_template_preview_form"
       target="_blank">
     <?= /* @noEscape */ $block->getBlockHtml('formkey') ?>
     <div class="no-display">
@@ -132,7 +137,7 @@ require([
             var self = this;
 
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to strip tags?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to strip tags?'))}",
                 actions: {
                     confirm: function () {
                         self.unconvertedText = $('template_text').value;
@@ -188,10 +193,10 @@ require([
 
         deleteTemplate: function() {
             confirm({
-                content: "{$block->escapeJs(__('Are you sure you want to delete this template?'))}",
+                content: "{$escaper->escapeJs(__('Are you sure you want to delete this template?'))}",
                 actions: {
                     confirm: function () {
-                        window.location.href = '{$block->escapeJs($block->getDeleteUrl())}';
+                        window.location.href = '{$escaper->escapeJs($block->getDeleteUrl())}';
                     }
                 }
             });
@@ -238,7 +243,7 @@ require([
                        }.bind(this));
                    } else {
                        alert({
-                           content: '{$block->escapeJs(__(
+                           content: '{$escaper->escapeJs(__(
                                'The template did not load. Please review the log for details.'
                             ))}'
                        });

--- a/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
+++ b/app/code/Magento/Email/view/adminhtml/templates/template/preview.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Email\Block\Adminhtml\Template\Preview */
+use Magento\Email\Block\Adminhtml\Template\Preview;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Preview $block */
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title><?= $block->escapeHtml(__('Email Preview')) ?></title>
+    <title><?= $escaper->escapeHtml(__('Email Preview')) ?></title>
 </head>
 <body>
     <?= $block->getChildHtml('content') ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Email` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37117: Chore: Email - Replace Block Escaping with Escaper