### PR TITLE
Chore: PayPal - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Paypal/view/adminhtml/templates/billing/agreement/form.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/billing/agreement/form.phtml
@@ -3,26 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Adminhtml\Billing\Agreement\View\Form $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Adminhtml\Billing\Agreement\View\Form;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Form $block */
+$code = $escaper->escapeHtml($block->getMethodCode());
 ?>
-<?php $code = $block->escapeHtml($block->getMethodCode()) ?>
 <fieldset class="form-list" id="payment_form_<?= /* @noEscape */ $code ?>">
     <div class="admin__field _required">
         <label for="<?= /* @noEscape */ $code ?>_ba_agreement_id" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Billing Agreement')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Billing Agreement')) ?></span>
         </label>
         <div class="admin__field-control">
             <select id="<?= /* @noEscape */ $code ?>_ba_agreement_id"
-                    name="payment[<?= $block->escapeHtml($block->getTransportBAId()) ?>]"
+                    name="payment[<?= $escaper->escapeHtml($block->getTransportBAId()) ?>]"
                     class="required-entry admin__control-select">
-                <option value=""><?= $block->escapeHtml(__('Please Select')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Please Select')) ?></option>
                 <?php foreach ($block->getBillingAgreements() as $id => $referenceId): ?>
-                    <option value="<?= $block->escapeHtml($id) ?>">
-                        <?= $block->escapeHtml($referenceId) ?>
+                    <option value="<?= $escaper->escapeHtml($id) ?>">
+                        <?= $escaper->escapeHtml($referenceId) ?>
                     </option>
                 <?php endforeach; ?>
             </select>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/billing/agreement/view/tab/info.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/billing/agreement/view/tab/info.phtml
@@ -3,38 +3,44 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/** @var \Magento\Paypal\Block\Adminhtml\Billing\Agreement\View\Tab\Info $block */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Adminhtml\Billing\Agreement\View\Tab\Info;
+
+/** @var Escaper $escaper */
+/** @var Info $block */
 ?>
 <section class="admin__page-section">
     <div class="admin__page-section-title">
-        <span class="title"><?= $block->escapeHtml(__('General Information')) ?></span>
+        <span class="title"><?= $escaper->escapeHtml(__('General Information')) ?></span>
     </div>
     <div class="admin__page-section-content log-details">
         <table class="data-table admin__table-secondary order-billing-agreement-table">
             <tbody>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Reference ID')) ?></th>
-                    <td><?= $block->escapeHtml($block->getReferenceId()) ?></td>
+                    <th><?= $escaper->escapeHtml(__('Reference ID')) ?></th>
+                    <td><?= $escaper->escapeHtml($block->getReferenceId()) ?></td>
                 </tr>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Customer')) ?></th>
+                    <th><?= $escaper->escapeHtml(__('Customer')) ?></th>
                     <td>
-                        <a href="<?= $block->escapeUrl($block->getCustomerUrl()) ?>">
-                            <?= $block->escapeHtml($block->getCustomerEmail()) ?>
+                        <a href="<?= $escaper->escapeUrl($block->getCustomerUrl()) ?>">
+                            <?= $escaper->escapeHtml($block->getCustomerEmail()) ?>
                         </a>
                     </td>
                 </tr>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Status')) ?></th>
-                    <td><?= $block->escapeHtml($block->getStatus()) ?></td>
+                    <th><?= $escaper->escapeHtml(__('Status')) ?></th>
+                    <td><?= $escaper->escapeHtml($block->getStatus()) ?></td>
                 </tr>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Created At')) ?></th>
-                    <td><?= $block->escapeHtml($block->getCreatedAt()) ?></td>
+                    <th><?= $escaper->escapeHtml(__('Created At')) ?></th>
+                    <td><?= $escaper->escapeHtml($block->getCreatedAt()) ?></td>
                 </tr>
                 <tr>
-                    <th><?= $block->escapeHtml(__('Updated At')) ?></th>
-                    <td><?= $block->escapeHtml($block->getUpdatedAt()) ?></td>
+                    <th><?= $escaper->escapeHtml(__('Updated At')) ?></th>
+                    <td><?= $escaper->escapeHtml($block->getUpdatedAt()) ?></td>
                 </tr>
             </tbody>
         </table>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/payflowpro/vault.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/payflowpro/vault.phtml
@@ -3,29 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
 use Magento\Vault\Model\Ui\TokenUiComponentProviderInterface;
 
-/** @var \Magento\Framework\View\Element\Template $block */
+/** @var Escaper $escaper */
+/** @var Template $block */
 $details = $block->getData('details');
 $icon = $block->getData('icons')[$details['cc_type']];
-$id = $block->escapeHtml($block->getData('id'));
+$id = $escaper->escapeHtml($block->getData('id'));
 ?>
 <div data-mage-init='{
         "Magento_Paypal/js/payflowpro/vault": {
             "container": "payment_<?= /* @noEscape */ $id ?>",
-            "publicHash": "<?= $block->escapeHtml($block->getData(TokenUiComponentProviderInterface::COMPONENT_PUBLIC_HASH)); ?>"
+            "publicHash": "<?= $escaper->escapeHtml($block->getData(TokenUiComponentProviderInterface::COMPONENT_PUBLIC_HASH)); ?>"
         }
     }' id="payment_<?= /* @noEscape */ $id ?>" class="admin__field">
     <div class="admin__field-control control">
         <input type="radio" id="token_switcher_<?= /* @noEscape */ $id ?>" name="payment[token_switcher]"/>
-        <img src="<?= $block->escapeUrl($icon['url']) ?>"
-             width="<?= $block->escapeHtml($icon['width']) ?>"
-             height="<?= $block->escapeHtml($icon['height']) ?>"
+        <img src="<?= $escaper->escapeUrl($icon['url']) ?>"
+             width="<?= $escaper->escapeHtml($icon['width']) ?>"
+             height="<?= $escaper->escapeHtml($icon['height']) ?>"
              class="payment-icon" >
-        <span><?= $block->escapeHtml(__('ending')) ?></span>
-        <span><?= $block->escapeHtml($details['cc_last_4']) ?></span>
-        (<span><?= $block->escapeHtml(__('expires')) ?></span>:
-        <span><?= /* @noEscape */ $block->escapeHtml($details['cc_exp_month'] . "/" . $details['cc_exp_year']); ?></span>)
+        <span><?= $escaper->escapeHtml(__('ending')) ?></span>
+        <span><?= $escaper->escapeHtml($details['cc_last_4']) ?></span>
+        (<span><?= $escaper->escapeHtml(__('expires')) ?></span>:
+        <span><?= /* @noEscape */ $escaper->escapeHtml($details['cc_exp_month'] . "/" . $details['cc_exp_year']); ?></span>)
     </div>
 </div>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/payment/form/billing/agreement.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/payment/form/billing/agreement.phtml
@@ -3,30 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Paypal\Block\Payment\Form\Billing\Agreement
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payment\Form\Billing\Agreement;
+
+/** @var Escaper $escaper */
+/** @var Agreement $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<?php $code = $block->escapeHtml($block->getMethodCode()) ?>
+<?php $code = $escaper->escapeHtml($block->getMethodCode()) ?>
 <fieldset class="admin__fieldset payment-method form-list" id="payment_form_<?= /* @noEscape */ $code ?>">
     <div class="admin__field _required">
         <label class="admin__field-label"
                for="<?= /* @noEscape */ $code ?>_ba_agreement_id">
-            <span><?= $block->escapeHtml(__('Billing Agreement')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Billing Agreement')) ?></span>
         </label>
         <div class="admin__field-control">
             <select id="<?= /* @noEscape */ $code ?>_ba_agreement_id"
-                    name="payment[<?= $block->escapeHtml($block->getTransportName()) ?>]"
+                    name="payment[<?= $escaper->escapeHtml($block->getTransportName()) ?>]"
                     class="required-entry admin__control-select">
-                <option value=""><?= $block->escapeHtml(__('Please Select')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Please Select')) ?></option>
                 <?php foreach ($block->getBillingAgreements() as $id => $referenceId): ?>
-                    <option value="<?= $block->escapeHtml($id) ?>"
+                    <option value="<?= $escaper->escapeHtml($id) ?>"
                         <?= ($id == $block->getInfoData($block->getTransportName())) ?
                             ' selected="selected"' : '';
                         ?>>
-                        <?= $block->escapeHtml($referenceId) ?>
+                        <?= $escaper->escapeHtml($referenceId) ?>
                     </option>
                 <?php endforeach; ?>
             </select>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/api_wizard.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/api_wizard.phtml
@@ -3,12 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Paypal\Block\Adminhtml\System\Config\ApiWizard
- * @var \Magento\Paypal\Block\Adminhtml\System\Config\ApiWizard $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Adminhtml\System\Config\ApiWizard;
+
+/** @var Escaper $escaper */
+/** @var ApiWizard $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="pp-buttons-container">
     <div id="paypal_api_config" dir="ltr" trbidi="on">
@@ -26,13 +29,13 @@ script;
 
         <a class="action-default"
            data-paypal-button="true"
-           href="<?= /* @noEscape */ $block->escapeUrl($block->getButtonUrl() . '?' . $block->getQuery()) ?>"
-           target="PPFrame"><?= $block->escapeHtml($block->getButtonLabel()) ?></a>
+           href="<?= /* @noEscape */ $escaper->escapeUrl($block->getButtonUrl() . '?' . $block->getQuery()) ?>"
+           target="PPFrame"><?= $escaper->escapeHtml($block->getButtonLabel()) ?></a>
 
         <a class="action-default"
            data-paypal-button="true"
-           href="<?= /* @noEscape */ $block->escapeUrl($block->getSandboxButtonUrl(). '?' . $block->getQuery()) ?>"
-           target="PPFrame"><?= $block->escapeHtml($block->getSandboxButtonLabel()) ?></a>
+           href="<?= /* @noEscape */ $escaper->escapeUrl($block->getSandboxButtonUrl(). '?' . $block->getQuery()) ?>"
+           target="PPFrame"><?= $escaper->escapeHtml($block->getSandboxButtonLabel()) ?></a>
     </div>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag("text-align: left;", 'div#paypal_api_config') ?>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/bml_api_wizard.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/bml_api_wizard.phtml
@@ -3,25 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Paypal\Block\Adminhtml\System\Config\BmlApiWizard
- * @var \Magento\Paypal\Block\Adminhtml\System\Config\BmlApiWizard $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Adminhtml\System\Config\BmlApiWizard;
+
+/** @var Escaper $escaper */
+/** @var BmlApiWizard $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div class="pp-buttons-container">
-    <button class="scalable" type="button" id="<?= $block->escapeHtml($block->getHtmlId()) ?>">
-        <span><span><span><?= $block->escapeHtml($block->getButtonLabel()) ?></span></span></span>
+    <button class="scalable" type="button" id="<?= $escaper->escapeHtml($block->getHtmlId()) ?>">
+        <span><span><span><?= $escaper->escapeHtml($block->getButtonLabel()) ?></span></span></span>
     </button>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
     'onclick',
     "window.open(
-            '" . $block->escapeUrl($block->getButtonUrl()) . "',
+            '" . $escaper->escapeUrl($block->getButtonUrl()) . "',
             'bmlapiwizard',
             'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, ,' +
             'left=100, top=100, width=550, height=550'
         );event.preventDefault()",
-    'button#' . $block->escapeHtml($block->getHtmlId())
+    'button#' . $escaper->escapeHtml($block->getHtmlId())
 ) ?>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/fieldset/hint.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/fieldset/hint.phtml
@@ -3,17 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Paypal\Block\System\Config\Fieldset\Hint
- * @var \Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Hint $block
- */
-$helpLink = $block->escapeUrl($block->getHelpLink());
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Hint;
+
+/** @see \Magento\Paypal\Block\System\Config\Fieldset\Hint */
+
+/** @var Escaper $escaper */
+/** @var Hint $block */
+$helpLink = $escaper->escapeUrl($block->getHelpLink());
 ?>
 <?php if ($helpLink) : ?>
     <div class="paypal-payment-notice">
-        <?= $block->escapeHtml(__('Not sure what PayPal payment method to use? Click ')) ?>
-        <a href="<?= /* @noEscape */ $helpLink; ?>" target="_blank"><?= $block->escapeHtml(__('here')) ?></a>
-        <?= $block->escapeHtml(__(' to learn more.')) ?>
+        <?= $escaper->escapeHtml(__('Not sure what PayPal payment method to use? Click ')) ?>
+        <a href="<?= /* @noEscape */ $helpLink; ?>" target="_blank"><?= $escaper->escapeHtml(__('here')) ?></a>
+        <?= $escaper->escapeHtml(__(' to learn more.')) ?>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/advanced.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/*
- * @var $block \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Advanced
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Advanced;
+
+/** @var Escaper $escaper */
+/** @var Advanced $block */
 ?>
 <div class="payflow-settings-notice">
     <p>
-        <strong class="important-label"><?= $block->escapeHtml(__('Important: ')) ?></strong>
-        <?= $block->escapeHtml(__('To use PayPal Payments Advanced, you must configure your PayPal Payments Advanced account on the PayPal website.')) ?>
-        <?= $block->escapeHtml(__('Once you log into your PayPal Advanced account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below')) ?>
+        <strong class="important-label"><?= $escaper->escapeHtml(__('Important: ')) ?></strong>
+        <?= $escaper->escapeHtml(__('To use PayPal Payments Advanced, you must configure your PayPal Payments Advanced account on the PayPal website.')) ?>
+        <?= $escaper->escapeHtml(__('Once you log into your PayPal Advanced account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below')) ?>
     </p>
     <ul class="options-list">
         <li><strong>AVS:</strong> No</li>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/info.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/system/config/payflowlink/info.phtml
@@ -3,17 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Info
- * @var \Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Info $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Adminhtml\System\Config\Payflowlink\Info;
 
+/** @var Escaper $escaper */
+/** @var Info $block */
 ?>
 <div class="payflow-settings-notice">
-    <strong class="important-label"><?= $block->escapeHtml(__('Important: ')) ?></strong>
-    <?= $block->escapeHtml(__('To use PayPal Payflow Link, you must configure your PayPal Payflow Link account on the PayPal website.')) ?>
-    <?= $block->escapeHtml(__('Once you log into your PayPal Payflow Link account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below')) ?>
+    <strong class="important-label"><?= $escaper->escapeHtml(__('Important: ')) ?></strong>
+    <?= $escaper->escapeHtml(__('To use PayPal Payflow Link, you must configure your PayPal Payflow Link account on the PayPal website.')) ?>
+    <?= $escaper->escapeHtml(__('Once you log into your PayPal Payflow Link account, navigate to the Service Settings - Hosted Checkout Pages - Set Up menu and set the options described below')) ?>
     <ul class="options-list">
         <li><strong>AVS:</strong> No</li>
         <li><strong>CSC:</strong> No</li>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/transparent/form.phtml
@@ -3,24 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Adminhtml\Payflowpro\CcForm $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-$code = $block->escapeHtml($block->getMethodCode());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Adminhtml\Payflowpro\CcForm;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var CcForm $block */
+$code = $escaper->escapeHtml($block->getMethodCode());
 $ccType = $block->getInfoData('cc_type');
 $ccExpYear = $block->getInfoData('cc_exp_year');
 $ccExpMonth = $block->getInfoData('cc_exp_month');
 ?>
-
 <!-- IFRAME for request to Payment Gateway -->
 <iframe id="<?= /* @noEscape */ $code ?>-transparent-iframe"
         data-container="<?= /* @noEscape */ $code ?>-transparent-iframe"
         allowtransparency="true"
         frameborder="0"
         name="iframeTransparent"
-        src="<?= $block->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
+        src="<?= $escaper->escapeUrl($block->getViewFileUrl('blank.html')) ?>"></iframe>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     "display: none; width: 100%; background-color: transparent;",
     "iframe#" . /* @noEscape */ $code . "-transparent-iframe"
@@ -30,20 +33,20 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
     class="admin__fieldset"
     data-mage-init='{
      "transparent":{
-        "controller":"<?= $block->escapeHtml($block->getRequest()->getControllerName()) ?>",
+        "controller":"<?= $escaper->escapeHtml($block->getRequest()->getControllerName()) ?>",
         "gateway":"<?= /* @noEscape */ $code ?>",
-        "dateDelim":"<?= $block->escapeHtml($block->getDateDelim()) ?>",
-        "cardFieldsMap":<?= $block->escapeHtml($block->getCardFieldsMap()) ?>,
-        "orderSaveUrl":"<?= $block->escapeUrl($block->getOrderUrl()) ?>",
-        "cgiUrl":"<?= $block->escapeUrl($block->getCgiUrl()) ?>",
-        "expireYearLength":"<?= $block->escapeHtml($block->getMethodConfigData('cc_year_length')) ?>",
-        "nativeAction":"<?= $block->escapeUrl(
+        "dateDelim":"<?= $escaper->escapeHtml($block->getDateDelim()) ?>",
+        "cardFieldsMap":<?= $escaper->escapeHtml($block->getCardFieldsMap()) ?>,
+        "orderSaveUrl":"<?= $escaper->escapeUrl($block->getOrderUrl()) ?>",
+        "cgiUrl":"<?= $escaper->escapeUrl($block->getCgiUrl()) ?>",
+        "expireYearLength":"<?= $escaper->escapeHtml($block->getMethodConfigData('cc_year_length')) ?>",
+        "nativeAction":"<?= $escaper->escapeUrl(
             $block->getUrl('*/*/save', ['_secure' => $block->getRequest()->isSecure()])
         ) ?>"
       }, "validation":[]}'>
     <div class="admin__field _required">
         <label for="<?= /* @noEscape */ $code ?>_cc_type" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Credit Card Type')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Type')) ?></span>
         </label>
 
         <div class="admin__field-control">
@@ -52,12 +55,12 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     name="payment[cc_type]"
                     data-validate='{required:true, "validate-cc-type-select":"#<?= /* @noEscape */ $code ?>_cc_number"}'
                     class="admin__control-select">
-                <option value=""><?= $block->escapeHtml(__('Please Select')) ?></option>
+                <option value=""><?= $escaper->escapeHtml(__('Please Select')) ?></option>
                 <?php foreach ($block->getCcAvailableTypes() as $typeCode => $typeName): ?>
                     <option
-                        value="<?= $block->escapeHtml($typeCode) ?>"
+                        value="<?= $escaper->escapeHtml($typeCode) ?>"
                         <?php if ($typeCode == $ccType): ?> selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($typeName) ?>
+                        <?= $escaper->escapeHtml($typeName) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -66,13 +69,13 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
 
     <div class="admin__field _required field-number">
         <label for="<?= /* @noEscape */ $code ?>_cc_number" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Credit Card Number')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Credit Card Number')) ?></span>
         </label>
 
         <div class="admin__field-control">
             <input type="text" id="<?= /* @noEscape */ $code ?>_cc_number"
                    data-container="<?= /* @noEscape */ $code ?>-cc-number"
-                   name="payment[cc_number]" title="<?= $block->escapeHtml(__('Credit Card Number')) ?>"
+                   name="payment[cc_number]" title="<?= $escaper->escapeHtml(__('Credit Card Number')) ?>"
                    class="admin__control-text" value="" autocomplete="off"
                    data-validate='{
                        "required-number":true,
@@ -99,7 +102,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
 
     <div class="admin__field _required field-date" id="<?= /* @noEscape */ $code ?>_cc_type_exp_div">
         <label for="<?= /* @noEscape */ $code ?>_expiration" class="admin__field-label">
-            <span><?= $block->escapeHtml(__('Expiration Date')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Expiration Date')) ?></span>
         </label>
 
         <div class="admin__field-control">
@@ -109,9 +112,9 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     data-validate='{required:true, "validate-cc-exp":"#<?= /* @noEscape */ $code ?>_expiration_yr"}'>
                 <?php foreach ($block->getCcMonths() as $k => $v): ?>
                     <option
-                        value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                        value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                         <?php if ($k == $ccExpMonth): ?> selected="selected"<?php endif; ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -121,9 +124,9 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                     data-container="<?= /* @noEscape */ $code ?>-cc-year" data-validate='{required:true}'>
                 <?php foreach ($block->getCcYears() as $k => $v): ?>
                     <option
-                        value="<?= /* @noEscape */ $k ? $block->escapeHtml($k) : '' ?>"
+                        value="<?= /* @noEscape */ $k ? $escaper->escapeHtml($k) : '' ?>"
                         <?php if ($k == $ccExpYear): ?> selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($v) ?>
+                        <?= $escaper->escapeHtml($v) ?>
                     </option>
                 <?php endforeach ?>
             </select>
@@ -132,11 +135,11 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
     <?php if ($block->hasVerification()): ?>
         <div class="admin__field _required field-cvv" id="<?= /* @noEscape */ $code ?>_cc_type_cvv_div">
             <label for="<?= /* @noEscape */ $code ?>_cc_cid" class="admin__field-label">
-                <span><?= $block->escapeHtml(__('Card Verification Number')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Card Verification Number')) ?></span>
             </label>
 
             <div class="admin__field-control">
-                <input type="text" title="<?= $block->escapeHtml(__('Card Verification Number')) ?>"
+                <input type="text" title="<?= $escaper->escapeHtml(__('Card Verification Number')) ?>"
                        data-container="<?= /* @noEscape */ $code ?>-cc-cvv" class="admin__control-text cvv"
                        id="<?= /* @noEscape */ $code ?>_cc_cid" name="payment[cc_cid]" value=""
                        data-validate='{"required-number":true, "validate-cc-cvn":"#<?=/* @noEscape */ $code?>_cc_type"}'
@@ -167,7 +170,7 @@ $ccExpMonth = $block->getInfoData('cc_exp_month');
                    name="payment[is_active_payment_token_enabler]"
                    class="admin__control-checkbox"/>
             <label class="admin__field-label" for="<?= /* @noEscape */ $code ?>_vault">
-                <span><?= $block->escapeHtml(__('Save for later use.')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Save for later use.')) ?></span>
             </label>
         </div>
     <?php endif; ?>

--- a/app/code/Magento/Paypal/view/adminhtml/templates/transparent/iframe.phtml
+++ b/app/code/Magento/Paypal/view/adminhtml/templates/transparent/iframe.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Payment\Block\Transparent\Iframe $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Payment\Block\Transparent\Iframe;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Iframe $block */
 $params = $block->getParams();
 
-/** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
+/** @var Data $jsonHelper */
 $jsonHelper = $block->getData('jsonHelper');
 ?>
 <html>
@@ -18,14 +23,14 @@ $jsonHelper = $block->getData('jsonHelper');
 <?php
 $scriptString = '';
 if (isset($params['redirect'])):
-    $scriptString .= 'window.location="' . $block->escapeJs($params['redirect']) . '";' . PHP_EOL;
+    $scriptString .= 'window.location="' . $escaper->escapeJs($params['redirect']) . '";' . PHP_EOL;
 elseif (isset($params['redirect_parent'])):
-    $scriptString .= 'window.top.location="' . $block->escapeJs($params['redirect_parent']) . '";' . PHP_EOL;
+    $scriptString .= 'window.top.location="' . $escaper->escapeJs($params['redirect_parent']) . '";' . PHP_EOL;
 elseif (isset($params['error_msg'])):
     $scriptString .= 'window.top.alert(' . /* @noEscape */ $jsonHelper->jsonEncode($params['error_msg']) . ');' .
         PHP_EOL;
 elseif (isset($params['order_success'])):
-    $scriptString .= 'window.top.location = "' . $block->escapeJs($params['order_success']) . '";' . PHP_EOL;
+    $scriptString .= 'window.top.location = "' . $escaper->escapeJs($params['order_success']) . '";' . PHP_EOL;
 else:
     $scriptString .= <<<script
     var require = window.top.require;

--- a/app/code/Magento/Paypal/view/frontend/templates/billing/agreement/view.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/billing/agreement/view.phtml
@@ -3,65 +3,68 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Billing\Agreement\View $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Billing\Agreement\View;
+
+/** @var Escaper $escaper */
+/** @var View $block */
 $relatedOrders = $block->getRelatedOrders();
 ?>
 <div class="block block-billing-agreements-view">
     <div class="block-title">
         <strong>
-            <?= $block->escapeHtml(__('Billing Agreement # ')) ?>
-            <?= $block->escapeHtml($block->getReferenceId()) ?>
+            <?= $escaper->escapeHtml(__('Billing Agreement # ')) ?>
+            <?= $escaper->escapeHtml($block->getReferenceId()) ?>
         </strong>
         <?php if ($block->getCanCancel()) : ?>
             <button data-mage-init='{"Magento_Paypal/js/in-context/billing-agreement": {
-                        "cancelMessage" : "<?= $block->escapeHtml(__('Are you sure you want to do this?')) ?>",
-                        "cancelUrl" : "<?= $block->escapeUrl($block->getCancelUrl()) ?>"
+                        "cancelMessage" : "<?= $escaper->escapeHtml(__('Are you sure you want to do this?')) ?>",
+                        "cancelUrl" : "<?= $escaper->escapeUrl($block->getCancelUrl()) ?>"
                     }}'
-                    type="button" title="<?= $block->escapeHtml(__('Cancel')) ?>"
+                    type="button" title="<?= $escaper->escapeHtml(__('Cancel')) ?>"
                     class="secondary action cancel">
-                <span><?= $block->escapeHtml(__('Cancel')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Cancel')) ?></span>
             </button>
         <?php endif; ?>
     </div>
     <div class="block-title">
-        <strong><?= $block->escapeHtml(__('Agreement Information')) ?></strong>
+        <strong><?= $escaper->escapeHtml(__('Agreement Information')) ?></strong>
     </div>
     <div class="block-content">
         <div class="table-wrapper billing-agreements-view">
             <table class="data table table-billing-agreements-view">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Agreement Information')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Agreement Information')) ?></caption>
                 <thead>
                 <tr>
-                    <th scope="col" class="col id"><?= $block->escapeHtml(__('Reference ID:')) ?></th>
-                    <th scope="col" class="col status"><?= $block->escapeHtml(__('Status:')) ?></th>
-                    <th scope="col" class="col created"><?= $block->escapeHtml(__('Created:')) ?></th>
+                    <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Reference ID:')) ?></th>
+                    <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Status:')) ?></th>
+                    <th scope="col" class="col created"><?= $escaper->escapeHtml(__('Created:')) ?></th>
                     <?php if ($block->getAgreementUpdatedAt()) : ?>
-                        <th scope="col" class="col updated"><?= $block->escapeHtml(__('Updated:')) ?></th>
+                        <th scope="col" class="col updated"><?= $escaper->escapeHtml(__('Updated:')) ?></th>
                     <?php endif; ?>
-                    <th scope="col" class="col payment"><?= $block->escapeHtml(__('Payment Method:')) ?></th>
+                    <th scope="col" class="col payment"><?= $escaper->escapeHtml(__('Payment Method:')) ?></th>
                 </tr>
                 </thead>
                 <tbody>
                 <tr>
-                    <td data-th="<?= $block->escapeHtml(__('Reference ID:')) ?>" class="col id">
-                        <?= $block->escapeHtml($block->getReferenceId()) ?>
+                    <td data-th="<?= $escaper->escapeHtml(__('Reference ID:')) ?>" class="col id">
+                        <?= $escaper->escapeHtml($block->getReferenceId()) ?>
                     </td>
-                    <td data-th="<?= $block->escapeHtml(__('Status:')) ?>" class="col status">
-                        <?= $block->escapeHtml($block->getAgreementStatus()) ?>
+                    <td data-th="<?= $escaper->escapeHtml(__('Status:')) ?>" class="col status">
+                        <?= $escaper->escapeHtml($block->getAgreementStatus()) ?>
                     </td>
-                    <td data-th="<?= $block->escapeHtml(__('Created:')) ?>" class="col created">
-                        <?= $block->escapeHtml($block->getAgreementCreatedAt()) ?>
+                    <td data-th="<?= $escaper->escapeHtml(__('Created:')) ?>" class="col created">
+                        <?= $escaper->escapeHtml($block->getAgreementCreatedAt()) ?>
                     </td>
                     <?php if ($block->getAgreementUpdatedAt()) : ?>
-                        <td data-th="<?= $block->escapeHtml(__('Updated:')) ?>" class="col updated">
-                            <?= $block->escapeHtml($block->getAgreementUpdatedAt()) ?>
+                        <td data-th="<?= $escaper->escapeHtml(__('Updated:')) ?>" class="col updated">
+                            <?= $escaper->escapeHtml($block->getAgreementUpdatedAt()) ?>
                         </td>
                     <?php endif; ?>
-                    <td data-th="<?= $block->escapeHtml(__('Payment Method:')) ?>" class="col payment">
-                        <?= $block->escapeHtml($block->getPaymentMethodTitle()) ?>
+                    <td data-th="<?= $escaper->escapeHtml(__('Payment Method:')) ?>" class="col payment">
+                        <?= $escaper->escapeHtml($block->getPaymentMethodTitle()) ?>
                     </td>
                 </tr>
                 </tbody>
@@ -73,55 +76,55 @@ $relatedOrders = $block->getRelatedOrders();
     <div class="block block-billing-orders-view">
         <?= $block->getChildHtml('pager') ?>
         <div class="block-title">
-            <span><?= $block->escapeHtml(__('Related Orders')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Related Orders')) ?></span>
         </div>
         <div class="block-content">
             <div class="table-wrapper billing-agreements-related">
                 <table class="data table table-billing-agreements-related" id="related-orders-table">
-                    <caption class="table-caption"><?= $block->escapeHtml(__('Related Orders')) ?></caption>
+                    <caption class="table-caption"><?= $escaper->escapeHtml(__('Related Orders')) ?></caption>
                     <thead>
                     <tr>
-                        <th scope="col" class="col id"><?= $block->escapeHtml(__('Order #')) ?></th>
-                        <th scope="col" class="col date"><?= $block->escapeHtml(__('Date')) ?></th>
-                        <th scope="col" class="col shipto"><?= $block->escapeHtml(__('Ship To')) ?></th>
-                        <th scope="col" class="col total"><?= $block->escapeHtml(__('Order Total')) ?></th>
-                        <th scope="col" class="col status"><?= $block->escapeHtml(__('Order Status')) ?></th>
+                        <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Order #')) ?></th>
+                        <th scope="col" class="col date"><?= $escaper->escapeHtml(__('Date')) ?></th>
+                        <th scope="col" class="col shipto"><?= $escaper->escapeHtml(__('Ship To')) ?></th>
+                        <th scope="col" class="col total"><?= $escaper->escapeHtml(__('Order Total')) ?></th>
+                        <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Order Status')) ?></th>
                         <th scope="col" class="col actions">&nbsp;</th>
                     </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($relatedOrders as $order) : ?>
                             <tr>
-                                <td data-th="<?= $block->escapeHtml(__('Order #')) ?>" class="col id">
-                                    <?= $block->escapeHtml($block->getOrderItemValue(
+                                <td data-th="<?= $escaper->escapeHtml(__('Order #')) ?>" class="col id">
+                                    <?= $escaper->escapeHtml($block->getOrderItemValue(
                                         $order,
                                         'order_increment_id'
                                     )); ?>
                                 </td>
-                                <td data-th="<?= $block->escapeHtml(__('Date')) ?>" class="col date">
-                                    <?= $block->escapeHtml($block->getOrderItemValue($order, 'created_at')) ?>
+                                <td data-th="<?= $escaper->escapeHtml(__('Date')) ?>" class="col date">
+                                    <?= $escaper->escapeHtml($block->getOrderItemValue($order, 'created_at')) ?>
                                 </td>
-                                <td data-th="<?= $block->escapeHtml(__('Ship To')) ?>" class="col shipto">
-                                    <?= $block->escapeHtml($block->getOrderItemValue(
+                                <td data-th="<?= $escaper->escapeHtml(__('Ship To')) ?>" class="col shipto">
+                                    <?= $escaper->escapeHtml($block->getOrderItemValue(
                                         $order,
                                         'shipping_address'
                                     )); ?>
                                 </td>
-                                <td data-th="<?= $block->escapeHtml(__('Order Total')) ?>" class="col total">
+                                <td data-th="<?= $escaper->escapeHtml(__('Order Total')) ?>" class="col total">
                                     <?= /* @noEscape */ $block->getOrderItemValue($order, 'order_total') ?>
                                 </td>
-                                <td data-th="<?= $block->escapeHtml(__('Order Status')) ?>" class="col status">
-                                    <?= $block->escapeHtml($block->getOrderItemValue(
+                                <td data-th="<?= $escaper->escapeHtml(__('Order Status')) ?>" class="col status">
+                                    <?= $escaper->escapeHtml($block->getOrderItemValue(
                                         $order,
                                         'status_label'
                                     )); ?>
                                 </td>
                                 <td data-th="" class="col actions">
-                                    <a href="<?= $block->escapeUrl($block->getOrderItemValue(
+                                    <a href="<?= $escaper->escapeUrl($block->getOrderItemValue(
                                         $order,
                                         'view_url'
                                     )); ?>" class="action view">
-                                        <span><?= $block->escapeHtml(__('View Order')) ?></span>
+                                        <span><?= $escaper->escapeHtml(__('View Order')) ?></span>
                                     </a>
                                 </td>
                             </tr>
@@ -135,8 +138,8 @@ $relatedOrders = $block->getRelatedOrders();
 
 <div class="actions-toolbar">
     <div class="secondary">
-        <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-            <?= $block->escapeHtml(__('Back to Billing Agreements')) ?>
+        <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+            <?= $escaper->escapeHtml(__('Back to Billing Agreements')) ?>
         </a>
     </div>
 </div>

--- a/app/code/Magento/Paypal/view/frontend/templates/billing/agreements.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/billing/agreements.phtml
@@ -3,11 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Billing\Agreements $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Billing\Agreements;
 
+/** @var Escaper $escaper */
+/** @var Agreements $block */
 $billingAgreements = $block->getBillingAgreements();
 $paymentMethods = $block->getWizardPaymentMethodOptions();
 ?>
@@ -16,39 +18,39 @@ $paymentMethods = $block->getWizardPaymentMethodOptions();
         <?= $block->getChildHtml('pager') ?>
         <div class="table-wrapper billing-agreements">
             <table id="billing-agreements" class="data table table-billing-agreements">
-                <caption class="table-caption"><?= $block->escapeHtml(__('Billing Agreements')) ?></caption>
+                <caption class="table-caption"><?= $escaper->escapeHtml(__('Billing Agreements')) ?></caption>
                 <thead>
                 <tr>
-                    <th scope="col" class="col id"><?= $block->escapeHtml(__('Reference ID')) ?></th>
-                    <th scope="col" class="col status"><?= $block->escapeHtml(__('Status')) ?></th>
-                    <th scope="col" class="col created"><?= $block->escapeHtml(__('Created At')) ?></th>
-                    <th scope="col" class="col updated"><?= $block->escapeHtml(__('Updated At')) ?></th>
-                    <th scope="col" class="col payment"><?= $block->escapeHtml(__('Payment Method')) ?></th>
+                    <th scope="col" class="col id"><?= $escaper->escapeHtml(__('Reference ID')) ?></th>
+                    <th scope="col" class="col status"><?= $escaper->escapeHtml(__('Status')) ?></th>
+                    <th scope="col" class="col created"><?= $escaper->escapeHtml(__('Created At')) ?></th>
+                    <th scope="col" class="col updated"><?= $escaper->escapeHtml(__('Updated At')) ?></th>
+                    <th scope="col" class="col payment"><?= $escaper->escapeHtml(__('Payment Method')) ?></th>
                     <th scope="col" class="col actions">&nbsp;</th>
                 </tr>
                 </thead>
                 <tbody>
                     <?php foreach ($billingAgreements as $item) : ?>
                         <tr>
-                            <td data-th="<?= $block->escapeHtml(__('Reference ID')) ?>" class="col id">
-                                <?= $block->escapeHtml($block->getItemValue($item, 'reference_id')) ?>
+                            <td data-th="<?= $escaper->escapeHtml(__('Reference ID')) ?>" class="col id">
+                                <?= $escaper->escapeHtml($block->getItemValue($item, 'reference_id')) ?>
                             </td>
-                            <td data-th="<?= $block->escapeHtml(__('Status')) ?>" class="col status">
-                                <?= $block->escapeHtml($block->getItemValue($item, 'status')) ?>
+                            <td data-th="<?= $escaper->escapeHtml(__('Status')) ?>" class="col status">
+                                <?= $escaper->escapeHtml($block->getItemValue($item, 'status')) ?>
                             </td>
-                            <td data-th="<?= $block->escapeHtml(__('Created At')) ?>" class="col created">
-                                <?= $block->escapeHtml($block->getItemValue($item, 'created_at')) ?>
+                            <td data-th="<?= $escaper->escapeHtml(__('Created At')) ?>" class="col created">
+                                <?= $escaper->escapeHtml($block->getItemValue($item, 'created_at')) ?>
                             </td>
-                            <td data-th="<?= $block->escapeHtml(__('Updated At')) ?>" class="col updated">
-                                <?= $block->escapeHtml($block->getItemValue($item, 'updated_at')) ?>
+                            <td data-th="<?= $escaper->escapeHtml(__('Updated At')) ?>" class="col updated">
+                                <?= $escaper->escapeHtml($block->getItemValue($item, 'updated_at')) ?>
                             </td>
-                            <td data-th="<?= $block->escapeHtml(__('Payment Method')) ?>" class="col payment">
-                                <?= $block->escapeHtml($block->getItemValue($item, 'payment_method_label')) ?>
+                            <td data-th="<?= $escaper->escapeHtml(__('Payment Method')) ?>" class="col payment">
+                                <?= $escaper->escapeHtml($block->getItemValue($item, 'payment_method_label')) ?>
                             </td>
                             <td data-th="" class="col actions">
-                                <a href="<?= $block->escapeUrl($block->getItemValue($item, 'edit_url')) ?>"
+                                <a href="<?= $escaper->escapeUrl($block->getItemValue($item, 'edit_url')) ?>"
                                    class="action view">
-                                    <span><?= $block->escapeHtml(__('View')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('View')) ?></span>
                                 </a>
                             </td>
                         </tr>
@@ -58,29 +60,29 @@ $paymentMethods = $block->getWizardPaymentMethodOptions();
         </div>
     <?php else : ?>
         <div class="message info empty">
-            <span><?= $block->escapeHtml(__('There are no billing agreements yet.')) ?></span>
+            <span><?= $escaper->escapeHtml(__('There are no billing agreements yet.')) ?></span>
         </div>
     <?php endif; ?>
 
     <?php if ($paymentMethods) : ?>
-        <form action="<?= $block->escapeUrl($block->getCreateUrl()) ?>" method="post"
+        <form action="<?= $escaper->escapeUrl($block->getCreateUrl()) ?>" method="post"
               class="form form-new-agreement">
             <fieldset class="fieldset">
                 <legend class="legend">
-                    <span><?= $block->escapeHtml(__('New Billing Agreement')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('New Billing Agreement')) ?></span>
                 </legend>
                 <br />
                 <p class="note">
-                    <?= $block->escapeHtml(__('You will be redirected to the payment system website.')) ?>
+                    <?= $escaper->escapeHtml(__('You will be redirected to the payment system website.')) ?>
                 </p>
 
                 <div class="field payment method">
                     <div class="control">
                         <select id="payment_method" name="payment_method">
-                            <option value=""><?= $block->escapeHtml(__('-- Please Select --')) ?></option>
+                            <option value=""><?= $escaper->escapeHtml(__('-- Please Select --')) ?></option>
                             <?php foreach ($paymentMethods as $code => $title) : ?>
-                                <option value="<?= $block->escapeHtml($code) ?>">
-                                    <?= $block->escapeHtml($title) ?>
+                                <option value="<?= $escaper->escapeHtml($code) ?>">
+                                    <?= $escaper->escapeHtml($title) ?>
                                 </option>
                             <?php endforeach; ?>
                         </select>
@@ -89,12 +91,12 @@ $paymentMethods = $block->getWizardPaymentMethodOptions();
                 <div class="actions-toolbar">
                     <div class="primary">
                         <button type="submit" class="primary action create">
-                            <span><?= $block->escapeHtml(__('Create...')) ?></span>
+                            <span><?= $escaper->escapeHtml(__('Create...')) ?></span>
                         </button>
                     </div>
                     <div class="secondary">
-                        <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                            <span><?= $block->escapeHtml(__('Back')) ?></span>
+                        <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                            <span><?= $escaper->escapeHtml(__('Back')) ?></span>
                         </a>
                     </div>
                 </div>
@@ -103,8 +105,8 @@ $paymentMethods = $block->getWizardPaymentMethodOptions();
     <?php else : ?>
     <div class="actions-toolbar">
         <div class="secondary">
-            <a href="<?= $block->escapeUrl($block->getBackUrl()) ?>" class="action back">
-                <span><?= $block->escapeHtml(__('Back')) ?></span>
+            <a href="<?= $escaper->escapeUrl($block->getBackUrl()) ?>" class="action back">
+                <span><?= $escaper->escapeHtml(__('Back')) ?></span>
             </a>
         </div>
     </div>

--- a/app/code/Magento/Paypal/view/frontend/templates/bml.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/bml.phtml
@@ -3,15 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @see \Magento\Paypal\Block\Bml\Banners
- */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Bml\Banners;
+
+/** @var Escaper $escaper */
+/** @var Banners $block */
 ?>
 <div class="paypal-logo">
-    <script data-pp-pubid="<?= $block->escapeHtml($block->getPublisherId()) ?>"
-            data-pp-placementtype="<?= $block->escapeHtml($block->getSize()) ?>"
+    <script data-pp-pubid="<?= $escaper->escapeHtml($block->getPublisherId()) ?>"
+            data-pp-placementtype="<?= $escaper->escapeHtml($block->getSize()) ?>"
         > (function (d, t) {
             "use strict";
             var s = d.getElementsByTagName(t)[0], n = d.createElement(t);

--- a/app/code/Magento/Paypal/view/frontend/templates/checkout/onepage/review/totals.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/checkout/onepage/review/totals.phtml
@@ -3,10 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Checkout\Block\Cart\Totals
- */
+use Magento\Checkout\Block\Cart\Totals;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Totals $block */
 ?>
 <?php if ($block->getTotals()) : ?>
     <?php $_colspan = 3; ?>
@@ -15,9 +18,9 @@
     <?php if ($block->needDisplayBaseGrandtotal()) : ?>
     <tr class="totals charge">
         <th class="mark" colspan="<?= /* @noEscape */ $_colspan ?>" scope="row">
-            <?= $block->escapeHtml(__('Your credit card will be charged for')) ?>
+            <?= $escaper->escapeHtml(__('Your credit card will be charged for')) ?>
         </th>
-        <td class="amount" data-th="<?= $block->escapeHtml(__('Your credit card will be charged for')) ?>">
+        <td class="amount" data-th="<?= $escaper->escapeHtml(__('Your credit card will be charged for')) ?>">
             <?= /* @noEscape */ $block->displayBaseGrandtotal() ?>
         </td>
     </tr>

--- a/app/code/Magento/Paypal/view/frontend/templates/checkout/onepage/success/billing_agreement.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/checkout/onepage/success/billing_agreement.phtml
@@ -3,15 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Checkout\Onepage\Success\BillingAgreement;
 
-/**
- * @var \Magento\Paypal\Block\Checkout\Onepage\Success\BillingAgreement $block
- */
+/** @var Escaper $escaper */
+/** @var BillingAgreement $block */
 ?>
 <p data-mage-init='{"Magento_Paypal/js/in-context/billing-agreement": {"invalidateOnLoad" : true}}'>
-    <?= $block->escapeHtml(__('Your billing agreement # is: ')) ?>
-    <a href="<?= $block->escapeUrl($block->getAgreementUrl()) ?>">
-        <?= $block->escapeHtml($block->getAgreementRefId()) ?>
+    <?= $escaper->escapeHtml(__('Your billing agreement # is: ')) ?>
+    <a href="<?= $escaper->escapeUrl($block->getAgreementUrl()) ?>">
+        <?= $escaper->escapeHtml($block->getAgreementRefId()) ?>
     </a>.
 </p>

--- a/app/code/Magento/Paypal/view/frontend/templates/express/in-context/shortcut/button.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/in-context/shortcut/button.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Express\InContext\Minicart\SmartButton $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Express\InContext\Minicart\SmartButton;
+
+/** @var Escaper $escaper */
+/** @var SmartButton $block */
 $widget = $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonDecode($block->getJsInitParams());
 $widgetConfig = $this->helper(\Magento\Framework\Json\Helper\Data::class)->jsonEncode($widget['Magento_Paypal/js/in-context/button']);
 ?>
 <div data-mage-init='{"Magento_Paypal/js/in-context/button":<?= /* @noEscape */ $widgetConfig ?>}'
-     class="paypal checkout paypal-logo <?= $block->escapeHtml($block->getContainerId()) ?>-container">
+     class="paypal checkout paypal-logo <?= $escaper->escapeHtml($block->getContainerId()) ?>-container">
 </div>

--- a/app/code/Magento/Paypal/view/frontend/templates/express/review.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/review.phtml
@@ -3,18 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Helper\SecureHtmlRenderer;
 use Magento\Paypal\Block\Express\Review;
+use Magento\Paypal\ViewModel\PaypalFundingSourceDataProvider;
 
-/**
- * @var Review $block
- * @var Escaper $escaper
- * @var SecureHtmlRenderer $secureRenderer
- */
-
-/** @var \Magento\Paypal\ViewModel\PaypalFundingSourceDataProvider $paypalFundingSourceDataProvider */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Review $block */
+/** @var PaypalFundingSourceDataProvider $paypalFundingSourceDataProvider */
 $paypalFundingSourceDataProvider = $block->getData('PaypalFundingSourceDataProvider');
 ?>
 <div class="paypal-review view">
@@ -47,7 +46,7 @@ $paypalFundingSourceDataProvider = $block->getData('PaypalFundingSourceDataProvi
                                                 ?>">
                                                     <?php foreach ($rates as $rate): ?>
                                                         <option value="<?=
-                                                                        $block->escapeHtml(
+                                                                        $escaper->escapeHtml(
                                                                             $block->renderShippingRateValue($rate)
                                                                         );
                                                                         ?>"
@@ -108,7 +107,7 @@ $paypalFundingSourceDataProvider = $block->getData('PaypalFundingSourceDataProvi
                         ?? $block->getPaymentMethodTitle()) ?><br>
                     <?= $escaper->escapeHtml($block->getEmail()) ?> <br>
                     <img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-medium.png"
-                         alt="<?= $block->escapeHtml(__('Buy now with PayPal')) ?>"/>
+                         alt="<?= $escaper->escapeHtml(__('Buy now with PayPal')) ?>"/>
                 </div>
                 <?php if ($block->getEditUrl()): ?>
                     <div class="box-actions">

--- a/app/code/Magento/Paypal/view/frontend/templates/express/review/details.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/review/details.phtml
@@ -3,21 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @see \Magento\Paypal\Block\Express\Review\Details
- * @var \Magento\Paypal\Block\Express\Review\Details $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Express\Review\Details;
+
+/** @var Escaper $escaper */
+/** @var Details $block */
 ?>
 <div id="details-reload" class="table-wrapper order-items cart">
     <table id="details-table" class="cart items data table table-paypal-review-items">
-        <caption class="table-caption"><?= $block->escapeHtml(__('Items in Your Shopping Cart')) ?></caption>
+        <caption class="table-caption"><?= $escaper->escapeHtml(__('Items in Your Shopping Cart')) ?></caption>
         <thead>
         <tr>
-            <th class="col name" scope="col"><?= $block->escapeHtml(__('Item')) ?></th>
-            <th class="col price" scope="col"><?= $block->escapeHtml(__('Price')) ?></th>
-            <th class="col qty" scope="col"><?= $block->escapeHtml(__('Qty')) ?></th>
-            <th class="col subtotal" scope="col"><?= $block->escapeHtml(__('Subtotal')) ?></th>
+            <th class="col name" scope="col"><?= $escaper->escapeHtml(__('Item')) ?></th>
+            <th class="col price" scope="col"><?= $escaper->escapeHtml(__('Price')) ?></th>
+            <th class="col qty" scope="col"><?= $escaper->escapeHtml(__('Qty')) ?></th>
+            <th class="col subtotal" scope="col"><?= $escaper->escapeHtml(__('Subtotal')) ?></th>
         </tr>
         </thead>
             <?php foreach ($block->getItems() as $item) : ?>

--- a/app/code/Magento/Paypal/view/frontend/templates/express/review/shipping/method.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/review/shipping/method.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Paypal\Block\Express\Review
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Express\Review;
+
+/** @var Escaper $escaper */
+/** @var Review $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <div id="shipping-method-container">
     <?php if ($block->getCanEditShippingMethod() || !$block->getCurrentShippingRate()): ?>
@@ -16,15 +20,15 @@
             <select name="shipping_method" id="shipping_method" class="required-entry">
                 <?php if (!$currentRate): ?>
                     <option value="">
-                        <?= $block->escapeHtml(__('Please select a shipping method...')) ?>
+                        <?= $escaper->escapeHtml(__('Please select a shipping method...')) ?>
                     </option>
                 <?php endif; ?>
                 <?php foreach ($groups as $code => $rates): ?>
                     <optgroup id="group_<?= /* @noEscape */ $code ?>"
-                              label="<?= $block->escapeHtml($block->getCarrierName($code)) ?>">
+                              label="<?= $escaper->escapeHtml($block->getCarrierName($code)) ?>">
                         <?php foreach ($rates as $rate): ?>
                             <option
-                                value="<?= $block->escapeHtml($block->renderShippingRateValue($rate)) ?>"
+                                value="<?= $escaper->escapeHtml($block->renderShippingRateValue($rate)) ?>"
                                     <?= ($currentRate === $rate) ? ' selected="selected"' : '' ?>>
                                 <?= /* @noEscape */ $block->renderShippingRateOption($rate) ?>
                             </option>
@@ -39,7 +43,7 @@
         <?php else: ?>
             <p>
                 <strong>
-                    <?= $block->escapeHtml(__('Sorry, no quotes are available for this order right now.')) ?>
+                    <?= $escaper->escapeHtml(__('Sorry, no quotes are available for this order right now.')) ?>
                 </strong>
             </p>
         <?php endif; ?>
@@ -52,7 +56,7 @@
     <?php endif; ?>
 </div>
 <div id="shipping_method_update">
-    <p><?= $block->escapeHtml(__('Please update order data to get shipping methods and rates')) ?></p>
+    <p><?= $escaper->escapeHtml(__('Please update order data to get shipping methods and rates')) ?></p>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',

--- a/app/code/Magento/Paypal/view/frontend/templates/express/shortcut.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/express/shortcut.phtml
@@ -3,25 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Express\Shortcut $block
- */
-?>
-<?php
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Express\Shortcut;
+
+/** @var Escaper $escaper */
+/** @var Shortcut $block */
+
 $labelPosition = '';
+
 if ($block->isOrPositionBefore()) {
     $labelPosition = ' before';
 } elseif ($block->isOrPositionAfter()) {
     $labelPosition = ' after';
 }
-$shortcutHtmlId = $block->escapeHtml($block->getShortcutHtmlId());
+
+$shortcutHtmlId = $escaper->escapeHtml($block->getShortcutHtmlId());
 $isInCatalogProduct = false;
+
 if ($block->getIsInCatalogProduct()) {
     $isInCatalogProduct = $block->getIsInCatalogProduct();
 }
 ?>
-<div data-label="<?= $block->escapeHtml(__('or')) ?>"
+<div data-label="<?= $escaper->escapeHtml(__('or')) ?>"
      class="paypal checkout <?= /* @noEscape */ $labelPosition ?> paypal-logo
         <?= /* @noEscape */ $shortcutHtmlId ?>"
      data-mage-init='{
@@ -32,14 +37,14 @@ if ($block->getIsInCatalogProduct()) {
      }'
     >
     <input type="image" data-action="checkout-form-submit"
-           data-checkout-url="<?= $block->escapeUrl($block->getCheckoutUrl()) ?>"
-           src="<?= $block->escapeUrl($block->getImageUrl()) ?>"
-           alt="<?= $block->escapeHtml(__('Checkout with PayPal')) ?>"
-           title="<?= $block->escapeHtml(__('Checkout with PayPal')) ?>"/>
+           data-checkout-url="<?= $escaper->escapeUrl($block->getCheckoutUrl()) ?>"
+           src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+           alt="<?= $escaper->escapeHtml(__('Checkout with PayPal')) ?>"
+           title="<?= $escaper->escapeHtml(__('Checkout with PayPal')) ?>"/>
     <?php if ($block->getAdditionalLinkImage()) : ?>
         <?php $linkImage = $block->getAdditionalLinkImage(); ?>
-        <a href="<?= $block->escapeUrl($linkImage['href']) ?>">
-            <img src="<?= $block->escapeHtml($linkImage['src']) ?>" />
+        <a href="<?= $escaper->escapeUrl($linkImage['href']) ?>">
+            <img src="<?= $escaper->escapeHtml($linkImage['src']) ?>" />
         </a>
     <?php endif; ?>
 </div>

--- a/app/code/Magento/Paypal/view/frontend/templates/hss/form.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/hss/form.phtml
@@ -3,22 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payflow\Link\Iframe;
 
-
-/**
- * @var \Magento\Paypal\Block\Payflow\Link\Iframe $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- * @see \Magento\Paypal\Block\Payflow\Link\Iframe
- */
+/** @var Escaper $escaper */
+/** @var Iframe $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <html>
 <head>
 </head>
 <body>
-<form id="token_form" method="POST" action="<?= $block->escapeUrl($block->getTransactionUrl()) ?>">
-    <input type="hidden" name="SECURETOKEN" value="<?= $block->escapeHtml($block->getSecureToken()) ?>"/>
-    <input type="hidden" name="SECURETOKENID" value="<?= $block->escapeHtml($block->getSecureTokenId()) ?>"/>
+<form id="token_form" method="POST" action="<?= $escaper->escapeUrl($block->getTransactionUrl()) ?>">
+    <input type="hidden" name="SECURETOKEN" value="<?= $escaper->escapeHtml($block->getSecureToken()) ?>"/>
+    <input type="hidden" name="SECURETOKENID" value="<?= $escaper->escapeHtml($block->getSecureTokenId()) ?>"/>
     <input type="hidden" name="MODE" value="<?= /* @noEscape */ $block->isTestMode() ? 'TEST' : 'LIVE' ?>"/>
 </form>
 <?php $scriptString = <<<script

--- a/app/code/Magento/Paypal/view/frontend/templates/hss/iframe.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/hss/iframe.phtml
@@ -3,13 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Payflow\Link\Iframe $block
- */
+use Magento\Framework\Escaper;
+use Magento\Paypal\Block\Payflow\Link\Iframe;
+
+/** @var Escaper $escaper */
+/** @var Iframe $block */
 ?>
 <div id="iframe-warning" class="message notice">
-    <div><?= $block->escapeHtml(__('Please do not refresh the page until you complete payment.')) ?></div>
+    <div><?= $escaper->escapeHtml(__('Please do not refresh the page until you complete payment.')) ?></div>
 </div>
 <iframe id="hss-iframe" data-container="paypal-iframe" class="paypal iframe" scrolling="no" frameborder="0" border="0"
-        src="<?= $block->escapeUrl($block->getFrameActionUrl()) ?>" height="610" width="100%"></iframe>
+        src="<?= $escaper->escapeUrl($block->getFrameActionUrl()) ?>" height="610" width="100%"></iframe>

--- a/app/code/Magento/Paypal/view/frontend/templates/hss/info.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/hss/info.phtml
@@ -3,18 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Payment\Info $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payment\Info;
+
+/** @var Escaper $escaper */
+/** @var Info $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<div id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>" class="hss items">
-    <?= $block->escapeHtml(__(
+<div id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>" class="hss items">
+    <?= $escaper->escapeHtml(__(
         'You will be required to enter your payment details after you place an order.'
     )); ?>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',
-    'div#payment_form_' . $block->escapeHtml($block->getMethodCode())
+    'div#payment_form_' . $escaper->escapeHtml($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/Paypal/view/frontend/templates/hss/review/button.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/hss/review/button.phtml
@@ -3,11 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
 
-
+/** @var Escaper $escaper */
 ?>
-<button type="submit" data-role="review-save" title="<?= $block->escapeHtml(__('Continue')) ?>"
+<button type="submit" data-role="review-save" title="<?= $escaper->escapeHtml(__('Continue')) ?>"
         class="button action checkout primary">
-    <span><?= $block->escapeHtml(__('Continue')) ?></span>
+    <span><?= $escaper->escapeHtml(__('Continue')) ?></span>
 </button>

--- a/app/code/Magento/Paypal/view/frontend/templates/partner/logo.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/partner/logo.phtml
@@ -3,29 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Logo;
 
-/**
- * @var \Magento\Paypal\Block\Logo $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- * @see \Magento\Paypal\Block\Logo
- */
+/** @var Escaper $escaper */
+/** @var Logo $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div class="block paypal acceptance">
     <div class="block-content">
-        <a href="#" title="<?= $block->escapeHtml(__('Additional Options')) ?>"
+        <a href="#" title="<?= $escaper->escapeHtml(__('Additional Options')) ?>"
            class="action paypal additional">
-            <img src="<?= $block->escapeUrl($block->getLogoImageUrl()) ?>"
-                 alt="<?= $block->escapeHtml(__('Additional Options')) ?>"
-                 title="<?= $block->escapeHtml(__('Additional Options')) ?>" />
+            <img src="<?= $escaper->escapeUrl($block->getLogoImageUrl()) ?>"
+                 alt="<?= $escaper->escapeHtml(__('Additional Options')) ?>"
+                 title="<?= $escaper->escapeHtml(__('Additional Options')) ?>" />
         </a>
     </div>
 </div>
 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
     'onclick',
     "window.open(
-               '" . $block->escapeJs($block->getAboutPaypalPageUrl()) . "',
+               '" . $escaper->escapeJs($block->getAboutPaypalPageUrl()) . "',
                'paypal',
                'width=600,height=350,left=0,top=0,location=no,status=yes,scrollbars=yes,resizable=yes'
                ); event.preventDefault();",

--- a/app/code/Magento/Paypal/view/frontend/templates/payflowadvanced/form.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/payflowadvanced/form.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Payflow\Advanced\Iframe $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payflow\Advanced\Iframe;
+
+/** @var Escaper $escaper */
+/** @var Iframe $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <html>
 <head>
 </head>
 <body>
-<form id="token_form" method="GET" action="<?= $block->escapeUrl($block->getTransactionUrl()) ?>">
-    <input type="hidden" name="SECURETOKEN" value="<?= $block->escapeHtml($block->getSecureToken()) ?>"/>
-    <input type="hidden" name="SECURETOKENID" value="<?= $block->escapeHtml($block->getSecureTokenId()) ?>"/>
+<form id="token_form" method="GET" action="<?= $escaper->escapeUrl($block->getTransactionUrl()) ?>">
+    <input type="hidden" name="SECURETOKEN" value="<?= $escaper->escapeHtml($block->getSecureToken()) ?>"/>
+    <input type="hidden" name="SECURETOKENID" value="<?= $escaper->escapeHtml($block->getSecureTokenId()) ?>"/>
     <input type="hidden" name="MODE" value="<?= /* @noEscape */ $block->isTestMode() ? 'TEST' : 'LIVE' ?>"/>
 </form>
 <?php $scriptString = <<<script

--- a/app/code/Magento/Paypal/view/frontend/templates/payflowadvanced/info.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/payflowadvanced/info.phtml
@@ -3,19 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Payflow\Advanced\Form $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payflow\Advanced\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<fieldset id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>"
+<fieldset id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>"
           class="fieldset payflowadvanced items redirect">
     <div>
-        <?= $block->escapeHtml(__('You will be required to enter your payment details after you place an order.')) ?>
+        <?= $escaper->escapeHtml(__('You will be required to enter your payment details after you place an order.')) ?>
     </div>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',
-    'fieldset#payment_form_' . $block->escapeHtml($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeHtml($block->getMethodCode())
 ) ?>

--- a/app/code/Magento/Paypal/view/frontend/templates/payment/form/billing/agreement.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/payment/form/billing/agreement.phtml
@@ -3,24 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Paypal\Block\Payment\Form\Billing\Agreement $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-$code = $block->escapeHtml($block->getMethodCode());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Payment\Form\Billing\Agreement;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Agreement $block */
+$code = $escaper->escapeHtml($block->getMethodCode());
 ?>
 <div class="field items required" id="payment_form_<?= /* @noEscape */ $code ?>">
     <label for="<?= /* @noEscape */ $code ?>_ba_agreement_id" class="label">
-        <span><?= $block->escapeHtml(__('Billing Agreement')) ?></span>
+        <span><?= $escaper->escapeHtml(__('Billing Agreement')) ?></span>
     </label>
     <div class="control">
         <select id="<?= /* @noEscape */ $code ?>_ba_agreement_id"
-                name="payment[<?= $block->escapeHtml($block->getTransportName()) ?>]" class="select">
-            <option value=""><?= $block->escapeHtml(__('-- Please Select Billing Agreement--')) ?></option>
+                name="payment[<?= $escaper->escapeHtml($block->getTransportName()) ?>]" class="select">
+            <option value=""><?= $escaper->escapeHtml(__('-- Please Select Billing Agreement--')) ?></option>
             <?php foreach ($block->getBillingAgreements() as $id => $referenceId): ?>
-                <option value="<?= $block->escapeHtml($id) ?>">
-                    <?= $block->escapeHtml($referenceId) ?>
+                <option value="<?= $escaper->escapeHtml($id) ?>">
+                    <?= $escaper->escapeHtml($referenceId) ?>
                 </option>
             <?php endforeach; ?>
         </select>

--- a/app/code/Magento/Paypal/view/frontend/templates/payment/mark.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/payment/mark.phtml
@@ -3,29 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Note: This mark is a requirement of PayPal
- * @var \Magento\Paypal\Block\Express\Form $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- * @see \Magento\Paypal\Block\Express\Form
- */
-$url = $block->escapeUrl($block->getPaymentAcceptanceMarkHref());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Paypal\Block\Express\Form;
+
+/** Note: This mark is a requirement of PayPal */
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Form $block */
+$url = $escaper->escapeUrl($block->getPaymentAcceptanceMarkHref());
 ?>
 <!-- PayPal Logo -->
-<img src="<?= $block->escapeUrl($block->getPaymentAcceptanceMarkSrc()) ?>"
-     alt="<?= $block->escapeHtml(__('Acceptance Mark')) ?>" class="paypal icon"/>
+<img src="<?= $escaper->escapeUrl($block->getPaymentAcceptanceMarkSrc()) ?>"
+     alt="<?= $escaper->escapeHtml(__('Acceptance Mark')) ?>" class="paypal icon"/>
 <a href="<?= /* @noEscape */ $url ?>" class="action paypal about">
     <?php if ($block->getPaymentWhatIs()) {
-        echo $block->escapeHtml(__($block->getPaymentWhatIs()));
+        echo $escaper->escapeHtml(__($block->getPaymentWhatIs()));
     } else {
-        echo $block->escapeHtml(__('What is PayPal?'));
+        echo $escaper->escapeHtml(__('What is PayPal?'));
     } ?>
 </a>
 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
     'onclick',
     "window.open(
-           '" . /* @noEscape */ $block->escapeJs($block->getPaymentAcceptanceMarkHref()) . "',
+           '" . /* @noEscape */ $escaper->escapeJs($block->getPaymentAcceptanceMarkHref()) . "',
            'olcwhatispaypal',
            'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, ,' +
            'left=0, top=0, width=400, height=350'

--- a/app/code/Magento/Paypal/view/frontend/templates/payment/redirect.phtml
+++ b/app/code/Magento/Paypal/view/frontend/templates/payment/redirect.phtml
@@ -3,28 +3,31 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\PayPal\Block\Express\Form $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- * @see \Magento\PayPal\Block\Express\Form
- */
-$code = $block->escapeHtml($block->getBillingAgreementCode());
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\PayPal\Block\Express\Form;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Form $block */
+$code = $escaper->escapeHtml($block->getBillingAgreementCode());
 ?>
-<fieldset class="fieldset paypal items redirect" id="payment_form_<?= $block->escapeHtml($block->getMethodCode()) ?>">
-    <div><?= $block->escapeHtml($block->getRedirectMessage()) ?></div>
+<fieldset class="fieldset paypal items redirect" id="payment_form_<?= $escaper->escapeHtml($block->getMethodCode()) ?>">
+    <div><?= $escaper->escapeHtml($block->getRedirectMessage()) ?></div>
     <?php  ?>
     <?php if ($code): ?>
         <input type="checkbox" id="<?= /* @noEscape */ $code ?>" value="1" class="checkbox"
                name="payment[<?= /* @noEscape */ $code ?>]">
         <label for="<?= /* @noEscape */ $code ?>" class="label">
             <span>
-                <?= $block->escapeHtml(__('Sign a billing agreement to streamline further purchases  with PayPal.')) ?>
+                <?= $escaper->escapeHtml(__('Sign a billing agreement to streamline further purchases  with PayPal.')) ?>
             </span>
         </label>
     <?php endif; ?>
 </fieldset>
 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
     'display:none',
-    'fieldset#payment_form_' . $block->escapeHtml($block->getMethodCode())
+    'fieldset#payment_form_' . $escaper->escapeHtml($block->getMethodCode())
 ) ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_PayPal` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

### Resolved issues:
1. [x] resolves magento/magento2#37173: Chore: PayPal - Replace Block Escaping with Escaper