### PR TITLE
Chore: Catalog Rule - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/CatalogRule/view/adminhtml/templates/promo/fieldset.phtml
+++ b/app/code/Magento/CatalogRule/view/adminhtml/templates/promo/fieldset.phtml
@@ -3,20 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**@var \Magento\Backend\Block\Widget\Form\Renderer\Fieldset $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Fieldset $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_element = $block->getElement() ?>
 <?php $_jsObjectName = $block->getFieldSetId() != null ? $block->getFieldSetId() : $_element->getHtmlId() ?>
 <div class="rule-tree">
-<fieldset id="<?= $block->escapeHtmlAttr($_jsObjectName) ?>" <?= /* @noEscape */ $_element->serialize(['class']) ?>
+<fieldset id="<?= $escaper->escapeHtmlAttr($_jsObjectName) ?>" <?= /* @noEscape */ $_element->serialize(['class']) ?>
           class="fieldset">
-        <legend class="legend"><span><?= $block->escapeHtml($_element->getLegend()) ?></span></legend>
+        <legend class="legend"><span><?= $escaper->escapeHtml($_element->getLegend()) ?></span></legend>
         <br>
     <?php if ($_element->getComment()): ?>
         <div class="messages">
-            <div class="message message-notice"><?= $block->escapeHtml($_element->getComment()) ?></div>
+            <div class="message message-notice"><?= $escaper->escapeHtml($_element->getComment()) ?></div>
         </div>
     <?php endif; ?>
     <div class="rule-tree-wrapper">


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_CatalogRule` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37105: Chore: Catalog Rule - Replace Block Escaping with Escaper