### PR TITLE
Chore: Checkout Agreements - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/agreements.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\CheckoutAgreements\Block\Agreements;
 use Magento\CheckoutAgreements\Model\AgreementModeOptions;
-?>
-<?php
-/**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
- */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php if (!$block->getAgreements()) {
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Agreements $block */
+
+if (!$block->getAgreements()) {
     return;
-} ?>
+}
+?>
 <ol id="checkout-agreements" class="agreements checkout items">
     <?php /** @var \Magento\CheckoutAgreements\Api\Data\AgreementInterface $agreement */ ?>
     <?php foreach ($block->getAgreements() as $agreement):?>
@@ -23,7 +26,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                 <?php if ($agreement->getIsHtml()):?>
                     <?= /* @noEscape */ $agreement->getContent() ?>
                 <?php else:?>
-                    <?= $block->escapeHtml(nl2br($agreement->getContent())) ?>
+                    <?= $escaper->escapeHtml(nl2br($agreement->getContent())) ?>
                 <?php endif; ?>
             </div>
             <?php if ($agreement->getContentHeight()): ?>
@@ -39,7 +42,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                        id="agreement-<?= (int) $agreement->getAgreementId() ?>"
                        name="agreement[<?= (int) $agreement->getAgreementId() ?>]"
                        value="1"
-                       title="<?= $block->escapeHtml($agreement->getCheckboxText()) ?>"
+                       title="<?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>"
                        class="checkbox"
                        data-validate="{required:true}"/>
                 <label class="label" for="agreement-<?= (int) $agreement->getAgreementId() ?>">
@@ -47,7 +50,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </label>
@@ -57,7 +60,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </div>

--- a/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
+++ b/app/code/Magento/CheckoutAgreements/view/frontend/templates/multishipping_agreements.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\CheckoutAgreements\Block\Agreements;
 use Magento\CheckoutAgreements\Model\AgreementModeOptions;
-?>
-<?php
-/**
- * @var $block \Magento\CheckoutAgreements\Block\Agreements
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-?>
-<?php if (!$block->getAgreements()) {
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $seureRenderer */
+/** @var Agreements $block */
+
+if (!$block->getAgreements()) {
     return;
-} ?>
+}
+?>
 <ol id="checkout-agreements" class="agreements checkout items">
     <?php /** @var \Magento\CheckoutAgreements\Api\Data\AgreementInterface $agreement */ ?>
     <?php foreach ($block->getAgreements() as $agreement):?>
@@ -23,7 +26,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                 <?php if ($agreement->getIsHtml()):?>
                     <?= /* @noEscape */ $agreement->getContent() ?>
                 <?php else:?>
-                    <?= $block->escapeHtml(nl2br($agreement->getContent())) ?>
+                    <?= $escaper->escapeHtml(nl2br($agreement->getContent())) ?>
                 <?php endif; ?>
             </div>
                 <?php if ($agreement->getContentHeight()): ?>
@@ -39,7 +42,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                        id="agreement-<?= (int) $agreement->getAgreementId() ?>"
                        name="agreement[<?= (int) $agreement->getAgreementId() ?>]"
                        value="1"
-                       title="<?= $block->escapeHtml($agreement->getCheckboxText()) ?>"
+                       title="<?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>"
                        class="checkbox"
                        data-validate="{required:true}"/>
                 <label class="label" for="agreement-<?= (int) $agreement->getAgreementId() ?>">
@@ -47,7 +50,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                         <?php if ($agreement->getIsHtml()):?>
                             <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                         <?php else:?>
-                            <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                            <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                         <?php endif; ?>
                     </span>
                 </label>
@@ -58,7 +61,7 @@ use Magento\CheckoutAgreements\Model\AgreementModeOptions;
                     <?php if ($agreement->getIsHtml()):?>
                         <?= /* @noEscape */ $agreement->getCheckboxText() ?>
                     <?php else:?>
-                        <?= $block->escapeHtml($agreement->getCheckboxText()) ?>
+                        <?= $escaper->escapeHtml($agreement->getCheckboxText()) ?>
                     <?php endif; ?>
                 </span>
             </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_CheckoutAgreements` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37109: Chore: Checkout Agreements - Replace Block Escaping with Escaper