### PR TITLE
Fixes regression bug introduced in AC-8077 where the html 'id' and 'f…

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
+++ b/app/code/Magento/Bundle/view/frontend/templates/catalog/product/view/type/bundle/option/radio.phtml
@@ -4,6 +4,8 @@
  * See COPYING.txt for license details.
  */
 use Magento\Bundle\ViewModel\ValidateQuantity;
+
+// phpcs:disable Generic.Files.LineLength.TooLong
 ?>
 <?php /* @var $block \Magento\Bundle\Block\Catalog\Product\View\Type\Bundle\Option\Radio */ ?>
 <?php $_option = $block->getOption(); ?>
@@ -49,8 +51,7 @@ $viewModel = $block->getData('validateQuantityViewModel');
                     <div class="field choice">
                         <input type="radio"
                                class="radio product bundle option change-container-classname"
-                               id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>
-                               -<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
+                               id="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                             <?php if ($_option->getRequired()) {
                                 echo 'data-validate="{\'validate-one-required-by-name\':true}"';
                             } ?>
@@ -61,8 +62,7 @@ $viewModel = $block->getData('validateQuantityViewModel');
                                value="<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>"
                                data-errors-message-box="#validation-message-box-radio"/>
                         <label class="label"
-                               for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>
-                               -<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>">
+                               for="bundle-option-<?= $block->escapeHtmlAttr($_option->getId()) ?>-<?= $block->escapeHtmlAttr($_selection->getSelectionId()) ?>">
                             <span><?= /* @noEscape */ $block->getSelectionTitlePrice($_selection) ?></span>
                             <br/>
                             <?= /* @noEscape */ $block->getTierPriceRenderer()->renderTierPrice($_selection) ?>


### PR DESCRIPTION
…or' attributes got whitespace introduced.

### Description (*)
[AC-8077::Upgrade JQuery Validation Plugin library to the latest version](https://github.com/magento/magento2/commit/a58a25080d0b2c3de775232d5f8380c03555c801?w=1) introduced a regression by accident probably, by fixing a coding standards complaint about having too long lines in the file.
This is fixed again in this PR and the coding standards complaint has been disabled for the entire file so this doesn't happen again by accident in the future.

More detailed, it added whitespace in an `id` and `for` html attribute which should not contain whitespace, for example it outputted `id="bundle-option-1 -1"` instead of `id="bundle-option-1-1"`

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. None 

### Manual testing scenarios (*)
1. Create a couple of simple products
2. Create a bundled product with one or multiple options of type "radio" and containing more than one option
3. Reindex, flush caches
4. Visit the bundled product on the frontend and inspect the html
5. Before this PR, it will contain invalid `id` attributes for the radio `<input>`fields and invalid `for`  attributes for the associated `<label>` elements (invalid: containing whitespace)
6. After the PR, it should be valid again

### Note to release notes team
This doesn't need to be mentioned on the release notes, it fixes a bug in something that wasn't released in a final version yet.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
