### PR TITLE
Chore: DHL - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Dhl/view/adminhtml/templates/unitofmeasure.phtml
+++ b/app/code/Magento/Dhl/view/adminhtml/templates/unitofmeasure.phtml
@@ -3,27 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var \Magento\Dhl\Block\Adminhtml\Unitofmeasure $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-?>
+declare(strict_types=1);
 
-<?php $scriptString = <<<script
+use Magento\Dhl\Block\Adminhtml\Unitofmeasure;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Unitofmeasure $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
     //<![CDATA[
     require(["prototype"], function(){
         function changeDimensions() {
-            var dimensionUnit = "({$block->escapeHtml($block->getInch())})";
-            var dhlUnitOfMeasureNote = "{$block->escapeHtml($block->getDivideOrderWeightNoteLbp())}";
+            var dimensionUnit = "({$escaper->escapeHtml($block->getInch())})";
+            var dhlUnitOfMeasureNote = "{$escaper->escapeHtml($block->getDivideOrderWeightNoteLbp())}";
             if ($("carriers_dhl_unit_of_measure").value == "K") {
-                dimensionUnit = "({$block->escapeHtml($block->getCm())})";
-                dhlUnitOfMeasureNote = "{$block->escapeHtml($block->getDivideOrderWeightNoteKg())}";
+                dimensionUnit = "({$escaper->escapeHtml($block->getCm())})";
+                dhlUnitOfMeasureNote = "{$escaper->escapeHtml($block->getDivideOrderWeightNoteKg())}";
             }
-            \$$('[for="carriers_dhl_height"]')[0].innerHTML = "{$block->escapeHtml($block->getHeight())} " +
+            \$$('[for="carriers_dhl_height"]')[0].innerHTML = "{$escaper->escapeHtml($block->getHeight())} " +
              dimensionUnit;
-            \$$('[for="carriers_dhl_depth"]')[0].innerHTML = "{$block->escapeHtml($block->getDepth())} " +
+            \$$('[for="carriers_dhl_depth"]')[0].innerHTML = "{$escaper->escapeHtml($block->getDepth())} " +
              dimensionUnit;
-            \$$('[for="carriers_dhl_width"]')[0].innerHTML = "{$block->escapeHtml($block->getWidth())} " +
+            \$$('[for="carriers_dhl_width"]')[0].innerHTML = "{$escaper->escapeHtml($block->getWidth())} " +
              dimensionUnit;
 
             $("carriers_dhl_divide_order_weight").next().down().innerHTML = dhlUnitOfMeasureNote;


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Dhl` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37115: Chore: DHL - Replace Block Escaping with Escaper