### PR TITLE
Chore: Analytics - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Analytics/view/adminhtml/templates/dashboard/section.phtml
+++ b/app/code/Magento/Analytics/view/adminhtml/templates/dashboard/section.phtml
@@ -3,25 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+?>
 <section class="dashboard-advanced-reports" data-index="dashboard-advanced-reports">
     <div class="dashboard-advanced-reports-description">
         <header class="dashboard-advanced-reports-title">
-            <?= $block->escapeHtml(__('Advanced Reporting')) ?>
+            <?= $escaper->escapeHtml(__('Advanced Reporting')) ?>
         </header>
         <div class="dashboard-advanced-reports-content">
-            <?= $block->escapeHtml(__('Gain new insights and take command of your business\' performance,' .
+            <?= $escaper->escapeHtml(__('Gain new insights and take command of your business\' performance,' .
                 ' using our dynamic product, order, and customer reports tailored to your customer data.')) ?>
         </div>
     </div>
     <div class="dashboard-advanced-reports-actions">
-        <a href="<?= $block->escapeUrl($block->getUrl('analytics/reports/show')) ?>"
+        <a href="<?= $escaper->escapeUrl($block->getUrl('analytics/reports/show')) ?>"
            target="_blank"
            class="action action-advanced-reports"
            data-index="analytics-service-link"
-           title="<?= $block->escapeHtmlAttr(__('Go to Advanced Reporting')) ?>">
-            <span><?= $block->escapeHtml(__('Go to Advanced Reporting')) ?></span>
+           title="<?= $escaper->escapeHtmlAttr(__('Go to Advanced Reporting')) ?>">
+            <span><?= $escaper->escapeHtml(__('Go to Advanced Reporting')) ?></span>
         </a>
     </div>
 </section>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Analytics` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37098: Chore: Analytics - Replace Block Escaping with Escaper