### PR TITLE
Chore: Catalog Search - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/form.phtml
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\CatalogSearch\Block\Advanced\Form;
 use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 /**
  * Catalog advanced search form
  *
- * @var $block \Magento\CatalogSearch\Block\Advanced\Form
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var Form $block
+ * @var SecureHtmlRenderer $secureRenderer
  * @var Escaper $escaper
  */
 ?>
@@ -19,15 +22,15 @@ use Magento\Framework\Escaper;
 /** @var \Magento\CatalogSearch\Helper\Data $catalogSearchHelper */
 $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
 <?php $maxQueryLength = $catalogSearchHelper->getMaxQueryLength();?>
-<form class="form search advanced" action="<?= $block->escapeUrl($block->getSearchPostUrl()) ?>" method="get"
+<form class="form search advanced" action="<?= $escaper->escapeUrl($block->getSearchPostUrl()) ?>" method="get"
       id="form-validate">
 <fieldset class="fieldset">
-    <legend class="legend"><span><?= $block->escapeHtml(__('Search Settings')) ?></span></legend><br />
+    <legend class="legend"><span><?= $escaper->escapeHtml(__('Search Settings')) ?></span></legend><br />
     <?php foreach ($block->getSearchableAttributes() as $_attribute): ?>
         <?php $_code = $_attribute->getAttributeCode() ?>
-        <div class="field <?= $block->escapeHtmlAttr($_code) ?>">
-            <label class="label" for="<?= $block->escapeHtmlAttr($_code) ?>">
-                <span><?= $block->escapeHtml(__($block->getAttributeLabel($_attribute))) ?></span>
+        <div class="field <?= $escaper->escapeHtmlAttr($_code) ?>">
+            <label class="label" for="<?= $escaper->escapeHtmlAttr($_code) ?>">
+                <span><?= $escaper->escapeHtml(__($block->getAttributeLabel($_attribute))) ?></span>
             </label>
             <div class="control">
                 <?php
@@ -38,27 +41,27 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                     <div class="field no-label">
                         <div class="control">
                             <input type="text"
-                                   name="<?= $block->escapeHtmlAttr($_code) ?>[from]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                   name="<?= $escaper->escapeHtmlAttr($_code) ?>[from]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                    data-validate="{number:true, 'less-than-equals-to':'#<?=
-                                    $block->escapeHtmlAttr($_code) ?>_to'}" />
+                                    $escaper->escapeHtmlAttr($_code) ?>_to'}" />
                         </div>
                     </div>
                     <div class="field no-label">
                         <div class="control">
                             <input type="text"
-                                   name="<?= $block->escapeHtmlAttr($_code) ?>[to]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>_to"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                   name="<?= $escaper->escapeHtmlAttr($_code) ?>[to]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>_to"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                    data-validate="{number:true, 'greater-than-equals-to':'#<?=
-                                    $block->escapeHtmlAttr($_code) ?>'}" />
+                                    $escaper->escapeHtmlAttr($_code) ?>'}" />
                         </div>
                     </div>
                 </div>
@@ -69,38 +72,38 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                 <div class="range price fields group group-2">
                     <div class="field no-label">
                         <div class="control">
-                            <input name="<?= $block->escapeHtmlAttr($_code) ?>[from]"
-                                   value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
-                                   id="<?= $block->escapeHtmlAttr($_code) ?>"
-                                   title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                            <input name="<?= $escaper->escapeHtmlAttr($_code) ?>[from]"
+                                   value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'from')) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                                   title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                    class="input-text"
                                    type="text"
-                                   maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                   maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                    data-validate="{
                                        number:true,
                                        'validate-not-negative-number':true,
-                                       'less-than-equals-to':'#<?= $block->escapeHtmlAttr($_code) ?>_to'
+                                       'less-than-equals-to':'#<?= $escaper->escapeHtmlAttr($_code) ?>_to'
                                    }" />
                         </div>
                     </div>
                     <div class="field with-addon no-label">
                         <div class="control">
                             <div class="addon">
-                                <input name="<?= $block->escapeHtmlAttr($_code) ?>[to]"
-                                       value="<?= $block->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
-                                       id="<?= $block->escapeHtmlAttr($_code) ?>_to"
-                                       title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                                <input name="<?= $escaper->escapeHtmlAttr($_code) ?>[to]"
+                                       value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute, 'to')) ?>"
+                                       id="<?= $escaper->escapeHtmlAttr($_code) ?>_to"
+                                       title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
                                        class="input-text"
                                        type="text"
-                                       maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>"
+                                       maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>"
                                        data-validate="{
                                            number:true,
                                            'validate-not-negative-number':true,
-                                           'greater-than-equals-to':'#<?= $block->escapeHtmlAttr($_code) ?>'
+                                           'greater-than-equals-to':'#<?= $escaper->escapeHtmlAttr($_code) ?>'
                                        }" />
                                 <label class="addafter"
-                                       for="<?= $block->escapeHtmlAttr($_code) ?>_to">
-                                    <?= $block->escapeHtml($block->getCurrency($_attribute)) ?>
+                                       for="<?= $escaper->escapeHtmlAttr($_code) ?>_to">
+                                    <?= $escaper->escapeHtml($block->getCurrency($_attribute)) ?>
                                 </label>
                                 <input type="hidden"
                                        name="<?= $escaper->escapeHtmlAttr($_code)?>[currency]"
@@ -140,12 +143,12 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
                     default:
                         ?>
                 <input type="text"
-                       name="<?= $block->escapeHtmlAttr($_code) ?>"
-                       id="<?= $block->escapeHtmlAttr($_code) ?>"
-                       value="<?= $block->escapeHtml($block->getAttributeValue($_attribute)) ?>"
-                       title="<?= $block->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
-                       class="input-text <?= $block->escapeHtmlAttr($block->getAttributeValidationClass($_attribute))?>"
-                       maxlength="<?= $block->escapeHtmlAttr($maxQueryLength) ?>" />
+                       name="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                       id="<?= $escaper->escapeHtmlAttr($_code) ?>"
+                       value="<?= $escaper->escapeHtml($block->getAttributeValue($_attribute)) ?>"
+                       title="<?= $escaper->escapeHtml($block->getAttributeLabel($_attribute)) ?>"
+                       class="input-text <?= $escaper->escapeHtmlAttr($block->getAttributeValidationClass($_attribute))?>"
+                       maxlength="<?= $escaper->escapeHtmlAttr($maxQueryLength) ?>" />
             <?php endswitch; ?>
             </div>
         </div>
@@ -155,8 +158,8 @@ $catalogSearchHelper = $block->getData('catalogSearchHelper'); ?>
   <div class="primary">
     <button type="submit"
             class="action search primary"
-            title="<?= $block->escapeHtml(__('Search')) ?>">
-        <span><?= $block->escapeHtml(__('Search')) ?></span>
+            title="<?= $escaper->escapeHtml(__('Search')) ?>">
+        <span><?= $escaper->escapeHtml(__('Search')) ?></span>
     </button>
   </div>
 </div>
@@ -177,8 +180,8 @@ require([
                 }
             },
             messages: {
-                'price[to]': {'greater-than-equals-to': '{$block->escapeJs(__('Please enter a valid price range.'))}'},
-                'price[from]': {'less-than-equals-to': '{$block->escapeJs(__('Please enter a valid price range.'))}'}
+                'price[to]': {'greater-than-equals-to': '{$escaper->escapeJs(__('Please enter a valid price range.'))}'},
+                'price[from]': {'less-than-equals-to': '{$escaper->escapeJs(__('Please enter a valid price range.'))}'}
             }
         });
 });

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/link.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/link.phtml
@@ -3,14 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\CatalogSearch\Helper\Data;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 
- /** @var \Magento\CatalogSearch\Helper\Data $helper */
-$helper = $this->helper(\Magento\CatalogSearch\Helper\Data::class);
+/** @var Data $helper */
+$helper = $this->helper(Data::class);
 ?>
 <div class="nested">
-    <a class="action advanced" href="<?= $block->escapeUrl($helper->getAdvancedSearchUrl()) ?>" data-action="advanced-search">
-        <?= $block->escapeHtml(__('Advanced Search')) ?>
+    <a class="action advanced" href="<?= $escaper->escapeUrl($helper->getAdvancedSearchUrl()) ?>" data-action="advanced-search">
+        <?= $escaper->escapeHtml(__('Advanced Search')) ?>
     </a>
 </div>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/advanced/result.phtml
@@ -3,11 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\CatalogSearch\Block\Advanced\Result
- */
+declare(strict_types=1);
+
+use Magento\CatalogSearch\Block\Advanced\Result;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Result $block */
 /** this changes need for valid apply filters and configuration before search process is started */
 $productList = $block->getProductListHtml();
 ?>
@@ -22,7 +24,7 @@ $productList = $block->getProductListHtml();
 <?php else : ?>
     <div role="alert" class="message error">
         <div>
-            <?= $block->escapeHtml(__('We can\'t find any items matching these search criteria.')) ?> <a href="<?= $block->escapeUrl($block->getFormUrl()) ?>"><?= $block->escapeHtml(__('Modify your search.')) ?></a>
+            <?= $escaper->escapeHtml(__('We can\'t find any items matching these search criteria.')) ?> <a href="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"><?= $escaper->escapeHtml(__('Modify your search.')) ?></a>
         </div>
     </div>
 <?php endif; ?>
@@ -33,7 +35,7 @@ $productList = $block->getProductListHtml();
         <?php if (!empty($searchCriterias[$side])) : ?>
             <ul class="items">
                 <?php foreach ($searchCriterias[$side] as $criteria) : ?>
-                    <li class="item"><strong><?= $block->escapeHtml(__($criteria['name'])) ?>:</strong> <?= $block->escapeHtml($criteria['value']) ?></li>
+                    <li class="item"><strong><?= $escaper->escapeHtml(__($criteria['name'])) ?>:</strong> <?= $escaper->escapeHtml($criteria['value']) ?></li>
                 <?php endforeach; ?>
             </ul>
         <?php endif; ?>
@@ -42,8 +44,8 @@ $productList = $block->getProductListHtml();
 <?php if ($block->getResultCount()) : ?>
     <div class="message notice">
         <div>
-            <?= $block->escapeHtml(__("Don't see what you're looking for?")) ?>
-            <a href="<?= $block->escapeUrl($block->getFormUrl()) ?>"><?= $block->escapeHtml(__('Modify your search.')) ?></a>
+            <?= $escaper->escapeHtml(__("Don't see what you're looking for?")) ?>
+            <a href="<?= $escaper->escapeUrl($block->getFormUrl()) ?>"><?= $escaper->escapeHtml(__('Modify your search.')) ?></a>
         </div>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/result.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @codingStandardsIgnoreFile
+declare(strict_types=1);
 
 use Magento\CatalogSearch\Block\Result;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 /** These changes need to valid applying filters and configuration before search process is started. */
-
-/** @var $block  Result*/
+/** @var Result $block */
 $productList = $block->getProductListHtml();
+
+// @codingStandardsIgnoreFile
 ?>
 <?php if ($block->getResultCount()) : ?>
     <?= /* @noEscape */ $block->getChildHtml('tagged_product_list_rss_link') ?>
@@ -30,7 +34,7 @@ $productList = $block->getProductListHtml();
 
 <div class="message notice">
     <div>
-        <?= $block->escapeHtml($block->getNoResultText() ? $block->getNoResultText() : __('Your search returned no results.')) ?>
+        <?= $escaper->escapeHtml($block->getNoResultText() ? $block->getNoResultText() : __('Your search returned no results.')) ?>
         <?= /* @noEscape */ $block->getAdditionalHtml() ?>
         <?php if ($messages = $block->getNoteMessages()) : ?>
             <?php foreach ($messages as $message) : ?>

--- a/app/code/Magento/CatalogSearch/view/frontend/templates/search_terms_log.phtml
+++ b/app/code/Magento/CatalogSearch/view/frontend/templates/search_terms_log.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php if ($block->getSearchTermsLog()->isPageCacheable()) : ?>
     <script type="text/x-magento-init">
     {
         "*": {
             "Magento_CatalogSearch/js/search-terms-log": {
-                "url": "<?= $block->escapeUrl($block->getUrl('catalogsearch/searchTermsLog/save')) ?>"
+                "url": "<?= $escaper->escapeUrl($block->getUrl('catalogsearch/searchTermsLog/save')) ?>"
             }
         }
     }


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_CatalogSearch` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37106: Chore: Catalog Search - Replace Block Escaping with Escaper