### PR TITLE
Chore: Cookie - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Cookie/view/frontend/templates/html/notices.phtml
@@ -3,30 +3,36 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Cookie\Block\Html\Notices $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
-/** @var \Magento\Cookie\Helper\Cookie $cookieHelper */
+use Magento\Cookie\Block\Html\Notices;
+use Magento\Cookie\Helper\Cookie;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Notices $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Cookie $cookieHelper */
 $cookieHelper = $block->getData('cookieHelper');
-if ($cookieHelper->isCookieRestrictionModeEnabled()): ?>
+?>
+<?php if ($cookieHelper->isCookieRestrictionModeEnabled()): ?>
     <div role="alertdialog"
          tabindex="-1"
          class="message global cookie"
          id="notice-cookie-block">
         <div role="document" class="content" tabindex="0">
             <p>
-                <strong><?= $block->escapeHtml(__('We use cookies to make your experience better.')) ?></strong>
-                <span><?= $block->escapeHtml(__(
+                <strong><?= $escaper->escapeHtml(__('We use cookies to make your experience better.')) ?></strong>
+                <span><?= $escaper->escapeHtml(__(
                     'To comply with the new e-Privacy directive, we need to ask for your consent to set the cookies.'
                 )) ?>
                 </span>
-                <?= $block->escapeHtml(__('<a href="%1">Learn more</a>.', $block->getPrivacyPolicyLink()), ['a']) ?>
+                <?= $escaper->escapeHtml(__('<a href="%1">Learn more</a>.', $block->getPrivacyPolicyLink()), ['a']) ?>
             </p>
             <div class="actions">
                 <button id="btn-cookie-allow" class="action allow primary">
-                    <span><?= $block->escapeHtml(__('Allow Cookies')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Allow Cookies')) ?></span>
                 </button>
             </div>
         </div>
@@ -37,10 +43,10 @@ if ($cookieHelper->isCookieRestrictionModeEnabled()): ?>
             "#notice-cookie-block": {
                 "cookieNotices": {
                     "cookieAllowButtonSelector": "#btn-cookie-allow",
-                    "cookieName": "<?= /* @noEscape */ \Magento\Cookie\Helper\Cookie::IS_USER_ALLOWED_SAVE_COOKIE ?>",
+                    "cookieName": "<?= /* @noEscape */ Cookie::IS_USER_ALLOWED_SAVE_COOKIE ?>",
                     "cookieValue": <?= /* @noEscape */ $cookieHelper->getAcceptedSaveCookiesWebsiteIds() ?>,
                     "cookieLifetime": <?= /* @noEscape */ $cookieHelper->getCookieRestrictionLifetime() ?>,
-                    "noCookiesUrl": "<?= $block->escapeJs($block->getUrl('cookie/index/noCookies')) ?>"
+                    "noCookiesUrl": "<?= $escaper->escapeJs($block->getUrl('cookie/index/noCookies')) ?>"
                 }
             }
         }


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Cookie` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37113: Chore: Cookie - Replace Block Escaping with Escaper