### PR TITLE
feat(catalog): faster category product count

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -170,7 +170,7 @@ abstract class AbstractAction
      */
     protected function reindex()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             if ($this->getPathFromCategoryId($store->getRootCategoryId())) {
                 $this->setCurrentStore($store);
                 $this->reindexRootCategory($store);
@@ -269,7 +269,7 @@ abstract class AbstractAction
                     ['path']
                 )->where(
                     'entity_id = ?',
-                    $categoryId
+                    $categoryId == 0 ? 1 : $categoryId
                 )
             );
         }
@@ -307,10 +307,6 @@ abstract class AbstractAction
                 'ccp.category_id = cc.entity_id',
                 []
             )->joinInner(
-                ['cpw' => $this->getTable('catalog_product_website')],
-                'cpw.product_id = ccp.product_id',
-                []
-            )->joinInner(
                 ['cpe' => $this->getTable('catalog_product_entity')],
                 'ccp.product_id = cpe.entity_id',
                 []
@@ -339,11 +335,6 @@ abstract class AbstractAction
                 $store->getId(),
                 []
             )->where(
-                'cc.path LIKE ' . $this->connection->quote($rootPath . '/%')
-            )->where(
-                'cpw.website_id = ?',
-                $store->getWebsiteId()
-            )->where(
                 $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
@@ -365,6 +356,19 @@ abstract class AbstractAction
                     ),
                 ]
             );
+
+            if ($store->getId() != 0) {
+                $select->joinInner(
+                    ['cpw' => $this->getTable('catalog_product_website')],
+                    'cpw.product_id = ccp.product_id',
+                    []
+                )->where(
+                    'cpw.website_id = ?',
+                    $store->getWebsiteId()
+                )->where(
+                    'cc.path LIKE ' . $this->connection->quote($rootPath . '/%')
+                );
+            }
 
             $this->addFilteringByChildProductsToSelect($select, $store);
 
@@ -516,6 +520,7 @@ abstract class AbstractAction
         $visibilityAttributeId = $this->config->getAttribute(Product::ENTITY, 'visibility')->getId();
         $rootCatIds = explode('/', $this->getPathFromCategoryId($store->getRootCategoryId()));
         array_pop($rootCatIds);
+        $rootCatIds = $rootCatIds ?: [1];
 
         $temporaryTreeTable = $this->makeTempCategoryTreeIndex();
 
@@ -546,10 +551,6 @@ abstract class AbstractAction
         )->joinInner(
             ['cpe' => $this->getTable('catalog_product_entity')],
             'ccp.product_id = cpe.entity_id',
-            []
-        )->joinInner(
-            ['cpw' => $this->getTable('catalog_product_website')],
-            'cpw.product_id = ccp.product_id',
             []
         )->joinInner(
             ['cpsd' => $this->getTable('catalog_product_entity_int')],
@@ -586,9 +587,6 @@ abstract class AbstractAction
             $store->getId(),
             []
         )->where(
-            'cpw.website_id = ?',
-            $store->getWebsiteId()
-        )->where(
             $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
             \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
         )->where(
@@ -613,6 +611,17 @@ abstract class AbstractAction
                 'visibility' => new \Zend_Db_Expr($this->connection->getIfNullSql('cpvs.value', 'cpvd.value')),
             ]
         );
+
+        if ($store->getId() != 0) {
+            $select->joinInner(
+                ['cpw' => $this->getTable('catalog_product_website')],
+                'cpw.product_id = ccp.product_id',
+                []
+            )->where(
+                'cpw.website_id = ?',
+                $store->getWebsiteId()
+            );
+        }
 
         $this->addFilteringByChildProductsToSelect($select, $store);
 
@@ -802,10 +811,6 @@ abstract class AbstractAction
                 ['cp' => $this->getTable('catalog_product_entity')],
                 []
             )->joinInner(
-                ['cpw' => $this->getTable('catalog_product_website')],
-                'cpw.product_id = cp.entity_id',
-                []
-            )->joinInner(
                 ['cpsd' => $this->getTable('catalog_product_entity_int')],
                 'cpsd.' . $linkField . ' = cp.' . $linkField . ' AND cpsd.store_id = 0' .
                 ' AND cpsd.attribute_id = ' .
@@ -834,9 +839,6 @@ abstract class AbstractAction
                 'ccp.product_id = cp.entity_id',
                 []
             )->where(
-                'cpw.website_id = ?',
-                $store->getWebsiteId()
-            )->where(
                 $this->connection->getIfNullSql('cpss.value', 'cpsd.value') . ' = ?',
                 \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED
             )->where(
@@ -864,6 +866,17 @@ abstract class AbstractAction
                     ),
                 ]
             );
+
+            if ($store->getId() != 0) {
+                $select->joinInner(
+                    ['cpw' => $this->getTable('catalog_product_website')],
+                    'cpw.product_id = ccp.product_id',
+                    []
+                )->where(
+                    'cpw.website_id = ?',
+                    $store->getWebsiteId()
+                );
+            }
 
             $this->productsSelects[$store->getId()] = $select;
         }

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -44,7 +44,8 @@ abstract class AbstractAction
 
     /**
      * Suffix for table to show it is temporary
-     * @deprecated see getIndexTable
+     * @deprecated 102.0.5
+     * @see getIndexTable
      */
     public const TEMPORARY_TABLE_SUFFIX = '_tmp';
 
@@ -221,6 +222,7 @@ abstract class AbstractAction
      *
      * @return string
      * @deprecated 102.0.5
+     * @see getIndexTable
      */
     protected function getMainTable()
     {
@@ -232,6 +234,7 @@ abstract class AbstractAction
      *
      * @return string
      * @deprecated 102.0.5
+     * @see getIndexTable
      */
     protected function getMainTmpTable()
     {

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -133,7 +133,7 @@ class Full extends AbstractAction
      */
     private function createTables(): void
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->tableMaintainer->createTablesForStore((int)$store->getId());
         }
     }
@@ -145,7 +145,7 @@ class Full extends AbstractAction
      */
     private function clearReplicaTables(): void
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->connection->truncateTable($this->tableMaintainer->getMainReplicaTable((int)$store->getId()));
         }
     }
@@ -158,7 +158,7 @@ class Full extends AbstractAction
     private function switchTables(): void
     {
         $tablesToSwitch = [];
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $tablesToSwitch[] = $this->tableMaintainer->getMainTable((int)$store->getId());
         }
         $this->activeTableSwitcher->switchTable($this->connection, $tablesToSwitch);
@@ -188,7 +188,7 @@ class Full extends AbstractAction
     {
         $userFunctions = [];
 
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             if ($this->getPathFromCategoryId($store->getRootCategoryId())) {
                 $userFunctions[$store->getId()] = function () use ($store) {
                     $this->reindexStore($store);

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
@@ -117,7 +117,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             || ($indexer->isScheduled() && !$useTempTable)
             || ($indexer->isScheduled() && $useTempTable && !$workingState)) {
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->truncateTable($this->getIndexTable($store->getId()));
                 }
             } else {
@@ -130,7 +130,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $workingState = $this->isWorkingState();
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $removalCategoryIds = array_diff($this->limitationByCategories, [$this->getRootCategoryId($store)]);
                     $this->connection->delete(
                         $this->tableMaintainer->getMainTable($store->getId()),
@@ -204,7 +204,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     private function removeEntries()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $removalCategoryIds = array_diff($this->limitationByCategories, [$this->getRootCategoryId($store)]);
             $this->connection->delete(
                 $this->getIndexTable($store->getId()),

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Rows.php
@@ -29,8 +29,6 @@ use Magento\Indexer\Model\WorkingStateProvider;
 class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractAction
 {
     /**
-     * Limitation by categories
-     *
      * @var int[]
      */
     protected $limitationByCategories;

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Plugin/StoreGroup.php
@@ -78,7 +78,7 @@ class StoreGroup
      */
     public function afterDelete(AbstractDb $subject, AbstractDb $objectResource, AbstractModel $storeGroup)
     {
-        foreach ($storeGroup->getStores() as $store) {
+        foreach ($storeGroup->getStores(true) as $store) {
             $this->tableMaintainer->dropTablesForStore((int)$store->getId());
         }
         return $objectResource;

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
@@ -115,7 +115,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $affectedCategories = $this->getCategoryIdsFromIndex($idsToBeReIndexed);
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->truncateTable($this->getIndexTable($store->getId()));
                 }
             } else {
@@ -127,7 +127,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
             $workingState = $this->isWorkingState();
 
             if ($useTempTable && !$workingState && $indexer->isScheduled()) {
-                foreach ($this->storeManager->getStores() as $store) {
+                foreach ($this->storeManager->getStores(true) as $store) {
                     $this->connection->delete(
                         $this->tableMaintainer->getMainTable($store->getId()),
                         ['product_id IN (?)' => $this->limitationByProducts]
@@ -236,7 +236,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
      */
     protected function removeEntries()
     {
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $this->connection->delete(
                 $this->getIndexTable($store->getId()),
                 ['product_id IN (?)' => $this->limitationByProducts]
@@ -299,7 +299,7 @@ class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractActio
     private function getCategoryIdsFromIndex(array $productIds): array
     {
         $categoryIds = [];
-        foreach ($this->storeManager->getStores() as $store) {
+        foreach ($this->storeManager->getStores(true) as $store) {
             $storeCategories = $this->connection->fetchCol(
                 $this->connection->select()
                     ->from($this->getIndexTable($store->getId()), ['category_id'])

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Category/Action/Rows.php
@@ -30,8 +30,6 @@ use Magento\Indexer\Model\WorkingStateProvider;
 class Rows extends \Magento\Catalog\Model\Indexer\Category\Product\AbstractAction
 {
     /**
-     * Limitation by products
-     *
      * @var int[]
      */
     protected $limitationByProducts;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -11,6 +11,7 @@ use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DB\Select;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
 
 /**
  * Category resource collection
@@ -77,6 +78,11 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     private $catalogProductVisibility;
 
     /**
+     * @var TableMaintainer
+     */
+    private $tableMaintainer;
+
+    /**
      * Constructor
      * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
      * @param \Psr\Log\LoggerInterface $logger
@@ -125,6 +131,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             \Magento\Framework\App\ObjectManager::getInstance()->get(ScopeConfigInterface::class);
         $this->catalogProductVisibility = $catalogProductVisibility ?:
             \Magento\Framework\App\ObjectManager::getInstance()->get(Visibility::class);
+        $this->tableMaintainer = \Magento\Framework\App\ObjectManager::getInstance()->get(TableMaintainer::class);
     }
 
     /**
@@ -329,7 +336,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             foreach ($anchor as $item) {
                 $productsCount = isset($categoryProductsCount[$item->getId()])
                     ? (int)$categoryProductsCount[$item->getId()]
-                    : $this->getProductsCountFromCategoryTable($item, $websiteId);
+                    : 0;
                 $item->setProductCount($productsCount);
             }
         }
@@ -509,45 +516,6 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     }
 
     /**
-     * Get products count using catalog_category_entity table
-     *
-     * @param Category $item
-     * @param string $websiteId
-     * @return int
-     */
-    private function getProductsCountFromCategoryTable(Category $item, string $websiteId): int
-    {
-        $productCount = 0;
-
-        if ($item->getAllChildren()) {
-            $bind = ['entity_id' => $item->getId(), 'c_path' => $item->getPath() . '/%'];
-            $select = $this->_conn->select();
-            $select->from(
-                ['main_table' => $this->getProductTable()],
-                new \Zend_Db_Expr('COUNT(DISTINCT main_table.product_id)')
-            )->joinInner(
-                ['e' => $this->getTable('catalog_category_entity')],
-                'main_table.category_id=e.entity_id',
-                []
-            )->where(
-                '(e.entity_id = :entity_id OR e.path LIKE :c_path)'
-            );
-            if ($websiteId) {
-                $select->join(
-                    ['w' => $this->getProductWebsiteTable()],
-                    'main_table.product_id = w.product_id',
-                    []
-                )->where(
-                    'w.website_id = ?',
-                    $websiteId
-                );
-            }
-            $productCount = (int)$this->_conn->fetchOne($select, $bind);
-        }
-        return $productCount;
-    }
-
-    /**
      * Get query for retrieve count of products per category
      *
      * @param array $categoryIds
@@ -556,8 +524,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      */
     private function getProductsCountQuery(array $categoryIds, $addVisibilityFilter = true): Select
     {
-        $connections = $this->_resource->getConnection();
-        $categoryTable = $connections->getTableName('catalog_category_product_index');
+        $categoryTable = $this->tableMaintainer->getMainTable($this->getProductStoreId());
         $select = $this->_conn->select()
             ->from(
                 ['cat_index' => $categoryTable],

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -335,9 +335,8 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $countSelect = $this->getProductsCountQuery($categoryIds, (bool)$websiteId);
             try {
                 $categoryProductsCount = $this->_conn->fetchPairs($countSelect);
-            }
-            catch(TableNotFoundException $e) {
-                // If the index has not run yet and no table exists, 
+            } catch (TableNotFoundException $e) {
+                // If the index has not run yet and no table exists,
                 // we do not compute a product count.
                 $categoryProductsCount = [];
             }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DB\Select;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
+use Magento\Framework\DB\Adapter\TableNotFoundException;
 
 /**
  * Category resource collection
@@ -332,7 +333,14 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             // Retrieve Anchor categories product counts
             $categoryIds = array_keys($anchor);
             $countSelect = $this->getProductsCountQuery($categoryIds, (bool)$websiteId);
-            $categoryProductsCount = $this->_conn->fetchPairs($countSelect);
+            try {
+                $categoryProductsCount = $this->_conn->fetchPairs($countSelect);
+            }
+            catch(TableNotFoundException $e) {
+                // If the index has not run yet and no table exists, 
+                // we do not compute a product count.
+                $categoryProductsCount = [];
+            }
             foreach ($anchor as $item) {
                 $productsCount = isset($categoryProductsCount[$item->getId()])
                     ? (int)$categoryProductsCount[$item->getId()]


### PR DESCRIPTION
Previously, in the admin panel, computing the CategoryTree UI (the left-hand element of the page that loads when you try to view the categories of your store) was wildly slow for the root scope when there were many `is_anchor` categories. This was due to several bugs:

1. Use of a missing index: `catalog_category_product_index` that is now defunct and always empty. It was replaced by `catalog_category_product_index_store*`. However, this table did not exist for the `store0`. This diff both adds that missing table and changes the collection to use the new tables.

2. A bad computation of the `rootCategoryIds` for the root store, causing a bad join condition against the temporary category recursion table resulting in the resulting index table (catalog_category_product_index_store0) always being empty.

3. An exceedingly slow private method (getProductsCountFromCategoryTable) which should not have been merged in the first place given how slow it is. I have removed this method. Removing this does cause a small UX bug when the index is empty: the category page will show 0 products before an index has run. It's either this or perform the computation on every page refresh. I see this an acceptable break, given how slow it is to attempt to compute these values manually.

### Related Pull Requests
Fixes: https://github.com/magento/magento2/pull/35216
Fixes: https://github.com/magento/magento2/pull/34111

### Fixed Issues (if relevant)
Fixes: https://github.com/magento/magento2/issues/34109
Fixes: https://github.com/magento/magento2/pull/35417

Here is a patch for [v2.4.4-p3](https://gist.github.com/damienwebdev/34534765bb548bf6ea14dab28245846c#file-34111-v2-4-4-p3-patch) - don't use this yet, I'm not keeping it up to date until the checks pass.

### Manual testing scenarios (*)
1. Attempt to view admin panel on root scope with many anchor categories (each with many products) ~4000 categories and ~4000 products. 
2. Wait until the end of time.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
