### PR TITLE
Chore: Admin Notification - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/notification/window.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/notification/window.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\AdminNotification\Block\Window
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\AdminNotification\Block\Window;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Window $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <ul class="message-system-list"
     data-mage-init='{
@@ -15,13 +19,13 @@
             "autoOpen": true,
             "buttons": false,
             "modalClass": "modal-system-messages",
-            "title": "<?= $block->escapeHtmlAttr($block->getHeaderText()) ?>"
+            "title": "<?= $escaper->escapeHtmlAttr($block->getHeaderText()) ?>"
         }
     }'>
     <li class="message message-warning warning">
-        <?= $block->escapeHtml($block->getNoticeMessageText()) ?><br/>
-        <a href="<?= $block->escapeUrl($block->getNoticeMessageUrl()) ?>">
-            <?= $block->escapeHtml($block->getReadDetailsText()) ?>
+        <?= $escaper->escapeHtml($block->getNoticeMessageText()) ?><br/>
+        <a href="<?= $escaper->escapeUrl($block->getNoticeMessageUrl()) ?>">
+            <?= $escaper->escapeHtml($block->getReadDetailsText()) ?>
         </a>
     </li>
 </ul>

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\AdminNotification\Block\System\Messages */
+use Magento\AdminNotification\Block\System\Messages;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Messages $block */
+$lastCritical = $block->getLastCritical();
 ?>
-
-<?php $lastCritical = $block->getLastCritical();?>
 <div id="system_messages"
      class="message-system<?php if ($lastCritical) : ?>
      message-system-unread<?php endif; ?>">
@@ -15,18 +19,20 @@
         <?php if ($lastCritical) : ?>
             <ul class="message-system-list">
                 <li class="message message-warning error">
-                    <?= $block->escapeHtml($lastCritical->getText()) ?>
+                    <?= $escaper->escapeHtml($lastCritical->getText()) ?>
                 </li>
             </ul>
         <?php endif; ?>
         <div class="message-system-short">
             <span class="message-system-short-label">
-                <?= $block->escapeHtml(__('System Messages:')) ?>
+                <?= $escaper->escapeHtml(__('System Messages:')) ?>
             </span>
 
             <?php if ($block->getCriticalCount()) : ?>
                 <div class="message message-warning error">
-                    <a class="message-link" href="#" title="<?= $block->escapeHtml(__('Critical System Messages')) ?>">
+                    <a class="message-link"
+                       href="#"
+                       title="<?= $escaper->escapeHtml(__('Critical System Messages')) ?>">
                         <?= (int) $block->getCriticalCount() ?>
                     </a>
                 </div>
@@ -34,12 +40,15 @@
 
             <?php if ($block->getMajorCount()) : ?>
                <div class="message message-warning warning">
-                   <a class="message-link" href="#" title="<?= $block->escapeHtml(__('Major System Messages')) ?>">
+                   <a class="message-link" href="#" title="<?= $escaper->escapeHtml(__('Major System Messages')) ?>">
                        <?= (int) $block->getMajorCount() ?>
                    </a>
                </div>
             <?php endif; ?>
         </div>
-        <div id="message-system-all" title="<?= $block->escapeHtml(__('System messages')) ?>" data-mage-init='<?= $block->escapeHtml($block->getSystemMessageDialogJson()) ?>'></div>
+        <div id="message-system-all"
+             title="<?= $escaper->escapeHtml(__('System messages')) ?>"
+             data-mage-init='<?= $escaper->escapeHtml($block->getSystemMessageDialogJson()) ?>'>
+        </div>
     </div>
 </div>

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages/popup.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/system/messages/popup.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\AdminNotification\Block\System\Messages\UnreadMessagePopup */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\AdminNotification\Block\System\Messages\UnreadMessagePopup;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var UnreadMessagePopup $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div id="system_messages_list" data-role="system_messages_list"
-     title="<?= $block->escapeHtmlAttr($block->getPopupTitle()) ?>">
+     title="<?= $escaper->escapeHtmlAttr($block->getPopupTitle()) ?>">
     <ul class="message-system-list messages">
         <?php foreach ($block->getUnreadMessages() as $message): ?>
-            <li class="message message-warning <?= $block->escapeHtmlAttr($block->getItemClass($message)) ?>">
-                <?= $block->escapeHtml($message->getText()) ?>
+            <li class="message message-warning <?= $escaper->escapeHtmlAttr($block->getItemClass($message)) ?>">
+                <?= $escaper->escapeHtml($message->getText()) ?>
             </li>
         <?php endforeach;?>
     </ul>

--- a/app/code/Magento/AdminNotification/view/adminhtml/templates/toolbar_entry.phtml
+++ b/app/code/Magento/AdminNotification/view/adminhtml/templates/toolbar_entry.phtml
@@ -3,10 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\AdminNotification\Block\ToolbarEntry;
+use Magento\Framework\Escaper;
+
 // phpcs:disable Generic.Files.LineLength
-/** @var $block \Magento\AdminNotification\Block\ToolbarEntry */
-    $notificationCount = $block->getUnreadNotificationCount();
-    $notificationCounterMax = $block->getNotificationCounterMax();
+
+/** @var Escaper $escaper */
+/** @var ToolbarEntry $block */
+$notificationCount = $block->getUnreadNotificationCount();
+$notificationCounterMax = $block->getNotificationCounterMax();
 ?>
 <div
     data-mage-init='{"toolbarEntry": {}}'
@@ -14,10 +21,10 @@
     data-notification-count="<?= (int)$notificationCount ?>">
     <?php if ($notificationCount > 0): ?>
         <a
-            href="<?= $block->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
+            href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
             class="notifications-action admin__action-dropdown"
             data-mage-init='{"dropdown":{}}'
-            title="<?= $block->escapeHtmlAttr(__('Notifications')) ?>"
+            title="<?= $escaper->escapeHtmlAttr(__('Notifications')) ?>"
             data-toggle="dropdown">
             <span class="notifications-counter">
                 <?= /* @noEscape */ ($notificationCount > $notificationCounterMax) ? (int)$notificationCounterMax . '+' : (int)$notificationCount ?>
@@ -25,56 +32,56 @@
         </a>
         <ul
             class="admin__action-dropdown-menu"
-            data-mark-as-read-url="<?= $block->escapeUrl($block->getUrl('adminhtml/notification/ajaxMarkAsRead')) ?>">
+            data-mark-as-read-url="<?= $escaper->escapeUrl($block->getUrl('adminhtml/notification/ajaxMarkAsRead')) ?>">
             <?php foreach ($block->getLatestUnreadNotifications() as $notification): ?>
                 <?php /** @var $notification \Magento\AdminNotification\Model\Inbox */ ?>
                 <li class="notifications-entry<?php if ($notification->getSeverity() == 1): ?> notifications-critical<?php endif; ?>"
-                    data-notification-id="<?= $block->escapeHtmlAttr($notification->getId()) ?>"
+                    data-notification-id="<?= $escaper->escapeHtmlAttr($notification->getId()) ?>"
                     data-notification-severity="<?php if ($notification->getSeverity() == 1): ?>1<?php endif; ?>">
                     <?php
                         $notificationDescription = $notification->getDescription() ?? '';
                         $notificationDescriptionLength = $block->getNotificationDescriptionLength();
                     ?>
                     <strong class="notifications-entry-title">
-                        <?= $block->escapeHtml($notification->getTitle()) ?>
+                        <?= $escaper->escapeHtml($notification->getTitle()) ?>
                     </strong>
                     <?php if (strlen($notificationDescription) > $notificationDescriptionLength): ?>
                         <p class="notifications-entry-description _cutted">
                             <span class="notifications-entry-description-start">
-                                <?= $block->escapeHtml(substr($notificationDescription, 0, $notificationDescriptionLength)) ?>
+                                <?= $escaper->escapeHtml(substr($notificationDescription, 0, $notificationDescriptionLength)) ?>
                             </span>
                             <span class="notifications-entry-description-end">
-                                <?= $block->escapeHtml(substr($notificationDescription, $notificationDescriptionLength)) ?>
+                                <?= $escaper->escapeHtml(substr($notificationDescription, $notificationDescriptionLength)) ?>
                             </span>
                         </p>
                     <?php else: ?>
                         <p class="notifications-entry-description">
-                            <?= $block->escapeHtml($notificationDescription) ?>
+                            <?= $escaper->escapeHtml($notificationDescription) ?>
                         </p>
                     <?php endif; ?>
                     <time class="notifications-entry-time">
-                        <?= $block->escapeHtml($block->formatNotificationDate($notification->getDateAdded())) ?>
+                        <?= $escaper->escapeHtml($block->formatNotificationDate($notification->getDateAdded())) ?>
                     </time>
                     <button
                         type="button"
                         class="notifications-close"
-                        title="<?= $block->escapeHtmlAttr(__('Close')) ?>"
+                        title="<?= $escaper->escapeHtmlAttr(__('Close')) ?>"
                         ></button>
                 </li>
             <?php endforeach; ?>
             <li class="notifications-entry notifications-entry-last">
                 <a
-                    href="<?= $block->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
+                    href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
                     class="action-tertiary action-more">
-                    <?= $block->escapeHtml(__('See All (')) ?><span class="notifications-counter"><?= (int)$notificationCount ?></span><?= $block->escapeHtml(__(' unread)')) ?>
+                    <?= $escaper->escapeHtml(__('See All (')) ?><span class="notifications-counter"><?= (int)$notificationCount ?></span><?= $escaper->escapeHtml(__(' unread)')) ?>
                 </a>
             </li>
         </ul>
     <?php else: ?>
         <a
             class="notifications-action admin__action-dropdown"
-            href="<?= $block->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
-            title="<?= $block->escapeHtmlAttr(__('Notifications')) ?>">
+            href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/notification/index')) ?>"
+            title="<?= $escaper->escapeHtmlAttr(__('Notifications')) ?>">
         </a>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_AdminNotification` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37096: Chore: Admin Notification - Replace Block Escaping with Escaper