### PR TITLE
Chore: Bundle - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Bundle/view/adminhtml/templates/catalog/product/edit/tab/attributes/extend.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/catalog/product/edit/tab/attributes/extend.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Attributes\Extend */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Attributes\Extend;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Extend $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 $elementHtml = $block->getParentElementHtml();
 
 $attributeCode = $block->getAttribute()
@@ -20,7 +26,7 @@ $isElementReadonly = $block->getElement()
 ?>
 
 <?php if (!($attributeCode === 'price' && $block->getCanReadPrice() === false)): ?>
-    <div class="<?= $block->escapeHtmlAttr($attributeCode) ?> "><?= /* @noEscape */ $elementHtml ?></div>
+    <div class="<?= $escaper->escapeHtmlAttr($attributeCode) ?> "><?= /* @noEscape */ $elementHtml ?></div>
 <?php endif; ?>
 
 <?= $block->getExtendedElement($switchAttributeCode)->toHtml() ?>
@@ -30,8 +36,8 @@ $isElementReadonly = $block->getElement()
     $scriptString = <<<script
         require(['prototype'], function () {
             function {$switchAttributeCode}_change() {
-                var $attribute = $('{$block->escapeJs($attributeCode)}');
-                if ($('{$switchAttributeCode}').value == '{$block->escapeJs($block::DYNAMIC)}') {
+                var $attribute = $('{$escaper->escapeJs($attributeCode)}');
+                if ($('{$switchAttributeCode}').value == '{$escaper->escapeJs($block::DYNAMIC)}') {
                     if ($attribute) {
                         $attribute.disabled = true;
                         $attribute.value = '';

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/bundle.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
-/* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Bundle;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Bundle $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $options = $block->decorateArray($block->getOptions(true)); ?>
@@ -15,7 +19,7 @@
 <fieldset id="catalog_product_composite_configure_fields_bundle"
           class="fieldset admin__fieldset composite-bundle<?= $block->getIsLastFieldset() ? ' last-fieldset' : '' ?>">
     <legend class="legend admin__legend">
-        <span><?= $block->escapeHtml(__('Bundle Items')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Bundle Items')) ?></span>
     </legend><br />
     <?php foreach ($options as $option): ?>
         <?php if ($option->getSelections()): ?>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/checkbox.phtml
@@ -3,16 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Checkbox;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Checkbox */ ?>
+<?php /* @var Checkbox $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections = $_option->getSelections(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
 
 <div class="field admin__field options<?php if ($_option->getRequired()) { echo ' _required'; } ?>">
     <label class="label admin__field-label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
 
     <div class="control admin__field-control">
@@ -21,30 +27,30 @@
             <?php if (count($_selections) == 1 && $_option->getRequired()) : ?>
                 <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>
                 <input type="hidden"
-                       name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                       value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
-                       price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
+                       name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                       value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                       price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
             <?php else :?>
 
                 <?php foreach ($_selections as $_selection) : ?>
                     <div class="field choice admin__field admin__field-option">
                         <input
-                            class="change-container-classname admin__control-checkbox checkbox bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?> <?php if ($_option->getRequired()) { echo 'validate-one-required-by-name'; } ?>"
-                            id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                            class="change-container-classname admin__control-checkbox checkbox bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?> <?php if ($_option->getRequired()) { echo 'validate-one-required-by-name'; } ?>"
+                            id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                             type="checkbox"
-                            name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>][<?= $block->escapeHtmlAttr($_selection->getId()) ?>]"
+                            name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>][<?= $escaper->escapeHtmlAttr($_selection->getId()) ?>]"
                             <?php if ($block->isSelected($_selection)) :?>
                                 <?= ' checked="checked"' ?>
                             <?php endif;?>
                             <?php if (!$_selection->isSaleable() && !$_skipSaleableCheck) :?>
                                 <?= ' disabled="disabled"' ?>
                             <?php endif;?>
-                            value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                            value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                             onclick="ProductConfigure.bundleControl.changeSelection(this)"
-                            price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>" />
+                            price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>" />
 
                         <label class="admin__field-label"
-                               for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>">
+                               for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>">
                             <span><?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selection) ?></span>
                         </label>
 
@@ -54,7 +60,7 @@
                     </div>
                 <?php endforeach; ?>
 
-                <div id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></div>
+                <div id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></div>
             <?php endif; ?>
         </div>
     </div>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/multi.phtml
@@ -3,33 +3,41 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Multi;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Multi */ ?>
+<?php /* @var Multi $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections = $_option->getSelections(); ?>
 <?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
+
 <div class="field admin__field <?php if ($_option->getRequired()) { echo ' _required'; } ?><?php if ($_option->getDecoratedIsLast()) :?> last<?php endif; ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $escaper->escapeHtml($_option->getTitle()) ?></span></label>
     <div class="control admin__field-control">
         <?php if (count($_selections) == 1 && $_option->getRequired()) : ?>
             <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>
-            <input type="hidden" name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
+            <input type="hidden" name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
         <?php else : ?>
-            <select multiple="multiple" size="5" id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>][]"
-                    class="admin__control-multiselect bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?><?php if ($_option->getRequired()) { echo ' required-entry'; } ?> multiselect change-container-classname"
+            <select multiple="multiple" size="5" id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                    name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>][]"
+                    class="admin__control-multiselect bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?><?php if ($_option->getRequired()) { echo ' required-entry'; } ?> multiselect change-container-classname"
                     onchange="ProductConfigure.bundleControl.changeSelection(this)">
             <?php if (!$_option->getRequired()) : ?>
-                <option value=""><?= $block->escapeHtml(__('None')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('None')) ?></option>
             <?php endif; ?>
             <?php foreach ($_selections as $_selection) : ?>
-                <option value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                <option value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                     <?php if ($block->isSelected($_selection)) { echo ' selected="selected"'; } ?>
                     <?php if (!$_selection->isSaleable() && !$_skipSaleableCheck) { echo ' disabled="disabled"'; } ?>
-                    price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>">
+                    price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>">
                     <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selection, false) ?></option>
             <?php endforeach; ?>
             </select>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/radio.phtml
@@ -3,9 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Radio;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Radio */ ?>
+<?php /* @var Radio $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default = $_option->getDefaultSelection(); ?>
@@ -13,26 +20,26 @@
 <?php list($_defaultQty, $_canChangeQty) = $block->getDefaultValues(); ?>
 
 <div class="field admin__field options<?php if ($_option->getRequired()) { echo ' _required'; } ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $escaper->escapeHtml($_option->getTitle()) ?></span></label>
     <div class="control admin__field-control">
         <div class="nested<?php if ($_option->getDecoratedIsLast()) :?> last<?php endif; ?>">
         <?php if ($block->showSingle()) : ?>
             <?= /* @noEscape */ $block->getSelectionTitlePrice($_selections[0]) ?>
             <input type="hidden"
-                   name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
+                   name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
         <?php else :?>
             <?php if (!$_option->getRequired()) : ?>
                 <div class="field choice admin__field admin__field-option">
                     <input type="radio"
                            class="radio admin__control-radio"
-                           id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                           name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"<?= ($_default && $_default->isSalable()) ? '' : ' checked="checked" ' ?>
+                           id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                           name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"<?= ($_default && $_default->isSalable()) ? '' : ' checked="checked" ' ?>
                            value=""
                            onclick="ProductConfigure.bundleControl.changeSelection(this)" />
                     <label class="admin__field-label"
-                           for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"><span><?= $block->escapeHtml(__('None')) ?></span></label>
+                           for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"><span><?= $escaper->escapeHtml(__('None')) ?></span></label>
                 </div>
             <?php endif; ?>
 
@@ -40,16 +47,16 @@
                 <div class="field choice admin__field admin__field-option">
                     <input type="radio"
                            class="radio admin__control-radio <?= $_option->getRequired() ? ' required-entry' : '' ?> change-container-classname"
-                           id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
-                           name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
+                           id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                           name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
                            <?php if ($block->isSelected($_selection)) { echo ' checked="checked"'; } ?>
                            <?php if (!$_selection->isSaleable() && !$_skipSaleableCheck) { echo ' disabled="disabled"'; } ?>
-                           value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                           value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                            onclick="ProductConfigure.bundleControl.changeSelection(this)"
-                           price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>"
-                           qtyId="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input" />
+                           price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>"
+                           qtyId="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input" />
                     <label class="admin__field-label"
-                           for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>">
+                           for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>">
                         <span><?= /* @noEscape */ $block->getSelectionTitlePrice($_selection) ?></span>
                     </label>
                 <?php if ($_option->getRequired()) : ?>
@@ -57,19 +64,19 @@
                 <?php endif; ?>
                 </div>
             <?php endforeach; ?>
-            <div id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></div>
+            <div id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></div>
         <?php endif; ?>
             <div class="field admin__field qty">
                 <label class="label admin__field-label"
-                       for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input">
-                    <span><?= $block->escapeHtml(__('Quantity:')) ?></span>
+                       for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input">
+                    <span><?= $escaper->escapeHtml(__('Quantity:')) ?></span>
                 </label>
                 <div class="control admin__field-control"><input <?php if (!$_canChangeQty) { echo ' disabled="disabled"'; } ?>
-                        id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input"
+                        id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input"
                         class="input-text admin__control-text qty validate-greater-than-zero<?php if (!$_canChangeQty) { echo ' qty-disabled'; } ?>"
                         type="text"
-                        name="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                        value="<?= $block->escapeHtmlAttr($_defaultQty) ?>"></div>
+                        name="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                        value="<?= $escaper->escapeHtmlAttr($_defaultQty) ?>"></div>
                 </div>
             </div>
         </div>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/composite/fieldset/options/type/select.phtml
@@ -3,9 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Select;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Composite\Fieldset\Options\Type\Select */ ?>
+<?php /* @var Select $block */ ?>
 <?php $_option      = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>
@@ -13,27 +20,27 @@
 <?php list($_defaultQty, $_canChangeQty) = $block->getDefaultValues(); ?>
 
 <div class="field admin__field option<?php if ($_option->getDecoratedIsLast()) :?> last<?php endif; ?><?php if ($_option->getRequired()) { echo ' _required'; } ?>">
-    <label class="label admin__field-label"><span><?= $block->escapeHtml($_option->getTitle()) ?></span></label>
+    <label class="label admin__field-label"><span><?= $escaper->escapeHtml($_option->getTitle()) ?></span></label>
     <div class="control admin__field-control">
         <?php if ($block->showSingle()) : ?>
             <?= /* @noEscape */ $block->getSelectionTitlePrice($_selections[0]) ?>
             <input type="hidden"
-                   name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
-                   price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
+                   name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                   price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selections[0])) ?>" />
         <?php else :?>
-            <select id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                    class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?><?php if ($_option->getRequired()) { echo ' required-entry'; } ?> select admin__control-select change-container-classname"
+            <select id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                    name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                    class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?><?php if ($_option->getRequired()) { echo ' required-entry'; } ?> select admin__control-select change-container-classname"
                     onchange="ProductConfigure.bundleControl.changeSelection(this)">
-                <option value=""><?= $block->escapeHtml(__('Choose a selection...')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Choose a selection...')) ?></option>
                 <?php foreach ($_selections as $_selection) : ?>
                     <option
-                        value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                        value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                         <?php if ($block->isSelected($_selection)) { echo ' selected="selected"'; } ?>
                         <?php if (!$_selection->isSaleable() && !$_skipSaleableCheck) { echo ' disabled="disabled"'; } ?>
-                        price="<?= $block->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>"
-                        qtyId="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input">
+                        price="<?= $escaper->escapeHtmlAttr($block->getSelectionPrice($_selection)) ?>"
+                        qtyId="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input">
                         <?= /* @noEscape */ $block->getSelectionTitlePrice($_selection, false) ?>
                     </option>
                 <?php endforeach; ?>
@@ -43,16 +50,16 @@
         <div class="nested">
             <div class="field admin__field qty">
                 <label class="label admin__field-label"
-                       for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input">
-                    <span><?= $block->escapeHtml(__('Quantity:')) ?></span>
+                       for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input">
+                    <span><?= $escaper->escapeHtml(__('Quantity:')) ?></span>
                 </label>
                 <div class="control admin__field-control">
                     <input <?php if (!$_canChangeQty) { echo ' disabled="disabled"'; } ?>
-                        id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input"
+                        id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input"
                         class="input-text admin__control-text qty validate-greater-than-zero<?php if (!$_canChangeQty) { echo ' qty-disabled'; } ?>"
                         type="text"
-                        name="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                        value="<?= $block->escapeHtmlAttr($_defaultQty) ?>" />
+                        name="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                        value="<?= $escaper->escapeHtmlAttr($_defaultQty) ?>" />
                 </div>
             </div>
         </div>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Bundle $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $scriptString = <<<script
@@ -19,19 +25,19 @@ script;
 <div id="bundle_product_container" class="entry-edit form-inline">
     <fieldset class="fieldset">
         <div class="field field-ship-bundle-items">
-            <label for="shipment_type" class="label"><?= $block->escapeHtml(__('Ship Bundle Items')) ?></label>
+            <label for="shipment_type" class="label"><?= $escaper->escapeHtml(__('Ship Bundle Items')) ?></label>
             <div class="control">
                 <select <?php if ($block->isReadonly()): ?>disabled="disabled" <?php endif;?>
                         id="shipment_type"
-                        name="<?= $block->escapeHtmlAttr($block->getFieldSuffix()) ?>[shipment_type]"
+                        name="<?= $escaper->escapeHtmlAttr($block->getFieldSuffix()) ?>[shipment_type]"
                         class="select">
-                    <option value="1"><?= $block->escapeHtml(__('Separately')) ?></option>
+                    <option value="1"><?= $escaper->escapeHtml(__('Separately')) ?></option>
                     <option value="0"
                         <?php if ($block->getProduct()->getShipmentType() == 0): ?>
                             selected="selected"
                         <?php endif; ?>
                     >
-                        <?= $block->escapeHtml(__('Together')) ?>
+                        <?= $escaper->escapeHtml(__('Together')) ?>
                     </option>
                 </select>
             </div>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option.phtml
@@ -3,18 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Option $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <script id="bundle-option-template" type="text/x-magento-template">
-    <div id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>" class="option-box">
+    <div id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>" class="option-box">
         <div class="fieldset-wrapper admin__collapsible-block-wrapper opened"
-             id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-wrapper">
+             id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-wrapper">
             <div class="fieldset-wrapper-title">
                 <strong class="admin__collapsible-title" data-bs-toggle="collapse"
-                        data-bs-target="#<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-content">
+                        data-bs-target="#<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-content">
                     <span><%- data.default_title %></span>
                 </strong>
                 <div class="actions">
@@ -23,41 +31,41 @@
                 <div data-role="draggable-handle" class="draggable-handle"></div>
             </div>
             <div class="fieldset-wrapper-content in collapse"
-                 id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-content">
+                 id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>-content">
                 <fieldset class="fieldset">
                     <fieldset class="fieldset-alt">
                         <div class="field field-option-title required">
-                            <label class="label" for="id_<?= $block->escapeHtmlAttr($block->getFieldName())
+                            <label class="label" for="id_<?= $escaper->escapeHtmlAttr($block->getFieldName())
                             ?>_<%- data.index %>_title">
-                                <?= $block->escapeHtml(__('Option Title')) ?>
+                                <?= $escaper->escapeHtml(__('Option Title')) ?>
                             </label>
                             <div class="control">
                                 <?php if ($block->isDefaultStore()): ?>
                                 <input class="input-text required-entry"
                                        type="text"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][title]"
-                                       id="id_<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       id="id_<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>_<%- data.index %>_title"
                                        value="<%- data.title %>"
                                        data-original-value="<%- data.title %>" />
                                 <?php else: ?>
                                 <input class="input-text required-entry"
                                        type="text"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][default_title]"
-                                       id="id_<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       id="id_<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>_<%- data.index %>_default_title"
                                        value="<%- data.default_title %>"
                                        data-original-value="<%- data.default_title %>" />
                                 <?php endif; ?>
                                 <input type="hidden"
-                                       id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_id_<%- data.index %>"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_id_<%- data.index %>"
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][option_id]"
                                        value="<%- data.option_id %>" />
                                 <input type="hidden"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][delete]"
                                        value=""
                                        data-state="deleted" />
@@ -65,25 +73,25 @@
                         </div>
                         <?php if (!$block->isDefaultStore()): ?>
                         <div class="field field-option-store-view required">
-                            <label class="label" for="id_<?= $block->escapeHtmlAttr($block->getFieldName())
+                            <label class="label" for="id_<?= $escaper->escapeHtmlAttr($block->getFieldName())
                             ?>_<%- data.index %>_title_store">
-                                <?= $block->escapeHtml(__('Store View Title')) ?>
+                                <?= $escaper->escapeHtml(__('Store View Title')) ?>
                             </label>
                             <div class="control">
                                 <input class="input-text required-entry"
                                        type="text"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][title]"
-                                       id="id_<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       id="id_<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>_<%- data.index %>_title_store"
                                        value="<%- data.title %>" />
                             </div>
                         </div>
                         <?php endif; ?>
                         <div class="field field-option-input-type required">
-                            <label class="label" for="<?= $block->escapeHtmlAttr($block->getFieldId() .
+                            <label class="label" for="<?= $escaper->escapeHtmlAttr($block->getFieldId() .
                                 '_<%- data.index %>_type') ?>">
-                                <?= $block->escapeHtml(__('Input Type')) ?>
+                                <?= $escaper->escapeHtml(__('Input Type')) ?>
                             </label>
                             <div class="control">
                                 <?= $block->getTypeSelectHtml() ?>
@@ -96,7 +104,7 @@
                                        checked="checked"
                                        id="field-option-req" />
                                 <label for="field-option-req">
-                                    <?= $block->escapeHtml(__('Required')) ?>
+                                    <?= $escaper->escapeHtml(__('Required')) ?>
                                 </label>
                                 <span><?= $block->getRequireSelectHtml() ?></span>
                             </div>
@@ -107,12 +115,12 @@
                         ) ?>
                         <div class="field field-option-position no-display">
                             <label class="label" for="field-option-position">
-                                <?= $block->escapeHtml(__('Position')) ?>
+                                <?= $escaper->escapeHtml(__('Position')) ?>
                             </label>
                             <div class="control">
                                 <input class="input-text validate-zero-or-greater"
                                        type="text"
-                                       name="<?= $block->escapeHtmlAttr($block->getFieldName())
+                                       name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                                         ?>[<%- data.index %>][position]"
                                        value="<%- data.position %>"
                                        id="field-option-position" />
@@ -121,13 +129,13 @@
                     </fieldset>
 
                     <div class="no-products-message">
-                        <?= $block->escapeHtml(__('There are no products in this option.')) ?>
+                        <?= $escaper->escapeHtml(__('There are no products in this option.')) ?>
                     </div>
                     <?= $block->getAddSelectionButtonHtml() ?>
                 </fieldset>
             </div>
         </div>
-        <div id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_search_<%- data.index %>"
+        <div id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_search_<%- data.index %>"
              class="selection-search">
         </div>
     </div>
@@ -166,7 +174,7 @@ function changeInputType(oldObject, oType) {
 
 Bundle.Option = Class.create();
 Bundle.Option.prototype = {
-    idLabel : '{$block->escapeJs($block->getFieldId())}',
+    idLabel : '{$escaper->escapeJs($block->getFieldId())}',
     templateText : '',
     itemsCount : 0,
     initialize : function(template) {
@@ -314,7 +322,7 @@ foreach ($block->getOptions() as $_option) {
     if ($_option->getSelections()) {
         foreach ($_option->getSelections() as $_selection) {
             /** @var $_selection \Magento\Catalog\Model\Product */
-            $_selection->setName($block->escapeHtml($_selection->getName()));
+            $_selection->setName($escaper->escapeHtml($_selection->getName()));
             $scriptString .= /* @noEscape */ 'bSelection.addRow(optionIndex,' . $_selection->toJson() . ');' . PHP_EOL;
         }
     }

--- a/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/selection.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/product/edit/bundle/option/selection.phtml
@@ -3,26 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Selection;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Selection $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Bundle\Block\Adminhtml\Catalog\Product\Edit\Tab\Bundle\Option\Selection */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <script id="bundle-option-selection-box-template" type="text/x-magento-template">
     <table class="admin__control-table">
         <thead>
             <tr class="headings">
                 <th class="col-draggable"></th>
-                <th class="col-default"><?= $block->escapeHtml(__('Default')) ?></th>
-                <th class="col-name"><?= $block->escapeHtml(__('Name')) ?></th>
-                <th class="col-sku"><?= $block->escapeHtml(__('SKU')) ?></th>
+                <th class="col-default"><?= $escaper->escapeHtml(__('Default')) ?></th>
+                <th class="col-name"><?= $escaper->escapeHtml(__('Name')) ?></th>
+                <th class="col-sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
             <?php if ($block->getCanReadPrice() !== false): ?>
-                <th class="col-price price-type-box"><?= $block->escapeHtml(__('Price')) ?></th>
-                <th class="col-price price-type-box"><?= $block->escapeHtml(__('Price Type')) ?></th>
+                <th class="col-price price-type-box"><?= $escaper->escapeHtml(__('Price')) ?></th>
+                <th class="col-price price-type-box"><?= $escaper->escapeHtml(__('Price Type')) ?></th>
             <?php endif; ?>
-                <th class="col-qty"><?= $block->escapeHtml(__('Default Quantity')) ?></th>
-                <th class="col-uqty qty-box"><?= $block->escapeHtml(__('User Defined')) ?></th>
-                <th class="col-order type-order"><?= $block->escapeHtml(__('Position')) ?></th>
+                <th class="col-qty"><?= $escaper->escapeHtml(__('Default Quantity')) ?></th>
+                <th class="col-uqty qty-box"><?= $escaper->escapeHtml(__('User Defined')) ?></th>
+                <th class="col-order type-order"><?= $escaper->escapeHtml(__('Position')) ?></th>
                 <th class="col-actions"></th>
             </tr>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display:none', 'th.col-order.type-order') ?>
@@ -35,20 +42,20 @@
     <td class="col-draggable">
         <span data-role="draggable-handle" class="draggable-handle"></span>
         <input type="hidden"
-               id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_id<%- data.index %>"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_id<%- data.index %>"
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][selection_id]"
                value="<%- data.selection_id %>"/>
         <input type="hidden"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][option_id]"
                value="<%- data.option_id %>"/>
         <input type="hidden"
                class="product"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][product_id]"
                value="<%- data.product_id %>"/>
-        <input type="hidden" name="<?= $block->escapeHtmlAttr($block->getFieldName())
+        <input type="hidden" name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
         ?>[<%- data.parentIndex %>][<%- data.index %>][delete]"
                value=""
                class="delete"/>
@@ -57,7 +64,7 @@
         <input onclick="bSelection.checkGroup(event)"
                type="<%- data.option_type %>"
                class="default"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][is_default]"
                value="1" <%- data.checked %> />
     </td>
@@ -65,10 +72,10 @@
     <td class="col-sku"><%- data.sku %></td>
 <?php if ($block->getCanReadPrice() !== false): ?>
     <td class="col-price price-type-box">
-        <input id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_value"
+        <input id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_value"
                class="input-text required-entry validate-zero-or-greater"
                type="text"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][selection_price_value]"
                value="<%- data.selection_price_value %>"
             <?php if ($block->getCanEditPrice() === false): ?>
@@ -81,24 +88,24 @@
     </td>
 <?php else: ?>
     <input type="hidden"
-           id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_value"
-           name="<?= $block->escapeHtmlAttr($block->getFieldName())
+           id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_value"
+           name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
             ?>[<%- data.parentIndex %>][<%- data.index %>][selection_price_value]" value="0" />
     <input type="hidden"
-           id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_type"
-           name="<?= $block->escapeHtmlAttr($block->getFieldName())
+           id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_type"
+           name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
             ?>[<%- data.parentIndex %>][<%- data.index %>][selection_price_type]" value="0" />
     <?php if ($block->isUsedWebsitePrice()): ?>
     <input type="hidden"
-           id="<?= $block->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_scope"
-           name="<?= $block->escapeHtmlAttr($block->getFieldName())
+           id="<?= $escaper->escapeHtmlAttr($block->getFieldId()) ?>_<%- data.index %>_price_scope"
+           name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
             ?>[<%- data.parentIndex %>][<%- data.index %>][default_price_scope]" value="1" />
     <?php endif; ?>
 <?php endif; ?>
     <td class="col-qty">
         <input class="input-text required-entry validate-greater-zero-based-on-option validate-zero-or-greater"
                type="text"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][selection_qty]"
                value="<%- data.selection_qty %>" />
     </td>
@@ -110,7 +117,7 @@
     <td class="col-order type-order"">
         <input class="input-text required-entry validate-zero-or-greater"
                type="text"
-               name="<?= $block->escapeHtmlAttr($block->getFieldName())
+               name="<?= $escaper->escapeHtmlAttr($block->getFieldName())
                 ?>[<%- data.parentIndex %>][<%- data.index %>][position]"
                value="<%- data.position %>" />
     </td>
@@ -134,7 +141,7 @@ var bundleTemplateBox = jQuery('#bundle-option-selection-box-template').html(),
 
 Bundle.Selection = Class.create();
 Bundle.Selection.prototype = {
-    idLabel : '{$block->escapeJs($block->getFieldId())}',
+    idLabel : '{$escaper->escapeJs($block->getFieldId())}',
     scopePrice : {$isUsedWebsitePrice},
     templateBox : '',
     templateRow : '',
@@ -143,7 +150,7 @@ Bundle.Selection.prototype = {
     gridSelection: new Hash(),
     gridRemoval: new Hash(),
     gridSelectedProductSkus: [],
-    selectionSearchUrl: '{$block->escapeJs($block->getSelectionSearchUrl())}',
+    selectionSearchUrl: '{$escaper->escapeJs($block->getSelectionSearchUrl())}',
 
     initialize : function() {
         this.templateBox = '<div class="tier form-list"

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/create/items/renderer.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
- */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -35,7 +38,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
@@ -52,9 +55,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index == $_count && !$_showlastRow) ? ' class="border"' : '' ?>>
         <?php if (!$_item->getOrderItem()->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -72,31 +75,31 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->canShowPriceInfo($_item)): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyOrdered() * 1 ?></td>
                     </tr>
                     <?php if ((float) $_item->getOrderItem()->getQtyInvoiced()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Invoiced')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Invoiced')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyInvoiced() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyShipped() &&
                         $block->isShipmentSeparately($_item)): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyRefunded()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Refunded')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Refunded')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyRefunded() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyCanceled()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Canceled')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Canceled')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyCanceled() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -104,12 +107,12 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php elseif ($block->isShipmentSeparately($_item)): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyOrdered() * 1 ?></td>
                     </tr>
                     <?php if ((float) $_item->getOrderItem()->getQtyShipped()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -124,7 +127,7 @@ $catalogHelper = $block->getData('catalogHelper');
                 <?php if ($block->canReturnItemToStock($_item)): ?>
                     <input type="checkbox"
                            class="admin__control-checkbox"
-                           name="creditmemo[items][<?= $block->escapeHtmlAttr($_item->getOrderItemId())
+                           name="creditmemo[items][<?= $escaper->escapeHtmlAttr($_item->getOrderItemId())
                             ?>][back_to_stock]"
                            value="1"<?php if ($_item->getBackToStock()):?> checked="checked"<?php endif;?> />
                     <label class="admin__field-label"></label>
@@ -139,7 +142,7 @@ $catalogHelper = $block->getData('catalogHelper');
                 <?php if ($block->canEditQty()): ?>
                     <input type="text"
                            class="input-text admin__control-text qty-input"
-                           name="creditmemo[items][<?= $block->escapeHtmlAttr($_item->getOrderItemId()) ?>][qty]"
+                           name="creditmemo[items][<?= $escaper->escapeHtmlAttr($_item->getOrderItemId()) ?>][qty]"
                            value="<?= (float)$_item->getQty() * 1 ?>" />
                 <?php else: ?>
                     <?= (float)$_item->getQty() * 1 ?>
@@ -184,16 +187,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions($_item->getOrderItem())): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions($_item->getOrderItem()) as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -211,7 +214,7 @@ script;
             <?php else: ?>
                 &nbsp;
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
         <td>&nbsp;</td>
         <td>&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/creditmemo/view/items/renderer.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
- */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -35,7 +38,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
@@ -50,9 +53,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index == $_count && !$_showlastRow) ? ' class="border"' : '' ?>>
         <?php if (!$_item->getOrderItem()->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -109,16 +112,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions()): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions() as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -134,7 +137,7 @@ script;
                 <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($block->getItem()->getDescription()) ?>
+            <?= $escaper->escapeHtml($block->getItem()->getDescription()) ?>
         </td>
         <td>&nbsp;</td>
         <td>&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/create/items/renderer.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
- */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -45,7 +48,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
@@ -61,9 +64,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index == $_count && !$_showlastRow) ? ' class="border"' : '' ?>>
         <?php if (!$_item->getOrderItem()->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -83,31 +86,31 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->canShowPriceInfo($_item) || $shipTogether): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><span><?= (float)$_item->getOrderItem()->getQtyOrdered() * 1 ?></span></td>
                     </tr>
                     <?php if ((float) $_item->getOrderItem()->getQtyInvoiced()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Invoiced')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Invoiced')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyInvoiced() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyShipped() &&
                         $block->isShipmentSeparately($_item)): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyRefunded()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Refunded')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Refunded')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyRefunded() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getOrderItem()->getQtyCanceled()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Canceled')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Canceled')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyCanceled() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -115,12 +118,12 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php elseif ($block->isShipmentSeparately($_item)): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyOrdered() * 1 ?></td>
                     </tr>
                     <?php if ((float) $_item->getOrderItem()->getQtyShipped()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getOrderItem()->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -134,7 +137,7 @@ $catalogHelper = $block->getData('catalogHelper');
                 <?php if ($block->canEditQty() && $canEditItemQty): ?>
                     <input type="text"
                            class="input-text admin__control-text qty-input"
-                           name="invoice[items][<?= $block->escapeHtmlAttr($_item->getOrderItemId()) ?>]"
+                           name="invoice[items][<?= $escaper->escapeHtmlAttr($_item->getOrderItemId()) ?>]"
                            value="<?= (float)$_item->getQty() * 1 ?>" />
                 <?php else: ?>
                     <?= (float)$_item->getQty() * 1 ?>
@@ -179,16 +182,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions($_item->getOrderItem())): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions($_item->getOrderItem()) as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -206,7 +209,7 @@ script;
             <?php else: ?>
                 &nbsp;
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
         <td>&nbsp;</td>
         <td>&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/invoice/view/items/renderer.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer
- */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -35,7 +38,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
@@ -50,9 +53,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index == $_count && !$_showlastRow) ? ' class="border"' : '' ?>>
         <?php if (!$_item->getOrderItem()->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         <?php else: ?>
@@ -110,16 +113,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions()): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions() as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -135,7 +138,7 @@ script;
                 <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($block->getItem()->getDescription()) ?>
+            <?= $escaper->escapeHtml($block->getItem()->getDescription()) ?>
         </td>
         <td>&nbsp;</td>
         <td>&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer
- */
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\View\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -35,7 +38,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td>&nbsp;</td>
             <td>&nbsp;</td>
@@ -53,11 +56,11 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index==$_count && !$_showlastRow)?' class="border"':'' ?>>
         <?php if (!$_item->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title" id="order_item_<?= $block->escapeHtmlAttr($_item->getId()) ?>_title">
-                <?= $block->escapeHtml($_item->getName()) ?>
+            <div class="product-title" id="order_item_<?= $escaper->escapeHtmlAttr($_item->getId()) ?>_title">
+                <?= $escaper->escapeHtml($_item->getName()) ?>
             </div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -68,7 +71,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php endif; ?>
         <td class="col-status">
             <?php if ($block->canShowPriceInfo($_item)): ?>
-                <?= $block->escapeHtml($_item->getStatus()) ?>
+                <?= $escaper->escapeHtml($_item->getStatus()) ?>
             <?php else: ?>
                 &nbsp;
             <?php endif; ?>
@@ -91,30 +94,30 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->canShowPriceInfo($_item)): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><?= (float)$_item->getQtyOrdered() * 1 ?></td>
                     </tr>
                     <?php if ((float) $_item->getQtyInvoiced()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Invoiced')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Invoiced')) ?></th>
                         <td><?= (float)$_item->getQtyInvoiced() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getQtyShipped() && $block->isShipmentSeparately($_item)): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getQtyRefunded()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Refunded')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Refunded')) ?></th>
                         <td><?= (float)$_item->getQtyRefunded() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
                     <?php if ((float) $_item->getQtyCanceled()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Canceled')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Canceled')) ?></th>
                         <td><?= (float)$_item->getQtyCanceled() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -122,12 +125,12 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php elseif ($block->isShipmentSeparately($_item)): ?>
                 <table class="qty-table">
                     <tr>
-                        <th><?= $block->escapeHtml(__('Ordered')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Ordered')) ?></th>
                         <td><?= (float)$_item->getQtyOrdered() * 1 ?></td>
                     </tr>
                     <?php if ((float) $_item->getQtyShipped()): ?>
                     <tr>
-                        <th><?= $block->escapeHtml(__('Shipped')) ?></th>
+                        <th><?= $escaper->escapeHtml(__('Shipped')) ?></th>
                         <td><?= (float)$_item->getQtyShipped() * 1 ?></td>
                     </tr>
                     <?php endif; ?>
@@ -179,16 +182,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions()): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions() as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?>:</dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?>:</dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -206,7 +209,7 @@ script;
             <?php else: ?>
                 &nbsp;
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
         <td>&nbsp;</td>
         <td>&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/create/items/renderer.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php
@@ -32,7 +38,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td class="col-product">&nbsp;</td>
             <td class="col-qty last">&nbsp;</td>
@@ -43,9 +49,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr class="<?= (++$_index == $_count && !$_showlastRow) ? 'border' : '' ?>">
         <?php if (!$_item->getOrderItem()->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -63,7 +69,7 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->isShipmentSeparately($_item)): ?>
                 <input type="text"
                        class="input-text admin__control-text"
-                       name="shipment[items][<?= $block->escapeHtmlAttr($_item->getOrderItemId()) ?>]"
+                       name="shipment[items][<?= $escaper->escapeHtmlAttr($_item->getOrderItemId()) ?>]"
                        value="<?= (float)$_item->getQty() * 1 ?>" />
             <?php else: ?>
                 &nbsp;
@@ -77,17 +83,17 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions($_item->getOrderItem())): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions($_item->getOrderItem()) as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
-                                <?= $block->escapeHtml($_remainder) ?>
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid()) ?>">
+                                <?= $escaper->escapeHtml($_remainder) ?>
                             </span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -105,7 +111,7 @@ script;
                         <?php else: ?>
                 &nbsp;
                         <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
         <td class="col-ordered-qty">&nbsp;</td>
         <td class="col-qty last">&nbsp;</td>

--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/shipment/view/items/renderer.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Bundle\Block\Adminhtml\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?php $_item = $block->getItem() ?>
@@ -33,7 +39,7 @@ $catalogHelper = $block->getData('catalogHelper');
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
-                <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                <div class="option-label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
             </td>
             <td class="col-qty last">&nbsp;</td>
         </tr>
@@ -43,9 +49,9 @@ $catalogHelper = $block->getData('catalogHelper');
     <tr<?= (++$_index == $_count && !$_showlastRow) ? ' class="border"' : '' ?>>
         <?php if (!$_item->getParentItem()): ?>
         <td class="col-product">
-            <div class="product-title"><?= $block->escapeHtml($_item->getName()) ?></div>
+            <div class="product-title"><?= $escaper->escapeHtml($_item->getName()) ?></div>
             <div class="product-sku-block">
-                <span><?= $block->escapeHtml(__('SKU')) ?>:</span>
+                <span><?= $escaper->escapeHtml(__('SKU')) ?>:</span>
                 <?= /* @noEscape */ implode('<br />', $catalogHelper->splitSku($_item->getSku())) ?>
             </div>
         </td>
@@ -58,7 +64,7 @@ $catalogHelper = $block->getData('catalogHelper');
                 <?php if (isset($shipItems[$_item->getId()])): ?>
                     <?= (float)$shipItems[$_item->getId()]->getQty() * 1 ?>
                 <?php elseif ($_item->getIsVirtual()): ?>
-                    <?= $block->escapeHtml(__('N/A')) ?>
+                    <?= $escaper->escapeHtml(__('N/A')) ?>
                 <?php else: ?>
                     0
                 <?php endif; ?>
@@ -74,16 +80,16 @@ $catalogHelper = $block->getData('catalogHelper');
             <?php if ($block->getOrderOptions($_item->getOrderItem())): ?>
                 <dl class="item-options">
                 <?php foreach ($block->getOrderOptions($_item->getOrderItem()) as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <dd>
                     <?php if (isset($option['custom_view']) && $option['custom_view']): ?>
-                        <?= $block->escapeHtml($option['value']) ?>
+                        <?= $escaper->escapeHtml($option['value']) ?>
                     <?php else: ?>
-                        <?= $block->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
+                        <?= $escaper->escapeHtml($block->truncateString($option['value'], 55, '', $_remainder)) ?>
                         <?php if ($_remainder):?>
-                            ... <span id="<?= $block->escapeHtmlAttr($_id = 'id' . uniqid())
-                            ?>"><?= $block->escapeHtml($_remainder) ?></span>
-                            <?php $escapedId = /* @noEscape */ $block->escapeJs($_id);
+                            ... <span id="<?= $escaper->escapeHtmlAttr($_id = 'id' . uniqid())
+                            ?>"><?= $escaper->escapeHtml($_remainder) ?></span>
+                            <?php $escapedId = /* @noEscape */ $escaper->escapeJs($_id);
                             $scriptString = <<<script
                                 require(['prototype'], function(){
                                     $('{$escapedId}').hide();
@@ -99,7 +105,7 @@ script;
                 <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
         <td class="last">&nbsp;</td>
     </tr>

--- a/app/code/Magento/Bundle/view/base/templates/product/price/tier_prices.phtml
+++ b/app/code/Magento/Bundle/view/base/templates/product/price/tier_prices.phtml
@@ -3,19 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
-/**
- * @var \Magento\Framework\Pricing\Render\PriceBox $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- */
-/** @var \Magento\Bundle\Pricing\Price\TierPrice $tierPriceModel */
+use Magento\Bundle\Pricing\Price\TierPrice;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+use Magento\Framework\Pricing\Render\PriceBox;
+
+/** @var Escaper $escaper */
+/** @var PriceBox $block */
+/** @var LocaleFormatter $localeFormatter */
+/** @var TierPrice $tierPriceModel */
 $tierPriceModel = $block->getPrice();
 $tierPrices = $tierPriceModel->getTierPriceList();
 ?>
 <?php if (count($tierPrices)):?>
-    <ul class="<?= $block->escapeHtmlAttr(($block->hasListClass() ? $block->getListClass() : 'prices-tier items')) ?>">
+    <ul class="<?= $escaper->escapeHtmlAttr(($block->hasListClass() ? $block->getListClass() : 'prices-tier items')) ?>">
         <?php foreach ($tierPrices as $index => $price): ?>
             <li class="item">
                 <?= /* @noEscape */ __(

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/backbutton.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/backbutton.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <button type="button"
         class="action back customization">
-    <span><?= $block->escapeHtml(__('Go back to product details')) ?></span>
+    <span><?= $escaper->escapeHtml(__('Go back to product details')) ?></span>
 </button>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/customize.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/customize.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 
 <?php $_product = $block->getProduct() ?>
@@ -11,7 +16,7 @@
         <button id="bundle-slide"
                 class="action primary customize"
                 type="button">
-            <span><?= $block->escapeHtml(__('Customize and Add to Cart')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Customize and Add to Cart')) ?></span>
         </button>
     </div>
 <?php endif;?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/options/notice.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/options/notice.phtml
@@ -3,5 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<p class="required"><?= $block->escapeHtml(__('* Required Fields')) ?></p>
+<p class="required"><?= $escaper->escapeHtml(__('* Required Fields')) ?></p>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/summary.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/summary.phtml
@@ -3,6 +3,11 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 $_product = $block->getProduct();
@@ -12,27 +17,27 @@ $_product = $block->getProduct();
      class="block-bundle-summary"
      data-mage-init='{"sticky":{"container": ".product-add-form"}}'>
     <div class="title">
-        <strong><?= $block->escapeHtml(__('Your Customization')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Your Customization')) ?></strong>
     </div>
     <div class="content">
         <div class="bundle-info">
             <?= $block->getImage($_product, 'bundled_product_customization_page')->toHtml() ?>
             <div class="product-details">
-                <strong class="product name"><?= $block->escapeHtml($_product->getName()) ?></strong>
+                <strong class="product name"><?= $escaper->escapeHtml($_product->getName()) ?></strong>
                 <?php if ($_product->getIsSalable()) : ?>
-                    <p class="available stock" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                        <span><?= $block->escapeHtml(__('In stock')) ?></span>
+                    <p class="available stock" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                        <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
                     </p>
                 <?php else : ?>
-                    <p class="unavailable stock" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                        <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                    <p class="unavailable stock" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                     </p>
                 <?php endif; ?>
                 <?= $block->getChildHtml('', true) ?>
             </div>
         </div>
         <div class="bundle-summary">
-            <strong class="subtitle"><?= $block->escapeHtml(__('Summary')) ?></strong>
+            <strong class="subtitle"><?= $escaper->escapeHtml(__('Summary')) ?></strong>
             <div id="bundle-summary" data-container="product-summary">
                 <ul data-mage-init='{"productSummary": []}' class="bundle items"></ul>
                 <script data-template="bundle-summary" type="text/x-magento-template">

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle */
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Bundle $block */
 ?>
 <?php $_product = $block->getProduct() ?>
 <?php if ($block->displayProductStockStatus()) : ?>
     <?php if ($_product->isAvailable()) : ?>
-        <p class="stock available" title="<?= $block->escapeHtmlAttr(__('Availability:')) ?>">
-            <span><?= $block->escapeHtml(__('In stock')) ?></span>
+        <p class="stock available" title="<?= $escaper->escapeHtmlAttr(__('Availability:')) ?>">
+            <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
         </p>
     <?php else : ?>
-        <p class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability:')) ?>">
-            <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+        <p class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability:')) ?>">
+            <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
         </p>
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/checkbox.phtml
@@ -3,20 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Checkbox;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Checkbox */ ?>
+<?php /* @var Checkbox $block */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_selections = $_option->getSelections() ?>
-<?php $inputClass = 'checkbox product bundle option bundle-option-' . $block->escapeHtmlAttr($_option->getId()) ?>
-<?php $inputId = 'bundle-option-' . $block->escapeHtmlAttr($_option->getId()) ?>
-<?php $inputName = 'bundle_option[' . $block->escapeHtmlAttr($_option->getId()) . ']' ?>
+<?php $inputClass = 'checkbox product bundle option bundle-option-' . $escaper->escapeHtmlAttr($_option->getId()) ?>
+<?php $inputId = 'bundle-option-' . $escaper->escapeHtmlAttr($_option->getId()) ?>
+<?php $inputName = 'bundle_option[' . $escaper->escapeHtmlAttr($_option->getId()) . ']' ?>
 <?php $dataValidation = 'data-validate="{\'validate-one-required-by-name\':\'input[name^=&quot;bundle_option[' .
-    $block->escapeHtmlAttr($_option->getId()) . ']&quot;]:checked\'}"' ?>
+    $escaper->escapeHtmlAttr($_option->getId()) . ']&quot;]:checked\'}"' ?>
 
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control">
         <div class="nested options-list">
@@ -24,38 +30,38 @@
                 <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>
                 <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($_selections[0]) ?>
                 <input type="hidden"
-                       class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>  product bundle option"
-                       name="bundle_option[<?= $block->escapeHtml($_option->getId()) ?>]"
-                       value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"/>
+                       class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>  product bundle option"
+                       name="bundle_option[<?= $escaper->escapeHtml($_option->getId()) ?>]"
+                       value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"/>
             <?php else: ?>
                 <?php foreach ($_selections as $selection): ?>
                     <?php $sectionId = $selection->getSelectionId() ?>
                     <div class="field choice">
                         <input class="<?=/* @noEscape */ $inputClass ?> change-container-classname"
-                               id="<?=/* @noEscape */ $inputId . '-' . $block->escapeHtmlAttr($sectionId)?>"
+                               id="<?=/* @noEscape */ $inputId . '-' . $escaper->escapeHtmlAttr($sectionId)?>"
                                type="checkbox"
                                <?php if ($_option->getRequired()): ?>
                                     <?= /* @noEscape */ $dataValidation ?>
                                <?php endif;?>
-                               name="<?=/* @noEscape */ $inputName .'['. $block->escapeHtmlAttr($sectionId)?>]"
-                               data-selector="<?= /* @noEscape */ $inputName.'['.$block->escapeHtmlAttr($sectionId)?>]"
+                               name="<?=/* @noEscape */ $inputName .'['. $escaper->escapeHtmlAttr($sectionId)?>]"
+                               data-selector="<?= /* @noEscape */ $inputName.'['.$escaper->escapeHtmlAttr($sectionId)?>]"
                                 <?php if ($block->isSelected($selection)): ?>
                                     <?= ' checked="checked"' ?>
                                 <?php endif; ?>
                                 <?php if (!$selection->isSaleable()): ?>
                                     <?= ' disabled="disabled"' ?>
                                 <?php endif; ?>
-                               value="<?= $block->escapeHtmlAttr($sectionId) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($sectionId) ?>"
                                data-errors-message-box="#validation-message-box"/>
                         <label class="label"
-                               for="<?= /* @noEscape */ $inputId . '-' . $block->escapeHtmlAttr($sectionId) ?>">
+                               for="<?= /* @noEscape */ $inputId . '-' . $escaper->escapeHtmlAttr($sectionId) ?>">
                             <span><?= /* @noEscape */ $block->getSelectionQtyTitlePrice($selection) ?></span>
                             <br/>
                             <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($selection) ?>
                         </label>
                     </div>
                 <?php endforeach; ?>
-                <div id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></div>
+                <div id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></div>
                 <div id="validation-message-box"></div>
             <?php endif; ?>
         </div>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/multi.phtml
@@ -3,34 +3,40 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Multi;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Multi */ ?>
+<?php /* @var Multi $block */ ?>
 <?php $_option = $block->getOption() ?>
 <?php $_selections = $_option->getSelections() ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
-    <label class="label" for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+    <label class="label" for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>">
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control">
         <?php if ($block->showSingle()) : ?>
             <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selections[0]) ?>
             <input type="hidden"
-                   name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>" 
-                   class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?> bundle option"/>
+                   name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"
+                   class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?> bundle option"/>
         <?php else : ?>
             <select multiple="multiple"
                     size="5"
-                    id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>][]"
-                    data-selector="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>][]"
-                    class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?> multiselect product bundle option change-container-classname"
+                    id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                    name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>][]"
+                    data-selector="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>][]"
+                    class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?> multiselect product bundle option change-container-classname"
                     <?php if ($_option->getRequired()) { echo 'data-validate={required:true}'; } ?>>
                 <?php if (!$_option->getRequired()) : ?>
-                    <option value=""><?= $block->escapeHtml(__('None')) ?></option>
+                    <option value=""><?= $escaper->escapeHtml(__('None')) ?></option>
                 <?php endif; ?>
                 <?php foreach ($_selections as $_selection) : ?>
-                    <option value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                    <option value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                             <?php if ($block->isSelected($_selection)) { echo ' selected="selected"'; } ?>
                             <?php if (!$_selection->isSaleable()) { echo ' disabled="disabled"'; } ?>>
                         <?= /* @noEscape */ $block->getSelectionQtyTitlePrice($_selection, false) ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Radio;
 use Magento\Bundle\ViewModel\ValidateQuantity;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Radio */ ?>
+<?php /* @var Radio $block */ ?>
 <?php $_option = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>
@@ -16,7 +22,7 @@ $viewModel = $block->getData('validateQuantityViewModel');
 ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
     <label class="label">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control">
         <div class="nested options-list">
@@ -35,13 +41,13 @@ $viewModel = $block->getData('validateQuantityViewModel');
                     <div class="field choice">
                         <input type="radio"
                                class="radio product bundle option"
-                               id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                               name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                               data-selector="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
+                               id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                               name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                               data-selector="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
                                <?= ($_default && $_default->isSalable())?'':' checked="checked" ' ?>
                                value=""/>
-                        <label class="label" for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>">
-                            <span><?= $block->escapeHtml(__('None')) ?></span>
+                        <label class="label" for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>">
+                            <span><?= $escaper->escapeHtml(__('None')) ?></span>
                         </label>
                     </div>
                 <?php endif; ?>
@@ -49,37 +55,37 @@ $viewModel = $block->getData('validateQuantityViewModel');
                     <div class="field choice">
                         <input type="radio"
                                class="radio product bundle option change-container-classname"
-                               id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                               id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                                <?php if ($_option->getRequired()) { echo 'data-validate="{\'validate-one-required-by-name\':true}"'; }?>
-                               name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                               data-selector="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
+                               name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                               data-selector="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
                                <?php if ($block->isSelected($_selection)) { echo ' checked="checked"'; } ?>
                                <?php if (!$_selection->isSaleable()) { echo ' disabled="disabled"'; } ?>
-                               value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"/>
+                               value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"/>
                         <label class="label"
-                               for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>">
+                               for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>">
                             <span><?= /* @noEscape */ $block->getSelectionTitlePrice($_selection) ?></span>
                             <br/>
                             <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($_selection) ?>
                         </label>
                     </div>
                 <?php endforeach; ?>
-                <div id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-container"></div>
+                <div id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-container"></div>
             <?php endif; ?>
             <div class="field qty qty-holder">
-                <label class="label" for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input">
-                    <span><?= $block->escapeHtml(__('Quantity')) ?></span>
+                <label class="label" for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input">
+                    <span><?= $escaper->escapeHtml(__('Quantity')) ?></span>
                 </label>
                 <div class="control">
                     <input <?php if (!$_canChangeQty) { echo ' disabled="disabled"'; } ?>
-                           id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input"
+                           id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input"
                            class="input-text qty<?php if (!$_canChangeQty) { echo ' qty-disabled'; } ?>"
                            type="number"
                            min="0"
-                           data-validate="<?= $block->escapeHtmlAttr($viewModel->getQuantityValidators()) ?>"
-                           name="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                           data-selector="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                           value="<?= $block->escapeHtmlAttr($_defaultQty) ?>"/>
+                           data-validate="<?= $escaper->escapeHtmlAttr($viewModel->getQuantityValidators()) ?>"
+                           name="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                           data-selector="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                           value="<?= $escaper->escapeHtmlAttr($_defaultQty) ?>"/>
                 </div>
             </div>
         </div>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/select.phtml
@@ -3,9 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Select;
 use Magento\Bundle\ViewModel\ValidateQuantity;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Select */ ?>
+<?php /* @var Select $block */ ?>
 <?php $_option      = $block->getOption(); ?>
 <?php $_selections  = $_option->getSelections(); ?>
 <?php $_default     = $_option->getDefaultSelection(); ?>
@@ -15,36 +22,36 @@ use Magento\Bundle\ViewModel\ValidateQuantity;
 $viewModel = $block->getData('validateQuantityViewModel');
 ?>
 <div class="field option <?= ($_option->getRequired()) ? ' required': '' ?>">
-    <label class="label" for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>">
-        <span><?= $block->escapeHtml($_option->getTitle()) ?></span>
+    <label class="label" for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>">
+        <span><?= $escaper->escapeHtml($_option->getTitle()) ?></span>
     </label>
     <div class="control">
         <?php if ($block->showSingle()) : ?>
             <?= /* @noEscape */ $block->getSelectionTitlePrice($_selections[0]) ?>
             <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($_selections[0]) ?>
             <input type="hidden"
-                   class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>  product bundle option"
-                   name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"/>
+                   class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>  product bundle option"
+                   name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($_selections[0]->getSelectionId()) ?>"/>
         <?php else :?>
-            <select id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>"
-                    name="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                    data-selector="bundle_option[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                    class="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?> product bundle option bundle-option-select change-container-classname"
+            <select id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>"
+                    name="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                    data-selector="bundle_option[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                    class="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?> product bundle option bundle-option-select change-container-classname"
                 <?php if ($_option->getRequired()) { echo 'data-validate = {required:true}'; } ?>>
-                <option value=""><?= $block->escapeHtml(__('Choose a selection...')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Choose a selection...')) ?></option>
                 <?php foreach ($_selections as $_selection) : ?>
-                    <option value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                    <option value="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                         <?php if ($block->isSelected($_selection)) { echo ' selected="selected"'; } ?>
                         <?php if (!$_selection->isSaleable()) { echo ' disabled="disabled"'; } ?>>
                         <?= /* @noEscape */ $block->getSelectionTitlePrice($_selection, false) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
-            <div id="option-tier-prices-<?= $block->escapeHtmlAttr($_option->getId()) ?>" class="option-tier-prices">
+            <div id="option-tier-prices-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>" class="option-tier-prices">
                 <?php foreach ($_selections as $_selection) : ?>
                     <div data-role="selection-tier-prices"
-                         data-selection-id="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                         data-selection-id="<?= $escaper->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                          class="selection-tier-prices">
                         <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($_selection) ?>
                     </div>
@@ -53,19 +60,19 @@ $viewModel = $block->getData('validateQuantityViewModel');
         <?php endif; ?>
         <div class="nested">
             <div class="field qty qty-holder">
-                <label class="label" for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input">
-                    <span><?= $block->escapeHtml(__('Quantity')) ?></span>
+                <label class="label" for="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input">
+                    <span><?= $escaper->escapeHtml(__('Quantity')) ?></span>
                 </label>
                 <div class="control">
                     <input <?php if (!$_canChangeQty) { echo ' disabled="disabled"'; } ?>
-                           id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-qty-input"
+                           id="bundle-option-<?= $escaper->escapeHtmlAttr($_option->getId()) ?>-qty-input"
                            class="input-text qty<?php if (!$_canChangeQty) { echo ' qty-disabled'; } ?>"
                            type="number"
                            min="0"
-                           data-validate="<?= $block->escapeHtmlAttr($viewModel->getQuantityValidators()) ?>"
-                           name="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                           data-selector="bundle_option_qty[<?= $block->escapeHtmlAttr($_option->getId()) ?>]"
-                           value="<?= $block->escapeHtmlAttr($_defaultQty) ?>"/>
+                           data-validate="<?= $escaper->escapeHtmlAttr($viewModel->getQuantityValidators()) ?>"
+                           name="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                           data-selector="bundle_option_qty[<?= $escaper->escapeHtmlAttr($_option->getId()) ?>]"
+                           value="<?= $escaper->escapeHtmlAttr($_defaultQty) ?>"/>
                 </div>
             </div>
         </div>

--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/options.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/options.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Catalog\Product\View\Type\Bundle;
+use Magento\Framework\Escaper;
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-?>
-<?php /** @var $block Magento\Bundle\Block\Catalog\Product\View\Type\Bundle */ ?>
-<?php
+
+/** @var Escaper $escaper */
+/** @var Bundle $block */
 $product = $block->getProduct();
 $helper = $this->helper(Magento\Catalog\Helper\Output::class);
 $stripSelection = $product->getConfigureMode() ? true : false;
@@ -26,7 +31,7 @@ $options = $block->decorateArray($block->getOptions($stripSelection));
 </script>
         <fieldset class="fieldset fieldset-bundle-options">
             <legend id="customizeTitle" class="legend title">
-                <span><?= $block->escapeHtml(__('Customize %1', $helper->productAttribute($product, $product->getName(), 'name'))) ?></span>
+                <span><?= $escaper->escapeHtml(__('Customize %1', $helper->productAttribute($product, $product->getName(), 'name'))) ?></span>
             </legend><br />
             <?= $block->getChildHtml('product_info_bundle_options_top') ?>
             <?php foreach ($options as $option) : ?>
@@ -40,6 +45,6 @@ $options = $block->decorateArray($block->getOptions($stripSelection));
             <?php endforeach; ?>
         </fieldset>
     <?php else : ?>
-        <p class="empty"><?= $block->escapeHtml(__('No options of this product are available.')) ?></p>
+        <p class="empty"><?= $escaper->escapeHtml(__('No options of this product are available.')) ?></p>
     <?php endif; ?>
 <?php endif;?>

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/creditmemo/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/creditmemo/default.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
 <?php $parentItem = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrder(); ?>
 
@@ -33,7 +39,7 @@
         <?php if ($_prevOptionId != $attributes['option_id']) : ?>
             <tr class="bundle-option-label">
                 <td colspan="3">
-                    <strong><?= $block->escapeHtml($attributes['option_label']) ?></strong>
+                    <strong><?= $escaper->escapeHtml($attributes['option_label']) ?></strong>
                 </td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
@@ -42,8 +48,8 @@
     <?php if (!$_item->getOrderItem()->getParentItem()) : ?>
         <tr class="bundle-item bundle-parent">
             <td class="item-info">
-                <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-                <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+                <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+                <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
             </td>
     <?php else : ?>
         <tr class="bundle-item bundle-option-value">
@@ -75,12 +81,12 @@
             <?php if ($block->getItemOptions()) : ?>
                 <dl>
                     <?php foreach ($block->getItemOptions() as $option) : ?>
-                        <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-                                    <dd><?= $block->escapeHtml($option['value']) ?></dd>
+                        <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+                                    <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
                     <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/invoice/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/invoice/default.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
-
 <?php $parentItem = $block->getItem() ?>
 <?php $items = $block->getChildren($parentItem) ?>
 <?php $_index = 0 ?>
@@ -34,7 +39,7 @@
         <?php if ($_prevOptionId != $attributes['option_id']) : ?>
             <tr class="bundle-option-label">
                 <td colspan="3">
-                    <strong><em><?= $block->escapeHtml($attributes['option_label']) ?></em></strong>
+                    <strong><em><?= $escaper->escapeHtml($attributes['option_label']) ?></em></strong>
                 </td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
@@ -43,8 +48,8 @@
     <?php if (!$_item->getOrderItem()->getParentItem()) : ?>
         <tr class="bundle-item bundle-parent">
             <td class="item-info">
-                <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-                <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+                <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+                <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
             </td>
     <?php else : ?>
         <tr class="bundle-item bundle-option-value">
@@ -76,12 +81,12 @@
             <?php if ($block->getItemOptions()) : ?>
                 <dl>
                     <?php foreach ($block->getItemOptions() as $option) : ?>
-                        <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-                                    <dd><?= $block->escapeHtml($option['value']) ?></dd>
+                        <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+                                    <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
                     <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/order/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/order/default.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
 <?php $_item = $block->getItem() ?>
 <?php $_order = $block->getOrder() ?>
 
@@ -27,7 +33,7 @@
         <?php if ($_prevOptionId != $attributes['option_id']) : ?>
             <tr class="bundle-option-label">
                 <td colspan="3">
-                    <strong><em><?= $block->escapeHtml($attributes['option_label']) ?></em></strong>
+                    <strong><em><?= $escaper->escapeHtml($attributes['option_label']) ?></em></strong>
                 </td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
@@ -36,8 +42,8 @@
     <?php if (!$_item->getParentItem()) : ?>
         <tr class="bundle-item bundle-parent">
             <td class="item-info">
-                <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-                <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+                <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+                <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
             </td>
             <td class="item-qty">
                 <?= (float)$_item->getQtyOrdered() * 1 ?>
@@ -62,8 +68,8 @@
             <?php if ($block->getItemOptions()) : ?>
             <dl>
                 <?php foreach ($block->getItemOptions() as $option) : ?>
-                <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-                            <dd><?= $block->escapeHtml($option['value']) ?></dd>
+                <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+                            <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
                 <?php endforeach; ?>
             </dl>
             <?php endif; ?>
@@ -71,11 +77,11 @@
                 <table class="message-gift">
                     <tr>
                         <td>
-                            <h3><?= $block->escapeHtml(__('Gift Message')) ?></h3>
-                            <strong><?= $block->escapeHtml(__('From:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getSender()) ?>
-                            <br /><strong><?= $block->escapeHtml(__('To:')) ?></strong> <?= $block->escapeHtml($_giftMessage->getRecipient()) ?>
-                            <br /><strong><?= $block->escapeHtml(__('Message:')) ?></strong>
-                            <br /><?= $block->escapeHtml($_giftMessage->getMessage()) ?>
+                            <h3><?= $escaper->escapeHtml(__('Gift Message')) ?></h3>
+                            <strong><?= $escaper->escapeHtml(__('From:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getSender()) ?>
+                            <br /><strong><?= $escaper->escapeHtml(__('To:')) ?></strong> <?= $escaper->escapeHtml($_giftMessage->getRecipient()) ?>
+                            <br /><strong><?= $escaper->escapeHtml(__('Message:')) ?></strong>
+                            <br /><?= $escaper->escapeHtml($_giftMessage->getMessage()) ?>
                         </td>
                     </tr>
                 </table>

--- a/app/code/Magento/Bundle/view/frontend/templates/email/order/items/shipment/default.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/email/order/items/shipment/default.phtml
@@ -3,10 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
-
 <?php $parentItem = $block->getItem() ?>
 
 <?php $items = array_merge([$parentItem->getOrderItem()], $parentItem->getOrderItem()->getChildrenItems()) ?>
@@ -27,7 +32,7 @@
         <?php if ($_prevOptionId != $attributes['option_id']) : ?>
             <tr class="bundle-option-label">
                 <td colspan="2">
-                    <strong><em><?= $block->escapeHtml($attributes['option_label']) ?></em></strong>
+                    <strong><em><?= $escaper->escapeHtml($attributes['option_label']) ?></em></strong>
                 </td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
@@ -36,8 +41,8 @@
     <?php if (!$_item->getParentItem()) : ?>
         <tr class="bundle-item bundle-parent">
             <td class="item-info">
-                <p class="product-name"><?= $block->escapeHtml($_item->getName()) ?></p>
-                <p class="sku"><?= $block->escapeHtml(__('SKU')) ?>: <?= $block->escapeHtml($block->getSku($_item)) ?></p>
+                <p class="product-name"><?= $escaper->escapeHtml($_item->getName()) ?></p>
+                <p class="sku"><?= $escaper->escapeHtml(__('SKU')) ?>: <?= $escaper->escapeHtml($block->getSku($_item)) ?></p>
             </td>
     <?php else : ?>
         <tr class="bundle-item bundle-option-value">
@@ -50,7 +55,7 @@
                     <?php if (isset($shipItems[$_item->getId()])) : ?>
                         <?= (float)$shipItems[$_item->getId()]->getQty() * 1 ?>
                     <?php elseif ($_item->getIsVirtual()) : ?>
-                        <?= $block->escapeHtml(__('N/A')) ?>
+                        <?= $escaper->escapeHtml(__('N/A')) ?>
                     <?php else : ?>
                         0
                     <?php endif; ?>
@@ -68,12 +73,12 @@
             <?php if ($block->getItemOptions()) : ?>
             <dl>
                 <?php foreach ($block->getItemOptions() as $option) : ?>
-                <dt><strong><em><?= $block->escapeHtml($option['label']) ?></em></strong></dt>
-                            <dd><?= $block->escapeHtml($option['value']) ?></dd>
+                <dt><strong><em><?= $escaper->escapeHtml($option['label']) ?></em></strong></dt>
+                            <dd><?= $escaper->escapeHtml($option['value']) ?></dd>
                 <?php endforeach; ?>
             </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/creditmemo/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/creditmemo/items/renderer.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var LocaleFormatter $localeFormatter */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.Files.LineLength
-?>
-<?php
-/**
- * @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- */
 ?>
 <?php $parentItem = $block->getItem() ?>
 
@@ -32,53 +36,53 @@
         <?php $attributes = $block->getSelectionAttributes($_item) ?>
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
             <tr class="options-label">
-                <td class="col label" colspan="7"><div class="option label"><?= $block->escapeHtml($attributes['option_label']) ?></div></td>
+                <td class="col label" colspan="7"><div class="option label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div></td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
         <?php endif; ?>
     <?php endif; ?>
-<tr id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>"
+<tr id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
     class="<?php if ($_item->getOrderItem()->getParentItem()): ?>item-options-container<?php else: ?>item-parent<?php endif; ?>"
     <?php if ($_item->getParentItem()): ?>
-        data-th="<?= $block->escapeHtmlAttr($attributes['option_label']) ?>"
+        data-th="<?= $escaper->escapeHtmlAttr($attributes['option_label']) ?>"
     <?php endif; ?>>
     <?php if (!$_item->getOrderItem()->getParentItem()): ?>
-        <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-            <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+        <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+            <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         </td>
     <?php else: ?>
-        <td class="col value" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
+        <td class="col value" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
     <?php endif; ?>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= $block->escapeHtml($_item->getSku()) ?></td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= $escaper->escapeHtml($_item->getSku()) ?></td>
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= $block->getItemPriceHtml($_item) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Quantity')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Quantity')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= /* @noEscape */ $localeFormatter->formatNumber((float)$_item->getQty() * 1) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= $block->getItemRowTotalHtml($_item) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col discount" data-th="<?= $block->escapeHtmlAttr(__('Discount Amount')) ?>">
+    <td class="col discount" data-th="<?= $escaper->escapeHtmlAttr(__('Discount Amount')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
-            <?= $block->escapeHtml($block->getOrder()->formatPrice(-$_item->getDiscountAmount()), ['span']) ?>
+            <?= $escaper->escapeHtml($block->getOrder()->formatPrice(-$_item->getDiscountAmount()), ['span']) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col rowtotal" data-th="<?= $block->escapeHtmlAttr(__('Row Total')) ?>">
+    <td class="col rowtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Row Total')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= $block->getItemRowTotalAfterDiscountHtml($_item) ?>
         <?php else: ?>
@@ -88,13 +92,13 @@
 </tr>
 <?php endforeach; ?>
 
-<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $block->escapeHtml($_item->getDescription()))): ?>
+<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $escaper->escapeHtml($_item->getDescription()))): ?>
     <tr>
         <td class="col options" colspan="7">
             <?php if ($_options = $block->getItemOptions()): ?>
                 <dl class="item-options">
                     <?php foreach ($_options as $_option): ?>
-                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                         <?php if (!$block->getPrintStatus()): ?>
                             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                             <dd<?php if (isset($_formatedOptionValue['full_view'])): ?> class="tooltip wrapper"<?php endif; ?>>
@@ -102,19 +106,19 @@
                                 <?php if (isset($_formatedOptionValue['full_view'])): ?>
                                     <div class="tooltip content">
                                         <dl class="item options">
-                                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                             <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                         </dl>
                                     </div>
                                 <?php endif; ?>
                             </dd>
                         <?php else: ?>
-                            <dd><?= $block->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
+                            <dd><?= $escaper->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
                         <?php endif; ?>
                     <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/invoice/items/renderer.phtml
@@ -3,11 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var LocaleFormatter $localeFormatter */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.Files.LineLength
-/** @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter */
 ?>
-<?php /** @var $block \Magento\Bundle\Block\Sales\Order\Items\Renderer */ ?>
 <?php $parentItem = $block->getItem() ?>
 <?php $_order = $block->getItem()->getOrderItem()->getOrder() ?>
 
@@ -28,42 +36,42 @@
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
             <tr class="options-label">
                 <td class="col label" colspan="5">
-                    <div class="option label"><?= $block->escapeHtml($attributes['option_label']) ?></div>
+                    <div class="option label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div>
                 </td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
         <?php endif; ?>
     <?php endif; ?>
-    <tr id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>"
+    <tr id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
         class="<?php if ($_item->getOrderItem()->getParentItem()): ?>item-options-container
         <?php else: ?>item-parent
         <?php endif; ?>"
         <?php if ($_item->getOrderItem()->getParentItem()): ?>
-            data-th="<?= $block->escapeHtmlAttr($attributes['option_label']) ?>"
+            data-th="<?= $escaper->escapeHtmlAttr($attributes['option_label']) ?>"
         <?php endif; ?>>
     <?php if (!$_item->getOrderItem()->getParentItem()): ?>
-        <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-            <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+        <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+            <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
         </td>
     <?php else: ?>
-        <td class="col value" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
+        <td class="col value" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
     <?php endif; ?>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= $block->escapeHtml($_item->getSku()) ?></td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')) ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= $escaper->escapeHtml($_item->getSku()) ?></td>
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= $block->getItemPriceHtml($_item) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty Invoiced')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty Invoiced')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= /* @noEscape */ $localeFormatter->formatNumber((float)$_item->getQty() * 1) ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?php if ($block->canShowPriceInfo($_item)): ?>
             <?= $block->getItemRowTotalHtml($_item) ?>
             <?php else: ?>
@@ -73,13 +81,13 @@
     </tr>
 <?php endforeach; ?>
 
-<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $block->escapeHtml($_item->getDescription()))): ?>
+<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $escaper->escapeHtml($_item->getDescription()))): ?>
     <tr>
         <td class="col options" colspan="5">
             <?php if ($_options = $block->getItemOptions()): ?>
                 <dl class="item-options">
                     <?php foreach ($_options as $_option): ?>
-                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                         <?php if (!$block->getPrintStatus()): ?>
                             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                             <dd<?php if (isset($_formatedOptionValue['full_view'])): ?> class="tooltip wrapper"<?php endif; ?>>
@@ -87,19 +95,19 @@
                                 <?php if (isset($_formatedOptionValue['full_view'])): ?>
                                     <div class="tooltip content">
                                         <dl class="item options">
-                                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                             <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                         </dl>
                                     </div>
                                 <?php endif; ?>
                             </dd>
                         <?php else: ?>
-                            <dd><?= $block->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
+                            <dd><?= $escaper->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
                         <?php endif; ?>
                     <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/items/renderer.phtml
@@ -3,12 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Bundle\ViewModel\Sales\Order\Items\Renderer as RendererViewModel;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var LocaleFormatter $localeFormatter */
+/** @var RendererViewModel $viewModel */
 // phpcs:disable Magento2.Templates.ThisInTemplate
-/**
- * @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- * @var \Magento\Bundle\ViewModel\Sales\Order\Items\Renderer $viewModel
- */
+
 $parentItem = $block->getItem();
 $viewModel = $block->getViewModel();
 $items = $viewModel->getOrderItems((int)$parentItem->getOrderId(), (int)$parentItem->getId());
@@ -32,7 +39,7 @@ $prevOptionId = '';
 
         <?php if (isset($attributes['option_id']) && $prevOptionId != $attributes['option_id']): ?>
             <tr class="options-label">
-                <td class="col label" colspan="5"><?= $block->escapeHtml($attributes['option_label']); ?></td>
+                <td class="col label" colspan="5"><?= $escaper->escapeHtml($attributes['option_label']); ?></td>
             </tr>
             <?php $prevOptionId = $attributes['option_id'] ?>
         <?php endif; ?>
@@ -44,28 +51,28 @@ $prevOptionId = '';
         item-parent
     <?php endif; ?>"
     <?php if ($item->getParentItem()): ?>
-        data-th="<?= $block->escapeHtmlAttr($attributes['option_label'] ?? ''); ?>"
+        data-th="<?= $escaper->escapeHtmlAttr($attributes['option_label'] ?? ''); ?>"
     <?php endif; ?>>
     <?php if (!$item->getParentItem()): ?>
-        <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')); ?>">
-            <strong class="product name product-item-name"><?= $block->escapeHtml($item->getName()); ?></strong>
+        <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')); ?>">
+            <strong class="product name product-item-name"><?= $escaper->escapeHtml($item->getName()); ?></strong>
         </td>
     <?php else: ?>
-        <td class="col value" data-th="<?= $block->escapeHtmlAttr(__('Product Name')); ?>">
+        <td class="col value" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')); ?>">
             <?= $block->getValueHtml($item); ?>
         </td>
     <?php endif; ?>
-    <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')); ?>">
+    <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')); ?>">
         <?= /* @noEscape */ $block->prepareSku($item->getSku()); ?>
     </td>
-    <td class="col price" data-th="<?= $block->escapeHtmlAttr(__('Price')); ?>">
+    <td class="col price" data-th="<?= $escaper->escapeHtmlAttr(__('Price')); ?>">
         <?php if (!$item->getParentItem()): ?>
             <?= /* @noEscape */ $block->getItemPriceHtml(); ?>
         <?php else: ?>
             &nbsp;
         <?php endif; ?>
     </td>
-    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Quantity')); ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Quantity')); ?>">
         <?php if (($item->getParentItem() && $block->isChildCalculated()) ||
         (!$item->getParentItem() && !$block->isChildCalculated()) ||
         ($item->getQtyShipped() > 0 && $item->getParentItem() && $block->isShipmentSeparately())): ?>
@@ -75,7 +82,7 @@ $prevOptionId = '';
             (!$item->getParentItem() && !$block->isChildCalculated())): ?>
             <?php if ($item->getQtyOrdered() > 0): ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Ordered')); ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Ordered')); ?></span>
                     <span class="content">
                         <?= /* @noEscape */ $localeFormatter->formatNumber($item->getQtyOrdered() * 1); ?>
                     </span>
@@ -83,7 +90,7 @@ $prevOptionId = '';
             <?php endif; ?>
             <?php if ($item->getQtyShipped() > 0 && !$block->isShipmentSeparately()): ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Shipped')); ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Shipped')); ?></span>
                     <span class="content">
                         <?= /* @noEscape */ $localeFormatter->formatNumber($item->getQtyShipped() * 1); ?>
                     </span>
@@ -91,7 +98,7 @@ $prevOptionId = '';
             <?php endif; ?>
             <?php if ($item->getQtyCanceled() > 0): ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Canceled')); ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Canceled')); ?></span>
                     <span class="content">
                         <?= /* @noEscape */ $localeFormatter->formatNumber($item->getQtyCanceled() * 1); ?>
                     </span>
@@ -99,7 +106,7 @@ $prevOptionId = '';
             <?php endif; ?>
             <?php if ($item->getQtyRefunded() > 0): ?>
                 <li class="item">
-                    <span class="title"><?= $block->escapeHtml(__('Refunded')); ?></span>
+                    <span class="title"><?= $escaper->escapeHtml(__('Refunded')); ?></span>
                     <span class="content">
                         <?= /* @noEscape */ $localeFormatter->formatNumber($item->getQtyRefunded() * 1); ?>
                     </span>
@@ -107,7 +114,7 @@ $prevOptionId = '';
             <?php endif; ?>
         <?php elseif ($item->getQtyShipped() > 0 && $item->getParentItem() && $block->isShipmentSeparately()): ?>
             <li class="item">
-                <span class="title"><?= $block->escapeHtml(__('Shipped')); ?></span>
+                <span class="title"><?= $escaper->escapeHtml(__('Shipped')); ?></span>
                 <span class="content">
                     <?= /* @noEscape */ $localeFormatter->formatNumber($item->getQtyShipped() * 1); ?>
                 </span>
@@ -123,7 +130,7 @@ $prevOptionId = '';
             </ul>
         <?php endif; ?>
     </td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtmlAttr(__('Subtotal')) ?>">
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtmlAttr(__('Subtotal')) ?>">
         <?php if (!$item->getParentItem()): ?>
             <?= /* @noEscape */ $block->getItemRowTotalHtml(); ?>
         <?php else: ?>
@@ -133,13 +140,13 @@ $prevOptionId = '';
 </tr>
 <?php endforeach; ?>
 
-<?php if ($showLastRow && (($options = $block->getItemOptions()) || $block->escapeHtml($item->getDescription()))): ?>
+<?php if ($showLastRow && (($options = $block->getItemOptions()) || $escaper->escapeHtml($item->getDescription()))): ?>
 <tr>
     <td class="col options" colspan="5">
         <?php if ($options = $block->getItemOptions()): ?>
             <dl class="item-options">
                 <?php foreach ($options as $option): ?>
-                    <dt><?= $block->escapeHtml($option['label']) ?></dt>
+                    <dt><?= $escaper->escapeHtml($option['label']) ?></dt>
                     <?php if (!$block->getPrintStatus()): ?>
                         <?php $formattedOptionValue = $block->getFormatedOptionValue($option) ?>
                         <dd<?php if (isset($formattedOptionValue['full_view'])): ?>
@@ -149,14 +156,14 @@ $prevOptionId = '';
                             <?php if (isset($formattedOptionValue['full_view'])): ?>
                                 <div class="tooltip content">
                                     <dl class="item options">
-                                        <dt><?= $block->escapeHtml($option['label']); ?></dt>
+                                        <dt><?= $escaper->escapeHtml($option['label']); ?></dt>
                                         <dd><?= /* @noEscape */ $formattedOptionValue['full_view']; ?></dd>
                                     </dl>
                                 </div>
                             <?php endif; ?>
                         </dd>
                     <?php else: ?>
-                        <dd><?= $block->escapeHtml((isset($option['print_value']) ?
+                        <dd><?= $escaper->escapeHtml((isset($option['print_value']) ?
                                 $option['print_value'] :
                                 $option['value'])); ?>
                         </dd>
@@ -164,7 +171,7 @@ $prevOptionId = '';
                 <?php endforeach; ?>
             </dl>
         <?php endif; ?>
-        <?= $block->escapeHtml($item->getDescription()); ?>
+        <?= $escaper->escapeHtml($item->getDescription()); ?>
     </td>
 </tr>
 <?php endif; ?>

--- a/app/code/Magento/Bundle/view/frontend/templates/sales/order/shipment/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/sales/order/shipment/items/renderer.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Bundle\Block\Sales\Order\Items\Renderer;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+/** @var LocaleFormatter $localeFormatter */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Generic.Files.LineLength
 ?>
-<?php
-/**
- * @var \Magento\Bundle\Block\Sales\Order\Items\Renderer $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- */
-?>
-
 <?php $parentItem = $block->getItem() ?>
 <?php $items = array_merge([$parentItem->getOrderItem()], $parentItem->getOrderItem()->getChildrenItems()) ?>
 <?php $shipItems = $block->getChildren($parentItem) ?>
@@ -32,26 +35,26 @@
         <?php $attributes = $block->getSelectionAttributes($_item) ?>
         <?php if ($_prevOptionId != $attributes['option_id']): ?>
             <tr class="options-label">
-                <td colspan="3" class="col label"><div class="option label"><?= $block->escapeHtml($attributes['option_label']) ?></div></td>
+                <td colspan="3" class="col label"><div class="option label"><?= $escaper->escapeHtml($attributes['option_label']) ?></div></td>
             </tr>
             <?php $_prevOptionId = $attributes['option_id'] ?>
         <?php endif; ?>
     <?php endif; ?>
-    <tr id="order-item-row-<?= $block->escapeHtmlAttr($_item->getId()) ?>" class="<?php if ($_item->getParentItem()): ?>item-options-container<?php else: ?>item-parent<?php endif; ?>"<?php if ($_item->getParentItem()): ?> data-th="<?= $block->escapeHtmlAttr($attributes['option_label']) ?>"<?php endif; ?>>
+    <tr id="order-item-row-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>" class="<?php if ($_item->getParentItem()): ?>item-options-container<?php else: ?>item-parent<?php endif; ?>"<?php if ($_item->getParentItem()): ?> data-th="<?= $escaper->escapeHtmlAttr($attributes['option_label']) ?>"<?php endif; ?>>
         <?php if (!$_item->getParentItem()): ?>
-            <td class="col name" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>">
-                <strong class="product name product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+            <td class="col name" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>">
+                <strong class="product name product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
             </td>
         <?php else: ?>
-            <td class="col value" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
+            <td class="col value" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getValueHtml($_item) ?></td>
         <?php endif; ?>
-        <td class="col sku" data-th="<?= $block->escapeHtmlAttr(__('SKU')) ?>"><?= $block->escapeHtml($_item->getSku()) ?></td>
-        <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty Shipped')) ?>">
+        <td class="col sku" data-th="<?= $escaper->escapeHtmlAttr(__('SKU')) ?>"><?= $escaper->escapeHtml($_item->getSku()) ?></td>
+        <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty Shipped')) ?>">
             <?php if (($block->isShipmentSeparately() && $_item->getParentItem()) || (!$block->isShipmentSeparately() && !$_item->getParentItem())): ?>
                 <?php if (isset($shipItems[$_item->getId()])): ?>
                     <?= /* @noEscape */ $localeFormatter->formatNumber((float)$shipItems[$_item->getId()]->getQty() * 1) ?>
                 <?php elseif ($_item->getIsVirtual()): ?>
-                    <?= $block->escapeHtml(__('N/A')) ?>
+                    <?= $escaper->escapeHtml(__('N/A')) ?>
                 <?php else: ?>
                     0
                 <?php endif; ?>
@@ -62,13 +65,13 @@
     </tr>
 <?php endforeach; ?>
 
-<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $block->escapeHtml($_item->getDescription()))): ?>
+<?php if ($_showlastRow && (($_options = $block->getItemOptions()) || $escaper->escapeHtml($_item->getDescription()))): ?>
     <tr>
         <td class="col options" colspan="3">
             <?php if ($_options = $block->getItemOptions()): ?>
                 <dl class="item-options">
                     <?php foreach ($_options as $_option): ?>
-                        <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                        <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                         <?php if (!$block->getPrintStatus()): ?>
                             <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
                             <dd<?php if (isset($_formatedOptionValue['full_view'])): ?> class="tooltip wrapper"<?php endif; ?>>
@@ -76,19 +79,19 @@
                                 <?php if (isset($_formatedOptionValue['full_view'])): ?>
                                     <div class="tooltip content">
                                         <dl class="item options">
-                                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                                             <dd><?= /* @noEscape */ $_formatedOptionValue['full_view'] ?></dd>
                                         </dl>
                                     </div>
                                 <?php endif; ?>
                             </dd>
                         <?php else: ?>
-                            <dd><?= $block->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
+                            <dd><?= $escaper->escapeHtml((isset($_option['print_value']) ? $_option['print_value']: $_option['value'])) ?></dd>
                         <?php endif; ?>
                     <?php endforeach; ?>
                 </dl>
             <?php endif; ?>
-            <?= $block->escapeHtml($_item->getDescription()) ?>
+            <?= $escaper->escapeHtml($_item->getDescription()) ?>
         </td>
     </tr>
 <?php endif; ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Bundle` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37101: Chore: Bundle - Replace Block Escaping with Escaper