### PR TITLE
Chore: UI - Replace Block Escaping with Escaper

### DIFF
--- a/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/default.phtml
@@ -3,13 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var $block \Magento\Ui\Component\Control\Button
- */
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var \Magento\Ui\Component\Control\Button $block */
 ?>
 <?= $block->getBeforeHtml() ?>
 <button <?= /* @noEscape */ $block->getAttributesHtml(), /* @noEscape */ $block->getUiId() ?>>
-    <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+    <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
 </button>
 <?= $block->getAfterHtml() ?>

--- a/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
+++ b/app/code/Magento/Ui/view/base/templates/control/button/split.phtml
@@ -3,17 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Ui\Component\Control\SplitButton */
+use Magento\Framework\Escaper;
+use Magento\Ui\Component\Control\SplitButton;
+
+/** @var Escaper $escaper */
+/** @var SplitButton $block */
 ?>
-
 <div <?= $block->getAttributesHtml() ?>>
     <button <?= $block->getButtonAttributesHtml() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+        <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
     </button>
     <?php if ($block->hasSplit()): ?>
         <button <?= $block->getToggleAttributesHtml() ?>>
-            <span><?= $block->escapeHtml(__('Select')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Select')) ?></span>
         </button>
 
         <?php if (!$block->getDisabled()): ?>
@@ -21,12 +25,12 @@
                 <?php foreach ($block->getOptions() as $key => $option): ?>
                 <li>
                     <span <?= $block->getOptionAttributesHtml($key, $option) ?>>
-                        <?= $block->escapeHtml($option['label']) ?>
+                        <?= $escaper->escapeHtml($option['label']) ?>
                     </span>
                     <?php if (isset($option['hint'])): ?>
                     <div class="tooltip" <?= /* @noEscape */ $block->getUiId('item', $key, 'tooltip') ?>>
-                        <a href="<?= $block->escapeUrl($option['hint']['href']) ?>" class="help">
-                            <?= $block->escapeHtml($option['hint']['label']) ?>
+                        <a href="<?= $escaper->escapeUrl($option['hint']['href']) ?>" class="help">
+                            <?= $escaper->escapeHtml($option['hint']['label']) ?>
                         </a>
                     </div>
                     <?php endif; ?>

--- a/app/code/Magento/Ui/view/base/templates/form/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/form/default.phtml
@@ -3,18 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Ui\Component\Form $block
- */
+use Magento\Framework\Escaper;
+use Magento\Ui\Component\Form;
+
+/** @var Escaper $escaper */
+/** @var Form $block */
 ?>
 <?=/* @noEscape */ $block->renderChildComponent('before_form') ?>
 <div data-role="spinner"
-     data-component="<?= $block->escapeHtmlAttr($block->getName()) ?>.areas"
+     data-component="<?= $escaper->escapeHtmlAttr($block->getName()) ?>.areas"
      class="admin__data-grid-loading-mask">
     <div class="grid-loader"></div>
 </div>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getName()) ?>.areas'"
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getName()) ?>.areas'"
      class="entry-edit form-inline">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/label/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/label/default.phtml
@@ -3,7 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <span>
-    <?= $block->escapeHtml($block->getData('label')) ?>
+    <?= $escaper->escapeHtml($block->getData('label')) ?>
 </span>

--- a/app/code/Magento/Ui/view/base/templates/layout/tabs/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/layout/tabs/default.phtml
@@ -3,11 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Ui\Component\Layout\Tabs $block
- */
+use Magento\Framework\Escaper;
+use Magento\Ui\Component\Layout\Tabs;
+
+/** @var Escaper $escaper */
+/** @var Tabs $block */
 ?>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/layout/tabs/nav/default.phtml
+++ b/app/code/Magento/Ui/view/base/templates/layout/tabs/nav/default.phtml
@@ -3,11 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Ui\Component\Layout\Tabs\Nav $block
- */
+use Magento\Framework\Escaper;
+use Magento\Ui\Component\Layout\Tabs\Nav;
+
+/** @var Escaper $escaper */
+/** @var Nav $block */
 ?>
-<div data-bind="scope: '<?= $block->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
+<div data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getDataScope()) ?>.sections' " class="ui-tabs">
     <!-- ko template: getTemplate() --><!-- /ko -->
 </div>

--- a/app/code/Magento/Ui/view/base/templates/logger.phtml
+++ b/app/code/Magento/Ui/view/base/templates/logger.phtml
@@ -3,15 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Ui\Block\Logger */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Ui\Block\Logger;
+
+/** @var Escaper $escaper */
+/** @var Logger $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($block->isLoggingEnabled()): ?>
     <?php $scriptString = <<<script
 
         window.onerror = function(msg, url, line) {
-            var key = "{$block->escapeJs($block->getSessionStorageKey())}";
+            var key = "{$escaper->escapeJs($block->getSessionStorageKey())}";
             var errors = {};
             if (sessionStorage.getItem(key)) {
                 errors = JSON.parse(sessionStorage.getItem(key));

--- a/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
+++ b/app/code/Magento/Ui/view/base/templates/stepswizard.phtml
@@ -3,23 +3,29 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Ui\Block\Component\StepsWizard;
+
+/** @var Escaper $escaper */
+/** @var StepsWizard $block */
 
 // phpcs:disable Magento2.Templates.ThisInTemplate.FoundThis
-/** @var $block \Magento\Ui\Block\Component\StepsWizard */
 ?>
 <div data-role="steps-wizard-main"
      class="steps-wizard <?= /* @noEscape */ $block->getData('config/dataScope') ?>"
-     data-bind="scope: '<?= $block->escapeHtmlAttr($block->getComponentName()) ?>'">
+     data-bind="scope: '<?= $escaper->escapeHtmlAttr($block->getComponentName()) ?>'">
     <div data-role="messages" class="messages"></div>
 
     <div data-role="steps-wizard-controls" class="steps-wizard-navigation">
         <ul class="nav-bar">
             <?php foreach ($block->getSteps() as $step) : ?>
                 <li data-role="collapsible"
-                    data-bind="css: { 'active': selectedStep() == '<?= $block->escapeHtmlAttr($step->getComponentName()) ?>'}">
-                    <a href="#<?= $block->escapeHtmlAttr($step->getComponentName()) ?>"
+                    data-bind="css: { 'active': selectedStep() == '<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>'}">
+                    <a href="#<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>"
                        data-bind="click: showSpecificStep">
-                        <?= $block->escapeHtml($step->getCaption()) ?>
+                        <?= $escaper->escapeHtml($step->getCaption()) ?>
                     </a>
                 </li>
             <?php endforeach; ?>
@@ -28,20 +34,20 @@
             <div class="action-wrap" data-role="closeBtn">
                 <button type="button"
                         class="action-cancel action-tertiary" data-bind="click: close">
-                    <span><?= $block->escapeHtml(__('Cancel')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Cancel')) ?></span>
                 </button>
             </div>
             <div class="action-wrap action-wrap-prev" data-role="step-wizard-prev">
                 <button type="button"
                         class="action-default action-back-step"
                         data-bind="click: back, css: { 'disabled': disabled}">
-                    <span><?= $block->escapeHtml(__('Back')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Back')) ?></span>
                 </button>
             </div>
             <div class="action-wrap action-wrap-next" data-role="step-wizard-next">
                 <button type="button"
                         class="action-default action-primary action-next-step" data-bind="click: next">
-                    <span><?= $block->escapeHtml(__('Next')) ?></span>
+                    <span><?= $escaper->escapeHtml(__('Next')) ?></span>
                 </button>
             </div>
         </div>
@@ -49,7 +55,7 @@
     <div data-role="steps-wizard-tab">
         <?php foreach ($block->getSteps() as $step) : ?>
             <div data-bind="visible: selectedStep() == $element.id, css: {'no-display':false}"
-                 class="content no-display" id="<?= $block->escapeHtmlAttr($step->getComponentName()) ?>"
+                 class="content no-display" id="<?= $escaper->escapeHtmlAttr($step->getComponentName()) ?>"
                  data-role="content">
                 <?= /* @noEscape */ $step->getContent() ?>
             </div>
@@ -62,7 +68,7 @@
         "*": {
             "Magento_Ui/js/core/app": {
                 "components": {
-                        "<?= $block->escapeJs($block->getComponentName()) ?>": {
+                        "<?= $escaper->escapeJs($block->getComponentName()) ?>": {
                             "component": "Magento_Ui/js/lib/step-wizard",
                             "initData": <?= /* @noEscape */ $this->helper(Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getInitData()) ?>,
                             "stepsNames": <?= /* @noEscape */ $this->helper(Magento\Framework\Json\Helper\Data::class)->jsonEncode($block->getStepComponents()) ?>,


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Ui` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper

