### PR TITLE
Chore: Theme - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content/files.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content/files.phtml
@@ -3,22 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files */
+use Magento\Framework\Escaper;
+use Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Files;
+
+/** @var Escaper $escaper */
+/** @var Files $block */
 ?>
-
 <?php if ($block->getFilesCount() > 0) : ?>
     <?php foreach ($block->getFiles() as $file) : ?>
-        <div class="filecnt file-font" id="<?= $block->escapeHtmlAttr($file['id']) ?>">
+        <div class="filecnt file-font" id="<?= $escaper->escapeHtmlAttr($file['id']) ?>">
             <p class="nm">
-                <?= $block->escapeHtml($file['text']) ?>
+                <?= $escaper->escapeHtml($file['text']) ?>
                 <?php if (isset($file['thumbnailParams'])) : ?>
-                    <img src="<?= $block->escapeUrl($block->getUrl('*/*/previewImage', $file['thumbnailParams'])) ?>"
-                         alt="<?= $block->escapeHtmlAttr(__('thumbnail')) ?>">
+                    <img src="<?= $escaper->escapeUrl($block->getUrl('*/*/previewImage', $file['thumbnailParams'])) ?>"
+                         alt="<?= $escaper->escapeHtmlAttr(__('thumbnail')) ?>">
                 <?php endif; ?>
             </p>
         </div>
     <?php endforeach; ?>
 <?php else : ?>
-    <?= $block->escapeHtml(__('We found no files.')) ?>
+    <?= $escaper->escapeHtml(__('We found no files.')) ?>
 <?php endif; ?>

--- a/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/browser/content/uploader.phtml
@@ -3,17 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader;
+
+/** @var Escaper $escaper */
+/** @var Uploader $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Theme\Block\Adminhtml\Wysiwyg\Files\Content\Uploader */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 ?>
-
 <div id="<?= $block->getHtmlId() ?>" class="uploader">
     <span class="fileinput-button form-buttons">
-        <span><?= $block->escapeHtml(__('Browse Files')) ?></span>
-        <input id="fileupload" type="file" name="<?= $block->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
-            data-url="<?= $block->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
+        <span><?= $escaper->escapeHtml(__('Browse Files')) ?></span>
+        <input id="fileupload" type="file" name="<?= $escaper->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
+            data-url="<?= $escaper->escapeUrl($block->getConfig()->getUrl()) ?>" multiple>
     </span>
     <div class="clear"></div>
     <script id="<?= $block->getHtmlId() ?>-template" type="text/x-magento-template">
@@ -47,7 +53,7 @@ require([
             form_key: FORM_KEY
         },
         sequentialUploads: true,
-        maxFileSize: {$block->escapeJs($block->getFileSizeService()->getMaxFileSize())} ,
+        maxFileSize: {$escaper->escapeJs($block->getFileSizeService()->getMaxFileSize())} ,
         add: function (e, data) {
             var progressTmpl = mageTemplate('#{$block->getHtmlId()}-template'),
                 fileSize,

--- a/app/code/Magento/Theme/view/adminhtml/templates/design/config/edit/scope.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/design/config/edit/scope.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Theme\Block\Adminhtml\Design\Config\Edit\Scope */
+use Magento\Framework\Escaper;
+use Magento\Theme\Block\Adminhtml\Design\Config\Edit\Scope;
+
+/** @var Escaper $escaper */
+/* @var Scope $block */
 ?>
-
 <div class="store-view">
-    <span class="store-switcher-label"><?= $block->escapeHtml(__('Scope:')) ?></span>
-    <span class="store-switcher-value"><?= $block->escapeHtml($block->getScopeTitle()) ?></span>
+    <span class="store-switcher-label"><?= $escaper->escapeHtml(__('Scope:')) ?></span>
+    <span class="store-switcher-value"><?= $escaper->escapeHtml($block->getScopeTitle()) ?></span>
 </div>

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/css.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/css.phtml
@@ -3,12 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/**
- * @var $block \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Css;
+
+/** @var Escaper $escaper */
+/** @var Css $block */
+/** @var SecureHtmlRenderer $secureRenderer */
+?>
 <?= $block->getFormHtml() ?>
 
 <?php $scriptString = <<<script
@@ -23,7 +27,7 @@ require([
     $( '#css_file_uploader' ).fileupload({
         dataType: 'json',
         replaceFileInput: false,
-        url : '{$block->escapeJs($block->getUrl('*/system_design_theme/uploadcss'))}',
+        url : '{$escaper->escapeJs($block->getUrl('*/system_design_theme/uploadcss'))}',
         acceptFileTypes: /(.|\/)(css)$/i,
 
         /**

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/fieldset/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/fieldset/js.phtml
@@ -3,17 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Widget\Form\Renderer\Fieldset;
+use Magento\Framework\Escaper;
+use Magento\Framework\Json\Helper\Data;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Fieldset $block */
+/** @var Data $jsonHelper */
+$jsonHelper = $block->getData('jsonHelper');
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/**
- * @var $block \Magento\Backend\Block\Widget\Form\Renderer\Fieldset
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-
-/** @var \Magento\Framework\Json\Helper\Data $jsonHelper */
-$jsonHelper = $block->getData('jsonHelper');
 ?>
-
 <div id="js-file-uploader" class="uploader">
 </div>
 <script id="js-file-uploader-template" type="text/x-magento-template">
@@ -42,7 +46,7 @@ $jsonHelper = $block->getData('jsonHelper');
                 id="remove_js_files_<%- data.id %>"
                 name="js_removed_files[]"
                 value="<%- data.id %>" />
-            <label for="remove_js_files_<%- data.id %>"><?= $block->escapeHtml(__('Remove')) ?></label>
+            <label for="remove_js_files_<%- data.id %>"><?= $escaper->escapeHtml(__('Remove')) ?></label>
         </div>
     </div>
 

--- a/app/code/Magento/Theme/view/adminhtml/templates/tabs/js.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/tabs/js.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Theme\Block\Adminhtml\System\Design\Theme\Edit\Tab\Js;
+
+/** @var Escaper $escaper */
+/** @var Js $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?= $block->getFormHtml() ?>
 
@@ -26,7 +30,7 @@ require([
         dataType: 'json',
         replaceFileInput: false,
         sequentialUploads: true,
-        url: '{$block->escapeJs($block->getJsUploadUrl())}',
+        url: '{$escaper->escapeJs($block->getJsUploadUrl())}',
 
         /**
          * Add data

--- a/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
+++ b/app/code/Magento/Theme/view/adminhtml/templates/title.phtml
@@ -3,16 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Theme\Block\Html\Title
- */
-$titleIdHtml = ($block->getTitleId()) ? ' id="' . $block->escapeHtmlAttr($block->getTitleId()) . '"' : '';
+use Magento\Framework\Escaper;
+use Magento\Theme\Block\Html\Title;
+
+/** @var Escaper $escaper */
+/** @var Title $block */
+$titleIdHtml = ($block->getTitleId()) ? ' id="' . $escaper->escapeHtmlAttr($block->getTitleId()) . '"' : '';
 $titleClass = ($block->getTitleClass()) ? ' ' . $block->getTitleClass() : '';
 $title = $block->getPageTitle();
 ?>
-
-<div class="page-title-wrapper<?= $block->escapeHtmlAttr($titleClass) ?>">
-    <h1 class="page-title"<?= /* @noEscape */ $titleIdHtml ?>><?= $block->escapeHtml($title) ?></h1>
+<div class="page-title-wrapper<?= $escaper->escapeHtmlAttr($titleClass) ?>">
+    <h1 class="page-title"<?= /* @noEscape */ $titleIdHtml ?>><?= $escaper->escapeHtml($title) ?></h1>
     <?= $block->getChildHtml() ?>
 </div>

--- a/app/code/Magento/Theme/view/frontend/templates/callouts/left_col.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/callouts/left_col.phtml
@@ -3,21 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="block block-banner">
     <div class="block-content">
         <?php if ($block->getLinkUrl() && strtolower(substr($block->getLinkUrl(), 0, 4)) === 'http'): ?>
-            <a href="<?= $block->escapeUrl($block->getLinkUrl()) ?>"
-               title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>">
+            <a href="<?= $escaper->escapeUrl($block->getLinkUrl()) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>">
         <?php elseif ($block->getLinkUrl()): ?>
-            <a href="<?= $block->escapeUrl($block->getUrl($block->getLinkUrl())) ?>"
-               title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>">
+            <a href="<?= $escaper->escapeUrl($block->getUrl($block->getLinkUrl())) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>">
         <?php endif; ?>
-            <img src="<?= $block->escapeUrl($block->getViewFileUrl($block->getImgSrc())) ?>"
+            <img src="<?= $escaper->escapeUrl($block->getViewFileUrl($block->getImgSrc())) ?>"
                 <?php if (!$block->getLinkUrl()): ?>
-                    title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>"
+                    title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>"
                 <?php endif; ?>
-                 alt="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>" />
+                 alt="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>" />
         <?php if ($block->getLinkUrl()): ?>
         </a>
         <?php endif ?>

--- a/app/code/Magento/Theme/view/frontend/templates/callouts/right_col.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/callouts/right_col.phtml
@@ -3,21 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="block block-banner">
     <div class="block-content">
         <?php if ($block->getLinkUrl() && strtolower(substr($block->getLinkUrl(), 0, 4)) === 'http'): ?>
-            <a href="<?= $block->escapeUrl($block->getLinkUrl()) ?>"
-               title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>">
+            <a href="<?= $escaper->escapeUrl($block->getLinkUrl()) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>">
         <?php elseif ($block->getLinkUrl()): ?>
-            <a href="<?= $block->escapeUrl($block->getUrl($block->getLinkUrl())) ?>"
-               title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>">
+            <a href="<?= $escaper->escapeUrl($block->getUrl($block->getLinkUrl())) ?>"
+               title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>">
         <?php endif; ?>
-            <img src="<?= $block->escapeUrl($block->getViewFileUrl($block->getImgSrc())) ?>"
+            <img src="<?= $escaper->escapeUrl($block->getViewFileUrl($block->getImgSrc())) ?>"
                 <?php if (!$block->getLinkUrl()): ?>
-                    title="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>"
+                    title="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>"
                 <?php endif; ?>
-                 alt="<?= $block->escapeHtmlAttr(__($block->getImgAlt())) ?>" />
+                 alt="<?= $escaper->escapeHtmlAttr(__($block->getImgAlt())) ?>" />
         <?php if ($block->getLinkUrl()): ?>
         </a>
         <?php endif ?>

--- a/app/code/Magento/Theme/view/frontend/templates/html/block.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/block.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<div class="block <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>">
-    <div class="block-title <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-title">
-        <strong><?= $block->escapeHtml($block->getBlockTitle()) ?></strong>
+<div class="block <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>">
+    <div class="block-title <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>-title">
+        <strong><?= $escaper->escapeHtml($block->getBlockTitle()) ?></strong>
     </div>
-    <div class="block-content <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-content">
+    <div class="block-content <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>-content">
         <?= $block->getChildHtml() ?>
     </div>
 </div>

--- a/app/code/Magento/Theme/view/frontend/templates/html/breadcrumbs.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/breadcrumbs.phtml
@@ -3,21 +3,26 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php if ($crumbs && is_array($crumbs)) : ?>
 <div class="breadcrumbs">
     <ul class="items">
         <?php foreach ($crumbs as $crumbName => $crumbInfo) : ?>
-            <li class="item <?= $block->escapeHtmlAttr($crumbName) ?>">
+            <li class="item <?= $escaper->escapeHtmlAttr($crumbName) ?>">
             <?php if ($crumbInfo['link']) : ?>
-                <a href="<?= $block->escapeUrl($crumbInfo['link']) ?>"
-                   title="<?= $block->escapeHtml($crumbInfo['title']) ?>">
-                    <?= $block->escapeHtml($crumbInfo['label']) ?>
+                <a href="<?= $escaper->escapeUrl($crumbInfo['link']) ?>"
+                   title="<?= $escaper->escapeHtml($crumbInfo['title']) ?>">
+                    <?= $escaper->escapeHtml($crumbInfo['label']) ?>
                 </a>
             <?php elseif ($crumbInfo['last']) : ?>
-                <strong><?= $block->escapeHtml($crumbInfo['label']) ?></strong>
+                <strong><?= $escaper->escapeHtml($crumbInfo['label']) ?></strong>
             <?php else : ?>
-                <?= $block->escapeHtml($crumbInfo['label']) ?>
+                <?= $escaper->escapeHtml($crumbInfo['label']) ?>
             <?php endif; ?>
             </li>
         <?php endforeach; ?>

--- a/app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/bugreport.phtml
@@ -3,11 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <small class="bugs">
-    <span><?= $block->escapeHtml(__('Help Us Keep Magento Healthy')) ?></span>
+    <span><?= $escaper->escapeHtml(__('Help Us Keep Magento Healthy')) ?></span>
     <a href="http://www.magentocommerce.com/bug-tracking"
-       target="_blank" title="<?= $block->escapeHtmlAttr(__('Report All Bugs')) ?>">
-        <?= $block->escapeHtml(__('Report All Bugs')) ?>
+       target="_blank" title="<?= $escaper->escapeHtmlAttr(__('Report All Bugs')) ?>">
+        <?= $escaper->escapeHtml(__('Report All Bugs')) ?>
     </a>
 </small>

--- a/app/code/Magento/Theme/view/frontend/templates/html/collapsible.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/collapsible.phtml
@@ -3,17 +3,22 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 
-<div class="block <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>">
-    <div class="title <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-title"
-         data-mage-init='{"toggleAdvanced": {"toggleContainers": "#<?= $block->escapeHtmlAttr($block->getBlockCss()) ?>", "selectorsToggleClass": "active"}}'>
+<div class="block <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>">
+    <div class="title <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>-title"
+         data-mage-init='{"toggleAdvanced": {"toggleContainers": "#<?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>", "selectorsToggleClass": "active"}}'>
         <strong>
-            <?= $block->escapeHtml(__($block->getBlockTitle())) ?>
+            <?= $escaper->escapeHtml(__($block->getBlockTitle())) ?>
         </strong>
     </div>
-    <div class="content <?= $block->escapeHtmlAttr($block->getBlockCss()) ?>-content"
-         id="<?= $block->escapeHtmlAttr($block->getBlockCss()) ?>">
+    <div class="content <?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>-content"
+         id="<?= $escaper->escapeHtmlAttr($block->getBlockCss()) ?>">
         <?= $block->getChildHtml() ?>
     </div>
 </div>

--- a/app/code/Magento/Theme/view/frontend/templates/html/copyright.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/copyright.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <small class="copyright">
-    <span><?= $block->escapeHtml($block->getCopyright()) ?></span>
+    <span><?= $escaper->escapeHtml($block->getCopyright()) ?></span>
 </small>

--- a/app/code/Magento/Theme/view/frontend/templates/html/footer.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/footer.phtml
@@ -3,14 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="footer-container">
     <div class="footer">
         <?= $block->getChildHtml() ?>
-        <p class="bugs"><?= $block->escapeHtml(__('Help Us Keep Magento Healthy')) ?> - <a
+        <p class="bugs"><?= $escaper->escapeHtml(__('Help Us Keep Magento Healthy')) ?> - <a
             href="http://www.magentocommerce.com/bug-tracking"
-            target="_blank"><strong><?= $block->escapeHtml(__('Report All Bugs')) ?></strong></a>
+            target="_blank"><strong><?= $escaper->escapeHtml(__('Report All Bugs')) ?></strong></a>
         </p>
-        <address><?= $block->escapeHtml($block->getCopyright()) ?></address>
+        <address><?= $escaper->escapeHtml($block->getCopyright()) ?></address>
     </div>
 </div>

--- a/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/header/logo.phtml
@@ -3,14 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Theme\Block\Html\Header\Logo $block
- */
+use Magento\Framework\Escaper;
+use Magento\Theme\Block\Html\Header\Logo;
+use Magento\Theme\ViewModel\Block\Html\Header\LogoSizeResolverInterface;
+
+/** @var Escaper $escaper */
+/** @var Logo $block */
 $storeName = $block->getThemeName() ? $block->getThemeName() : $block->getLogoAlt();
-/**
- * @var \Magento\Theme\ViewModel\Block\Html\Header\LogoSizeResolverInterface|null $logoSizeResolver
- */
+
+/** @var LogoSizeResolverInterface|null $logoSizeResolver */
 $logoSizeResolver = $block->getLogoSizeResolver();
 $logoWidth = $logoSizeResolver !== null && $logoSizeResolver->getWidth()
     ? $logoSizeResolver->getWidth()
@@ -19,16 +22,16 @@ $logoHeight = $logoSizeResolver !== null && $logoSizeResolver->getHeight()
     ? $logoSizeResolver->getHeight()
     : $block->getLogoHeight();
 ?>
-<span data-action="toggle-nav" class="action nav-toggle"><span><?= $block->escapeHtml(__('Toggle Nav')) ?></span></span>
+<span data-action="toggle-nav" class="action nav-toggle"><span><?= $escaper->escapeHtml(__('Toggle Nav')) ?></span></span>
 <a
     class="logo"
-    href="<?= $block->escapeUrl($block->getUrl('')) ?>"
-    title="<?= $block->escapeHtmlAttr($storeName) ?>"
+    href="<?= $escaper->escapeUrl($block->getUrl('')) ?>"
+    title="<?= $escaper->escapeHtmlAttr($storeName) ?>"
     aria-label="store logo">
-    <img src="<?= $block->escapeUrl($block->getLogoSrc()) ?>"
-         title="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
-         alt="<?= $block->escapeHtmlAttr($block->getLogoAlt()) ?>"
-            <?= $logoWidth ? 'width="' . $block->escapeHtmlAttr($logoWidth) . '"' : '' ?>
-            <?= $logoHeight ? 'height="' . $block->escapeHtmlAttr($logoHeight) . '"' : '' ?>
+    <img src="<?= $escaper->escapeUrl($block->getLogoSrc()) ?>"
+         title="<?= $escaper->escapeHtmlAttr($block->getLogoAlt()) ?>"
+         alt="<?= $escaper->escapeHtmlAttr($block->getLogoAlt()) ?>"
+            <?= $logoWidth ? 'width="' . $escaper->escapeHtmlAttr($logoWidth) . '"' : '' ?>
+            <?= $logoHeight ? 'height="' . $escaper->escapeHtmlAttr($logoHeight) . '"' : '' ?>
     />
 </a>

--- a/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/notices.phtml
@@ -3,20 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Theme\Block\Html\Notices
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Theme\Block\Html\Notices;
+
+/** @var Escaper $escaper */
+/** @var Notices $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->displayNoscriptNotice()): ?>
     <noscript>
         <div class="message global noscript">
             <div class="content">
                 <p>
-                    <strong><?= $block->escapeHtml(__('JavaScript seems to be disabled in your browser.')) ?></strong>
+                    <strong><?= $escaper->escapeHtml(__('JavaScript seems to be disabled in your browser.')) ?></strong>
                     <span>
-                        <?= $block->escapeHtml(
+                        <?= $escaper->escapeHtml(
                             __('For the best experience on our site, be sure to turn on Javascript in your browser.')
                         ) ?>
                     </span>
@@ -29,9 +33,9 @@
     <div class="notice global site local_storage">
         <div class="content">
             <p>
-                <strong><?= $block->escapeHtml(__('Local Storage seems to be disabled in your browser.')) ?></strong>
+                <strong><?= $escaper->escapeHtml(__('Local Storage seems to be disabled in your browser.')) ?></strong>
                 <br />
-                <?= $block->escapeHtml(
+                <?= $escaper->escapeHtml(
                     __('For the best experience on our site, be sure to turn on Local Storage in your browser.')
                 ) ?>
             </p>
@@ -64,7 +68,7 @@ script;
 <?php if ($block->displayDemoNotice()): ?>
     <div class="message global demo">
         <div class="content">
-            <p><?= $block->escapeHtml(__('This is a demo store. No orders will be fulfilled.')) ?></p>
+            <p><?= $escaper->escapeHtml(__('This is a demo store. No orders will be fulfilled.')) ?></p>
         </div>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/Theme/view/frontend/templates/html/pager.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/pager.phtml
@@ -3,15 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Pager template
- *
- * @var \Magento\Theme\Block\Html\Pager $block
- * @var \Magento\Framework\Escaper $escaper
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+use Magento\Theme\Block\Html\Pager;
 
+/** @var Escaper $escaper */
+/** @var Pager $block */
+/** @var LocaleFormatter $localeFormatter */
 ?>
 <?php if ($block->getCollection()->getSize()): ?>
 
@@ -23,7 +23,7 @@
         <p class="toolbar-amount">
             <span class="toolbar-number">
             <?php if ($block->getLastPageNum()>1): ?>
-                <?= $block->escapeHtml(
+                <?= $escaper->escapeHtml(
                     __(
                         'Items %1 to %2 of %3 total',
                         $localeFormatter->formatNumber($block->getFirstNum()),
@@ -32,9 +32,9 @@
                     )
                 ) ?>
             <?php elseif ($block->getTotalNum() == 1): ?>
-                <?= $block->escapeHtml(__('%1 Item', $localeFormatter->formatNumber($block->getTotalNum()))) ?>
+                <?= $escaper->escapeHtml(__('%1 Item', $localeFormatter->formatNumber($block->getTotalNum()))) ?>
             <?php else: ?>
-                <?= $block->escapeHtml(__('%1 Item(s)', $localeFormatter->formatNumber($block->getTotalNum()))) ?>
+                <?= $escaper->escapeHtml(__('%1 Item(s)', $localeFormatter->formatNumber($block->getTotalNum()))) ?>
             <?php endif; ?>
             </span>
         </p>
@@ -42,25 +42,25 @@
 
         <?php if ($block->getLastPageNum()>1): ?>
         <div class="pages">
-            <strong class="label pages-label" id="paging-label"><?= $block->escapeHtml(__('Page')) ?></strong>
+            <strong class="label pages-label" id="paging-label"><?= $escaper->escapeHtml(__('Page')) ?></strong>
             <ul class="items pages-items" aria-labelledby="paging-label">
             <?php if (!$block->isFirstPage()): ?>
                 <li class="item pages-item-previous">
                     <?php $text = $block->getAnchorTextForPrevious() ? $block->getAnchorTextForPrevious() : '';?>
-                    <a class="<?= $block->escapeHtmlAttr($text ? 'link ' : 'action ') ?> previous"
-                       href="<?= $block->escapeUrl($block->getPreviousPageUrl()) ?>"
-                       title="<?= $block->escapeHtmlAttr($text ? $text : __('Previous')) ?>">
-                        <span class="label"><?= $block->escapeHtml(__('Page')) ?></span>
-                        <span><?= $block->escapeHtml($text ? $text : __('Previous')) ?></span>
+                    <a class="<?= $escaper->escapeHtmlAttr($text ? 'link ' : 'action ') ?> previous"
+                       href="<?= $escaper->escapeUrl($block->getPreviousPageUrl()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($text ? $text : __('Previous')) ?>">
+                        <span class="label"><?= $escaper->escapeHtml(__('Page')) ?></span>
+                        <span><?= $escaper->escapeHtml($text ? $text : __('Previous')) ?></span>
                     </a>
                 </li>
             <?php endif;?>
 
             <?php if ($block->canShowFirst()): ?>
                 <li class="item">
-                    <a class="page first" href="<?= $block->escapeUrl($block->getFirstPageUrl()) ?>">
-                        <span class="label"><?= $block->escapeHtml(__('Page')) ?></span>
-                        <span><?= $block->escapeHtml($localeFormatter->formatNumber(1)) ?></span>
+                    <a class="page first" href="<?= $escaper->escapeUrl($block->getFirstPageUrl()) ?>">
+                        <span class="label"><?= $escaper->escapeHtml(__('Page')) ?></span>
+                        <span><?= $escaper->escapeHtml($localeFormatter->formatNumber(1)) ?></span>
                     </a>
                 </li>
             <?php endif;?>
@@ -73,7 +73,7 @@
                            'Skip to page %1',
                            $localeFormatter->formatNumber($block->getPreviousJumpPage())
                        )) ?>"
-                       href="<?= $block->escapeUrl($block->getPreviousJumpUrl()) ?>">
+                       href="<?= $escaper->escapeUrl($block->getPreviousJumpUrl()) ?>">
                         <span>...</span>
                     </a>
                 </li>
@@ -83,15 +83,15 @@
                 <?php if ($block->isPageCurrent($_page)): ?>
                     <li class="item current">
                         <strong class="page">
-                            <span class="label"><?= $block->escapeHtml(__('You\'re currently reading page')) ?></span>
-                            <span><?= $block->escapeHtml($localeFormatter->formatNumber($_page)) ?></span>
+                            <span class="label"><?= $escaper->escapeHtml(__('You\'re currently reading page')) ?></span>
+                            <span><?= $escaper->escapeHtml($localeFormatter->formatNumber($_page)) ?></span>
                         </strong>
                     </li>
                 <?php else: ?>
                     <li class="item">
-                        <a href="<?= $block->escapeUrl($block->getPageUrl($_page)) ?>" class="page">
-                            <span class="label"><?= $block->escapeHtml(__('Page')) ?></span>
-                            <span><?= $block->escapeHtml($localeFormatter->formatNumber($_page)) ?></span>
+                        <a href="<?= $escaper->escapeUrl($block->getPageUrl($_page)) ?>" class="page">
+                            <span class="label"><?= $escaper->escapeHtml(__('Page')) ?></span>
+                            <span><?= $escaper->escapeHtml($localeFormatter->formatNumber($_page)) ?></span>
                         </a>
                     </li>
                 <?php endif;?>
@@ -105,7 +105,7 @@
                            'Skip to page %1',
                            $localeFormatter->formatNumber($block->getNextJumpPage())
                        )) ?>"
-                       href="<?= $block->escapeUrl($block->getNextJumpUrl()) ?>">
+                       href="<?= $escaper->escapeUrl($block->getNextJumpUrl()) ?>">
                         <span>...</span>
                     </a>
                 </li>
@@ -113,9 +113,9 @@
 
             <?php if ($block->canShowLast()): ?>
               <li class="item">
-                  <a class="page last" href="<?= $block->escapeUrl($block->getLastPageUrl()) ?>">
-                      <span class="label"><?= $block->escapeHtml(__('Page')) ?></span>
-                      <span><?= $block->escapeHtml($localeFormatter->formatNumber($block->getLastPageNum())) ?></span>
+                  <a class="page last" href="<?= $escaper->escapeUrl($block->getLastPageUrl()) ?>">
+                      <span class="label"><?= $escaper->escapeHtml(__('Page')) ?></span>
+                      <span><?= $escaper->escapeHtml($localeFormatter->formatNumber($block->getLastPageNum())) ?></span>
                   </a>
               </li>
             <?php endif;?>
@@ -124,10 +124,10 @@
                 <li class="item pages-item-next">
                     <?php $text = $block->getAnchorTextForNext() ? $block->getAnchorTextForNext() : '';?>
                     <a class="<?= /* @noEscape */ $text ? 'link ' : 'action ' ?> next"
-                       href="<?= $block->escapeUrl($block->getNextPageUrl()) ?>"
-                       title="<?= $block->escapeHtmlAttr($text ? $text : __('Next')) ?>">
-                        <span class="label"><?= $block->escapeHtml(__('Page')) ?></span>
-                        <span><?= $block->escapeHtml($text ? $text : __('Next')) ?></span>
+                       href="<?= $escaper->escapeUrl($block->getNextPageUrl()) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($text ? $text : __('Next')) ?>">
+                        <span class="label"><?= $escaper->escapeHtml(__('Page')) ?></span>
+                        <span><?= $escaper->escapeHtml($text ? $text : __('Next')) ?></span>
                     </a>
                 </li>
             <?php endif;?>
@@ -137,17 +137,17 @@
 
     <?php if ($block->isShowPerPage()): ?>
         <div class="limiter">
-            <strong class="limiter-label"><?= $block->escapeHtml(__('Show')) ?></strong>
+            <strong class="limiter-label"><?= $escaper->escapeHtml(__('Show')) ?></strong>
             <select id="limiter" data-mage-init='{"redirectUrl": {"event":"change"}}' class="limiter-options">
                 <?php foreach ($block->getAvailableLimit() as $_key => $_limit): ?>
-                    <option value="<?= $block->escapeUrl($block->getLimitUrl($_key)) ?>"
+                    <option value="<?= $escaper->escapeUrl($block->getLimitUrl($_key)) ?>"
                         <?php if ($block->isLimitCurrent($_key)): ?>
                         selected="selected"<?php endif ?>>
-                        <?= $block->escapeHtml($localeFormatter->formatNumber((int) $_limit)) ?>
+                        <?= $escaper->escapeHtml($localeFormatter->formatNumber((int) $_limit)) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
-            <span class="limiter-text"><?= $block->escapeHtml(__('per page')) ?></span>
+            <span class="limiter-text"><?= $escaper->escapeHtml(__('per page')) ?></span>
         </div>
     <?php endif ?>
 

--- a/app/code/Magento/Theme/view/frontend/templates/html/sections.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/sections.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- *  General template for displaying group of blocks divided into sections
- */
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
+/**  General template for displaying group of blocks divided into sections */
 
 $group = $block->getGroupName();
 $groupCss = $block->getGroupCss();
 ?>
 <?php if ($detailedInfoGroup = $block->getGroupChildNames($group)):?>
-    <div class="sections <?= $block->escapeHtmlAttr($groupCss) ?>">
+    <div class="sections <?= $escaper->escapeHtmlAttr($groupCss) ?>">
         <?php $layout = $block->getLayout(); ?>
-        <div class="section-items <?= $block->escapeHtmlAttr($groupCss) ?>-items"
+        <div class="section-items <?= $escaper->escapeHtmlAttr($groupCss) ?>-items"
              data-mage-init='{"tabs":{"openedState":"active"}}'>
             <?php foreach ($detailedInfoGroup as $name):?>
                 <?php
@@ -25,15 +28,15 @@ $groupCss = $block->getGroupCss();
                     $alias = $layout->getElementAlias($name);
                     $label = $block->getChildData($alias, 'title');
                 ?>
-                <div class="section-item-title <?= $block->escapeHtmlAttr($groupCss) ?>-item-title"
+                <div class="section-item-title <?= $escaper->escapeHtmlAttr($groupCss) ?>-item-title"
                      data-role="collapsible">
-                    <a class="<?= $block->escapeHtmlAttr($groupCss) ?>-item-switch"
-                       data-toggle="switch" href="#<?= $block->escapeHtmlAttr($alias) ?>">
+                    <a class="<?= $escaper->escapeHtmlAttr($groupCss) ?>-item-switch"
+                       data-toggle="switch" href="#<?= $escaper->escapeHtmlAttr($alias) ?>">
                         <?= /* @noEscape */ $label ?>
                     </a>
                 </div>
-                <div class="section-item-content <?= $block->escapeHtmlAttr($groupCss) ?>-item-content"
-                     id="<?= $block->escapeHtmlAttr($alias) ?>"
+                <div class="section-item-content <?= $escaper->escapeHtmlAttr($groupCss) ?>-item-content"
+                     id="<?= $escaper->escapeHtmlAttr($alias) ?>"
                      data-role="content">
                     <?= /* @noEscape */ $html ?>
                 </div>

--- a/app/code/Magento/Theme/view/frontend/templates/html/skip.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/skip.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 $target = $block->getTarget();
 $label = $block->getLabel();
 ?>
-<a class="action skip <?= $block->escapeHtmlAttr($target) ?>"
-   href="#<?= $block->escapeHtmlAttr($target) ?>">
+<a class="action skip <?= $escaper->escapeHtmlAttr($target) ?>"
+   href="#<?= $escaper->escapeHtmlAttr($target) ?>">
     <span>
-        <?= $block->escapeHtml($label) ?>
+        <?= $escaper->escapeHtml($label) ?>
     </span>
 </a>

--- a/app/code/Magento/Theme/view/frontend/templates/html/skiptarget.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/skiptarget.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 
 $target_id = $block->getTargetId();
 ?>
-<a id="<?= $block->escapeHtmlAttr($target_id) ?>" tabindex="-1"></a>
+<a id="<?= $escaper->escapeHtmlAttr($target_id) ?>" tabindex="-1"></a>

--- a/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
@@ -3,26 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Theme\Block\Html\Title
- */
+use Magento\Framework\Escaper;
+use Magento\Theme\Block\Html\Title;
+
+/** @var Escaper $escaper */
+/** @var Title $block */
 $cssClass = $block->getCssClass() ? ' ' . $block->getCssClass() : '';
 $titleHtml = '';
+
 if (trim($block->getPageHeading())) {
     $titleHtml = '<span class="base" data-ui-id="page-title-wrapper" '
         . $block->getAddBaseAttribute()
         . '>'
-        . $block->escapeHtml($block->getPageHeading())
+        . $escaper->escapeHtml($block->getPageHeading())
         . '</span>';
 }
 ?>
 <?php if ($titleHtml) : ?>
-<div class="page-title-wrapper<?= $block->escapeHtmlAttr($cssClass) ?>">
+<div class="page-title-wrapper<?= $escaper->escapeHtmlAttr($cssClass) ?>">
     <h1 class="page-title"
-        <?php if ($block->getId()) : ?> id="<?= $block->escapeHtmlAttr($block->getId()) ?>" <?php endif; ?>
+        <?php if ($block->getId()) : ?> id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>" <?php endif; ?>
         <?php if ($block->getAddBaseAttributeAria()) : ?>
-            aria-labelledby="<?= $block->escapeHtmlAttr($block->getAddBaseAttributeAria()) ?>"
+            aria-labelledby="<?= $escaper->escapeHtmlAttr($block->getAddBaseAttributeAria()) ?>"
         <?php endif; ?>>
         <?= /* @noEscape */ $titleHtml ?>
     </h1>

--- a/app/code/Magento/Theme/view/frontend/templates/js/calendar.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/calendar.phtml
@@ -3,18 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-/** @var \Magento\Framework\View\Element\Html\Calendar $block */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Html\Calendar;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-/**
- * Calendar localization script. Should be put into page header.
- *
- * @see \Magento\Framework\View\Element\Html\Calendar
- */
-?>
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Calendar $block */
 
-<?php $intFirstDay = (int)$firstDay;
+/** Calendar localization script. Should be put into page header. */
+
+$intFirstDay = (int)$firstDay;
 $scriptString = <<<script
 
 require([
@@ -28,16 +29,16 @@ require([
             dayNamesMin: {$days['abbreviated']},
             monthNames: {$months['wide']},
             monthNamesShort: {$months['abbreviated']},
-            infoTitle: '{$block->escapeJs(__('About the calendar'))}',
+            infoTitle: '{$escaper->escapeJs(__('About the calendar'))}',
             firstDay: {$intFirstDay},
-            closeText: '{$block->escapeJs(__('Close'))}',
-            currentText: '{$block->escapeJs(__('Go Today'))}',
-            prevText: '{$block->escapeJs(__('Previous'))}',
-            nextText: '{$block->escapeJs(__('Next'))}',
-            weekHeader: '{$block->escapeJs(__('WK'))}',
-            timeText: '{$block->escapeJs(__('Time'))}',
-            hourText: '{$block->escapeJs(__('Hour'))}',
-            minuteText: '{$block->escapeJs(__('Minute'))}',
+            closeText: '{$escaper->escapeJs(__('Close'))}',
+            currentText: '{$escaper->escapeJs(__('Go Today'))}',
+            prevText: '{$escaper->escapeJs(__('Previous'))}',
+            nextText: '{$escaper->escapeJs(__('Next'))}',
+            weekHeader: '{$escaper->escapeJs(__('WK'))}',
+            timeText: '{$escaper->escapeJs(__('Time'))}',
+            hourText: '{$escaper->escapeJs(__('Hour'))}',
+            minuteText: '{$escaper->escapeJs(__('Minute'))}',
             dateFormat: "D, d M yy", // $.datepicker.RFC_2822
             showOn: 'button',
             showAnim: '',

--- a/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/cookie.phtml
@@ -3,23 +3,25 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * Cookie settings initialization script
- *
- * @var $block \Magento\Framework\View\Element\Js\Cookie
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Js\Cookie;
+
+/** @var Escaper $escaper */
+/** @var Cookie $block */
+
+/** Cookie settings initialization script */
 ?>
-
 <script type="text/x-magento-init">
     {
         "*": {
             "mage/cookies": {
                 "expires": null,
-                "path": "<?= $block->escapeJs($block->getPath()) ?>",
-                "domain": "<?= $block->escapeJs($block->getDomain()) ?>",
+                "path": "<?= $escaper->escapeJs($block->getPath()) ?>",
+                "domain": "<?= $escaper->escapeJs($block->getDomain()) ?>",
                 "secure": <?= $block->getSessionConfig()->getCookieSecure() ? 'true' : 'false'; ?>,
-                "lifetime": "<?= $block->escapeJs($block->getLifetime()) ?>"
+                "lifetime": "<?= $escaper->escapeJs($block->getLifetime()) ?>"
             }
         }
     }

--- a/app/code/Magento/Theme/view/frontend/templates/js/cookie_status.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/js/cookie_status.phtml
@@ -3,14 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-/**
- * @var Magento\Framework\View\Element\Template $block
- */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Template $block */
+?>
 <div class="cookie-status-message" id="cookie-status">
-    <?= $block->escapeHtml(__('The store will not work correctly when cookies are disabled.')); ?>
+    <?= $escaper->escapeHtml(__('The store will not work correctly when cookies are disabled.')); ?>
 </div>
 <?php
 $script = 'document.querySelector("#cookie-status").style.display = "none";';


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Theme` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

### Resolved issues:
1. [x] resolves magento/magento2#37177: Chore: Theme - Replace Block Escaping with Escaper