### PR TITLE
Chore: Advanced Search - Replace Deprecated Output Escaping

### DIFF
--- a/app/code/Magento/AdvancedSearch/view/adminhtml/templates/system/config/testconnection.phtml
+++ b/app/code/Magento/AdvancedSearch/view/adminhtml/templates/system/config/testconnection.phtml
@@ -3,12 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<button class="scalable" type="button" id="<?= $block->getHtmlId() ?>" data-mage-init='{"testConnection":{
-    "url": "<?= $block->escapeUrl($block->getAjaxUrl()) ?>",
-    "elementId": "<?= $block->getHtmlId() ?>",
-    "successText": "<?= $block->escapeHtmlAttr(__('Successful! Test again?')) ?>",
-    "failedText": "<?= $block->escapeHtmlAttr(__('Connection failed! Test again?')) ?>",
-    "fieldMapping": "<?= /* @noEscape */ $block->getFieldMapping() ?>"}, "validation": {}}'>
-    <span id="<?= $block->getHtmlId() ?>_result"><?= $block->escapeHtml($block->getButtonLabel()) ?></span>
+<button class="scalable" type="button" id="<?= $block->getHtmlId(); ?>" data-mage-init='{"testConnection":{
+    "url": "<?= $escaper->escapeUrl($block->getAjaxUrl()); ?>",
+    "elementId": "<?= $block->getHtmlId(); ?>",
+    "successText": "<?= $escaper->escapeHtmlAttr(__('Successful! Test again?')); ?>",
+    "failedText": "<?= $escaper->escapeHtmlAttr(__('Connection failed! Test again?')); ?>",
+    "fieldMapping": "<?= /* @noEscape */ $block->getFieldMapping(); ?>"}, "validation": {}}'>
+    <span id="<?= $block->getHtmlId(); ?>_result"><?= $escaper->escapeHtml($block->getButtonLabel()); ?></span>
 </button>

--- a/app/code/Magento/AdvancedSearch/view/frontend/templates/search_data.phtml
+++ b/app/code/Magento/AdvancedSearch/view/frontend/templates/search_data.phtml
@@ -3,25 +3,30 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\AdvancedSearch\Block\SearchData $block
- * @var \Magento\Framework\Locale\LocaleFormatter $localeFormatter
- */
-?>
-<?php
-/** @var \Magento\Search\Model\QueryResult[] $data */
+use Magento\AdvancedSearch\Block\SearchData;
+use Magento\Framework\Escaper;
+use Magento\Framework\Locale\LocaleFormatter;
+use Magento\Search\Model\QueryResult;
+
+/** @var SearchData $block */
+/** @var Escaper $escaper */
+/** @var LocaleFormatter $localeFormatter */
+/** @var QueryResult[] $data */
 $data = $block->getItems();
-if (count($data)): ?>
+?>
+<?php if (count($data)): ?>
     <dl class="block">
-        <dt class="title"><?= $block->escapeHtml(__($block->getTitle())) ?></dt>
+        <dt class="title"><?= $escaper->escapeHtml(__($block->getTitle())); ?></dt>
         <?php foreach ($data as $additionalInfo): ?>
             <dd class="item">
-                <a href="<?= $block->escapeUrl($block->getLink($additionalInfo->getQueryText())) ?>"
-                    ><?= $block->escapeHtml($additionalInfo->getQueryText()) ?></a>
+                <a href="<?= $escaper->escapeUrl($block->getLink($additionalInfo->getQueryText())); ?>">
+                    <?= $escaper->escapeHtml($additionalInfo->getQueryText()); ?>
+                </a>
                 <?php if ($block->isShowResultsCount()): ?>
                     <span class="count">
-                        <?= /* @noEscape */ $localeFormatter->formatNumber((int)$additionalInfo->getResultsCount()) ?>
+                        <?= /* @noEscape */ $localeFormatter->formatNumber((int)$additionalInfo->getResultsCount()); ?>
                     </span>
                 <?php endif; ?>
             </dd>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_AdvancedSearch` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37097: Chore: Advanced Search - Replace Block Escaping with Escaper