### PR TITLE
Chore: Currency Symbol - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/grid.phtml
@@ -3,48 +3,51 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\CurrencySymbol\Block\Adminhtml\System\Currencysymbol;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Currencysymbol $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
-<form id="currency-symbols-form" action="<?= $block->escapeUrl($block->getFormActionUrl()) ?>" method="post">
-    <input name="form_key" type="hidden" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" />
+<form id="currency-symbols-form" action="<?= $escaper->escapeUrl($block->getFormActionUrl()) ?>" method="post">
+    <input name="form_key" type="hidden" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" />
     <fieldset class="admin__fieldset">
         <?php foreach ($block->getCurrencySymbolsData() as $code => $data): ?>
         <div class="admin__field _required">
-            <label class="admin__field-label" for="custom_currency_symbol<?= $block->escapeHtmlAttr($code) ?>">
-                <span><?= $block->escapeHtml($code) ?> (<?= $block->escapeHtml($data['displayName']) ?>)</span>
+            <label class="admin__field-label" for="custom_currency_symbol<?= $escaper->escapeHtmlAttr($code) ?>">
+                <span><?= $escaper->escapeHtml($code) ?> (<?= $escaper->escapeHtml($data['displayName']) ?>)</span>
             </label>
             <div class="admin__field-control">
-                <input id="custom_currency_symbol<?= $block->escapeHtmlAttr($code) ?>"
+                <input id="custom_currency_symbol<?= $escaper->escapeHtmlAttr($code) ?>"
                        class="required-entry admin__control-text"
                        type="text"
-                       value="<?= $block->escapeHtmlAttr($data['displaySymbol']) ?>"
-                       name="custom_currency_symbol[<?= $block->escapeHtmlAttr($code) ?>]"
+                       value="<?= $escaper->escapeHtmlAttr($data['displaySymbol']) ?>"
+                       name="custom_currency_symbol[<?= $escaper->escapeHtmlAttr($code) ?>]"
                         <?= $data['inherited'] ? 'disabled' : '' ?>>
                 <div class="admin__field admin__field-option">
                     <?php
-                        $escapedCode = $block->escapeHtmlAttr($block->escapeJs($code));
-                        $escapedSymbol = $block->escapeJs($data['parentSymbol']);
+                        $escapedCode = $escaper->escapeHtmlAttr($escaper->escapeJs($code));
+                        $escapedSymbol = $escaper->escapeJs($data['parentSymbol']);
                     ?>
-                    <input id="custom_currency_symbol_inherit<?= $block->escapeHtmlAttr($code) ?>"
+                    <input id="custom_currency_symbol_inherit<?= $escaper->escapeHtmlAttr($code) ?>"
                            class="admin__control-checkbox" type="checkbox"
                             <?= $data['inherited'] ? ' checked="checked"' : '' ?>
                            value="1"
-                           name="inherit_custom_currency_symbol[<?= $block->escapeHtmlAttr($code) ?>]">
+                           name="inherit_custom_currency_symbol[<?= $escaper->escapeHtmlAttr($code) ?>]">
                     <label class="admin__field-label"
-                           for="custom_currency_symbol_inherit<?= $block->escapeHtmlAttr($code) ?>">
+                           for="custom_currency_symbol_inherit<?= $escaper->escapeHtmlAttr($code) ?>">
                         <span>
-                            <?= $block->escapeHtml($block->getInheritText()) ?>
+                            <?= $escaper->escapeHtml($block->getInheritText()) ?>
                         </span>
                     </label>
                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                         'onclick',
                         "toggleUseDefault('" . $escapedCode . "','" . $escapedSymbol . "')",
-                        '#custom_currency_symbol_inherit' . $block->escapeJs($code)
+                        '#custom_currency_symbol_inherit' . $escaper->escapeJs($code)
                     ) ?>
                 </div>
             </div>

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/matrix.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/matrix.phtml
@@ -3,24 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Matrix
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Matrix;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Matrix $block */
 $_oldRates = $block->getOldRates();
 $_newRates = $block->getNewRates();
 $_rates = ($_newRates) ? $_newRates : $_oldRates;
 ?>
 <?php if (empty($_rates)): ?>
     <div class="message message-warning warning"><p>
-            <?= $block->escapeHtml(
+            <?= $escaper->escapeHtml(
                 __('You must first configure currency options before being able to see currency rates.')
             ) ?></p>
     </div>
 <?php else: ?>
-    <form name="rateForm" id="rate-form" method="post" action="<?= $block->escapeUrl($block->getRatesFormAction()) ?>">
+    <form name="rateForm" id="rate-form" method="post" action="<?= $escaper->escapeUrl($block->getRatesFormAction()) ?>">
         <?= $block->getBlockHtml('formkey') ?>
         <div class="admin__control-table-wrapper">
             <table class="admin__control-table">
@@ -28,7 +31,7 @@ $_rates = ($_newRates) ? $_newRates : $_oldRates;
                     <tr>
                         <th>&nbsp;</th>
                         <?php $_i = 0; foreach ($block->getAllowedCurrencies() as $_currencyCode): ?>
-                            <th><span><?= $block->escapeHtml($_currencyCode) ?></span></th>
+                            <th><span><?= $escaper->escapeHtml($_currencyCode) ?></span></th>
                         <?php endforeach; ?>
                     </tr>
                 </thead>
@@ -37,42 +40,42 @@ $_rates = ($_newRates) ? $_newRates : $_oldRates;
                     <?php if (isset($_rates[$_currencyCode]) && is_array($_rates[$_currencyCode])): ?>
                         <?php foreach ($_rates[$_currencyCode] as $_rate => $_value): ?>
                             <?php if (++$_j == 1): ?>
-                                <td><span class="admin__control-support-text"><?= $block->escapeHtml($_currencyCode) ?>
+                                <td><span class="admin__control-support-text"><?= $escaper->escapeHtml($_currencyCode) ?>
                                     </span></td>
                                 <td>
                                     <input type="text"
-                                           name="rate[<?= $block->escapeHtmlAttr($_currencyCode)
-                                            ?>][<?= $block->escapeHtmlAttr($_rate) ?>]"
+                                           name="rate[<?= $escaper->escapeHtmlAttr($_currencyCode)
+                                            ?>][<?= $escaper->escapeHtmlAttr($_rate) ?>]"
                                            value="<?= ($_currencyCode == $_rate) ? '1.0000' :
-                                               ($_value>0 ? $block->escapeHtmlAttr($_value) :
+                                               ($_value>0 ? $escaper->escapeHtmlAttr($_value) :
                                                    (isset($_oldRates[$_currencyCode][$_rate]) ?
-                                                       $block->escapeHtmlAttr($_oldRates[$_currencyCode][$_rate]) : ''))
+                                                       $escaper->escapeHtmlAttr($_oldRates[$_currencyCode][$_rate]) : ''))
                                                     ?>"
                                            class="admin__control-text"
                                             <?= ($_currencyCode == $_rate) ? ' disabled' : '' ?> />
                                     <?php if (isset($_newRates) && $_currencyCode != $_rate &&
                                         isset($_oldRates[$_currencyCode][$_rate])): ?>
-                                    <div class="admin__field-note"><?= $block->escapeHtml(__('Old rate:')) ?>
-                                        <strong><?= $block->escapeHtml($_oldRates[$_currencyCode][$_rate]) ?></strong>
+                                    <div class="admin__field-note"><?= $escaper->escapeHtml(__('Old rate:')) ?>
+                                        <strong><?= $escaper->escapeHtml($_oldRates[$_currencyCode][$_rate]) ?></strong>
                                     </div>
                                     <?php endif; ?>
                                 </td>
                             <?php else: ?>
                                 <td>
                                     <input type="text"
-                                           name="rate[<?= $block->escapeHtmlAttr($_currencyCode)
-                                            ?>][<?= $block->escapeHtmlAttr($_rate) ?>]"
+                                           name="rate[<?= $escaper->escapeHtmlAttr($_currencyCode)
+                                            ?>][<?= $escaper->escapeHtmlAttr($_rate) ?>]"
                                            value="<?= ($_currencyCode == $_rate) ? '1.0000' :
-                                               ($_value>0 ? $block->escapeHtmlAttr($_value) :
+                                               ($_value>0 ? $escaper->escapeHtmlAttr($_value) :
                                                    (isset($_oldRates[$_currencyCode][$_rate]) ?
-                                                       $block->escapeHtmlAttr($_oldRates[$_currencyCode][$_rate]) : ''))
+                                                       $escaper->escapeHtmlAttr($_oldRates[$_currencyCode][$_rate]) : ''))
                                                     ?>"
                                            class="admin__control-text"
                                            <?= ($_currencyCode == $_rate) ? ' disabled' : '' ?> />
                                     <?php if (isset($_newRates) && $_currencyCode != $_rate &&
                                         isset($_oldRates[$_currencyCode][$_rate])): ?>
-                                    <div class="admin__field-note"><?= $block->escapeHtml(__('Old rate:')) ?>
-                                        <strong><?= $block->escapeHtml($_oldRates[$_currencyCode][$_rate]) ?></strong>
+                                    <div class="admin__field-note"><?= $escaper->escapeHtml(__('Old rate:')) ?>
+                                        <strong><?= $escaper->escapeHtml($_oldRates[$_currencyCode][$_rate]) ?></strong>
                                     </div>
                                     <?php endif; ?>
                                 </td>

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/services.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rate/services.phtml
@@ -3,14 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Services
- */
+declare(strict_types=1);
+
+use Magento\CurrencySymbol\Block\Adminhtml\System\Currency\Rate\Services;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Services $block */
 ?>
 <div class="admin__field">
-    <label class="admin__field-label"><span><?= $block->escapeHtml(__('Import Service')) ?></span></label>
+    <label class="admin__field-label"><span><?= $escaper->escapeHtml(__('Import Service')) ?></span></label>
     <div class="admin__field-control">
         <?= $block->getChildHtml('import_services') ?>
     </div>

--- a/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rates.phtml
+++ b/app/code/Magento/CurrencySymbol/view/adminhtml/templates/system/currency/rates.phtml
@@ -3,14 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\CurrencySymbol\Block\Adminhtml\System\Currency
- */
-?>
+declare(strict_types=1);
 
-<form action="<?= $block->escapeUrl($block->getImportFormAction()) ?>" method="post" class="import-service">
+use Magento\CurrencySymbol\Block\Adminhtml\System\Currency;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Currency $block */
+?>
+<form action="<?= $escaper->escapeUrl($block->getImportFormAction()) ?>" method="post" class="import-service">
     <?= $block->getBlockHtml('formkey') ?>
     <fieldset class="admin__fieldset admin__fieldset-import-service">
         <?= $block->getServicesHtml() ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_CurrencySymbol` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37114: Chore: Currency Symbol - Replace Block Escaping with Escaper