### PR TITLE
Chore: Catalog - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/checkboxes/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/checkboxes/tree.phtml
@@ -3,27 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Catalog\Block\Adminhtml\Category\Tree
- */
+use Magento\Catalog\Block\Adminhtml\Category\Tree;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Tree $block */
 ?>
 
-<?php $divId = $block->escapeHtml('tree-div_' . time()) ?>
+<?php $divId = $escaper->escapeHtml('tree-div_' . time()) ?>
 <div id="<?= /* @noEscape */ $divId ?>" class="tree"></div>
 
 <script type="text/x-magento-init">
     {
         "*": {
             "categoryCheckboxTree": {
-                "dataUrl":       "<?= $block->escapeUrl($block->getLoadTreeUrl()) ?>",
+                "dataUrl":       "<?= $escaper->escapeUrl($block->getLoadTreeUrl()) ?>",
                 "divId":         "<?= /* @noEscape */ $divId ?>",
                 "rootVisible":   false,
-                "useAjax":       <?= $block->escapeHtml($block->getUseAjax()) ?>,
+                "useAjax":       <?= $escaper->escapeHtml($block->getUseAjax()) ?>,
                 "currentNodeId": <?= (int)$block->getCategoryId() ?>,
                 "jsFormObject":  "<?= /* @noEscape */ $block->getJsFormObject() ?>",
-                "name":          "<?= $block->escapeHtml($block->getRoot()->getName()) ?>",
-                "checked":       "<?= $block->escapeHtml($block->getRoot()->getChecked()) ?>",
+                "name":          "<?= $escaper->escapeHtml($block->getRoot()->getName()) ?>",
+                "checked":       "<?= $escaper->escapeHtml($block->getRoot()->getChecked()) ?>",
                 "allowdDrop":    <?= /* @noEscape */ $block->getRoot()->getIsVisible() ? 'true' : 'false' ?>,
                 "rootId":        <?= (int)$block->getRoot()->getId() ?>,
                 "expanded":      true,

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/edit.phtml
@@ -3,15 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Catalog\Block\Adminhtml\Category\Edit
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Catalog\Block\Adminhtml\Category\Edit;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-id="information-dialog-category" class="messages">
     <div class="message message-notice">
-        <div><?= $block->escapeHtml(__('This operation can take a long time')) ?></div>
+        <div><?= $escaper->escapeHtml(__('This operation can take a long time')) ?></div>
     </div>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display: none;', 'div[data-id="information-dialog-category"]') ?>
@@ -19,7 +23,7 @@
 <script type="text/x-magento-init">
     {
         "*": {
-            "categoryForm": {"refreshUrl": "<?= $block->escapeJs($block->escapeUrl($block->getRefreshPathUrl())) ?>"}
+            "categoryForm": {"refreshUrl": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getRefreshPathUrl())) ?>"}
         }
     }
 </script>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/tree.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Category\Tree */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Category\Tree;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Tree $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="categories-side-col">
     <div class="sidebar-actions">
@@ -16,9 +22,9 @@
     </div>
     <div class="tree-actions">
         <?php if ($block->getRoot()):?>
-            <a id="colapseAll" href="#"><?= $block->escapeHtml(__('Collapse All')) ?></a>
+            <a id="colapseAll" href="#"><?= $escaper->escapeHtml(__('Collapse All')) ?></a>
             <span class="separator">|</span>
-            <a id="expandAll" href="#"><?= $block->escapeHtml(__('Expand All')) ?></a>
+            <a id="expandAll" href="#"><?= $escaper->escapeHtml(__('Expand All')) ?></a>
         <?php endif; ?>
     </div>
     <?php if ($block->getRoot()):?>
@@ -39,7 +45,7 @@
 
     <div data-id="information-dialog-tree" class="messages">
         <div class="message message-notice">
-            <div><?= $block->escapeHtml(__('This operation can take a long time')) ?></div>
+            <div><?= $escaper->escapeHtml(__('This operation can take a long time')) ?></div>
         </div>
     </div>
         <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
@@ -183,7 +189,7 @@
 
                     if (!this.collapsed) {
                         this.collapsed = true;
-                        this.loader.dataUrl = '{$block->escapeJs($block->getLoadTreeUrl(false))}';
+                        this.loader.dataUrl = '{$escaper->escapeJs($block->getLoadTreeUrl(false))}';
                         this.request(this.loader.dataUrl, false);
                     }
                 },
@@ -192,7 +198,7 @@
                     this.expandAll();
                     if (this.collapsed) {
                         this.collapsed = false;
-                        this.loader.dataUrl = '{$block->escapeJs($block->getLoadTreeUrl(true))}';
+                        this.loader.dataUrl = '{$escaper->escapeJs($block->getLoadTreeUrl(true))}';
                         this.request(this.loader.dataUrl, false);
                     }
                 },
@@ -227,7 +233,7 @@
                 if (tree && switcherParams) {
                     var url;
                     if (switcherParams.useConfirm) {
-                        if (!confirm("{$block->escapeJs(__(
+                        if (!confirm("{$escaper->escapeJs(__(
     'Please confirm site switching. All data that hasn\'t been saved will be lost.'
 ))}")) {
                             return false;
@@ -272,7 +278,7 @@
                             }
                         });
                     } else {
-                        var baseUrl = '{$block->escapeJs($block->getEditUrl())}';
+                        var baseUrl = '{$escaper->escapeJs($block->getEditUrl())}';
                         var urlExt = switcherParams.scopeParams + 'id/' + tree.currentNodeId + '/';
                         url = parseSidUrl(baseUrl, urlExt);
                         setLocation(url);
@@ -324,7 +330,7 @@ endif;
 
             jQuery(function () {
                 categoryLoader = new Ext.tree.TreeLoader({
-                    dataUrl: '{$block->escapeJs($block->getLoadTreeUrl())}'
+                    dataUrl: '{$escaper->escapeJs($block->getLoadTreeUrl())}'
                 });
 
                 categoryLoader.processResponse = function (response, parent, callback) {
@@ -409,11 +415,11 @@ endif;
 script;
         $scriptString .= '
                     rootVisible: \'' . ($block->getRoot()->getIsVisible() ? 'true' : 'false') . '\',
-                    useAjax: ' . $block->escapeJs($block->getUseAjax()) . ',
-                    switchTreeUrl: \'' . $block->escapeJs($block->escapeUrl($block->getSwitchTreeUrl())) .'\',
-                    editUrl: \'' . $block->escapeJs($block->escapeUrl($block->getEditUrl())) .'\',
+                    useAjax: ' . $escaper->escapeJs($block->getUseAjax()) . ',
+                    switchTreeUrl: \'' . $escaper->escapeJs($escaper->escapeUrl($block->getSwitchTreeUrl())) .'\',
+                    editUrl: \'' . $escaper->escapeJs($escaper->escapeUrl($block->getEditUrl())) .'\',
                     currentNodeId: ' . (int)$block->getCategoryId() . ',
-                    baseUrl: \'' . $block->escapeJs($block->escapeUrl($block->getEditUrl())) . '\'
+                    baseUrl: \'' . $escaper->escapeJs($escaper->escapeUrl($block->getEditUrl())) . '\'
                 };
 
                 defaultLoadTreeParams = {
@@ -504,7 +510,7 @@ script;
                         click: function () {
                             (function ($) {
                                 $.ajax({
-                                    url: '{$block->escapeJs($block->getMoveUrl())}',
+                                    url: '{$escaper->escapeJs($block->getMoveUrl())}',
                                     method: 'POST',
                                     data: registry.get('pd'),
                                     showLoader: true

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/widget/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/widget/tree.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_divId = 'tree' . $block->getId() ?>
-<div id="<?= $block->escapeHtmlAttr($_divId) ?>" class="tree"></div>
+<div id="<?= $escaper->escapeHtmlAttr($_divId) ?>" class="tree"></div>
 <?php
 $isUseMassaction = $block->getUseMassaction() ? 1 : 0;
 $isAnchorOnly = $block->getIsAnchorOnly() ? 1 : 0;
@@ -18,7 +23,7 @@ $scriptString = <<<script
 
 require(['jquery', 'prototype', 'extjs/ext-tree-checkbox'], function(jQuery){
 
-var tree{$block->escapeJs($block->getId())};
+var tree{$escaper->escapeJs($block->getId())};
 
 var useMassaction = {$isUseMassaction};
 
@@ -71,7 +76,7 @@ script;
 $scriptString .= <<<script
 
     var categoryLoader = new Ext.tree.TreeLoader({
-       dataUrl: '{$block->escapeJs($block->escapeUrl($block->getLoadTreeUrl()))}'
+       dataUrl: '{$escaper->escapeJs($escaper->escapeUrl($block->getLoadTreeUrl()))}'
     });
 
     categoryLoader.processResponse = function (response, parent, callback) {
@@ -100,7 +105,7 @@ $scriptString .= <<<script
                 // Add empty node to reset category filter
                 if(!emptyNodeAdded) {
                     var empty = Object.clone(_node);
-                    empty.text = '{$block->escapeJs(__('None'))}';
+                    empty.text = '{$escaper->escapeJs(__('None'))}';
                     empty.children = [];
                     empty.id = 'none';
                     empty.path = '1/none';
@@ -174,10 +179,10 @@ $scriptString .= <<<script
         treeLoader.baseParams.id = node.attributes.id;
         treeLoader.baseParams.store = node.attributes.store;
         treeLoader.baseParams.form_key = FORM_KEY;
-        $('{$block->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
+        $('{$escaper->escapeJs($_divId)}').fire('category:beforeLoad', {treeLoader:treeLoader});
     });
 
-    tree{$block->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$block->escapeJs($_divId)}', {
+    tree{$escaper->escapeJs($block->getId())} = new Ext.tree.TreePanel.Enhanced('{$escaper->escapeJs($_divId)}', {
         animate:          false,
         loader:           categoryLoader,
         enableDD:         false,
@@ -189,9 +194,9 @@ $scriptString .= <<<script
     });
 
     if (useMassaction) {
-        tree{$block->escapeJs($block->getId())}.on('check', function(node) {
-            $('{$block->escapeJs($_divId)}').fire('node:changed', {node:node});
-        }, tree{$block->escapeJs($block->getId())});
+        tree{$escaper->escapeJs($block->getId())}.on('check', function(node) {
+            $('{$escaper->escapeJs($_divId)}').fire('node:changed', {node:node});
+        }, tree{$escaper->escapeJs($block->getId())});
     }
 
     // set the root node
@@ -203,7 +208,7 @@ $scriptString .= <<<script
         category_id: {$intCategoryId}
     };
 
-    tree{$block->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$block->getTreeJson()}},true);
+    tree{$escaper->escapeJs($block->getId())}.loadTree({parameters:parameters, data:{$block->getTreeJson()}},true);
 
 });
 

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/form/renderer/fieldset/element.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/form/renderer/fieldset/element.phtml
@@ -3,16 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var $block \Magento\Catalog\Block\Adminhtml\Form\Renderer\Fieldset\Element */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
-/* @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset\Element */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Form\Renderer\Fieldset\Element;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Element $block */
 $element = $block->getElement();
 $note = $element->getNote() ?
-    '<div class="note admin__field-note">' . $block->escapeHtml($element->getNote()) . '</div>' : '';
+    '<div class="note admin__field-note">' . $escaper->escapeHtml($element->getNote()) . '</div>' : '';
 $elementBeforeLabel = $element->getExtType() == 'checkbox' || $element->getExtType() == 'radio';
 $addOn = $element->getBeforeElementHtml() || $element->getAfterElementHtml();
 $fieldId = ($element->getHtmlId()) ? ' id="attribute-' . $element->getHtmlId() . '-container"' : '';
@@ -24,8 +26,8 @@ $fieldClass .= ($element->getRequired()) ? ' required' : '';
 $fieldClass .= ($note) ? ' with-note' : '';
 $fieldClass .= ($entity && $entity->getIsUserDefined()) ? ' user-defined type-' . $entity->getFrontendInput() : '';
 
-$fieldAttributes = $fieldId . ' class="' . $block->escapeHtmlAttr($fieldClass) . '" '
-    . $block->getUiId('form-field', $block->escapeHtmlAttr($element->getId()));
+$fieldAttributes = $fieldId . ' class="' . $escaper->escapeHtmlAttr($fieldClass) . '" '
+    . $block->getUiId('form-field', $escaper->escapeHtmlAttr($element->getId()));
 
 /** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
@@ -64,13 +66,13 @@ $jsonHelper = $block->getData('jsonHelper');
                             class="use-default-control"
                             id="<?= $element->getHtmlId() ?>_default"
                             <?php if ($block->usedDefault()):?> checked="checked"<?php endif; ?>
-                            value="<?= $block->escapeHtmlAttr($block->getAttributeCode()) ?>"/>
+                            value="<?= $escaper->escapeHtmlAttr($block->getAttributeCode()) ?>"/>
                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                         'onclick',
                         $elementToggleCode,
                         "#" . $element->getHtmlId() . "_default"
                     ) ?>
-                    <span class="use-default-label"><?= $block->escapeHtml(__('Use Default Value')) ?></span>
+                    <span class="use-default-label"><?= $escaper->escapeHtml(__('Use Default Value')) ?></span>
                 </label>
             <?php endif; ?>
         </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/form.phtml
@@ -3,27 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-?>
-<?php
-/**
- * @var $block \Magento\Backend\Block\Widget\Form\Container
- */
+use Magento\Backend\Block\Widget\Form\Container;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Container $block */
 ?>
 <?= /* @noEscape */ $block->getFormInitScripts() ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions attribute-popup-actions" <?= /* @noEscape */ $block->getUiId('content-header') ?>>
     <?= $block->getButtonsHtml('header') ?>
 </div>
 
-<form id="edit_form" class="admin__scope-old edit-form" action="<?= $block->escapeHtml($block->getSaveUrl()) ?>" method="post">
-    <input name="form_key" type="hidden" value="<?= $block->escapeHtml($block->getFormKey()) ?>" />
+<form id="edit_form" class="admin__scope-old edit-form" action="<?= $escaper->escapeHtml($block->getSaveUrl()) ?>" method="post">
+    <input name="form_key" type="hidden" value="<?= $escaper->escapeHtml($block->getFormKey()) ?>" />
     <?= $block->getChildHtml('form') ?>
 </form>
 <script type="text/x-magento-init">
     {
         "#edit_form": {
             "Magento_Catalog/catalog/product/edit/attribute": {
-                "validationUrl": "<?= $block->escapeJs($block->escapeUrl($block->getValidationUrl())) ?>"
+                "validationUrl": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getValidationUrl())) ?>"
             }
         }
     }

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/js.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-use Magento\Catalog\Helper\Data;
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Template $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Template;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php
@@ -215,7 +220,7 @@ function switchDefaultValueField()
 script;
 foreach ($jsonHelper->getAttributeHiddenFields() as $type => $fields):
             $scriptString .= <<<script
-            case '{$block->escapeJs($type)}':
+            case '{$escaper->escapeJs($type)}':
                 var isFrontTabHidden = false;
 script;
     foreach ($fields as $one):
@@ -234,7 +239,7 @@ script;
         elseif ($one == '_scope'):
             $scriptString .= 'scopeVisibility = false;';
         else:
-            $scriptString .= "setRowVisibility('" . $block->escapeJs($one) . "', false);";
+            $scriptString .= "setRowVisibility('" . $escaper->escapeJs($one) . "', false);";
         endif;
     endforeach;
     $scriptString .= <<<script

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/labels.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/labels.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels  */
+use Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Labels;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Labels $block */
 ?>
-
 <div class="fieldset-wrapper admin__collapsible-block-wrapper opened" id="manage-titles-wrapper">
     <div class="fieldset-wrapper-title">
         <strong class="admin__collapsible-title" data-bs-toggle="collapse" data-bs-target="#manage-titles-content">
-            <span><?= $block->escapeHtml(__('Manage Titles (Size, Color, etc.)')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Manage Titles (Size, Color, etc.)')) ?></span>
         </strong>
     </div>
     <div class="fieldset-wrapper-content in collapse" id="manage-titles-content">
@@ -20,7 +24,7 @@
                     <thead>
                     <tr>
                         <?php foreach ($block->getStores() as $_store): ?>
-                            <th class="col-store-view"><?= $block->escapeHtml($_store->getName()) ?></th>
+                            <th class="col-store-view"><?= $escaper->escapeHtml($_store->getName()) ?></th>
                         <?php endforeach; ?>
                     </tr>
                     </thead>
@@ -33,8 +37,8 @@
                                 <?php $isRequiredClass = $isRequired ? 'required-option' : ''; ?>
                                 <input class="input-text validate-no-html-tags <?= /* @noEscape */ $isRequiredClass ?>"
                                        type="text"
-                                       name="frontend_label[<?= $block->escapeHtmlAttr($_store->getId()) ?>]"
-                                       value="<?= $block->escapeHtmlAttr($_labels[$_store->getId()]) ?>"
+                                       name="frontend_label[<?= $escaper->escapeHtmlAttr($_store->getId()) ?>]"
+                                       value="<?= $escaper->escapeHtmlAttr($_labels[$_store->getId()]) ?>"
                                     <?php if ($block->getReadOnly()): ?>
                                         disabled="disabled"
                                     <?php endif;?>/>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -3,15 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options */
 
 $stores = $block->getStoresSortedBySortOrder();
 ?>
 <fieldset class="admin__fieldset fieldset">
     <legend class="legend">
-        <span><?= $block->escapeHtml(__('Manage Options (Values of Your Attribute)')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Manage Options (Values of Your Attribute)')) ?></span>
     </legend><br />
     <div class="admin__control-table-wrapper" id="manage-options-panel" data-index="attribute_options_select_container">
         <table class="admin__control-table" data-index="attribute_options_select">
@@ -19,12 +25,12 @@ $stores = $block->getStoresSortedBySortOrder();
                 <tr id="attribute-options-table">
                     <th class="col-draggable"></th>
                     <th class="col-default control-table-actions-th">
-                        <span><?= $block->escapeHtml(__('Is Default')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Is Default')) ?></span>
                     </th>
                     <?php
                     foreach ($stores as $_store) :?>
                         <th<?php if ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) :?> class="_required"<?php endif; ?>>
-                            <span><?= $block->escapeHtml(__($_store->getName())) ?></span>
+                            <span><?= $escaper->escapeHtml(__($_store->getName())) ?></span>
                         </th>
                     <?php endforeach;
                     $storetotal = count($stores) + 3;
@@ -44,9 +50,9 @@ $stores = $block->getStoresSortedBySortOrder();
                 <th colspan="<?= (int) $storetotal ?>" class="col-actions-add">
                     <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
                         <button id="add_new_option_button" data-action="add_new_row"
-                                title="<?= $block->escapeHtml(__('Add Option')) ?>"
+                                title="<?= $escaper->escapeHtml(__('Add Option')) ?>"
                                 type="button" class="action- scalable add">
-                            <span><?= $block->escapeHtml(__('Add Option')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Add Option')) ?></span>
                         </button>
                     <?php endif; ?>
                 </th>
@@ -60,7 +66,7 @@ $stores = $block->getStoresSortedBySortOrder();
             <td class="col-draggable">
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
                     <div data-role="draggable-handle" class="draggable-handle"
-                         title="<?= $block->escapeHtml(__('Sort Option')) ?>">
+                         title="<?= $escaper->escapeHtml(__('Sort Option')) ?>">
                     </div>
                 <?php endif; ?>
                 <input data-role="order" type="hidden" name="option[order][<%- data.id %>]"  value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
@@ -74,10 +80,10 @@ $stores = $block->getStoresSortedBySortOrder();
             <td id="delete_button_container_<%- data.id %>" class="col-delete">
                 <input type="hidden" class="delete-flag" name="option[delete][<%- data.id %>]" value="" />
                 <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) :?>
-                    <button id="delete_button_<%- data.id %>" title="<?= $block->escapeHtml(__('Delete')) ?>" type="button"
+                    <button id="delete_button_<%- data.id %>" title="<?= $escaper->escapeHtml(__('Delete')) ?>" type="button"
                         class="action- scalable delete delete-option"
                         >
-                        <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Delete')) ?></span>
                     </button>
                 <?php endif;?>
             </td>
@@ -102,7 +108,7 @@ $stores = $block->getStoresSortedBySortOrder();
                 },
                 "Magento_Catalog/catalog/product/attribute/unique-validate": {
                     "element": "required-dropdown-attribute-unique",
-                    "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
+                    "message": "<?= $escaper->escapeHtml(__("The value of Admin must be unique.")) ?>"
                 }
             }
         }

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/main.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Attribute\Set\Main;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Main $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="attribute-set">
 
@@ -33,12 +39,12 @@ script;
     </div>
     <div class="attribute-set-col fieldset-wrapper">
         <div class="fieldset-wrapper-title">
-            <span class="title"><?= $block->escapeHtml(__('Groups')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Groups')) ?></span>
         </div>
         <?php if (!$block->getIsReadOnly()):?>
             <?= /* @noEscape */ $block->getAddGroupButton() ?>&nbsp;
             <?= /* @noEscape */ $block->getDeleteGroupButton() ?>
-            <p class="note-block"><?= $block->escapeHtml(__('Double click on a group to rename it.')) ?></p>
+            <p class="note-block"><?= $escaper->escapeHtml(__('Double click on a group to rename it.')) ?></p>
         <?php endif; ?>
 
         <?= $block->getSetsFilterHtml() ?>
@@ -46,13 +52,13 @@ script;
     </div>
     <div class="attribute-set-col fieldset-wrapper">
         <div class="fieldset-wrapper-title">
-            <span class="title"><?= $block->escapeHtml(__('Unassigned Attributes')) ?></span>
+            <span class="title"><?= $escaper->escapeHtml(__('Unassigned Attributes')) ?></span>
         </div>
         <div id="tree-div2" class="attribute-set-tree"></div>
         <?php $readOnly = ($block->getIsReadOnly() ? 'false' : 'true');
         $groupTree = /* @noEscape */ $block->getGroupTreeJson();
         $attributeTreeJson = /* @noEscape */ $block->getAttributeTreeJson();
-        $systemAttributeWarning = $block->escapeJs(
+        $systemAttributeWarning = $escaper->escapeJs(
             __('This group contains system attributes. Please move system attributes to another group and try again.')
         );
         $scriptString = <<<script
@@ -102,7 +108,7 @@ script;
 
                             this.ge = new Ext.tree.TreeEditor(tree, {
                                 allowBlank:false,
-                                blankText:'{$block->escapeJs(__('A name is required.'))}',
+                                blankText:'{$escaper->escapeJs(__('A name is required.'))}',
                                 selectOnFocus:true,
                                 cls:'folder'
                             });
@@ -271,7 +277,7 @@ script;
                         SystemNodesExists : function(currentNode) {
                             if (!currentNode) {
                                 alert({
-                                    content: '{$block->escapeJs(__('Please select a node.'))}'
+                                    content: '{$escaper->escapeJs(__('Please select a node.'))}'
                                 });
                                 return;
                             }
@@ -292,8 +298,8 @@ script;
 
                         addGroup : function() {
                             prompt({
-                                title: "{$block->escapeJs($block->escapeHtml(__('Add New Group')))}",
-                                content: "{$block->escapeJs($block->escapeHtml(__('Please enter a new group name.')))}",
+                                title: "{$escaper->escapeJs($escaper->escapeHtml(__('Add New Group')))}",
+                                content: "{$escaper->escapeJs($escaper->escapeHtml(__('Please enter a new group name.')))}",
                                 value: "",
                                 validation: true,
                                 validationRules: ['required-entry'],
@@ -359,7 +365,7 @@ script;
                             for (var i=0; i < TreePanels.root.childNodes.length; i++) {
                                 if (TreePanels.root.childNodes[i].text.toLowerCase() == name.toLowerCase() &&
                                     TreePanels.root.childNodes[i].id != exceptNodeId) {
-                                    errorText = '{$block->escapeJs(
+                                    errorText = '{$escaper->escapeJs(
                                         __('An attribute group named "/name/" already exists.')
                                     )}';
                                     alert({
@@ -389,7 +395,7 @@ script;
                                 editSet.req.form_key = FORM_KEY;
                             }
                             var req = {data : Ext.util.JSON.encode(editSet.req)};
-                            var con = new Ext.lib.Ajax.request('POST', '{$block->escapeJs($block->getMoveUrl())}',
+                            var con = new Ext.lib.Ajax.request('POST', '{$escaper->escapeJs($block->getMoveUrl())}',
                              {success:editSet.success,failure:editSet.failure}, req);
                         },
 
@@ -408,7 +414,7 @@ script;
 
                         failure : function(o) {
                             alert({
-                                content: '{$block->escapeJs(__('Sorry, we\'re unable to complete this request.'))}'
+                                content: '{$escaper->escapeJs(__('Sorry, we\'re unable to complete this request.'))}'
                             });
                         },
 
@@ -425,7 +431,7 @@ script;
                         rightBeforeAppend : function(tree, nodeThis, node, newParent) {
                             if (node.attributes.is_user_defined == 0) {
                                 alert({
-                                    content: '{$block->escapeJs(
+                                    content: '{$escaper->escapeJs(
                                         __('You can\'t remove attributes from this attribute set.')
                                     )}'
                                 });
@@ -443,7 +449,7 @@ script;
 
                             if (node.attributes.is_unassignable == 0) {
                                 alert({
-                                    content: '{$block->escapeJs(
+                                    content: '{$escaper->escapeJs(
                                         __('You can\'t remove attributes from this attribute set.')
                                     )}'
                                 });
@@ -469,7 +475,7 @@ script;
                         rightRemove : function(tree, nodeThis, node) {
                             if( nodeThis.firstChild == null && node.id != 'empty' ) {
                                 var newNode = new Ext.tree.TreeNode({
-                                    text : '{$block->escapeJs(__('Empty'))}',
+                                    text : '{$escaper->escapeJs(__('Empty'))}',
                                     id : 'empty',
                                     cls : 'folder',
                                     is_user_defined : 1,

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/toolbar/add.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/attribute/set/toolbar/add.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getFormHtml() ?>
 
 <?php $scriptString = <<<script
 require(['jquery', "mage/mage"], function(jQuery){
 
-    jQuery('#{$block->escapeJs($block->getFormId())}').mage('form').mage('validation');
+    jQuery('#{$escaper->escapeJs($block->getFormId())}').mage('form').mage('validation');
 
 });
 script;

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/configure.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/configure.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 $blockId = $block->getId();
 ?>
 <div id="product_composite_configure"
-     class="product-configure-popup product-configure-popup-<?= $block->escapeHtmlAttr($blockId) ?>">
+     class="product-configure-popup product-configure-popup-<?= $escaper->escapeHtmlAttr($blockId) ?>">
     <iframe name="product_composite_configure_iframe" id="product_composite_configure_iframe"></iframe>
 
     <form action="" method="post" id="product_composite_configure_form" enctype="multipart/form-data"
@@ -24,7 +29,7 @@ $blockId = $block->getId();
             </div>
         </div>
         <input type="hidden" name="as_js_varname" value="iFrameResponse" />
-        <input type="hidden" name="form_key" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" />
+        <input type="hidden" name="form_key" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()) ?>" />
     </form>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onsubmit',

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options.phtml
@@ -3,22 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
+$options = $block->decorateArray($block->getOptions());
 ?>
-
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options */ ?>
-<?php $options = $block->decorateArray($block->getOptions()); ?>
 <?php if (count($options)) :?>
-
     <?= $block->getChildHtml('options_js') ?>
 
     <fieldset id="product_composite_configure_fields_options"
               class="fieldset admin__fieldset <?= $block->getIsLastFieldset() ? 'last-fieldset' : '' ?>">
         <legend class="legend admin__legend">
-            <span><?= $block->escapeHtml(__('Custom Options')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Custom Options')) ?></span>
         </legend><br>
         <?php foreach ($options as $option) :?>
             <?= $block->getOptionHtml($option) ?>
         <?php endforeach;?>
     </fieldset>
-
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/date.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Product\View\Options\Type\Date;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Date $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <?php $_option = $block->getOption(); ?>
 <?php $_optionId = (int)$_option->getId(); ?>
 <?php $optionId = /* @noEscape */ $_optionId ?>
 <div class="admin__field field<?= $_option->getIsRequire() ? ' required' : '' ?>">
     <label class="label admin__field-label">
-        <?= $block->escapeHtml($_option->getTitle()) ?>
+        <?= $escaper->escapeHtml($_option->getTitle()) ?>
         <?= /* @noEscape */ $block->getFormattedPrice() ?>
     </label>
     <div class="admin__field-control control">
@@ -66,7 +71,7 @@ script;
                         if (dateTimeParts[i].value == "") return false;
                     }
                     return true;
-                }, '{$block->escapeJs(__('This is a required option.'))}');
+                }, '{$escaper->escapeJs(__('This is a required option.'))}');
 script;
         else:
             $scriptString .= <<<script
@@ -84,7 +89,7 @@ script;
                         }
                     }
                     return hasWithValue ^ hasWithNoValue;
-                }, '{$block->escapeJs(__('The field isn\'t complete.'))}');
+                }, '{$escaper->escapeJs(__('The field isn\'t complete.'))}');
 script;
         endif;
         $scriptString .= <<<script

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/default.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/default.phtml
@@ -3,13 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Options */ ?>
 <?php $option = $block->getOption(); ?>
 <div class="admin__field field">
     <label class="admin__field-label label">
         <span>
-            <?= $block->escapeHtml($option->getTitle()) ?>
+            <?= $escaper->escapeHtml($option->getTitle()) ?>
         </span>
     </label>
 </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/file.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Product\View\Options\Type\File;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var File $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_fileInfo = $block->getFileInfo(); ?>
@@ -70,14 +76,14 @@ script;
 
 <div class="admin__field <?= $_option->getIsRequire() ? ' required _required' : '' ?>">
     <label class="admin__field-label label">
-        <?= $block->escapeHtml($_option->getTitle()) ?>
+        <?= $escaper->escapeHtml($_option->getTitle()) ?>
         <?= /* @noEscape */ $block->getFormattedPrice() ?>
     </label>
     <div class="admin__field-control control" id="<?= /* @noEscape */ $_fileName ?>">
         <?php if ($_fileExists):?>
-            <span class="<?= /* @noEscape */ $_fileNamed ?>"><?= $block->escapeHtml($_fileInfo->getTitle()) ?></span>
+            <span class="<?= /* @noEscape */ $_fileNamed ?>"><?= $escaper->escapeHtml($_fileInfo->getTitle()) ?></span>
             <a href="#" class="label">
-                <?= $block->escapeHtml(__('Change')) ?>
+                <?= $escaper->escapeHtml(__('Change')) ?>
             </a>&nbsp;
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',
@@ -87,44 +93,44 @@ script;
             ); ?>
             <?php if (!$_option->getIsRequire()):?>
                 <input type="checkbox"
-                       price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"/>
+                       price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"/>
                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                     'onclick',
                     "opFile" . /* @noEscape */ $_rand . ".toggleFileDelete($(this), $(this).next('.input-box'))",
                     '#' . /* @noEscape */ $_fileName . ' input[type="checkbox"]'
                 ) ?>
-                <span class="label"><?= $block->escapeHtml(__('Delete')) ?></span>
+                <span class="label"><?= $escaper->escapeHtml(__('Delete')) ?></span>
             <?php endif; ?>
         <?php endif; ?>
         <div class="input-box" <?= $_fileExists ? 'style="display:none"' : '' ?>>
             <!-- ToDo UI: add appropriate file class when z-index issue in ui dialog will be resolved  -->
             <input type="file" name="<?= /* @noEscape */ $_fileName ?>"
                    class="product-custom-option<?= $_option->getIsRequire() ? ' required-entry' : '' ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"
                 <?= $_fileExists ? 'disabled="disabled"' : '' ?>/>
             <input type="hidden" name="<?= /* @noEscape */ $_fieldNameAction ?>"
                    value="<?= /* @noEscape */ $_fieldValueAction ?>" />
 
             <?php if ($_option->getFileExtension()):?>
                 <div class="admin__field-note">
-                    <span><?= $block->escapeHtml(__('Compatible file extensions to upload')) ?>:
-                        <strong><?= $block->escapeHtml($_option->getFileExtension()) ?></strong>
+                    <span><?= $escaper->escapeHtml(__('Compatible file extensions to upload')) ?>:
+                        <strong><?= $escaper->escapeHtml($_option->getFileExtension()) ?></strong>
                     </span>
                 </div>
             <?php endif; ?>
 
             <?php if ($_option->getImageSizeX() > 0):?>
                 <div class="admin__field-note">
-                    <span><?= $block->escapeHtml(__('Maximum image width')) ?>:
-                        <strong><?= (int)$_option->getImageSizeX() ?> <?= $block->escapeHtml(__('px.')) ?></strong>
+                    <span><?= $escaper->escapeHtml(__('Maximum image width')) ?>:
+                        <strong><?= (int)$_option->getImageSizeX() ?> <?= $escaper->escapeHtml(__('px.')) ?></strong>
                     </span>
                 </div>
             <?php endif; ?>
 
             <?php if ($_option->getImageSizeY() > 0):?>
                 <div class="admin__field-note">
-                    <span><?= $block->escapeHtml(__('Maximum image height')) ?>:
-                        <strong><?= (int)$_option->getImageSizeY() ?> <?= $block->escapeHtml(__('px.')) ?></strong>
+                    <span><?= $escaper->escapeHtml(__('Maximum image height')) ?>:
+                        <strong><?= (int)$_option->getImageSizeY() ?> <?= $escaper->escapeHtml(__('px.')) ?></strong>
                     </span>
                 </div>
             <?php endif; ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/select.phtml
@@ -3,18 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\View\Options\Type\Select;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Select $block */
+$_option = $block->getOption();
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select */ ?>
-<?php $_option = $block->getOption(); ?>
 <div class="admin__field field<?= $_option->getIsRequire() ? ' _required' : '' ?>">
     <label class="label admin__field-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control admin__field-control">
         <?= $block->getValuesHtml() ?>
         <?php if ($_option->getIsRequire()) :?>
             <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO || $_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_CHECKBOX) :?>
-                <span id="options-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></span>
+                <span id="options-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></span>
             <?php endif; ?>
         <?php endif;?>
     </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/options/type/text.phtml
@@ -3,33 +3,39 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\View\Options\Type\Text;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Text $block */
+$_option = $block->getOption();
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
-<?php $_option = $block->getOption(); ?>
 <div class="field admin__field<?= $_option->getIsRequire() ? ' required _required' : '' ?>">
     <label class="admin__field-label label">
-        <?= $block->escapeHtml($_option->getTitle()) ?>
+        <?= $escaper->escapeHtml($_option->getTitle()) ?>
         <?= /* @noEscape */ $block->getFormattedPrice() ?>
     </label>
     <div class="control admin__field-control">
         <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_FIELD) :?>
             <input type="text"
-                   id="options_<?= $block->escapeHtmlAttr($_option->getId()) ?>_text"
+                   id="options_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>_text"
                    class="input-text admin__control-text <?= $_option->getIsRequire() ? ' required-entry' : '' ?> <?= $_option->getMaxCharacters() ? ' validate-length maximum-length-' . (int) $_option->getMaxCharacters() : '' ?> product-custom-option"
-                   name="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($block->getDefaultValue()) ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>" />
+                   name="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($block->getDefaultValue()) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>" />
         <?php elseif ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_AREA) :?>
-            <textarea id="options_<?= $block->escapeHtmlAttr($_option->getId()) ?>_text"
+            <textarea id="options_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>_text"
                       class="admin__control-textarea <?= $_option->getIsRequire() ? ' required-entry' : '' ?> <?= $_option->getMaxCharacters() ? ' validate-length maximum-length-' . (int) $_option->getMaxCharacters() : '' ?> product-custom-option"
-                      name="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
+                      name="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
                       rows="5"
                       cols="25"
-                      price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"><?= $block->escapeHtml($block->getDefaultValue()) ?></textarea>
+                      price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_option->getPrice(true))) ?>"><?= $escaper->escapeHtml($block->getDefaultValue()) ?></textarea>
         <?php endif;?>
 
         <?php if ($_option->getMaxCharacters()) :?>
-            <p class="note"><?= $block->escapeHtml(__('Maximum number of characters:')) ?> <strong><?= (int) $_option->getMaxCharacters() ?></strong></p>
+            <p class="note"><?= $escaper->escapeHtml(__('Maximum number of characters:')) ?> <strong><?= (int) $_option->getMaxCharacters() ?></strong></p>
         <?php endif; ?>
     </div>
 </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/qty.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/composite/fieldset/qty.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Qty $block */
 ?>
-
-<?php /* @var $block \Magento\Catalog\Block\Adminhtml\Product\Composite\Fieldset\Qty */ ?>
-
 <fieldset id="product_composite_configure_fields_qty"
           class="fieldset product-composite-qty-block admin__fieldset <?= $block->getIsLastFieldset() ? 'last-fieldset' : '' ?>">
     <div class="field admin__field">
-        <label class="label admin__field-label"><span><?= $block->escapeHtml(__('Quantity')) ?></span></label>
+        <label class="label admin__field-label"><span><?= $escaper->escapeHtml(__('Quantity')) ?></span></label>
         <div class="control admin__field-control">
             <input id="product_composite_configure_input_qty" class="input-text admin__control-text qty" type="text" name="qty" value="<?= $block->getQtyValue() * 1 ?>">
         </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit.phtml
@@ -3,22 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Catalog\Block\Adminhtml\Product\Edit;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Edit $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="admin__scope-old">
     <div class="product-actions">
         <div id="product-template-suggest-container" class="suggest-expandable">
             <div class="action-dropdown">
                 <button type="button" class="action-toggle" data-mage-init='{"dropdown":{}}' data-toggle="dropdown">
-                    <span><?= $block->escapeHtml($block->getAttributeSetName()) ?></span>
+                    <span><?= $escaper->escapeHtml($block->getAttributeSetName()) ?></span>
                 </button>
                 <ul class="dropdown-menu">
                     <li><input type="text" id="product-template-suggest" class="search"
-                           placeholder="<?= $block->escapeHtmlAttr(__('start typing to search template')) ?>"/></li>
+                           placeholder="<?= $escaper->escapeHtmlAttr(__('start typing to search template')) ?>"/></li>
                 </ul>
             </div>
         </div>
@@ -27,9 +31,9 @@
             <input type="checkbox" id="product-online-switcher" name="product-online-switcher" />
             <label class="switcher-label"
                    for="product-online-switcher"
-                   data-text-on="<?= $block->escapeHtmlAttr(__('Product online')) ?>"
-                   data-text-off="<?= $block->escapeHtmlAttr(__('Product offline')) ?>"
-                   title="<?= $block->escapeHtmlAttr(__('Product online status')) ?>"></label>
+                   data-text-on="<?= $escaper->escapeHtmlAttr(__('Product online')) ?>"
+                   data-text-off="<?= $escaper->escapeHtmlAttr(__('Product offline')) ?>"
+                   title="<?= $escaper->escapeHtmlAttr(__('Product online status')) ?>"></label>
         </div>
 
         <?php if ($block->getProductId()):?>
@@ -43,17 +47,17 @@
     </div>
 </div>
 <?php if ($block->getUseContainer()): ?>
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" enctype="multipart/form-data"
-      data-form="edit-product" data-product-id="<?= $block->escapeHtmlAttr($block->getProduct()->getId()) ?>">
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>" method="post" enctype="multipart/form-data"
+      data-form="edit-product" data-product-id="<?= $escaper->escapeHtmlAttr($block->getProduct()->getId()) ?>">
 <?php endif; ?>
     <?= $block->getBlockHtml('formkey') ?>
     <div data-role="tabs" id="product-edit-form-tabs"></div>
     <?php /* @TODO: remove id after elimination of setDestElementId('product-edit-form-tabs') */?>
     <?= $block->getChildHtml('product-type-tabs') ?>
     <input type="hidden" id="product_type_id"
-           value="<?= $block->escapeHtmlAttr($block->getProduct()->getTypeId()) ?>"/>
+           value="<?= $escaper->escapeHtmlAttr($block->getProduct()->getTypeId()) ?>"/>
     <input type="hidden" id="attribute_set_id"
-           value="<?= $block->escapeHtmlAttr($block->getProduct()->getAttributeSetId()) ?>"/>
+           value="<?= $escaper->escapeHtmlAttr($block->getProduct()->getAttributeSetId()) ?>"/>
     <button type="submit" class="hidden"></button>
 <?php if ($block->getUseContainer()):?>
 </form>
@@ -137,7 +141,7 @@ require([
             }
         }
     });
-    \$form.mage('validation', {validationUrl: '{$block->escapeJs($block->getValidationUrl())}'});
+    \$form.mage('validation', {validationUrl: '{$escaper->escapeJs($block->getValidationUrl())}'});
 
     var masks = {$jsonFieldsAutogenerationMasks};
     var availablePlaceholders = {$jsonAttributesAllowedForAutogeneration};

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/attribute.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Attribute $block */
 ?>
-
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>"
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()) ?>"
       method="post"
       id="attributes-edit-form"
       class="attributes-edit-form"
@@ -19,7 +23,7 @@
         "#attributes-edit-form": {
             "Magento_Catalog/js/product/weight-handler": {},
             "Magento_Catalog/catalog/product/edit/attribute": {
-                "validationUrl": "<?= $block->escapeJs($block->escapeUrl($block->getValidationUrl())) ?>"
+                "validationUrl": "<?= $escaper->escapeJs($escaper->escapeUrl($block->getValidationUrl())) ?>"
             }
         }
     }

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/inventory.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Inventory $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $scriptString = <<<script
@@ -43,14 +49,14 @@ if (!is_numeric($defaultMinSaleQty)) {
 <div class="fieldset-wrapper form-inline advanced-inventory-edit">
     <div class="fieldset-wrapper-title">
         <strong class="title">
-            <span><?= $block->escapeHtml(__('Advanced Inventory')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Advanced Inventory')) ?></span>
         </strong>
     </div>
     <div class="fieldset-wrapper-content">
         <fieldset class="fieldset" id="table_cataloginventory">
         <div class="field">
             <label class="label" for="inventory_manage_stock">
-                <span><?= $block->escapeHtml(__('Manage Stock')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Manage Stock')) ?></span>
             </label>
 
             <div class="control">
@@ -59,11 +65,11 @@ if (!is_numeric($defaultMinSaleQty)) {
                         <select id="inventory_manage_stock"
                                 name="<?= /* @noEscape */ $block->getFieldSuffix() ?>[manage_stock]"
                                 class="select" disabled="disabled">
-                            <option value="1"><?= $block->escapeHtml(__('Yes')) ?></option>
+                            <option value="1"><?= $escaper->escapeHtml(__('Yes')) ?></option>
                             <option value="0"
                                 <?php if ($block->getFieldValue('manage_stock') == 0):?>
                                     selected="selected"
-                                <?php endif; ?>><?= $block->escapeHtml(__('No')) ?></option>
+                                <?php endif; ?>><?= $escaper->escapeHtml(__('No')) ?></option>
                         </select>
                     </div>
                     <div class="field choice">
@@ -72,21 +78,21 @@ if (!is_numeric($defaultMinSaleQty)) {
                                id="inventory_use_config_manage_stock" data-role="toggle-editability" value="1"
                                checked="checked" disabled="disabled"/>
                         <label for="inventory_use_config_manage_stock"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox" id="inventory_manage_stock_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_manage_stock_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field required">
             <label class="label" for="inventory_qty">
-                <span><?= $block->escapeHtml(__('Qty')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Qty')) ?></span>
             </label>
 
             <div class="control">
@@ -99,16 +105,16 @@ if (!is_numeric($defaultMinSaleQty)) {
                     <div class="field choice">
                         <input type="checkbox" id="inventory_qty_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_qty_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field with-addon">
             <label class="label" for="inventory_min_qty">
-                <span><?= $block->escapeHtml(__('Out-of-Stock Threshold')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Out-of-Stock Threshold')) ?></span>
             </label>
 
             <div class="control">
@@ -123,22 +129,22 @@ if (!is_numeric($defaultMinSaleQty)) {
                                name="<?= /* @noEscape */ $block->getFieldSuffix() ?>[use_config_min_qty]" value="1"
                                data-role="toggle-editability" checked="checked" disabled="disabled"/>
                         <label for="inventory_use_config_min_qty" class="label">
-                            <span><?= $block->escapeHtml(__('Use Config Settings')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span>
                         </label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox" id="inventory_min_qty_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_min_qty_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_min_sale_qty">
-                <span><?= $block->escapeHtml(__('Minimum Qty Allowed in Shopping Cart')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Minimum Qty Allowed in Shopping Cart')) ?></span>
             </label>
 
             <div class="control">
@@ -157,21 +163,21 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_min_sale_qty"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox" id="inventory_min_sale_qty_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_min_sale_qty_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_max_sale_qty">
-                <span><?= $block->escapeHtml(__('Maximum Qty Allowed in Shopping Cart')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Maximum Qty Allowed in Shopping Cart')) ?></span>
             </label>
 
             <div class="control">
@@ -191,21 +197,21 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_max_sale_qty"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox" id="inventory_max_sale_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_max_sale_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_is_qty_decimal">
-                <span><?= $block->escapeHtml(__('Qty Uses Decimals')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Qty Uses Decimals')) ?></span>
             </label>
 
             <div class="control">
@@ -215,11 +221,11 @@ if (!is_numeric($defaultMinSaleQty)) {
                                 name="<?= /* @noEscape */ $block->getFieldSuffix() ?>[is_qty_decimal]"
                                 class="select"
                                 disabled="disabled">
-                            <option value="0"><?= $block->escapeHtml(__('No')) ?></option>
+                            <option value="0"><?= $escaper->escapeHtml(__('No')) ?></option>
                             <option value="1"
                                 <?php if ($block->getDefaultConfigValue('is_qty_decimal') == 1):?>
                                     selected="selected"
-                                <?php endif; ?>><?= $block->escapeHtml(__('Yes')) ?></option>
+                                <?php endif; ?>><?= $escaper->escapeHtml(__('Yes')) ?></option>
                         </select>
                     </div>
                     <div class="field choice">
@@ -227,16 +233,16 @@ if (!is_numeric($defaultMinSaleQty)) {
                                id="inventory_is_qty_decimal_checkbox"
                                data-role="toggle-editability-all"/>
                         <label for="inventory_is_qty_decimal_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_backorders">
-                <span><?= $block->escapeHtml(__('Backorders')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Backorders')) ?></span>
             </label>
 
             <div class="control">
@@ -250,8 +256,8 @@ if (!is_numeric($defaultMinSaleQty)) {
                                 <?php $_selected = ($option['value'] == $block->getDefaultConfigValue('backorders')) ?
                                     ' selected="selected"' : '' ?>
                                 <option
-                                    value="<?= $block->escapeHtmlAttr($option['value']) ?>"
-                                    <?= /* @noEscape */ $_selected ?>><?= $block->escapeHtml($option['label']) ?>
+                                    value="<?= $escaper->escapeHtmlAttr($option['value']) ?>"
+                                    <?= /* @noEscape */ $_selected ?>><?= $escaper->escapeHtml($option['label']) ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
@@ -264,22 +270,22 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_backorders"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox" id="inventory_backorders_checkbox" data-role="toggle-editability-all"/>
                         <label for="inventory_backorders_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
 
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_notify_stock_qty">
-                <span><?= $block->escapeHtml(__('Notify for Quantity Below')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Notify for Quantity Below')) ?></span>
             </label>
 
             <div class="control">
@@ -299,23 +305,23 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_notify_stock_qty"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox"
                                id="inventory_notify_stock_qty_checkbox"
                                data-role="toggle-editability-all"/>
                         <label for="inventory_notify_stock_qty_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_enable_qty_increments">
-                <span><?= $block->escapeHtml(__('Enable Qty Increments')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Enable Qty Increments')) ?></span>
             </label>
 
             <div class="control">
@@ -325,11 +331,11 @@ if (!is_numeric($defaultMinSaleQty)) {
                                 name="<?= /* @noEscape */ $block->getFieldSuffix() ?>[enable_qty_increments]"
                                 class="select"
                                 disabled="disabled">
-                            <option value="1"><?= $block->escapeHtml(__('Yes')) ?></option>
+                            <option value="1"><?= $escaper->escapeHtml(__('Yes')) ?></option>
                             <option value="0"
                                 <?php if ($block->getDefaultConfigValue('enable_qty_increments') == 0):?>
                                     selected="selected"
-                                <?php endif; ?>><?= $block->escapeHtml(__('No')) ?></option>
+                                <?php endif; ?>><?= $escaper->escapeHtml(__('No')) ?></option>
                         </select>
                     </div>
                     <div class="field choice">
@@ -340,23 +346,23 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_enable_qty_increments"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox"
                                id="inventory_enable_qty_increments_checkbox"
                                data-role="toggle-editability-all"/>
                         <label for="inventory_enable_qty_increments_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_qty_increments">
-                <span><?= $block->escapeHtml(__('Qty Increments')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Qty Increments')) ?></span>
             </label>
 
             <div class="control">
@@ -376,23 +382,23 @@ if (!is_numeric($defaultMinSaleQty)) {
                                checked="checked"
                                disabled="disabled"/>
                         <label for="inventory_use_config_qty_increments"
-                               class="label"><span><?= $block->escapeHtml(__('Use Config Settings')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Use Config Settings')) ?></span></label>
                     </div>
                     <div class="field choice">
                         <input type="checkbox"
                                id="inventory_qty_increments_checkbox"
                                data-role="toggle-editability-all"/>
                         <label for="inventory_qty_increments_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_stock_availability">
-                <span><?= $block->escapeHtml(__('Stock Availability')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Stock Availability')) ?></span>
             </label>
 
             <div class="control">
@@ -401,10 +407,10 @@ if (!is_numeric($defaultMinSaleQty)) {
                         <select id="inventory_stock_availability"
                                 name="<?= /* @noEscape */ $block->getFieldSuffix() ?>[is_in_stock]" class="select"
                                 disabled="disabled">
-                            <option value="1"><?= $block->escapeHtml(__('In Stock')) ?></option>
+                            <option value="1"><?= $escaper->escapeHtml(__('In Stock')) ?></option>
                             <option value="0"
                                 <?php if ($block->getDefaultConfigValue('is_in_stock') == 0):?> selected<?php endif; ?>>
-                                <?= $block->escapeHtml(__('Out of Stock')) ?>
+                                <?= $escaper->escapeHtml(__('Out of Stock')) ?>
                             </option>
                         </select>
                     </div>
@@ -413,11 +419,11 @@ if (!is_numeric($defaultMinSaleQty)) {
                                id="inventory_stock_availability_checkbox"
                                data-role="toggle-editability-all"/>
                         <label for="inventory_stock_availability_checkbox"
-                               class="label"><span><?= $block->escapeHtml(__('Change')) ?></span></label>
+                               class="label"><span><?= $escaper->escapeHtml(__('Change')) ?></span></label>
                     </div>
                 </div>
             </div>
-            <div class="field-service" value-scope="<?= $block->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
+            <div class="field-service" value-scope="<?= $escaper->escapeHtmlAttr(__('[GLOBAL]')) ?>"></div>
         </div>
         </fieldset>
     </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/websites.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/action/websites.phtml
@@ -3,15 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Action\Attribute\Tab\Websites;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Websites $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <div class="fieldset-wrapper" id="add-products-to-website-wrapper">
     <fieldset class="fieldset" id="grop_fields">
         <legend class="legend">
-            <span><?= $block->escapeHtml(__('Add Product To Websites')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Add Product To Websites')) ?></span>
         </legend>
         <br>
         <div class="store-scope">
@@ -19,26 +25,26 @@
                 <?php foreach ($block->getWebsiteCollection() as $_website):?>
                     <div class="website-name">
                         <input name="add_website_ids[]"
-                               value="<?= $block->escapeHtmlAttr($_website->getId()) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($_website->getId()) ?>"
                             <?php if ($block->getWebsitesReadonly()):?>
                                 disabled="disabled"
                             <?php endif;?>
                                class="checkbox website-checkbox"
-                               id="add_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>"
+                               id="add_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>"
                                type="checkbox" />
-                        <label for="add_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>">
-                            <?= $block->escapeHtml($_website->getName()) ?>
+                        <label for="add_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>">
+                            <?= $escaper->escapeHtml($_website->getName()) ?>
                         </label>
                     </div>
                     <dl class="webiste-groups"
-                        id="add_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>_data">
+                        id="add_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>_data">
                         <?php foreach ($block->getGroupCollection($_website) as $_group):?>
-                            <dt><?= $block->escapeHtml($_group->getName()) ?></dt>
+                            <dt><?= $escaper->escapeHtml($_group->getName()) ?></dt>
                             <dd class="group-stores">
                                 <ul>
                                 <?php foreach ($block->getStoreCollection($_group) as $_store):?>
                                     <li>
-                                        <?= $block->escapeHtml($_store->getName()) ?>
+                                        <?= $escaper->escapeHtml($_store->getName()) ?>
                                     </li>
                                 <?php endforeach; ?>
                                 </ul>
@@ -54,12 +60,12 @@
 <div class="fieldset-wrapper" id="remove-products-to-website-wrapper">
     <fieldset class="fieldset" id="grop_fields">
         <legend class="legend">
-            <span><?= $block->escapeHtml(__('Remove Product From Websites')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Remove Product From Websites')) ?></span>
         </legend>
         <br>
         <div class="messages">
             <div class="message message-notice">
-                <div><?= $block->escapeHtml(
+                <div><?= $escaper->escapeHtml(
                     __('To hide an item in catalog or search results, set the status to "Disabled".')
                 ) ?>
                 </div>
@@ -70,26 +76,26 @@
                 <?php foreach ($block->getWebsiteCollection() as $_website):?>
                     <div class="website-name">
                         <input name="remove_website_ids[]"
-                               value="<?= $block->escapeHtmlAttr($_website->getId()) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($_website->getId()) ?>"
                             <?php if ($block->getWebsitesReadonly()):?>
                                 disabled="disabled"
                             <?php endif;?>
                                class="checkbox website-checkbox"
-                               id="remove_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>"
+                               id="remove_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>"
                                type="checkbox" />
-                        <label for="remove_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>">
-                            <?= $block->escapeHtml($_website->getName()) ?>
+                        <label for="remove_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>">
+                            <?= $escaper->escapeHtml($_website->getName()) ?>
                         </label>
                     </div>
                     <dl class="webiste-groups"
-                        id="remove_product_website_<?= $block->escapeHtmlAttr($_website->getId()) ?>_data">
+                        id="remove_product_website_<?= $escaper->escapeHtmlAttr($_website->getId()) ?>_data">
                         <?php foreach ($block->getGroupCollection($_website) as $_group):?>
-                            <dt><?= $block->escapeHtml($_group->getName()) ?></dt>
+                            <dt><?= $escaper->escapeHtml($_group->getName()) ?></dt>
                             <dd class="group-stores">
                                 <ul>
                                 <?php foreach ($block->getStoreCollection($_group) as $_store):?>
                                     <li>
-                                        <?= $block->escapeHtml($_store->getName()) ?>
+                                        <?= $escaper->escapeHtml($_store->getName()) ?>
                                     </li>
                                 <?php endforeach; ?>
                                 </ul>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/category/new/form.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/category/new/form.phtml
@@ -3,14 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/* @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\NewCategory */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\NewCategory;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var NewCategory $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<div id="<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>">
+<div id="<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>">
     <?= $block->getFormHtml() ?>
     <?= $block->getAfterElementHtml() ?>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',
-    $block->escapeJs($block->getNameInLayout())
+    $escaper->escapeJs($block->getNameInLayout())
 ) ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options.phtml
@@ -3,15 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <div class="fieldset-wrapper" id="product-custom-options-wrapper" data-block="product-custom-options">
     <div class="fieldset-wrapper-title">
         <strong class="title">
-            <span><?= $block->escapeHtml(__('Custom Options')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Custom Options')) ?></span>
         </strong>
     </div>
     <div class="fieldset-wrapper-content" id="product-custom-options-content"
@@ -21,7 +27,7 @@
                 <div class="message message-error" id="dynamic-price-warning">
                     <div class="message-inner">
                         <div class="message-content">
-                            <?= $block->escapeHtml(__(
+                            <?= $escaper->escapeHtml(__(
                                 'We can\'t save custom-defined options for bundles with dynamic pricing.'
                             )) ?></div>
                     </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/option.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/option.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Option $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Option */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getTemplatesHtml() ?>
 <script id="custom-option-base-template" type="text/x-magento-template">
@@ -22,16 +28,16 @@
             </strong>
             <div class="actions">
                 <button type="button"
-                        title="<?= $block->escapeHtmlAttr(__('Delete Custom Option')) ?>"
+                        title="<?= $escaper->escapeHtmlAttr(__('Delete Custom Option')) ?>"
                         class="action-delete"
                         id="<?= /* @noEscape */ $block->getFieldId() ?>_<%- data.id %>_delete">
-                    <span><?= $block->escapeHtml(__('Delete Custom Option')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Delete Custom Option')) ?></span>
                 </button>
             </div>
             <div id="<?= /* @noEscape */ $block->getFieldId() ?>_<%- data.id %>_move"
                  data-role="draggable-handle"
                  class="draggable-handle"
-                 title="<?= $block->escapeHtmlAttr(__('Sort Custom Options')) ?>"></div>
+                 title="<?= $escaper->escapeHtmlAttr(__('Sort Custom Options')) ?>"></div>
         </div>
         <div class="fieldset-wrapper-content in collapse" id="<%- data.id %>-content">
             <fieldset class="fieldset">
@@ -62,7 +68,7 @@
 
                     <div class="field field-option-title required">
                         <label class="label" for="<?= /* @noEscape */ $block->getFieldId() ?>_<%- data.id %>_title">
-                            <?= $block->escapeHtml(__('Option Title')) ?>
+                            <?= $escaper->escapeHtml(__('Option Title')) ?>
                         </label>
                         <div class="control">
                             <input id="<?= /* @noEscape */ $block->getFieldId() ?>_<%- data.id %>_title"
@@ -80,7 +86,7 @@
 
                     <div class="field field-option-input-type required">
                         <label class="label" for="<?= /* @noEscape */ $block->getFieldId() ?>_<%- data.id %>_title">
-                            <?= $block->escapeHtml(__('Input Type')) ?>
+                            <?= $escaper->escapeHtml(__('Input Type')) ?>
                         </label>
                         <div class="control opt-type">
                             <?= $block->getTypeSelectHtml() ?>
@@ -94,7 +100,7 @@
                                    type="checkbox"
                                    checked="checked"/>
                             <label for="field-option-req">
-                                <?= $block->escapeHtml(__('Required')) ?>
+                                <?= $escaper->escapeHtml(__('Required')) ?>
                             </label>
                             <span id="span_<?= /* @noEscape */ $block->getFieldId() ?>">
                                 <?= $block->getRequireSelectHtml() ?>
@@ -123,9 +129,9 @@ $jsonHelper = $block->getData('jsonHelper');
 $customOptions = /* @noEscape */ $jsonHelper->jsonEncode(
     [
         'fieldId' => $block->getFieldId(),
-        'productGridUrl' => $block->escapeJs($block->getProductGridUrl()),
+        'productGridUrl' => $escaper->escapeJs($block->getProductGridUrl()),
         'formKey' => $block->getFormKey(),
-        'customOptionsUrl' => $block->escapeJs($block->getCustomOptionsUrl()),
+        'customOptionsUrl' => $escaper->escapeJs($block->getCustomOptionsUrl()),
         'isReadonly' => (bool) $block->isReadonly(),
         'itemCount' => (int) $block->getItemCount(),
         'currentProductId' => (int) $block->getCurrentProductId(),

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/date.phtml
@@ -3,20 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Date;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Date $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Date */ ?>
 <script id="custom-option-date-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">
             <thead>
             <tr class="headings">
                 <?php if ($block->getCanReadPrice() !== false) : ?>
-                <th><?= $block->escapeHtml(__('Price')) ?></th>
-                <th><?= $block->escapeHtml(__('Price Type')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Price')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Price Type')) ?></th>
                 <?php endif; ?>
-                <th><?= $block->escapeHtml(__('SKU')) ?></th>
+                <th><?= $escaper->escapeHtml(__('SKU')) ?></th>
             </tr>
             </thead>
             <tr>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/file.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\File;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var File $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\File */
 ?>
 <script id="custom-option-file-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
@@ -13,12 +19,12 @@
             <thead>
             <tr>
                 <?php if ($block->getCanReadPrice() !== false) : ?>
-                    <th><?= $block->escapeHtml(__('Price')) ?></th>
-                    <th><?= $block->escapeHtml(__('Price Type')) ?></th>
+                    <th><?= $escaper->escapeHtml(__('Price')) ?></th>
+                    <th><?= $escaper->escapeHtml(__('Price Type')) ?></th>
                 <?php endif; ?>
-                <th><?= $block->escapeHtml(__('SKU')) ?></th>
-                <th><?= $block->escapeHtml(__('Compatible File Extensions')) ?></th>
-                <th><?= $block->escapeHtml(__('Maximum Image Size')) ?></th>
+                <th><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Compatible File Extensions')) ?></th>
+                <th><?= $escaper->escapeHtml(__('Maximum Image Size')) ?></th>
             </tr>
             </thead>
             <tr>
@@ -41,7 +47,7 @@
                 <td>
                     <input name="product[options][<%- data.option_id %>][file_extension]" class="input-text" type="text" value="<%- data.file_extension %>">
                 </td>
-                <td class="col-file"><?= $block->escapeHtml(
+                <td class="col-file"><?= $escaper->escapeHtml(
                     __(
                         '%1 <span>x</span> %2 <span>px.</span>',
                         '<input class="input-text" type="text" name="product[options][<%- data.option_id %>][image_size_x]" value="<%- data.image_size_x %>">',
@@ -49,7 +55,7 @@
                     ),
                     ['span', 'input']
                 ) ?>
-                    <div class="note"><?= $block->escapeHtml(__('Please leave blank if it is not an image.')) ?></div>
+                    <div class="note"><?= $escaper->escapeHtml(__('Please leave blank if it is not an image.')) ?></div>
                 </td>
             </tr>
         </table>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/select.phtml
@@ -3,22 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Select;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Select $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Select */ ?>
 <script id="custom-option-select-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">
             <thead>
                 <tr>
                     <th class="col-draggable">&nbsp;</th>
-                    <th class="col-name required"><?= $block->escapeHtml(__('Title')) ?><span class="required">*</span></th>
+                    <th class="col-name required"><?= $escaper->escapeHtml(__('Title')) ?><span class="required">*</span></th>
                     <?php if ($block->getCanReadPrice() !== false) : ?>
-                    <th class="col-price"><?= $block->escapeHtml(__('Price')) ?></th>
-                    <th class="col-price-type"><?= $block->escapeHtml(__('Price Type')) ?></th>
+                    <th class="col-price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                    <th class="col-price-type"><?= $escaper->escapeHtml(__('Price Type')) ?></th>
                     <?php endif; ?>
-                    <th class="col-sku"><?= $block->escapeHtml(__('SKU')) ?></th>
+                    <th class="col-sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
                     <th class="col-actions">&nbsp;</th>
                 </tr>
             </thead>
@@ -37,7 +43,7 @@
     <tr id="product_option_<%- data.id %>_select_<%- data.select_id %>">
         <td class="col-draggable">
             <div data-role="draggable-handle" class="draggable-handle"
-                 title="<?= $block->escapeHtmlAttr(__('Sort Custom Option')) ?>"></div>
+                 title="<?= $escaper->escapeHtmlAttr(__('Sort Custom Option')) ?>"></div>
             <input name="product[options][<%- data.id %>][values][<%- data.select_id %>][sort_order]" type="hidden" value="<%- data.sort_order %>">
         </td>
         <td class="col-name select-opt-title">

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/options/type/text.phtml
@@ -3,21 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Text;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Text $block */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
-<?php /** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Options\Type\Text */ ?>
 <script id="custom-option-text-type-template" type="text/x-magento-template">
     <div id="product_option_<%- data.option_id %>_type_<%- data.group %>" class="fieldset">
         <table class="data-table">
             <thead>
             <tr>
                 <?php if ($block->getCanReadPrice() !== false) : ?>
-                <th class="type-price"><?= $block->escapeHtml(__('Price')) ?></th>
-                <th class="type-type"><?= $block->escapeHtml(__('Price Type')) ?></th>
+                <th class="type-price"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                <th class="type-type"><?= $escaper->escapeHtml(__('Price Type')) ?></th>
                 <?php endif; ?>
-                <th class="type-sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                <th class="type-last last"><?= $block->escapeHtml(__('Max Characters')) ?></th>
+                <th class="type-sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                <th class="type-last last"><?= $escaper->escapeHtml(__('Max Characters')) ?></th>
             </tr>
             </thead>
             <tr>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/price/tier.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/price/tier.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Price\Tier;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-/* @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Price\Tier */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Tier $block */
 $element = $block->getElement();
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
 <?php $_htmlId      = $block->getElement()->getHtmlId() ?>
 <?php $_htmlClass   = $block->getElement()->getClass() ?>
@@ -25,21 +30,21 @@ $element = $block->getElement();
 $jsonHelper = $block->getData('jsonHelper'); ?>
 <div class="field" id="attribute-<?= /* @noEscape */ $_htmlId ?>-container"
      data-attribute-code="<?= /* @noEscape */ $_htmlId ?>"
-     data-apply-to="<?= $block->escapeHtml(
+     data-apply-to="<?= $escaper->escapeHtml(
          $jsonHelper->jsonEncode($element->hasEntityAttribute() ? $element->getEntityAttribute()->getApplyTo() : [])
      )?>">
-    <label class="label"><span><?= $block->escapeHtml($block->getElement()->getLabel()) ?></span></label>
+    <label class="label"><span><?= $escaper->escapeHtml($block->getElement()->getLabel()) ?></span></label>
     <div class="control">
         <table class="admin__control-table tiers_table" id="tiers_table">
             <thead>
                 <tr>
-                    <th class="col-websites"><?= $block->escapeHtml(__('Web Site')) ?></th>
-                    <th class="col-customer-group"><?= $block->escapeHtml(__('Customer Group')) ?></th>
-                    <th class="col-qty required"><?= $block->escapeHtml(__('Quantity')) ?></th>
+                    <th class="col-websites"><?= $escaper->escapeHtml(__('Web Site')) ?></th>
+                    <th class="col-customer-group"><?= $escaper->escapeHtml(__('Customer Group')) ?></th>
+                    <th class="col-qty required"><?= $escaper->escapeHtml(__('Quantity')) ?></th>
                     <th class="col-price required">
-                        <?= $block->escapeHtml($block->getPriceColumnHeader(__('Item Price'))) ?>
+                        <?= $escaper->escapeHtml($block->getPriceColumnHeader(__('Item Price'))) ?>
                     </th>
-                    <th class="col-delete"><?= $block->escapeHtml(__('Action')) ?></th>
+                    <th class="col-delete"><?= $escaper->escapeHtml(__('Action')) ?></th>
                 </tr>
                 <?php if (!$_showWebsite): ?>
                     <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display:none', 'th.col-websites'); ?>
@@ -66,16 +71,16 @@ require([
 //<![CDATA[
 var tierPriceRowTemplate = '<tr>'
     + '<td class="col-websites">'
-    + '<select class="{$block->escapeHtmlAttr($_htmlClass)} required-entry"
+    + '<select class="{$escaper->escapeHtmlAttr($_htmlClass)} required-entry"
      name="{$htmlName}[<%- data.index %>][website_id]" id="tier_price_row_<%- data.index %>_website">'
 script;
 foreach ($block->getWebsites() as $_websiteId => $_info):
     $scriptString .= <<<script
-    + '<option value="{$block->escapeHtmlAttr($_websiteId)}">{$block->escapeHtml($_info['name'])}
+    + '<option value="{$escaper->escapeHtmlAttr($_websiteId)}">{$escaper->escapeHtml($_info['name'])}
 script;
     if (!empty($_info['currency'])):
         $scriptString .= <<<script
-            [{$block->escapeHtml($_info['currency'])}]
+            [{$escaper->escapeHtml($_info['currency'])}]
 script;
     endif;
     $scriptString .= <<<script
@@ -84,31 +89,31 @@ script;
     endforeach;
     $scriptString .= <<<script
     + '</select></td>'
-    + '<td class="col-customer-group"><select class="{$block->escapeJs($_htmlClass)} custgroup required-entry"
+    + '<td class="col-customer-group"><select class="{$escaper->escapeJs($_htmlClass)} custgroup required-entry"
      name="{$htmlName}[<%- data.index %>][cust_group]" id="tier_price_row_<%- data.index %>_cust_group">'
 script;
 foreach ($block->getCustomerGroups() as $_groupId => $_groupName):
     $scriptString .= <<<script
-    + '<option value="{$block->escapeJs($_groupId)}">{$block->escapeJs($_groupName)}</option>'
+    + '<option value="{$escaper->escapeJs($_groupId)}">{$escaper->escapeJs($_groupName)}</option>'
 script;
     endforeach;
     $scriptString .= <<<script
     + '</select></td>'
     + '<td class="col-qty">'
-        + '<input class="{$block->escapeJs($_htmlClass)} qty required-entry validate-greater-than-zero"
+        + '<input class="{$escaper->escapeJs($_htmlClass)} qty required-entry validate-greater-than-zero"
          type="text" name="{$htmlName}[<%- data.index %>][price_qty]" value="<%- data.qty %>"
           id="tier_price_row_<%- data.index %>_qty" />'
-        + '<span>{$block->escapeHtml(__("and above"))}</span>'
+        + '<span>{$escaper->escapeHtml(__("and above"))}</span>'
     + '</td>'
-    + '<td class="col-price"><input class="{$block->escapeJs($_htmlClass)} required-entry
-     {$block->escapeJs($_priceValueValidation)}" type="text" name="{$htmlName}[<%- data.index %>][price]"
+    + '<td class="col-price"><input class="{$escaper->escapeJs($_htmlClass)} required-entry
+     {$escaper->escapeJs($_priceValueValidation)}" type="text" name="{$htmlName}[<%- data.index %>][price]"
       value="<%- data.price %>" id="tier_price_row_<%- data.index %>_price" /></td>'
     + '<td class="col-delete"><input type="hidden" name="{$htmlName}[<%- data.index %>][delete]" class="delete"
      value="" id="tier_price_row_<%- data.index %>_delete" />'
-    + '<button title="{$block->escapeJs(__('Delete Tier'))}" type="button"
+    + '<button title="{$escaper->escapeJs(__('Delete Tier'))}" type="button"
      class="action- scalable delete icon-btn delete-product-option"
       id="tier_price_row_<%- data.index %>_delete_button">'
-    + '<span>{$block->escapeJs(__("Delete"))}</span></button></td>'
+    + '<span>{$escaper->escapeJs(__("Delete"))}</span></button></td>'
     + '</tr>';
 script;
 
@@ -156,7 +161,7 @@ script;
             data.readOnly = arguments[4];
         }
 
-        Element.insert($('{$block->escapeJs($_htmlId)}_container'), {
+        Element.insert($('{$escaper->escapeJs($_htmlId)}_container'), {
             bottom : this.template({
                 data: data
             })
@@ -186,12 +191,12 @@ script;
 script;
     if ($_readonly):
         $scriptString .= <<<script
-        $('{$block->escapeJs($_htmlId)}_container').select('input', 'select').each(this.disableElement);
-        $('{$block->escapeJs($_htmlId)}_container').up('table').select('button').each(this.disableElement);
+        $('{$escaper->escapeJs($_htmlId)}_container').select('input', 'select').each(this.disableElement);
+        $('{$escaper->escapeJs($_htmlId)}_container').up('table').select('button').each(this.disableElement);
 script;
     else:
         $scriptString .= <<<script
-        $('{$block->escapeJs($_htmlId)}_container').select('input', 'select').each(function(el) {
+        $('{$escaper->escapeJs($_htmlId)}_container').select('input', 'select').each(function(el) {
             Event.observe(el, 'change', el.setHasChanges.bind(el));
         });
 script;
@@ -219,14 +224,14 @@ script;
     <?php $readonly = (int)!empty($_item['readonly']);
     $price_qty = $_item['price_qty']*1;
      $scriptString .= <<<script
-tierPriceControl.addItem('{$block->escapeJs($_item['website_id'])}', '{$block->escapeJs($_item['cust_group'])}',
- '{$price_qty}', '{$block->escapeJs($_item['price'])}', {$readonly});
+tierPriceControl.addItem('{$escaper->escapeJs($_item['website_id'])}', '{$escaper->escapeJs($_item['cust_group'])}',
+ '{$price_qty}', '{$escaper->escapeJs($_item['price'])}', {$readonly});
 script;
     ?>
 <?php endforeach; ?>
 <?php if ($_readonly):?>
     <?php $scriptString .= <<<script
-$('{$block->escapeJs($_htmlId)}_container').up('table').select('button').each(tierPriceControl.disableElement);
+$('{$escaper->escapeJs($_htmlId)}_container').up('table').select('button').each(tierPriceControl.disableElement);
 script;
     ?>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/serializer.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/serializer.phtml
@@ -3,17 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax\Serializer */
-?>
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Ajax\Serializer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Serializer $block */
 
 // phpcs:disable Magento2.Security.InsecureFunction.DiscouragedWithAlternative
-<?php
 // md5() here is not for cryptographic use.
 // phpcs:ignore Magento2.Security.InsecureFunction
 $_id = 'id_' . md5(microtime())
 ?>
 <input type="hidden"
-       name="<?= $block->escapeHtmlAttr($block->getInputElementName()) ?>"
+       name="<?= $escaper->escapeHtmlAttr($block->getInputElementName()) ?>"
        value=""
        id="<?= /* @noEscape */ $_id ?>" />

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/websites.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/edit/websites.phtml
@@ -3,17 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Websites */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Websites;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Websites $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <fieldset id="grop_fields" class="fieldset">
-    <legend class="legend"><span><?= $block->escapeHtml(__('Product In Websites')) ?></span></legend>
+    <legend class="legend"><span><?= $escaper->escapeHtml(__('Product In Websites')) ?></span></legend>
     <br>
     <?php if ($block->getProductId()):?>
     <div class="messages">
         <div class="message message-notice">
-            <?= $block->escapeHtml(__('To hide an item in catalog or search results, set the status to "Disabled".')) ?>
+            <?= $escaper->escapeHtml(__('To hide an item in catalog or search results, set the status to "Disabled".')) ?>
         </div>
     </div>
     <?php endif; ?>
@@ -37,20 +43,20 @@
                     <?php endif; ?>
                 />
                 <label for="product_website_<?= (int) $_website->getId() ?>">
-                    <?= $block->escapeHtml($_website->getName()) ?>
+                    <?= $escaper->escapeHtml($_website->getName()) ?>
                 </label>
             </div>
             <dl class="webiste-groups" id="product_website_<?= (int) $_website->getId() ?>_data">
                 <?php foreach ($block->getGroupCollection($_website) as $_group):?>
-                <dt><?= $block->escapeHtml($_group->getName()) ?></dt>
+                <dt><?= $escaper->escapeHtml($_group->getName()) ?></dt>
                 <dd>
                     <ul>
                         <?php foreach ($block->getStoreCollection($_group) as $_store):?>
                         <li>
-                            <?= $block->escapeHtml($_store->getName()) ?>
+                            <?= $escaper->escapeHtml($_store->getName()) ?>
                             <?php if ($block->getWebsites() && !$block->hasWebsite($_website->getId())):?>
                                 <span class="website-<?= (int) $_website->getId() ?>-select">
-                                <?= $block->escapeHtml(
+                                <?= $escaper->escapeHtml(
                                     __('(Copy data from: %1)', $block->getChooseFromStoreHtml($_store)),
                                     ['select', 'option', 'optgroup']
                                 ) ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/helper/gallery.phtml
@@ -3,39 +3,47 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Content $block */
 $elementName = $block->getElement()->getName() . '[images]';
 $formName = $block->getFormName();
+
 /** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
+
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
 <div id="<?= $block->getHtmlId() ?>"
      class="gallery"
      data-mage-init='{"productGallery":{"template":"#<?= $block->getHtmlId() ?>-template"}}'
-     data-parent-component="<?= $block->escapeHtml($block->getData('config/parentComponent')) ?>"
-     data-images="<?= $block->escapeHtml($block->getImagesJson()) ?>"
-     data-types="<?= $block->escapeHtml($jsonHelper->jsonEncode($block->getImageTypes())) ?>"
+     data-parent-component="<?= $escaper->escapeHtml($block->getData('config/parentComponent')) ?>"
+     data-images="<?= $escaper->escapeHtml($block->getImagesJson()) ?>"
+     data-types="<?= $escaper->escapeHtml($jsonHelper->jsonEncode($block->getImageTypes())) ?>"
 >
     <?php if (!$block->getElement()->getReadonly()) {?>
         <div class="image image-placeholder">
             <?= $block->getUploaderHtml() ?>
             <div class="product-image-wrapper">
                 <p class="image-placeholder-text">
-                    <?= $block->escapeHtml(__('Browse to find or drag image here')) ?>
+                    <?= $escaper->escapeHtml(__('Browse to find or drag image here')) ?>
                 </p>
             </div>
         </div>
     <?php } ?>
     <?php foreach ($block->getImageTypes() as $typeData) {
         ?>
-        <input name="<?= $block->escapeHtmlAttr($typeData['name']) ?>"
-               data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
-               class="image-<?= $block->escapeHtmlAttr($typeData['code']) ?>"
+        <input name="<?= $escaper->escapeHtmlAttr($typeData['name']) ?>"
+               data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
+               class="image-<?= $escaper->escapeHtmlAttr($typeData['code']) ?>"
                type="hidden"
-               value="<?= $block->escapeHtmlAttr($typeData['value']) ?>"/>
+               value="<?= $escaper->escapeHtmlAttr($typeData['value']) ?>"/>
         <?php
     } ?>
 
@@ -43,33 +51,33 @@ $jsonHelper = $block->getData('jsonHelper');
         <div class="image item<% if (data.disabled == 1) { %> hidden-for-front<% } %>"
              data-role="image">
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][position]"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][position]"
                    value="<%- data.position %>"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    class="position"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][file]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][file]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value="<%- data.file %>"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][value_id]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][value_id]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value="<%- data.value_id %>"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][label]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][label]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value="<%- data.label %>"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][disabled]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][disabled]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value="<%- data.disabled %>"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][media_type]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][media_type]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value="image"/>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][removed]"
-                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][removed]"
+                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                    value=""
                    class="is-removed"/>
 
@@ -83,14 +91,14 @@ $jsonHelper = $block->getData('jsonHelper');
                     <button type="button"
                             class="action-remove"
                             data-role="delete-button"
-                            title="<?= $block->escapeHtmlAttr(__('Delete image')) ?>">
+                            title="<?= $escaper->escapeHtmlAttr(__('Delete image')) ?>">
                     <span>
-                        <?= $block->escapeHtml(__('Delete image')) ?>
+                        <?= $escaper->escapeHtml(__('Delete image')) ?>
                     </span>
                     </button>
                     <div class="draggable-handle"></div>
                 </div>
-                <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')) ?></span></div>
+                <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')) ?></span></div>
             </div>
 
 
@@ -105,9 +113,9 @@ $jsonHelper = $block->getData('jsonHelper');
                 <?php
                 foreach ($block->getImageTypes() as $typeData) {
                     ?>
-                    <li data-role-code="<?= $block->escapeHtmlAttr($typeData['code']) ?>"
-                        class="item-role item-role-<?= $block->escapeHtmlAttr($typeData['code']) ?>">
-                        <?= $block->escapeHtml($typeData['label']) ?>
+                    <li data-role-code="<?= $escaper->escapeHtmlAttr($typeData['code']) ?>"
+                        class="item-role item-role-<?= $escaper->escapeHtmlAttr($typeData['code']) ?>">
+                        <?= $escaper->escapeHtml($typeData['label']) ?>
                     </li>
                     <?php
                 }
@@ -131,14 +139,14 @@ $jsonHelper = $block->getData('jsonHelper');
             <fieldset class="admin__fieldset fieldset-image-panel">
                 <div class="admin__field field-image-description">
                     <label class="admin__field-label" for="image-description">
-                        <span><?= $block->escapeHtml(__('Alt Text')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Alt Text')) ?></span>
                     </label>
 
                     <div class="admin__field-control">
                             <textarea data-role="image-description"
                                       rows="3"
                                       class="admin__control-textarea"
-                                      name="<?= $block->escapeHtmlAttr($elementName)
+                                      name="<?= $escaper->escapeHtmlAttr($elementName)
                                         ?>[<%- data.file_id %>][label]"><%- data.label %>
                             </textarea>
                       </div>
@@ -146,7 +154,7 @@ $jsonHelper = $block->getData('jsonHelper');
 
                 <div class="admin__field field-image-role">
                     <label class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Role')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Role')) ?></span>
                     </label>
                     <div class="admin__field-control">
                         <ul class="multiselect-alt">
@@ -157,11 +165,11 @@ $jsonHelper = $block->getData('jsonHelper');
                                     <label>
                                         <input class="image-type"
                                                data-role="type-selector"
-                                               data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                                               data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                                                type="checkbox"
-                                               value="<?= $block->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
+                                               value="<?= $escaper->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
                                                />
-                                        <?= $block->escapeHtml(
+                                        <?= $escaper->escapeHtml(
                                             $attribute->getFrontendLabel()
                                         ) ?>
                                     </label>
@@ -175,17 +183,17 @@ $jsonHelper = $block->getData('jsonHelper');
 
                 <div class="admin__field admin__field-inline field-image-size" data-role="size">
                     <label class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Image Size')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Image Size')) ?></span>
                     </label>
-                    <div class="admin__field-value" data-message="<?= $block->escapeHtmlAttr(__('{size}')) ?>"></div>
+                    <div class="admin__field-value" data-message="<?= $escaper->escapeHtmlAttr(__('{size}')) ?>"></div>
                 </div>
 
                 <div class="admin__field admin__field-inline field-image-resolution" data-role="resolution">
                     <label class="admin__field-label">
-                        <span><?= $block->escapeHtml(__('Image Resolution')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Image Resolution')) ?></span>
                     </label>
                     <div class="admin__field-value"
-                         data-message="<?= $block->escapeHtmlAttr(__('{width}^{height} px')) ?>"></div>
+                         data-message="<?= $escaper->escapeHtmlAttr(__('{width}^{height} px')) ?>"></div>
                 </div>
 
                 <div class="admin__field field-image-hide">
@@ -194,14 +202,14 @@ $jsonHelper = $block->getData('jsonHelper');
                             <input type="checkbox"
                                    id="hide-from-product-page"
                                    data-role="visibility-trigger"
-                                   data-form-part="<?= $block->escapeHtmlAttr($formName) ?>"
+                                   data-form-part="<?= $escaper->escapeHtmlAttr($formName) ?>"
                                    value="1"
                                    class="admin__control-checkbox"
-                                   name="<?= $block->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][disabled]"
+                                   name="<?= $escaper->escapeHtmlAttr($elementName) ?>[<%- data.file_id %>][disabled]"
                             <% if (data.disabled == 1) { %>checked="checked"<% } %> />
 
                             <label for="hide-from-product-page" class="admin__field-label">
-                                <?= $block->escapeHtml(__('Hide from Product Page')) ?>
+                                <?= $escaper->escapeHtml(__('Hide from Product Page')) ?>
                             </label>
                         </div>
                     </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/js.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/js.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Catalog\Block\Adminhtml\Product\Edit\Js $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Js;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php
+/** @var Escaper $escaper */
+/** @var Js $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 /** @var TaxHelper $taxHelper */
 $taxHelper = $block->getData('taxHelper');
 $priceFormat = /* @noEscape */ $taxHelper->getPriceFormat($block->getStore());
@@ -84,9 +87,9 @@ script;
 if ($tabsBlock = $block->getLayout()->getBlock('product_tabs')):
     $scriptString .= <<<script
 jQuery(function () {
-    if (jQuery('#{$block->escapeJs($tabsBlock->getId())}').length &&
-        jQuery('#{$block->escapeJs($tabsBlock->getId())}').is(':mage-tabs')) {
-        var activeAnchor = jQuery('#{$block->escapeJs($tabsBlock->getId())}').tabs('activeAnchor');
+    if (jQuery('#{$escaper->escapeJs($tabsBlock->getId())}').length &&
+        jQuery('#{$escaper->escapeJs($tabsBlock->getId())}').is(':mage-tabs')) {
+        var activeAnchor = jQuery('#{$escaper->escapeJs($tabsBlock->getId())}').tabs('activeAnchor');
         if (activeAnchor && $('store_switcher')) {
             $('store_switcher').switchParams = 'active_tab/' + activeAnchor.prop('name') + '/';
         }

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/alert.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/alert.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-?>
-<?php
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 /**
  * Template for block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Alerts
  */
 ?>
 <div id="alert_messages_block"><?= $block->getMessageHtml() ?></div>
 <div>
-    <h4 class="icon-head head-edit-form"><?= $block->escapeHtml(__('Product Alerts')) ?></h4>
+    <h4 class="icon-head head-edit-form"><?= $escaper->escapeHtml(__('Product Alerts')) ?></h4>
 </div>
 <div class="clear"></div>
 <?= $block->getAccordionHtml() ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/product/tab/inventory.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Inventory;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Inventory $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->isReadonly()):?>
     <?php $_readonly = ' disabled="disabled" '; ?>
@@ -13,25 +19,25 @@
     <?php $_readonly = ''; ?>
 <?php endif; ?>
 <fieldset class="fieldset form-inline">
-    <legend class="legend"><span><?= $block->escapeHtml(__('Advanced Inventory')) ?></span></legend>
+    <legend class="legend"><span><?= $escaper->escapeHtml(__('Advanced Inventory')) ?></span></legend>
     <br>
     <div id="table_cataloginventory">
         <div class="field">
             <label class="label" for="inventory_manage_stock">
-                <span><?= $block->escapeHtml(__('Manage Stock')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Manage Stock')) ?></span>
             </label>
             <div class="control">
                 <select id="inventory_manage_stock"
                         name="<?= /* @noEscape */ $block->getFieldSuffix()
                         ?>[stock_data][manage_stock]" <?= /* @noEscape */ $_readonly ?>>
-                    <option value="1"><?= $block->escapeHtml(__('Yes')) ?></option>
+                    <option value="1"><?= $escaper->escapeHtml(__('Yes')) ?></option>
                     <option value="0"<?php if ($block->getFieldValue('manage_stock') == 0):?>
-                        selected="selected"<?php endif; ?>><?= $block->escapeHtml(__('No')) ?>
+                        selected="selected"<?php endif; ?>><?= $escaper->escapeHtml(__('No')) ?>
                     </option>
                 </select>
                 <input type="hidden"
                        id="inventory_manage_stock_default"
-                       value="<?= $block->escapeHtmlAttr($block->getDefaultConfigValue('manage_stock')) ?>">
+                       value="<?= $escaper->escapeHtmlAttr($block->getDefaultConfigValue('manage_stock')) ?>">
                 <?php $_checked = ($block->getFieldValue('use_config_manage_stock') || $block->isNew()) ?
                     'checked="checked"' : '' ?>
                 <input type="checkbox"
@@ -43,7 +49,7 @@
                     "toggleValueElements(this, this.parentNode);",
                     "#inventory_use_config_manage_stock"
                 ) ?>
-                <label for="inventory_use_config_manage_stock"><?= $block->escapeHtml(__('Use Config Settings')) ?>
+                <label for="inventory_use_config_manage_stock"><?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                 </label>
                 <?php if (!$block->isReadonly()):?>
                     <?php $scriptString = <<<script
@@ -57,14 +63,14 @@ script;
                 <?php endif; ?>
             </div>
             <?php if (!$block->isSingleStoreMode()): ?>
-                <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
             <?php endif; ?>
         </div>
 
         <?php if (!$block->getProduct()->isComposite()): ?>
             <div class="field">
                 <label class="label" for="inventory_qty">
-                    <span><?= $block->escapeHtml(__('Qty')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Qty')) ?></span>
                 </label>
                 <div class="control">
                     <?php if (!$_readonly): ?>
@@ -81,13 +87,13 @@ script;
                            value="<?= $block->getFieldValue('qty') * 1 ?>" <?= /* @noEscape */ $_readonly ?>>
                 </div>
                 <?php if (!$block->isSingleStoreMode()): ?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
             <div class="field">
                 <label class="label" for="inventory_min_qty">
-                    <span><?= $block->escapeHtml(__('Out-of-Stock Threshold')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Out-of-Stock Threshold')) ?></span>
                 </label>
                 <div class="control">
                     <input type="text"
@@ -109,7 +115,7 @@ script;
                             "#inventory_use_config_min_qty"
                         ) ?>
 
-                        <label for="inventory_use_config_min_qty"><?= $block->escapeHtml(__('Use Config Settings')) ?>
+                        <label for="inventory_use_config_min_qty"><?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                         </label>
                     </div>
 
@@ -125,13 +131,13 @@ script;
                     <?php endif; ?>
                 </div>
                 <?php if (!$block->isSingleStoreMode()):?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
             <div class="field">
                 <label class="label" for="inventory_min_sale_qty">
-                    <span><?= $block->escapeHtml(__('Minimum Qty Allowed in Shopping Cart')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Minimum Qty Allowed in Shopping Cart')) ?></span>
                 </label>
                 <div class="control">
                     <input type="text" class="input-text validate-number" id="inventory_min_sale_qty"
@@ -152,7 +158,7 @@ script;
                             "#inventory_use_config_min_sale_qty"
                         ) ?>
                         <label for="inventory_use_config_min_sale_qty">
-                            <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                            <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                         </label>
                     </div>
                     <?php if (!$block->isReadonly()):?>
@@ -167,13 +173,13 @@ script;
                     <?php endif; ?>
                 </div>
                 <?php if (!$block->isSingleStoreMode()): ?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
             <div class="field">
                 <label class="label" for="inventory_max_sale_qty">
-                    <span><?= $block->escapeHtml(__('Maximum Qty Allowed in Shopping Cart')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Maximum Qty Allowed in Shopping Cart')) ?></span>
                 </label>
                 <div class="control">
                     <input type="text"
@@ -196,7 +202,7 @@ script;
                             "#inventory_use_config_max_sale_qty"
                         ) ?>
                         <label for="inventory_use_config_max_sale_qty">
-                            <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                            <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                         </label>
                     </div>
                     <?php if (!$block->isReadonly()):?>
@@ -211,46 +217,46 @@ script;
                     <?php endif; ?>
                 </div>
                 <?php if (!$block->isSingleStoreMode()):?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
             <?php if ($block->canUseQtyDecimals()): ?>
                 <div class="field">
                     <label class="label" for="inventory_is_qty_decimal">
-                        <span><?= $block->escapeHtml(__('Qty Uses Decimals')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Qty Uses Decimals')) ?></span>
                     </label>
                     <div class="control">
                         <select id="inventory_is_qty_decimal"
                                 name="<?= /* @noEscape */ $block->getFieldSuffix()
                                 ?>[stock_data][is_qty_decimal]" <?= /* @noEscape */ $_readonly ?>>
-                            <option value="0"><?= $block->escapeHtml(__('No')) ?></option>
+                            <option value="0"><?= $escaper->escapeHtml(__('No')) ?></option>
                             <option value="1"<?php if ($block->getFieldValue('is_qty_decimal') == 1):?>
-                                selected="selected"<?php endif; ?>><?= $block->escapeHtml(__('Yes')) ?>
+                                selected="selected"<?php endif; ?>><?= $escaper->escapeHtml(__('Yes')) ?>
                             </option>
                         </select>
                     </div>
                     <?php if (!$block->isSingleStoreMode()): ?>
-                        <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                        <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                     <?php endif; ?>
                 </div>
 
                 <?php if (!$block->isVirtual()): ?>
                     <div class="field">
                         <label class="label" for="inventory_is_decimal_divided">
-                            <span><?= $block->escapeHtml(__('Allow Multiple Boxes for Shipping')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Allow Multiple Boxes for Shipping')) ?></span>
                         </label>
                         <div class="control">
                             <select id="inventory_is_decimal_divided"
                                     name="<?= /* @noEscape */ $block->getFieldSuffix()
                                     ?>[stock_data][is_decimal_divided]" <?= /* @noEscape */ $_readonly ?>>
-                                <option value="0"><?= $block->escapeHtml(__('No')) ?></option>
+                                <option value="0"><?= $escaper->escapeHtml(__('No')) ?></option>
                                 <option value="1"<?php if ($block->getFieldValue('is_decimal_divided') == 1): ?>
-                                    selected="selected"<?php endif; ?>><?= $block->escapeHtml(__('Yes')) ?></option>
+                                    selected="selected"<?php endif; ?>><?= $escaper->escapeHtml(__('Yes')) ?></option>
                             </select>
                         </div>
                         <?php if (!$block->isSingleStoreMode()):?>
-                            <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                            <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
@@ -258,7 +264,7 @@ script;
 
             <div class="field">
                 <label class="label" for="inventory_backorders">
-                    <span><?= $block->escapeHtml(__('Backorders')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Backorders')) ?></span>
                 </label>
                 <div class="control">
                     <select id="inventory_backorders"
@@ -267,8 +273,8 @@ script;
                         <?php foreach ($block->getBackordersOption() as $option):?>
                             <?php $_selected = ($option['value'] == $block->getFieldValue('backorders')) ?
                                 'selected="selected"' : '' ?>
-                            <option value="<?= $block->escapeHtmlAttr($option['value']) ?>"
-                                <?= /* @noEscape */ $_selected ?>><?= $block->escapeHtml($option['label']) ?>
+                            <option value="<?= $escaper->escapeHtmlAttr($option['value']) ?>"
+                                <?= /* @noEscape */ $_selected ?>><?= $escaper->escapeHtml($option['label']) ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
@@ -286,7 +292,7 @@ script;
                             "#inventory_use_config_backorders"
                         ) ?>
                         <label for="inventory_use_config_backorders">
-                            <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                            <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                         </label>
                     </div>
                     <?php if (!$block->isReadonly()): ?>
@@ -301,13 +307,13 @@ script;
                     <?php endif; ?>
                 </div>
                 <?php if (!$block->isSingleStoreMode()): ?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
             <div class="field">
                 <label class="label" for="inventory_notify_stock_qty">
-                    <span><?= $block->escapeHtml(__('Notify for Quantity Below')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Notify for Quantity Below')) ?></span>
                 </label>
                 <div class="control">
                     <input type="text"
@@ -331,7 +337,7 @@ script;
                             "#inventory_use_config_notify_stock_qty"
                         ) ?>
                         <label for="inventory_use_config_notify_stock_qty">
-                            <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                            <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                         </label>
                     </div>
                     <?php if (!$block->isReadonly()): ?>
@@ -346,14 +352,14 @@ script;
                     <?php endif; ?>
                 </div>
                 <?php if (!$block->isSingleStoreMode()):?>
-                    <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                    <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
                 <?php endif; ?>
             </div>
 
         <?php endif; ?>
         <div class="field">
             <label class="label" for="inventory_enable_qty_increments">
-                <span><?= $block->escapeHtml(__('Enable Qty Increments')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Enable Qty Increments')) ?></span>
             </label>
             <div class="control">
                 <?php $qtyIncrementsEnabled = $block->getFieldValue('enable_qty_increments'); ?>
@@ -361,15 +367,15 @@ script;
                         name="<?= /* @noEscape */ $block->getFieldSuffix()
                         ?>[stock_data][enable_qty_increments]" <?= /* @noEscape */ $_readonly ?>>
                     <option value="1"<?php if ($qtyIncrementsEnabled):?> selected="selected"<?php endif; ?>>
-                        <?= $block->escapeHtml(__('Yes')) ?>
+                        <?= $escaper->escapeHtml(__('Yes')) ?>
                     </option>
                     <option value="0"<?php if (!$qtyIncrementsEnabled):?> selected="selected"<?php endif; ?>>
-                        <?= $block->escapeHtml(__('No')) ?>
+                        <?= $escaper->escapeHtml(__('No')) ?>
                     </option>
                 </select>
                 <input type="hidden"
                        id="inventory_enable_qty_increments_default"
-                       value="<?= $block->escapeHtmlAttr($block->getDefaultConfigValue('enable_qty_increments')) ?>">
+                       value="<?= $escaper->escapeHtmlAttr($block->getDefaultConfigValue('enable_qty_increments')) ?>">
 
                 <div class="control-inner-wrap">
                     <?php $_checked = ($block->getFieldValue('use_config_enable_qty_inc') || $block->isNew()) ?
@@ -385,7 +391,7 @@ script;
                         "#inventory_use_config_enable_qty_increments"
                     ) ?>
                     <label for="inventory_use_config_enable_qty_increments">
-                        <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                        <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                     </label>
                 </div>
                 <?php if (!$block->isReadonly()): ?>
@@ -400,13 +406,13 @@ script;
                 <?php endif; ?>
             </div>
             <?php if (!$block->isSingleStoreMode()): ?>
-                <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
             <?php endif; ?>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_qty_increments">
-                <span><?= $block->escapeHtml(__('Qty Increments')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Qty Increments')) ?></span>
             </label>
             <div class="control">
                 <input type="text"
@@ -427,7 +433,7 @@ script;
                         "#inventory_use_config_qty_increments"
                     ) ?>
                     <label for="inventory_use_config_qty_increments">
-                        <?= $block->escapeHtml(__('Use Config Settings')) ?>
+                        <?= $escaper->escapeHtml(__('Use Config Settings')) ?>
                     </label>
                 </div>
                 <?php if (!$block->isReadonly()): ?>
@@ -442,13 +448,13 @@ script;
                 <?php endif; ?>
             </div>
             <?php if (!$block->isSingleStoreMode()): ?>
-                <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
             <?php endif; ?>
         </div>
 
         <div class="field">
             <label class="label" for="inventory_stock_availability">
-                <span><?= $block->escapeHtml(__('Stock Availability')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Stock Availability')) ?></span>
             </label>
             <div class="control">
                 <select id="inventory_stock_availability"
@@ -457,14 +463,14 @@ script;
                     <?php foreach ($block->getStockOption() as $option):?>
                         <?php $_selected = ($block->getFieldValue('is_in_stock') !== null &&
                             $option['value'] == $block->getFieldValue('is_in_stock')) ? 'selected="selected"' : '' ?>
-                        <option value="<?= $block->escapeHtmlAttr($option['value']) ?>"
-                            <?= /* @noEscape */ $_selected ?>><?= $block->escapeHtml($option['label']) ?>
+                        <option value="<?= $escaper->escapeHtmlAttr($option['value']) ?>"
+                            <?= /* @noEscape */ $_selected ?>><?= $escaper->escapeHtml($option['label']) ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             </div>
             <?php if (!$block->isSingleStoreMode()):?>
-                <div class="field-service"><?= $block->escapeHtml(__('[GLOBAL]')) ?></div>
+                <div class="field-service"><?= $escaper->escapeHtml(__('[GLOBAL]')) ?></div>
             <?php endif; ?>
         </div>
     </div>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/attribute/search.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/attribute/search.phtml
@@ -3,26 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes\Search;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Search $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tab\Attributes\Search */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="product-attribute-search-container" class="suggest-expandable attribute-selector">
     <div class="action-dropdown">
         <button type="button" class="action-toggle action-choose" data-mage-init='{"dropdown":{}}'
                 data-toggle="dropdown">
-            <span><?= $block->escapeHtml(__('Add Attribute')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Add Attribute')) ?></span>
         </button>
         <div class="dropdown-menu">
             <input data-role="product-attribute-search"
-                   data-group="<?= $block->escapeHtmlAttr($block->getGroupCode()) ?>"
+                   data-group="<?= $escaper->escapeHtmlAttr($block->getGroupCode()) ?>"
                    class="search" type="text"
-                   placeholder="<?= $block->escapeHtmlAttr(__('start typing to search attribute')) ?>" />
+                   placeholder="<?= $escaper->escapeHtmlAttr(__('start typing to search attribute')) ?>" />
         </div>
     </div>
 
-<script data-template-for="product-attribute-search-<?= $block->escapeHtmlAttr($block->getGroupId()) ?>"
+<script data-template-for="product-attribute-search-<?= $escaper->escapeHtmlAttr($block->getGroupId()) ?>"
         type="text/x-magento-template">
     <ul data-mage-init='{"menu":[]}'>
         <% if (data.items.length) { %>
@@ -31,7 +38,7 @@
         <% }); %>
         <% } else { %><span class="mage-suggest-no-records"><%- data.noRecordsText %></span><% } %>
     </ul>
-    <div class="actions"><?= $block->escapeHtml($block->getAttributeCreate()) ?></div>
+    <div class="actions"><?= $escaper->escapeHtml($block->getAttributeCreate()) ?></div>
 </script>
 
 <?php
@@ -40,7 +47,7 @@ $jsonHelper = $block->getData('jsonHelper');
 $selectorOptions = /* @noEscape */ $jsonHelper->jsonEncode($block->getSelectorOptions());
 $scriptString = <<<script
     require(["jquery","mage/mage","mage/backend/suggest"], function($) {
-        var $suggest = $('[data-role="product-attribute-search"][data-group="{$block->escapeHtml(
+        var $suggest = $('[data-role="product-attribute-search"][data-group="{$escaper->escapeHtml(
             $block->getGroupCode()
         )}"]');
 
@@ -65,7 +72,7 @@ $scriptString = <<<script
                 var templateId = $('#attribute_set_id').val();
                 if (ui.item.id) {
                     $.ajax({
-                        url: '{$block->escapeJs($block->getAddAttributeUrl())}',
+                        url: '{$escaper->escapeJs($block->getAddAttributeUrl())}',
                         type: 'POST',
                         dataType: 'json',
                         data: {attribute_id: ui.item.id, template_id: templateId, group: $(this).data('group')},

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/edit/tabs.phtml
@@ -3,36 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs */
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Tabs $block */
 ?>
 <?php if (!empty($tabs)) :?>
     <?php $tabGroups = [
-        \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs::BASIC_TAB_GROUP_CODE,
-        \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs::ADVANCED_TAB_GROUP_CODE,
+        Tabs::BASIC_TAB_GROUP_CODE,
+        Tabs::ADVANCED_TAB_GROUP_CODE,
     ];?>
 
-    <div id="<?= $block->escapeHtmlAttr($block->getId()) ?>"
+    <div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>"
          data-mage-init='{"tabs":{
-        "active": "<?= $block->escapeHtmlAttr($block->getActiveTabId()) ?>",
-        "destination": "#<?= $block->escapeHtmlAttr($block->getDestElementId()) ?>",
+        "active": "<?= $escaper->escapeHtmlAttr($block->getActiveTabId()) ?>",
+        "destination": "#<?= $escaper->escapeHtmlAttr($block->getDestElementId()) ?>",
         "shadowTabs": "<?= /* @noEscape */ $block->getAllShadowTabs() ?>",
-        "tabsBlockPrefix": "<?= $block->escapeHtmlAttr($block->getId()) ?>_",
+        "tabsBlockPrefix": "<?= $escaper->escapeHtmlAttr($block->getId()) ?>_",
         "tabIdArgument": "active_tab",
-        "tabPanelClass": "<?= $block->escapeHtmlAttr($block->getPanelsClass()) ?>",
-        "excludedPanel": "<?= $block->escapeHtmlAttr($block->getExcludedPanel()) ?>",
+        "tabPanelClass": "<?= $escaper->escapeHtmlAttr($block->getPanelsClass()) ?>",
+        "excludedPanel": "<?= $escaper->escapeHtmlAttr($block->getExcludedPanel()) ?>",
         "groups": "ul.tabs"
     }}'>
         <?php foreach ($tabGroups as $tabGroupCode) :?>
             <?php
                 $tabGroupId = $block->getId() . '-' . $tabGroupCode;
-                $isBasic = $tabGroupCode == \Magento\Catalog\Block\Adminhtml\Product\Edit\Tabs::BASIC_TAB_GROUP_CODE;
+                $isBasic = $tabGroupCode == Tabs::BASIC_TAB_GROUP_CODE;
                 $activeCollapsible = $block->isAdvancedTabGroupActive() ? true : false;
             ?>
 
             <div class="admin__page-nav <?php if (!$isBasic) :?> <?= '_collapsed' ?> <?php endif;?>"
                 data-role="container"
-                id="<?= $block->escapeHtmlAttr($tabGroupId) ?>"
+                id="<?= $escaper->escapeHtmlAttr($tabGroupId) ?>"
                 <?php if (!$isBasic) :?>
                     data-mage-init='{"collapsible":{
                     "active": "<?= /* @noEscape */ $activeCollapsible ?>",
@@ -47,7 +52,7 @@
                     <div class="admin__page-nav-title <?php if (!$isBasic) :?> <?= '_collapsible' ?><?php endif;?>"
                         data-role="trigger">
                         <strong>
-                            <?= $block->escapeHtml($isBasic ? __('Basic Settings') : __('Advanced Settings')) ?>
+                            <?= $escaper->escapeHtml($isBasic ? __('Basic Settings') : __('Advanced Settings')) ?>
                         </strong>
                         <span data-role="title-messages" class="admin__page-nav-title-messages"></span>
                     </div>
@@ -64,24 +69,24 @@
                         <?php $_tabType = (!preg_match('/\s?ajax\s?/', $_tabClass) && $block->getTabUrl($_tab) != '#') ? 'link' : '' ?>
                         <?php $_tabHref = $block->getTabUrl($_tab) == '#' ? '#' . $block->getTabId($_tab) . '_content' : $block->getTabUrl($_tab) ?>
                         <li class="admin__page-nav-item <?php if ($block->getTabIsHidden($_tab)) :?> <?= "no-display" ?> <?php endif; ?> " <?= /* @noEscape */ $block->getUiId('tab', 'item', $_tab->getId()) ?>>
-                            <a href="<?= $block->escapeUrl($_tabHref) ?>" id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
-                               name="<?= $block->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
-                               title="<?= $block->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
-                               class="admin__page-nav-link <?= $block->escapeHtmlAttr($_tabClass) ?>"
+                            <a href="<?= $escaper->escapeUrl($_tabHref) ?>" id="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab)) ?>"
+                               name="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
+                               title="<?= $escaper->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
+                               class="admin__page-nav-link <?= $escaper->escapeHtmlAttr($_tabClass) ?>"
                                data-tab-type="<?= /* @noEscape */ $_tabType ?>" <?= /* @noEscape */ $block->getUiId('tab', 'link', $_tab->getId()) ?>
                             >
-                                <span><?= $block->escapeHtml($block->getTabLabel($_tab)) ?></span>
+                                <span><?= $escaper->escapeHtml($block->getTabLabel($_tab)) ?></span>
                                 <span class="admin__page-nav-item-messages" data-role="item-messages">
                                    <span class="admin__page-nav-item-message _changed">
                                        <span class="admin__page-nav-item-message-icon"></span>
                                        <span class="admin__page-nav-item-message-tooltip">
-                                           <?= $block->escapeHtml(__('Changes have been made to this section that have not been saved.')) ?>
+                                           <?= $escaper->escapeHtml(__('Changes have been made to this section that have not been saved.')) ?>
                                        </span>
                                    </span>
                                    <span class="admin__page-nav-item-message _error">
                                        <span class="admin__page-nav-item-message-icon"></span>
                                        <span class="admin__page-nav-item-message-tooltip">
-                                           <?= $block->escapeHtml(__('This tab contains invalid data. Please resolve this before saving.')) ?>
+                                           <?= $escaper->escapeHtml(__('This tab contains invalid data. Please resolve this before saving.')) ?>
                                        </span>
                                    </span>
                                     <span class="admin__page-nav-item-message-loader">
@@ -92,8 +97,8 @@
                                    </span>
                                 </span>
                             </a>
-                            <div id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>_content" class="no-display"
-                                 data-tab-panel="<?= $block->escapeHtmlAttr($_tab->getTabId()) ?>"
+                            <div id="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab)) ?>_content" class="no-display"
+                                 data-tab-panel="<?= $escaper->escapeHtmlAttr($_tab->getTabId()) ?>"
                                 <?= /* @noEscape */ $block->getUiId('tab', 'content', $_tab->getId()) ?>
                             >
                                 <?= /* @noEscape */ $block->getTabContent($_tab) ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/product/grid/massaction_extended.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Product\Grid */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Adminhtml\Product\Grid;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Grid $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="<?= $block->getHtmlId() ?>" class="admin__grid-massaction">
     <?php if ($block->getHideFormElement() !== true):?>
@@ -17,12 +23,12 @@
                 id="<?= $block->getHtmlId() ?>-select"
                 class="local-validation admin__control-select">
                 <option class="admin__control-select-placeholder" value=""
-                        selected><?= $block->escapeHtml(__('Actions')) ?>
+                        selected><?= $escaper->escapeHtml(__('Actions')) ?>
                 </option>
                 <?php foreach ($block->getItems() as $_item):?>
-                    <option value="<?= $block->escapeHtmlAttr($_item->getId()) ?>"
+                    <option value="<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
                         <?= ($_item->getSelected() ? ' selected="selected"' : '') ?>>
-                        <?= $block->escapeHtml($_item->getLabel()) ?>
+                        <?= $escaper->escapeHtml($_item->getLabel()) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
@@ -35,29 +41,29 @@
     <?php endif ?>
     <div class="no-display">
     <?php foreach ($block->getItems() as $_item):?>
-        <div id="<?= $block->getHtmlId() ?>-item-<?= $block->escapeHtmlAttr($_item->getId()) ?>-block">
+        <div id="<?= $block->getHtmlId() ?>-item-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>-block">
             <?= $_item->getAdditionalActionBlockHtml() ?>
         </div>
     <?php endforeach; ?>
     </div>
 
     <div class="mass-select-wrap">
-        <select id="<?= $block->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select" data-menu="grid-mass-select">
-            <optgroup label="<?= $block->escapeHtmlAttr(__('Mass Actions')) ?>">
+        <select id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select" data-menu="grid-mass-select">
+            <optgroup label="<?= $escaper->escapeHtmlAttr(__('Mass Actions')) ?>">
                 <option disabled selected></option>
                 <?php if ($block->getUseSelectAll()):?>
                     <option value="selectAll">
-                        <?= $block->escapeHtml(__('Select All')) ?>
+                        <?= $escaper->escapeHtml(__('Select All')) ?>
                     </option>
                     <option value="unselectAll">
-                        <?= $block->escapeHtml(__('Unselect All')) ?>
+                        <?= $escaper->escapeHtml(__('Unselect All')) ?>
                     </option>
                 <?php endif; ?>
                 <option value="selectVisible">
-                    <?= $block->escapeHtml(__('Select Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Select Visible')) ?>
                 </option>
                 <option value="unselectVisible">
-                    <?= $block->escapeHtml(__('Unselect Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Unselect Visible')) ?>
                 </option>
             </optgroup>
         </select>
@@ -74,19 +80,19 @@ script;
     if ($block->getUseSelectAll()):
         $scriptString .= <<<script
                 case 'selectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectAll();
                     break
                 case 'unselectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectAll();
                     break
 script;
     endif;
     $scriptString .= <<<script
                 case 'selectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectVisible();
                     break
                 case 'unselectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectVisible();
                     break
             }
             this.blur();
@@ -95,7 +101,7 @@ script;
     });
 script;
     if (!$block->getParentBlock()->canDisplayContainer()):
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . ".setGridIds('" .
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . ".setGridIds('" .
             /* @noEscape */ $block->getGridIdsJson() . "');";
     endif;
     ?>

--- a/app/code/Magento/Catalog/view/adminhtml/templates/rss/grid/link.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/rss/grid/link.phtml
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Adminhtml\Rss\Grid\Link */
+use Magento\Catalog\Block\Adminhtml\Rss\Grid\Link;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink()) :?>
-<a href="<?= $block->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $block->escapeHtml($block->getLabel()) ?></a>
+<a href="<?= $escaper->escapeUrl($block->getLink()) ?>" class="link-feed"><?= $escaper->escapeHtml($block->getLabel()) ?></a>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/base/templates/product/composite/fieldset/options/view/checkable.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/composite/fieldset/options/view/checkable.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Catalog\Block\Product\View\Options\Type\Select\Checkable;
 use Magento\Catalog\Model\Product\Option;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-/**
- * @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select\Checkable
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Checkable $block */
 $option = $block->getOption();
 if ($option): ?>
     <?php
@@ -19,14 +22,14 @@ if ($option): ?>
     $count = 1;
     ?>
 
-<div class="options-list nested" id="options-<?= $block->escapeHtmlAttr($option->getId()) ?>-list">
+<div class="options-list nested" id="options-<?= $escaper->escapeHtmlAttr($option->getId()) ?>-list">
     <?php if ($optionType === Option::OPTION_TYPE_RADIO && !$option->getIsRequire()):?>
     <div class="field choice admin__field admin__field-option">
         <input type="radio"
-               id="options_<?= $block->escapeHtmlAttr($option->getId()) ?>"
+               id="options_<?= $escaper->escapeHtmlAttr($option->getId()) ?>"
                class="radio admin__control-radio product-custom-option"
-               name="options[<?= $block->escapeHtmlAttr($option->getId()) ?>]"
-               data-selector="options[<?= $block->escapeHtmlAttr($option->getId()) ?>]"
+               name="options[<?= $escaper->escapeHtmlAttr($option->getId()) ?>]"
+               data-selector="options[<?= $escaper->escapeHtmlAttr($option->getId()) ?>]"
                value=""
                checked="checked"
         />
@@ -34,12 +37,12 @@ if ($option): ?>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onclick',
                 'opConfig.reloadPrice()',
-                "options_" . $block->escapeJs($option->getId())
+                "options_" . $escaper->escapeJs($option->getId())
             ) ?>
         <?php endif; ?>
-        <label class="label admin__field-label" for="options_<?= $block->escapeHtmlAttr($option->getId()) ?>">
+        <label class="label admin__field-label" for="options_<?= $escaper->escapeHtmlAttr($option->getId()) ?>">
                         <span>
-                            <?= $block->escapeHtml(__('None'))  ?>
+                            <?= $escaper->escapeHtml(__('None'))  ?>
                         </span>
         </label>
     </div>
@@ -61,24 +64,24 @@ if ($option): ?>
         ?>
 
         <div class="field choice admin__field admin__field-option">
-            <input type="<?= $block->escapeHtmlAttr($optionType) ?>"
+            <input type="<?= $escaper->escapeHtmlAttr($optionType) ?>"
                    class="<?= $optionType === Option::OPTION_TYPE_RADIO
                        ? 'radio admin__control-radio'
                        : 'checkbox admin__control-checkbox' ?> <?= $option->getIsRequire()
                        ? 'required': '' ?>
                        product-custom-option
                         <?= $block->getSkipJsReloadPrice() ? '' : 'opConfig.reloadPrice()' ?>"
-                   name="options[<?= $block->escapeHtmlAttr($option->getId()) ?>]<?= /* @noEscape */ $arraySign ?>"
-                   id="options_<?= $block->escapeHtmlAttr($option->getId() . '_' . $count) ?>"
-                   value="<?= $block->escapeHtmlAttr($value->getOptionTypeId()) ?>"
-                <?= $block->escapeHtml($checked) ?>
-                   data-selector="<?= $block->escapeHtmlAttr($dataSelector) ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getCurrencyByStore($value)) ?>"
+                   name="options[<?= $escaper->escapeHtmlAttr($option->getId()) ?>]<?= /* @noEscape */ $arraySign ?>"
+                   id="options_<?= $escaper->escapeHtmlAttr($option->getId() . '_' . $count) ?>"
+                   value="<?= $escaper->escapeHtmlAttr($value->getOptionTypeId()) ?>"
+                <?= $escaper->escapeHtml($checked) ?>
+                   data-selector="<?= $escaper->escapeHtmlAttr($dataSelector) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getCurrencyByStore($value)) ?>"
             />
             <label class="label admin__field-label"
-                   for="options_<?= $block->escapeHtmlAttr($option->getId() . '_' . $count) ?>">
+                   for="options_<?= $escaper->escapeHtmlAttr($option->getId() . '_' . $count) ?>">
                 <span>
-                    <?= $block->escapeHtml($value->getTitle()) ?>
+                    <?= $escaper->escapeHtml($value->getTitle()) ?>
                 </span>
                 <?= /* @noEscape */ $block->formatPrice($value) ?>
             </label>

--- a/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/amount/default.phtml
@@ -3,26 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\Pricing\Render\Amount;
+
+/** @var Escaper $escaper */
+/** @var Amount $block */
 ?>
-
-<?php /** @var $block \Magento\Framework\Pricing\Render\Amount */ ?>
-
-<span class="price-container <?= $block->escapeHtmlAttr($block->getAdjustmentCssClasses()) ?>"
+<span class="price-container <?= $escaper->escapeHtmlAttr($block->getAdjustmentCssClasses()) ?>"
         <?= $block->getSchema() ? ' itemprop="offers" itemscope itemtype="http://schema.org/Offer"' : '' ?>>
     <?php if ($block->getDisplayLabel()) :?>
-        <span class="price-label"><?= $block->escapeHtml($block->getDisplayLabel()) ?></span>
+        <span class="price-label"><?= $escaper->escapeHtml($block->getDisplayLabel()) ?></span>
     <?php endif; ?>
-    <span <?php if ($block->getPriceId()) :?> id="<?= $block->escapeHtmlAttr($block->getPriceId()) ?>"<?php endif;?>
-        <?= ($block->getPriceDisplayLabel()) ? 'data-label="' . $block->escapeHtmlAttr($block->getPriceDisplayLabel() . $block->getPriceDisplayInclExclTaxes()) . '"' : '' ?>
-        data-price-amount="<?= $block->escapeHtmlAttr($block->getDisplayValue()) ?>"
-        data-price-type="<?= $block->escapeHtmlAttr($block->getPriceType()) ?>"
-        class="price-wrapper <?= $block->escapeHtmlAttr($block->getPriceWrapperCss()) ?>"
-    ><?= $block->escapeHtml($block->formatCurrency($block->getDisplayValue(), (bool)$block->getIncludeContainer()), ['span']) ?></span>
+    <span <?php if ($block->getPriceId()) :?> id="<?= $escaper->escapeHtmlAttr($block->getPriceId()) ?>"<?php endif;?>
+        <?= ($block->getPriceDisplayLabel()) ? 'data-label="' . $escaper->escapeHtmlAttr($block->getPriceDisplayLabel() . $block->getPriceDisplayInclExclTaxes()) . '"' : '' ?>
+        data-price-amount="<?= $escaper->escapeHtmlAttr($block->getDisplayValue()) ?>"
+        data-price-type="<?= $escaper->escapeHtmlAttr($block->getPriceType()) ?>"
+        class="price-wrapper <?= $escaper->escapeHtmlAttr($block->getPriceWrapperCss()) ?>"
+    ><?= $escaper->escapeHtml($block->formatCurrency($block->getDisplayValue(), (bool)$block->getIncludeContainer()), ['span']) ?></span>
     <?php if ($block->hasAdjustmentsHtml()) :?>
         <?= $block->getAdjustmentsHtml() ?>
     <?php endif; ?>
     <?php if ($block->getSchema()) :?>
-        <meta itemprop="price" content="<?= $block->escapeHtmlAttr($block->getDisplayValue()) ?>" />
-        <meta itemprop="priceCurrency" content="<?= $block->escapeHtmlAttr($block->getDisplayCurrencyCode()) ?>" />
+        <meta itemprop="price" content="<?= $escaper->escapeHtmlAttr($block->getDisplayValue()) ?>" />
+        <meta itemprop="priceCurrency" content="<?= $escaper->escapeHtmlAttr($block->getDisplayCurrencyCode()) ?>" />
     <?php endif; ?>
 </span>

--- a/app/code/Magento/Catalog/view/base/templates/product/price/configured_price.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/configured_price.phtml
@@ -3,17 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Catalog\Pricing\Render\FinalPriceBox $block */
+declare(strict_types=1);
+
+use Magento\Catalog\Pricing\Price\ConfiguredPrice;
+use Magento\Catalog\Pricing\Price\ConfiguredPriceInterface;
+use Magento\Catalog\Pricing\Price\ConfiguredRegularPrice;
+use Magento\Catalog\Pricing\Render\FinalPriceBox;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var FinalPriceBox $block */
 $schema = ($block->getZone() == 'item_view') ? true : false;
 $idSuffix = $block->getIdSuffix() ? $block->getIdSuffix() : '';
-/** @var \Magento\Catalog\Pricing\Price\ConfiguredPrice $configuredPrice */
+
+/** @var ConfiguredPrice $configuredPrice */
 $configuredPrice = $block->getPrice();
-/** @var \Magento\Catalog\Pricing\Price\ConfiguredRegularPrice $configuredRegularPrice */
-$configuredRegularPrice = $block->getPriceType(
-    \Magento\Catalog\Pricing\Price\ConfiguredPriceInterface::CONFIGURED_REGULAR_PRICE_CODE
-);
+
+/** @var ConfiguredRegularPrice $configuredRegularPrice */
+$configuredRegularPrice = $block->getPriceType(ConfiguredPriceInterface::CONFIGURED_REGULAR_PRICE_CODE);
 ?>
 <?php if ($configuredPrice->getAmount()->getValue() < $configuredRegularPrice->getAmount()->getValue()) : ?>
     <p class="price-as-configured">
@@ -21,8 +28,8 @@ $configuredRegularPrice = $block->getPriceType(
             <?= /* @noEscape */ $block->renderAmount(
                 $configuredPrice->getAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Special Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Special Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                     'price_type'        => 'finalPrice',
                     'include_container' => true,
                     'schema' => $schema,
@@ -33,8 +40,8 @@ $configuredRegularPrice = $block->getPriceType(
             <?= /* @noEscape */ $block->renderAmount(
                 $configuredRegularPrice->getAmount(),
                 [
-                    'display_label'     => $block->escapeHtml(__('Regular Price')),
-                    'price_id'          => $block->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
+                    'display_label'     => $escaper->escapeHtml(__('Regular Price')),
+                    'price_id'          => $escaper->escapeHtml($block->getPriceId('old-price-' . $idSuffix)),
                     'price_type'        => 'oldPrice',
                     'include_container' => true,
                     'skip_adjustments'  => true,
@@ -52,8 +59,8 @@ $configuredRegularPrice = $block->getPriceType(
         <?= /* @noEscape */ $block->renderAmount(
             $configuredPrice->getAmount(),
             [
-                'display_label'     => $block->escapeHtml($priceLabel),
-                'price_id'          => $block->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
+                'display_label'     => $escaper->escapeHtml($priceLabel),
+                'price_id'          => $escaper->escapeHtml($block->getPriceId('product-price-' . $idSuffix)),
                 'price_type'        => 'finalPrice',
                 'include_container' => true,
                 'schema' => $schema,

--- a/app/code/Magento/Catalog/view/base/templates/product/price/final_price.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/final_price.phtml
@@ -3,17 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
-/** @var \Magento\Catalog\Pricing\Render\FinalPriceBox $block */
+use Magento\Catalog\Pricing\Render\FinalPriceBox;
+use Magento\Framework\Escaper;
+use Magento\Framework\Pricing\Price\PriceInterface;
+
+/** @var Escaper $escaper */
+/** @var FinalPriceBox $block */
 
 /** ex: \Magento\Catalog\Pricing\Price\RegularPrice */
-/** @var \Magento\Framework\Pricing\Price\PriceInterface $priceModel */
+/** @var PriceInterface $priceModel */
 $priceModel = $block->getPriceType('regular_price');
 
 /** ex: \Magento\Catalog\Pricing\Price\FinalPrice */
-/** @var \Magento\Framework\Pricing\Price\PriceInterface $finalPriceModel */
+/** @var PriceInterface $finalPriceModel */
 $finalPriceModel = $block->getPriceType('final_price');
 $idSuffix = $block->getIdSuffix() ? $block->getIdSuffix() : '';
 $schema = ($block->getZone() == 'item_view') ? true : false;
@@ -48,7 +52,7 @@ $schema = ($block->getZone() == 'item_view') ? true : false;
 
 <?php if ($block->showMinimalPrice()) :?>
     <?php if ($block->getUseLinkForAsLowAs()) :?>
-        <a href="<?= $block->escapeUrl($block->getSaleableItem()->getProductUrl()) ?>" class="minimal-price-link">
+        <a href="<?= $escaper->escapeUrl($block->getSaleableItem()->getProductUrl()) ?>" class="minimal-price-link">
             <?= /* @noEscape */ $block->renderAmountMinimal() ?>
         </a>
     <?php else :?>

--- a/app/code/Magento/Catalog/view/base/templates/product/price/tier_prices.phtml
+++ b/app/code/Magento/Catalog/view/base/templates/product/price/tier_prices.phtml
@@ -3,23 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
+use Magento\Catalog\Pricing\Price\TierPrice;
+use Magento\Catalog\Pricing\Render\PriceBox;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.WhiteSpace.ScopeIndent
 
-/** @var \Magento\Catalog\Pricing\Render\PriceBox $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-/** @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter*/
-/** @var \Magento\Catalog\Pricing\Price\TierPrice $tierPriceModel */
+/** @var Escaper $escaper */
+/** @var PriceBox $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var LocaleFormatter $localeFormatter*/
+/** @var TierPrice $tierPriceModel */
 $tierPriceModel = $block->getPrice();
 $tierPrices = $tierPriceModel->getTierPriceList();
 $msrpShowOnGesture = $block->getPriceType('msrp_price')->isShowPriceOnGesture();
 $product = $block->getSaleableItem();
 ?>
 <?php if (count($tierPrices)): ?>
-    <ul class="<?= $block->escapeHtmlAttr(($block->hasListClass() ? $block->getListClass(): 'prices-tier items')) ?>">
+    <ul class="<?= $escaper->escapeHtmlAttr(($block->hasListClass() ? $block->getListClass(): 'prices-tier items')) ?>">
         <?php foreach ($tierPrices as $index => $price): ?>
             <li class="item">
                 <?php
@@ -56,16 +62,16 @@ $product = $block->getSaleableItem();
                         $tierPriceData['qty'] = $price['price_qty'];
                     }
                     ?>
-                    <?= $block->escapeHtml(__('Buy %1 for: ', $price['price_qty'])) ?>
+                    <?= $escaper->escapeHtml(__('Buy %1 for: ', $price['price_qty'])) ?>
                     <a href="#"
-                       id="<?= $block->escapeHtmlAttr($popupId) ?>"
-                       data-tier-price="<?= $block->escapeHtml($block->jsonEncode($tierPriceData)) ?>">
-                        <?= $block->escapeHtml(__('Click for price')) ?>
+                       id="<?= $escaper->escapeHtmlAttr($popupId) ?>"
+                       data-tier-price="<?= $escaper->escapeHtml($block->jsonEncode($tierPriceData)) ?>">
+                        <?= $escaper->escapeHtml(__('Click for price')) ?>
                     </a>
                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                         'onclick',
                         'event.preventDefault()',
-                        'a#' . $block->escapeHtmlAttr($popupId)
+                        'a#' . $escaper->escapeHtmlAttr($popupId)
                     ) ?>
                 <?php else:
                     $priceAmountBlock = $block->renderAmount(

--- a/app/code/Magento/Catalog/view/frontend/templates/category/image.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/image.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Category\View;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 /**
  * Category view template
  *
- * @var $block \Magento\Catalog\Block\Category\View
+ * @var View $block
  */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
@@ -20,11 +25,11 @@
     $_imgHtml   = '';
     if ($_imgUrl = $block->getImage()->getUrl($_category)) {
         $_imgHtml = '<div class="category-image"><img src="'
-            . $block->escapeUrl($_imgUrl)
+            . $escaper->escapeUrl($_imgUrl)
             . '" alt="'
-            . $block->escapeHtmlAttr($_category->getName())
+            . $escaper->escapeHtmlAttr($_category->getName())
             . '" title="'
-            . $block->escapeHtmlAttr($_category->getName())
+            . $escaper->escapeHtmlAttr($_category->getName())
             . '" class="image" /></div>';
         $_imgHtml = $block->getOutput()->categoryAttribute($_category, $_imgHtml, 'image');
         /* @noEscape */ echo $_imgHtml;

--- a/app/code/Magento/Catalog/view/frontend/templates/category/rss.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/rss.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Category\Rss\Link */
+use Magento\Catalog\Block\Category\Rss\Link;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
 <?php if ($block->isRssAllowed() && $block->getLink() && $block->isTopCategory()) :?>
-    <a href="<?= $block->escapeUrl($block->getLink()) ?>"
-       class="action link rss"><span><?= $block->escapeHtml($block->getLabel()) ?></span></a>
+    <a href="<?= $escaper->escapeUrl($block->getLink()) ?>"
+       class="action link rss"><span><?= $escaper->escapeHtml($block->getLabel()) ?></span></a>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_block.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_block.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="widget block block-category-link">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $block->escapeHtml($block->getLabel()) ?></span></a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $escaper->escapeHtml($block->getLabel()) ?></span></a>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_href.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_href.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var Magento\Catalog\Block\Widget\Link $block */
+use Magento\Catalog\Block\Widget\Link;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Link $block */
 ?>
-<?= $block->escapeHtml($block->getHref()) ?>
+<?= $escaper->escapeHtml($block->getHref()) ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_inline.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/category/widget/link/link_inline.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <span class="widget block block-category-link-inline">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $block->escapeHtml($block->getLabel()) ?></span></a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $escaper->escapeHtml($block->getLabel()) ?></span></a>
 </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/frontend_storage_manager.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/frontend_storage_manager.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\FrontendStorageManager */
+use Magento\Catalog\Block\FrontendStorageManager;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var FrontendStorageManager $block */
 ?>
 <script type="text/x-magento-init">
         {
@@ -13,7 +18,7 @@
                     "components": {
                         "storage-manager": {
                             "component": "Magento_Catalog/js/storage-manager",
-                            "appendTo": "<?= $block->escapeJs($block->getParentComponentName()) ?>",
+                            "appendTo": "<?= $escaper->escapeJs($block->getParentComponentName()) ?>",
                             "storagesConfiguration" : <?= /* @noEscape */ $block->getConfigurationJson() ?>
                         }
                     }

--- a/app/code/Magento/Catalog/view/frontend/templates/messages/addCompareSuccessMessage.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/messages/addCompareSuccessMessage.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Element\Template $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
-<?= $block->escapeHtml(
+<?= $escaper->escapeHtml(
     __(
         'You added product %1 to the <a href="%2">comparison list</a>.',
         $block->getData('product_name'),

--- a/app/code/Magento/Catalog/view/frontend/templates/navigation/left.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/navigation/left.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Navigation;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
 
 /**
  * Category left navigation
  *
- * @var \Magento\Catalog\Block\Navigation $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
+ * @var Navigation $block
+ * @var LocaleFormatter $localeFormatter
+ * @var Escaper $escaper
  */
 ?>
 <?php if (!$block->getCategory()) {
@@ -19,25 +25,25 @@
 <?php if ($_count):?>
     <div class="block filter">
         <div class="title">
-            <strong><?= $block->escapeHtml(__('Shop By')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('Shop By')) ?></strong>
         </div>
         <div class="content">
-            <strong class="subtitle"><?= $block->escapeHtml(__('Shopping Options')) ?></strong>
+            <strong class="subtitle"><?= $escaper->escapeHtml(__('Shopping Options')) ?></strong>
             <dl class="options" id="narrow-by-list2">
-                <dt><?= $block->escapeHtml(__('Category')) ?></dt>
+                <dt><?= $escaper->escapeHtml(__('Category')) ?></dt>
                 <dd>
                     <ol class="items">
                         <?php /** @var \Magento\Catalog\Model\Category $_category */ ?>
                         <?php foreach ($_categories as $_category):?>
                             <?php if ($_category->getIsActive()):?>
                                 <li class="item">
-                                    <a href="<?= $block->escapeUrl($block->getCategoryUrl($_category)) ?>"
+                                    <a href="<?= $escaper->escapeUrl($block->getCategoryUrl($_category)) ?>"
                                         <?php if ($block->isCategoryActive($_category)):?>
                                             class="current"
                                         <?php endif; ?>
-                                    ><?= $block->escapeHtml($_category->getName()) ?></a>
+                                    ><?= $escaper->escapeHtml($_category->getName()) ?></a>
                                     <span class="count">
-                                        <?= $block->escapeHtml(
+                                        <?= $escaper->escapeHtml(
                                             $localeFormatter->formatNumber($_category->getProductCount())
                                         ) ?>
                                     </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/link.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/link.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Framework\View\Element\Template */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/** @var Template $block */
 ?>
 <li class="item link compare" data-bind="scope: 'compareProducts'" data-role="compare-products-link">
-    <a class="action compare no-display" title="<?= $block->escapeHtmlAttr(__('Compare Products')) ?>"
+    <a class="action compare no-display" title="<?= $escaper->escapeHtmlAttr(__('Compare Products')) ?>"
        data-bind="attr: {'href': compareProducts().listUrl}, css: {'no-display': !compareProducts().count}"
     >
-        <?= $block->escapeHtml(__('Compare Products')) ?>
+        <?= $escaper->escapeHtml(__('Compare Products')) ?>
         <span class="counter qty" data-bind="text: compareProducts().countCaption"></span>
     </a>
 </li>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/list.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Compare\ListCompare;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/* @var $block ListCompare */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PSR2.ControlStructures.SwitchDeclaration
 // phpcs:disable Generic.WhiteSpace.ScopeIndent
-
-/* @var $block \Magento\Catalog\Block\Product\Compare\ListCompare */
+$total = $block->getItems()->getSize();
 ?>
-<?php $total = $block->getItems()->getSize() ?>
 <?php if ($total) :?>
-    <a href="#" class="action print hidden-print" title="<?= $block->escapeHtmlAttr(__('Print This Page')) ?>">
-        <span><?= $block->escapeHtml(__('Print This Page')) ?></span>
+    <a href="#" class="action print hidden-print" title="<?= $escaper->escapeHtmlAttr(__('Print This Page')) ?>">
+        <span><?= $escaper->escapeHtml(__('Print This Page')) ?></span>
     </a>
         <div class="table-wrapper comparison">
             <table class="data table table-comparison" id="product-comparison"
@@ -23,19 +28,19 @@
                     "selectors":{
                         "productAddToCartSelector":"button.action.tocart"}
                 }}'>
-                <caption class="table-caption"><?= $block->escapeHtml(__('Compare Products')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Compare Products')) ?></caption>
                 <thead>
                 <tr>
                     <?php $index = 0 ?>
                     <?php foreach ($block->getItems() as $item) :?>
                         <?php if ($index++ == 0) :?>
-                            <th scope="row" class="cell label remove"><span><?= $block->escapeHtml(__('Remove Product')) ?></span></th>
+                            <th scope="row" class="cell label remove"><span><?= $escaper->escapeHtml(__('Remove Product')) ?></span></th>
                         <?php endif; ?>
                         <td class="cell remove product hidden-print">
                             <?php $compareHelper = $this->helper(Magento\Catalog\Helper\Product\Compare::class);?>
                             <a href="#" data-post='<?= /* @noEscape */ $compareHelper->getPostDataRemove($item) ?>'
-                               class="action delete" title="<?= $block->escapeHtmlAttr(__('Remove Product')) ?>">
-                                <span><?= $block->escapeHtml(__('Remove Product')) ?></span>
+                               class="action delete" title="<?= $escaper->escapeHtmlAttr(__('Remove Product')) ?>">
+                                <span><?= $escaper->escapeHtml(__('Remove Product')) ?></span>
                             </a>
                         </td>
                     <?php endforeach; ?>
@@ -49,17 +54,17 @@
                     <?php foreach ($block->getItems() as $item) :?>
                         <?php if ($index++ == 0) :?>
                             <th scope="row" class="cell label product">
-                                <span><?= $block->escapeHtml(__('Product')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Product')) ?></span>
                             </th>
                         <?php endif; ?>
-                        <td data-th="<?= $block->escapeHtmlAttr(__('Product')) ?>" class="cell product info">
+                        <td data-th="<?= $escaper->escapeHtmlAttr(__('Product')) ?>" class="cell product info">
                             <a class="product-item-photo"
-                               href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>"
+                               href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>"
                                title="<?= /* @noEscape */ $block->stripTags($item->getName(), null, true) ?>">
                                 <?= $block->getImage($item, 'product_comparison_list')->toHtml() ?>
                             </a>
                             <strong class="product-item-name">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($item)) ?>"
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>"
                                    title="<?= /* @noEscape */ $block->stripTags($item->getName(), null, true) ?>">
                                     <?= /* @noEscape */ $helper->productAttribute($item, $item->getName(), 'name') ?>
                                 </a>
@@ -70,18 +75,18 @@
                                 <div class="actions-primary">
                                     <?php if ($item->isSaleable()) :?>
                                         <form data-role="tocart-form"
-                                              action="<?= $block->escapeUrl($this->helper(Magento\Catalog\Helper\Product\Compare::class)->getAddToCartUrl($item)) ?>"
+                                              action="<?= $escaper->escapeUrl($this->helper(Magento\Catalog\Helper\Product\Compare::class)->getAddToCartUrl($item)) ?>"
                                               method="post">
                                             <?= $block->getBlockHtml('formkey') ?>
                                             <button type="submit" class="action tocart primary" disabled>
-                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                             </button>
                                         </form>
                                     <?php else :?>
                                         <?php if ($item->isAvailable()) :?>
-                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                         <?php else :?>
-                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                         <?php endif; ?>
                                     <?php endif; ?>
                                 </div>
@@ -91,7 +96,7 @@
                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($item) ?>'
                                            class="action towishlist"
                                            data-action="add-to-wishlist">
-                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                         </a>
                                     </div>
                                 <?php endif; ?>
@@ -109,7 +114,7 @@
                                 <?php if ($index++ == 0) :?>
                                     <th scope="row" class="cell label">
                                         <span class="attribute label">
-                                            <?= $block->escapeHtml($attribute->getStoreLabel() ? $attribute->getStoreLabel() : __($attribute->getFrontendLabel())) ?>
+                                            <?= $escaper->escapeHtml($attribute->getStoreLabel() ? $attribute->getStoreLabel() : __($attribute->getFrontendLabel())) ?>
                                         </span>
                                     </th>
                                 <?php endif; ?>
@@ -131,7 +136,7 @@
                                                 <?php if (is_string($block->getProductAttributeValue($item, $attribute))) :?>
                                                     <?= /* @noEscape */ $helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode()) ?>
                                                 <?php else : ?>
-                                                    <?=  $block->escapeHtml($helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode())) ?>
+                                                    <?=  $escaper->escapeHtml($helper->productAttribute($item, $block->getProductAttributeValue($item, $attribute), $attribute->getAttributeCode())) ?>
                                                 <?php endif; ?>
                                                 <?php break;
                                         } ?>
@@ -152,5 +157,5 @@
         }
         </script>
 <?php else :?>
-    <div class="message info empty"><div><?= $block->escapeHtml(__('You have no items to compare.')) ?></div></div>
+    <div class="message info empty"><div><?= $escaper->escapeHtml(__('You have no items to compare.')) ?></div></div>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/compare/sidebar.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/compare/sidebar.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+
+/** @var Escaper $escaper */
+/* @var Template $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-
-/* @var $block \Magento\Framework\View\Element\Template */
 ?>
 <div class="block block-compare" data-bind="scope: 'compareProducts'" data-role="compare-products-sidebar">
     <div class="block-title">
-        <strong id="block-compare-heading" role="heading" aria-level="2"><?= $block->escapeHtml(__('Compare Products')) ?></strong>
+        <strong id="block-compare-heading" role="heading" aria-level="2"><?= $escaper->escapeHtml(__('Compare Products')) ?></strong>
         <span class="counter qty no-display" data-bind="text: compareProducts().countCaption, css: {'no-display': !compareProducts().count}"></span>
     </div>
     <!-- ko if: compareProducts().count -->
@@ -23,28 +28,28 @@
                     </strong>
                     <a href="#"
                        data-bind="attr: {'data-post': remove_url}"
-                       title="<?= $block->escapeHtmlAttr(__('Remove This Item')) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Remove This Item')) ?>"
                        class="action delete">
-                        <span><?= $block->escapeHtml(__('Remove This Item')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('Remove This Item')) ?></span>
                     </a>
                 </li>
         </ol>
         <div class="actions-toolbar">
             <div class="primary">
-                <a data-bind="attr: {'href': compareProducts().listUrl}" class="action compare primary"><span><?= $block->escapeHtml(__('Compare')) ?></span></a>
+                <a data-bind="attr: {'href': compareProducts().listUrl}" class="action compare primary"><span><?= $escaper->escapeHtml(__('Compare')) ?></span></a>
             </div>
             <div class="secondary">
-                <a id="compare-clear-all" href="#" class="action clear" data-post="<?=$block->escapeHtml(
+                <a id="compare-clear-all" href="#" class="action clear" data-post="<?=$escaper->escapeHtml(
                     $this->helper(Magento\Catalog\Helper\Product\Compare::class)->getPostDataClearList()
                 ) ?>">
-                    <span><?= $block->escapeHtml(__('Clear All')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Clear All')) ?></span>
                 </a>
             </div>
         </div>
     </div>
     <!-- /ko -->
     <!-- ko ifnot: compareProducts().count -->
-    <div class="empty"><?= $block->escapeHtml(__('You have no items to compare.')) ?></div>
+    <div class="empty"><?= $escaper->escapeHtml(__('You have no items to compare.')) ?></div>
     <!-- /ko -->
 </div>
 <script type="text/x-magento-init">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/gallery.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/gallery.phtml
@@ -3,53 +3,59 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Catalog\Block\Product\Gallery $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Product\Gallery;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Gallery $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php $_width = $block->getImageWidth(); ?>
 <div class="product-image-popup">
     <div class="buttons-set"><a href="#" class="button" role="close-window">
-            <span><?= $block->escapeHtml(__('Close Window')) ?></span></a></div>
+            <span><?= $escaper->escapeHtml(__('Close Window')) ?></span></a></div>
     <?php if ($block->getPreviousImageUrl() || $block->getNextImageUrl()):?>
         <div class="nav">
             <?php if ($_prevUrl = $block->getPreviousImageUrl()):?>
-                <a href="<?= $block->escapeUrl($_prevUrl) ?>"
-                   class="prev">&laquo; <?= $block->escapeHtml(__('Prev')) ?></a>
+                <a href="<?= $escaper->escapeUrl($_prevUrl) ?>"
+                   class="prev">&laquo; <?= $escaper->escapeHtml(__('Prev')) ?></a>
             <?php endif; ?>
             <?php if ($_nextUrl = $block->getNextImageUrl()):?>
-                <a href="<?= $block->escapeUrl($_nextUrl) ?>"
-                   class="next"><?= $block->escapeHtml(__('Next')) ?> &raquo;</a>
+                <a href="<?= $escaper->escapeUrl($_nextUrl) ?>"
+                   class="next"><?= $escaper->escapeHtml(__('Next')) ?> &raquo;</a>
             <?php endif; ?>
         </div>
     <?php endif; ?>
-    <?php if ($_imageTitle = $block->escapeHtml($block->getCurrentImage()->getLabel())):?>
+    <?php if ($_imageTitle = $escaper->escapeHtml($block->getCurrentImage()->getLabel())):?>
         <h1 class="image-label"><?= /* @noEscape */ $_imageTitle ?></h1>
     <?php endif; ?>
     <?php
     $imageUrl = $block->getImageUrl();
     ?>
-    <img src="<?= $block->escapeUrl($imageUrl) ?>"
+    <img src="<?= $escaper->escapeUrl($imageUrl) ?>"
         <?php if ($_width):?>
             width="<?= /* @noEscape */ $_width ?>"
         <?php endif; ?>
-         alt="<?= $block->escapeHtmlAttr($block->getCurrentImage()->getLabel()) ?>"
-         title="<?= $block->escapeHtmlAttr($block->getCurrentImage()->getLabel()) ?>"
+         alt="<?= $escaper->escapeHtmlAttr($block->getCurrentImage()->getLabel()) ?>"
+         title="<?= $escaper->escapeHtmlAttr($block->getCurrentImage()->getLabel()) ?>"
          id="product-gallery-image"
          class="image"
          data-mage-init='{"catalogGallery":{}}'/>
     <div class="buttons-set"><
-        a href="#" class="button" role="close-window"><span><?= $block->escapeHtml(__('Close Window')) ?></span></a>
+        a href="#" class="button" role="close-window"><span><?= $escaper->escapeHtml(__('Close Window')) ?></span></a>
     </div>
     <?php if ($block->getPreviousImageUrl() || $block->getNextImageUrl()):?>
         <div class="nav">
             <?php if ($_prevUrl = $block->getPreviousImageUrl()):?>
-                <a href="<?= $block->escapeUrl($_prevUrl) ?>"
-                   class="prev">&laquo; <?= $block->escapeHtml(__('Prev')) ?></a>
+                <a href="<?= $escaper->escapeUrl($_prevUrl) ?>"
+                   class="prev">&laquo; <?= $escaper->escapeHtml(__('Prev')) ?></a>
             <?php endif; ?>
             <?php if ($_nextUrl = $block->getNextImageUrl()):?>
-                <a href="<?= $block->escapeUrl($_nextUrl) ?>"
-                   class="next"><?= $block->escapeHtml(__('Next')) ?> &raquo;</a>
+                <a href="<?= $escaper->escapeUrl($_nextUrl) ?>"
+                   class="next"><?= $escaper->escapeHtml(__('Next')) ?> &raquo;</a>
             <?php endif; ?>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/addto/compare.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/addto/compare.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare */
+use Magento\Catalog\Block\Product\ProductList\Item\AddTo\Compare;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Compare $block */
 ?>
 <a href="#"
    class="action tocompare"
-   title="<?= $block->escapeHtml(__('Add to Compare')) ?>"
-   aria-label="<?= $block->escapeHtml(__('Add to Compare')) ?>"
+   title="<?= $escaper->escapeHtml(__('Add to Compare')) ?>"
+   aria-label="<?= $escaper->escapeHtml(__('Add to Compare')) ?>"
    data-post='<?= /* @noEscape */ $block->getCompareHelper()->getPostDataParams($block->getProduct()) ?>'
    role="button">
-    <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+    <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
 </a>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/items.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Catalog\Block\Product\AbstractProduct;
 use Magento\Catalog\ViewModel\Product\Listing\PreparePostData;
 use Magento\Framework\App\ActionInterface;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-/* @var $block \Magento\Catalog\Block\Product\AbstractProduct */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/** @var Escaper $escaper */
+/** @var AbstractProduct $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <?php
 switch ($type = $block->getType()) {
 
@@ -162,34 +166,34 @@ $_item = null;
 
     <?php if ($type == 'related' || $type == 'upsell'):?>
         <?php if ($type == 'related'):?>
-<div class="block <?= $block->escapeHtmlAttr($class) ?>"
+<div class="block <?= $escaper->escapeHtmlAttr($class) ?>"
      data-mage-init='{"relatedProducts":{"relatedCheckbox":".related.checkbox"}}'
-     data-limit="<?= $block->escapeHtmlAttr($limit) ?>"
+     data-limit="<?= $escaper->escapeHtmlAttr($limit) ?>"
      data-shuffle="<?= /* @noEscape */ $shuffle ?>"
      data-shuffle-weighted="<?= /* @noEscape */ $isWeightedRandom ?>">
     <?php else:?>
-    <div class="block <?= $block->escapeHtmlAttr($class) ?>"
+    <div class="block <?= $escaper->escapeHtmlAttr($class) ?>"
          data-mage-init='{"upsellProducts":{}}'
-         data-limit="<?= $block->escapeHtmlAttr($limit) ?>"
+         data-limit="<?= $escaper->escapeHtmlAttr($limit) ?>"
          data-shuffle="<?= /* @noEscape */ $shuffle ?>"
          data-shuffle-weighted="<?= /* @noEscape */ $isWeightedRandom ?>">
         <?php endif; ?>
         <?php else:?>
-        <div class="block <?= $block->escapeHtmlAttr($class) ?>">
+        <div class="block <?= $escaper->escapeHtmlAttr($class) ?>">
             <?php endif; ?>
             <div class="block-title title">
-                <strong id="block-<?= $block->escapeHtmlAttr($class) ?>-heading" role="heading"
-                        aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+                <strong id="block-<?= $escaper->escapeHtmlAttr($class) ?>-heading" role="heading"
+                        aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
             </div>
-            <div class="block-content content" aria-labelledby="block-<?= $block->escapeHtmlAttr($class) ?>-heading">
+            <div class="block-content content" aria-labelledby="block-<?= $escaper->escapeHtmlAttr($class) ?>-heading">
                 <?php if ($type == 'related' && $canItemsAddToCart):?>
                     <div class="block-actions">
-                        <?= $block->escapeHtml(__('Check items to add to the cart or')) ?>
+                        <?= $escaper->escapeHtml(__('Check items to add to the cart or')) ?>
                         <button type="button" class="action select"
-                                data-role="select-all"><span><?= $block->escapeHtml(__('select all')) ?></span></button>
+                                data-role="select-all"><span><?= $escaper->escapeHtml(__('select all')) ?></span></button>
                     </div>
                 <?php endif; ?>
-                <div class="products wrapper grid products-grid products-<?= $block->escapeHtmlAttr($type) ?>">
+                <div class="products wrapper grid products-grid products-<?= $escaper->escapeHtmlAttr($type) ?>">
                     <ol class="products list items product-items">
                         <?php foreach ($items as $_item):?>
                             <?php $available = ''; ?>
@@ -201,7 +205,7 @@ $_item = null;
                             <?php if ($type == 'related' || $type == 'upsell'):?>
                                 <li class="item product product-item"
                                 id="product-item_<?= /* @noEscape */ $_item->getId() ?>"
-                                data-shuffle-group="<?= $block->escapeHtmlAttr($_item->getPriority()) ?>" >
+                                data-shuffle-group="<?= $escaper->escapeHtmlAttr($_item->getPriority()) ?>" >
                                 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                                     'display:none;',
                                     'li#product-item_' . $_item->getId()
@@ -211,16 +215,16 @@ $_item = null;
                             <?php endif; ?>
                             <div class="product-item-info <?= /* @noEscape */ $available ?>">
                                 <?= /* @noEscape */ '<!-- ' . $image . '-->' ?>
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                    class="product photo product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product details product-item-details">
                                     <strong class="product name product-item-name"><a
                                                 class="product-item-link"
-                                                title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                                href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>">
-                                            <?= $block->escapeHtml($_item->getName()) ?></a>
+                                                title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                                href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>">
+                                            <?= $escaper->escapeHtml($_item->getName()) ?></a>
                                     </strong>
 
                                     <?= /* @noEscape */ $block->getProductPrice($_item) ?>
@@ -236,12 +240,12 @@ $_item = null;
                                                 <input
                                                     type="checkbox"
                                                     class="checkbox related"
-                                                    id="related-checkbox<?= $block->escapeHtmlAttr($_item->getId()) ?>"
+                                                    id="related-checkbox<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
                                                     name="related_products[]"
-                                                    value="<?= $block->escapeHtmlAttr($_item->getId()) ?>" />
+                                                    value="<?= $escaper->escapeHtmlAttr($_item->getId()) ?>" />
                                                 <label class="label"
-                                                       for="related-checkbox<?= $block->escapeHtmlAttr($_item->getId())
-                                                        ?>"><span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                       for="related-checkbox<?= $escaper->escapeHtmlAttr($_item->getId())
+                                                        ?>"><span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                 </label>
                                             </div>
                                         <?php endif; ?>
@@ -256,22 +260,22 @@ $_item = null;
                                                     <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)):?>
                                                         <button
                                                                 class="action tocart primary"
-                                                                data-mage-init='{"redirectUrl": {"url": "<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}' type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                data-mage-init='{"redirectUrl": {"url": "<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}' type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                         </button>
                                                     <?php else :?>
                                                         <?php
                                                         /** @var $viewModel PreparePostData */
                                                         $viewModel = $block->getViewModel();
                                                         $postArray = $viewModel->getPostData(
-                                                            $block->escapeUrl($block->getAddToCartUrl($_item)),
+                                                            $escaper->escapeUrl($block->getAddToCartUrl($_item)),
                                                             ['product' => $_item->getEntityId()]
                                                         );
                                                         $value = $postArray['data'][ActionInterface::PARAM_NAME_URL_ENCODED];
                                                         ?>
                                                         <form data-role="tocart-form"
-                                                              data-product-sku="<?= $block->escapeHtmlAttr($_item->getSku()) ?>"
-                                                              action="<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"
+                                                              data-product-sku="<?= $escaper->escapeHtmlAttr($_item->getSku()) ?>"
+                                                              action="<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"
                                                               method="post">
                                                             <input type="hidden" name="product"
                                                                    value="<?= /* @noEscape */ (int)$_item->getEntityId() ?>">
@@ -280,20 +284,20 @@ $_item = null;
                                                                    value="<?= /* @noEscape */ $value ?>">
                                                             <?= $block->getBlockHtml('formkey') ?>
                                                             <button type="submit"
-                                                                    title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>"
+                                                                    title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>"
                                                                     class="action tocart primary">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         </form>
                                                     <?php endif; ?>
                                                 <?php else:?>
                                                     <?php if ($_item->isAvailable()):?>
                                                         <div class="stock available">
-                                                            <span><?= $block->escapeHtml(__('In stock')) ?></span>
+                                                            <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
                                                         </div>
                                                     <?php else:?>
                                                         <div class="stock unavailable">
-                                                            <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                                                            <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                                                         </div>
                                                     <?php endif; ?>
                                                 <?php endif; ?>
@@ -324,7 +328,7 @@ $_item = null;
             {
                 "[data-role=tocart-form], .form.map.checkout": {
                     "catalogAddToCart": {
-                        "product_sku": "<?= $block->escapeJs($_item->getSku()) ?>"
+                        "product_sku": "<?= $escaper->escapeJs($_item->getSku()) ?>"
                     }
                 }
             }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/amount.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/amount.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\ProductList\Toolbar;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
 /**
  * Product list toolbar
  *
- * @var \Magento\Catalog\Block\Product\ProductList\Toolbar $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
+ * @var Toolbar $block
+ * @var LocaleFormatter $localeFormatter
+ * @var Escaper $escaper
  */
 ?>
 <p class="toolbar-amount" id="toolbar-amount">
     <?php if ($block->getLastPageNum() > 1):?>
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             __(
                 'Items %1-%2 of %3',
                 '<span class="toolbar-number">' . $localeFormatter->formatNumber($block->getFirstNum()) . '</span>',
@@ -24,7 +29,7 @@
             ['span']
         ) ?>
     <?php elseif ($block->getTotalNum() == 1):?>
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             __(
                 '%1 Item',
                 '<span class="toolbar-number">' . $localeFormatter->formatNumber($block->getTotalNum()) . '</span>'
@@ -32,7 +37,7 @@
             ['span']
         ) ?>
     <?php else:?>
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             __(
                 '%1 Items',
                 '<span class="toolbar-number">' . $localeFormatter->formatNumber($block->getTotalNum()) . '</span>'

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/limiter.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/limiter.phtml
@@ -3,32 +3,37 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\ProductList\Toolbar;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
 /**
  * Product list toolbar
  *
- * @var \Magento\Catalog\Block\Product\ProductList\Toolbar $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
+ * @var Toolbar $block
+ * @var LocaleFormatter $localeFormatter
+ * @var Escaper $escaper
  */
 ?>
 <div class="field limiter">
     <label class="label" for="limiter">
-        <span><?= $block->escapeHtml(__('Show')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Show')) ?></span>
     </label>
     <div class="control">
         <select id="limiter" data-role="limiter" class="limiter-options">
             <?php foreach ($block->getAvailableLimit() as $_key => $_limit):?>
-                <option value="<?= $block->escapeHtmlAttr($_key) ?>"
+                <option value="<?= $escaper->escapeHtmlAttr($_key) ?>"
                     <?php if ($block->isLimitCurrent($_key)):?>
                         selected="selected"
                     <?php endif ?>>
-                    <?= $block->escapeHtml(
+                    <?= $escaper->escapeHtml(
                         is_numeric($_limit) ? $localeFormatter->formatNumber((int) $_limit) : $_limit
                     ) ?>
                 </option>
             <?php endforeach; ?>
         </select>
     </div>
-    <span class="limiter-text"><?= $block->escapeHtml(__('per page')) ?></span>
+    <span class="limiter-text"><?= $escaper->escapeHtml(__('per page')) ?></span>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/sorter.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/sorter.phtml
@@ -3,42 +3,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\ProductList\Toolbar;
+use Magento\Framework\Escaper;
+
 /**
  * Product list toolbar
  *
- * @var $block \Magento\Catalog\Block\Product\ProductList\Toolbar
+ * @var Toolbar $block
+ * @var Escaper $escaper
  */
 ?>
 <div class="toolbar-sorter sorter">
-    <label class="sorter-label" for="sorter"><?= $block->escapeHtml(__('Sort By')) ?></label>
+    <label class="sorter-label" for="sorter"><?= $escaper->escapeHtml(__('Sort By')) ?></label>
     <select id="sorter" data-role="sorter" class="sorter-options">
         <?php foreach ($block->getAvailableOrders() as $_key => $_order) :?>
-            <option value="<?= $block->escapeHtmlAttr($_key) ?>"
+            <option value="<?= $escaper->escapeHtmlAttr($_key) ?>"
                 <?php if ($block->isOrderCurrent($_key)) :?>
                     selected="selected"
                 <?php endif; ?>
                 >
-                <?= $block->escapeHtml(__($_order)) ?>
+                <?= $escaper->escapeHtml(__($_order)) ?>
             </option>
         <?php endforeach; ?>
     </select>
     <?php if ($block->getCurrentDirection() == 'desc') :?>
-        <a title="<?= $block->escapeHtmlAttr(__('Set Ascending Direction')) ?>"
+        <a title="<?= $escaper->escapeHtmlAttr(__('Set Ascending Direction')) ?>"
            href="#"
            class="action sorter-action sort-desc"
            data-role="direction-switcher"
            data-value="asc">
-            <span><?= $block->escapeHtml(__('Set Ascending Direction')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Set Ascending Direction')) ?></span>
         </a>
     <?php else :?>
-        <a title="<?= $block->escapeHtmlAttr(__('Set Descending Direction')) ?>"
+        <a title="<?= $escaper->escapeHtmlAttr(__('Set Descending Direction')) ?>"
            href="#"
            class="action sorter-action sort-asc"
            data-role="direction-switcher"
            data-value="desc">
-            <span><?= $block->escapeHtml(__('Set Descending Direction')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Set Descending Direction')) ?></span>
         </a>
     <?php endif; ?>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/viewmode.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/list/toolbar/viewmode.phtml
@@ -3,35 +3,39 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\ProductList\Toolbar;
+use Magento\Framework\Escaper;
+
 /**
  * Product list toolbar
  *
- * @var $block \Magento\Catalog\Block\Product\ProductList\Toolbar
+ * @var Toolbar $block
+ * @var Escaper $escaper
  */
 ?>
 <?php if ($block->isEnabledViewSwitcher()) :?>
     <div class="modes">
         <?php $_modes = $block->getModes(); ?>
         <?php if ($_modes && count($_modes) > 1) :?>
-            <strong class="modes-label" id="modes-label"><?= $block->escapeHtml(__('View as')) ?></strong>
+            <strong class="modes-label" id="modes-label"><?= $escaper->escapeHtml(__('View as')) ?></strong>
             <?php foreach ($block->getModes() as $_code => $_label) :?>
                 <?php if ($block->isModeActive($_code)) :?>
-                    <strong title="<?= $block->escapeHtmlAttr($_label) ?>"
-                            class="modes-mode active mode-<?= $block->escapeHtmlAttr(strtolower($_code)) ?>"
-                            data-value="<?= $block->escapeHtmlAttr(strtolower($_code)) ?>">
-                        <span><?= $block->escapeHtml($_label) ?></span>
+                    <strong title="<?= $escaper->escapeHtmlAttr($_label) ?>"
+                            class="modes-mode active mode-<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>"
+                            data-value="<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>">
+                        <span><?= $escaper->escapeHtml($_label) ?></span>
                     </strong>
                 <?php else :?>
-                    <a class="modes-mode mode-<?= $block->escapeHtmlAttr(strtolower($_code)) ?>"
-                       title="<?= $block->escapeHtmlAttr($_label) ?>"
+                    <a class="modes-mode mode-<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($_label) ?>"
                        href="#"
                        data-role="mode-switcher"
-                       data-value="<?= $block->escapeHtmlAttr(strtolower($_code)) ?>"
-                       id="mode-<?= $block->escapeHtmlAttr(strtolower($_code)) ?>"
-                       aria-labelledby="modes-label mode-<?= $block->escapeHtmlAttr(strtolower($_code)) ?>">
-                        <span><?= $block->escapeHtml($_label) ?></span>
+                       data-value="<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>"
+                       id="mode-<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>"
+                       aria-labelledby="modes-label mode-<?= $escaper->escapeHtmlAttr(strtolower($_code)) ?>">
+                        <span><?= $escaper->escapeHtml($_label) ?></span>
                     </a>
                 <?php endif; ?>
             <?php endforeach; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/listing.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/listing.phtml
@@ -3,24 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-// phpcs:disable Magento2.Files.LineLength.MaxExceeded
-// phpcs:disable Magento2.Security.LanguageConstruct.DirectOutput
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\ListProduct;
+use Magento\Framework\Escaper;
 
 /**
  * Product list template
  *
- * @var $block \Magento\Catalog\Block\Product\ListProduct
+ * @var ListProduct $block
+ * @var Escaper $escaper
  */
-?>
-<?php
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+// phpcs:disable Magento2.Files.LineLength.MaxExceeded
+// phpcs:disable Magento2.Security.LanguageConstruct.DirectOutput
+
 $_productCollection = $block->getLoadedProductCollection();
 $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
 ?>
 <?php if (!$_productCollection->count()) :?>
-    <p class="message note"><?= $block->escapeHtml(__('We can\'t find products matching the selection.')) ?></p>
+    <p class="message note"><?= $escaper->escapeHtml(__('We can\'t find products matching the selection.')) ?></p>
 <?php else :?>
     <?= $block->getToolbarHtml() ?>
     <?= $block->getAdditionalHtml() ?>
@@ -43,7 +46,7 @@ $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
                 <li class="item product">
                     <div class="product">
                         <?php // Product Image ?>
-                        <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>" class="product photo">
+                        <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>" class="product photo">
                             <?= $block->getImage($_product, $image)->toHtml() ?>
                         </a>
                         <div class="product details">
@@ -51,7 +54,7 @@ $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
 
                             $info = [];
                             $info['name'] = '<strong class="product name">'
-                                . ' <a href="' . $block->escapeUrl($_product->getProductUrl()) . '" title="'
+                                . ' <a href="' . $escaper->escapeUrl($_product->getProductUrl()) . '" title="'
                                 . $block->stripTags($_product->getName(), null, true) . '">'
                                 . $_helper->productAttribute($_product, $_product->getName(), 'name')
                                 . '</a></strong>';
@@ -59,26 +62,26 @@ $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
                             $info['review'] = $block->getReviewsSummaryHtml($_product, $templateType);
 
                             if ($_product->isSaleable()) {
-                                $info['button'] = '<button type="button" title="' . $block->escapeHtmlAttr(__('Add to Cart')) . '" class="action tocart"'
-                                    . ' data-mage-init=\'{ "redirectUrl": { "event": "click", url: "' . $block->escapeUrl($block->getAddToCartUrl($_product)) . '"} }\'>'
-                                    . '<span>' . $block->escapeHtml(__('Add to Cart')) . '</span></button>';
+                                $info['button'] = '<button type="button" title="' . $escaper->escapeHtmlAttr(__('Add to Cart')) . '" class="action tocart"'
+                                    . ' data-mage-init=\'{ "redirectUrl": { "event": "click", url: "' . $escaper->escapeUrl($block->getAddToCartUrl($_product)) . '"} }\'>'
+                                    . '<span>' . $escaper->escapeHtml(__('Add to Cart')) . '</span></button>';
                             } else {
-                                $info['button'] = $_product->isAvailable() ?   '<div class="stock available"><span>' . $block->escapeHtml(__('In stock')) . '</span></div>' :
-                                    '<div class="stock unavailable"><span>' . $block->escapeHtml(__('Out of stock')) . '</span></div>';
+                                $info['button'] = $_product->isAvailable() ?   '<div class="stock available"><span>' . $escaper->escapeHtml(__('In stock')) . '</span></div>' :
+                                    '<div class="stock unavailable"><span>' . $escaper->escapeHtml(__('Out of stock')) . '</span></div>';
                             }
 
                             $info['links'] = '<div class="product links" data-role="add-to-links">'
                                 . '<a href="#" data-post=\'' . $this->helper(Magento\Wishlist\Helper\Data::class)->getAddParams($_product) . '\' class="action towishlist" data-action="add-to-wishlist">'
-                                . '<span>' . $block->escapeHtml(__('Add to Wish List')) . '</span></a>'
-                                . '<a href="' . $block->escapeUrl($block->getAddToCompareUrl($_product)) . '" class="action tocompare">'
-                                . '<span>' . $block->escapeHtml(__('Add to Compare')) . '</span></a></div>';
+                                . '<span>' . $escaper->escapeHtml(__('Add to Wish List')) . '</span></a>'
+                                . '<a href="' . $escaper->escapeUrl($block->getAddToCompareUrl($_product)) . '" class="action tocompare">'
+                                . '<span>' . $escaper->escapeHtml(__('Add to Compare')) . '</span></a></div>';
                             $info['actions'] = '<div class="product action">' . $info['button'] . $info['links'] . '</div>';
 
                             if ($showDescription) {
                                 $info['description'] =  '<div class="product description">'
                                     . $_helper->productAttribute($_product, $_product->getShortDescription(), 'short_description')
-                                    . ' <a href="' . $block->escapeUrl($_product->getProductUrl()) . '" class="action more">'
-                                    . $block->escapeHtml(__('Learn More')) . '</a></div>';
+                                    . ' <a href="' . $escaper->escapeUrl($_product->getProductUrl()) . '" class="action more">'
+                                    . $escaper->escapeHtml(__('Learn More')) . '</a></div>';
                             } else {
                                 $info['description'] = '';
                             }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addto/compare.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Product\View\Addto\Compare */
+use Magento\Catalog\Block\Product\View\Addto\Compare;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Compare $block */
+$viewModel = $block->getData('addToCompareViewModel');
 ?>
-
-<?php $viewModel = $block->getData('addToCompareViewModel'); ?>
 <?php if ($viewModel->isAvailableForCompare($block->getProduct())) :?>
 <a href="#" data-post='<?= /* @noEscape */ $block->getPostDataParams() ?>'
         data-role="add-to-links"
-        class="action tocompare"><span><?= $block->escapeHtml(__('Add to Compare')) ?></span></a>
+        class="action tocompare"><span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span></a>
 <?php endif; ?>
 

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/addtocart.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+use Magento\Catalog\Block\Product\View;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 ?>
 <?php $_product = $block->getProduct(); ?>
 <?php $buttonTitle = __('Add to Cart'); ?>
@@ -13,26 +18,26 @@
     <div class="fieldset">
         <?php if ($block->shouldRenderQuantity()) :?>
         <div class="field qty">
-            <label class="label" for="qty"><span><?= $block->escapeHtml(__('Qty')) ?></span></label>
+            <label class="label" for="qty"><span><?= $escaper->escapeHtml(__('Qty')) ?></span></label>
             <div class="control">
                 <input type="number"
                        name="qty"
                        id="qty"
                        min="0"
                        value="<?= $block->getProductDefaultQty() * 1 ?>"
-                       title="<?= $block->escapeHtmlAttr(__('Qty')) ?>"
+                       title="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"
                        class="input-text qty"
-                       data-validate="<?= $block->escapeHtml(json_encode($block->getQuantityValidators())) ?>"
+                       data-validate="<?= $escaper->escapeHtml(json_encode($block->getQuantityValidators())) ?>"
                        />
             </div>
         </div>
         <?php endif; ?>
         <div class="actions">
             <button type="submit"
-                    title="<?= $block->escapeHtmlAttr($buttonTitle) ?>"
+                    title="<?= $escaper->escapeHtmlAttr($buttonTitle) ?>"
                     class="action primary tocart"
                     id="product-addtocart-button" disabled>
-                <span><?= $block->escapeHtml($buttonTitle) ?></span>
+                <span><?= $escaper->escapeHtml($buttonTitle) ?></span>
             </button>
             <?= $block->getChildHtml('', true) ?>
         </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attribute.phtml
@@ -3,16 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+use Magento\Catalog\Block\Product\View\Description;
+use Magento\Framework\Escaper;
 
 /**
  * Product view template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Description
+ * @var Description $block
+ * @var Escaper $escaper
  */
-?>
-<?php
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+
 $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
 $_product = $block->getProduct();
 
@@ -46,9 +50,9 @@ if ($_attributeType && $_attributeType == 'text') {
 ?>
 
 <?php if ($_attributeValue) :?>
-<div class="product attribute <?= $block->escapeHtmlAttr($_className) ?>">
+<div class="product attribute <?= $escaper->escapeHtmlAttr($_className) ?>">
     <?php if ($renderLabel) :?>
-        <strong class="type"><?= $block->escapeHtml($_attributeLabel) ?></strong>
+        <strong class="type"><?= $escaper->escapeHtml($_attributeLabel) ?></strong>
     <?php endif; ?>
     <div class="value" <?= /* @noEscape */ $_attributeAddAttribute ?>><?= /* @noEscape */ $_attributeValue ?></div>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/attributes.phtml
@@ -3,28 +3,32 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+use Magento\Catalog\Block\Product\View\Attributes;
+use Magento\Framework\Escaper;
 
 /**
  * Product additional attributes template
  *
- * @var $block \Magento\Catalog\Block\Product\View\Attributes
+ * @var Attributes $block
+ * @var Escaper $escaper
  */
-?>
-<?php
-    $_helper = $this->helper(Magento\Catalog\Helper\Output::class);
-    $_product = $block->getProduct();
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+
+$_helper = $this->helper(Magento\Catalog\Helper\Output::class);
+$_product = $block->getProduct();
 ?>
 <?php if ($_additional = $block->getAdditionalData()) :?>
     <div class="additional-attributes-wrapper table-wrapper">
         <table class="data table additional-attributes" id="product-attribute-specs-table">
-            <caption class="table-caption"><?= $block->escapeHtml(__('More Information')) ?></caption>
+            <caption class="table-caption"><?= $escaper->escapeHtml(__('More Information')) ?></caption>
             <tbody>
             <?php foreach ($_additional as $_data) :?>
                 <tr>
-                    <th class="col label" scope="row"><?= $block->escapeHtml($_data['label']) ?></th>
-                    <td class="col data" data-th="<?= $block->escapeHtmlAttr($_data['label']) ?>"><?= /* @noEscape */ $_helper->productAttribute($_product, $_data['value'], $_data['code']) ?></td>
+                    <th class="col label" scope="row"><?= $escaper->escapeHtml($_data['label']) ?></th>
+                    <td class="col data" data-th="<?= $escaper->escapeHtmlAttr($_data['label']) ?>"><?= /* @noEscape */ $_helper->productAttribute($_product, $_data['value'], $_data['code']) ?></td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/details.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Catalog\Block\Product\View\Details $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Product\View\Details;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Details $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($detailedInfoGroup = $block->getGroupSortedChildNames('detailed_info', 'getChildHtml')):?>
     <div class="product info detailed">
@@ -22,24 +28,24 @@
                 $label = $block->getChildData($alias, 'title');
                 ?>
                 <div class="data item title <?= !$hideTabContent ? 'active' : ''?>"
-                     data-role="collapsible" id="tab-label-<?= $block->escapeHtmlAttr($alias) ?>">
+                     data-role="collapsible" id="tab-label-<?= $escaper->escapeHtmlAttr($alias) ?>">
                     <a class="data switch"
                        tabindex="-1"
                        data-toggle="trigger"
-                       href="#<?= $block->escapeUrl($alias) ?>"
-                       id="tab-label-<?= $block->escapeHtmlAttr($alias) ?>-title">
+                       href="#<?= $escaper->escapeUrl($alias) ?>"
+                       id="tab-label-<?= $escaper->escapeHtmlAttr($alias) ?>-title">
                         <?= /* @noEscape */ $label ?>
                     </a>
                 </div>
                 <div class="data item content"
-                     aria-labelledby="tab-label-<?= $block->escapeHtmlAttr($alias) ?>-title"
-                     id="<?= $block->escapeHtmlAttr($alias) ?>" data-role="content">
+                     aria-labelledby="tab-label-<?= $escaper->escapeHtmlAttr($alias) ?>-title"
+                     id="<?= $escaper->escapeHtmlAttr($alias) ?>" data-role="content">
                     <?= /* @noEscape */ $html ?>
                 </div>
                 <?= $hideTabContent
                     ? /* @noEscape */ $secureRenderer->renderStyleAsTag(
                         'display: none;',
-                        '#' . $block->escapeHtmlAttr($alias)
+                        '#' . $escaper->escapeHtmlAttr($alias)
                     )
                     : '' ?>
                 <?php $hideTabContent = true; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/form.phtml
@@ -4,20 +4,26 @@
  * See COPYING.txt for license details.
  */
 
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\View;
+use Magento\Framework\Escaper;
 
 /**
  * Product view template
  *
- * @var $block \Magento\Catalog\Block\Product\View
+ * @var View $block
+ * @var Escaper $escaper
  */
-?>
-<?php $_helper = $this->helper(Magento\Catalog\Helper\Output::class); ?>
-<?php $_product = $block->getProduct(); ?>
 
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+
+$_helper = $this->helper(Magento\Catalog\Helper\Output::class);
+$_product = $block->getProduct();
+?>
 <div class="product-add-form">
-    <form data-product-sku="<?= $block->escapeHtml($_product->getSku()) ?>"
-          action="<?= $block->escapeUrl($block->getSubmitUrl($_product)) ?>" method="post"
+    <form data-product-sku="<?= $escaper->escapeHtml($_product->getSku()) ?>"
+          action="<?= $escaper->escapeUrl($block->getSubmitUrl($_product)) ?>" method="post"
           id="product_addtocart_form"<?php if ($_product->getOptions()) :?> enctype="multipart/form-data"<?php endif; ?>>
         <input type="hidden" name="product" value="<?= (int)$_product->getId() ?>" />
         <input type="hidden" name="selected_configurable_option" value="" />
@@ -42,7 +48,7 @@
 
 <script type="text/x-magento-init">
     {
-        "[data-role=priceBox][data-price-box=product-id-<?= $block->escapeHtml($_product->getId()) ?>]": {
+        "[data-role=priceBox][data-price-box=product-id-<?= $escaper->escapeHtml($_product->getId()) ?>]": {
             "priceBox": {
                 "priceConfig":  <?= /* @noEscape */ $block->getJsonConfig() ?>
             }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/mailto.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/mailto.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
 <?php $_product = $block->getProduct() ?>
 <?php if ($block->canEmailToFriend()) :?>
-    <a href="<?= $block->escapeUrl($this->helper(Magento\Catalog\Helper\Product::class)->getEmailToFriendUrl($_product)) ?>"
-       class="action mailto friend"><span><?= $block->escapeHtml(__('Email')) ?></span></a>
+    <a href="<?= $escaper->escapeUrl($this->helper(Magento\Catalog\Helper\Product::class)->getEmailToFriendUrl($_product)) ?>"
+       class="action mailto friend"><span><?= $escaper->escapeHtml(__('Email')) ?></span></a>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/opengraph/general.phtml
@@ -3,22 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Catalog\Block\Product\View */
+use Magento\Catalog\Block\Product\View;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 ?>
-
 <meta property="og:type" content="product" />
 <meta property="og:title"
-      content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getName())) ?>" />
+      content="<?= $escaper->escapeHtmlAttr($block->stripTags($block->getProduct()->getName())) ?>" />
 <meta property="og:image"
-      content="<?= $block->escapeUrl($block->getImage($block->getProduct(), 'product_base_image')->getImageUrl()) ?>" />
+      content="<?= $escaper->escapeUrl($block->getImage($block->getProduct(), 'product_base_image')->getImageUrl()) ?>" />
 <meta property="og:description"
-      content="<?= $block->escapeHtmlAttr($block->stripTags($block->getProduct()->getShortDescription())) ?>" />
-<meta property="og:url" content="<?= $block->escapeUrl($block->getProduct()->getProductUrl()) ?>" />
+      content="<?= $escaper->escapeHtmlAttr($block->stripTags($block->getProduct()->getShortDescription())) ?>" />
+<meta property="og:url" content="<?= $escaper->escapeUrl($block->getProduct()->getProductUrl()) ?>" />
 <?php if ($priceAmount = $block->getProduct()
           ->getPriceInfo()
           ->getPrice(\Magento\Catalog\Pricing\Price\FinalPrice::PRICE_CODE)
           ->getAmount()):?>
-    <meta property="product:price:amount" content="<?= $block->escapeHtmlAttr($priceAmount) ?>"/>
+    <meta property="product:price:amount" content="<?= $escaper->escapeHtmlAttr($priceAmount) ?>"/>
     <?= $block->getChildHtml('meta.currency') ?>
 <?php endif;?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options */
+use Magento\Catalog\Block\Product\View\Options;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Options $block */
 ?>
 
 <?php $_options = $block->decorateArray($block->getOptions()) ?>
@@ -16,7 +21,7 @@
             "priceOptions": {
                 "optionConfig": <?= /* @noEscape */ $block->getJsonConfig() ?>,
                 "controlContainer": ".field",
-                "priceHolderSelector": "[data-product-id='<?= $block->escapeHtml($_productId) ?>'][data-role=priceBox]"
+                "priceHolderSelector": "[data-product-id='<?= $escaper->escapeHtml($_productId) ?>'][data-role=priceBox]"
             }
         }
     }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/date.phtml
@@ -3,16 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\View\Options\Type\Date;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Date $block */
 ?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Date */ ?>
 <?php $_option = $block->getOption() ?>
-<?php $_optionId = $block->escapeHtmlAttr($_option->getId()) ?>
+<?php $_optionId = $escaper->escapeHtmlAttr($_option->getId()) ?>
 <?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>
 <div class="field date<?= /* @noEscape */ $class ?>"
     data-mage-init='{"priceOptionDate":{"fromSelector":"#product_addtocart_form"}}'>
     <fieldset class="fieldset fieldset-product-options-inner<?= /* @noEscape */ $class ?>">
         <legend class="legend">
-            <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+            <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
             <?= /* @noEscape */ $block->getFormattedPrice() ?>
         </legend>
         <div class="control">

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/default.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php $_option = $block->getOption() ?>
 <div class="field">
-    <label class="label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label"><span><?= $escaper->escapeHtml($_option->getTitle()) ?></span></label>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/file.phtml
@@ -3,29 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Catalog\Block\Product\View\Options\Type\File */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Catalog\Block\Product\View\Options\Type\File;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var File $block */
+$_option = $block->getOption();
+$_fileInfo = $block->getFileInfo();
+$_fileExists = $_fileInfo->hasData();
+$_fileName = 'options_' . $escaper->escapeHtmlAttr($_option->getId()) . '_file';
+$_fieldNameAction = $_fileName . '_action';
+$_fieldValueAction = $_fileExists ? 'save_old' : 'save_new';
+$_fileNamed = $_fileName . '_name';
+$class = ($_option->getIsRequire()) ? ' required' : '';
 ?>
-<?php $_option = $block->getOption(); ?>
-<?php $_fileInfo = $block->getFileInfo(); ?>
-<?php $_fileExists = $_fileInfo->hasData(); ?>
-<?php $_fileName = 'options_' . $block->escapeHtmlAttr($_option->getId()) . '_file'; ?>
-<?php $_fieldNameAction = $_fileName . '_action'; ?>
-<?php $_fieldValueAction = $_fileExists ? 'save_old' : 'save_new'; ?>
-<?php $_fileNamed = $_fileName . '_name'; ?>
-<?php $class = ($_option->getIsRequire()) ? ' required' : ''; ?>
-
 <div class="field file<?= /* @noEscape */ $class ?>">
     <label class="label" for="<?= /* @noEscape */ $_fileName ?>" id="<?= /* @noEscape */ $_fileName ?>-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
         <?= /* @noEscape */ $block->getFormattedPrice() ?>
     </label>
     <?php if ($_fileExists):?>
     <div class="control">
-        <span class="<?= /* @noEscape */ $_fileNamed ?>"><?= $block->escapeHtml($_fileInfo->getTitle()) ?></span>
+        <span class="<?= /* @noEscape */ $_fileNamed ?>"><?= $escaper->escapeHtml($_fileInfo->getTitle()) ?></span>
         <a href="#" class="label" id="change-<?= /* @noEscape */ $_fileName ?>" >
-            <?= $block->escapeHtml(__('Change')) ?>
+            <?= $escaper->escapeHtml(__('Change')) ?>
         </a>
         <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
             'onclick',
@@ -34,7 +39,7 @@
         ) ?>
         <?php if (!$_option->getIsRequire()):?>
             <input type="checkbox" id="delete-<?= /* @noEscape */ $_fileName ?>" />
-            <span class="label"><?= $block->escapeHtml(__('Delete')) ?></span>
+            <span class="label"><?= $escaper->escapeHtml(__('Delete')) ?></span>
         <?php endif; ?>
     </div>
     <?php endif; ?>
@@ -55,20 +60,20 @@
                value="<?= /* @noEscape */ $_fieldValueAction ?>" />
         <?php if ($_option->getFileExtension()):?>
             <p class="note">
-                <?= $block->escapeHtml(__('Compatible file extensions to upload')) ?>:
-                <strong><?= $block->escapeHtml($_option->getFileExtension()) ?></strong>
+                <?= $escaper->escapeHtml(__('Compatible file extensions to upload')) ?>:
+                <strong><?= $escaper->escapeHtml($_option->getFileExtension()) ?></strong>
             </p>
         <?php endif; ?>
         <?php if ($_option->getImageSizeX() > 0):?>
             <p class="note">
-                <?= $block->escapeHtml(__('Maximum image width')) ?>: <strong><?= (int)$_option->getImageSizeX()
-                ?> <?= $block->escapeHtml(__('px.')) ?></strong>
+                <?= $escaper->escapeHtml(__('Maximum image width')) ?>: <strong><?= (int)$_option->getImageSizeX()
+                ?> <?= $escaper->escapeHtml(__('px.')) ?></strong>
             </p>
         <?php endif; ?>
         <?php if ($_option->getImageSizeY() > 0):?>
             <p class="note">
-                <?= $block->escapeHtml(__('Maximum image height')) ?>: <strong><?= (int)$_option->getImageSizeY()
-                ?> <?= $block->escapeHtml(__('px.')) ?></strong>
+                <?= $escaper->escapeHtml(__('Maximum image height')) ?>: <strong><?= (int)$_option->getImageSizeY()
+                ?> <?= $escaper->escapeHtml(__('px.')) ?></strong>
             </p>
         <?php endif; ?>
     </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/select.phtml
@@ -3,22 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Select */ ?>
-<?php
+use Magento\Catalog\Block\Product\View\Options\Type\Select;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Select $block */
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';
 ?>
 <div class="field<?= /* @noEscape */ $class ?>">
-    <label class="label" for="select_<?= $block->escapeHtmlAttr($_option->getId()) ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+    <label class="label" for="select_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>">
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control">
         <?= $block->getValuesHtml() ?>
         <?php if ($_option->getIsRequire()) :?>
             <?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO || $_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_CHECKBOX) :?>
-                <span id="options-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></span>
+                <span id="options-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></span>
             <?php endif; ?>
         <?php endif;?>
     </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/type/text.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\Options\Type\Text */ ?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\View\Options\Type\Text;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Text $block */
 $_option = $block->getOption();
 $class = ($_option->getIsRequire()) ? ' required' : '';
 ?>
-
 <div class="field<?php if ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_AREA) {
     echo ' textarea';
 } ?><?= /* @noEscape */ $class ?>">
-    <label class="label" for="options_<?= $block->escapeHtmlAttr($_option->getId()) ?>_text">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+    <label class="label" for="options_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>_text">
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
         <?= /* @noEscape */ $block->getFormattedPrice() ?>
     </label>
 
@@ -30,14 +33,14 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
             $_textValidate['validate-no-utf8mb4-characters'] = true;
             ?>
             <input type="text"
-                   id="options_<?= $block->escapeHtmlAttr($_option->getId()) ?>_text"
+                   id="options_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>_text"
                    class="input-text product-custom-option"
                 <?php if (!empty($_textValidate)) {?>
-                    data-validate="<?= $block->escapeHtml(json_encode($_textValidate)) ?>"
+                    data-validate="<?= $escaper->escapeHtml(json_encode($_textValidate)) ?>"
                 <?php } ?>
-                   name="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   data-selector="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtml($block->getDefaultValue()) ?>"/>
+                   name="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   data-selector="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtml($block->getDefaultValue()) ?>"/>
         <?php elseif ($_option->getType() == \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_AREA) :?>
             <?php $_textAreaValidate = null;
             if ($_option->getIsRequire()) {
@@ -48,19 +51,19 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
             }
             $_textAreaValidate['validate-no-utf8mb4-characters'] = true;
             ?>
-            <textarea id="options_<?= $block->escapeHtmlAttr($_option->getId()) ?>_text"
+            <textarea id="options_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>_text"
                       class="product-custom-option"
                     <?php if (!empty($_textAreaValidate)) {?>
-                        data-validate="<?= $block->escapeHtml(json_encode($_textAreaValidate)) ?>"
+                        data-validate="<?= $escaper->escapeHtml(json_encode($_textAreaValidate)) ?>"
                     <?php } ?>
-                      name="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                      data-selector="options[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
+                      name="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                      data-selector="options[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
                       rows="5"
-                      cols="25"><?= $block->escapeHtml($block->getDefaultValue()) ?></textarea>
+                      cols="25"><?= $escaper->escapeHtml($block->getDefaultValue()) ?></textarea>
         <?php endif; ?>
         <?php if ($_option->getMaxCharacters()) :?>
-            <p class="note note_<?= $block->escapeHtmlAttr($_option->getId()) ?>">
-                <?= $block->escapeHtml(__('Maximum %1 characters', $_option->getMaxCharacters())) ?>
+            <p class="note note_<?= $escaper->escapeHtmlAttr($_option->getId()) ?>">
+                <?= $escaper->escapeHtml(__('Maximum %1 characters', $_option->getMaxCharacters())) ?>
                 <span class="character-counter no-display"></span>
             </p>
         <?php endif; ?>
@@ -68,11 +71,11 @@ $class = ($_option->getIsRequire()) ? ' required' : '';
     <?php if ($_option->getMaxCharacters()) :?>
         <script type="text/x-magento-init">
         {
-            "[data-selector='options[<?= $block->escapeJs($_option->getId()) ?>]']": {
+            "[data-selector='options[<?= $escaper->escapeJs($_option->getId()) ?>]']": {
                 "Magento_Catalog/js/product/remaining-characters": {
                     "maxLength":  "<?= (int)$_option->getMaxCharacters() ?>",
-                    "noteSelector": ".note_<?= $block->escapeJs($_option->getId()) ?>",
-                    "counterSelector": ".note_<?= $block->escapeJs($_option->getId()) ?> .character-counter"
+                    "noteSelector": ".note_<?= $escaper->escapeJs($_option->getId()) ?>",
+                    "counterSelector": ".note_<?= $escaper->escapeJs($_option->getId()) ?> .character-counter"
                 }
             }
         }

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/options/wrapper.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/options/wrapper.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block Magento\Catalog\Block\Product\View */
-?>
-<?php
+use Magento\Catalog\Block\Product\View;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 $required = '';
+
 if ($block->hasRequiredOptions()) {
-    $required = ' data-hasrequired="' . $block->escapeHtmlAttr(__('* Required Fields')) . '"';
+    $required = ' data-hasrequired="' . $escaper->escapeHtmlAttr(__('* Required Fields')) . '"';
 }
 ?>
 <div class="product-options-wrapper" id="product-options-wrapper"<?= /* @noEscape */ $required ?>>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/view/type/default.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/view/type/default.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\AbstractView */?>
-<?php $_product = $block->getProduct() ?>
+declare(strict_types=1);
 
+use Magento\Catalog\Block\Product\View\AbstractView;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var AbstractView $block */
+$_product = $block->getProduct();
+?>
 <?php if ($block->displayProductStockStatus()) :?>
     <?php if ($_product->isAvailable()) :?>
-        <div class="stock available" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-            <span><?= $block->escapeHtml(__('In stock')) ?></span>
+        <div class="stock available" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+            <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
         </div>
     <?php else :?>
-        <div class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-            <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+        <div class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+            <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
         </div>
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/link/link_block.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/link/link_block.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="widget block block-product-link">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $block->escapeHtml($block->getLabel()) ?></span></a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $escaper->escapeHtml($block->getLabel()) ?></span></a>
 </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/link/link_inline.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/link/link_inline.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <span class="widget block block-product-link-inline">
-    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $block->escapeHtml($block->getLabel()) ?></span></a>
+    <a <?= /* @noEscape */ $block->getLinkAttributes() ?>><span><?= $escaper->escapeHtml($block->getLabel()) ?></span></a>
 </span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_default_list.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable Magento2.Files.LineLength.MaxExceeded
@@ -10,21 +15,21 @@
 <?php if (($_products = $block->getProductCollection()) && $_products->getSize()) :?>
     <div class="block widget block-new-products-list">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('New Products')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('New Products')) ?></strong>
         </div>
         <div class="block-content">
             <?php $suffix = $block->getNameInLayout(); ?>
-            <ol class="product-items" id="widget-new-products-<?= $block->escapeHtmlAttr($suffix) ?>">
+            <ol class="product-items" id="widget-new-products-<?= $escaper->escapeHtmlAttr($suffix) ?>">
                 <?php foreach ($_products->getItems() as $_product) :?>
                     <li class="product-item">
                         <div class="product-item-info">
-                            <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
+                            <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
                                title="<?= /* @noEscape */ $block->stripTags($_product->getName(), null, true) ?>">
                                 <?= $block->getImage($_product, 'side_column_widget_product_thumbnail')->toHtml() ?>
                             </a>
                             <div class="product-item-details">
                                 <strong class="product-item-name">
-                                    <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
+                                    <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
                                        title="<?= /* @noEscape */ $block->stripTags($_product->getName(), null, true) ?>)"
                                        class="product-item-link">
                                         <?= /* @noEscape */ $this->helper(Magento\Catalog\Helper\Output::class)->productAttribute($_product, $_product->getName(), 'name') ?>
@@ -35,30 +40,30 @@
                                     <div class="actions-primary">
                                         <?php if ($_product->isSaleable()) :?>
                                             <?php if (!$_product->getTypeInstance()->isPossibleBuyFromList($_product)) :?>
-                                                <button type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>"
+                                                <button type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>"
                                                         class="action tocart primary"
-                                                        data-mage-init='{"redirectUrl":{"url":"<?= $block->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'>
-                                                    <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                        data-mage-init='{"redirectUrl":{"url":"<?= $escaper->escapeUrl($block->getAddToCartUrl($_product)) ?>"}}'>
+                                                    <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                 </button>
                                             <?php else :?>
                                                 <?php
                                                 $postDataHelper = $this->helper(Magento\Framework\Data\Helper\PostHelper::class);
-                                                $postData = $postDataHelper->getPostData($block->escapeUrl($block->getAddToCartUrl($_product)), ['product' => $_product->getEntityId()]);
+                                                $postData = $postDataHelper->getPostData($escaper->escapeUrl($block->getAddToCartUrl($_product)), ['product' => $_product->getEntityId()]);
                                                 ?>
-                                                <button type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>"
+                                                <button type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>"
                                                         class="action tocart primary"
                                                         data-post='<?= /* @noEscape */ $postData ?>'>
-                                                    <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                    <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                 </button>
                                             <?php endif; ?>
                                         <?php else :?>
                                             <?php if ($_product->isAvailable()) :?>
-                                                <div class="stock available" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                                                    <span><?= $block->escapeHtml(__('In stock')) ?></span>
+                                                <div class="stock available" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                                                    <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
                                                 </div>
                                             <?php else :?>
-                                                <div class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                                                    <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                                                <div class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                                                    <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                                                 </div>
                                             <?php endif; ?>
                                         <?php endif; ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_images_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_images_list.phtml
@@ -3,19 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php if (($_products = $block->getProductCollection()) && $_products->getSize()) :?>
     <div class="block widget block-new-products-images">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('New Products')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('New Products')) ?></strong>
         </div>
         <div class="block-content">
             <?php $suffix = $block->getNameInLayout(); ?>
-            <ol id="widget-new-products-<?= $block->escapeHtmlAttr($suffix) ?>"
+            <ol id="widget-new-products-<?= $escaper->escapeHtmlAttr($suffix) ?>"
                 class="product-items product-items-images">
                 <?php foreach ($_products->getItems() as $_product) :?>
                     <li class="product-item">
-                        <a class="product-item-photo" href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
+                        <a class="product-item-photo" href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
                            title="<?= /* @noEscape */ $block->stripTags($_product->getName(), null, true) ?>">
                             <?php /* new_products_images_only_widget */ ?>
                             <?= $block->getImage($_product, 'new_products_images_only_widget')->toHtml() ?>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_names_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/column/new_names_list.phtml
@@ -3,22 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
 <?php if (($_products = $block->getProductCollection()) && $_products->getSize()) :?>
     <div class="block widget block-new-products-names">
         <div class="block-title">
-            <strong><?= $block->escapeHtml(__('New Products')) ?></strong>
+            <strong><?= $escaper->escapeHtml(__('New Products')) ?></strong>
         </div>
         <div class="block-content">
             <?php $suffix = $block->getNameInLayout(); ?>
-            <ol id="widget-new-products-<?= $block->escapeHtmlAttr($suffix) ?>"
+            <ol id="widget-new-products-<?= $escaper->escapeHtmlAttr($suffix) ?>"
                 class="product-items product-items-names">
                 <?php foreach ($_products->getItems() as $_product) :?>
                     <li class="product-item">
                         <strong class="product-item-name">
-                            <a href="<?= $block->escapeUrl($_product->getProductUrl()) ?>"
+                            <a href="<?= $escaper->escapeUrl($_product->getProductUrl()) ?>"
                                title="<?= /* @noEscape */ $block->stripTags($_product->getName(), null, true) ?>)"
                                class="product-item-link">
                                 <?= /* @noEscape */ $this->helper(

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_grid.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Widget\NewWidget;
+use Magento\Framework\Escaper;
+
 /**
  * Template for displaying new products widget
  *
- * @var $block \Magento\Catalog\Block\Product\Widget\NewWidget
+ * @var NewWidget $block
+ * @var Escaper $escaper
  */
 
 // phpcs:disable Magento2.Files.LineLength.MaxExceeded
@@ -34,7 +38,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
 <?php if ($exist) :?>
     <div class="block widget block-new-products <?= /* @noEscape */ $mode ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
             <?= /* @noEscape */ '<!-- ' . $image . '-->' ?>
@@ -43,16 +47,16 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                     <?php foreach ($items as $_item) :?>
                     <li class="product-item">
                         <div class="product-item-info">
-                            <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                            <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                class="product-item-photo">
                                 <?= $block->getImage($_item, $image)->toHtml() ?>
                             </a>
                             <div class="product-item-details">
                                 <strong class="product-item-name">
-                                    <a title="<?= $block->escapeHtml($_item->getName()) ?>"
-                                       href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                                    <a title="<?= $escaper->escapeHtml($_item->getName()) ?>"
+                                       href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                        class="product-item-link">
-                                        <?= $block->escapeHtml($_item->getName()) ?>
+                                        <?= $escaper->escapeHtml($_item->getName()) ?>
                                     </a>
                                 </strong>
                                 <?= $block->getProductPriceHtml($_item, $type); ?>
@@ -68,34 +72,34 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                 <?php if ($_item->isSaleable()) :?>
                                                     <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)) :?>
                                                         <button class="action tocart primary"
-                                                                data-mage-init='{"redirectUrl":{"url":"<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                                data-mage-init='{"redirectUrl":{"url":"<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
                                                                 type="button"
-                                                                title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                         </button>
                                                     <?php else :?>
                                                         <?php
                                                             $postDataHelper = $this->helper(Magento\Framework\Data\Helper\PostHelper::class);
                                                             $postData = $postDataHelper->getPostData(
-                                                                $block->escapeUrl($block->getAddToCartUrl($_item)),
+                                                                $escaper->escapeUrl($block->getAddToCartUrl($_item)),
                                                                 ['product' => (int) $_item->getEntityId()]
                                                             )
                                                         ?>
                                                         <button class="action tocart primary"
                                                                 data-post='<?= /* @noEscape */ $postData ?>'
                                                                 type="button"
-                                                                title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                         </button>
                                                     <?php endif; ?>
                                                 <?php else :?>
                                                     <?php if ($_item->isAvailable()) :?>
                                                         <div class="stock available">
-                                                            <span><?= $block->escapeHtml(__('In stock')) ?></span>
+                                                            <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
                                                         </div>
                                                     <?php else :?>
                                                         <div class="stock unavailable">
-                                                            <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                                                            <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                                                         </div>
                                                     <?php endif; ?>
                                                 <?php endif; ?>
@@ -108,16 +112,16 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                        data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
                                                        class="action towishlist"
                                                        data-action="add-to-wishlist"
-                                                       title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                        <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                       title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                        <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                     </a>
                                                 <?php endif; ?>
                                                 <?php if ($block->getAddToCompareUrl() && $showCompare) :?>
                                                     <?php $compareHelper = $this->helper(Magento\Catalog\Helper\Product\Compare::class);?>
                                                     <a href="#" class="action tocompare"
                                                        data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
-                                                       title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>">
-                                                        <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                       title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>">
+                                                        <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                     </a>
                                                 <?php endif; ?>
                                             </div>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/widget/new/content/new_list.phtml
@@ -3,8 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Catalog\Block\Product\Widget\NewWidget;
+use Magento\Framework\Escaper;
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable Magento2.Files.LineLength.MaxExceeded
@@ -12,8 +14,10 @@
 /**
  * Template for displaying new products widget
  *
- * @var $block \Magento\Catalog\Block\Product\Widget\NewWidget
+ * @var NewWidget $block
+ * @var Escaper $escaper
  */
+
 if ($exist = ($block->getProductCollection() && $block->getProductCollection()->getSize())) {
     $type = 'widget-new-list';
 
@@ -36,7 +40,7 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
 <?php if ($exist) :?>
     <div class="block widget block-new-products <?= /* @noEscape */ $mode ?>">
         <div class="block-title">
-            <strong role="heading" aria-level="2"><?= $block->escapeHtml($title) ?></strong>
+            <strong role="heading" aria-level="2"><?= $escaper->escapeHtml($title) ?></strong>
         </div>
         <div class="block-content">
             <?= /* @noEscape */ '<!-- ' . $image . '-->' ?>
@@ -45,16 +49,16 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                     <?php foreach ($items as $_item) :?>
                         <li class="product-item">
                             <div class="product-item-info">
-                                <a href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                                <a href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                    class="product-item-photo">
                                     <?= $block->getImage($_item, $image)->toHtml() ?>
                                 </a>
                                 <div class="product-item-details">
                                     <strong class="product-item-name">
-                                        <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                           href="<?= $block->escapeUrl($block->getProductUrl($_item)) ?>"
+                                        <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                           href="<?= $escaper->escapeUrl($block->getProductUrl($_item)) ?>"
                                            class="product-item-link">
-                                            <?= $block->escapeHtml($_item->getName()) ?>
+                                            <?= $escaper->escapeHtml($_item->getName()) ?>
                                         </a>
                                     </strong>
                                     <?= $block->getProductPriceHtml($_item, $type) ?>
@@ -71,10 +75,10 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                         <?php if (!$_item->getTypeInstance()->isPossibleBuyFromList($_item)
                                                         ) :?>
                                                             <button class="action tocart primary"
-                                                                    data-mage-init='{"redirectUrl":{"url":"<?= $block->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
+                                                                    data-mage-init='{"redirectUrl":{"url":"<?= $escaper->escapeUrl($block->getAddToCartUrl($_item)) ?>"}}'
                                                                     type="button"
-                                                                    title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php else :?>
                                                             <?php
@@ -83,15 +87,15 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                             ?>
                                                             <button class="action tocart primary"
                                                                     data-post='<?= /* @noEscape */ $postData ?>'
-                                                                    type="button" title="<?= $block->escapeHtmlAttr(__('Add to Cart')) ?>">
-                                                                <span><?= $block->escapeHtml(__('Add to Cart')) ?></span>
+                                                                    type="button" title="<?= $escaper->escapeHtmlAttr(__('Add to Cart')) ?>">
+                                                                <span><?= $escaper->escapeHtml(__('Add to Cart')) ?></span>
                                                             </button>
                                                         <?php endif; ?>
                                                     <?php else :?>
                                                         <?php if ($_item->isAvailable()) :?>
-                                                            <div class="stock available"><span><?= $block->escapeHtml(__('In stock')) ?></span></div>
+                                                            <div class="stock available"><span><?= $escaper->escapeHtml(__('In stock')) ?></span></div>
                                                         <?php else :?>
-                                                            <div class="stock unavailable"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></div>
+                                                            <div class="stock unavailable"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></div>
                                                         <?php endif; ?>
                                                     <?php endif; ?>
                                                 </div>
@@ -102,17 +106,17 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                         <a href="#"
                                                            data-post='<?= /* @noEscape */ $block->getAddToWishlistParams($_item) ?>'
                                                            class="action towishlist" data-action="add-to-wishlist"
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Wish List')) ?>">
-                                                            <span><?= $block->escapeHtml(__('Add to Wish List')) ?></span>
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Wish List')) ?>">
+                                                            <span><?= $escaper->escapeHtml(__('Add to Wish List')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                     <?php if ($block->getAddToCompareUrl() && $showCompare) :?>
                                                         <?php $compareHelper = $this->helper(Magento\Catalog\Helper\Product\Compare::class); ?>
                                                         <a href="#" class="action tocompare"
-                                                           title="<?= $block->escapeHtmlAttr(__('Add to Compare')) ?>"
+                                                           title="<?= $escaper->escapeHtmlAttr(__('Add to Compare')) ?>"
                                                            data-post='<?= /* @noEscape */ $compareHelper->getPostDataParams($_item) ?>'
                                                         >
-                                                            <span><?= $block->escapeHtml(__('Add to Compare')) ?></span>
+                                                            <span><?= $escaper->escapeHtml(__('Add to Compare')) ?></span>
                                                         </a>
                                                     <?php endif; ?>
                                                 </div>
@@ -126,9 +130,9 @@ if ($exist = ($block->getProductCollection() && $block->getProductCollection()->
                                                 $_item->getShortDescription(),
                                                 'short_description'
                                             ) ?>
-                                            <a title="<?= $block->escapeHtmlAttr($_item->getName()) ?>"
-                                               href="<?= $block->escapeUrl($block->getProductUrl($_item))?>"
-                                               class="action more"><?= $block->escapeHtml(__('Learn More')) ?></a>
+                                            <a title="<?= $escaper->escapeHtmlAttr($_item->getName()) ?>"
+                                               href="<?= $escaper->escapeUrl($block->getProductUrl($_item))?>"
+                                               class="action more"><?= $escaper->escapeHtml(__('Learn More')) ?></a>
                                         </div>
                                     <?php endif; ?>
                                 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Catalog` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37103: Chore: Catalog - Replace Block Escaping with Escaper