### PR TITLE
Chore: Configurable Product - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/attribute/set/js.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/attribute/set/js.phtml
@@ -4,11 +4,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php $scriptString = <<<script
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
 
 require([
     "Magento_Ui/js/modal/alert",
@@ -30,7 +34,7 @@ editSet.submit = editSet.submit.wrap(function(original) {
     if (editSet.currentNode){
         if (ConfigurableNodeExists(editSet.currentNode)) {
             alert({
-                content: '{$block->escapeJs(
+                content: '{$escaper->escapeJs(
                     __('This group contains attributes used in configurable products. ' .
                         'Please move these attributes to another group and try again.')
                 )}'
@@ -44,7 +48,7 @@ editSet.submit = editSet.submit.wrap(function(original) {
 editSet.rightBeforeAppend = editSet.rightBeforeAppend.wrap(function(original, tree, nodeThis, node, newParent) {
     if (node.attributes.is_configurable == 1) {
         alert({
-            content: '{$block->escapeJs(
+            content: '{$escaper->escapeJs(
                 __('This attribute is used in configurable products. You cannot remove it from the attribute set.')
             )}'
         });
@@ -56,7 +60,7 @@ editSet.rightBeforeAppend = editSet.rightBeforeAppend.wrap(function(original, tr
 editSet.rightBeforeInsert = editSet.rightBeforeInsert.wrap(function(original, tree, nodeThis, node, newParent) {
     if (node.attributes.is_configurable == 1) {
         alert({
-            content: '{$block->escapeJs(
+            content: '{$escaper->escapeJs(
                 __('This attribute is used in configurable products. You cannot remove it from the attribute set.')
             )}'
         });

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/composite/fieldset/configurable.phtml
@@ -3,36 +3,42 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php $_product = $block->getProduct(); ?>
-<?php $_attributes = $block->decorateArray($block->getAllowAttributes()); ?>
-<?php
-/** @var \Magento\Catalog\Helper\Product $productHelper */
+use Magento\Catalog\Helper\Product;
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Composite\Fieldset\Configurable;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Configurable $block */
+$_product = $block->getProduct();
+$_attributes = $block->decorateArray($block->getAllowAttributes());
+
+/** @var Product $productHelper */
 $productHelper = $block->getData('productHelper');
+$_skipSaleableCheck = $productHelper->getSkipSaleableCheck();
 ?>
-<?php $_skipSaleableCheck = $productHelper->getSkipSaleableCheck(); ?>
 <?php if (($_product->isSaleable() || $_skipSaleableCheck) && count($_attributes)):?>
 <fieldset id="catalog_product_composite_configure_fields_configurable" class="fieldset admin__fieldset">
     <legend class="legend admin__legend">
-        <span><?= $block->escapeHtml(__('Associated Products')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Associated Products')) ?></span>
     </legend>
     <div class="product-options fieldset admin__fieldset">
         <?php foreach ($_attributes as $_attribute): ?>
             <div class="field admin__field required">
                 <label class="label admin__field-label"><?=
-                    $block->escapeHtml($_attribute->getProductAttribute()->getStoreLabel($_product->getStoreId()));
+                    $escaper->escapeHtml($_attribute->getProductAttribute()->getStoreLabel($_product->getStoreId()));
                 ?></label>
                 <div class="control admin__field-control <?php
                 if ($_attribute->getDecoratedIsLast()):
                     ?> last<?php
                     endif; ?>">
-                    <select name="super_attribute[<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
-                            id="attribute<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>"
+                    <select name="super_attribute[<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
+                            id="attribute<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>"
                             class="admin__control-select required-entry super-attribute-select">
-                        <option><?= $block->escapeHtml(__('Choose an Option...')) ?></option>
+                        <option><?= $escaper->escapeHtml(__('Choose an Option...')) ?></option>
                     </select>
                 </div>
             </div>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/attributes_values.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues */
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\AttributeValues;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var AttributeValues $block */
 $isAllowedToManageAttributes = $block->getPermissions()->isAllowedToManageAttributes();
 $attributesUrl = $block->getUrl('catalog/product_attribute/getAttributes');
 $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');
 ?>
 <div data-bind="scope: '<?= /* @noEscape */  $block->getComponentName() ?>'">
-    <h2 class="steps-wizard-title"><?= $block->escapeHtml(
+    <h2 class="steps-wizard-title"><?= $escaper->escapeHtml(
         __('Step 2: Attribute Values')
     ); ?></h2>
     <div class="steps-wizard-info">
-        <span><?= $block->escapeHtml(
+        <span><?= $escaper->escapeHtml(
             __('Select values from each attribute to include in this product. ' .
                 'Each unique combination of values creates a unique product SKU.')
         );?></span>
@@ -26,12 +31,12 @@ $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');
                 <div class="attribute-entity-title-block">
                     <span class="draggable-handle"
                           data-role="draggable"
-                          title="<?= $block->escapeHtml(__('Sort Variations')) ?>">
+                          title="<?= $escaper->escapeHtml(__('Sort Variations')) ?>">
                     </span>
                     <div class="attribute-entity-title" data-bind="text: label"></div>
                     <div class="attribute-options-block">
                         (<span class="attribute-length" data-bind="text: $data.options().length"></span>
-                        <?= $block->escapeHtml(
+                        <?= $escaper->escapeHtml(
                             __('Options')
                         ); ?>)
                     </div>
@@ -41,24 +46,24 @@ $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');
                     <button type="button"
                             class="action-select-all action-tertiary"
                             data-bind="click: $parent.selectAllAttributes"
-                            title="<?= $block->escapeHtml(__('Select All')) ?>">
-                        <span><?= $block->escapeHtml(
+                            title="<?= $escaper->escapeHtml(__('Select All')) ?>">
+                        <span><?= $escaper->escapeHtml(
                             __('Select All')
                         ); ?></span>
                     </button>
                     <button type="button"
                             class="action-deselect-all action-tertiary"
                             data-bind="click: $parent.deSelectAllAttributes"
-                            title="<?= $block->escapeHtml(__('Deselect All')) ?>">
-                        <span><?= $block->escapeHtml(
+                            title="<?= $escaper->escapeHtml(__('Deselect All')) ?>">
+                        <span><?= $escaper->escapeHtml(
                             __('Deselect All')
                         ); ?></span>
                     </button>
                     <button type="button"
                             class="action-remove-all action-tertiary"
                             data-bind="click: $parent.removeAttribute.bind($parent)"
-                            title="<?= $block->escapeHtml(__('Remove Attribute')) ?>">
-                        <span><?= $block->escapeHtml(
+                            title="<?= $escaper->escapeHtml(__('Remove Attribute')) ?>">
+                        <span><?= $escaper->escapeHtml(
                             __('Remove Attribute')
                         ); ?></span>
                     </button>
@@ -86,19 +91,19 @@ $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');
                             </div>
                             <button type="button"
                                     class="action-save"
-                                    title="<?= $block->escapeHtml(__('Save Option')) ?>"
+                                    title="<?= $escaper->escapeHtml(__('Save Option')) ?>"
                                     data-action="save"
                                     data-bind="click: $parents[1].saveOption.bind($parent)">
-                                <span><?= $block->escapeHtml(
+                                <span><?= $escaper->escapeHtml(
                                     __('Save Option')
                                 ); ?></span>
                             </button>
                             <button type="button"
                                     class="action-remove"
-                                    title="<?= $block->escapeHtml(__('Remove Option')) ?>"
+                                    title="<?= $escaper->escapeHtml(__('Remove Option')) ?>"
                                     data-action="remove"
                                     data-bind="click: $parents[1].removeOption.bind($parent)">
-                                <span><?= $block->escapeHtml(
+                                <span><?= $escaper->escapeHtml(
                                     __('Remove Option')
                                 ); ?></span>
                             </button>
@@ -111,7 +116,7 @@ $optionsUrl = $block->getUrl('catalog/product_attribute/createOptions');
                         type="button"
                         data-action="addOption"
                         data-bind="click: $parent.createOption, visible: canCreateOption">
-                    <span><?= $block->escapeHtml(__('Create New Value')); ?></span>
+                    <span><?= $escaper->escapeHtml(__('Create New Value')); ?></span>
                 </button>
             <?php endif; ?>
         </div>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/bulk.phtml
@@ -3,18 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk;
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Bulk $block */
+/** @var Data $jsonHelper */
+$jsonHelper = $block->getData('jsonHelper');
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Bulk */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-
-<?php
-/** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
-$jsonHelper = $block->getData('jsonHelper');
 ?>
 <div data-bind="scope: '<?= /* @noEscape */  $block->getComponentName() ?>'" data-role="bulk-step">
-    <h2 class="steps-wizard-title"><?= $block->escapeHtml(__('Step 3: Bulk Images, Price and Quantity')) ?></h2>
+    <h2 class="steps-wizard-title"><?= $escaper->escapeHtml(__('Step 3: Bulk Images, Price and Quantity')) ?></h2>
     <div class="steps-wizard-info">
         <?= /* @noEscape */ __(
             'Based on your selections %1 new products will be created. ' .
@@ -26,7 +31,7 @@ $jsonHelper = $block->getData('jsonHelper');
     <div data-bind="with: sections().images" class="steps-wizard-section">
         <div data-role="section">
             <div class="steps-wizard-section-title">
-                <span><?= $block->escapeHtml(__('Images')); ?></span>
+                <span><?= $escaper->escapeHtml(__('Images')); ?></span>
             </div>
 
             <ul class="steps-wizard-section-list">
@@ -38,7 +43,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                value="single"
                                data-bind="checked:type">
                         <label for="apply-single-set-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply single set of images to all SKUs')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply single set of images to all SKUs')); ?></span>
                         </label>
                     </div>
                 </li>
@@ -50,7 +55,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                value="each"
                                data-bind="checked:type">
                         <label for="apply-unique-images-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply unique images by attribute to each SKU')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply unique images by attribute to each SKU')) ?></span>
                         </label>
                     </div>
                 </li>
@@ -63,7 +68,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                checked
                                data-bind="checked:type">
                         <label for="skip-images-uploading-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Skip image uploading at this time')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Skip image uploading at this time')) ?></span>
                         </label>
                     </div>
                 </li>
@@ -75,13 +80,13 @@ $jsonHelper = $block->getData('jsonHelper');
                 <div data-role="gallery"
                      class="gallery"
                      data-images="[]"
-                     data-types="<?= $block->escapeHtmlAttr($jsonHelper->jsonEncode(
+                     data-types="<?= $escaper->escapeHtmlAttr($jsonHelper->jsonEncode(
                          $block->getImageTypes()
                      )) ?>">
                     <div class="image image-placeholder">
                         <div data-role="uploader" class="uploader">
                             <div class="image-browse">
-                                <span><?= $block->escapeHtml(__('Browse Files...')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Browse Files...')) ?></span>
                                 <input type="file"
                                        id=""
                                        name="image"
@@ -92,17 +97,17 @@ $jsonHelper = $block->getData('jsonHelper');
                             </div>
                         </div>
                         <div class="product-image-wrapper">
-                            <p class="image-placeholder-text"><?= $block->escapeHtml(__(
+                            <p class="image-placeholder-text"><?= $escaper->escapeHtml(__(
                                 'Browse to find or drag image here'
                             )) ?></p>
                         </div>
                     </div>
 
                     <?php foreach ($block->getImageTypes() as $typeData): ?>
-                        <input name="<?= $block->escapeHtml($typeData['name']) ?>"
-                               class="image-<?= $block->escapeHtml($typeData['code']) ?>"
+                        <input name="<?= $escaper->escapeHtml($typeData['name']) ?>"
+                               class="image-<?= $escaper->escapeHtml($typeData['code']) ?>"
                                type="hidden"
-                               value="<?= $block->escapeHtml($typeData['value']) ?>"/>
+                               value="<?= $escaper->escapeHtml($typeData['value']) ?>"/>
                     <?php endforeach; ?>
 
                     <script data-template="uploader" type="text/x-magento-template">
@@ -149,12 +154,12 @@ $jsonHelper = $block->getData('jsonHelper');
                                     <button type="button"
                                             class="action-remove"
                                             data-role="delete-button"
-                                            title="<?= $block->escapeHtml(__('Remove image')) ?>">
-                                        <span><?= $block->escapeHtml(__('Remove image')) ?></span>
+                                            title="<?= $escaper->escapeHtml(__('Remove image')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Remove image')) ?></span>
                                     </button>
                                     <div class="draggable-handle"></div>
                                 </div>
-                                <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')) ?></span></div>
+                                <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')) ?></span></div>
                             </div>
                             <div class="item-description">
                                 <div class="item-title" data-role="img-title"><%- data.label %></div>
@@ -165,9 +170,9 @@ $jsonHelper = $block->getData('jsonHelper');
                             </div>
                             <ul class="item-roles" data-role="roles-labels">
                                 <?php foreach ($block->getMediaAttributes() as $attribute):?>
-                                    <li data-role-code="<?= $block->escapeHtml($attribute->getAttributeCode()) ?>"
+                                    <li data-role-code="<?= $escaper->escapeHtml($attribute->getAttributeCode()) ?>"
                                         class="item-role item-role-<?=
-                                        $block->escapeHtml($attribute->getAttributeCode()) ?>">
+                                        $escaper->escapeHtml($attribute->getAttributeCode()) ?>">
                                         <?= /* @noEscape */ $attribute->getFrontendLabel() ?>
                                     </li>
                                 <?php endforeach; ?>
@@ -188,14 +193,14 @@ $jsonHelper = $block->getData('jsonHelper');
                                     <button type="button"
                                             class="action-remove"
                                             data-role="delete-button"
-                                            title="<?= $block->escapeHtml(__('Remove image')) ?>">
-                                        <span><?= $block->escapeHtml(__('Remove image')) ?></span>
+                                            title="<?= $escaper->escapeHtml(__('Remove image')) ?>">
+                                        <span><?= $escaper->escapeHtml(__('Remove image')) ?></span>
                                     </button>
 
                                     <div class="draggable-handle"></div>
                                 </div>
 
-                                <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')) ?></span></div>
+                                <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')) ?></span></div>
                             </div>
                             <!--<ul class="item-roles">
                                 <li class="item-role item-role-base">Base</li>
@@ -218,7 +223,7 @@ $jsonHelper = $block->getData('jsonHelper');
                             <fieldset class="admin__fieldset fieldset-image-panel">
                                 <div class="admin__field field-image-description">
                                     <label class="admin__field-label" for="image-description">
-                                        <span><?= $block->escapeHtml(__('Alt Text')) ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Alt Text')) ?></span>
                                     </label>
 
                                     <div class="admin__field-control">
@@ -232,7 +237,7 @@ $jsonHelper = $block->getData('jsonHelper');
 
                                 <div class="admin__field field-image-role">
                                     <label class="admin__field-label">
-                                        <span><?= $block->escapeHtml(__('Role')); ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Role')); ?></span>
                                     </label>
                                     <div class="admin__field-control">
                                         <ul class="multiselect-alt">
@@ -245,9 +250,9 @@ $jsonHelper = $block->getData('jsonHelper');
                                                                data-role="type-selector"
                                                                type="checkbox"
                                                                value="<?=
-                                                                $block->escapeHtml($attribute->getAttributeCode()) ?>"
+                                                                $escaper->escapeHtml($attribute->getAttributeCode()) ?>"
                                                         />
-                                                        <?= $block->escapeHtml($attribute->getFrontendLabel()); ?>
+                                                        <?= $escaper->escapeHtml($attribute->getFrontendLabel()); ?>
                                                     </label>
                                                 </li>
                                             <?php endforeach; ?>
@@ -257,19 +262,19 @@ $jsonHelper = $block->getData('jsonHelper');
 
                                 <div class="admin__field admin__field-inline field-image-size" data-role="size">
                                     <label class="admin__field-label">
-                                        <span><?= $block->escapeHtml(__('Image Size')); ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Image Size')); ?></span>
                                     </label>
                                     <div class="admin__field-value"
-                                         data-message="<?= $block->escapeHtml(__('{size}'));?>"></div>
+                                         data-message="<?= $escaper->escapeHtml(__('{size}'));?>"></div>
                                 </div>
 
                                 <div class="admin__field admin__field-inline field-image-resolution"
                                      data-role="resolution">
                                     <label class="admin__field-label">
-                                        <span><?= $block->escapeHtml(__('Image Resolution')); ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Image Resolution')); ?></span>
                                     </label>
                                     <div class="admin__field-value"
-                                         data-message="<?= $block->escapeHtml(__('{width}^{height} px'));?>"></div>
+                                         data-message="<?= $escaper->escapeHtml(__('{width}^{height} px'));?>"></div>
                                 </div>
 
                                 <div class="admin__field field-image-hide">
@@ -284,7 +289,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                             <% if (data.disabled == 1) { %>checked="checked"<% } %> />
 
                                             <label for="hide-from-product-page" class="admin__field-label">
-                                                <?= $block->escapeHtml(__('Hide from Product Page')); ?>
+                                                <?= $escaper->escapeHtml(__('Hide from Product Page')); ?>
                                             </label>
                                         </div>
                                     </div>
@@ -299,7 +304,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 <fieldset class="admin__fieldset bulk-attribute-values">
                     <div class="admin__field _required">
                         <label class="admin__field-label" for="apply-images-attributes">
-                            <span><?= $block->escapeHtml(__('Select attribute')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Select attribute')); ?></span>
                         </label>
                         <div class="admin__field-control">
                             <select
@@ -309,7 +314,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                 options: $parent.attributes,
                                 optionsText: 'label',
                                 value: attribute,
-                                optionsCaption: '<?= $block->escapeHtml(__("Select")); ?>'
+                                optionsCaption: '<?= $escaper->escapeHtml(__("Select")); ?>'
                                 ">
                             </select>
                         </div>
@@ -326,13 +331,13 @@ $jsonHelper = $block->getData('jsonHelper');
                         <div data-role="gallery"
                              class="gallery"
                              data-images="[]"
-                             data-types="<?= $block->escapeHtmlAttr(
+                             data-types="<?= $escaper->escapeHtmlAttr(
                                  $jsonHelper->jsonEncode($block->getImageTypes())
                              ) ?>">
                             <div class="image image-placeholder">
                                 <div data-role="uploader" class="uploader">
                                     <div class="image-browse">
-                                        <span><?= $block->escapeHtml(__('Browse Files...')); ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Browse Files...')); ?></span>
                                         <input type="file" name="image" multiple="multiple"
                                                data-url="<?=
                                                /* @noEscape */ $block->getUrl('catalog/product_gallery/upload') ?>" />
@@ -340,7 +345,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                 </div>
                                 <div class="product-image-wrapper">
                                     <p class="image-placeholder-text">
-                                        <?= $block->escapeHtml(__('Browse to find or drag image here')); ?>
+                                        <?= $escaper->escapeHtml(__('Browse to find or drag image here')); ?>
                                     </p>
                                 </div>
                                 <div class="spinner">
@@ -350,10 +355,10 @@ $jsonHelper = $block->getData('jsonHelper');
                             </div>
 
                             <?php foreach ($block->getImageTypes() as $typeData): ?>
-                                <input name="<?= $block->escapeHtml($typeData['name']) ?>"
-                                       class="image-<?= $block->escapeHtml($typeData['code']) ?>"
+                                <input name="<?= $escaper->escapeHtml($typeData['name']) ?>"
+                                       class="image-<?= $escaper->escapeHtml($typeData['code']) ?>"
                                        type="hidden"
-                                       value="<?= $block->escapeHtml($typeData['value']) ?>"/>
+                                       value="<?= $escaper->escapeHtml($typeData['value']) ?>"/>
                             <?php endforeach; ?>
 
                             <script data-template="uploader" type="text/x-magento-template">
@@ -402,12 +407,12 @@ $jsonHelper = $block->getData('jsonHelper');
                                             <button type="button"
                                                     class="action-remove"
                                                     data-role="delete-button"
-                                                    title="<?= $block->escapeHtml(__('Remove image')) ?>">
-                                                <span><?= $block->escapeHtml(__('Remove image')); ?></span>
+                                                    title="<?= $escaper->escapeHtml(__('Remove image')) ?>">
+                                                <span><?= $escaper->escapeHtml(__('Remove image')); ?></span>
                                             </button>
                                             <div class="draggable-handle"></div>
                                         </div>
-                                        <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')); ?></span>
+                                        <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')); ?></span>
                                         </div>
                                     </div>
                                     <div class="item-description">
@@ -419,11 +424,11 @@ $jsonHelper = $block->getData('jsonHelper');
                                     </div>
                                     <ul class="item-roles" data-role="roles-labels">
                                         <?php foreach ($block->getMediaAttributes() as $attribute):?>
-                                            <li data-role-code="<?= $block->escapeHtml($attribute->getAttributeCode())
+                                            <li data-role-code="<?= $escaper->escapeHtml($attribute->getAttributeCode())
                                             ?>"
                                                 class="item-role item-role-<?=
-                                                $block->escapeHtml($attribute->getAttributeCode()) ?>">
-                                                <?= $block->escapeHtml($attribute->getFrontendLabel()) ?>
+                                                $escaper->escapeHtml($attribute->getAttributeCode()) ?>">
+                                                <?= $escaper->escapeHtml($attribute->getFrontendLabel()) ?>
                                             </li>
                                         <?php endforeach; ?>
                                     </ul>
@@ -442,12 +447,12 @@ $jsonHelper = $block->getData('jsonHelper');
                                             <button type="button"
                                                     class="action-remove"
                                                     data-role="delete-button"
-                                                    title="<?= $block->escapeHtml(__('Remove image')) ?>">
-                                                <span><?= $block->escapeHtml(__('Remove image')) ?></span>
+                                                    title="<?= $escaper->escapeHtml(__('Remove image')) ?>">
+                                                <span><?= $escaper->escapeHtml(__('Remove image')) ?></span>
                                             </button>
                                             <div class="draggable-handle"></div>
                                         </div>
-                                        <div class="image-fade"><span><?= $block->escapeHtml(__('Hidden')) ?></span>
+                                        <div class="image-fade"><span><?= $escaper->escapeHtml(__('Hidden')) ?></span>
                                         </div>
                                     </div>
                                     <!--<ul class="item-roles">
@@ -472,7 +477,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                     <fieldset class="admin__fieldset fieldset-image-panel">
                                         <div class="admin__field field-image-description">
                                             <label class="admin__field-label" for="image-description">
-                                                <span><?= $block->escapeHtml(__('Alt Text'));?></span>
+                                                <span><?= $escaper->escapeHtml(__('Alt Text'));?></span>
                                             </label>
 
                                             <div class="admin__field-control">
@@ -486,7 +491,7 @@ $jsonHelper = $block->getData('jsonHelper');
 
                                         <div class="admin__field field-image-role">
                                             <label class="admin__field-label">
-                                                <span><?= $block->escapeHtml(__('Role'));?></span>
+                                                <span><?= $escaper->escapeHtml(__('Role'));?></span>
                                             </label>
                                             <div class="admin__field-control">
                                                 <ul class="multiselect-alt">
@@ -497,9 +502,9 @@ $jsonHelper = $block->getData('jsonHelper');
                                                                        data-role="type-selector"
                                                                        type="checkbox"
                                                                 // @codingStandardsIgnoreLine
-                                                                value="<?= $block->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
+                                                                value="<?= $escaper->escapeHtmlAttr($attribute->getAttributeCode()) ?>"
                                                                 />
-                                                                <?= $block->escapeHtml($attribute->getFrontendLabel())?>
+                                                                <?= $escaper->escapeHtml($attribute->getFrontendLabel())?>
                                                             </label>
                                                         </li>
                                                     <?php endforeach; ?>
@@ -509,19 +514,19 @@ $jsonHelper = $block->getData('jsonHelper');
 
                                         <div class="admin__field admin__field-inline field-image-size" data-role="size">
                                             <label class="admin__field-label">
-                                                <span><?= $block->escapeHtml(__('Image Size')); ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Image Size')); ?></span>
                                             </label>
                                             <div class="admin__field-value"
-                                                 data-message="<?= $block->escapeHtml(__('{size}')); ?>"></div>
+                                                 data-message="<?= $escaper->escapeHtml(__('{size}')); ?>"></div>
                                         </div>
 
                                         <div class="admin__field admin__field-inline field-image-resolution"
                                              data-role="resolution">
                                             <label class="admin__field-label">
-                                                <span><?= $block->escapeHtml(__('Image Resolution')); ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Image Resolution')); ?></span>
                                             </label>
                                             <div class="admin__field-value"
-                                                 data-message="<?= $block->escapeHtml(__('{width}^{height} px')); ?>">
+                                                 data-message="<?= $escaper->escapeHtml(__('{width}^{height} px')); ?>">
                                             </div>
                                         </div>
 
@@ -538,7 +543,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                                     <% if (data.disabled == 1) { %>checked="checked"<% } %> />
 
                                                     <label for="hide-from-product-page" class="admin__field-label">
-                                                        <?= $block->escapeHtml(__('Hide from Product Page')); ?>
+                                                        <?= $escaper->escapeHtml(__('Hide from Product Page')); ?>
                                                     </label>
                                                 </div>
                                             </div>
@@ -557,7 +562,7 @@ $jsonHelper = $block->getData('jsonHelper');
     <div data-bind="with: sections().price" class="steps-wizard-section">
         <div data-role="section">
             <div class="steps-wizard-section-title">
-                <span><?= $block->escapeHtml(__('Price')); ?></span>
+                <span><?= $escaper->escapeHtml(__('Price')); ?></span>
             </div>
             <ul class="steps-wizard-section-list">
                 <li>
@@ -569,7 +574,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                data-bind="checked:type" />
                         <label for="apply-single-price-radio"
                                class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply single price to all SKUs')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply single price to all SKUs')); ?></span>
                         </label>
                     </div>
                 </li>
@@ -582,7 +587,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                data-bind="checked:type" />
                         <label for="apply-unique-prices-radio"
                                class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply unique prices by attribute to each SKU')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply unique prices by attribute to each SKU')); ?></span>
                         </label>
                     </div>
                 </li>
@@ -595,7 +600,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                checked
                                data-bind="checked:type" />
                         <label for="skip-pricing-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Skip price at this time')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Skip price at this time')); ?></span>
                         </label>
                     </div>
                 </li>
@@ -604,7 +609,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 <fieldset class="admin__fieldset bulk-attribute-values" data-bind="visible: type() == 'single'">
                     <div class="admin__field _required">
                         <label for="apply-single-price-input" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Price')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Price')); ?></span>
                         </label>
                         <div class="admin__field-control">
                             <div class="currency-addon">
@@ -621,7 +626,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 <fieldset class="admin__fieldset bulk-attribute-values">
                     <div class="admin__field _required">
                         <label for="select-each-price" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Select attribute')); ?></span>
+                            <span><?= $escaper->escapeHtml(__('Select attribute')); ?></span>
                         </label>
                         <div class="admin__field-control">
                             <select id="select-each-price" class="admin__control-select" data-bind="
@@ -661,7 +666,7 @@ $jsonHelper = $block->getData('jsonHelper');
     <div data-bind="with: sections().quantity" class="steps-wizard-section">
         <div data-role="section">
             <div class="steps-wizard-section-title">
-                <span><?= $block->escapeHtml(__('Quantity')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Quantity')) ?></span>
             </div>
             <ul class="steps-wizard-section-list">
                 <li>
@@ -672,7 +677,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                value="single"
                                data-bind="checked: type" />
                         <label for="apply-single-inventory-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply single quantity to each SKUs')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply single quantity to each SKUs')) ?></span>
                         </label>
                     </div>
                 </li>
@@ -684,7 +689,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                value="each"
                                data-bind="checked: type" />
                         <label for="apply-unique-inventory-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Apply unique quantity by attribute to each SKU')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Apply unique quantity by attribute to each SKU')) ?></span>
                         </label>
                     </div>
                 </li>
@@ -697,7 +702,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                checked
                                data-bind="checked: type" />
                         <label for="skip-inventory-radio" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Skip quantity at this time')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Skip quantity at this time')) ?></span>
                         </label>
                     </div>
                 </li>
@@ -707,7 +712,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 <fieldset class="admin__fieldset bulk-attribute-values" data-bind="visible: type() == 'single'">
                     <div class="admin__field _required">
                         <label for="apply-single-inventory-input" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Quantity')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Quantity')) ?></span>
                         </label>
                         <div class="admin__field-control">
                             <input type="text"
@@ -723,7 +728,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 <fieldset class="admin__fieldset bulk-attribute-values">
                     <div class="admin__field _required">
                         <label for="apply-single-price-input-qty" class="admin__field-label">
-                            <span><?= $block->escapeHtml(__('Select attribute')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Select attribute')) ?></span>
                         </label>
                         <div class="admin__field-control">
                             <select id="apply-single-price-input-qty" class="admin__control-select" data-bind="

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/select_attributes.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/select_attributes.phtml
@@ -3,20 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\SelectAttributes */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\SelectAttributes;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SelectAttributes $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="select-attributes-block <?= /* @noEscape */ $block->getData('config/dataScope') ?>"
      data-role="select-attributes-step">
     <div class="select-attributes-actions" data-type="skipKO">
         <?= /* @noEscape */  $block->getAddNewAttributeButton() ?>
     </div>
-    <h2 class="steps-wizard-title"><?= $block->escapeHtml(
+    <h2 class="steps-wizard-title"><?= $escaper->escapeHtml(
         __('Step 1: Select Attributes')
     ); ?></h2>
     <div class="selected-attributes" data-bind="scope: '<?= /* @noEscape */  $block->getComponentName() ?>'">
-        <?= $block->escapeHtml(
+        <?= $escaper->escapeHtml(
             __('Selected Attributes:')
         ); ?>
         <span data-bind="text: selectedAttributes() || '--'"></span>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/summary.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/attribute/steps/summary.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Summary */
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Steps\Summary;
+use Magento\Framework\Escaper;
 
+/** @var Escaper $escaper */
+/** @var Summary $block */
 ?>
 <div data-bind="scope: '<?= /* @noEscape */  $block->getComponentName() ?>'">
-    <h2 class="steps-wizard-title"><?= $block->escapeHtml(
+    <h2 class="steps-wizard-title"><?= $escaper->escapeHtml(
         __('Step 4: Summary')
     ); ?></h2>
 

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/config.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/config.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config */
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Config $block */
 ?>
-<div class="entry-edit form-inline" id="<?= $block->escapeHtmlAttr($block->getId()) ?>" data-panel="product-variations">
+<div class="entry-edit form-inline" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>" data-panel="product-variations">
     <div data-bind="scope: 'variation-steps-wizard'" class="product-create-configuration">
         <div class="product-create-configuration-info">
             <div class="note" data-role="product-create-configuration-info">
-                <?= $block->escapeHtml(__('Configurable products allow customers to choose options (Ex: shirt color).
+                <?= $escaper->escapeHtml(__('Configurable products allow customers to choose options (Ex: shirt color).
             You need to create a simple product for each configuration (Ex: a product for each color).'));?>
             </div>
         </div>
@@ -18,8 +23,8 @@
             <div class="product-create-configuration-action">
                 <button type="button" data-action="open-steps-wizard" title="Create Product Configurations"
                         class="action-secondary" data-bind="click: open">
-                <span data-role="button-label" data-edit-label="<?= $block->escapeHtmlAttr(__('Edit Configurations')) ?>">
-                    <?= $block->escapeHtml($block->isHasVariations()
+                <span data-role="button-label" data-edit-label="<?= $escaper->escapeHtmlAttr(__('Edit Configurations')) ?>">
+                    <?= $escaper->escapeHtml($block->isHasVariations()
                         ? __('Edit Configurations')
                         : __('Create Configurations'))
 ?>
@@ -29,7 +34,7 @@
             <div class="product-create-configuration-action" data-bind="scope: 'configurableProductGrid'">
                 <button class="action-tertiary action-menu-item" type="button" data-action="choose"
                         data-bind="click: showManuallyGrid, visible: button">
-                    <?= $block->escapeHtml(__('Add Products Manually')) ?>
+                    <?= $escaper->escapeHtml(__('Add Products Manually')) ?>
                 </button>
             </div>
         </div>

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/matrix.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/matrix.phtml
@@ -3,24 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix;
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Matrix $block */
 $productMatrix = $block->getProductMatrix();
 $attributes = $block->getProductAttributes();
 $currencySymbol = $block->getCurrencySymbol();
 
-/** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
+/** @var Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
-?>
 
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
+?>
 <div id="product-variations-matrix" data-role="product-variations-matrix">
     <div data-bind="scope: 'configurableVariations'">
         <h3 class="hidden" data-bind="css: {hidden: !showVariations() }" class="title">
-            <?= $block->escapeHtml(__('Current Variations')) ?>
+            <?= $escaper->escapeHtml(__('Current Variations')) ?>
         </h3>
 
         <script data-template-for="variation-image" type="text/x-magento-template">
@@ -60,22 +65,22 @@ $jsonHelper = $block->getData('jsonHelper');
                         <thead>
                             <tr>
                                 <th class="data-grid-th data-grid-thumbnail-cell col-image" data-column="image">
-                                    <?= $block->escapeHtml(__('Image')) ?>
+                                    <?= $escaper->escapeHtml(__('Image')) ?>
                                 </th>
                                 <th class="data-grid-th col-name" data-column="name">
-                                    <?= $block->escapeHtml(__('Name')) ?>
+                                    <?= $escaper->escapeHtml(__('Name')) ?>
                                 </th>
                                 <th class="data-grid-th col-sku" data-column="sku">
-                                    <?= $block->escapeHtml(__('SKU')) ?>
+                                    <?= $escaper->escapeHtml(__('SKU')) ?>
                                 </th>
                                 <th class="data-grid-th col-price" data-column="price">
-                                    <?= $block->escapeHtml(__('Price')) ?>
+                                    <?= $escaper->escapeHtml(__('Price')) ?>
                                 </th>
                                 <th class="data-grid-th col-qty" data-column="qty">
-                                    <?= $block->escapeHtml(__('Quantity')) ?>
+                                    <?= $escaper->escapeHtml(__('Quantity')) ?>
                                 </th>
                                 <th class="data-grid-th col-weight" data-column="weight">
-                                    <?= $block->escapeHtml(__('Weight')) ?>
+                                    <?= $escaper->escapeHtml(__('Weight')) ?>
                                 </th>
                                 <!-- ko foreach: getAttributesOptions() -->
                                     <th data-bind="attr: {class:'data-grid-th col-' + $data.attribute_code},
@@ -83,7 +88,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                     </th>
                                 <!-- /ko -->
                                 <th class="data-grid-th">
-                                    <?= $block->escapeHtml(__('Actions')) ?>
+                                    <?= $escaper->escapeHtml(__('Actions')) ?>
                                 </th>
                             </tr>
                         </thead>
@@ -101,10 +106,10 @@ $jsonHelper = $block->getData('jsonHelper');
                                                 <input type="hidden" data-bind="
                                                     attr: {id: $parent.getRowId(variation, 'image'),
                                                     name: $parent.getVariationRowName(variation, 'image')}"/>
-                                                <span><?= $block->escapeHtml(__('Upload Image')) ?></span>
+                                                <span><?= $escaper->escapeHtml(__('Upload Image')) ?></span>
                                                 <input name="image" type="file"
-                                                       data-url="<?= $block->escapeHtml($block->getImageUploadUrl()) ?>"
-                                                       title="<?= $block->escapeHtml(__('Upload image')) ?>"/>
+                                                       data-url="<?= $escaper->escapeHtml($block->getImageUploadUrl()) ?>"
+                                                       title="<?= $escaper->escapeHtml(__('Upload image')) ?>"/>
                                             <!-- /ko -->
                                         </div>
                                         <!-- ko if: variation.editable -->
@@ -115,12 +120,12 @@ $jsonHelper = $block->getData('jsonHelper');
                                         <!-- /ko -->
                                         <button type="button" class="action toggle no-display" data-toggle="dropdown"
                                                 data-mage-init='{"dropdown":{}}'>
-                                            <span><?= $block->escapeHtml(__('Select')) ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Select')) ?></span>
                                         </button>
                                         <ul class="dropdown">
                                             <li>
                                                 <a class="item" data-action="no-image">
-                                                    <?= $block->escapeHtml(__('No Image')) ?>
+                                                    <?= $escaper->escapeHtml(__('No Image')) ?>
                                                 </a>
                                             </li>
                                         </ul>
@@ -227,7 +232,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                                     "
                                                    data-action="choose"
                                                    href="#">
-                                                    <?= $block->escapeHtml(__('Choose a different Product')) ?>
+                                                    <?= $escaper->escapeHtml(__('Choose a different Product')) ?>
                                                 </a>
                                             </li>
                                             <li>
@@ -240,7 +245,7 @@ $jsonHelper = $block->getData('jsonHelper');
                                             <li>
                                                 <a class="action-menu-item"
                                                    data-bind="click: $parent.removeProduct.bind($parent, $index())">
-                                                    <?= $block->escapeHtml(__('Remove Product')) ?>
+                                                    <?= $escaper->escapeHtml(__('Remove Product')) ?>
                                                 </a>
                                             </li>
                                         </ul>
@@ -255,7 +260,7 @@ $jsonHelper = $block->getData('jsonHelper');
     </div>
     <div data-role="step-wizard-dialog"
          data-mage-init='{"Magento_Ui/js/modal/modal":{"type":"slide","title":"<?=
-            $block->escapeJs(__('Create Product Configurations')) ?>",
+            $escaper->escapeJs(__('Create Product Configurations')) ?>",
          "buttons":[]}}'
          class="no-display">
         <?= /* @noEscape */ $block->getVariationWizard([

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/catalog/product/edit/super/wizard.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
-/** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
+use Magento\ConfigurableProduct\Block\Adminhtml\Product\Edit\Tab\Variations\Config\Matrix;
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Matrix $block */
+/** @var Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
 $productMatrix = $block->getProductMatrix();
 $attributes = $block->getProductAttributes();
@@ -31,7 +36,7 @@ $currencySymbol = $block->getCurrencySymbol();
                     "<?= /* @noEscape */ $block->getData('config/form') ?>.<?= /* @noEscape */ $block->getModal() ?>": {
                         "component": "Magento_ConfigurableProduct/js/components/modal-configurable",
                         "options": {"type": "slide",
-                         "title": "<?= $block->escapeHtml(__('Create Product Configurations')) ?>"},
+                         "title": "<?= $escaper->escapeHtml(__('Create Product Configurations')) ?>"},
                         "formName": "<?= /* @noEscape */ $block->getForm() ?>",
                         "isTemplate": false,
                         "stepWizard": "<?= /* @noEscape */ $block->getData('config/nameStepWizard') ?>",
@@ -57,7 +62,7 @@ $currencySymbol = $block->getCurrencySymbol();
                         ?>.configurable_attribute_set_handler_modal",
                         "wizardModalButtonName": "<?= /* @noEscape */ $block->getForm()
                         ?>.configurable.configurable_products_button_set.create_configurable_products_button",
-                        "wizardModalButtonTitle": "<?= $block->escapeHtml(__('Edit Configurations')) ?>",
+                        "wizardModalButtonTitle": "<?= $escaper->escapeHtml(__('Edit Configurations')) ?>",
                         "productAttributes":<?=/* @noEscape */ $jsonHelper->jsonEncode($attributes)?>,
                         "productUrl": "<?= /* @noEscape */ $block->getUrl('catalog/product/edit', ['id' => '%id%']) ?>",
                         "variations": <?= /* @noEscape */ $jsonHelper->jsonEncode($productMatrix) ?>,

--- a/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/adminhtml/templates/product/configurable/affected-attribute-set-selector/js.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\ConfigurableProduct\Block\Product\Configurable\AttributeSelector;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-<?php $scriptString = <<<script
+/** @var Escaper $escaper */
+/** @var AttributeSelector $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$scriptString = <<<script
 (function(){
     'use strict';
 
@@ -48,12 +53,12 @@
 
         _form
             .modal({
-                title: '{$block->escapeJs(__('Choose Affected Attribute Set'))}',
+                title: '{$escaper->escapeJs(__('Choose Affected Attribute Set'))}',
                 closed: function () {
                     resetValidation();
                 },
                 buttons: [{
-                    text: '{$block->escapeJs(__('Confirm'))}',
+                    text: '{$escaper->escapeJs(__('Confirm'))}',
                     attr: {
                         'data-action': 'confirm'
                     },
@@ -77,12 +82,12 @@
 
                         $.ajax({
                             type: 'POST',
-                            url: '{$block->escapeUrl($block->getAttributeSetCreationUrl())}',
+                            url: '{$escaper->escapeUrl($block->getAttributeSetCreationUrl())}',
                             data: {
                                 gotoEdit: 1,
                                 attribute_set_name: _form.find('input[name=new-attribute-set-name]').val(),
                                 skeleton_set: $('#attribute_set_id').val(),
-                                form_key: '{$block->escapeJs($block->getFormKey())}',
+                                form_key: '{$escaper->escapeJs($block->getFormKey())}',
                                 return_session_messages_only: 1
                             },
                             dataType: 'json',
@@ -102,8 +107,8 @@
                         return false;
                     }
                 },{
-                    text: '{$block->escapeJs(__('Cancel'))}',
-                    id: '{$block->escapeJs($block->getJsId('close-button'))}',
+                    text: '{$escaper->escapeJs(__('Cancel'))}',
+                    id: '{$escaper->escapeJs($block->getJsId('close-button'))}',
                     'class': 'action-close',
                     click: function() {
                         _form.modal('closeModal');

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/final_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/final_price.phtml
@@ -3,11 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\ConfigurableProduct\Pricing\Render\FinalPriceBox$block */
-/** @var \Magento\Framework\Pricing\Price\PriceInterface $priceModel */
+use Magento\ConfigurableProduct\Pricing\Render\FinalPriceBox;
+use Magento\Framework\Escaper;
+use Magento\Framework\Pricing\Price\PriceInterface;
+
+/** @var Escaper $escaper */
+/** @var FinalPriceBox$block */
+/** @var PriceInterface $priceModel */
 $priceModel = $block->getPriceType('regular_price');
-/** @var \Magento\Framework\Pricing\Price\PriceInterface $finalPriceModel */
+
+/** @var PriceInterface $finalPriceModel */
 $finalPriceModel = $block->getPriceType('final_price');
 $idSuffix = $block->getIdSuffix() ? $block->getIdSuffix() : '';
 $schema = ($block->getZone() == 'item_view') ? true : false;
@@ -37,7 +44,7 @@ $schema = ($block->getZone() == 'item_view') ? true : false;
 
 <?php if ($block->showMinimalPrice()) : ?>
     <?php if ($block->getUseLinkForAsLowAs()) :?>
-        <a href="<?= $block->escapeUrl($block->getSaleableItem()->getProductUrl()) ?>" class="minimal-price-link">
+        <a href="<?= $escaper->escapeUrl($block->getSaleableItem()->getProductUrl()) ?>" class="minimal-price-link">
             <?= /* @noEscape */ $block->renderAmountMinimal() ?>
         </a>
     <?php else :?>

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -3,12 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
 <script type="text/x-magento-template" id="tier-prices-template">
     <ul class="prices-tier items">
         <% var basePriceTemplate = ' <span class="price-wrapper price-excluding-tax"'
-        + 'data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">'
+        + 'data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">'
         + '<span class="price">&nbsp;%1</span>'
         + '</span>'
         %>
@@ -26,12 +32,12 @@
                     + '</span>' + itemBasePrice + '</span>';
         %>
         <li class="item">
-            <%= '<?= $block->escapeHtml(__('Buy %1 for %2 each and', '%1', '%2')) ?>'
+            <%= '<?= $escaper->escapeHtml(__('Buy %1 for %2 each and', '%1', '%2')) ?>'
             .replace('%1', item.qty)
             .replace('%2', priceStr)
             %>
             <strong class="benefit">
-                <?= $block->escapeHtml(__('save')) ?><span
+                <?= $escaper->escapeHtml(__('save')) ?><span
                     class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
             </strong>
         </li>

--- a/app/code/Magento/ConfigurableProduct/view/frontend/templates/product/view/type/options/configurable.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/frontend/templates/product/view/type/options/configurable.phtml
@@ -3,26 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
-/** @var $block \Magento\ConfigurableProduct\Block\Product\View\Type\Configurable*/
+use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Configurable $block */
 $_product    = $block->getProduct();
 $_attributes = $block->decorateArray($block->getAllowAttributes());
 ?>
 <?php if ($_product->isSaleable() && count($_attributes)) :?>
     <?php foreach ($_attributes as $_attribute) : ?>
         <div class="field configurable required">
-            <label class="label" for="attribute<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>">
-                <span><?= $block->escapeHtml($_attribute->getProductAttribute()->getStoreLabel()) ?></span>
+            <label class="label" for="attribute<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>">
+                <span><?= $escaper->escapeHtml($_attribute->getProductAttribute()->getStoreLabel()) ?></span>
             </label>
             <div class="control">
-                <select name="super_attribute[<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
-                        data-selector="super_attribute[<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
+                <select name="super_attribute[<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
+                        data-selector="super_attribute[<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>]"
                         data-validate="{required:true}"
-                        id="attribute<?= $block->escapeHtmlAttr($_attribute->getAttributeId()) ?>"
+                        id="attribute<?= $escaper->escapeHtmlAttr($_attribute->getAttributeId()) ?>"
                         class="super-attribute-select">
-                    <option value=""><?= $block->escapeHtml(__('Choose an Option...')) ?></option>
+                    <option value=""><?= $escaper->escapeHtml(__('Choose an Option...')) ?></option>
                 </select>
             </div>
         </div>
@@ -32,7 +35,7 @@ $_attributes = $block->decorateArray($block->getAllowAttributes());
             "#product_addtocart_form": {
                 "configurable": {
                     "spConfig": <?= /* @noEscape */ $block->getJsonConfig() ?>,
-                    "gallerySwitchStrategy": "<?= $block->escapeJs($block->getVar(
+                    "gallerySwitchStrategy": "<?= $escaper->escapeJs($block->getVar(
                         'gallery_switch_strategy',
                         'Magento_ConfigurableProduct'
                     ) ?: 'replace'); ?>"


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_ConfigurableProduct` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

### Resolved issues:
1. [x] resolves magento/magento2#37168: Chore: Configurable Product - Replace Block Escaping with Escaper