### PR TITLE
Chore: Checkout - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/templates/button.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/button.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php /** @var $block \Magento\Checkout\Block\Onepage\Success */ ?>
+declare(strict_types=1);
 
+use Magento\Checkout\Block\Onepage\Success;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Success $block */
+?>
 <?php if ($block->getCanViewOrder() && $block->getCanPrintOrder()) :?>
-    <a href="<?= $block->escapeUrl($block->getPrintUrl()) ?>"
+    <a href="<?= $escaper->escapeUrl($block->getPrintUrl()) ?>"
        class="action print"
        target="_blank"
        rel="noopener">
-        <?= $block->escapeHtml(__('Print receipt')) ?>
+        <?= $escaper->escapeHtml(__('Print receipt')) ?>
     </a>
     <?= $block->getChildHtml() ?>
 <?php endif;?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/coupon.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\AbstractBlock;
+
+/** @var Escaper $escaper */
+/** @var AbstractBlock $block */
 
 // phpcs:disable Generic.Files.LineLength.TooLong
-
-/**
- * @var \Magento\Framework\View\Element\AbstractBlock $block
- */
 
 // We should use strlen function because coupon code could be "0", converted to bool will lead to false
 $hasCouponCode = $block->getCouponCode() !== null && strlen($block->getCouponCode()) > 0;
@@ -17,11 +20,11 @@ $hasCouponCode = $block->getCouponCode() !== null && strlen($block->getCouponCod
      id="block-discount"
      data-mage-init='{"collapsible":{"active": <?= $hasCouponCode ? 'true' : 'false' ?>, "openedState": "active", "saveState": false}}'>
     <div class="title" data-role="title">
-        <strong id="block-discount-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Apply Discount Code')) ?></strong>
+        <strong id="block-discount-heading" role="heading" aria-level="2"><?= $escaper->escapeHtml(__('Apply Discount Code')) ?></strong>
     </div>
     <div class="content" data-role="content" aria-labelledby="block-discount-heading">
         <form id="discount-coupon-form"
-              action="<?= $block->escapeUrl($block->getUrl('checkout/cart/couponPost')) ?>"
+              action="<?= $escaper->escapeUrl($block->getUrl('checkout/cart/couponPost')) ?>"
               method="post"
               data-mage-init='{"discountCode":{"couponCodeSelector": "#coupon_code",
                                                "removeCouponSelector": "#remove-coupon",
@@ -31,15 +34,15 @@ $hasCouponCode = $block->getCouponCode() !== null && strlen($block->getCouponCod
                 <input type="hidden" name="remove" id="remove-coupon" value="0" />
                 <div class="field">
                     <label for="coupon_code" class="label">
-                        <span><?= $block->escapeHtml(__('Enter discount code')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Enter discount code')) ?></span>
                     </label>
                     <div class="control">
                         <input type="text"
                                class="input-text"
                                id="coupon_code"
                                name="coupon_code"
-                               value="<?= $block->escapeHtmlAttr($block->getCouponCode()) ?>"
-                               placeholder="<?= $block->escapeHtmlAttr(__('Enter discount code')) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($block->getCouponCode()) ?>"
+                               placeholder="<?= $escaper->escapeHtmlAttr(__('Enter discount code')) ?>"
                                 <?php if ($hasCouponCode): ?>
                                    disabled="disabled"
                                 <?php endif; ?>
@@ -50,15 +53,15 @@ $hasCouponCode = $block->getCouponCode() !== null && strlen($block->getCouponCod
                     <?php if (!$hasCouponCode): ?>
                     <div class="primary">
                         <button class="action apply primary" type="button"
-                                value="<?= $block->escapeHtmlAttr(__('Apply Discount')) ?>">
-                            <span><?= $block->escapeHtml(__('Apply Discount')) ?></span>
+                                value="<?= $escaper->escapeHtmlAttr(__('Apply Discount')) ?>">
+                            <span><?= $escaper->escapeHtml(__('Apply Discount')) ?></span>
                         </button>
                     </div>
                     <?php else: ?>
                         <div class="primary">
                             <button  type="button" class="action cancel primary"
-                                     value="<?= $block->escapeHtmlAttr(__('Cancel Coupon')) ?>">
-                                <span><?= $block->escapeHtml(__('Cancel Coupon')) ?></span>
+                                     value="<?= $escaper->escapeHtmlAttr(__('Cancel Coupon')) ?>">
+                                <span><?= $escaper->escapeHtml(__('Cancel Coupon')) ?></span>
                             </button>
                         </div>
                     <?php endif; ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/form.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Cart\Grid;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Grid $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/**  @var $block \Magento\Checkout\Block\Cart\Grid */
 ?>
 <?php $mergedCells = ($this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices() ? 2 : 1); ?>
 <?= $block->getChildHtml('form_before') ?>
-<form action="<?= $block->escapeUrl($block->getUrl('checkout/cart/updatePost')) ?>"
+<form action="<?= $escaper->escapeUrl($block->getUrl('checkout/cart/updatePost')) ?>"
           method="post"
           id="form-validate"
           data-mage-init='{"Magento_Checkout/js/action/update-shopping-cart":
-              {"validationURL" : "<?= $block->escapeUrl($block->getUrl('checkout/cart/updateItemQty')) ?>",
+              {"validationURL" : "<?= $escaper->escapeUrl($block->getUrl('checkout/cart/updateItemQty')) ?>",
               "updateCartActionContainer": "#update_cart_action_container"}
           }'
           class="form form-cart">
@@ -29,13 +34,13 @@
                class="cart items data table"
                data-mage-init='{"shoppingCart":{"emptyCartButton": ".action.clear",
                "updateCartActionContainer": "#update_cart_action_container"}}'>
-            <caption class="table-caption"><?= $block->escapeHtml(__('Shopping Cart Items')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('Shopping Cart Items')) ?></caption>
             <thead>
                 <tr>
-                    <th class="col item" scope="col"><span><?= $block->escapeHtml(__('Item')) ?></span></th>
-                    <th class="col price" scope="col"><span><?= $block->escapeHtml(__('Price')) ?></span></th>
-                    <th class="col qty" scope="col"><span><?= $block->escapeHtml(__('Qty')) ?></span></th>
-                    <th class="col subtotal" scope="col"><span><?= $block->escapeHtml(__('Subtotal')) ?></span></th>
+                    <th class="col item" scope="col"><span><?= $escaper->escapeHtml(__('Item')) ?></span></th>
+                    <th class="col price" scope="col"><span><?= $escaper->escapeHtml(__('Price')) ?></span></th>
+                    <th class="col qty" scope="col"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></th>
+                    <th class="col subtotal" scope="col"><span><?= $escaper->escapeHtml(__('Subtotal')) ?></span></th>
                 </tr>
             </thead>
             <?php foreach ($block->getItems() as $_item): ?>
@@ -51,9 +56,9 @@
     <div class="cart main actions">
         <?php if ($block->getContinueShoppingUrl()): ?>
             <a class="action continue"
-               href="<?= $block->escapeUrl($block->getContinueShoppingUrl()) ?>"
-               title="<?= $block->escapeHtml(__('Continue Shopping')) ?>">
-                <span><?= $block->escapeHtml(__('Continue Shopping')) ?></span>
+               href="<?= $escaper->escapeUrl($block->getContinueShoppingUrl()) ?>"
+               title="<?= $escaper->escapeHtml(__('Continue Shopping')) ?>">
+                <span><?= $escaper->escapeHtml(__('Continue Shopping')) ?></span>
             </a>
         <?php endif; ?>
         <?php if ($block->getViewModel()->isClearShoppingCartEnabled()): ?>
@@ -61,18 +66,18 @@
                     name="update_cart_action"
                     data-cart-empty=""
                     value="empty_cart"
-                    title="<?= $block->escapeHtml(__('Clear Shopping Cart')) ?>"
+                    title="<?= $escaper->escapeHtml(__('Clear Shopping Cart')) ?>"
                     class="action clear" id="empty_cart_button">
-                <span><?= $block->escapeHtml(__('Clear Shopping Cart')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Clear Shopping Cart')) ?></span>
             </button>
         <?php endif ?>
         <button type="submit"
                 name="update_cart_action"
                 data-cart-item-update=""
                 value="update_qty"
-                title="<?= $block->escapeHtml(__('Update Shopping Cart')) ?>"
+                title="<?= $escaper->escapeHtml(__('Update Shopping Cart')) ?>"
                 class="action update">
-            <span><?= $block->escapeHtml(__('Update Shopping Cart')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Update Shopping Cart')) ?></span>
         </button>
         <input type="hidden" value="" id="update_cart_action_container" data-cart-item-update=""/>
     </div>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/configure/updatecart.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+use Magento\Catalog\Block\Product\View;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 ?>
 <?php $_product = $block->getProduct(); ?>
 <?php $buttonTitle = __('Update Cart'); ?>
@@ -13,25 +18,25 @@
         <fieldset class="fieldset">
             <?php if ($block->shouldRenderQuantity()) :?>
             <div class="field qty">
-                <label class="label" for="qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></label>
+                <label class="label" for="qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></label>
                 <div class="control">
                     <input type="number"
                            name="qty"
                            id="qty"
                            min="0"
                            value=""
-                           title="<?= $block->escapeHtmlAttr(__('Qty')) ?>"
+                           title="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"
                            class="input-text qty"
-                           data-validate="<?= $block->escapeHtml(json_encode($block->getQuantityValidators())) ?>"/>
+                           data-validate="<?= $escaper->escapeHtml(json_encode($block->getQuantityValidators())) ?>"/>
                 </div>
             </div>
             <?php endif; ?>
             <div class="actions">
                 <button type="submit"
-                        title="<?= $block->escapeHtmlAttr($buttonTitle) ?>"
+                        title="<?= $escaper->escapeHtmlAttr($buttonTitle) ?>"
                         class="action primary tocart"
                         id="product-updatecart-button">
-                    <span><?= $block->escapeHtml($buttonTitle) ?></span>
+                    <span><?= $escaper->escapeHtml($buttonTitle) ?></span>
                 </button>
                 <?= $block->getChildHtml('', true) ?>
             </div>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/default.phtml
@@ -3,25 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Cart\Item\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.Files.LineLength
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer */
-
 $_item = $block->getItem();
 $product = $_item->getProduct();
 $isVisibleProduct = $product->isVisibleInSiteVisibility();
+
 /** @var \Magento\Msrp\Helper\Data $helper */
 $helper = $this->helper(Magento\Msrp\Helper\Data::class);
 $canApplyMsrp = $helper->isShowBeforeOrderConfirm($product) && $helper->isMinimalPriceLessMsrp($product);
 ?>
 <tbody class="cart item">
     <tr class="item-info">
-        <td data-th="<?= $block->escapeHtml(__('Item')) ?>" class="col item">
+        <td data-th="<?= $escaper->escapeHtml(__('Item')) ?>" class="col item">
             <?php if ($block->hasProductUrl()): ?>
-                <a href="<?= $block->escapeUrl($block->getProductUrl()) ?>"
-                   title="<?= $block->escapeHtml($block->getProductName()) ?>"
+                <a href="<?= $escaper->escapeUrl($block->getProductUrl()) ?>"
+                   title="<?= $escaper->escapeHtml($block->getProductName()) ?>"
                    tabindex="-1"
                    class="product-item-photo">
             <?php else: ?>
@@ -36,21 +42,21 @@ $canApplyMsrp = $helper->isShowBeforeOrderConfirm($product) && $helper->isMinima
             <div class="product-item-details">
                 <strong class="product-item-name">
                     <?php if ($block->hasProductUrl()): ?>
-                        <a href="<?= $block->escapeUrl($block->getProductUrl()) ?>"><?= $block->escapeHtml($block->getProductName()) ?></a>
+                        <a href="<?= $escaper->escapeUrl($block->getProductUrl()) ?>"><?= $escaper->escapeHtml($block->getProductName()) ?></a>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->getProductName()) ?>
+                        <?= $escaper->escapeHtml($block->getProductName()) ?>
                     <?php endif; ?>
                 </strong>
                 <?php if ($_options = $block->getOptionList()): ?>
                     <dl class="item-options">
                         <?php foreach ($_options as $_option): ?>
                             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
-                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                             <dd>
                                 <?php if (isset($_formatedOptionValue['full_view'])): ?>
-                                        <?= $block->escapeHtml($_formatedOptionValue['full_view'], ['span', 'a']) ?>
+                                        <?= $escaper->escapeHtml($_formatedOptionValue['full_view'], ['span', 'a']) ?>
                                     <?php else: ?>
-                                        <?= $block->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
+                                        <?= $escaper->escapeHtml($_formatedOptionValue['value'], ['span', 'a']) ?>
                                 <?php endif; ?>
                             </dd>
                         <?php endforeach; ?>
@@ -58,8 +64,8 @@ $canApplyMsrp = $helper->isShowBeforeOrderConfirm($product) && $helper->isMinima
                 <?php endif; ?>
                 <?php if ($messages = $block->getMessages()): ?>
                     <?php foreach ($messages as $message): ?>
-                        <div class= "cart item message <?= $block->escapeHtmlAttr($message['type']) ?>">
-                            <div><?= $block->escapeHtml($message['text']) ?></div>
+                        <div class= "cart item message <?= $escaper->escapeHtmlAttr($message['type']) ?>">
+                            <div><?= $escaper->escapeHtml($message['text']) ?></div>
                         </div>
                     <?php endforeach; ?>
                 <?php endif; ?>
@@ -71,53 +77,53 @@ $canApplyMsrp = $helper->isShowBeforeOrderConfirm($product) && $helper->isMinima
         </td>
 
         <?php if ($canApplyMsrp): ?>
-            <td class="col msrp" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+            <td class="col msrp" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
                 <span class="pricing msrp">
-                    <span class="msrp notice"><?= $block->escapeHtml(__('See price before order confirmation.')) ?></span>
+                    <span class="msrp notice"><?= $escaper->escapeHtml(__('See price before order confirmation.')) ?></span>
                     <?php $helpLinkId = 'cart-msrp-help-' . $_item->getId(); ?>
                     <a href="#" class="action help map"
-                       id="<?= ($block->escapeHtmlAttr($helpLinkId)) ?>"
+                       id="<?= ($escaper->escapeHtmlAttr($helpLinkId)) ?>"
                        data-mage-init='{"addToCart":{
                                             "origin": "info",
-                                            "helpLinkId": "#<?= $block->escapeJs($block->escapeHtml($helpLinkId)) ?>",
-                                            "productName": "<?= $block->escapeJs($block->escapeHtml($product->getName())) ?>",
+                                            "helpLinkId": "#<?= $escaper->escapeJs($escaper->escapeHtml($helpLinkId)) ?>",
+                                            "productName": "<?= $escaper->escapeJs($escaper->escapeHtml($product->getName())) ?>",
                                             "showAddToCart": false
                                             }
                                         }'
                     >
-                        <span><?= $block->escapeHtml(__("What's this?")) ?></span>
+                        <span><?= $escaper->escapeHtml(__("What's this?")) ?></span>
                     </a>
                 </span>
             </td>
         <?php else: ?>
-            <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+            <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
                 <?= $block->getUnitPriceHtml($_item) ?>
             </td>
         <?php endif; ?>
-        <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>">
+        <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>">
             <div class="field qty">
                 <div class="control qty">
-                    <label for="cart-<?= $block->escapeHtmlAttr($_item->getId()) ?>-qty">
-                        <span class="label"><?= $block->escapeHtml(__('Qty')) ?></span>
-                        <input id="cart-<?= $block->escapeHtmlAttr($_item->getId()) ?>-qty"
-                               name="cart[<?= $block->escapeHtmlAttr($_item->getId()) ?>][qty]"
-                               data-cart-item-id="<?= $block->escapeHtmlAttr($_item->getSku()) ?>"
-                               value="<?= $block->escapeHtmlAttr($block->getQty()) ?>"
+                    <label for="cart-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>-qty">
+                        <span class="label"><?= $escaper->escapeHtml(__('Qty')) ?></span>
+                        <input id="cart-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>-qty"
+                               name="cart[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>][qty]"
+                               data-cart-item-id="<?= $escaper->escapeHtmlAttr($_item->getSku()) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($block->getQty()) ?>"
                                type="number"
                                min="0"
                                size="4"
                                step="any"
-                               title="<?= $block->escapeHtmlAttr(__('Qty')) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"
                                class="input-text qty"
                                data-validate="{required:true,'validate-greater-than-zero':true}"
-                               data-item-qty="<?= $block->escapeHtmlAttr($block->getQty()) ?>"
+                               data-item-qty="<?= $escaper->escapeHtmlAttr($block->getQty()) ?>"
                                data-role="cart-item-qty"/>
                     </label>
                 </div>
             </div>
         </td>
 
-        <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+        <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
             <?php if ($canApplyMsrp): ?>
                 <span class="cart msrp subtotal">--</span>
             <?php else: ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/price/sidebar.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/price/sidebar.phtml
@@ -3,16 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
 ?>
 <?php $_item = $block->getItem() ?>
 <div class="price-container">
-    <span class="price-label"><?= $block->escapeHtml(__('Price')) ?></span>
+    <span class="price-label"><?= $escaper->escapeHtml(__('Price')) ?></span>
     <span class="price-wrapper">
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_item->getCalculationPrice()),
             ['span']
         ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/edit.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit */
+use Magento\Checkout\Block\Cart\Item\Renderer\Actions\Edit;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
 ?>
 <?php if ($block->isProductVisibleInSiteVisibility()) :?>
     <a class="action action-edit"
-       href="<?= $block->escapeUrl($block->getConfigureUrl()) ?>"
-       title="<?= $block->escapeHtmlAttr(__('Edit item parameters')) ?>">
-        <span><?= $block->escapeHtml(__('Edit')) ?></span>
+       href="<?= $escaper->escapeUrl($block->getConfigureUrl()) ?>"
+       title="<?= $escaper->escapeHtmlAttr(__('Edit item parameters')) ?>">
+        <span><?= $escaper->escapeHtml(__('Edit')) ?></span>
     </a>
 <?php endif ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/remove.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/item/renderer/actions/remove.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove */
+use Magento\Checkout\Block\Cart\Item\Renderer\Actions\Remove;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Remove $block */
 ?>
 <a href="#"
-   title="<?= $block->escapeHtml(__('Remove item')) ?>"
+   title="<?= $escaper->escapeHtml(__('Remove item')) ?>"
    class="action action-delete"
    data-post='<?= /* @noEscape */ $block->getDeletePostJson() ?>'>
     <span>
-        <?= $block->escapeHtml(__('Remove item')) ?>
+        <?= $escaper->escapeHtml(__('Remove item')) ?>
     </span>
 </a>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/minicart.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Cart\Sidebar */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Checkout\Block\Cart\Sidebar;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Sidebar $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div data-block="minicart" class="minicart-wrapper">
-    <a class="action showcart" href="<?= $block->escapeUrl($block->getShoppingCartUrl()) ?>"
+    <a class="action showcart" href="<?= $escaper->escapeUrl($block->getShoppingCartUrl()) ?>"
        data-bind="scope: 'minicart_content'">
-        <span class="text"><?= $block->escapeHtml(__('My Cart')) ?></span>
+        <span class="text"><?= $escaper->escapeHtml(__('My Cart')) ?></span>
         <span class="counter qty empty"
               data-bind="css: { empty: !!getCartParam('summary_count') == false && !isLoading() },
                blockLoader: isLoading">
@@ -64,8 +69,8 @@ script;
             "Magento_Ui/js/core/app": <?= /* @noEscape */ $block->getJsLayout() ?>
         },
         "*": {
-            "Magento_Ui/js/block-loader": "<?= $block->escapeJs(
-                $block->escapeUrl($block->getViewFileUrl('images/loader-1.gif'))
+            "Magento_Ui/js/block-loader": "<?= $escaper->escapeJs(
+                $escaper->escapeUrl($block->getViewFileUrl('images/loader-1.gif'))
             ) ?>"
         }
     }

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/noItems.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/noItems.phtml
@@ -3,16 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**  @var $block \Magento\Checkout\Block\Cart */
+use Magento\Checkout\Block\Cart;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Cart $block */
 ?>
 <div class="cart-empty">
     <?= $block->getChildHtml('checkout_cart_empty_widget') ?>
-    <p><?= $block->escapeHtml(__('You have no items in your shopping cart.')) ?></p>
-    <p><?= $block->escapeHtml(
+    <p><?= $escaper->escapeHtml(__('You have no items in your shopping cart.')) ?></p>
+    <p><?= $escaper->escapeHtml(
         __(
             'Click <a href="%1">here</a> to continue shopping.',
-            $block->escapeUrl($block->getContinueShoppingUrl())
+            $escaper->escapeUrl($block->getContinueShoppingUrl())
         ),
         ['a']
     ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/cart/shipping.phtml
@@ -3,10 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Checkout\Block\Cart\Shipping;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Shipping $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Cart\Shipping */ ?>
-<?php /** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */ ?>
 <div id="block-shipping"
      class="block shipping"
      data-mage-init='{"collapsible":{"openedState": "active", "saveState": true}}'
@@ -14,8 +20,8 @@
     <div class="title" data-role="title">
         <strong id="block-shipping-heading" role="heading" aria-level="2">
             <?= $block->getQuote()->isVirtual()
-                ? $block->escapeHtml(__('Estimate Tax'))
-                : $block->escapeHtml(__('Estimate Shipping and Tax'))
+                ? $escaper->escapeHtml(__('Estimate Tax'))
+                : $escaper->escapeHtml(__('Estimate Shipping and Tax'))
             ?>
         </strong>
     </div>
@@ -45,9 +51,9 @@ $scriptString = <<<script
                 'Magento_Ui/js/block-loader'
             ], function(url, blockLoader) {
                 blockLoader(
-                    "{$block->escapeJs($block->escapeUrl($block->getViewFileUrl('images/loader-1.gif')))}"
+                    "{$escaper->escapeJs($escaper->escapeUrl($block->getViewFileUrl('images/loader-1.gif')))}"
                 );
-                return url.setBaseUrl('{$block->escapeJs($block->escapeUrl($block->getBaseUrl()))}');
+                return url.setBaseUrl('{$escaper->escapeJs($escaper->escapeUrl($block->getBaseUrl()))}');
             })
 script;
 ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/item/price/row.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
-<span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+<span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
     <span class="cart-price">
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_item->getRowTotal()),
             ['span']
         ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/item/price/unit.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
-<span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+<span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
     <span class="cart-price">
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_item->getCalculationPrice()),
             ['span']
         ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/messages/addCartSuccessMessage.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
-
-<?= $block->escapeHtml(__(
+<?= $escaper->escapeHtml(__(
     'You added %1 to your <a href="%2">shopping cart</a>.',
     $block->getData('product_name'),
     $block->getData('cart_url')

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage.phtml
@@ -3,16 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Onepage */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Checkout\Block\Onepage;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Onepage $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div id="checkout" data-bind="scope:'checkout'" class="checkout-container">
     <div id="checkout-loader" data-role="checkout-loader" class="loading-mask" data-mage-init='{"checkoutLoader": {}}'>
         <div class="loader">
-            <img src="<?= $block->escapeUrl($block->getViewFileUrl('images/loader-1.gif')) ?>"
-                 alt="<?= $block->escapeHtmlAttr(__('Loading...')) ?>">
+            <img src="<?= $escaper->escapeUrl($block->getViewFileUrl('images/loader-1.gif')) ?>"
+                 alt="<?= $escaper->escapeHtmlAttr(__('Loading...')) ?>">
         </div>
     </div>
     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("position: absolute;", "#checkout-loader img") ?>
@@ -38,8 +43,8 @@ script;
             'mage/url',
             'Magento_Ui/js/block-loader'
         ], function(url, blockLoader) {
-            blockLoader("{$block->escapeJs($block->escapeUrl($block->getViewFileUrl('images/loader-1.gif')))}");
-            return url.setBaseUrl('{$block->escapeJs($block->escapeUrl($block->getBaseUrl()))}');
+            blockLoader("{$escaper->escapeJs($escaper->escapeUrl($block->getViewFileUrl('images/loader-1.gif')))}");
+            return url.setBaseUrl('{$escaper->escapeJs($escaper->escapeUrl($block->getBaseUrl()))}');
         })
 script;
     ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/failure.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/failure.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Onepage\Failure */
+use Magento\Checkout\Block\Onepage\Failure;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Failure $block */
 ?>
 <?php if ($block->getRealOrderId()) :?>
-    <p><?= $block->escapeHtml(__('Order #') . $block->getRealOrderId()) ?></p>
+    <p><?= $escaper->escapeHtml(__('Order #') . $block->getRealOrderId()) ?></p>
 <?php endif ?>
 <?php if ($error = $block->getErrorMessage()) :?>
-    <p><?= $block->escapeHtml($error) ?></p>
+    <p><?= $escaper->escapeHtml($error) ?></p>
 <?php endif ?>
-<p><?= $block->escapeHtml(
-    __('Click <a href="%1">here</a> to continue shopping.', $block->escapeUrl($block->getContinueShoppingUrl())),
+<p><?= $escaper->escapeHtml(
+    __('Click <a href="%1">here</a> to continue shopping.', $escaper->escapeUrl($block->getContinueShoppingUrl())),
     ['a']
 ) ?>
 </p>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item.phtml
@@ -3,29 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Cart\Item\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block Magento\Checkout\Block\Cart\Item\Renderer */
-
-$_item = $block->getItem();
 $taxDataHelper = $this->helper(Magento\Tax\Helper\Data::class);
 ?>
 <tbody class="cart item">
     <tr>
-        <td class="col item" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">
+        <td class="col item" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>">
             <span class="product-item-photo">
                 <?= $block->getImage($block->getProductForThumbnail(), 'cart_page_product_thumbnail')->toHtml() ?>
             </span>
             <div class="product-item-details">
                 <strong class="product name product-item-name">
-                    <?= $block->escapeHtml($block->getProductName()) ?>
+                    <?= $escaper->escapeHtml($block->getProductName()) ?>
                 </strong>
                 <?php if ($_options = $block->getOptionList()) :?>
                     <dl class="item-options">
                         <?php foreach ($_options as $_option) :?>
                             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
-                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                             <dd>
                                 <?php if (isset($_formatedOptionValue['full_view'])) :?>
                                     <?= /* @noEscape */ $_formatedOptionValue['full_view'] ?>
@@ -41,31 +45,31 @@ $taxDataHelper = $this->helper(Magento\Tax\Helper\Data::class);
                 <?php endif;?>
             </div>
         </td>
-        <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+        <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
             <?php if ($taxDataHelper->displayCartPriceInclTax() || $taxDataHelper->displayCartBothPrices()) :?>
-                <span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Incl. Tax')) ?>">
+                <span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Incl. Tax')) ?>">
                     <?= $block->getUnitPriceInclTaxHtml($_item) ?>
                 </span>
             <?php endif; ?>
             <?php if ($taxDataHelper->displayCartPriceExclTax() || $taxDataHelper->displayCartBothPrices()) :?>
-                <span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+                <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
                     <?= $block->getUnitPriceExclTaxHtml($_item) ?>
                 </span>
             <?php endif; ?>
         </td>
         <td class="col qty"
-            data-th="<?= $block->escapeHtml(__('Qty')) ?>"
+            data-th="<?= $escaper->escapeHtml(__('Qty')) ?>"
         >
-            <span class="qty"><?= $block->escapeHtml($_item->getQty()) ?></span>
+            <span class="qty"><?= $escaper->escapeHtml($_item->getQty()) ?></span>
         </td>
-        <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+        <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
             <?php if ($taxDataHelper->displayCartPriceInclTax() || $taxDataHelper->displayCartBothPrices()) :?>
-                <span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Incl. Tax')) ?>">
+                <span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Incl. Tax')) ?>">
                     <?= $block->getRowTotalInclTaxHtml($_item) ?>
                 </span>
             <?php endif; ?>
             <?php if ($taxDataHelper->displayCartPriceExclTax() || $taxDataHelper->displayCartBothPrices()) :?>
-                <span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+                <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
                     <?= $block->getRowTotalExclTaxHtml($_item) ?>
                 </span>
             <?php endif; ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_excl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_excl_tax.phtml
@@ -3,15 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
 <span class="cart-price">
-    <?= $block->escapeHtml(
+    <?= $escaper->escapeHtml(
         $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_item->getRowTotal()),
         ['span']
     ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_incl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/row_incl_tax.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
 <?php $_incl = $this->helper(Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
 <span class="cart-price">
-    <?= $block->escapeHtml(
+    <?= $escaper->escapeHtml(
         $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_incl),
         ['span']
     ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_excl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_excl_tax.phtml
@@ -3,15 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
 <span class="cart-price">
-    <?= $block->escapeHtml(
+    <?= $escaper->escapeHtml(
         $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_item->getCalculationPrice()),
         ['span']
     ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_incl_tax.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/onepage/review/item/price/unit_incl_tax.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Item\Price\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-
-/** @var $block \Magento\Checkout\Block\Item\Price\Renderer */
-
-$_item = $block->getItem();
 ?>
 <?php $_incl = $this->helper(Magento\Checkout\Helper\Data::class)->getPriceInclTax($_item); ?>
 <span class="cart-price">
-    <?= $block->escapeHtml(
+    <?= $escaper->escapeHtml(
         $this->helper(Magento\Checkout\Helper\Data::class)->formatPrice($_incl),
         ['span']
     ) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/registration.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/registration.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Registration */
+use Magento\Checkout\Block\Registration;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Registration $block */
 ?>
 <div id="registration" data-bind="scope:'registration'">
     <br />
@@ -18,8 +23,8 @@
                             "component": "Magento_Checkout/js/view/registration",
                             "config": {
                                 "registrationUrl":
-                                    "<?= $block->escapeJs($block->escapeUrl($block->getCreateAccountUrl())) ?>",
-                                "email": "<?= $block->escapeJs($block->getEmailAddress()) ?>"
+                                    "<?= $escaper->escapeJs($escaper->escapeUrl($block->getCreateAccountUrl())) ?>",
+                                "email": "<?= $escaper->escapeJs($block->getEmailAddress()) ?>"
                             },
                             "children": {
                                 "errors": {

--- a/app/code/Magento/Checkout/view/frontend/templates/shipping/price.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/shipping/price.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Checkout\Block\Shipping\Price;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Price $block */
+$shippingPrice = $block->getShippingPrice();
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Shipping\Price */ ?>
-
-<?php $shippingPrice = $block->getShippingPrice(); ?>
-<?= $block->escapeHtml($shippingPrice) ?>
+<?= $escaper->escapeHtml($shippingPrice) ?>

--- a/app/code/Magento/Checkout/view/frontend/templates/success.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/success.phtml
@@ -3,24 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Checkout\Block\Onepage\Success;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Success $block */
 ?>
-<?php /** @var $block \Magento\Checkout\Block\Onepage\Success */ ?>
 <div class="checkout-success">
     <?php if ($block->getOrderId()) :?>
         <?php if ($block->getCanViewOrder()) :?>
-            <p><?= $block->escapeHtml(__('Your order number is: %1.', sprintf('<a href="%s" class="order-number"><strong>%s</strong></a>', $block->escapeUrl($block->getViewOrderUrl()), $block->getOrderId())), ['a', 'strong']) ?></p>
+            <p><?= $escaper->escapeHtml(__('Your order number is: %1.', sprintf('<a href="%s" class="order-number"><strong>%s</strong></a>', $escaper->escapeUrl($block->getViewOrderUrl()), $block->getOrderId())), ['a', 'strong']) ?></p>
         <?php  else :?>
-            <p><?= $block->escapeHtml(__('Your order # is: <span>%1</span>.', $block->getOrderId()), ['span']) ?></p>
+            <p><?= $escaper->escapeHtml(__('Your order # is: <span>%1</span>.', $block->getOrderId()), ['span']) ?></p>
         <?php endif;?>
-            <p><?= $block->escapeHtml(__('We\'ll email you an order confirmation with details and tracking info.')) ?></p>
+            <p><?= $escaper->escapeHtml(__('We\'ll email you an order confirmation with details and tracking info.')) ?></p>
     <?php endif;?>
 
     <?= $block->getAdditionalInfoHtml() ?>
 
     <div class="actions-toolbar">
         <div class="primary">
-            <a class="action primary continue" href="<?= $block->escapeUrl($block->getContinueUrl()) ?>"><span><?= $block->escapeHtml(__('Continue Shopping')) ?></span></a>
+            <a class="action primary continue" href="<?= $escaper->escapeUrl($block->getContinueUrl()) ?>"><span><?= $escaper->escapeHtml(__('Continue Shopping')) ?></span></a>
         </div>
     </div>
 </div>

--- a/app/code/Magento/Checkout/view/frontend/templates/total/default.phtml
+++ b/app/code/Magento/Checkout/view/frontend/templates/total/default.phtml
@@ -3,33 +3,37 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Checkout\Block\Total\DefaultTotal */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Checkout\Block\Total\DefaultTotal;
+use Magento\Checkout\Helper\Data;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php
-/** @var \Magento\Checkout\Helper\Data $checkoutHelper */
+/** @var Escaper $escaper */
+/** @var DefaultTotal $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Data $checkoutHelper */
 $checkoutHelper = $block->getData('checkoutHelper');
 ?>
 <tr class="totals">
-    <th colspan="<?= $block->escapeHtmlAttr($block->getColspan()) ?>"
+    <th colspan="<?= $escaper->escapeHtmlAttr($block->getColspan()) ?>"
         class="mark" scope="row">
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()):?>
             <strong>
         <?php endif; ?>
-        <?= $block->escapeHtml($block->getTotal()->getTitle()) ?>
+        <?= $escaper->escapeHtml($block->getTotal()->getTitle()) ?>
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()):?>
             </strong>
         <?php endif; ?>
     </th>
     <td class="amount"
-        data-th="<?= $block->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
+        data-th="<?= $escaper->escapeHtmlAttr($block->getTotal()->getTitle()) ?>">
         <?php if ($block->getRenderingArea() == $block->getTotal()->getArea()):?>
             <strong>
         <?php endif; ?>
             <span>
-                <?= $block->escapeHtml(
+                <?= $escaper->escapeHtml(
                     $checkoutHelper->formatPrice($block->getTotal()->getValue()),
                     ['span']
                 ) ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Checkout` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37108: Chore: Checkout - Replace Block Escaping with Escaper