### PR TITLE
Chore: Multishipping - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/address/select.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/address/select.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Multishipping\Block\Checkout\Address\Select $block */
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\Address\Select;
+
+/** @var Escaper $escaper */
+/** @var Select $block */
 ?>
 <div class="multicheckout">
     <div class="block block-billing">
@@ -14,19 +19,19 @@
                 <address>
                     <?= $block->getAddressAsHtml($address) ?>
                     <?php if ($block->isAddressDefaultBilling($address)) : ?>
-                        <br /><strong><?= $block->escapeHtml(__('Default Billing')); ?></strong>
+                        <br /><strong><?= $escaper->escapeHtml(__('Default Billing')); ?></strong>
                     <?php endif; ?>
                     <?php if ($block->isAddressDefaultShipping($address)) : ?>
-                        <br /><strong><?= $block->escapeHtml(__('Default Shipping')); ?></strong>
+                        <br /><strong><?= $escaper->escapeHtml(__('Default Shipping')); ?></strong>
                     <?php endif; ?>
                 </address>
             </div>
             <div class="box-actions">
-                <a href="<?= $block->escapeUrl($block->getEditAddressUrl($address)); ?>" class="action edit">
-                    <span><?= $block->escapeHtml(__('Edit Address')); ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getEditAddressUrl($address)); ?>" class="action edit">
+                    <span><?= $escaper->escapeHtml(__('Edit Address')); ?></span>
                 </a>
-                <a href="<?= $block->escapeUrl($block->getSetAddressUrl($address)); ?>" class="action select">
-                    <span><?= $block->escapeHtml(__('Select Address')); ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getSetAddressUrl($address)); ?>" class="action select">
+                    <span><?= $escaper->escapeHtml(__('Select Address')); ?></span>
                 </a>
             </div>
         </div>
@@ -34,13 +39,13 @@
     </div>
     <div class="actions-toolbar">
         <div class="primary">
-            <button type="button" class="action add primary" role="add-address" title="<?= $block->escapeHtml(__('Add New Address')); ?>">
-                <span><?= $block->escapeHtml(__('Add New Address')); ?></span>
+            <button type="button" class="action add primary" role="add-address" title="<?= $escaper->escapeHtml(__('Add New Address')); ?>">
+                <span><?= $escaper->escapeHtml(__('Add New Address')); ?></span>
             </button>
         </div>
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()); ?>" class="action back">
-                <span><?= $block->escapeHtml(__('Back to Billing Information')); ?></span>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()); ?>" class="action back">
+                <span><?= $escaper->escapeHtml(__('Back to Billing Information')); ?></span>
             </a>
         </div>
     </div>
@@ -50,7 +55,7 @@
         ".action": {
             "address": {
                 "addAddress": "button[role='add-address']",
-                "addAddressLocation": "<?= $block->escapeUrl($block->getAddNewUrl()); ?>"
+                "addAddressLocation": "<?= $escaper->escapeUrl($block->getAddNewUrl()); ?>"
             }
         }
     }

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/addresses.phtml
@@ -3,42 +3,42 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\Addresses;
+
+/** @var Escaper $escaper */
+/** @var Addresses $block */
 
 // phpcs:disable Generic.Files.LineLength
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundHelper
-?>
-<?php
-/**
- * Ship to multiple address template
- *
- * @var $block \Magento\Multishipping\Block\Checkout\Addresses
- */
 ?>
 <form id="checkout_multishipping_form"
       data-mage-init='{
           "multiShipping": {"itemsQty": <?= /* @noEscape */ (int)$block->getCheckout()->getQuote()->getItemsSummaryQty() ?>},
           "cartUpdate": {
-               "validationURL": "<?= $block->escapeUrl($block->getUrl('multishipping/checkout/checkItems')) ?>",
+               "validationURL": "<?= $escaper->escapeUrl($block->getUrl('multishipping/checkout/checkItems')) ?>",
                "eventName": "updateMulticartItemQty"
           }}'
-      action="<?= $block->escapeUrl($block->getPostActionUrl()) ?>"
+      action="<?= $escaper->escapeUrl($block->getPostActionUrl()) ?>"
       method="post"
       class="multicheckout address form">
     <div class="title">
-        <strong><?= $block->escapeHtml(__('Please select a shipping address for applicable items.')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Please select a shipping address for applicable items.')) ?></strong>
     </div>
     <input type="hidden" name="continue" value="0" id="can_continue_flag"/>
     <input type="hidden" name="new_address" value="0" id="add_new_address_flag"/>
     <div class="table-wrapper">
         <table class="items data table" id="multiship-addresses-table">
             <caption class="table-caption">
-                <?= $block->escapeHtml(__('Please select a shipping address for applicable items.')) ?>
+                <?= $escaper->escapeHtml(__('Please select a shipping address for applicable items.')) ?>
             </caption>
             <thead>
             <tr>
-                <th class="col product" scope="col"><?= $block->escapeHtml(__('Product')) ?></th>
-                <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
-                <th class="col address" scope="col"><?= $block->escapeHtml(__('Send To')) ?></th>
+                <th class="col product" scope="col"><?= $escaper->escapeHtml(__('Product')) ?></th>
+                <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
+                <th class="col address" scope="col"><?= $escaper->escapeHtml(__('Send To')) ?></th>
                 <th class="col actions" scope="col">&nbsp;</th>
             </tr>
             </thead>
@@ -46,21 +46,21 @@
             <?php foreach ($block->getItems() as $_index => $_item): ?>
                 <?php if ($_item->getQuoteItem()): ?>
                     <tr>
-                        <td class="col product" data-th="<?= $block->escapeHtml(__('Product')) ?>">
+                        <td class="col product" data-th="<?= $escaper->escapeHtml(__('Product')) ?>">
                             <?= $block->getItemHtml($_item->getQuoteItem()) ?>
                         </td>
-                        <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>">
+                        <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>">
                             <div class="field qty">
-                                <label for="ship-<?= $block->escapeHtml($_index) ?>-<?= $block->escapeHtml($_item->getQuoteItemId()) ?>-qty"
+                                <label for="ship-<?= $escaper->escapeHtml($_index) ?>-<?= $escaper->escapeHtml($_item->getQuoteItemId()) ?>-qty"
                                        class="label">
-                                    <span><?= $block->escapeHtml(__('Qty')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Qty')) ?></span>
                                 </label>
                                 <div class="control">
                                     <input type="number"
-                                           data-multiship-item-id="<?= $block->escapeHtml($_item->getSku()) ?>"
-                                           id="ship-<?= $block->escapeHtml($_index) ?>-<?= $block->escapeHtml($_item->getQuoteItemId()) ?>-qty"
-                                           name="ship[<?= $block->escapeHtml($_index) ?>][<?= $block->escapeHtml($_item->getQuoteItemId()) ?>][qty]"
-                                           value="<?= $block->escapeHtml($_item->getQty()) ?>"
+                                           data-multiship-item-id="<?= $escaper->escapeHtml($_item->getSku()) ?>"
+                                           id="ship-<?= $escaper->escapeHtml($_index) ?>-<?= $escaper->escapeHtml($_item->getQuoteItemId()) ?>-qty"
+                                           name="ship[<?= $escaper->escapeHtml($_index) ?>][<?= $escaper->escapeHtml($_item->getQuoteItemId()) ?>][qty]"
+                                           value="<?= $escaper->escapeHtml($_item->getQty()) ?>"
                                            size="2"
                                            min="0"
                                            class="input-text qty"
@@ -70,16 +70,16 @@
                                 </div>
                             </div>
                         </td>
-                        <td class="col address" data-th="<?= $block->escapeHtml(__('Send To')) ?>">
+                        <td class="col address" data-th="<?= $escaper->escapeHtml(__('Send To')) ?>">
                             <?php if ($_item->getProduct()->getIsVirtual()): ?>
                                 <div class="applicable">
-                                    <?= $block->escapeHtml(__('A shipping selection is not applicable.')) ?>
+                                    <?= $escaper->escapeHtml(__('A shipping selection is not applicable.')) ?>
                                 </div>
                             <?php else: ?>
                                 <div class="field address">
-                                    <label for="ship_<?= $block->escapeHtml($_index) ?>_<?= $block->escapeHtml($_item->getQuoteItemId()) ?>_address"
+                                    <label for="ship_<?= $escaper->escapeHtml($_index) ?>_<?= $escaper->escapeHtml($_item->getQuoteItemId()) ?>_address"
                                            class="label">
-                                        <span><?= $block->escapeHtml(__('Send To')) ?></span>
+                                        <span><?= $escaper->escapeHtml(__('Send To')) ?></span>
                                     </label>
                                     <div class="control">
                                         <?= $block->getAddressesHtmlSelect($_item, $_index) ?>
@@ -87,16 +87,16 @@
                                 </div>
                             <?php endif; ?>
                         </td>
-                        <td class="col actions" data-th="<?= $block->escapeHtml(__('Actions')) ?>">
+                        <td class="col actions" data-th="<?= $escaper->escapeHtml(__('Actions')) ?>">
                             <a href="#"
-                               title="<?= $block->escapeHtml(__('Remove Item')) ?>"
+                               title="<?= $escaper->escapeHtml(__('Remove Item')) ?>"
                                data-post='<?= /* @noEscape */
                                 $this->helper(\Magento\Framework\Data\Helper\PostHelper::class)
                                    ->getPostData($block->getItemDeleteUrl($_item))
                                 ?>'
                                class="action delete"
                                data-multiship-item-remove="">
-                                <span><?= $block->escapeHtml(__('Remove item')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Remove item')) ?></span>
                             </a>
                         </td>
                     </tr>
@@ -108,14 +108,14 @@
     <div class="actions-toolbar">
         <div class="primary">
             <button type="submit"
-                    title="<?= $block->escapeHtml(__('Go to Shipping Information')) ?>"
+                    title="<?= $escaper->escapeHtml(__('Go to Shipping Information')) ?>"
                     class="action primary continue<?= $block->isContinueDisabled() ? ' disabled' : '' ?>"
                     data-role="can-continue"
                     data-flag="1"
                 <?php if ($block->isContinueDisabled()): ?>
                     disabled="disabled"
                 <?php endif; ?>>
-                <span><?= $block->escapeHtml(__('Go to Shipping Information')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Go to Shipping Information')) ?></span>
             </button>
         </div>
         <div class="secondary">
@@ -124,17 +124,17 @@
                     class="action update"
                     data-role="can-continue"
                     data-flag="0">
-                <span><?= $block->escapeHtml(__('Update Qty &amp; Addresses')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Update Qty &amp; Addresses')) ?></span>
             </button>
             <button type="button"
-                    title="<?= $block->escapeHtml(__('Enter a New Address')) ?>"
+                    title="<?= $escaper->escapeHtml(__('Enter a New Address')) ?>"
                     class="action add"
                     data-role="add-new-address">
-                <span><?= $block->escapeHtml(__('Enter a New Address')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Enter a New Address')) ?></span>
             </button>
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>"
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>"
                class="action back">
-                <span><?= $block->escapeHtml(__('Back to Shopping Cart')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Back to Shopping Cart')) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/billing/items.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/billing/items.phtml
@@ -3,30 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php if ($block->getQuote()->hasVirtualItems()) : ?>
 <div class="block block-other">
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Other items in your order')) ?></strong>
-        <a href="<?= $block->escapeUrl($block->getVirtualProductEditUrl()) ?>" class="action edit"><span><?= $block->escapeHtml(__('Edit Items')) ?></span></a>
+        <strong><?= $escaper->escapeHtml(__('Other items in your order')) ?></strong>
+        <a href="<?= $escaper->escapeUrl($block->getVirtualProductEditUrl()) ?>" class="action edit"><span><?= $escaper->escapeHtml(__('Edit Items')) ?></span></a>
     </div>
     <div class="block-content">
-        <p><?= $block->escapeHtml(__('Shipping is not applicable.')) ?></p>
+        <p><?= $escaper->escapeHtml(__('Shipping is not applicable.')) ?></p>
         <div class="table-wrapper">
             <table class="items data table" id="unavailable-shipping-table">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Other items in your order')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Other items in your order')) ?></caption>
                 <thead>
                     <tr>
-                        <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                        <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
+                        <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                        <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                     </tr>
                 </thead>
                 <tbody>
                 <?php foreach ($block->getVirtualQuoteItems() as $_item) : ?>
                     <tr>
-                        <td class="col item" data-th="<?= $block->escapeHtml(__('Product Name')) ?>"><?= $block->getItemHtml($_item) ?></td>
-                        <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>"><?= $block->escapeHtml($_item->getQty()) ?></td>
+                        <td class="col item" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>"><?= $block->getItemHtml($_item) ?></td>
+                        <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>"><?= $escaper->escapeHtml($_item->getQty()) ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/link.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/link.phtml
@@ -3,6 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<a class="action multicheckout" href="<?= $block->escapeUrl($block->getCheckoutUrl()) ?>"><span><?= $block->escapeHtml(__('Check Out with Multiple Addresses')) ?></span></a>
+<a class="action multicheckout" href="<?= $escaper->escapeUrl($block->getCheckoutUrl()) ?>">
+    <span><?= $escaper->escapeHtml(__('Check Out with Multiple Addresses')) ?></span>
+</a>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview.phtml
@@ -3,41 +3,47 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Multishipping\Block\Checkout\Overview $block */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Multishipping\Block\Checkout\Overview;
 
-<?php
+/** @var Escaper $escaper */
+/** @var Overview $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 /** @var \Magento\Tax\Helper\Data $taxHelper */
 $taxHelper = $block->getData('taxHelper');
+
 /** @var \Magento\Checkout\Helper\Data $checkoutHelper */
 $checkoutHelper = $block->getData('checkoutHelper');
+
+$errors = $block->getCheckoutData()->getAddressErrors();
 ?>
-<?php $errors = $block->getCheckoutData()->getAddressErrors(); ?>
 <?php foreach ($errors as $addressId => $error): ?>
     <div class="message message-error error">
-        <?= $block->escapeHtml($error); ?>
-        <?= $block->escapeHtml(__('Please see')); ?>
-        <a href="#<?= $block->escapeHtml($block->getCheckoutData()->getAddressAnchorName($addressId)); ?>">
-            <?= $block->escapeHtml(__('details below')); ?></a>.
+        <?= $escaper->escapeHtml($error); ?>
+        <?= $escaper->escapeHtml(__('Please see')); ?>
+        <a href="#<?= $escaper->escapeHtml($block->getCheckoutData()->getAddressAnchorName($addressId)); ?>">
+            <?= $escaper->escapeHtml(__('details below')); ?></a>.
     </div>
 <?php endforeach;?>
-<form action="<?= $block->escapeUrl($block->getPostActionUrl()); ?>"
+<form action="<?= $escaper->escapeUrl($block->getPostActionUrl()); ?>"
       method="post"
       id="review-order-form"
       data-mage-init='{"orderOverview": {}, "validation":{}}'
       class="form multicheckout order-review">
     <?= /* @noEscape */ $block->getBlockHtml('formkey'); ?>
     <div class="block block-billing">
-        <div class="block-title"><strong><?= $block->escapeHtml(__('Billing Information')); ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('Billing Information')); ?></strong></div>
         <div class="block-content">
             <div class="box box-billing-address">
                 <?php $address = $block->getBillingAddress() ?>
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Billing Address')); ?></span>
-                    <a href="<?= $block->escapeUrl($block->getEditBillingAddressUrl($address)); ?>"
-                       class="action edit"><span><?= $block->escapeHtml(__('Change')); ?></span></a>
+                    <span><?= $escaper->escapeHtml(__('Billing Address')); ?></span>
+                    <a href="<?= $escaper->escapeUrl($block->getEditBillingAddressUrl($address)); ?>"
+                       class="action edit"><span><?= $escaper->escapeHtml(__('Change')); ?></span></a>
                 </strong>
                 <div class="box-content">
                     <address>
@@ -47,45 +53,45 @@ $checkoutHelper = $block->getData('checkoutHelper');
             </div>
             <div class="box box-billing-method">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Payment Method')); ?></span>
-                    <a href="<?= $block->escapeUrl($block->getEditBillingUrl()); ?>"
-                       class="action edit"><span><?= $block->escapeHtml(__('Change')); ?></span></a>
+                    <span><?= $escaper->escapeHtml(__('Payment Method')); ?></span>
+                    <a href="<?= $escaper->escapeUrl($block->getEditBillingUrl()); ?>"
+                       class="action edit"><span><?= $escaper->escapeHtml(__('Change')); ?></span></a>
                 </strong>
                 <div class="box-content">
                     <input type="hidden"
                            name="payment[cc_number]"
-                           value="<?= $block->escapeHtml($block->getPayment()->getCcNumber()) ?>" />
+                           value="<?= $escaper->escapeHtml($block->getPayment()->getCcNumber()) ?>" />
                     <input type="hidden"
                            name="payment[cc_cid]"
-                           value="<?= $block->escapeHtml($block->getPayment()->getCcCid()) ?>" />
+                           value="<?= $escaper->escapeHtml($block->getPayment()->getCcCid()) ?>" />
                     <?= /* @noEscape */ $block->getPaymentHtml() ?>
                 </div>
             </div>
         </div>
     </div>
     <div class="block block-shipping">
-        <div class="block-title"><strong><?= $block->escapeHtml(__('Shipping Information')); ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('Shipping Information')); ?></strong></div>
         <?php $mergedCells = ($taxHelper->displayCartBothPrices() ? 2 : 1); ?>
         <?php foreach ($block->getShippingAddresses() as $index => $address): ?>
             <div class="block-content">
-                <a name="<?= $block->escapeHtml($block->getCheckoutData()
+                <a name="<?= $escaper->escapeHtml($block->getCheckoutData()
                     ->getAddressAnchorName($address->getId())); ?>"></a>
                 <div class="title">
-                    <strong><?= $block->escapeHtml(__('Address')); ?> <?= $block->escapeHtml($index + 1); ?>
+                    <strong><?= $escaper->escapeHtml(__('Address')); ?> <?= $escaper->escapeHtml($index + 1); ?>
                         <span>
-                            <?= $block->escapeHtml(__('of')); ?>
-                            <?= $block->escapeHtml($block->getShippingAddressCount())?>
+                            <?= $escaper->escapeHtml(__('of')); ?>
+                            <?= $escaper->escapeHtml($block->getShippingAddressCount())?>
                         </span>
                     </strong>
                 </div>
                 <?php if ($error = $block->getCheckoutData()->getAddressError($address)): ?>
-                    <div class="error-description"><?= $block->escapeHtml($error); ?></div>
+                    <div class="error-description"><?= $escaper->escapeHtml($error); ?></div>
                 <?php endif;?>
                 <div class="box box-shipping-address">
                     <strong class="box-title">
-                        <span><?= $block->escapeHtml(__('Shipping To')); ?></span>
-                        <a href="<?= $block->escapeUrl($block->getEditShippingAddressUrl($address)); ?>"
-                           class="action edit"><span><?= $block->escapeHtml(__('Change')); ?></span></a>
+                        <span><?= $escaper->escapeHtml(__('Shipping To')); ?></span>
+                        <a href="<?= $escaper->escapeUrl($block->getEditShippingAddressUrl($address)); ?>"
+                           class="action edit"><span><?= $escaper->escapeHtml(__('Change')); ?></span></a>
                     </strong>
                     <div class="box-content">
                         <address>
@@ -95,14 +101,14 @@ $checkoutHelper = $block->getData('checkoutHelper');
                 </div>
                 <div class="box box-shipping-method">
                     <strong class="box-title">
-                        <span><?= $block->escapeHtml(__('Shipping Method')); ?></span>
-                        <a href="<?= $block->escapeUrl($block->getEditShippingUrl()); ?>"
-                           class="action edit"><span><?= $block->escapeHtml(__('Change')); ?></span></a>
+                        <span><?= $escaper->escapeHtml(__('Shipping Method')); ?></span>
+                        <a href="<?= $escaper->escapeUrl($block->getEditShippingUrl()); ?>"
+                           class="action edit"><span><?= $escaper->escapeHtml(__('Change')); ?></span></a>
                     </strong>
                     <?php if ($_rate = $block->getShippingAddressRate($address)): ?>
                         <div class="box-content">
-                            <?= $block->escapeHtml($_rate->getCarrierTitle()) ?>
-                            (<?= $block->escapeHtml($_rate->getMethodTitle()) ?>)
+                            <?= $escaper->escapeHtml($_rate->getCarrierTitle()) ?>
+                            (<?= $escaper->escapeHtml($_rate->getMethodTitle()) ?>)
                             <?php
                             $exclTax = $block->getShippingPriceExclTax($address);
                             $inclTax = $block->getShippingPriceInclTax($address);
@@ -110,11 +116,11 @@ $checkoutHelper = $block->getData('checkoutHelper');
                             ?>
                             <?php if ($displayBothPrices): ?>
                                 <span class="price-including-tax"
-                                      data-label="<?= $block->escapeHtml(__('Incl. Tax')); ?>">
+                                      data-label="<?= $escaper->escapeHtml(__('Incl. Tax')); ?>">
                                     <?= /* @noEscape */ $inclTax ?>
                                 </span>
                                 <span class="price-excluding-tax"
-                                      data-label="<?= $block->escapeHtml(__('Excl. Tax')); ?>">
+                                      data-label="<?= $escaper->escapeHtml(__('Excl. Tax')); ?>">
                                     <?= /* @noEscape */ $exclTax; ?>
                                 </span>
                             <?php else: ?>
@@ -127,19 +133,19 @@ $checkoutHelper = $block->getData('checkoutHelper');
                     <div class="box-content">
                         <div class="order-review-wrapper table-wrapper">
                             <table class="items data table table-order-review"
-                                   id="overview-table-<?= $block->escapeHtml($address->getId()); ?>">
-                                <caption class="table-caption"><?= $block->escapeHtml(__('Order Review')); ?></caption>
+                                   id="overview-table-<?= $escaper->escapeHtml($address->getId()); ?>">
+                                <caption class="table-caption"><?= $escaper->escapeHtml(__('Order Review')); ?></caption>
                                 <thead>
                                 <tr>
-                                    <th class="col item" scope="col"><?= $block->escapeHtml(__('Item')); ?>
-                                        <a href="<?= $block->escapeUrl($block->getAddressesEditUrl()); ?>"
+                                    <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Item')); ?>
+                                        <a href="<?= $escaper->escapeUrl($block->getAddressesEditUrl()); ?>"
                                            class="action edit">
-                                            <span><?= $block->escapeHtml(__('Edit')); ?></span>
+                                            <span><?= $escaper->escapeHtml(__('Edit')); ?></span>
                                         </a>
                                     </th>
-                                    <th class="col price" scope="col"><?= $block->escapeHtml(__('Price')); ?></th>
-                                    <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')); ?></th>
-                                    <th class="col subtotal" scope="col"><?= $block->escapeHtml(__('Subtotal')); ?></th>
+                                    <th class="col price" scope="col"><?= $escaper->escapeHtml(__('Price')); ?></th>
+                                    <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')); ?></th>
+                                    <th class="col subtotal" scope="col"><?= $escaper->escapeHtml(__('Subtotal')); ?></th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -163,28 +169,28 @@ $checkoutHelper = $block->getData('checkoutHelper');
     <?php if ($block->getQuote()->hasVirtualItems()): ?>
     <div class="block block-other">
         <?php $billingAddress = $block->getQuote()->getBillingAddress(); ?>
-        <a name="<?= $block->escapeHtml($block->getCheckoutData()
+        <a name="<?= $escaper->escapeHtml($block->getCheckoutData()
             ->getAddressAnchorName($billingAddress->getId())); ?>"></a>
-        <div class="block-title"><strong><?= $block->escapeHtml(__('Other items in your order')); ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('Other items in your order')); ?></strong></div>
         <?php if ($error = $block->getCheckoutData()->getAddressError($billingAddress)): ?>
-                <div class="error-description"><?= $block->escapeHtml($error); ?></div>
+                <div class="error-description"><?= $escaper->escapeHtml($error); ?></div>
         <?php endif;?>
         <div class="block-content">
             <strong class="subtitle">
-                <span><?= $block->escapeHtml(__('Items')); ?></span>
-                <a href="<?= $block->escapeUrl($block->getVirtualProductEditUrl()); ?>"
-                   class="action edit"><span><?= $block->escapeHtml(__('Edit Items')); ?></span></a>
+                <span><?= $escaper->escapeHtml(__('Items')); ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getVirtualProductEditUrl()); ?>"
+                   class="action edit"><span><?= $escaper->escapeHtml(__('Edit Items')); ?></span></a>
             </strong>
             <?php $mergedCells = ($taxHelper->displayCartBothPrices() ? 2 : 1); ?>
             <div class="order-review-wrapper table-wrapper">
                 <table class="items data table table-order-review" id="virtual-overview-table">
-                    <caption class="table-caption"><?= $block->escapeHtml(__('Items')); ?></caption>
+                    <caption class="table-caption"><?= $escaper->escapeHtml(__('Items')); ?></caption>
                     <thead>
                         <tr>
-                            <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')); ?></th>
-                            <th class="col price" scope="col"><?= $block->escapeHtml(__('Price')); ?></th>
-                            <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')); ?></th>
-                            <th class="col subtotal" scope="col"><?= $block->escapeHtml(__('Subtotal')); ?></th>
+                            <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')); ?></th>
+                            <th class="col price" scope="col"><?= $escaper->escapeHtml(__('Price')); ?></th>
+                            <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')); ?></th>
+                            <th class="col subtotal" scope="col"><?= $escaper->escapeHtml(__('Subtotal')); ?></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -206,7 +212,7 @@ $checkoutHelper = $block->getData('checkoutHelper');
     <div id="checkout-review-submit" class="checkout-review">
         <?= /* @noEscape */ $block->getChildHtml('agreements') ?>
         <div class="grand totals">
-            <strong class="mark"><?= $block->escapeHtml(__('Grand Total:')); ?></strong>
+            <strong class="mark"><?= $escaper->escapeHtml(__('Grand Total:')); ?></strong>
             <strong class="amount">
                 <?= /* @noEscape */ $checkoutHelper->formatPrice($block->getTotal()); ?>
             </strong>
@@ -216,18 +222,18 @@ $checkoutHelper = $block->getData('checkoutHelper');
                 <?= $block->getChildHtml('captcha') ?>
                 <button type="submit"
                         class="action primary submit"
-                        id="review-button"><span><?= $block->escapeHtml(__('Place Order')); ?></span>
+                        id="review-button"><span><?= $escaper->escapeHtml(__('Place Order')); ?></span>
                 </button>
             </div>
             <div class="secondary">
-                <a href="<?= $block->escapeUrl($block->getBackUrl()); ?>" class="action back">
-                    <span><?= $block->escapeHtml(__('Back to Billing Information')); ?></span>
+                <a href="<?= $escaper->escapeUrl($block->getBackUrl()); ?>" class="action back">
+                    <span><?= $escaper->escapeHtml(__('Back to Billing Information')); ?></span>
                 </a>
             </div>
             <span id="review-please-wait"
                   class="please-wait load indicator"
-                  data-text="<?= $block->escapeHtml(__('Submitting order information...')); ?>">
-                <span><?= $block->escapeHtml(__('Submitting order information...')); ?></span>
+                  data-text="<?= $escaper->escapeHtml(__('Submitting order information...')); ?>">
+                <span><?= $escaper->escapeHtml(__('Submitting order information...')); ?></span>
             </span>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('display: none;', 'span#review-please-wait') ?>
         </div>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview/item.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/overview/item.phtml
@@ -3,52 +3,50 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Checkout\Block\Cart\Item\Renderer;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Files.LineLength, Magento2.Templates.ThisInTemplate
-
 ?>
-<?php
-/**
- * Quote Item row html
- *
- * @see \Magento\Checkout\Block\Cart\Item\Renderer
- */
-?>
-<?php /** @var $block Magento\Checkout\Block\Cart\Item\Renderer */ ?>
-<?php $_item = $block->getItem() ?>
 <tr>
-    <td class="col item" data-th="<?= $block->escapeHtml(__('Product Name')) ?>">
+    <td class="col item" data-th="<?= $escaper->escapeHtml(__('Product Name')) ?>">
         <?= $block->getRenderedBlock()->getItemHtml($_item) ?>
     </td>
-    <td class="col price" data-th="<?= $block->escapeHtml(__('Price')) ?>">
+    <td class="col price" data-th="<?= $escaper->escapeHtml(__('Price')) ?>">
         <?php /* Including Tax */ ?>
             <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayCartPriceInclTax() || $this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices()) : ?>
-                <span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Incl. Tax')) ?>">
+                <span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Incl. Tax')) ?>">
                     <?= $block->getUnitPriceInclTaxHtml($_item) ?>
                 </span>
             <?php endif; ?>
         <?php /* end Including Tax */ ?>
         <?php /* Excluding Tax */ ?>
         <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayCartPriceExclTax() || $this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices()) : ?>
-            <span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+            <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
                 <?= $block->getUnitPriceExclTaxHtml($_item) ?>
             </span>
         <?php endif; ?>
         <?php /* end Excluding Tax */ ?>
     </td>
 
-    <td class="col qty" data-th="<?= $block->escapeHtml(__('Qty')) ?>"><?= $_item->getQty() * 1 ?></td>
-    <td class="col subtotal" data-th="<?= $block->escapeHtml(__('Subtotal')) ?>">
+    <td class="col qty" data-th="<?= $escaper->escapeHtml(__('Qty')) ?>"><?= $_item->getQty() * 1 ?></td>
+    <td class="col subtotal" data-th="<?= $escaper->escapeHtml(__('Subtotal')) ?>">
     <?php /* Including Tax Subtotal */ ?>
         <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayCartPriceInclTax() || $this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices()) : ?>
-        <span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Incl. Tax')) ?>">
+        <span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Incl. Tax')) ?>">
             <?= $block->getRowTotalInclTaxHtml($_item) ?>
         </span>
         <?php endif; ?>
     <?php /* end Including Tax Subtotal */ ?>
     <?php /* Excluding Tax Subtotal */ ?>
     <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayCartPriceExclTax() || $this->helper(Magento\Tax\Helper\Data::class)->displayCartBothPrices()) : ?>
-        <span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
+        <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
             <?= $block->getRowTotalExclTaxHtml($_item) ?>
         </span>
     <?php endif; ?>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/results.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/results.phtml
@@ -3,42 +3,46 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Multishipping\Block\Checkout\Results $block */
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\Results;
 
+/** @var Escaper $escaper */
+/** @var Results $block */
 $orderIds = $block->getOrderIds();
 ?>
 <div class="multicheckout results">
     <p class="block-content">
         <?php if (!empty($orderIds)) : ?>
-            <?= $block->escapeHtml(__('Not all items were included.')); ?>
+            <?= $escaper->escapeHtml(__('Not all items were included.')); ?>
         <?php endif; ?>
-        <?= $block->escapeHtml(__('For details, see')); ?>
-        <a href="#failed"><?= $block->escapeHtml(__('Failed to Order')); ?></a>
-        <?= $block->escapeHtml(__('section below')); ?>
+        <?= $escaper->escapeHtml(__('For details, see')); ?>
+        <a href="#failed"><?= $escaper->escapeHtml(__('Failed to Order')); ?></a>
+        <?= $escaper->escapeHtml(__('section below')); ?>
     </p>
     <?php if (!empty($orderIds)) : ?>
     <p class="block-content">
-        <?= $block->escapeHtml(__('For successfully ordered items, you\'ll receive a confirmation email '.
+        <?= $escaper->escapeHtml(__('For successfully ordered items, you\'ll receive a confirmation email '.
             'including order numbers, tracking information, and more details.')); ?>
     </p>
     <div class="orders-succeed">
-        <h3 class="subtitle"><?= $block->escapeHtml(__('Successfully Ordered')); ?></h3>
+        <h3 class="subtitle"><?= $escaper->escapeHtml(__('Successfully Ordered')); ?></h3>
         <ul class="orders-list">
             <?php foreach ($orderIds as $orderId => $incrementId) : ?>
                 <li class="shipping-list">
-                    <div class="order-id"><a href="<?= $block->escapeUrl($block->getViewOrderUrl($orderId)); ?>">
-                    <?= $block->escapeHtml($incrementId); ?></a></div>
+                    <div class="order-id"><a href="<?= $escaper->escapeUrl($block->getViewOrderUrl($orderId)); ?>">
+                    <?= $escaper->escapeHtml($incrementId); ?></a></div>
                     <?php $shippingAddress = $block->getOrderShippingAddress($orderId); ?>
                     <div class="shipping-item">
                         <?php if ($shippingAddress) : ?>
-                        <span class="shipping-label"><?= $block->escapeHtml(__('Ship to:')); ?></span>
+                        <span class="shipping-label"><?= $escaper->escapeHtml(__('Ship to:')); ?></span>
                         <span class="shipping-address">
-                            <?= $block->escapeHtml($block->formatOrderShippingAddress($shippingAddress)); ?>
+                            <?= $escaper->escapeHtml($block->formatOrderShippingAddress($shippingAddress)); ?>
                         </span>
                         <?php else : ?>
                             <span class="shipping-address">
-                                <?= $block->escapeHtml(__('No shipping required.')); ?>
+                                <?= $escaper->escapeHtml(__('No shipping required.')); ?>
                             </span>
                         <?php endif; ?>
                     </div>
@@ -48,13 +52,13 @@ $orderIds = $block->getOrderIds();
     </div>
     <?php endif; ?>
     <div class="orders-failed">
-        <h3 class="subtitle"><a name="failed"><?= $block->escapeHtml(__('Failed to Order')); ?></a></h3>
+        <h3 class="subtitle"><a name="failed"><?= $escaper->escapeHtml(__('Failed to Order')); ?></a></h3>
         <div class="message message-error error">
             <div>
-                <?= $block->escapeHtml(__('To purchase these items: Return to the')); ?>
-                <a href="<?= $block->escapeUrl($block->getUrl('*/*/overview')) ?>">
-                    <?= $block->escapeHtml(__('Review page in Checkout')); ?></a>,
-                <?= $block->escapeHtml(__('resolve any errors, and place a new order.'))?>
+                <?= $escaper->escapeHtml(__('To purchase these items: Return to the')); ?>
+                <a href="<?= $escaper->escapeUrl($block->getUrl('*/*/overview')) ?>">
+                    <?= $escaper->escapeHtml(__('Review page in Checkout')); ?></a>,
+                <?= $escaper->escapeHtml(__('resolve any errors, and place a new order.'))?>
             </div>
         </div>
         <?php $failedAddresses = $block->getFailedAddresses() ?>
@@ -65,18 +69,18 @@ $orderIds = $block->getOrderIds();
                     <dl class="shipping-item">
                         <dt class="shipping-block">
                             <?php if ($block->isShippingAddress($address)) : ?>
-                            <span class="shipping-label"><?= $block->escapeHtml(__('Ship to:')); ?></span>
+                            <span class="shipping-label"><?= $escaper->escapeHtml(__('Ship to:')); ?></span>
                             <span class="shipping-address">
-                                <?= $block->escapeHtml($block->formatQuoteShippingAddress($address)); ?>
+                                <?= $escaper->escapeHtml($block->formatQuoteShippingAddress($address)); ?>
                             </span>
                             <?php else : ?>
                             <span class="shipping-address">
-                                <?= $block->escapeHtml(__('No shipping required.')); ?>
+                                <?= $escaper->escapeHtml(__('No shipping required.')); ?>
                             </span>
                             <?php endif; ?>
                         </dt>
                         <dd class="error-block">
-                            <span class="error-label"><?= $block->escapeHtml(__('Error:')); ?></span>
+                            <span class="error-label"><?= $escaper->escapeHtml(__('Error:')); ?></span>
                             <span class="error-description">
                                 <?= /* @noEscape */ $block->getAddressError($address); ?>
                             </span>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/shipping.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/shipping.phtml
@@ -3,27 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\Shipping;
+
+/** @var Escaper $escaper */
+/** @var Shipping $block */
 
 // phpcs:disable Magento2.Files.LineLength, Magento2.Templates.ThisInTemplate
-
 ?>
-<?php
-/**
- * Multishipping checkout shipping template
- *
- * @var $block \Magento\Multishipping\Block\Checkout\Shipping
- */
-?>
-<form action="<?= $block->escapeUrl($block->getPostActionUrl()) ?>" method="post" id="shipping_method_form" class="form multicheckout shipping">
+<form action="<?= $escaper->escapeUrl($block->getPostActionUrl()) ?>" method="post" id="shipping_method_form" class="form multicheckout shipping">
     <?php foreach ($block->getAddresses() as $_index => $_address) : ?>
     <div class="block block-shipping">
-        <div class="block-title"><strong><?= $block->escapeHtml(__('Address %1 <span>of %2</span>', ($_index+1), $block->getAddressCount()), ['span']) ?></strong></div>
+        <div class="block-title"><strong><?= $escaper->escapeHtml(__('Address %1 <span>of %2</span>', ($_index+1), $block->getAddressCount()), ['span']) ?></strong></div>
         <div class="block-content">
             <div class="box box-shipping-address">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Shipping To')) ?></span>
-                    <a href="<?= $block->escapeUrl($block->getAddressEditUrl($_address)) ?>" class="action edit">
-                        <span><?= $block->escapeHtml(__('Change')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Shipping To')) ?></span>
+                    <a href="<?= $escaper->escapeUrl($block->getAddressEditUrl($_address)) ?>" class="action edit">
+                        <span><?= $escaper->escapeHtml(__('Change')) ?></span>
                     </a>
                 </strong>
                 <div class="box-content">
@@ -32,46 +31,46 @@
             </div>
             <div class="box box-shipping-method">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Shipping Method')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Shipping Method')) ?></span>
                 </strong>
                 <div class="box-content">
                     <?php if (!($_shippingRateGroups = $block->getShippingRates($_address))) : ?>
-                        <p><?= $block->escapeHtml(__('Sorry, no quotes are available for this order right now.')) ?></p>
+                        <p><?= $escaper->escapeHtml(__('Sorry, no quotes are available for this order right now.')) ?></p>
                     <?php else : ?>
                     <dl class="items methods-shipping">
                         <?php $_sole = count($_shippingRateGroups) == 1; foreach ($_shippingRateGroups as $code => $_rates) : ?>
-                            <dt class="item-title"><?= $block->escapeHtml($block->getCarrierName($code)) ?></dt>
+                            <dt class="item-title"><?= $escaper->escapeHtml($block->getCarrierName($code)) ?></dt>
                             <dd class="item-content">
                                 <fieldset class="fieldset">
                                     <legend class="legend">
-                                        <span><?= $block->escapeHtml($block->getCarrierName($code)) ?></span>
+                                        <span><?= $escaper->escapeHtml($block->getCarrierName($code)) ?></span>
                                     </legend><br>
                                     <?php $_sole = $_sole && count($_rates) == 1; foreach ($_rates as $_rate) : ?>
                                     <div class="field choice">
                                         <?php if ($_rate->getErrorMessage()) : ?>
-                                        <strong><?= $block->escapeHtml($_rate->getCarrierTitle()) ?>: <?= $block->escapeHtml($_rate->getErrorMessage()) ?></strong>
+                                        <strong><?= $escaper->escapeHtml($_rate->getCarrierTitle()) ?>: <?= $escaper->escapeHtml($_rate->getErrorMessage()) ?></strong>
                                         <?php else : ?>
                                         <div class="control">
                                             <?php if ($_sole) : ?>
-                                                <input type="radio" name="shipping_method[<?= (int) $_address->getId() ?>]" value="<?= $block->escapeHtmlAttr($_rate->getCode()) ?>" id="s_method_<?= (int) $_address->getId() ?>_<?= $block->escapeHtmlAttr($_rate->getCode()) ?>" class="radio solo method" checked="checked"/>
+                                                <input type="radio" name="shipping_method[<?= (int) $_address->getId() ?>]" value="<?= $escaper->escapeHtmlAttr($_rate->getCode()) ?>" id="s_method_<?= (int) $_address->getId() ?>_<?= $escaper->escapeHtmlAttr($_rate->getCode()) ?>" class="radio solo method" checked="checked"/>
                                             <?php else : ?>
-                                                <input type="radio" name="shipping_method[<?= (int) $_address->getId() ?>]" value="<?= $block->escapeHtmlAttr($_rate->getCode()) ?>" id="s_method_<?= (int) $_address->getId() ?>_<?= $block->escapeHtmlAttr($_rate->getCode()) ?>" <?= ($_rate->getCode()===$block->getAddressShippingMethod($_address)) ? ' checked="checked"' : '' ?> class="radio" />
+                                                <input type="radio" name="shipping_method[<?= (int) $_address->getId() ?>]" value="<?= $escaper->escapeHtmlAttr($_rate->getCode()) ?>" id="s_method_<?= (int) $_address->getId() ?>_<?= $escaper->escapeHtmlAttr($_rate->getCode()) ?>" <?= ($_rate->getCode()===$block->getAddressShippingMethod($_address)) ? ' checked="checked"' : '' ?> class="radio" />
                                             <?php endif; ?>
                                         </div>
-                                        <label for="s_method_<?= (int) $_address->getId() ?>_<?= $block->escapeHtmlAttr($_rate->getCode()) ?>">
-                                            <?= $block->escapeHtml($_rate->getMethodTitle()) ?>
+                                        <label for="s_method_<?= (int) $_address->getId() ?>_<?= $escaper->escapeHtmlAttr($_rate->getCode()) ?>">
+                                            <?= $escaper->escapeHtml($_rate->getMethodTitle()) ?>
                                             <?php $_excl = $block->getShippingPrice($_address, $_rate->getPrice(), $this->helper(Magento\Tax\Helper\Data::class)->displayShippingPriceIncludingTax()); ?>
                                             <?php $_incl = $block->getShippingPrice($_address, $_rate->getPrice(), true); ?>
                                             <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayShippingBothPrices() && $_incl != $_excl) : ?>
-                                            <span class="price-including-tax" data-label="<?= $block->escapeHtml(__('Incl. Tax')) ?>">
+                                            <span class="price-including-tax" data-label="<?= $escaper->escapeHtml(__('Incl. Tax')) ?>">
                                             <?php endif; ?>
-                                                <?= $block->escapeHtml($_incl, ['span']) ?>
+                                                <?= $escaper->escapeHtml($_incl, ['span']) ?>
                                             <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayShippingBothPrices() && $_incl != $_excl) : ?>
                                             </span>
                                             <?php endif; ?>
                                             <?php if ($this->helper(Magento\Tax\Helper\Data::class)->displayShippingBothPrices() && $_incl != $_excl) : ?>
-                                            <span class="price-excluding-tax" data-label="<?= $block->escapeHtml(__('Excl. Tax')) ?>">
-                                                <?= $block->escapeHtml($_excl, ['span']) ?>
+                                            <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtml(__('Excl. Tax')) ?>">
+                                                <?= $escaper->escapeHtml($_excl, ['span']) ?>
                                             </span>
                                             <?php endif; ?>
                                         </label>
@@ -88,24 +87,24 @@
             </div>
             <div class="box box-items">
                 <strong class="box-title">
-                    <span><?= $block->escapeHtml(__('Items')) ?></span>
-                    <a href="<?= $block->escapeUrl($block->getItemsEditUrl($_address)) ?>" class="action edit"><span><?= $block->escapeHtml(__('Edit Items')) ?></span></a>
+                    <span><?= $escaper->escapeHtml(__('Items')) ?></span>
+                    <a href="<?= $escaper->escapeUrl($block->getItemsEditUrl($_address)) ?>" class="action edit"><span><?= $escaper->escapeHtml(__('Edit Items')) ?></span></a>
                 </strong>
                 <div class="box-content">
                     <div class="table-wrapper">
                         <table class="items data table" id="shipping-table-<?= (int) $_address->getId() ?>">
-                            <caption class="table-caption"><?= $block->escapeHtml(__('Items')) ?></caption>
+                            <caption class="table-caption"><?= $escaper->escapeHtml(__('Items')) ?></caption>
                             <thead>
                             <tr>
-                                <th class="col item" scope="col"><?= $block->escapeHtml(__('Product Name')) ?></th>
-                                <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
+                                <th class="col item" scope="col"><?= $escaper->escapeHtml(__('Product Name')) ?></th>
+                                <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
                             </tr>
                             </thead>
                             <tbody>
                             <?php foreach ($block->getAddressItems($_address) as $_item) : ?>
                                 <tr>
-                                    <td class="col item" data-th="<?= $block->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getItemHtml($_item->getQuoteItem()) ?></td>
-                                    <td class="col qty" data-th="<?= $block->escapeHtmlAttr(__('Qty')) ?>"><?= $block->escapeHtml($_item->getQty()) ?></td>
+                                    <td class="col item" data-th="<?= $escaper->escapeHtmlAttr(__('Product Name')) ?>"><?= $block->getItemHtml($_item->getQuoteItem()) ?></td>
+                                    <td class="col qty" data-th="<?= $escaper->escapeHtmlAttr(__('Qty')) ?>"><?= $escaper->escapeHtml($_item->getQty()) ?></td>
                                 </tr>
                             <?php endforeach; ?>
                             </tbody>
@@ -119,10 +118,10 @@
     <?= $block->getChildHtml('checkout_billing_items') ?>
     <div class="actions-toolbar">
         <div class="primary">
-            <button class="action primary continue" type="submit"><span><?= $block->escapeHtml(__('Continue to Billing Information')) ?></span></button>
+            <button class="action primary continue" type="submit"><span><?= $escaper->escapeHtml(__('Continue to Billing Information')) ?></span></button>
         </div>
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back"><span><?= $block->escapeHtml(__('Back to Select Addresses')) ?></span></a>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back"><span><?= $escaper->escapeHtml(__('Back to Select Addresses')) ?></span></a>
         </div>
     </div>
 </form>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/state.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/state.phtml
@@ -3,21 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\State;
+
+/** @var Escaper $escaper */
+/** @var State $block */
 
 // phpcs:disable Magento2.Files.LineLength
-
-?>
-<?php
-/**
- * Mustishipping state
- *
- * @see \Magento\Multishipping\Block\Checkout\State
- */
 ?>
 <ol class="block multicheckout progress items" id="checkout-progress-state">
     <?php foreach ($block->getSteps() as $_step) : ?>
-        <li title="<?= $block->escapeHtmlAttr($_step->getLabel()) ?>" class="item<?= ($_step->getIsActive()) ? ' active' : '' ?>">
-            <span><?= $block->escapeHtml($_step->getLabel()) ?></span>
+        <li title="<?= $escaper->escapeHtmlAttr($_step->getLabel()) ?>" class="item<?= ($_step->getIsActive()) ? ' active' : '' ?>">
+            <span><?= $escaper->escapeHtml($_step->getLabel()) ?></span>
         </li>
     <?php endforeach; ?>
 </ol>

--- a/app/code/Magento/Multishipping/view/frontend/templates/checkout/success.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/checkout/success.phtml
@@ -3,34 +3,39 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Multishipping\Block\Checkout\Success $block */
+use Magento\Framework\Escaper;
+use Magento\Multishipping\Block\Checkout\Success;
+
+/** @var Escaper $escaper */
+/** @var Success $block */
 ?>
-<form action="<?= $block->escapeUrl($block->getContinueUrl()); ?>" method="post">
+<form action="<?= $escaper->escapeUrl($block->getContinueUrl()); ?>" method="post">
     <div class="multicheckout success">
-        <p><?= $block->escapeHtml(__('For successfully order items, you\'ll receive a confirmation email including '.
+        <p><?= $escaper->escapeHtml(__('For successfully order items, you\'ll receive a confirmation email including '.
                 'order numbers, tracking information and more details.')) ?></p>
         <?php if ($orderIds = $block->getOrderIds()) : ?>
-            <h3><?= $block->escapeHtml(__('Successfully ordered'))?></h3>
+            <h3><?= $escaper->escapeHtml(__('Successfully ordered'))?></h3>
             <div class="orders-succeed">
             <ul class="orders-list">
             <?php foreach ($orderIds as $orderId => $incrementId) : ?>
                 <li class="shipping-list">
-                    <div class="order-id"><a href="<?= $block->escapeUrl($block->getViewOrderUrl($orderId)); ?>">
-                        <?= $block->escapeHtml($incrementId); ?></a>
+                    <div class="order-id"><a href="<?= $escaper->escapeUrl($block->getViewOrderUrl($orderId)); ?>">
+                        <?= $escaper->escapeHtml($incrementId); ?></a>
                     </div>
                 <?php $shippingAddress = $block->getCheckoutData()->getOrderShippingAddress($orderId); ?>
                     <div class="shipping-item">
                         <?php if ($shippingAddress) : ?>
-                        <span class="shipping-label"><?= $block->escapeHtml(__('Ship to:')); ?></span>
+                        <span class="shipping-label"><?= $escaper->escapeHtml(__('Ship to:')); ?></span>
                         <span class="shipping-address">
-                            <?= $block->escapeHtml(
+                            <?= $escaper->escapeHtml(
                                 $block->getCheckoutData()->formatOrderShippingAddress($shippingAddress)
                             ); ?>
                         </span>
                         <?php else : ?>
                             <span class="shipping-address">
-                                <?= $block->escapeHtml(__('No shipping required.')); ?>
+                                <?= $escaper->escapeHtml(__('No shipping required.')); ?>
                             </span>
                         <?php endif; ?>
                     </div>
@@ -43,7 +48,7 @@
         <div class="actions-toolbar" id="review-buttons-container">
             <div class="primary">
                 <button type="submit"
-                        class="action primary submit"><span><?= $block->escapeHtml(__('Continue Shopping')); ?></span>
+                        class="action primary submit"><span><?= $escaper->escapeHtml(__('Continue Shopping')); ?></span>
                 </button>
             </div>
         </div>

--- a/app/code/Magento/Multishipping/view/frontend/templates/multishipping/item/default.phtml
+++ b/app/code/Magento/Multishipping/view/frontend/templates/multishipping/item/default.phtml
@@ -3,22 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Files.LineLength
 ?>
 <div class="product details">
-    <strong class="product name"><a href="<?= $block->escapeUrl($block->getProductUrl()) ?>"><?= $block->escapeHtml($block->getProductName()) ?></a></strong>
+    <strong class="product name"><a href="<?= $escaper->escapeUrl($block->getProductUrl()) ?>"><?= $escaper->escapeHtml($block->getProductName()) ?></a></strong>
     <?php if ($_options = $block->getOptionList()) : ?>
         <dl class="item options">
             <?php foreach ($_options as $_option) : ?>
                 <?php $_formatedOptionValue = $block->getFormatedOptionValue($_option) ?>
-                <dt><?= $block->escapeHtml($_option['label']) ?></dt>
+                <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
                 <dd<?= isset($_formatedOptionValue['full_view']) ? ' class="tooltip wrapper"' : '' ?>>
-                    <?= $block->escapeHtml($_formatedOptionValue['value']) ?>
+                    <?= $escaper->escapeHtml($_formatedOptionValue['value']) ?>
                     <?php if (isset($_formatedOptionValue['full_view'])) : ?>
                         <dl class="item options tooltip content">
-                            <dt><?= $block->escapeHtml($_option['label']) ?></dt>
-                            <dd><?= $block->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
+                            <dt><?= $escaper->escapeHtml($_option['label']) ?></dt>
+                            <dd><?= $escaper->escapeHtml($_formatedOptionValue['full_view']) ?></dd>
                         </dl>
                     <?php endif; ?>
                 </dd>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Multishipping` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

### Resolved issues:
1. [x] resolves magento/magento2#37172: Chore: Multishipping - Replace Block Escaping with Escaper