### PR TITLE
Chore: Tax - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Tax/view/adminhtml/templates/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/items/price/row.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
-
-$_item = $block->getItem();
 ?>
 <?php if ($block->displayBothPrices() || $block->displayPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
         <?= /* @noEscape */ $block->displayPrices($_item->getBaseRowTotal(), $_item->getRowTotal()) ?>
     </div>
@@ -22,7 +25,7 @@ $_item = $block->getItem();
 <?php if ($block->displayBothPrices() || $block->displayPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($block->displayBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
         <?php $_baseIncl = $this->helper(\Magento\Checkout\Helper\Data::class)->getBaseSubtotalInclTax($_item); ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/items/price/unit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/items/price/unit.phtml
@@ -3,19 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
-<?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
-
-$_item = $block->getItem();
-?>
-
 <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices() || $this->helper(\Magento\Tax\Helper\Data::class)->displaySalesPriceExclTax()) : ?>
     <div class="price-excl-tax">
         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
         <?php endif; ?>
 
         <?= /* @noEscape */ $block->displayPrices($_item->getBasePrice(), $_item->getPrice()) ?>
@@ -24,7 +26,7 @@ $_item = $block->getItem();
 <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices() || $this->helper(\Magento\Tax\Helper\Data::class)->displaySalesPriceInclTax()) : ?>
     <div class="price-incl-tax">
         <?php if ($this->helper(\Magento\Tax\Helper\Data::class)->displaySalesBothPrices()) : ?>
-            <span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+            <span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
         <?php endif; ?>
         <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getPriceInclTax($_item); ?>
         <?php $_baseIncl = $this->helper(\Magento\Checkout\Helper\Data::class)->getBasePriceInclTax($_item); ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/row.phtml
@@ -3,25 +3,28 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
-
-$_item = $block->getItem();
 ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices($block->getStore())) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($_item->getRowTotal()) ?>
 <?php endif; ?>
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/total.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/total.phtml
@@ -3,17 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 $_item = $block->getItem();
 ?>
-
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php $_rowTotalWithoutDiscount = $_item->getRowTotal() - $_item->getTotalDiscountAmount(); ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice(max(0, $_rowTotalWithoutDiscount)) ?>
 <?php endif; ?>
@@ -21,7 +23,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices($block->getStore())) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $block->getTotalAmount($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/unit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/order/create/items/price/unit.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Items\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
-?>
-<?php
-/** @var \Magento\Tax\Block\Adminhtml\Items\Price\Renderer $block */
-
-$_item = $block->getItem();
 ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $block->formatPrice($_item->getCalculationPrice()) ?>
 <?php endif; ?>
@@ -22,7 +25,7 @@ $_item = $block->getItem();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getPriceInclTax($_item); ?>
     <?= /* @noEscape */ $block->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rate/title.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rate/title.phtml
@@ -3,20 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <fieldset id="tax-rate-titles-table" class="admin__fieldset">
     <?php $_labels = $block->getTitles() ?>
     <?php foreach ($block->getStores() as $_store) : ?>
         <div class="admin__field">
             <label class="admin__field-label">
-                <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                <span><?= $escaper->escapeHtml($_store->getName()) ?></span>
             </label>
             <div class="admin__field-control">
                 <input
                     class="admin__control-text<?php if ($_store->getId() == 0) : ?> required-entry<?php endif; ?>"
                     type="text"
                     name="title[<?= (int) $_store->getId() ?>]"
-                    value="<?= $block->escapeHtmlAttr($_labels[(int) $_store->getId()]) ?>" />
+                    value="<?= $escaper->escapeHtmlAttr($_labels[(int) $_store->getId()]) ?>" />
             </div>
         </div>
     <?php endforeach; ?>
@@ -24,8 +29,8 @@
     <div class="messages">
         <div class="message message-notice">
             <div>
-                <strong><?= $block->escapeHtml(__('Note:')) ?></strong>
-                <?= $block->escapeHtml(__('Leave this field empty if you wish to use the tax identifier.')) ?>
+                <strong><?= $escaper->escapeHtml(__('Note:')) ?></strong>
+                <?= $escaper->escapeHtml(__('Leave this field empty if you wish to use the tax identifier.')) ?>
             </div>
         </div>
     </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/edit.phtml
@@ -3,13 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Tax\Block\Adminhtml\Rule\Edit\Form */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php $formElementId = /* @noEscape */ \Magento\Tax\Block\Adminhtml\Rate\Form::FORM_ELEMENT_ID;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Tax\Block\Adminhtml\Rule\Edit\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+$formElementId = /* @noEscape */ \Magento\Tax\Block\Adminhtml\Rate\Form::FORM_ELEMENT_ID;
 $jsId = /* @noEscape */ $block->getJsId();
+
 //phpcs:ignore Magento2.SQL.RawQuery
+
 $scriptString = <<<script
 require([
     'jquery',
@@ -83,7 +91,7 @@ require([
             $.ajax({
                 type: "POST",
                 data: {id:id},
-                url: '{$block->escapeJs($block->getTaxRateLoadUrl())}',
+                url: '{$escaper->escapeJs($block->getTaxRateLoadUrl())}',
                 success: function(result, status) {
                     $('body').trigger('processStop');
                     if (result.success) {
@@ -100,14 +108,14 @@ require([
                             });
                         else
                             alert({
-                                content: '{$block->escapeJs(__('An error occurred'))}'
+                                content: '{$escaper->escapeJs(__('An error occurred'))}'
                             });
                     }
                 },
                 error: function () {
                     $('body').trigger('processStop');
                     alert({
-                        content: '{$block->escapeJs(__('An error occurred'))}'
+                        content: '{$escaper->escapeJs(__('An error occurred'))}'
                     });
                 },
                 dataType: "json"
@@ -118,9 +126,9 @@ require([
             var options = {
                 mselectContainer: '#tax_rate + section.mselect-list',
                 toggleAddButton:false,
-                addText: '{$block->escapeJs(__('Add New Tax Rate'))}',
+                addText: '{$escaper->escapeJs(__('Add New Tax Rate'))}',
                 parse: null,
-                nextPageUrl: '{$block->escapeJs($block->getTaxRatesPageUrl())}',
+                nextPageUrl: '{$escaper->escapeJs($block->getTaxRatesPageUrl())}',
                 selectedValues: this.settings.selected_values,
                 mselectInputSubmitCallback: function (value, options) {
                     var select = $('#tax_rate');
@@ -177,7 +185,7 @@ script;
                             rateValue = that.parent().find('input[type="checkbox"]').val();
 
                         confirm({
-                            content: '{$block->escapeJs(__('Do you really want to delete this tax rate?'))}',
+                            content: '{$escaper->escapeJs(__('Do you really want to delete this tax rate?'))}',
                             actions: {
                                 /**
                                  * Confirm action.
@@ -191,7 +199,7 @@ script;
                                             form_key: $('input[name="form_key"]').val()
                                         },
                                         dataType: 'json',
-                                        url: '{$block->escapeJs($block->getTaxRateDeleteUrl())}',
+                                        url: '{$escaper->escapeJs($block->getTaxRateDeleteUrl())}',
                                         success: function(result, status) {
                                             $('body').trigger('processStop');
                                             if (result.success) {
@@ -209,14 +217,14 @@ script;
                                                     });
                                                 else
                                                     alert({
-                                                        content: '{$block->escapeJs(__('An error occurred'))}'
+                                                        content: '{$escaper->escapeJs(__('An error occurred'))}'
                                                     });
                                             }
                                         },
                                         error: function () {
                                             $('body').trigger('processStop');
                                             alert({
-                                                content: '{$block->escapeJs(__('An error occurred'))}'
+                                                content: '{$escaper->escapeJs(__('An error occurred'))}'
                                             });
                                         }
                                     };
@@ -239,7 +247,7 @@ script;
             taxRateFormElement.mage('form').mage('validation');
 
             taxRateForm.dialogRates({
-                title: '{$block->escapeJs(__('Tax Rate'))}',
+                title: '{$escaper->escapeJs(__('Tax Rate'))}',
                 type: 'slide',
                 id: '{$jsId}',
                 modalClass: 'tax-rate-popup',
@@ -247,7 +255,7 @@ script;
                     taxRateFormElement.data('validation').clearError();
                 },
                 buttons: [{
-                    text: '{$block->escapeJs(__('Save'))}',
+                    text: '{$escaper->escapeJs(__('Save'))}',
                     'class': 'action-save action-primary',
                     click: function() {
                         this.updateItemRate();
@@ -272,7 +280,7 @@ $scriptString.= <<<script
                             type: 'POST',
                             data: itemRateData,
                             dataType: 'json',
-                            url: '{$block->escapeJs($block->getTaxRateSaveUrl())}',
+                            url: '{$escaper->escapeJs($block->getTaxRateSaveUrl())}',
                             success: function(result, status) {
                                 $('body').trigger('processStop');
                                 if (result.success) {
@@ -297,14 +305,14 @@ $scriptString.= <<<script
                                         });
                                     else
                                         alert({
-                                            content: '{$block->escapeJs(__('An error occurred'))}'
+                                            content: '{$escaper->escapeJs(__('An error occurred'))}'
                                         });
                                 }
                             },
                             error: function () {
                                 $('body').trigger('processStop');
                                 alert({
-                                    content: '{$block->escapeJs(__('An error occurred'))}'
+                                    content: '{$escaper->escapeJs(__('An error occurred'))}'
                                 });
                             }
                         };

--- a/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/rule/rate/form.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/* @var $block \Magento\Tax\Block\Adminhtml\Rate\Form */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Adminhtml\Rate\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
+?>
 <div data-role="spinner" class="grid-loading-mask">
     <div class="grid-loader"></div>
 </div>
 
-<div class="form-inline no-display" id="<?= $block->escapeHtmlAttr($block->getNameInLayout()) ?>">
+<div class="form-inline no-display" id="<?= $escaper->escapeHtmlAttr($block->getNameInLayout()) ?>">
     <?= $block->getFormHtml() ?>
     <?= $block->getChildHtml('form_after') ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/add.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/add.phtml
@@ -3,16 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 // @deprecated
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <button type="button" id="addNewClass">
-        <?= $block->escapeHtml(__('Add New Class')) ?>
+        <?= $escaper->escapeHtml(__('Add New Class')) ?>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "window.location.href='" . $block->escapeJs($createUrl) . "'",
+        "window.location.href='" . $escaper->escapeJs($createUrl) . "'",
         'button#addNewClass'
     ) ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/class/save.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @deprecated
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+// @deprecated
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
@@ -17,7 +23,7 @@
     <?php $scriptString = <<<script
     require(['jquery', "mage/mage"], function(jQuery){
 
-        jQuery('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        jQuery('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
     });
 script;

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rate/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rate/save.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Tax\Block\Adminhtml\Rate\Form $form */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Tax\Block\Adminhtml\Rate\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $form */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($form): ?>
     <?= $form->toHtml() ?>
@@ -15,7 +21,7 @@
         "mage/mage"
     ], function($){
 
-        $('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        $('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
         $(document).ready(function () {
             'use strict';

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/add.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/add.phtml
@@ -3,16 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 // @deprecated
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <button type="button" id="addNewTaxRule">
-        <?= $block->escapeHtml(__('Add New Tax Rule')) ?>
+        <?= $escaper->escapeHtml(__('Add New Tax Rule')) ?>
     </button>
     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "window.location.href='" . $block->escapeJs($createUrl) . "'",
+        "window.location.href='" . $escaper->escapeJs($createUrl) . "'",
         'button#addNewClass'
     ) ?>
 </div>

--- a/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/save.phtml
+++ b/app/code/Magento/Tax/view/adminhtml/templates/toolbar/rule/save.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-// @deprecated
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+// @deprecated
 ?>
 <div data-mage-init='{"floatingHeader": {}}' class="page-actions">
     <?= $block->getBackButtonHtml() ?>
@@ -18,7 +24,7 @@
     <?php $scriptString = <<<script
     require(['jquery', "mage/mage"], function(jQuery){
 
-        jQuery('#{$block->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
+        jQuery('#{$escaper->escapeJs($form->getForm()->getId())}').mage('form').mage('validation');
 
     });
 script;

--- a/app/code/Magento/Tax/view/base/templates/pricing/adjustment/bundle.phtml
+++ b/app/code/Magento/Tax/view/base/templates/pricing/adjustment/bundle.phtml
@@ -3,9 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php /** @var \Magento\Tax\Pricing\Render\Adjustment $block */ ?>
+use Magento\Framework\Escaper;
+use Magento\Tax\Pricing\Render\Adjustment;
+
+/** @var Escaper $escaper */
+/** @var Adjustment $block */
+?>
 <?php if ($block->displayPriceIncludingTax()) : ?>
     <?= /* @noEscape */ $block->getDisplayAmount() ?>
 <?php elseif ($block->displayPriceExcludingTax()) : ?>
@@ -13,6 +18,6 @@
 <?php elseif ($block->displayBothPrices()) : ?>
     <?= /* @noEscape */ $block->getDisplayAmount() ?>
     <?php if ($block->getDisplayAmountExclTax() !== $block->getDisplayAmount()) : ?>
-        (+<?= /* @noEscape */ $block->getDisplayAmountExclTax() ?> <?= $block->escapeHtml(__('Excl. Tax')) ?>)
+        (+<?= /* @noEscape */ $block->getDisplayAmountExclTax() ?> <?= $escaper->escapeHtml(__('Excl. Tax')) ?>)
     <?php endif; ?>
 <?php endif; ?>

--- a/app/code/Magento/Tax/view/frontend/templates/email/items/price/row.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/email/items/price/row.phtml
@@ -3,20 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Sales\Model\Order;
+use Magento\Tax\Block\Item\Price\Renderer;
+
+/** @var Escaper $escaper */
+/** @var Renderer $block */
+$_item = $block->getItem();
+
+/** @var Order $_order */
+$_order = $_item->getOrder();
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 ?>
-<?php
-/** @var \Magento\Tax\Block\Item\Price\Renderer $block */
-
-$_item = $block->getItem();
-/** @var \Magento\Sales\Model\Order $_order */
-$_order = $_item->getOrder();
-?>
-
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <span class="label"><?= $block->escapeHtml(__('Excl. Tax')) ?>:</span>
+        <span class="label"><?= $escaper->escapeHtml(__('Excl. Tax')) ?>:</span>
     <?php endif; ?>
     <?= /* @noEscape */ $_order->formatPrice($_item->getRowTotal()) ?>
 <?php endif; ?>
@@ -24,7 +28,7 @@ $_order = $_item->getOrder();
 
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
     <?php if ($block->displayBothPrices()) : ?>
-        <br /><span class="label"><?= $block->escapeHtml(__('Incl. Tax')) ?>:</span>
+        <br /><span class="label"><?= $escaper->escapeHtml(__('Incl. Tax')) ?>:</span>
     <?php endif; ?>
     <?php $_incl = $this->helper(\Magento\Checkout\Helper\Data::class)->getSubtotalInclTax($_item); ?>
     <?= /* @noEscape */ $_order->formatPrice($_incl) ?>

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/row.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Item\Price\Renderer;
 
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 $_item = $block->getItem();
 ?>
 <?php if (($block->displayPriceInclTax() || $block->displayBothPrices()) && !$_item->getNoSubtotal()) : ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_item->getRowTotalInclTax()) ?>
         </span>
@@ -17,7 +21,7 @@ $_item = $block->getItem();
 <?php endif; ?>
 
 <?php if (($block->displayPriceExclTax() || $block->displayBothPrices()) && !$_item->getNoSubtotal()) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_item->getRowTotal()) ?>
         </span>

--- a/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/item/price/unit.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Tax\Block\Item\Price\Renderer */
+use Magento\Framework\Escaper;
+use Magento\Tax\Block\Item\Price\Renderer;
 
+/** @var Escaper $escaper */
+/** @var Renderer $block */
 $_item = $block->getItem();
 ?>
 <?php if ($block->displayPriceInclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-including-tax" data-label="<?= $block->escapeHtmlAttr(__('Incl. Tax')) ?>">
+    <span class="price-including-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Incl. Tax')) ?>">
         <?php $_incl = $_item->getPriceInclTax(); ?>
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($_incl) ?>
@@ -18,7 +22,7 @@ $_item = $block->getItem();
 <?php endif; ?>
 
 <?php if ($block->displayPriceExclTax() || $block->displayBothPrices()) : ?>
-    <span class="price-excluding-tax" data-label="<?= $block->escapeHtmlAttr(__('Excl. Tax')) ?>">
+    <span class="price-excluding-tax" data-label="<?= $escaper->escapeHtmlAttr(__('Excl. Tax')) ?>">
         <span class="cart-price">
             <?= /* @noEscape */ $block->formatPrice($block->getItemDisplayPriceExclTax()) ?>
         </span>

--- a/app/code/Magento/Tax/view/frontend/templates/order/tax.phtml
+++ b/app/code/Magento/Tax/view/frontend/templates/order/tax.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate
 // phpcs:disable Squiz.PHP.GlobalKeyword.NotAllowed
-?>
-<?php
-    $_order  = $block->getOrder();
-    $_source = $block->getSource();
-    $_fullInfo = $this->helper(\Magento\Tax\Helper\Data::class)->getCalculatedTaxes($_source);
-    global $taxIter;
-    $taxIter++;
-?>
 
+$_order  = $block->getOrder();
+$_source = $block->getSource();
+$_fullInfo = $this->helper(\Magento\Tax\Helper\Data::class)->getCalculatedTaxes($_source);
+global $taxIter;
+$taxIter++;
+?>
 <?php if ($_fullInfo && $block->displayFullSummary()) : ?>
         <?php foreach ($_fullInfo as $info) : ?>
             <?php
@@ -25,7 +28,7 @@
             ?>
             <tr class="totals tax details details-<?= (int) $taxIter ?><?= ($block->getIsPlaneMode()) ? ' plane' : '' ?>">
                 <td <?= /* @noEscape */ $block->getLabelProperties() ?>>
-                    <?= $block->escapeHtml($title) ?>
+                    <?= $escaper->escapeHtml($title) ?>
                     <?php if ($percent !== null) : ?>
                         (<?= (float) $percent ?>%)
                     <?php endif; ?>
@@ -47,12 +50,12 @@
 <?php endif; ?>
     <th <?= /* @noEscape */ $block->getLabelProperties() ?> scope="row">
         <?php if ($block->displayFullSummary()) : ?>
-            <div class="detailed"><?= $block->escapeHtml(__('Tax')) ?></div>
+            <div class="detailed"><?= $escaper->escapeHtml(__('Tax')) ?></div>
         <?php else : ?>
-            <?= $block->escapeHtml(__('Tax')) ?>
+            <?= $escaper->escapeHtml(__('Tax')) ?>
         <?php endif; ?>
     </th>
-    <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $block->escapeHtmlAttr(__('Tax')) ?>">
+    <td <?= /* @noEscape */ $block->getValueProperties() ?> data-th="<?= $escaper->escapeHtmlAttr(__('Tax')) ?>">
         <?= /* @noEscape */ $_order->formatPrice($_source->getTaxAmount()) ?>
     </td>
 </tr>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Tax` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

### Resolved issues:
1. [x] resolves magento/magento2#37176: Chore: Tax - Replace Block Escaping with Escaper