### PR TITLE
Chore: Admin Analytics - Replace Deprecated Output Escaping

### DIFF
--- a/app/code/Magento/AdminAnalytics/view/adminhtml/templates/tracking.phtml
+++ b/app/code/Magento/AdminAnalytics/view/adminhtml/templates/tracking.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
+use Magento\AdminAnalytics\ViewModel\Metadata;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 
 <?= /* @noEscape */ $secureRenderer->renderTag(
@@ -20,19 +24,19 @@
 ) ?>
 
 <?php
-/** @var \Magento\AdminAnalytics\ViewModel\Metadata $metadata */
+/** @var Metadata $metadata */
 $metadata = $block->getMetadata();
 $scriptString = '
     var adminAnalyticsMetadata = {
-        "secure_base_url": "' . $block->escapeJs($metadata->getSecureBaseUrlForScope()) . '",
-        "version": "' . $block->escapeJs($metadata->getMagentoVersion()) . '",
-        "product_edition": "' . $block->escapeJs($metadata->getProductEdition()) . '",
-        "user": "' . $block->escapeJs($metadata->getCurrentUser()) . '",
-        "mode": "' . $block->escapeJs($metadata->getMode()) . '",
-        "store_name_default": "' . $block->escapeJs($metadata->getStoreNameForScope()) . '",
-        "admin_user_created": "' . $block->escapeJs($metadata->getCurrentUserCreatedDate()) . '",
-        "admin_user_logdate": "' . $block->escapeJs($metadata->getCurrentUserLogDate()) . '",
-        "admin_user_role_name": "' . $block->escapeJs($metadata->getCurrentUserRoleName()) . '"
+        "secure_base_url": "' . $escaper->escapeJs($metadata->getSecureBaseUrlForScope()) . '",
+        "version": "' . $escaper->escapeJs($metadata->getMagentoVersion()) . '",
+        "product_edition": "' . $escaper->escapeJs($metadata->getProductEdition()) . '",
+        "user": "' . $escaper->escapeJs($metadata->getCurrentUser()) . '",
+        "mode": "' . $escaper->escapeJs($metadata->getMode()) . '",
+        "store_name_default": "' . $escaper->escapeJs($metadata->getStoreNameForScope()) . '",
+        "admin_user_created": "' . $escaper->escapeJs($metadata->getCurrentUserCreatedDate()) . '",
+        "admin_user_logdate": "' . $escaper->escapeJs($metadata->getCurrentUserLogDate()) . '",
+        "admin_user_role_name": "' . $escaper->escapeJs($metadata->getCurrentUserRoleName()) . '"
     };
 ';
 ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_AdminAnalytics` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37095: Chore: Admin Analytics - Replace Block Escaping with Escaper