### PR TITLE
Chore: CMS - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
- /** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content */
+use Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Content $block */
 ?>
-
-<div class="media-gallery-modal" data-mage-init='{"mediabrowser": <?= $block->escapeHtml($block->getFilebrowserSetupObject()) ?>}'>
+<div class="media-gallery-modal" data-mage-init='{"mediabrowser": <?= $escaper->escapeHtml($block->getFilebrowserSetupObject()) ?>}'>
     <div class="page-main-actions">
         <div class="page-actions">
             <div class="page-actions-inner">

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/files.phtml
@@ -3,11 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files */
+use Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Files;
+use Magento\Framework\Escaper;
 
+/** @var Escaper $escaper */
+/** @var Files $block */
 $_width  = $block->getImagesWidth();
-
 ?>
 <?php if ($block->getFilesCount() > 0): ?>
     <?php foreach ($block->getFiles() as $file): ?>
@@ -20,22 +23,22 @@ $_width  = $block->getImagesWidth();
     <div
         data-row="file"
         class="filecnt"
-        id="<?= $block->escapeHtmlAttr($block->getFileId($file)) ?>"
-        data-size="<?= $block->escapeHtmlAttr($file->getSize()) ?>"
-        data-mime-type="<?= $block->escapeHtmlAttr($file->getMimeType()) ?>"
+        id="<?= $escaper->escapeHtmlAttr($block->getFileId($file)) ?>"
+        data-size="<?= $escaper->escapeHtmlAttr($file->getSize()) ?>"
+        data-mime-type="<?= $escaper->escapeHtmlAttr($file->getMimeType()) ?>"
     >
         <p class="nm">
         <?php if ($block->getFileThumbUrl($file)): ?>
-            <img src="<?= $block->escapeHtmlAttr($src) ?>" alt="<?= $block->escapeHtmlAttr($filename) ?>"/>
+            <img src="<?= $escaper->escapeHtmlAttr($src) ?>" alt="<?= $escaper->escapeHtmlAttr($filename) ?>"/>
         <?php endif; ?>
         </p>
         <?php if ($block->getFileWidth($file)): ?>
-              <small><?= $block->escapeHtmlAttr($width) ?>x<?= $block->escapeHtmlAttr($height) ?>
-                                                                   <?= $block->escapeHtml(__('px.')) ?></small><br/>
+              <small><?= $escaper->escapeHtmlAttr($width) ?>x<?= $escaper->escapeHtmlAttr($height) ?>
+                                                                   <?= $escaper->escapeHtml(__('px.')) ?></small><br/>
         <?php endif; ?>
-        <small><?= $block->escapeHtml($block->getFileShortName($file)) ?></small>
+        <small><?= $escaper->escapeHtml($block->getFileShortName($file)) ?></small>
     </div>
     <?php endforeach; ?>
 <?php else: ?>
-    <div class="empty"><?= $block->escapeHtml(__('No files found')) ?></div>
+    <div class="empty"><?= $escaper->escapeHtml(__('No files found')) ?></div>
 <?php endif; ?>

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Uploader $block */
+$blockHtmlId = $block->getHtmlId();
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader */
-
-$blockHtmlId = $block->getHtmlId();
 ?>
 
 <div id="<?= /* @noEscape */ $blockHtmlId ?>" class="uploader"
@@ -21,10 +26,10 @@ $blockHtmlId = $block->getHtmlId();
     }'
 >
     <span class="fileinput-button form-buttons">
-        <span><?= $block->escapeHtml(__('Upload Images')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Upload Images')) ?></span>
         <input class="fileupload" type="file"
-               name="<?= $block->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
-               data-url="<?= $block->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
+               name="<?= $escaper->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
+               data-url="<?= $escaper->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
     </span>
     <div class="clear"></div>
     <script type="text/x-magento-template" id="<?= /* @noEscape */ $blockHtmlId ?>-template">

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/tree.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/tree.phtml
@@ -3,21 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Tree;
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php
-/** Magento\Framework\Json\Helper\Data $jsonHelper */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Tree $block */
+/** @var Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
 ?>
 <div class="tree-panel" >
     <div class="categories-side-col">
         <div class="tree-actions">
-            <a id="collapseAll"><?= $block->escapeHtml(__('Collapse All')) ?></a>
+            <a id="collapseAll"><?= $escaper->escapeHtml(__('Collapse All')) ?></a>
             <span class="separator">|</span>
-            <a id="expandAll"><?= $block->escapeHtml(__('Expand All')) ?></a>
+            <a id="expandAll"><?= $escaper->escapeHtml(__('Expand All')) ?></a>
         </div>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
@@ -30,7 +34,7 @@ $jsonHelper = $block->getData('jsonHelper');
             '#div.tree-actions a#expandAll'
         ) ?>
     </div>
-    <div data-role="tree" data-mage-init='<?= $block->escapeHtml(
+    <div data-role="tree" data-mage-init='<?= $escaper->escapeHtml(
         $jsonHelper->jsonEncode($block->getTreeWidgetOptions())
     ) ?>'>
     </div>

--- a/app/code/Magento/Cms/view/frontend/templates/widget/link/link_block.phtml
+++ b/app/code/Magento/Cms/view/frontend/templates/widget/link/link_block.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Cms\Block\Widget\Page\Link $block
- */
+use Magento\Cms\Block\Widget\Page\Link;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <div class="widget block block-cms-link">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </a>
 </div>

--- a/app/code/Magento/Cms/view/frontend/templates/widget/link/link_inline.phtml
+++ b/app/code/Magento/Cms/view/frontend/templates/widget/link/link_inline.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Cms\Block\Widget\Page\Link $block
- */
+use Magento\Cms\Block\Widget\Page\Link;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <span class="widget block block-cms-link-inline">
     <a <?= /* @noEscape */ $block->getLinkAttributes() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </a>
 </span>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Cms` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37110: Chore: CMS - Replace Block Escaping with Escaper