### PR TITLE
Chore: Grouped Product - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/catalog/product/composite/fieldset/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/catalog/product/composite/fieldset/grouped.phtml
@@ -3,32 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-?>
+declare(strict_types=1);
 
-<?php /* @var $block \Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped */ ?>
-<?php $_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck(); ?>
+use Magento\Framework\Escaper;
+use Magento\GroupedProduct\Block\Adminhtml\Product\Composite\Fieldset\Grouped;
+
+/** @var Escaper $escaper */
+/** @var Grouped $block */
+
+// phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
+$_skipSaleableCheck = $this->helper(Magento\Catalog\Helper\Product::class)->getSkipSaleableCheck();
+?>
 <div id="catalog_product_composite_configure_fields_grouped" class="<?= $block->getIsLastFieldset() ? 'last-fieldset' : '' ?>">
-    <h4><?= $block->escapeHtml(__('Associated Products')) ?></h4>
+    <h4><?= $escaper->escapeHtml(__('Associated Products')) ?></h4>
     <div class="product-options">
         <?php $_product = $block->getProduct(); ?>
         <?php $block->setPreconfiguredValue(); ?>
         <?php $_associatedProducts = $block->getAssociatedProducts(); ?>
         <?php $_hasAssociatedProducts = count($_associatedProducts) > 0; ?>
         <?php if ((!$_product->isAvailable() && !$_skipSaleableCheck) || !$_hasAssociatedProducts) : ?>
-            <p class="availability out-of-stock"><?= $block->escapeHtml(__('Availability:')) ?> <span><?= $block->escapeHtml(__('Out of stock')) ?></span></p>
+            <p class="availability out-of-stock"><?= $escaper->escapeHtml(__('Availability:')) ?> <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></p>
         <?php endif; ?>
         <table class="data-table admin__table-primary grouped-items-table" id="super-product-table">
             <thead>
                 <tr class="headings">
-                    <th class="col-id"><?= $block->escapeHtml(__('ID')) ?></th>
-                    <th class="col-sku"><?= $block->escapeHtml(__('SKU')) ?></th>
-                    <th class="col-name"><?= $block->escapeHtml(__('Product Name')) ?></th>
+                    <th class="col-id"><?= $escaper->escapeHtml(__('ID')) ?></th>
+                    <th class="col-sku"><?= $escaper->escapeHtml(__('SKU')) ?></th>
+                    <th class="col-name"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
                     <?php if ($block->getCanShowProductPrice($_product)) : ?>
-                    <th class="col-price"><?= $block->escapeHtml(__('Price')) ?></th>
+                    <th class="col-price"><?= $escaper->escapeHtml(__('Price')) ?></th>
                     <?php endif; ?>
                     <?php if ($_product->isSaleable() || $_skipSaleableCheck) : ?>
-                    <th class="col-qty"><?= $block->escapeHtml(__('Qty')) ?></th>
+                    <th class="col-qty"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                     <?php endif; ?>
                 </tr>
             </thead>
@@ -36,10 +42,10 @@
             <?php if ($_hasAssociatedProducts) : ?>
                 <?php $i = 0 ?>
                 <?php foreach ($_associatedProducts as $_item) : ?>
-                <tr class="<?= $block->escapeHtmlAttr((++$i % 2) ? 'even' : 'odd') ?>">
-                    <td class="col-id"><?= $block->escapeHtml($_item->getId()) ?></td>
-                    <td class="col-sku"><?= $block->escapeHtml($_item->getSku()) ?></td>
-                    <td class="col-name"><?= $block->escapeHtml($_item->getName()) ?></td>
+                <tr class="<?= $escaper->escapeHtmlAttr((++$i % 2) ? 'even' : 'odd') ?>">
+                    <td class="col-id"><?= $escaper->escapeHtml($_item->getId()) ?></td>
+                    <td class="col-sku"><?= $escaper->escapeHtml($_item->getSku()) ?></td>
+                    <td class="col-name"><?= $escaper->escapeHtml($_item->getName()) ?></td>
                     <?php if ($block->getCanShowProductPrice($_product)) : ?>
                     <td class="col-price">
                         <?php if ($block->getCanShowProductPrice($_item)) : ?>
@@ -51,15 +57,15 @@
                     <td class="col-qty">
                         <?php if ($_item->isSaleable() || $_skipSaleableCheck) : ?>
                         <input type="text"
-                               name="super_group[<?= $block->escapeHtmlAttr($_item->getId()) ?>]"
-                               id="super_group[<?= $block->escapeHtmlAttr($_item->getId()) ?>]"
+                               name="super_group[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>]"
+                               id="super_group[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>]"
                                maxlength="12"
-                               value="<?= $block->escapeHtmlAttr($_item->getQty()*1) ?>"
-                               title="<?= $block->escapeHtmlAttr(__('Qty')) ?>"
+                               value="<?= $escaper->escapeHtmlAttr($_item->getQty()*1) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"
                                class="input-text admin__control-text qty" />
-                        <input type="hidden" value="1" price="<?= $block->escapeHtmlAttr($block->getCurrencyPrice($_item->getPrice())) ?>" qtyId="super_group[<?= $block->escapeHtmlAttr($_item->getId()) ?>]" />
+                        <input type="hidden" value="1" price="<?= $escaper->escapeHtmlAttr($block->getCurrencyPrice($_item->getPrice())) ?>" qtyId="super_group[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>]" />
                     <?php else : ?>
-                        <p class="availability out-of-stock"><span><?= $block->escapeHtml(__('Out of stock')) ?></span></p>
+                        <p class="availability out-of-stock"><span><?= $escaper->escapeHtml(__('Out of stock')) ?></span></p>
                     <?php endif; ?>
                     </td>
                     <?php endif; ?>
@@ -67,7 +73,7 @@
             <?php endforeach; ?>
             <?php else : ?>
                <tr>
-                   <td class="empty-text" colspan="<?php if ($_product->isSaleable() || $_skipSaleableCheck) : ?>4<?php else : ?>3<?php endif; ?>"><?= $block->escapeHtml(__('No options of this product are available.')) ?></td>
+                   <td class="empty-text" colspan="<?php if ($_product->isSaleable() || $_skipSaleableCheck) : ?>4<?php else : ?>3<?php endif; ?>"><?= $escaper->escapeHtml(__('No options of this product are available.')) ?></td>
                </tr>
             <?php endif; ?>
             </tbody>

--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/grouped.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Framework\View\Element\Template */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
 
-/** @var $block \Magento\Framework\View\Element\Template */
+/** @var Escaper $escaper */
+/** @var Template $block */
 $_gridPopupBlock = $block->getChildBlock('catalog.product.group.grid.popup.container')->getChildBlock('grid');
 $_gridPopupBlock->setRowClickCallback('function(){}');
 ?>
-<div id="grouped-product-container" data-mage-init='{"groupedProduct":{"gridPopup":"[data-grid-id=<?= $block->escapeHtmlAttr($_gridPopupBlock->getId()) ?>]"}}'>
+<div id="grouped-product-container" data-mage-init='{"groupedProduct":{"gridPopup":"[data-grid-id=<?= $escaper->escapeHtmlAttr($_gridPopupBlock->getId()) ?>]"}}'>
     <div class="no-products-message">
-        <?= $block->escapeHtml(__('There are no grouped products.')) ?>
+        <?= $escaper->escapeHtml(__('There are no grouped products.')) ?>
     </div>
     <?= $block->getChildHtml('list') ?>
     <div data-role="add-product-dialog" class="no-display">

--- a/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/list.phtml
+++ b/app/code/Magento/GroupedProduct/view/adminhtml/templates/product/grouped/list.phtml
@@ -3,9 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts;
+
+/** @var Escaper $escaper */
+/** @var ListAssociatedProducts $block */
+
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/* @var $block \Magento\GroupedProduct\Block\Product\Grouped\AssociatedProducts\ListAssociatedProducts */
 ?>
 <script type="text/x-magento-template" id="group-product-template">
 <tr title="#" class="pointer" data-role="row">
@@ -48,7 +55,7 @@
 </script>
 <div class="grid-container no-display">
     <table class="admin__control-table" data-role="grouped-product-grid"
-        data-products="<?= $block->escapeHtml(
+        data-products="<?= $escaper->escapeHtml(
             $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getAssociatedProducts())
         ); ?>">
         <thead>
@@ -57,16 +64,16 @@
                     <span></span>
                 </th>
                 <th data-column="name" class="no-link col-name">
-                    <span><?= $block->escapeHtml(__('Name')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Name')) ?></span>
                 </th>
                 <th data-column="sku" class="no-link col-sku">
-                    <span><?= $block->escapeHtml(__('SKU')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('SKU')) ?></span>
                 </th>
                 <th data-column="price" class="no-link col-price">
-                    <span><?= $block->escapeHtml(__('Price')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Price')) ?></span>
                     </th>
                 <th data-column="qty" class="no-link col-qty">
-                    <span><?= $block->escapeHtml(__('Default Qty')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Default Qty')) ?></span>
                 </th>
                 <th data-column="actions" class="last no-link col-actions">
                     <span></span>

--- a/app/code/Magento/GroupedProduct/view/base/templates/product/price/final_price.phtml
+++ b/app/code/Magento/GroupedProduct/view/base/templates/product/price/final_price.phtml
@@ -3,12 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Template for displaying grouped product price
- */
-?>
-<?php
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 $minProduct = $block->getSaleableItem()
     ->getPriceInfo()
     ->getPrice(\Magento\Catalog\Pricing\Price\FinalPrice::PRICE_CODE)
@@ -27,7 +27,7 @@ if ($minProduct) {
 <div class="price-box">
     <?php if ($minProduct && \Magento\Framework\Pricing\Render::ZONE_ITEM_VIEW != $block->getZone()) : ?>
     <p class="minimal-price">
-        <span class="price-label"><?= $block->escapeHtml(__('Starting at')) ?></span><?= $amountRender->toHtml() ?>
+        <span class="price-label"><?= $escaper->escapeHtml(__('Starting at')) ?></span><?= $amountRender->toHtml() ?>
     </p>
     <?php endif ?>
 </div>

--- a/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/default.phtml
+++ b/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/default.phtml
@@ -3,20 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php /* @var $block \Magento\Catalog\Block\Product\View\AbstractView */?>
-<?php $_product = $block->getProduct() ?>
+declare(strict_types=1);
 
-<?php $_associatedProducts = $block->getAssociatedProducts(); ?>
-<?php $_hasAssociatedProducts = count($_associatedProducts) > 0; ?>
+use Magento\Catalog\Block\Product\View\AbstractView;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var AbstractView $block */
+$_product = $block->getProduct();
+$_associatedProducts = $block->getAssociatedProducts();
+$_hasAssociatedProducts = count($_associatedProducts) > 0;
+?>
 <?php if ($block->displayProductStockStatus()) : ?>
     <?php if ($_product->isAvailable() && $_hasAssociatedProducts) : ?>
-        <div class="stock available" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-            <span><?= $block->escapeHtml(__('In stock')) ?></span>
+        <div class="stock available" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+            <span><?= $escaper->escapeHtml(__('In stock')) ?></span>
         </div>
     <?php else : ?>
-        <div class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-            <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+        <div class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+            <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
         </div>
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/grouped.phtml
+++ b/app/code/Magento/GroupedProduct/view/frontend/templates/product/view/type/grouped.phtml
@@ -3,29 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Grouped product data template
- *
- * @var $block \Magento\Catalog\Block\Product\View\BaseImage
- * @var $block \Magento\GroupedProduct\Block\Product\View\Type\Grouped
- */
+use Magento\Framework\Escaper;
+use Magento\GroupedProduct\Block\Product\View\Type\Grouped;
+
+/** @var Escaper $escaper */
+/** @var Grouped $block */
+$block->setPreconfiguredValue();
+$_product = $block->getProduct();
+$_associatedProducts = $block->getAssociatedProducts();
+$_hasAssociatedProducts = count($_associatedProducts) > 0;
 ?>
-<?php $block->setPreconfiguredValue(); ?>
-<?php $_product = $block->getProduct(); ?>
-<?php $_associatedProducts = $block->getAssociatedProducts(); ?>
-<?php $_hasAssociatedProducts = count($_associatedProducts) > 0; ?>
-
 <div class="table-wrapper grouped">
     <table class="table data grouped"
            id="super-product-table"
            data-mage-init='{ "Magento_GroupedProduct/js/product-ids-resolver": {} }'>
-        <caption class="table-caption"><?= $block->escapeHtml(__('Grouped product items')) ?></caption>
+        <caption class="table-caption"><?= $escaper->escapeHtml(__('Grouped product items')) ?></caption>
         <thead>
         <tr>
-            <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')) ?></th>
+            <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
             <?php if ($_product->isSaleable()) : ?>
-                <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
+                <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
             <?php endif; ?>
         </tr>
         </thead>
@@ -34,8 +33,8 @@
         <tbody>
             <?php foreach ($_associatedProducts as $_item) : ?>
             <tr>
-                <td data-th="<?= $block->escapeHtml(__('Product Name')) ?>" class="col item">
-                    <strong class="product-item-name"><?= $block->escapeHtml($_item->getName()) ?></strong>
+                <td data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>" class="col item">
+                    <strong class="product-item-name"><?= $escaper->escapeHtml($_item->getName()) ?></strong>
                     <?php if ($block->getCanShowProductPrice($_product)) : ?>
                         <?php if ($block->getCanShowProductPrice($_item)) : ?>
                             <?= /* @noEscape */ $block->getProductPrice($_item) ?>
@@ -43,21 +42,21 @@
                         <?php endif; ?>
                 </td>
                 <?php if ($_product->isSaleable()) : ?>
-                <td data-th="<?= $block->escapeHtml(__('Qty')) ?>" class="col qty">
+                <td data-th="<?= $escaper->escapeHtml(__('Qty')) ?>" class="col qty">
                     <?php if ($_item->isSaleable()) : ?>
                     <div class="control qty">
                         <input type="number"
-                               name="super_group[<?= $block->escapeHtmlAttr($_item->getId()) ?>]"
-                               data-selector="super_group[<?= $block->escapeHtmlAttr($_item->getId()) ?>]"
-                               value="<?= $block->escapeHtmlAttr($_item->getQty() * 1) ?>"
-                               title="<?= $block->escapeHtmlAttr(__('Qty')) ?>"
+                               name="super_group[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>]"
+                               data-selector="super_group[<?= $escaper->escapeHtmlAttr($_item->getId()) ?>]"
+                               value="<?= $escaper->escapeHtmlAttr($_item->getQty() * 1) ?>"
+                               title="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"
                                class="input-text qty"
                                data-validate="{'validate-grouped-qty':'#super-product-table'}"
                                data-errors-message-box="#validation-message-box"/>
                     </div>
                 <?php else : ?>
-                    <div class="stock unavailable" title="<?= $block->escapeHtmlAttr(__('Availability')) ?>">
-                        <span><?= $block->escapeHtml(__('Out of stock')) ?></span>
+                    <div class="stock unavailable" title="<?= $escaper->escapeHtmlAttr(__('Availability')) ?>">
+                        <span><?= $escaper->escapeHtml(__('Out of stock')) ?></span>
                     </div>
                 <?php endif; ?>
                 </td>
@@ -85,7 +84,7 @@
             <tr>
                 <td class="unavailable"
                     colspan="<?php if ($_product->isSaleable()) : ?>4<?php else : ?>3<?php endif; ?>">
-                    <?= $block->escapeHtml(__('No options of this product are available.')) ?>
+                    <?= $escaper->escapeHtml(__('No options of this product are available.')) ?>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_GroupedProduct` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37171: Chore: Grouped Product - Replace Block Escaping with Escaper