### PR TITLE
Chore: Directory - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Directory/view/frontend/templates/currency.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency.phtml
@@ -3,35 +3,35 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Currency switcher
- *
- * @var \Magento\Directory\Block\Currency $block
- */
+use Magento\Directory\Block\Currency;
+use Magento\Framework\Escaper;
 
+/** @var Escaper $escaper */
+/** @var Currency $block */
 ?>
 <?php if ($block->getCurrencyCount() > 1) : ?>
     <?php $currencies = $block->getCurrencies(); ?>
     <?php $currentCurrencyCode = $block->getCurrentCurrencyCode(); ?>
     <?php $id = $block->getIdModifier() ? '-' . $block->getIdModifier() : '' ?>
-    <div class="switcher currency switcher-currency" id="switcher-currency<?= $block->escapeHtmlAttr($id) ?>">
-        <strong class="label switcher-label"><span><?= $block->escapeHtml(__('Currency')) ?></span></strong>
+    <div class="switcher currency switcher-currency" id="switcher-currency<?= $escaper->escapeHtmlAttr($id) ?>">
+        <strong class="label switcher-label"><span><?= $escaper->escapeHtml(__('Currency')) ?></span></strong>
         <div class="actions dropdown options switcher-options">
             <div class="action toggle switcher-trigger"
-                 id="switcher-currency-trigger<?= $block->escapeHtmlAttr($id) ?>"
+                 id="switcher-currency-trigger<?= $escaper->escapeHtmlAttr($id) ?>"
                  data-mage-init='{"dropdown":{}}'
                  data-toggle="dropdown"
                  data-trigger-keypress-button="true">
-                <strong class="language-<?= $block->escapeHtml($block->getCurrentCurrencyCode()) ?>">
-                    <span><?= $block->escapeHtml($currentCurrencyCode) ?> - <?= $currencies[$currentCurrencyCode] ? $block->escapeHtml($currencies[$currentCurrencyCode]) : '' ?></span>
+                <strong class="language-<?= $escaper->escapeHtml($block->getCurrentCurrencyCode()) ?>">
+                    <span><?= $escaper->escapeHtml($currentCurrencyCode) ?> - <?= $currencies[$currentCurrencyCode] ? $escaper->escapeHtml($currencies[$currentCurrencyCode]) : '' ?></span>
                 </strong>
             </div>
             <ul class="dropdown switcher-dropdown" data-target="dropdown">
                 <?php foreach ($currencies as $_code => $_name) : ?>
                     <?php if ($_code != $currentCurrencyCode) : ?>
-                        <li class="currency-<?= $block->escapeHtmlAttr($_code) ?> switcher-option">
-                            <a href="#" data-post='<?= /* @noEscape */ $block->getSwitchCurrencyPostData($_code) ?>'><?= $block->escapeHtml($_code) ?> - <?= $block->escapeHtml($_name) ?></a>
+                        <li class="currency-<?= $escaper->escapeHtmlAttr($_code) ?> switcher-option">
+                            <a href="#" data-post='<?= /* @noEscape */ $block->getSwitchCurrencyPostData($_code) ?>'><?= $escaper->escapeHtml($_code) ?> - <?= $escaper->escapeHtml($_name) ?></a>
                         </li>
                     <?php endif; ?>
                 <?php endforeach; ?>

--- a/app/code/Magento/Directory/view/frontend/templates/currency/switch.phtml
+++ b/app/code/Magento/Directory/view/frontend/templates/currency/switch.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
 
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
-<p><?= $block->escapeHtml(__('Your current currency is: %1.', $currency->getCode())) ?></p>
-<p><a href="<?= $block->escapeUrl($block->getBaseUrl()) ?>" class="action continue"><span><?= $block->escapeHtml(__('Continue')) ?></span></a></p>
+<p><?= $escaper->escapeHtml(__('Your current currency is: %1.', $currency->getCode())) ?></p>
+<p><a href="<?= $escaper->escapeUrl($block->getBaseUrl()) ?>" class="action continue"><span><?= $escaper->escapeHtml(__('Continue')) ?></span></a></p>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Directory` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37116: Chore: Directory - Replace Block Escaping with Escaper