### PR TITLE
Chore: Catalog Inventory - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/qtyincrements.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\CatalogInventory\Block\Qtyincrements
- */
+use Magento\CatalogInventory\Block\Qtyincrements;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Qtyincrements $block */
 ?>
 <?php if ($block->getProductQtyIncrements()) : ?>
     <div class="product pricing">
-        <?= $block->escapeHtml(__('%1 is available to buy in increments of %2', $block->getProductName(), $block->getProductQtyIncrements())) ?>
+        <?= $escaper->escapeHtml(__('%1 is available to buy in increments of %2', $block->getProductName(), $block->getProductQtyIncrements())) ?>
     </div>
 <?php endif ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/composite.phtml
@@ -3,29 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\CatalogInventory\Block\Stockqty\Composite
- */
+use Magento\CatalogInventory\Block\Stockqty\Composite;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Composite $block */
 ?>
 <?php if ($block->isMsgVisible()) : ?>
     <div class="availability only">
         <a href="#"
-           data-mage-init='{"toggleAdvanced": {"selectorsToggleClass": "active", "baseToggleClass": "expanded", "toggleContainers": "#<?= $block->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>"}}'
-           id="<?= $block->escapeHtmlAttr($block->getPlaceholderId()) ?>"
-           title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>"
+           data-mage-init='{"toggleAdvanced": {"selectorsToggleClass": "active", "baseToggleClass": "expanded", "toggleContainers": "#<?= $escaper->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>"}}'
+           id="<?= $escaper->escapeHtmlAttr($block->getPlaceholderId()) ?>"
+           title="<?= $escaper->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>"
            class="action show">
-            <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
+            <?= /* @noEscape */ __('Only %1 left', "<strong>{$escaper->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
         </a>
     </div>
-    <div class="availability only detailed" id="<?= $block->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>">
+    <div class="availability only detailed" id="<?= $escaper->escapeHtmlAttr($block->getDetailsPlaceholderId()) ?>">
         <div class="table-wrapper">
             <table class="data table">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Product availability')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Product availability')) ?></caption>
                 <thead>
                 <tr>
-                    <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                    <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
+                    <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                 </tr>
                 </thead>
                 <tbody>
@@ -33,8 +36,8 @@
                     <?php $childProductStockQty = $block->getProductStockQty($childProduct); ?>
                     <?php if ($childProductStockQty > 0) : ?>
                         <tr>
-                            <td data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>" class="col item"><?= $block->escapeHtml($childProduct->getName()) ?></td>
-                            <td data-th="<?= $block->escapeHtmlAttr(__('Qty')) ?>" class="col qty"><?= $block->escapeHtml($childProductStockQty) ?></td>
+                            <td data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>" class="col item"><?= $escaper->escapeHtml($childProduct->getName()) ?></td>
+                            <td data-th="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>" class="col qty"><?= $escaper->escapeHtml($childProductStockQty) ?></td>
                         </tr>
                     <?php endif ?>
                 <?php endforeach ?>

--- a/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
+++ b/app/code/Magento/CatalogInventory/view/frontend/templates/stockqty/default.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\CatalogInventory\Block\Stockqty\DefaultStockqty
- */
+use Magento\CatalogInventory\Block\Stockqty\DefaultStockqty;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var DefaultStockqty $block */
 ?>
 <?php if ($block->isMsgVisible()) : ?>
-    <div class="availability only" title="<?= $block->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
-        <?= /* @noEscape */ __('Only %1 left', "<strong>{$block->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
+    <div class="availability only" title="<?= $escaper->escapeHtmlAttr(__('Only %1 left', ($block->getStockQtyLeft()))) ?>">
+        <?= /* @noEscape */ __('Only %1 left', "<strong>{$escaper->escapeHtml($block->getStockQtyLeft())}</strong>") ?>
     </div>
 <?php endif ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_CatalogInventory` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37104: Chore: Catalog Inventory - Replace Block Escaping with Escaper