### PR TITLE
Chore: Backend - Replace Deprecated Output Escaping

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/access_denied.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/access_denied.phtml
@@ -3,30 +3,50 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @see \Magento\Backend\Block\Denied
- */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Denied;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Denied $block */
 
 // phpcs:disable Magento2.Security.Superglobal
 ?>
 <hr class="access-denied-hr"/>
 <div class="access-denied-page">
-    <h2 class="page-heading"><?= $block->escapeHtml(__('Sorry, you need permissions to view this content.')) ?></h2>
-    <strong><?= $block->escapeHtml(__('Next steps')) ?></strong>
+    <h2 class="page-heading">
+        <?= $escaper->escapeHtml(__('Sorry, you need permissions to view this content.')); ?>
+    </h2>
+    <strong><?= $escaper->escapeHtml(__('Next steps')); ?></strong>
     <ul>
-        <li><span><?= $block->escapeHtml(__('If you think this is an error, try signing out and signing in again.'))  ?></span></li>
-        <li><span><?= $block->escapeHtml(__('Contact a system administrator or store owner to gain permissions.')) ?></span></li>
         <li>
-            <span><?= $block->escapeHtml(__('Return to ')) ?>
-                <?php if (isset($_SERVER['HTTP_REFERER'])) : ?>
-                    <a href="<?= $block->escapeUrl($_SERVER['HTTP_REFERER']) ?>">
-                        <?= $block->escapeHtml(__('previous page')) ?></a><?= $block->escapeHtml(__('.')) ?>
-                <?php else : ?>
-                    <a href="<?= $block->escapeHtmlAttr('javascript:history.back()') ?>">
-                        <?= $block->escapeHtml(__('previous page')) ?></a><?= $block->escapeHtml(__('.')) ?>
-                <?php endif ?>
+            <span>
+                <?= $escaper->escapeHtml(
+                    __('If you think this is an error, try signing out and signing in again.')
+                ); ?>
+            </span>
+        </li>
+        <li>
+            <span>
+                <?= $escaper->escapeHtml(
+                    __('Contact a system administrator or store owner to gain permissions.')
+                ); ?>
+            </span>
+        </li>
+        <li>
+            <span><?= $escaper->escapeHtml(__('Return to ')); ?>
+                <?php if (isset($_SERVER['HTTP_REFERER'])): ?>
+                    <a href="<?= $escaper->escapeUrl($_SERVER['HTTP_REFERER']); ?>">
+                        <?= $escaper->escapeHtml(__('previous page')); ?>
+                    </a>
+                    <?= $escaper->escapeHtml(__('.')); ?>
+                <?php else: ?>
+                    <a href="<?= $escaper->escapeHtmlAttr('javascript:history.back()'); ?>">
+                        <?= $escaper->escapeHtml(__('previous page')); ?>
+                    </a>
+                    <?= $escaper->escapeHtml(__('.')); ?>
+                <?php endif; ?>
             </span>
         </li>
     </ul>

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/formkey.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/formkey.phtml
@@ -3,5 +3,10 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<div><input name="form_key" type="hidden" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" /></div>
+<div><input name="form_key" type="hidden" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()); ?>"/></div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/login.phtml
@@ -3,21 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/**
- * @var \Magento\Framework\View\Element\AbstractBlock $block
- */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\AbstractBlock;
+
+/** @var Escaper $escaper */
+/** @var AbstractBlock $block */
 ?>
-
 <form method="post" action="" id="login-form" data-mage-init='{"form": {}, "validation": {}}' autocomplete="off">
     <fieldset class="admin__fieldset">
         <legend class="admin__legend">
-            <span><?= $block->escapeHtml(__('Welcome, please sign in')) ?></span>
+            <span><?= $escaper->escapeHtml(__('Welcome, please sign in')); ?></span>
         </legend><br/>
-        <input name="form_key" type="hidden" value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>" />
+        <input name="form_key" type="hidden" value="<?= $escaper->escapeHtmlAttr($block->getFormKey()); ?>"/>
         <div class="admin__field _required field-username">
             <label for="username" class="admin__field-label">
-                <span><?= $block->escapeHtml(__('Username')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Username')); ?></span>
             </label>
             <div class="admin__field-control">
                 <input id="username"
@@ -27,14 +29,13 @@
                        autofocus
                        value=""
                        data-validate="{required:true}"
-                       placeholder="<?= $block->escapeHtmlAttr(__('user name')) ?>"
-                       autocomplete="off"
-                    />
+                       placeholder="<?= $escaper->escapeHtmlAttr(__('user name')); ?>"
+                       autocomplete="off"/>
             </div>
         </div>
         <div class="admin__field _required field-password">
             <label for="login" class="admin__field-label">
-                <span><?= $block->escapeHtml(__('Password')) ?></span>
+                <span><?= $escaper->escapeHtml(__('Password')); ?></span>
             </label>
             <div class="admin__field-control">
                 <input id="login"
@@ -43,14 +44,13 @@
                        name="login[password]"
                        data-validate="{required:true}"
                        value=""
-                       placeholder="<?= $block->escapeHtmlAttr(__('password')) ?>"
-                       autocomplete="off"
-                    />
+                       placeholder="<?= $escaper->escapeHtmlAttr(__('password')); ?>"
+                       autocomplete="off"/>
             </div>
         </div>
-        <?= $block->getChildHtml('form.additional.info') ?>
+        <?= $block->getChildHtml('form.additional.info'); ?>
         <div class="form-actions">
-            <?= $block->getChildHtml('form.buttons') ?>
+            <?= $block->getChildHtml('form.buttons'); ?>
         </div>
     </fieldset>
 </form>

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/login_buttons.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/login_buttons.phtml
@@ -3,11 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="actions">
-    <button
-        <?php $block->getUiId(); ?>
-        class="action-login action-primary">
-        <span><?= $block->escapeHtml(__('Sign in')) ?></span>
+    <button <?php $block->getUiId(); ?>
+            class="action-login action-primary">
+        <span><?= $escaper->escapeHtml(__('Sign in')); ?></span>
     </button>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/overlay_popup.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/overlay_popup.phtml
@@ -3,34 +3,42 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="wrapper-popup">
     <div class="middle" id="anchor-content">
         <div id="page:main-container">
-        <?php if ($block->getChildHtml('left')) : ?>
-            <div class="columns <?= $block->escapeHtmlAttr($block->getContainerCssClass()) ?>" id="page:container">
-                <div id="page:left" class="side-col">
-                    <?= $block->getChildHtml('left') ?>
-                </div>
-                <div class="main-col" id="content">
-                    <div class="main-col-inner">
-                        <div id="messages" class="messages" data-container-for="messages">
-                            <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
+            <?php if ($block->getChildHtml('left')): ?>
+                <div class="columns <?= $escaper->escapeHtmlAttr($block->getContainerCssClass()); ?>"
+                     id="page:container">
+                    <div id="page:left" class="side-col">
+                        <?= $block->getChildHtml('left'); ?>
+                    </div>
+                    <div class="main-col" id="content">
+                        <div class="main-col-inner">
+                            <div id="messages" class="messages" data-container-for="messages">
+                                <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml(); ?>
+                            </div>
+                            <?= $block->getChildHtml('content'); ?>
                         </div>
-                        <?= $block->getChildHtml('content') ?>
                     </div>
                 </div>
-            </div>
-        <?php else : ?>
-          <div id="messages" data-container-for="messages"><?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?></div>
-          <?= $block->getChildHtml('content') ?>
-        <?php endif; ?>
-         </div>
+            <?php else: ?>
+                <div id="messages" data-container-for="messages">
+                    <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml(); ?>
+                </div>
+                <?= $block->getChildHtml('content'); ?>
+            <?php endif; ?>
+        </div>
     </div>
-    <?php if ($block->getChildHtml('footer')) : ?>
-    <div class="footer">
-        <?= $block->getChildHtml('footer') ?>
-    </div>
+    <?php if ($block->getChildHtml('footer')): ?>
+        <div class="footer">
+            <?= $block->getChildHtml('footer'); ?>
+        </div>
     <?php endif; ?>
-    <?= $block->getChildHtml('js') ?>
+    <?= $block->getChildHtml('js'); ?>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/admin/page.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/admin/page.phtml
@@ -3,53 +3,63 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Page;
+use Magento\Framework\Escaper;
+
+/** @var Page $block */
+/** @var Escaper $escaper */
 ?>
-<?php /** @var $block \Magento\Backend\Block\Page */ ?>
 <!doctype html>
-<html lang="<?= $block->escapeHtmlAttr($block->getLang()) ?>" class="no-js">
+<html lang="<?= $escaper->escapeHtmlAttr($block->getLang()); ?>" class="no-js">
 
 <head>
-    <?= $block->getChildHtml('head') ?>
+    <?= $block->getChildHtml('head'); ?>
 </head>
 
-<body id="html-body" class="<?= $block->escapeHtmlAttr($block->getBodyClass()) ?>" data-container="body" data-mage-init='{"loaderAjax":{},"loader":{}}'>
+<body id="html-body"
+      class="<?= $escaper->escapeHtmlAttr($block->getBodyClass()); ?>"
+      data-container="body"
+      data-mage-init='{"loaderAjax":{},"loader":{}}'>
     <div class="page-wrapper">
-        <?= $block->getChildHtml('notification_window') ?>
-        <?= $block->getChildHtml('global_notices') ?>
+        <?= $block->getChildHtml('notification_window'); ?>
+        <?= $block->getChildHtml('global_notices'); ?>
         <div class="page-header-wrapper">
-            <?= $block->getChildHtml('header') ?>
+            <?= $block->getChildHtml('header'); ?>
         </div>
-        <?= $block->getChildHtml('menu') ?>
-        <?= $block->getChildHtml('notifications') ?>
+        <?= $block->getChildHtml('menu'); ?>
+        <?= $block->getChildHtml('notifications'); ?>
 
         <main class="page-content" id="anchor-content">
-            <?= $block->getChildHtml('main-top') ?>
+            <?= $block->getChildHtml('main-top'); ?>
             <div class="messages" id="messages" data-container-for="messages">
-                <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
+                <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml(); ?>
             </div>
-            <?= $block->getChildHtml('page_main_actions') ?>
-            <?php if ($block->getChildHtml('left')) : ?>
-                <div id="page:main-container" class="<?= $block->escapeHtmlAttr($block->getContainerCssClass()) ?> col-2-left-layout">
+            <?= $block->getChildHtml('page_main_actions'); ?>
+            <?php if ($block->getChildHtml('left')): ?>
+                <div id="page:main-container"
+                     class="<?= $escaper->escapeHtmlAttr($block->getContainerCssClass()); ?> col-2-left-layout">
                     <div class="main-col" id="content">
-                        <?= $block->getChildHtml('content') ?>
+                        <?= $block->getChildHtml('content'); ?>
                     </div>
 
                     <div class="side-col" id="page:left">
-                        <?= $block->getChildHtml('left') ?>
+                        <?= $block->getChildHtml('left'); ?>
                     </div>
                 </div>
-            <?php else : ?>
+            <?php else: ?>
                 <div id="page:main-container" class="col-1-layout">
-                    <?= $block->getChildHtml('content') ?>
+                    <?= $block->getChildHtml('content'); ?>
                 </div>
             <?php endif; ?>
         </main>
 
-        <?= $block->getChildHtml('js') ?>
+        <?= $block->getChildHtml('js'); ?>
         <footer class="page-footer">
-            <?= $block->getChildHtml('footer') ?>
+            <?= $block->getChildHtml('footer'); ?>
         </footer>
     </div>
-    <?= $block->getChildHtml('before_body_end') ?>
+    <?= $block->getChildHtml('before_body_end'); ?>
 </body>
 </html>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/graph.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/graph.phtml
@@ -3,6 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Helper\Dashboard\Data;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 /**
  * @deprecated dashboard graphs were migrated to dynamic chart.js solution
  * @see Magento_Backend::dashboard/chart.phtml
@@ -11,30 +18,40 @@
 ?>
 <div class="dashboard-diagram">
     <div class="dashboard-diagram-switcher">
-        <label for="order_<?= $block->getHtmlId() ?>_period"
-               class="label"><?= $block->escapeHtml(__('Select Range:')) ?></label>
-        <select name="period" id="order_<?= $block->getHtmlId() ?>_period"
-                onchange="changeDiagramsPeriod(this);" class="admin__control-select">
+        <label for="order_<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>_period"
+               class="label">
+            <?= $escaper->escapeHtml(__('Select Range:')); ?>
+        </label>
+        <select name="period"
+                id="order_<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>_period"
+                onchange="changeDiagramsPeriod(this);"
+                class="admin__control-select">
             <?php //phpcs:disable ?>
-            <?php foreach ($this->helper(\Magento\Backend\Helper\Dashboard\Data::class)->getDatePeriods() as $value => $label) : ?>
-                <?php
-                //phpcs:enable
-                if (in_array($value, ['custom'])) {
-                    continue;
-                } ?>
-                <option value="<?= /* @noEscape */ $value ?>"
-                    <?php if ($block->getRequest()->getParam('period') == $value) : ?> selected="selected"<?php endif; ?>
-                    ><?= $block->escapeHtml($label) ?></option>
+            <?php foreach ($this->helper(Data::class)->getDatePeriods() as $value => $label): ?>
+                <?php //phpcs:enable ?>
+                <?php if (in_array($value, ['custom'])): ?>
+                    <?php continue; ?>
+                <?php endif; ?>
+
+                <option value="<?= /* @noEscape */ $value; ?>"
+                        <?php if ($block->getRequest()->getParam('period') == $value): ?>
+                            selected="selected"
+                        <?php endif; ?>>
+                    <?= $escaper->escapeHtml($label); ?>
+                </option>
             <?php endforeach; ?>
         </select>
     </div>
-    <?php if ($block->getCount()) : ?>
-    <div class="dashboard-diagram-image">
-        <img src="<?= $block->escapeUrl($block->getChartUrl(false)) ?>" class="dashboard-diagram-chart" alt="Chart" title="Chart" />
-    </div>
+    <?php if ($block->getCount()): ?>
+        <div class="dashboard-diagram-image">
+            <img src="<?= $escaper->escapeUrl($block->getChartUrl(false)); ?>"
+                 class="dashboard-diagram-chart"
+                 alt="<?= $escaper->escapeHtmlAttr(__('Chart')); ?>"
+                 title="<?= $escaper->escapeHtmlAttr(__('Chart')); ?>"/>
+        </div>
     <?php else : ?>
-    <div class="dashboard-diagram-nodata">
-        <span><?= $block->escapeHtml(__('No Data Found')) ?></span>
-    </div>
+        <div class="dashboard-diagram-nodata">
+            <span><?= $escaper->escapeHtml(__('No Data Found')); ?></span>
+        </div>
     <?php endif; ?>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/graph/disabled.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/graph/disabled.phtml
@@ -3,6 +3,12 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
 /**
  * @deprecated dashboard graphs were migrated to dynamic chart.js solution
  * @see Magento_Backend::dashboard/chart/disabled.phtml
@@ -10,5 +16,11 @@
  */
 ?>
 <div class="dashboard-diagram-disabled">
-    <?= /* @noEscape */ __('Chart is disabled. To enable the chart, click <a href="%1">here</a>.', $block->escapeUrl($block->getConfigUrl())) ?>
+    <?= $escaper->escapeHtml(
+        __(
+            'Chart is disabled. To enable the chart, click <a href="%1">here</a>.',
+            $escaper->escapeUrl($block->getConfigUrl())
+        ),
+        ['a']
+    ); ?>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/grid.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/grid.phtml
@@ -3,18 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 $numColumns = count($block->getColumns());
 ?>
 <?php if ($block->getCollection()): ?>
     <div class="dashboard-item-content">
         <?php if ($block->getCollection()->getSize() > 0): ?>
             <table class="admin__table-primary dashboard-data"
-                   id="<?= $block->escapeHtmlAttr($block->getId()) ?>_table">
+                   id="<?= $escaper->escapeHtmlAttr($block->getId()); ?>_table">
                 <?php
                 /* This part is commented to remove all <col> tags from the code. */
                 /* foreach ($block->getColumns() as $_column): ?>
@@ -25,7 +27,7 @@ $numColumns = count($block->getColumns());
                     <?php if ($block->getHeadersVisibility()): ?>
                         <tr>
                             <?php foreach ($block->getColumns() as $_column): ?>
-                                <?= $_column->getHeaderHtml() ?>
+                                <?= $_column->getHeaderHtml(); ?>
                             <?php endforeach; ?>
                         </tr>
                     <?php endif; ?>
@@ -34,12 +36,16 @@ $numColumns = count($block->getColumns());
                 <?php if (!$block->getIsCollapsed()): ?>
                     <tbody>
                     <?php foreach ($block->getCollection() as $_index => $_item): ?>
-                        <tr title="<?= $block->escapeHtmlAttr($block->getRowUrl($_item)) ?>">
-                            <?php $i = 0; foreach ($block->getColumns() as $_column): ?>
-                                <td class="<?= $block->escapeHtmlAttr($_column->getCssProperty());
-                                ?> <?= /* @noEscape */ ++$i == $numColumns ? 'last' : '';
-?>"><?= /* @noEscape */ (($_html = $_column->getRowField($_item)) != '' ?
-                                        $_html : '&nbsp;') ?></td>
+                        <tr title="<?= $escaper->escapeHtmlAttr($block->getRowUrl($_item)); ?>">
+                            <?php $i = 0; ?>
+                            <?php foreach ($block->getColumns() as $_column): ?>
+                                <td class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()); ?>
+                                    <?= /* @noEscape */ ++$i == $numColumns ? ' last' : ''; ?>">
+                                    <?= /* @noEscape */ (($_html = $_column->getRowField($_item)) != ''
+                                        ? $_html
+                                        : '&nbsp;'
+                                    ); ?>
+                                </td>
                             <?php endforeach; ?>
                         </tr>
                     <?php endforeach; ?>
@@ -47,8 +53,9 @@ $numColumns = count($block->getColumns());
                 <?php endif; ?>
             </table>
         <?php else: ?>
-            <div class="<?= $block->escapeHtmlAttr($block->getEmptyTextClass());
-            ?>"><?= $block->escapeHtml($block->getEmptyText()) ?></div>
+            <div class="<?= $escaper->escapeHtmlAttr($block->getEmptyTextClass()); ?>">
+                <?= $escaper->escapeHtml($block->getEmptyText()); ?>
+            </div>
         <?php endif; ?>
     </div>
     <?php if ($block->canDisplayContainer()): ?>
@@ -68,34 +75,35 @@ $numColumns = count($block->getColumns());
         '//TODO: getJsObjectName and getRowClickCallback has unexpected behavior. Should be removed' . PHP_EOL;
 
         if ($block->getDependencyJsObject()) {
-            $scriptString .= 'registry.get(\'' . $block->escapeJs($block->getDependencyJsObject()) .
-                '\', function ('. $block->escapeJs($block->getDependencyJsObject()) . ') {' . PHP_EOL;
+            $scriptString .= 'registry.get(\'' . $escaper->escapeJs($block->getDependencyJsObject()) .
+                '\', function ('. $escaper->escapeJs($block->getDependencyJsObject()) . ') {' . PHP_EOL;
         }
 
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . ' = new varienGrid(\'' .
-            $block->escapeJs($block->getId()) . '\', \'' . $block->escapeJs($block->getGridUrl()) . '\', \'' .
-            $block->escapeJs($block->getVarNamePage()) .'\', \'' .
-            $block->escapeJs($block->getVarNameSort()) . '\', \'' .
-            $block->escapeJs($block->getVarNameDir()) . '\', \'' .
-            $block->escapeJs($block->getVarNameFilter()) .'\');' . PHP_EOL;
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . ' = new varienGrid(\'' .
+            $escaper->escapeJs($block->getId()) . '\', \'' . $escaper->escapeJs($block->getGridUrl()) . '\', \'' .
+            $escaper->escapeJs($block->getVarNamePage()) .'\', \'' .
+            $escaper->escapeJs($block->getVarNameSort()) . '\', \'' .
+            $escaper->escapeJs($block->getVarNameDir()) . '\', \'' .
+            $escaper->escapeJs($block->getVarNameFilter()) .'\');' . PHP_EOL;
 
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) .'.useAjax = \'' .
-            $block->escapeJs($block->getUseAjax()) . '\';' . PHP_EOL;
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) .'.useAjax = \'' .
+            $escaper->escapeJs($block->getUseAjax()) . '\';' . PHP_EOL;
+
         if ($block->getRowClickCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.rowClickCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.rowClickCallback = ' .
                 /* @noEscape */ $block->getRowClickCallback() . ';' . PHP_EOL;
         }
 
         if ($block->getCheckboxCheckCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.checkboxCheckCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.checkboxCheckCallback = ' .
                 /* @noEscape */ $block->getCheckboxCheckCallback() . ';' . PHP_EOL;
         }
 
         if ($block->getRowInitCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.initRowCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.initRowCallback = ' .
                 /* @noEscape */ $block->getRowInitCallback() . ';' . PHP_EOL;
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.rows.each(function(row){' .
-                /* @noEscape */ $block->getRowInitCallback() . '(' . $block->escapeJs($block->getJsObjectName()) .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.rows.each(function(row){' .
+                /* @noEscape */ $block->getRowInitCallback() . '(' . $escaper->escapeJs($block->getJsObjectName()) .
                 ', row)});' . PHP_EOL;
         }
 

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/index.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/index.phtml
@@ -3,42 +3,45 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+?>
 <div class="dashboard-container row">
     <div class="dashboard-main col-m-8 col-m-push-4">
         <div class="dashboard-diagram-container">
-            <?= $block->getChildHtml('chartDisabled') ?>
-            <?= $block->getChildHtml('diagrams') ?>
-            <?php
-                $diagramsBlock = $block->getChildBlock('diagrams');
-                $tabsIds = $diagramsBlock ? $diagramsBlock->getTabsIds() : [];
-            ?>
+            <?= $block->getChildHtml('chartDisabled'); ?>
+            <?= $block->getChildHtml('diagrams'); ?>
+            <?php $diagramsBlock = $block->getChildBlock('diagrams'); ?>
+            <?php $tabsIds = $diagramsBlock ? $diagramsBlock->getTabsIds() : []; ?>
+
             <?php if (is_array($tabsIds)): ?>
-                <?= $block->getChildHtml('diagramsPeriod') ?>
+                <?= $block->getChildHtml('diagramsPeriod'); ?>
                 <div id="diagram_tab_content" class="dashboard-diagram-tab-content"></div>
             <?php endif; ?>
         </div>
-        <?= $block->getChildHtml('totals') ?>
+        <?= $block->getChildHtml('totals'); ?>
         <div class="dashboard-store-stats">
-            <?= $block->getChildHtml('grids') ?>
+            <?= $block->getChildHtml('grids'); ?>
             <div id="grid_tab_content" class="dashboard-store-stats-content"></div>
-            <?= $block->getChildHtml('refresh_statistics') ?>
+            <?= $block->getChildHtml('refresh_statistics'); ?>
         </div>
     </div>
     <div class="dashboard-secondary col-m-4 col-m-pull-8">
-        <?= $block->getChildHtml('sales') ?>
+        <?= $block->getChildHtml('sales'); ?>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?= $block->escapeHtml(__('Last Orders')) ?></div>
-            <?= $block->getChildHtml('lastOrders') ?>
+            <div class="dashboard-item-title"><?= $escaper->escapeHtml(__('Last Orders')); ?></div>
+            <?= $block->getChildHtml('lastOrders'); ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?= $block->escapeHtml(__('Last Search Terms')) ?></div>
-            <?= $block->getChildHtml('lastSearches') ?>
+            <div class="dashboard-item-title"><?= $escaper->escapeHtml(__('Last Search Terms')); ?></div>
+            <?= $block->getChildHtml('lastSearches'); ?>
         </div>
         <div class="dashboard-item">
-            <div class="dashboard-item-title"><?= $block->escapeHtml(__('Top Search Terms')) ?></div>
-            <?= $block->getChildHtml('topSearches') ?>
+            <div class="dashboard-item-title"><?= $escaper->escapeHtml(__('Top Search Terms')); ?></div>
+            <?= $block->getChildHtml('topSearches'); ?>
         </div>
     </div>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/salebar.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/salebar.phtml
@@ -3,15 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php if (count($block->getTotals()) > 0) : ?>
-    <?php foreach ($block->getTotals() as $_total) : ?>
+<?php if (count($block->getTotals()) > 0): ?>
+    <?php foreach ($block->getTotals() as $_total): ?>
     <div class="dashboard-item dashboard-item-primary">
-        <div class="dashboard-item-title"><?= $block->escapeHtml($_total['label']) ?></div>
+        <div class="dashboard-item-title"><?= $escaper->escapeHtml($_total['label']); ?></div>
         <div class="dashboard-item-content">
             <strong class="dashboard-sales-value">
-                <?= /* @noEscape */ $_total['value'] ?>
-                <span class="dashboard-sales-decimals"><?= /* @noEscape */ $_total['decimals'] ?></span>
+                <?= /* @noEscape */ $_total['value']; ?>
+                <span class="dashboard-sales-decimals"><?= /* @noEscape */ $_total['decimals']; ?></span>
             </strong>
         </div>
     </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/searches.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/searches.phtml
@@ -3,13 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php if (count($block->getCollection()->getItems()) > 0) : ?>
+<?php if (count($block->getCollection()->getItems()) > 0): ?>
     <div class="searches-results">
-        <?php foreach ($block->getCollection()->getItems() as $item) : ?>
-        <span><?= $block->escapeHtml($item->getQueryText()) ?></span><br />
+        <?php foreach ($block->getCollection()->getItems() as $item): ?>
+            <span><?= $escaper->escapeHtml($item->getQueryText()); ?></span><br/>
         <?php endforeach; ?>
     </div>
-<?php else : ?>
-    <div class="empty-text"><?= $block->escapeHtml(__('There are no search keywords.')) ?></div>
+<?php else: ?>
+    <div class="empty-text"><?= $escaper->escapeHtml(__('There are no search keywords.')); ?></div>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/store/switcher.phtml
@@ -3,48 +3,69 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<p class="switcher"><label for="store_switcher"><?= $block->escapeHtml(__('View Statistics For:')) ?></label>
-<?= $block->getHintHtml() ?>
-<select name="store_switcher" id="store_switcher" class="left-col-block">
-    <option value=""><?= $block->escapeHtml(__('All Websites')) ?></option>
-    <?php foreach ($block->getWebsiteCollection() as $_website): ?>
-        <?php $showWebsite = false; ?>
-        <?php foreach ($block->getGroupCollection($_website) as $_group): ?>
-            <?php $showGroup = false; ?>
-            <?php foreach ($block->getStoreCollection($_group) as $_store): ?>
-                <?php if ($showWebsite == false): ?>
-                    <?php $showWebsite = true; ?>
-                    <option website="true"
-                            value="<?= $block->escapeHtmlAttr($_website->getId()) ?>"<?php
-                            if ($block->getRequest()->getParam('website') == $_website->getId()):
-                                ?> selected="selected"<?php endif; ?>><?= $block->escapeHtml($_website->getName()) ?>
+<p class="switcher">
+    <label for="store_switcher"><?= $escaper->escapeHtml(__('View Statistics For:')); ?></label>
+    <?= $block->getHintHtml(); ?>
+    <select name="store_switcher" id="store_switcher" class="left-col-block">
+        <option value=""><?= $escaper->escapeHtml(__('All Websites')); ?></option>
+
+        <?php foreach ($block->getWebsiteCollection() as $_website): ?>
+            <?php $showWebsite = false; ?>
+
+            <?php foreach ($block->getGroupCollection($_website) as $_group): ?>
+                <?php $showGroup = false; ?>
+
+                <?php foreach ($block->getStoreCollection($_group) as $_store): ?>
+                    <?php if ($showWebsite == false): ?>
+                        <?php $showWebsite = true; ?>
+                        <option website="true"
+                                value="<?= $escaper->escapeHtmlAttr($_website->getId()); ?>"
+                                <?php if ($block->getRequest()->getParam('website') == $_website->getId()): ?>
+                                    selected="selected"
+                                <?php endif; ?>>
+                            <?= $escaper->escapeHtml($_website->getName()); ?>
+                        </option>
+                    <?php endif; ?>
+
+                    <?php if ($showGroup == false): ?>
+                        <?php $showGroup = true; ?>
+                        <!--optgroup label="&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtmlAttr($_group->getName()); ?>"-->
+                        <option group="true"
+                                value="<?= $escaper->escapeHtmlAttr($_group->getId()); ?>"
+                                <?php if ($block->getRequest()->getParam('group') == $_group->getId()): ?>
+                                    selected="selected"
+                                <?php endif; ?>>
+                            &nbsp;&nbsp;<?= $escaper->escapeHtml($_group->getName()); ?>
+                        </option>
+                    <?php endif; ?>
+
+                    <option value="<?= $escaper->escapeHtmlAttr($_store->getId()); ?>"
+                            <?php if ($block->getStoreId() == $_store->getId()): ?>
+                                selected="selected"
+                            <?php endif; ?>>
+                        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $escaper->escapeHtml($_store->getName()); ?>
                     </option>
+                <?php endforeach; ?>
+
+                <?php if ($showGroup): ?>
+                    <!--</optgroup>-->
                 <?php endif; ?>
-                <?php if ($showGroup == false): ?>
-                    <?php $showGroup = true; ?>
-                    <!--optgroup label="&nbsp;&nbsp;&nbsp;<?= $block->escapeHtmlAttr($_group->getName()) ?>"-->
-                    <option group="true" value="<?= $block->escapeHtmlAttr($_group->getId()) ?>"<?php
-                    if ($block->getRequest()->getParam('group') == $_group->getId()): ?> selected="selected"<?php
-                    endif; ?>>&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_group->getName()) ?></option>
-                <?php endif; ?>
-                <option value="<?= $block->escapeHtmlAttr($_store->getId()) ?>"<?php
-                if ($block->getStoreId() == $_store->getId()): ?> selected="selected"<?php
-                endif; ?>>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?= $block->escapeHtml($_store->getName()) ?></option>
             <?php endforeach; ?>
-            <?php if ($showGroup): ?>
-                <!--</optgroup>-->
-            <?php endif; ?>
         <?php endforeach; ?>
-    <?php endforeach; ?>
-</select>
-<?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
-    'onchange',
-    'return switchStore(this);',
-    'select#store_switcher'
-) ?>
+    </select>
+    <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
+        'onchange',
+        'return switchStore(this);',
+        'select#store_switcher'
+    ); ?>
 </p>
 <?php $scriptString = <<<script
     require([
@@ -69,7 +90,7 @@
                 var select = $('order_amounts_period');
             }
             var periodParam = select.value ? 'period/' + select.value + '/' : '';
-            setLocation('{$block->escapeJs($block->getSwitchUrl())}' + storeParam + periodParam);
+            setLocation('{$escaper->escapeJs($block->getSwitchUrl())}' + storeParam + periodParam);
         }
     });
 script;

--- a/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/dashboard/totalbar/refreshstatistics.phtml
@@ -3,24 +3,27 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="page-actions">
     <div class="page-actions-inner">
         <div class="page-actions-buttons">
-            <?= $block->getChildHtml() ?>
+            <?= $block->getChildHtml(); ?>
 
             <form class="action-element"
-                  action="<?= $block->escapeUrl($block->getUrl('*/*/refreshStatistics')) ?>"
+                  action="<?= $escaper->escapeUrl($block->getUrl('*/*/refreshStatistics')); ?>"
                   method="post">
-                <input
-                    name="form_key"
-                    type="hidden"
-                    value="<?= $block->escapeHtmlAttr($block->getFormKey()) ?>"/>
-                <button
-                    class="action-primary"
-                    type="submit"
-                    title="<?= $block->escapeHtmlAttr(__('Reload Data')) ?>">
-                    <?= $block->escapeHtml(__('Reload Data')) ?>
+                <input name="form_key"
+                       type="hidden"
+                       value="<?= $escaper->escapeHtmlAttr($block->getFormKey()); ?>"/>
+                <button class="action-primary"
+                        type="submit"
+                        title="<?= $escaper->escapeHtmlAttr(__('Reload Data')); ?>">
+                    <?= $escaper->escapeHtml(__('Reload Data')); ?>
                 </button>
             </form>
         </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/media/uploader.phtml
@@ -3,28 +3,38 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Media\Uploader;
+use Magento\Framework\Escaper;
+
+/** @var Uploader $block*/
+/** @var Escaper $escaper */
 
 // phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
-/** @var $block \Magento\Backend\Block\Media\Uploader */
 ?>
-
-<div id="<?= $block->getHtmlId() ?>" class="uploader"
-    data-mage-init='{
-        "Magento_Backend/js/media-uploader" : {
-            "maxFileSize": <?= /* @noEscape */ $block->getFileSizeService()->getMaxFileSize() ?>,
-            "maxWidth": <?= /* @noEscape */ $block->getImageUploadMaxWidth() ?>,
-            "maxHeight": <?= /* @noEscape */ $block->getImageUploadMaxHeight() ?>,
-            "isResizeEnabled": <?= /* @noEscape */ $block->getImageUploadConfigData()->getIsResizeEnabled() ?>
-        }
-    }'
->
+<div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>"
+     class="uploader"
+     data-mage-init='{
+         "Magento_Backend/js/media-uploader" : {
+             "maxFileSize": <?= /* @noEscape */ $block->getFileSizeService()->getMaxFileSize(); ?>,
+             "maxWidth": <?= /* @noEscape */ $block->getImageUploadMaxWidth(); ?>,
+             "maxHeight": <?= /* @noEscape */ $block->getImageUploadMaxHeight(); ?>,
+             "isResizeEnabled": <?= /* @noEscape */ $block->getImageUploadConfigData()->getIsResizeEnabled(); ?>
+         }
+     }'>
     <div class="fileinput-button form-buttons button">
-        <span><?= $block->escapeHtml(__('Browse Files...')) ?></span>
-        <input id="fileupload" type="file" name="<?= $block->escapeHtmlAttr($block->getConfig()->getFileField()) ?>"
-            data-url="<?= $block->escapeHtmlAttr($block->getConfig()->getUrl()) ?>" multiple="multiple" />
+        <span><?= $escaper->escapeHtml(__('Browse Files...')); ?></span>
+        <input id="fileupload"
+               type="file"
+               name="<?= $escaper->escapeHtmlAttr($block->getConfig()->getFileField()); ?>"
+               data-url="<?= $escaper->escapeHtmlAttr($block->getConfig()->getUrl()); ?>"
+               multiple="multiple"/>
     </div>
     <div class="clear"></div>
-    <script id="<?= $block->getHtmlId() ?>-template" type="text/x-magento-template" data-template="uploader">
+    <script id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>-template"
+            type="text/x-magento-template"
+            data-template="uploader">
         <div id="<%- data.id %>" class="file-row">
             <span class="file-info"><%- data.name %> (<%- data.size %>)</span>
             <div class="progressbar-container">
@@ -34,4 +44,3 @@
         </div>
     </script>
 </div>
-

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/copyright.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/copyright.phtml
@@ -3,6 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<a class="link-copyright" href="http://magento.com" target="_blank" title="<?= $block->escapeHtmlAttr(__('Magento')) ?>"></a>
-<?= $block->escapeHtml(__('Copyright &copy; %1 Magento Commerce Inc. All rights reserved.', date('Y'))) ?>
+<a class="link-copyright"
+   href="http://magento.com"
+   target="_blank"
+   title="<?= $escaper->escapeHtmlAttr(__('Magento')); ?>">
+</a>
+<?= $escaper->escapeHtml(__('Copyright &copy; %1 Magento Commerce Inc. All rights reserved.', date('Y'))); ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/footer.phtml
@@ -3,8 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <p class="magento-version">
-    <strong><?= $block->escapeHtml(__('Magento')) ?></strong>
-    <?= $block->escapeHtml(__('ver. %1', $block->getMagentoVersion())) ?>
+    <strong><?= $escaper->escapeHtml(__('Magento')); ?></strong>
+    <?= $escaper->escapeHtml(__('ver. %1', $block->getMagentoVersion())); ?>
 </p>

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/header.phtml
@@ -3,62 +3,75 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Backend\Block\Page\Header */
+use Magento\Backend\Block\Page\Header;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Header $block */
 $part = $block->getShowPart();
 ?>
-<?php if ($part === 'logo') : ?>
-        <?php $edition = $block->hasEdition() ? 'data-edition="' . $block->escapeHtml($block->getEdition()) . '"' : ''; ?>
-        <?php $logoSrc = ($block->hasLogoImageSrc()) ? $block->escapeHtml($block->getLogoImageSrc()) : 'images/magento-logo.svg' ?>
-        <a
-            href="<?= $block->escapeUrl($block->getHomeLink()) ?>"
-            <?= /* @noEscape */ $edition ?>
-            class="logo">
-            <img class="logo-img" src="<?= /* @noEscape */ $block->getViewFileUrl($logoSrc) ?>"
-            alt="<?= $block->escapeHtml(__('Magento Admin Panel')) ?>" title="<?= $block->escapeHtml(__('Magento Admin Panel')) ?>"/>
-        </a>
-<?php elseif ($part === 'user') : ?>
-        <div class="admin-user admin__action-dropdown-wrap">
-            <a
-                href="<?= /* @noEscape */ $block->getUrl('adminhtml/system_account/index') ?>"
-                class="admin__action-dropdown"
-                title="<?= $block->escapeHtml(__('My Account')) ?>"
-                data-mage-init='{"dropdown":{}}'
-                data-toggle="dropdown">
-                <span class="admin__action-dropdown-text">
-                    <span class="admin-user-account-text"><?= $block->escapeHtml($block->getUser()->getUserName()) ?></span>
+<?php if ($part === 'logo'): ?>
+    <?php $edition = $block->hasEdition()
+        ? 'data-edition="' . $escaper->escapeHtmlAttr($block->getEdition()) . '"'
+        : ''; ?>
+    <?php $logoSrc = ($block->hasLogoImageSrc())
+        ? $escaper->escapeHtml($block->getLogoImageSrc())
+        : 'images/magento-logo.svg'; ?>
+    <a href="<?= $escaper->escapeUrl($block->getHomeLink()); ?>"
+       <?= /* @noEscape */ $edition; ?>
+       class="logo">
+        <img class="logo-img"
+             src="<?= $escaper->escapeUrl($block->getViewFileUrl($logoSrc)); ?>"
+             alt="<?= $escaper->escapeHtmlAttr(__('Magento Admin Panel')); ?>"
+             title="<?= $escaper->escapeHtmlAttr(__('Magento Admin Panel')); ?>"/>
+    </a>
+<?php elseif ($part === 'user'): ?>
+    <div class="admin-user admin__action-dropdown-wrap">
+        <a href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/system_account/index')); ?>"
+           class="admin__action-dropdown"
+           title="<?= $escaper->escapeHtmlAttr(__('My Account')); ?>"
+           data-mage-init='{"dropdown":{}}'
+           data-toggle="dropdown">
+            <span class="admin__action-dropdown-text">
+                <span class="admin-user-account-text">
+                    <?= $escaper->escapeHtml($block->getUser()->getUserName()); ?>
                 </span>
-            </a>
-            <ul class="admin__action-dropdown-menu">
-                <?php if ($block->getAuthorization()->isAllowed('Magento_Backend::myaccount')) : ?>
-                <li>
-                    <a
-                        href="<?= /* @noEscape */ $block->getUrl('adminhtml/system_account/index') ?>"
-                        <?= /* @noEscape */ $block->getUiId('user', 'account', 'settings') ?>
-                        title="<?= $block->escapeHtml(__('Account Setting')) ?>">
-                        <?= $block->escapeHtml(__('Account Setting')) ?> (<span class="admin-user-name"><?= $block->escapeHtml($block->getUser()->getUserName()) ?></span>)
-                    </a>
-                </li>
-                <?php endif; ?>
-                <li>
-                    <a
-                        href="<?= /* @noEscape */ $block->getBaseUrl() ?>"
-                        title="<?= $block->escapeHtml(__('Customer View')) ?>"
-                        target="_blank" class="store-front">
-                        <?= $block->escapeHtml(__('Customer View')) ?>
-                    </a>
-                </li>
-                <li>
-                    <a
-                        href="<?= /* @noEscape */ $block->getLogoutLink() ?>"
-                        class="account-signout"
-                        title="<?= $block->escapeHtml(__('Sign Out')) ?>">
-                        <?= $block->escapeHtml(__('Sign Out')) ?>
-                    </a>
-                </li>
-            </ul>
-        </div>
-
-<?php elseif ($part === 'other') : ?>
-    <?= $block->getChildHtml() ?>
+            </span>
+        </a>
+        <ul class="admin__action-dropdown-menu">
+            <?php if ($block->getAuthorization()->isAllowed('Magento_Backend::myaccount')): ?>
+            <li>
+                <a href="<?= $escaper->escapeUrl($block->getUrl('adminhtml/system_account/index')); ?>"
+                   <?= /* @noEscape */ $block->getUiId('user', 'account', 'settings'); ?>
+                   title="<?= $escaper->escapeHtmlAttr(__('Account Setting')); ?>">
+                    <?= $escaper->escapeHtml(__('Account Setting')); ?>
+                    (
+                    <span class="admin-user-name">
+                        <?= $escaper->escapeHtml($block->getUser()->getUserName()); ?>
+                    </span>
+                    )
+                </a>
+            </li>
+            <?php endif; ?>
+            <li>
+                <a href="<?= $escaper->escapeUrl($block->getBaseUrl()); ?>"
+                   title="<?= $escaper->escapeHtmlAttr(__('Customer View')); ?>"
+                   target="_blank"
+                   class="store-front">
+                    <?= $escaper->escapeHtml(__('Customer View')); ?>
+                </a>
+            </li>
+            <li>
+                <a href="<?= $escaper->escapeUrl($block->getLogoutLink()); ?>"
+                   class="account-signout"
+                   title="<?= $escaper->escapeHtmlAttr(__('Sign Out')); ?>">
+                    <?= $escaper->escapeHtml(__('Sign Out')); ?>
+                </a>
+            </li>
+        </ul>
+    </div>
+<?php elseif ($part === 'other'): ?>
+    <?= $block->getChildHtml(); ?>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/js/calendar.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/js/calendar.phtml
@@ -3,16 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
+declare(strict_types=1);
 
-<?php
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Html\Calendar;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
 /**
  * Calendar localization script. Should be put into page header.
- *
- * @see \Magento\Framework\View\Element\Html\Calendar
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/** @var Escaper $escaper */
+/** @var Calendar $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 $scriptString = '
 require([
@@ -26,16 +29,16 @@ require([
             dayNamesMin: ' . /* @noEscape */ $days['abbreviated'] . ',
             monthNames: ' . /* @noEscape */ $months['wide'] . ',
             monthNamesShort: ' . /* @noEscape */ $months['abbreviated'] . ',
-            infoTitle: "' . $block->escapeJs(__('About the calendar')) . '",
+            infoTitle: "' . $escaper->escapeJs(__('About the calendar')) . '",
             firstDay: ' . /* @noEscape */ $firstDay . ',
-            closeText: "' . $block->escapeJs(__('Close')) . '",
-            currentText: "' . $block->escapeJs(__('Go Today')) . '",
-            prevText: "' . $block->escapeJs(__('Previous')) . '",
-            nextText: "' . $block->escapeJs(__('Next')) . '",
-            weekHeader: "' . $block->escapeJs(__('WK')) . '",
-            timeText: "' . $block->escapeJs(__('Time')) . '",
-            hourText: "' . $block->escapeJs(__('Hour')) . '",
-            minuteText: "' . $block->escapeJs(__('Minute')) . '",
+            closeText: "' . $escaper->escapeJs(__('Close')) . '",
+            currentText: "' . $escaper->escapeJs(__('Go Today')) . '",
+            prevText: "' . $escaper->escapeJs(__('Previous')) . '",
+            nextText: "' . $escaper->escapeJs(__('Next')) . '",
+            weekHeader: "' . $escaper->escapeJs(__('WK')) . '",
+            timeText: "' . $escaper->escapeJs(__('Time')) . '",
+            hourText: "' . $escaper->escapeJs(__('Hour')) . '",
+            minuteText: "' . $escaper->escapeJs(__('Minute')) . '",
             dateFormat: $.datepicker.RFC_2822,
             showOn: "button",
             showAnim: "",
@@ -52,7 +55,7 @@ require([
             showMinute: false,
             serverTimezoneSeconds: ' . (int) $block->getStoreTimestamp() . ',
             serverTimezoneOffset: ' . (int) $block->getTimezoneOffsetSeconds() . ',
-            yearRange: \'' . $block->escapeJs($block->getYearRange()) . '\'
+            yearRange: \'' . $escaper->escapeJs($block->getYearRange()) . '\'
         }
     });
 

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/notices.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/notices.phtml
@@ -3,26 +3,33 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Page\Notices;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Notices $block */
 ?>
-<?php
-/**
- * @see \Magento\Backend\Block\Page\Notices
- */
-?>
-<?php if ($block->displayNoscriptNotice()) : ?>
+<?php if ($block->displayNoscriptNotice()): ?>
     <noscript>
         <div class="messages">
             <div class="message message-warning message-noscript">
-                <strong><?= $block->escapeHtml(__('JavaScript may be disabled in your browser.')) ?></strong>
-                <?= $block->escapeHtml(__('To use this website you must first enable JavaScript in your browser.')) ?>
+                <strong><?= $escaper->escapeHtml(__('JavaScript may be disabled in your browser.')); ?></strong>
+                <?= $escaper->escapeHtml(
+                    __('To use this website you must first enable JavaScript in your browser.')
+                ); ?>
             </div>
         </div>
     </noscript>
 <?php endif; ?>
-<?php if ($block->displayDemoNotice()) : ?>
+
+<?php if ($block->displayDemoNotice()): ?>
     <div class="messages">
         <div class="message message-warning message-demo-mode">
-            <?= $block->escapeHtml(__('This is only a demo store. You can browse and place orders, but nothing will be processed.')) ?>
+            <?= $escaper->escapeHtml(
+                __('This is only a demo store. You can browse and place orders, but nothing will be processed.')
+            ); ?>
         </div>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/privacyPolicy.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/privacyPolicy.phtml
@@ -3,9 +3,15 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-
-<a class="link-report" href="<?= $block->escapeUrl($block->getPrivacypolicyUrl()) ?>" id="footer_privacy" target="_blank">
-    <?= $block->escapeHtml(__('Privacy Policy')) ?>
+<a class="link-report"
+   href="<?= $escaper->escapeUrl($block->getPrivacypolicyUrl()); ?>"
+   id="footer_privacy"
+   target="_blank">
+    <?= $escaper->escapeHtml(__('Privacy Policy')); ?>
 </a> |

--- a/app/code/Magento/Backend/view/adminhtml/templates/page/report.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/page/report.phtml
@@ -3,9 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
-<?php if ($block->getBugreportUrl()) : ?>
-    <a class="link-report" href="<?= $block->escapeUrl($block->getBugreportUrl()) ?>" id="footer_bug_tracking" target="_blank">
-        <?= $block->escapeHtml(__('Report an Issue')) ?>
+<?php if ($block->getBugreportUrl()): ?>
+    <a class="link-report"
+       href="<?= $escaper->escapeUrl($block->getBugreportUrl()); ?>"
+       id="footer_bug_tracking"
+       target="_blank">
+        <?= $escaper->escapeHtml(__('Report an Issue')); ?>
     </a>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher.phtml
@@ -3,49 +3,63 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/* @var $block \Magento\Backend\Block\Store\Switcher */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Store\Switcher;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Switcher $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if ($websites = $block->getWebsites()): ?>
     <div class="store-switcher store-view">
-        <span class="store-switcher-label"><?= $block->escapeHtml(__('Scope:')) ?></span>
+        <span class="store-switcher-label"><?= $escaper->escapeHtml(__('Scope:')); ?></span>
         <div class="actions dropdown closable">
-            <input type="hidden" name="store_switcher" id="store_switcher"
-                   data-role="store-view-id" data-param="<?= $block->escapeHtmlAttr($block->getStoreVarName()) ?>"
-                   value="<?= $block->escapeHtml($block->getStoreId()) ?>"
-                <?= /* @noEscape */ $block->getUiId() ?> />
+            <input type="hidden"
+                   name="store_switcher"
+                   id="store_switcher"
+                   data-role="store-view-id"
+                   data-param="<?= $escaper->escapeHtmlAttr($block->getStoreVarName()); ?>"
+                   value="<?= $escaper->escapeHtmlAttr($block->getStoreId()); ?>"
+                   <?= /* @noEscape */ $block->getUiId(); ?>/>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onchange',
                 'switchScope(this);',
                 '#store_switcher'
-            ) ?>
-            <input type="hidden" name="store_group_switcher" id="store_group_switcher"
-                   data-role="store-group-id" data-param="<?= $block->escapeHtmlAttr($block->getStoreGroupVarName()) ?>"
-                   value="<?= $block->escapeHtml($block->getStoreGroupId()) ?>"
-                <?= /* @noEscape */ $block->getUiId() ?> />
+            ); ?>
+            <input type="hidden"
+                   name="store_group_switcher"
+                   id="store_group_switcher"
+                   data-role="store-group-id"
+                   data-param="<?= $escaper->escapeHtmlAttr($block->getStoreGroupVarName()); ?>"
+                   value="<?= $escaper->escapeHtmlAttr($block->getStoreGroupId()); ?>"
+                   <?= /* @noEscape */ $block->getUiId(); ?>/>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onchange',
                 'switchScope(this);',
                 '#store_group_switcher'
-            ) ?>
-            <input type="hidden" name="website_switcher" id="website_switcher"
-                   data-role="website-id" data-param="<?= $block->escapeHtmlAttr($block->getWebsiteVarName()) ?>"
-                   value="<?= $block->escapeHtml($block->getWebsiteId()) ?>"
-                <?= /* @noEscape */ $block->getUiId() ?> />
+            ); ?>
+            <input type="hidden"
+                   name="website_switcher"
+                   id="website_switcher"
+                   data-role="website-id"
+                   data-param="<?= $escaper->escapeHtmlAttr($block->getWebsiteVarName()); ?>"
+                   value="<?= $escaper->escapeHtmlAttr($block->getWebsiteId()); ?>"
+                   <?= /* @noEscape */ $block->getUiId(); ?>/>
             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                 'onchange',
                 'switchScope(this);',
                 '#website_switcher'
-            ) ?>
-            <button
-                type="button"
-                class="admin__action-dropdown"
-                data-mage-init='{"dropdown":{}}'
-                data-toggle="dropdown"
-                aria-haspopup="true"
-                id="store-change-button">
-                <?= $block->escapeHtml($block->getCurrentSelectionName()) ?>
+            ); ?>
+            <button type="button"
+                    class="admin__action-dropdown"
+                    data-mage-init='{"dropdown":{}}'
+                    data-toggle="dropdown"
+                    aria-haspopup="true"
+                    id="store-change-button">
+                <?= $escaper->escapeHtml($block->getCurrentSelectionName()); ?>
             </button>
             <ul class="dropdown-menu" data-role="stores-list">
                 <?php if ($block->hasDefaultOption()): ?>
@@ -54,17 +68,20 @@
                     ?> <?php if (!$block->hasScopeSelected()): ?>current<?php endif; ?>">
                         <?php if ($block->getDefaultSelectionName() != $block->getCurrentSelectionName()): ?>
                             <a data-role="store-view-id" data-value="" href="#">
-                                <?= $block->escapeHtml($block->getDefaultSelectionName()) ?>
+                                <?= $escaper->escapeHtml($block->getDefaultSelectionName()); ?>
                             </a>
                         <?php else: ?>
-                            <span><?= $block->escapeHtml($block->getDefaultSelectionName()) ?></span>
+                            <span><?= $escaper->escapeHtml($block->getDefaultSelectionName()); ?></span>
                         <?php endif; ?>
                     </li>
                 <?php endif; ?>
+
                 <?php foreach ($websites as $website): ?>
                     <?php $showWebsite = false; ?>
+
                     <?php foreach ($website->getGroups() as $group): ?>
                         <?php $showGroup = false; ?>
+
                         <?php foreach ($block->getStores($group) as $store): ?>
                             <?php if ($showWebsite == false): ?>
                                 <?php $showWebsite = true; ?>
@@ -72,15 +89,17 @@
                                     ! $block->isWebsiteSelected($website))): ?>disabled<?php endif; ?> <?php
                                 if ($block->isWebsiteSelected($website)): ?>current<?php endif; ?>">
                                     <?php if ($block->isWebsiteSwitchEnabled() && ! $block->isWebsiteSelected($website)): ?>
-                                        <a data-role="website-id" data-value="<?= $block->escapeHtmlAttr($website->getId());
-                                        ?>" href="#">
-                                            <?= $block->escapeHtml($website->getName()) ?>
+                                        <a data-role="website-id"
+                                           data-value="<?= $escaper->escapeHtmlAttr($website->getId()); ?>"
+                                           href="#">
+                                            <?= $escaper->escapeHtml($website->getName()); ?>
                                         </a>
                                     <?php else: ?>
-                                        <span><?= $block->escapeHtml($website->getName()) ?></span>
+                                        <span><?= $escaper->escapeHtml($website->getName()); ?></span>
                                     <?php endif; ?>
                                 </li>
                             <?php endif; ?>
+
                             <?php if ($showGroup == false): ?>
                                 <?php $showGroup = true; ?>
                                 <li class="store-switcher-store <?php if (!($block->isStoreGroupSwitchEnabled() &&
@@ -89,39 +108,44 @@
                                     <?php if ($block->isStoreGroupSwitchEnabled() &&
                                         ! $block->isStoreGroupSelected($group)): ?>
                                         <a data-role="store-group-id"
-                                           data-value="<?= $block->escapeHtmlAttr($group->getId()) ?>" href="#">
-                                            <?= $block->escapeHtml($group->getName()) ?>
+                                           data-value="<?= $escaper->escapeHtmlAttr($group->getId()); ?>"
+                                           href="#">
+                                            <?= $escaper->escapeHtml($group->getName()); ?>
                                         </a>
                                     <?php else: ?>
-                                        <span><?= $block->escapeHtml($group->getName()) ?></span>
+                                        <span><?= $escaper->escapeHtml($group->getName()); ?></span>
                                     <?php endif; ?>
                                 </li>
                             <?php endif; ?>
+
                             <li class="store-switcher-store-view <?php if (!($block->isStoreSwitchEnabled() &&
                                 !$block->isStoreSelected($store))): ?>disabled<?php endif; ?> <?php
                             if ($block->isStoreSelected($store)):?>current<?php endif; ?>">
                                 <?php if ($block->isStoreSwitchEnabled() && ! $block->isStoreSelected($store)): ?>
                                     <a data-role="store-view-id"
-                                       data-value="<?= $block->escapeHtmlAttr($store->getId()) ?>" href="#">
-                                        <?= $block->escapeHtml($store->getName()) ?>
+                                       data-value="<?= $escaper->escapeHtmlAttr($store->getId()); ?>"
+                                       href="#">
+                                        <?= $escaper->escapeHtml($store->getName()); ?>
                                     </a>
                                 <?php else: ?>
-                                    <span><?= $block->escapeHtml($store->getName()) ?></span>
+                                    <span><?= $escaper->escapeHtml($store->getName()); ?></span>
                                 <?php endif; ?>
                             </li>
                         <?php endforeach; ?>
                     <?php endforeach; ?>
                 <?php endforeach; ?>
+
                 <?php if ($block->getShowManageStoresLink() &&
                     $block->getAuthorization()->isAllowed('Magento_Backend::store')): ?>
                     <li class="dropdown-toolbar">
-                        <a href="<?= /* @noEscape */ $block->getUrl('*/system_store');
-                        ?>"><?= $block->escapeHtml(__('Stores Configuration')) ?></a>
+                        <a href="<?= $escaper->escapeUrl($block->getUrl('*/system_store')); ?>">
+                            <?= $escaper->escapeHtml(__('Stores Configuration')); ?>
+                        </a>
                     </li>
                 <?php endif; ?>
             </ul>
         </div>
-        <?= $block->getHintHtml() ?>
+        <?= $block->getHintHtml(); ?>
     </div>
 
     <script type="text/x-magento-init">
@@ -130,7 +154,7 @@
                 "Magento_Backend/js/store-switcher": {
                     "useConfirm": <?= /* @noEscape */ (int)$block->getUseConfirm(); ?>,
                     "isUsingIframe": <?= /* @noEscape */ (int)$block->isUsingIframe(); ?>,
-                    "switchUrl": "<?= $block->escapeUrl($block->getSwitchUrl()); ?>",
+                    "switchUrl": "<?= $escaper->escapeUrl($block->getSwitchUrl()); ?>",
                     "storeId": <?= /* @noEscape */ (int)$block->getStoreId(); ?>
                 }
             }

--- a/app/code/Magento/Backend/view/adminhtml/templates/store/switcher/form/renderer/fieldset.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/store/switcher/form/renderer/fieldset.phtml
@@ -3,40 +3,51 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+
+$_element = $block->getElement();
 ?>
-<?php $_element = $block->getElement() ?>
-<?php if ($_element->getFieldsetContainerId()) : ?>
-    <div id="<?= $block->escapeHtmlAttr($_element->getFieldsetContainerId()) ?>">789
+<?php if ($_element->getFieldsetContainerId()): ?>
+    <div id="<?= $escaper->escapeHtmlAttr($_element->getFieldsetContainerId()); ?>">789
 <?php endif; ?>
 
-<?php if (!$_element->getNoContainer()) : ?>
-    <fieldset class="admin__fieldset fieldset <?= $block->escapeHtmlAttr($_element->getClass()) ?>" id="<?= $_element->getHtmlId() ?>">
+<?php if (!$_element->getNoContainer()): ?>
+    <fieldset class="admin__fieldset fieldset <?= $escaper->escapeHtmlAttr($_element->getClass()); ?>"
+              id="<?= $escaper->escapeHtmlAttr($_element->getHtmlId()); ?>">
 <?php endif; ?>
 
-    <?php if ($_element->getLegend()) : ?>
-        <legend class="admin__legend legend">
-            <span><?= $block->escapeHtml($_element->getLegend()) ?></span>
-            <?= $block->getHintHtml() ?>
-        </legend><br/>
-        <?= /* @noEscape */ $_element->getHeaderBar() ?>
-    <?php else : ?>
-        <?= $block->getHintHtml() ?>
+<?php if ($_element->getLegend()): ?>
+    <legend class="admin__legend legend">
+        <span><?= $escaper->escapeHtml($_element->getLegend()); ?></span>
+        <?= $block->getHintHtml(); ?>
+    </legend>
+    <br/>
+    <?= /* @noEscape */ $_element->getHeaderBar(); ?>
+<?php else: ?>
+    <?= $block->getHintHtml(); ?>
+<?php endif; ?>
+
+<div class="admin__fieldset tree-store-scope">
+    <?php if ($_element->getComment()): ?>
+        <p class="comment"><?= $escaper->escapeHtml($_element->getComment()); ?></p>
     <?php endif; ?>
-        <div class="admin__fieldset tree-store-scope">
-            <?php if ($_element->getComment()) : ?>
-            <p class="comment"><?= $block->escapeHtml($_element->getComment()) ?></p>
-            <?php endif; ?>
-            <?php if ($_element->hasHtmlContent()) : ?>
-                <?= $_element->getHtmlContent() ?>
-            <?php else : ?>
-                <?= $_element->getChildrenHtml() ?>
-            <?php endif; ?>
-        </div>
-<?= $_element->getSubFieldsetHtml() ?>
 
-<?php if (!$_element->getNoContainer()) : ?>
+    <?php if ($_element->hasHtmlContent()): ?>
+        <?= $_element->getHtmlContent(); ?>
+    <?php else : ?>
+        <?= $_element->getChildrenHtml(); ?>
+    <?php endif; ?>
+</div>
+<?= $_element->getSubFieldsetHtml(); ?>
+
+<?php if (!$_element->getNoContainer()): ?>
     </fieldset>
 <?php endif; ?>
-<?php if ($_element->getFieldsetContainerId()) : ?>
+
+<?php if ($_element->getFieldsetContainerId()): ?>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/autocomplete.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/autocomplete.phtml
@@ -3,13 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <ul class="dropdown-menu">
-    <?php foreach ($items as $item) : ?>
-    <li id="<?= $block->escapeHtmlAttr($item['id']) ?>" class="item">
-        <a href="<?= $block->escapeUrl($item['url']) ?>" class="title"><?= $block->escapeHtml($item['name']) ?></a>
-        <div class="type"><?= $block->escapeHtml($item['type']) ?></div>
-        <?= $block->escapeHtml($item['description']) ?>
-    </li>
-    <?php endforeach ?>
+    <?php foreach ($items as $item): ?>
+        <li id="<?= $escaper->escapeHtmlAttr($item['id']); ?>" class="item">
+            <a href="<?= $escaper->escapeUrl($item['url']); ?>" class="title">
+                <?= $escaper->escapeHtml($item['name']); ?>
+            </a>
+            <div class="type"><?= $escaper->escapeHtml($item['type']); ?></div>
+            <?= $escaper->escapeHtml($item['description']); ?>
+        </li>
+    <?php endforeach; ?>
 </ul>

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/cache/additional.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/cache/additional.phtml
@@ -3,56 +3,63 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Backend\Block\Cache\Permissions|null $permissions */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Cache\Permissions;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Permissions|null $permissions */
 $permissions = $block->getData('permissions');
 ?>
 <?php if ($permissions && $permissions->hasAccessToAdditionalActions()): ?>
     <div class="additional-cache-management">
         <h2>
-            <span><?= $block->escapeHtml(__('Additional Cache Management')); ?></span>
+            <span><?= $escaper->escapeHtml(__('Additional Cache Management')); ?></span>
         </h2>
         <?php if ($permissions->hasAccessToFlushCatalogImages()): ?>
             <p>
                 <button id="flushCatalogImages" type="button">
-                    <?= $block->escapeHtml(__('Flush Catalog Images Cache')); ?>
+                    <?= $escaper->escapeHtml(__('Flush Catalog Images Cache')); ?>
                 </button>
                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                     'onclick',
-                    'setLocation(\'' . $block->escapeJs($block->getCleanImagesUrl()) . '\')',
+                    'setLocation(\'' . $escaper->escapeJs($block->getCleanImagesUrl()) . '\')',
                     'button#flushCatalogImages'
-                ) ?>
-                <span><?= $block->escapeHtml(__('Pregenerated product images files')); ?></span>
+                ); ?>
+                <span><?= $escaper->escapeHtml(__('Pregenerated product images files')); ?></span>
             </p>
         <?php endif; ?>
         <?php if ($permissions->hasAccessToFlushJsCss()): ?>
             <p>
                 <button id="flushJsCss" type="button">
-                    <?= $block->escapeHtml(__('Flush JavaScript/CSS Cache')); ?>
+                    <?= $escaper->escapeHtml(__('Flush JavaScript/CSS Cache')); ?>
                 </button>
                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                     'onclick',
-                    'setLocation(\'' . $block->escapeJs($block->getCleanMediaUrl()) . '\')',
+                    'setLocation(\'' . $escaper->escapeJs($block->getCleanMediaUrl()) . '\')',
                     'button#flushJsCss'
-                ) ?>
-                <span><?= $block->escapeHtml(__('Themes JavaScript and CSS files combined to one file')) ?></span>
+                ); ?>
+                <span>
+                    <?= $escaper->escapeHtml(__('Themes JavaScript and CSS files combined to one file')); ?>
+                </span>
             </p>
         <?php endif; ?>
         <?php if (!$block->isInProductionMode() && $permissions->hasAccessToFlushStaticFiles()): ?>
             <p>
                 <button id="flushStaticFiles" type="button">
-                    <?= $block->escapeHtml(__('Flush Static Files Cache')); ?>
+                    <?= $escaper->escapeHtml(__('Flush Static Files Cache')); ?>
                 </button>
                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                     'onclick',
-                    'setLocation(\'' . $block->escapeJs($block->getCleanStaticFilesUrl()) . '\')',
+                    'setLocation(\'' . $escaper->escapeJs($block->getCleanStaticFilesUrl()) . '\')',
                     'button#flushStaticFiles'
-                ) ?>
-                <span><?= $block->escapeHtml(__('Preprocessed view files and static files')); ?></span>
+                ); ?>
+                <span><?= $escaper->escapeHtml(__('Preprocessed view files and static files')); ?></span>
             </p>
         <?php endif; ?>
-        <?= $block->getChildHtml() ?>
+        <?= $block->getChildHtml(); ?>
     </div>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/cache/edit.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/cache/edit.phtml
@@ -3,10 +3,14 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 /**
  * @methods
  *  getTitle() - string
@@ -15,10 +19,12 @@
  *  getForm() - html
  */
 ?>
-<div data-mage-init='{"floatingHeader": {}}' class="page-actions"><?= $block->getSaveButtonHtml() ?></div>
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="config-edit-form"
+<div data-mage-init='{"floatingHeader": {}}' class="page-actions"><?= $block->getSaveButtonHtml(); ?></div>
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()); ?>"
+      method="post"
+      id="config-edit-form"
       enctype="multipart/form-data">
-    <?= $block->getBlockHtml('formkey') ?>
+    <?= $block->getBlockHtml('formkey'); ?>
 
     <?php $scriptString = <<<script
     window.setCacheAction = function(id, button) {
@@ -30,26 +36,26 @@ script;
     ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
 
-    <input type="hidden" id="catalog_action" name="catalog_action" value="" />
-    <input type="hidden" id="jscss_action" name="jscss_action" value="" />
+    <input type="hidden" id="catalog_action" name="catalog_action" value=""/>
+    <input type="hidden" id="jscss_action" name="jscss_action" value=""/>
 
-    <?= $block->getChildHtml('form') ?>
+    <?= $block->getChildHtml('form'); ?>
     <div class="entry-edit">
         <div class="entry-edit-head">
-            <h4 class="icon-head head-edit-form fieldset-legend"><?= $block->escapeHtml(__('Catalog')) ?></h4>
+            <h4 class="icon-head head-edit-form fieldset-legend">
+                <?= $escaper->escapeHtml(__('Catalog')); ?>
+            </h4>
         </div>
         <fieldset id="catalog">
             <table class="form-list">
                 <tbody>
                     <?php foreach ($block->getCatalogData() as $_item): ?>
                         <?php /* disable reindex buttons. functionality moved to index management*/?>
-                        <?php
-                        if ($_item['buttons'][0]['name'] != 'clear_images_cache') {
-                            continue;
-                        }
-                        ?>
+                        <?php if ($_item['buttons'][0]['name'] != 'clear_images_cache'): ?>
+                            <?php continue; ?>
+                        <?php endif; ?>
                     <tr>
-                        <td class="label"><label><?= $block->escapeHtml($_item['label']) ?></label></td>
+                        <td class="label"><label><?= $escaper->escapeHtml($_item['label']); ?></label></td>
                         <td class="value">
                             <?php foreach ($_item['buttons'] as $_button): ?>
                                 <?php $clickAction = "setCacheAction('catalog_action',this)"; ?>
@@ -59,22 +65,29 @@ script;
                                         "')) {{$clickAction}}"; ?>
                                     <?php //phpcs:enable ?>
                                 <?php endif; ?>
-                                <button
-                                    id="<?= $block->escapeHtmlAttr($_button['name']) ?>"
-                                    type="button"
-                                    class="scalable
+                                <button id="<?= $escaper->escapeHtmlAttr($_button['name']); ?>"
+                                        type="button"
+                                        class="scalable
                                 <?php if (isset($_button['disabled']) && $_button['disabled']):?>disabled<?php endif;?>"
-                                ><span><span><span><?= $block->escapeHtml($_button['action']) ?></span></span></span>
+                                >
+                                    <span>
+                                        <span>
+                                            <span><?= $escaper->escapeHtml($_button['action']); ?></span>
+                                        </span>
+                                    </span>
                                 </button>
-                                <?php if (!isset($_button['disabled']) || !$_button['disabled']):?>
+
+                                <?php if (!isset($_button['disabled']) || !$_button['disabled']): ?>
                                     <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                         'onclick',
                                         /* @noEscape */ $clickAction,
-                                        '#' . $block->escapeJs($_button['name'])
-                                    ) ?>
+                                        '#' . $escaper->escapeJs($_button['name'])
+                                    ); ?>
                                 <?php endif; ?>
-                                <?php if (isset($_button['comment'])): ?> <br />
-                                    <small><?= $block->escapeHtml($_button['comment']) ?></small>
+
+                                <?php if (isset($_button['comment'])): ?>
+                                    <br />
+                                    <small><?= $escaper->escapeHtml($_button['comment']); ?></small>
                                 <?php endif; ?>
                             <?php endforeach; ?>
                         </td>
@@ -88,25 +101,29 @@ script;
 
     <div class="entry-edit">
         <div class="entry-edit-head">
-            <h4 class="icon-head head-edit-form fieldset-legend"><?= $block->escapeHtml(__('JavaScript/CSS')) ?></h4>
+            <h4 class="icon-head head-edit-form fieldset-legend">
+                <?= $escaper->escapeHtml(__('JavaScript/CSS')); ?>
+            </h4>
         </div>
 
         <fieldset id="jscss">
             <table class="form-list">
                 <tbody>
                     <tr>
-                        <td class="label"><label><?= $block->escapeHtml(__('JavaScript/CSS Cache')) ?></label></td>
+                        <td class="label">
+                            <label><?= $escaper->escapeHtml(__('JavaScript/CSS Cache')); ?></label>
+                        </td>
                         <td class="value">
                             <button id='jscss_action'
                                     type="button"
                                     class="scalable">
-                                <span><span><span><?= $block->escapeHtml(__('Clear')) ?></span></span></span>
+                                <span><span><span><?= $escaper->escapeHtml(__('Clear')); ?></span></span></span>
                             </button>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 "setCacheAction('jscss_action', this)",
                                 '#jscss_action'
-                            ) ?>
+                            ); ?>
                         </td>
                     </tr>
                 </tbody>

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/design/edit.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/design/edit.phtml
@@ -3,11 +3,18 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<form action="<?= $block->escapeUrl($block->getSaveUrl()) ?>" method="post" id="design-edit-form">
-    <?= $block->getBlockHtml('formkey') ?>
+<form action="<?= $escaper->escapeUrl($block->getSaveUrl()); ?>"
+      method="post"
+      id="design-edit-form">
+    <?= $block->getBlockHtml('formkey'); ?>
 </form>
 
 <?php $scriptString = <<<script

--- a/app/code/Magento/Backend/view/adminhtml/templates/system/search.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/system/search.phtml
@@ -3,65 +3,81 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-
-// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
+declare(strict_types=1);
 
 use Magento\Backend\Block\GlobalSearch;
+use Magento\Framework\Escaper;
 use Magento\Framework\Json\Helper\Data;
 
-/** @var $block GlobalSearch */
+/** @var GlobalSearch $block */
+/** @var Escaper $escaper */
 /** @var Data $helper */
 $helper = $this->helper(Data::class);
 
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
 ?>
 <div class="search-global" data-mage-init='{"globalSearch": {}}'>
     <form action="#" id="form-search">
         <div class="search-global-field">
             <label class="search-global-label" for="search-global"></label>
-            <input
-                    type="text"
-                    class="search-global-input"
-                    id="search-global"
-                    name="query"
-                    data-mage-init='<?= /* @noEscape */ $helper->jsonEncode($block->getWidgetInitOptions()) ?>'>
-            <button
-                type="submit"
-                class="search-global-action"
-                title="<?= $block->escapeHtmlAttr(__('Search')) ?>"
-                ></button>
+            <input type="text"
+                   class="search-global-input"
+                   id="search-global"
+                   name="query"
+                   data-mage-init='<?= /* @noEscape */ $helper->jsonEncode($block->getWidgetInitOptions()); ?>'>
+            <button type="submit"
+                    class="search-global-action"
+                    title="<?= $escaper->escapeHtmlAttr(__('Search')); ?>">
+            </button>
         </div>
     </form>
     <script data-template="search-suggest" type="text/x-magento-template">
         <ul class="search-global-menu">
-        <li class="item">
-            <a id="searchPreviewProducts" href="<?= $block->escapeUrl($block->getUrl('catalog/product/index/')) ?>?search=<%- data.term%>" class="title">"<%- data.term%>" in Products</a>
-        </li>
-        <li class="item">
-            <a id="searchPreviewOrders" href="<?= $block->escapeUrl($block->getUrl('sales/order/index/')) ?>?search=<%- data.term%>" class="title">"<%- data.term%>" in Orders</a>
-        </li>
-        <li class="item">
-            <a id="searchPreviewCustomers" href="<?= $block->escapeUrl($block->getUrl('customer/index/index/')) ?>?search=<%- data.term%>" class="title">"<%- data.term%>" in Customers</a>
-        </li>
-        <li class="item">
-            <a id="searchPreviewPages" href="<?= $block->escapeUrl($block->getUrl('cms/page/index/')) ?>?search=<%- data.term%>" class="title">"<%- data.term%>" in Pages</a>
-        </li>
+            <li class="item">
+                <a id="searchPreviewProducts"
+                   href="<?= $escaper->escapeUrl($block->getUrl('catalog/product/index/')); ?>?search=<%- data.term%>"
+                   class="title">
+                    "<%- data.term%>" in Products
+                </a>
+            </li>
+            <li class="item">
+                <a id="searchPreviewOrders"
+                   href="<?= $escaper->escapeUrl($block->getUrl('sales/order/index/')); ?>?search=<%- data.term%>"
+                   class="title">
+                    "<%- data.term%>" in Orders
+                </a>
+            </li>
+            <li class="item">
+                <a id="searchPreviewCustomers"
+                   href="<?= $escaper->escapeUrl($block->getUrl('customer/index/index/')); ?>?search=<%- data.term%>"
+                   class="title">
+                    "<%- data.term%>" in Customers
+                </a>
+            </li>
+            <li class="item">
+                <a id="searchPreviewPages"
+                   href="<?= $escaper->escapeUrl($block->getUrl('cms/page/index/')); ?>?search=<%- data.term%>"
+                   class="title">
+                    "<%- data.term%>" in Pages
+                </a>
+            </li>
             <% if (data.items.length) { %>
-            <% _.each(data.items, function(value){ %>
-            <li class="item"
-                <%= data.optionData(value) %>
-                >
-                <a href="<%- value.url %>" class="title"><%- value.name %></a>
-                <span class="type"><%- value.type %></span>
-                <%- value.description || "" %>
-            </li>
-            <% }); %>
-        <% } else { %>
-            <li>
-                <span class="mage-suggest-no-records">
-                    <?= $block->escapeHtml(__('No records found.')) ?>
-                </span>
-            </li>
-        <% } %>
+                <% _.each(data.items, function(value){ %>
+                    <li class="item"
+                        <%= data.optionData(value) %>
+                        >
+                        <a href="<%- value.url %>" class="title"><%- value.name %></a>
+                        <span class="type"><%- value.type %></span>
+                        <%- value.description || "" %>
+                    </li>
+                <% }); %>
+            <% } else { %>
+                <li>
+                    <span class="mage-suggest-no-records">
+                        <?= $escaper->escapeHtml(__('No records found.')); ?>
+                    </span>
+                </li>
+            <% } %>
         </ul>
     </script>
 </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/accordion.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/accordion.phtml
@@ -3,17 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
-?>
-<?php
-/**
- * Template for \Magento\Backend\Block\Widget\Accordion
- */
+use Magento\Backend\Block\Widget\Accordion;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+/** @var Accordion $block */
 $items = $block->getItems();
 ?>
 <?php if (!empty($items)): ?>
-    <dl id="tab_content_<?= $block->getHtmlId() ?>" name="tab_content_<?= $block->getHtmlId() ?>" class="accordion">
+    <dl id="tab_content_<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>"
+        name="tab_content_<?= $block->getHtmlId() ?>"
+        class="accordion">
     <?php foreach ($items as $_item): ?>
         <?= $block->getChildHtml($_item->getId()) ?>
     <?php endforeach ?>
@@ -23,7 +27,7 @@ $items = $block->getItems();
             'mage/adminhtml/accordion'
         ], function(){
             tab_content_{$block->getHtmlId()}AccordionJs = new varienAccordion('tab_content_{$block->getHtmlId()}',
-             '{$block->escapeJs($block->getShowOnlyOne())}');
+             '{$escaper->escapeJs($block->getShowOnlyOne())}');
         });
 script;
     ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/breadcrumbs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/breadcrumbs.phtml
@@ -3,25 +3,34 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <?php if (!empty($links)) : ?>
-<ul class="breadcrumbs">
-    <?php $_size = count($links); ?>
-    <?php foreach ($links as $_index => $_link) : ?>
-    <li>
-        <?php if (empty($_link['url'])) : ?>
-            <?php if ($_index != $_size-1) : ?>
-                <span><?= $block->escapeHtml($_link['label']) ?></span>
-            <?php else : ?>
-                <strong><?= $block->escapeHtml($_link['label']) ?></strong>
-            <?php endif; ?>
-        <?php else : ?>
-            <a href="<?=  $block->escapeUrl($_link['url']) ?>" title="<?= $block->escapeHtml($_link['title']) ?>"><?= $block->escapeHtml($_link['label']) ?></a>
-        <?php endif; ?>
-        <?php if ($_index != $_size-1) : ?>
-            &raquo;
-        <?php endif; ?>
-    </li>
-    <?php endforeach; ?>
-</ul>
+    <ul class="breadcrumbs">
+        <?php $_size = count($links); ?>
+        <?php foreach ($links as $_index => $_link) : ?>
+            <li>
+                <?php if (empty($_link['url'])) : ?>
+                    <?php if ($_index != $_size-1) : ?>
+                        <span><?= $escaper->escapeHtml($_link['label']) ?></span>
+                    <?php else : ?>
+                        <strong><?= $escaper->escapeHtml($_link['label']) ?></strong>
+                    <?php endif; ?>
+                <?php else : ?>
+                    <a href="<?= $escaper->escapeUrl($_link['url']) ?>"
+                       title="<?= $escaper->escapeHtmlAttr($_link['title']) ?>">
+                        <?= $escaper->escapeHtml($_link['label']) ?>
+                    </a>
+                <?php endif; ?>
+
+                <?php if ($_index != $_size-1): ?>
+                    &raquo;
+                <?php endif; ?>
+            </li>
+        <?php endforeach; ?>
+    </ul>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/button.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/button.phtml
@@ -3,14 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\Backend\Block\Widget\Button
- */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Widget\Button;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Button $block */
 ?>
 <?= $block->getBeforeHtml() ?>
 <button <?= /* @noEscape */ $block->getAttributesHtml(), $block->getUiId() ?>>
-    <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+    <span><?= $escaper->escapeHtml($block->getLabel()) ?></span>
 </button>
 <?= $block->getAfterHtml() ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/button/split.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/button/split.phtml
@@ -3,41 +3,44 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var $block \Magento\Backend\Block\Widget\Button\SplitButton */
-?>
+declare(strict_types=1);
 
-<div <?= $block->getAttributesHtml() ?>>
-    <button <?= $block->getButtonAttributesHtml() ?>>
-        <span><?= $block->escapeHtml($block->getLabel()) ?></span>
+use Magento\Backend\Block\Widget\Button\SplitButton;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var SplitButton $block */
+?>
+<div <?= $block->getAttributesHtml(); ?>>
+    <button <?= $block->getButtonAttributesHtml(); ?>>
+        <span><?= $escaper->escapeHtml($block->getLabel()); ?></span>
     </button>
     <?php if ($block->hasSplit()): ?>
-        <button <?= $block->getToggleAttributesHtml() ?>>
-            <span>Select</span>
+        <button <?= $block->getToggleAttributesHtml(); ?>>
+            <span><?= $escaper->escapeHtml(__('Select')); ?></span>
         </button>
 
         <?php if (!$block->getDisabled()): ?>
-            <ul class="dropdown-menu" <?= /* @noEscape */ $block->getUiId("dropdown-menu") ?>>
+            <ul class="dropdown-menu" <?= /* @noEscape */ $block->getUiId('dropdown-menu'); ?>>
                 <?php foreach ($block->getOptions() as $key => $option): ?>
-                <li>
-                    <span <?= $block->getOptionAttributesHtml($key, $option) ?>>
-                        <?= $block->escapeHtml($option['label']) ?>
-                    </span>
-                    <?php if (isset($option['hint'])): ?>
-                    <div class="tooltip" <?= /* @noEscape */ $block->getUiId('item', $key, 'tooltip') ?>>
-                        <a href="<?= $block->escapeHtml($option['hint']['href']) ?>" class="help">
-                            <?= $block->escapeHtml($option['hint']['label']) ?>
-                        </a>
-                    </div>
-                    <?php endif; ?>
-                </li>
+                    <li>
+                        <span <?= $block->getOptionAttributesHtml($key, $option); ?>>
+                            <?= $escaper->escapeHtml($option['label']); ?>
+                        </span>
+                        <?php if (isset($option['hint'])): ?>
+                        <div class="tooltip" <?= /* @noEscape */ $block->getUiId('item', $key, 'tooltip'); ?>>
+                            <a href="<?= $escaper->escapeUrl($option['hint']['href']); ?>" class="help">
+                                <?= $escaper->escapeHtml($option['hint']['label']); ?>
+                            </a>
+                        </div>
+                        <?php endif; ?>
+                    </li>
                 <?php endforeach; ?>
             </ul>
         <?php endif; ?>
     <?php endif; ?>
 </div>
-<?= /* @noEscape */$block->getAfterHtml() ?>
+<?= /* @noEscape */$block->getAfterHtml(); ?>
 
 <script type="text/x-magento-init">
     {

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/container.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/container.phtml
@@ -3,29 +3,36 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Backend\Block\Widget\Form\Container */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Widget\Form\Container;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Container $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<?= /* @noEscape */ $block->getFormInitScripts() ?>
+<?= /* @noEscape */ $block->getFormInitScripts(); ?>
+
 <?php if ($block->getButtonsHtml('header')): ?>
-    <div class="page-form-actions" <?= /* @noEscape */ $block->getUiId('content-header') ?>>
-        <?= $block->getButtonsHtml('header') ?>
+    <div class="page-form-actions" <?= /* @noEscape */ $block->getUiId('content-header'); ?>>
+        <?= $block->getButtonsHtml('header'); ?>
     </div>
 <?php endif; ?>
 <?php if ($block->getButtonsHtml('toolbar')): ?>
     <div class="page-main-actions">
         <div class="page-actions">
             <div class="page-actions-buttons">
-                <?= $block->getButtonsHtml('toolbar') ?>
+                <?= $block->getButtonsHtml('toolbar'); ?>
             </div>
         </div>
     </div>
 <?php endif; ?>
-<?= $block->getFormHtml() ?>
+<?= $block->getFormHtml(); ?>
 <?php if ($block->hasFooterButtons()): ?>
     <div class="content-footer">
-        <p class="form-buttons"><?= $block->getButtonsHtml('footer') ?></p>
+        <p class="form-buttons"><?= $block->getButtonsHtml('footer'); ?></p>
     </div>
 <?php endif; ?>
 <?php $scriptString = <<<script
@@ -36,7 +43,7 @@ require([
 ], function($){
 
     $('#edit_form').mage('form').mage('validation', {
-            validationUrl: '{$block->escapeJs($block->getValidationUrl())}',
+            validationUrl: '{$escaper->escapeJs($block->getValidationUrl())}',
             highlight: function(element) {
                 var detailsElement = $(element).closest('details');
                 if (detailsElement.length && detailsElement.is('.details')) {
@@ -52,5 +59,5 @@ require([
 
 script;
 ?>
-<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
-<?= /* @noEscape */ $block->getFormScripts() ?>
+<?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
+<?= /* @noEscape */ $block->getFormScripts(); ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element.phtml
@@ -3,37 +3,43 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 
 $type = $element->getType();
 $htmlId = $element->getHtmlId();
 ?>
 <?php if ($type === 'fieldset'): ?>
     <fieldset>
-        <legend><?= $block->escapeHtml($element->getLegend()) ?></legend><br />
+        <legend><?= $escaper->escapeHtml($element->getLegend()); ?></legend>
+        <br />
         <?php foreach ($element->getElements() as $_element): ?>
-            <?= /* @noEscape */ $formBlock->drawElement($_element) ?>
+            <?= /* @noEscape */ $formBlock->drawElement($_element); ?>
         <?php endforeach; ?>
     </fieldset>
 <?php elseif ($type === 'hidden'): ?>
-    <input type="<?= $block->escapeHtmlAttr($element->getType()) ?>"
-           name="<?= $block->escapeHtmlAttr($element->getName()) ?>"
-           id="<?= /* @noEscape */ $htmlId ?>"
-           value="<?= $block->escapeHtmlAttr($element->getValue()) ?>">
-    <?php elseif ($type === 'select'): ?>
+    <input type="<?= $escaper->escapeHtmlAttr($element->getType()); ?>"
+           name="<?= $escaper->escapeHtmlAttr($element->getName()); ?>"
+           id="<?= /* @noEscape */ $htmlId; ?>"
+           value="<?= $escaper->escapeHtmlAttr($element->getValue()); ?>">
+<?php elseif ($type === 'select'): ?>
     <span class="form_row">
         <?php if ($element->getLabel()): ?>
-            <label for="<?= /* @noEscape */ $htmlId ?>"><?= $block->escapeHtml($element->getLabel()) ?>:</label>
+            <label for="<?= /* @noEscape */ $htmlId; ?>"><?= $escaper->escapeHtml($element->getLabel()); ?>:</label>
         <?php endif; ?>
-        <select name="<?= $block->escapeHtmlAttr($element->getName()) ?>"
-                id="<?= /* @noEscape */ $htmlId ?>"
-                class="select<?= $block->escapeHtmlAttr($element->getClass()) ?>"
-                title="<?=  $block->escapeHtmlAttr($element->getTitle()) ?>">
+        <select name="<?= $escaper->escapeHtmlAttr($element->getName()); ?>"
+                id="<?= /* @noEscape */ $htmlId; ?>"
+                class="select<?= $escaper->escapeHtmlAttr($element->getClass()); ?>"
+                title="<?=  $escaper->escapeHtmlAttr($element->getTitle()); ?>">
         <?php foreach ($element->getValues() as $_value): ?>
-            <option <?= /* @noEscape */ $_value->serialize() ?>
+            <option <?= /* @noEscape */ $_value->serialize(); ?>
                 <?php if ($_value->getValue() == $element->getValue()): ?> selected="selected"<?php endif; ?>>
-                <?= $block->escapeHtml($_value->getLabel()) ?>
+                <?= $escaper->escapeHtml($_value->getLabel()); ?>
             </option>
         <?php endforeach; ?>
         </select>
@@ -41,49 +47,49 @@ $htmlId = $element->getHtmlId();
 <?php elseif ($type === 'text' || $type === 'button' || $type === 'password'): ?>
     <span class="form_row">
         <?php if ($element->getLabel()): ?>
-            <label for="<?= /* @noEscape */ $htmlId ?>" <?= /* @noEscape */ $block->getUiId('label') ?>>
-                <?= $block->escapeHtml($element->getLabel()) ?>:
+            <label for="<?= /* @noEscape */ $htmlId; ?>" <?= /* @noEscape */ $block->getUiId('label'); ?>>
+                <?= $escaper->escapeHtml($element->getLabel()); ?>:
             </label>
         <?php endif; ?>
-        <input type="<?= $block->escapeHtmlAttr($element->getType()) ?>"
-               name="<?= $block->escapeHtmlAttr($element->getName()) ?>"
-               id="<?= /* @noEscape */ $htmlId ?>"
-               value="<?= $block->escapeHtmlAttr($element->getValue()) ?>"
-               class="input-text <?= $block->escapeHtmlAttr($element->getClass()) ?>"
-               title="<?= $block->escapeHtmlAttr($element->getTitle()) ?>" />
+        <input type="<?= $escaper->escapeHtmlAttr($element->getType()); ?>"
+               name="<?= $escaper->escapeHtmlAttr($element->getName()); ?>"
+               id="<?= /* @noEscape */ $htmlId; ?>"
+               value="<?= $escaper->escapeHtmlAttr($element->getValue()); ?>"
+               class="input-text <?= $escaper->escapeHtmlAttr($element->getClass()); ?>"
+               title="<?= $escaper->escapeHtmlAttr($element->getTitle()); ?>" />
         <?php if ($listener = $element->getOnclick()): ?>
-            <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag('onclick', $listener, "#{$htmlId}")  ?>
+            <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag('onclick', $listener, "#{$htmlId}"); ?>
         <?php endif; ?>
     </span>
 <?php elseif ($type === 'radio'): ?>
     <span class="form_row">
         <?php if ($element->getLabel()): ?>
-            <label for="<?= /* @noEscape */ $htmlId ?>"><?= $block->escapeHtml($element->getLabel()) ?>:</label>
+            <label for="<?= /* @noEscape */ $htmlId; ?>"><?= $escaper->escapeHtml($element->getLabel()); ?>:</label>
         <?php endif; ?>
-        <input type="<?=  $block->escapeHtmlAttr($element->getType()) ?>"
-               name="<?=  $block->escapeHtmlAttr($element->getName()) ?>"
-               id="<?= /* @noEscape */ $htmlId ?>"
-               value="<?=  $block->escapeHtmlAttr($element->getValue()) ?>"
-               class="input-text <?= $block->escapeHtmlAttr($element->getClass()) ?>"
-               title="<?=  $block->escapeHtmlAttr($element->getTitle()) ?>"/>
+        <input type="<?=  $escaper->escapeHtmlAttr($element->getType()); ?>"
+               name="<?=  $escaper->escapeHtmlAttr($element->getName()); ?>"
+               id="<?= /* @noEscape */ $htmlId; ?>"
+               value="<?=  $escaper->escapeHtmlAttr($element->getValue()); ?>"
+               class="input-text <?= $escaper->escapeHtmlAttr($element->getClass()); ?>"
+               title="<?=  $escaper->escapeHtmlAttr($element->getTitle()); ?>"/>
     </span>
 <?php elseif ($type === 'radios'): ?>
     <span class="form_row">
-        <label for="<?= /* @noEscape */ $htmlId ?>"><?= $block->escapeHtml($element->getLabel()) ?>:</label>
-    <?php foreach ($element->getRadios() as $_radio): ?>
-    <input type="radio"
-           name="<?=  $block->escapeHtmlAttr($_radio->getName()) ?>"
-           id="<?= $_radio->getHtmlId() ?>"
-           value="<?=  $block->escapeHtmlAttr($_radio->getValue()) ?>"
-           class="input-radio <?= $block->escapeHtmlAttr($_radio->getClass()) ?>"
-           title="<?=  $block->escapeHtmlAttr($_radio->getTitle()) ?>"
-           <?= ($_radio->getValue() == $element->getChecked()) ? 'checked="true"' : '' ?> >
-        <?= $block->escapeHtml($_radio->getLabel()) ?>
-    <?php endforeach; ?>
+        <label for="<?= /* @noEscape */ $htmlId; ?>"><?= $escaper->escapeHtml($element->getLabel()); ?>:</label>
+        <?php foreach ($element->getRadios() as $_radio): ?>
+            <input type="radio"
+                   name="<?=  $escaper->escapeHtmlAttr($_radio->getName()); ?>"
+                   id="<?= $_radio->getHtmlId(); ?>"
+                   value="<?=  $escaper->escapeHtmlAttr($_radio->getValue()); ?>"
+                   class="input-radio <?= $escaper->escapeHtmlAttr($_radio->getClass()); ?>"
+                   title="<?=  $escaper->escapeHtmlAttr($_radio->getTitle()); ?>"
+                   <?= ($_radio->getValue() == $element->getChecked()) ? 'checked="true"' : ''; ?> >
+                <?= $escaper->escapeHtml($_radio->getLabel()); ?>
+        <?php endforeach; ?>
     </span>
 <?php elseif ($type === 'wysiwyg'): ?>
     <span class="form_row">
-      <label for="<?= /* @noEscape */ $htmlId ?>"><?= $block->escapeHtml($element->getLabel()) ?>:</label>
+      <label for="<?= /* @noEscape */ $htmlId; ?>"><?= $escaper->escapeHtml($element->getLabel()); ?>:</label>
         <?php $scriptString = <<<script
         require([
             "wysiwygAdapter"
@@ -92,7 +98,7 @@ $htmlId = $element->getHtmlId();
             tinyMCE.init({
                 mode : "exact",
                 theme : "advanced",
-                elements : "{$block->escapeJs($element->getName())}",
+                elements : "{$escaper->escapeJs($element->getName())}",
                 plugins : "inlinepopups,style,layer,table,save,advhr,advimage,advlink,emotions,iespell,"
                     + "insertdatetime,preview,zoom,media,searchreplace,print,paste,directionality,"
                     + "fullscreen,noneditable,visualchars,nonbreaking,xhtmlxtras",
@@ -123,28 +129,28 @@ $htmlId = $element->getHtmlId();
         });
 script;
         ?>
-        <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
-      <textarea name="<?= $block->escapeHtmlAttr($element->getName()) ?>"
-                title="<?=  $block->escapeHtmlAttr($element->getTitle()) ?>"
-                id="<?= /* @noEscape */ $htmlId ?>"
-                class="textarea <?= $block->escapeHtmlAttr($element->getClass()) ?>"
+        <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>
+      <textarea name="<?= $escaper->escapeHtmlAttr($element->getName()); ?>"
+                title="<?=  $escaper->escapeHtmlAttr($element->getTitle()); ?>"
+                id="<?= /* @noEscape */ $htmlId; ?>"
+                class="textarea <?= $escaper->escapeHtmlAttr($element->getClass()); ?>"
                 cols="80" rows="20">
-          <?= $block->escapeHtml($element->getValue()) ?>
+          <?= $escaper->escapeHtml($element->getValue()); ?>
       </textarea>
     </span>
 <?php elseif ($type === 'textarea'): ?>
-            <span class="form_row">
-                    <label for="<?= /* @noEscape */ $htmlId ?>"><?= $block->escapeHtml($element->getLabel()) ?>:</label>
-                    <textarea name="<?= $block->escapeHtmlAttr($element->getName()) ?>"
-                              title="<?=  $block->escapeHtmlAttr($element->getTitle()) ?>"
-                              id="<?= /* @noEscape */ $htmlId ?>"
-                              class="textarea <?= $block->escapeHtmlAttr($element->getClass()) ?>"
-                              cols="15"
-                              rows="2">
-                        <?= $block->escapeHtml($element->getValue()) ?>
-                    </textarea>
-            </span>
+    <span class="form_row">
+            <label for="<?= /* @noEscape */ $htmlId; ?>"><?= $escaper->escapeHtml($element->getLabel()); ?>:</label>
+            <textarea name="<?= $escaper->escapeHtmlAttr($element->getName()); ?>"
+                      title="<?=  $escaper->escapeHtmlAttr($element->getTitle()); ?>"
+                      id="<?= /* @noEscape */ $htmlId; ?>"
+                      class="textarea <?= $escaper->escapeHtmlAttr($element->getClass()); ?>"
+                      cols="15"
+                      rows="2">
+                <?= $escaper->escapeHtml($element->getValue()); ?>
+            </textarea>
+    </span>
 <?php endif; ?>
 <?php if ($element->getScript()): ?>
-    <?php /* @noEscape */ $secureRenderer->renderTag('script', [], $element->getScript(), false) ?>
+    <?php /* @noEscape */ $secureRenderer->renderTag('script', [], $element->getScript(), false); ?>
 <?php endif; ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/element/gallery.phtml
@@ -3,45 +3,50 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <tr>
 <td colspan="2">
-<label for="gallery"><?= $block->escapeHtml(__('Images')) ?></label>
+<label for="gallery"><?= $escaper->escapeHtml(__('Images')); ?></label>
 <table id="gallery" class="gallery" border="0" cellspacing="3" cellpadding="0">
 <thead id="gallery_thead" class="gallery">
     <tr class="gallery">
-        <td class="gallery" valign="middle" align="center"><?= $block->escapeHtml(__('Big Image')) ?></td>
-        <td class="gallery" valign="middle" align="center"><?= $block->escapeHtml(__('Thumbnail')) ?></td>
-        <td class="gallery" valign="middle" align="center"><?= $block->escapeHtml(__('Sort Order')) ?></td>
-        <td class="gallery" valign="middle" align="center"><?= $block->escapeHtml(__('Delete')) ?></td>
+        <td class="gallery" valign="middle" align="center"><?= $escaper->escapeHtml(__('Big Image')); ?></td>
+        <td class="gallery" valign="middle" align="center"><?= $escaper->escapeHtml(__('Thumbnail')); ?></td>
+        <td class="gallery" valign="middle" align="center"><?= $escaper->escapeHtml(__('Sort Order')); ?></td>
+        <td class="gallery" valign="middle" align="center"><?= $escaper->escapeHtml(__('Delete')); ?></td>
     </tr>
 </thead>
 
 <tfoot class="gallery">
-<tr class="gallery">
-<td class="gallery v-middle a-left"colspan="5"><?= $block->getAddButtonHtml() ?></td>
-</tr>
+    <tr class="gallery">
+        <td class="gallery v-middle a-left"colspan="5"><?= $block->getAddButtonHtml(); ?></td>
+    </tr>
 </tfoot>
 
 <tbody class="gallery">
 
 <?php $i = 0; if ($block->getValues() !== null): ?>
     <?php foreach ($block->getValues() as $image): $i++; ?>
-        <?php $trId = $block->getElement()->getHtmlId() . '_tr_' . $block->escapeHtmlAttr($image->getValueId()); ?>
+        <?php $trId = $block->getElement()->getHtmlId() . '_tr_' . $escaper->escapeHtmlAttr($image->getValueId()); ?>
         <tr id="<?= /* @noEscape */ $trId ?>" class="gallery">
         <?php foreach ($block->getValues()->getAttributeBackend()->getImageTypes() as $type): ?>
-            <?php $typeId = $block->getElement()->getHtmlId() . '_image_' . $block->escapeHtmlAttr($type);
-            $imgId =  $typeId . '_' . $block->escapeHtmlAttr($image->getValueId()); ?>
+            <?php $typeId = $block->getElement()->getHtmlId() . '_image_' . $escaper->escapeHtmlAttr($type);
+            $imgId =  $typeId . '_' . $escaper->escapeHtmlAttr($image->getValueId()); ?>
             <td class="gallery" align="center" id="<?= /* @noEscape */ $typeId ?>">
-            <a href="<?= $block->escapeUrl($image->setType($type)->getSourceUrl()) ?>"
+            <a href="<?= $escaper->escapeUrl($image->setType($type)->getSourceUrl()) ?>"
                id = <?= /* @noEscape */ 'a_' . $imgId ?>
                target="_blank"
             <img id="<?= /* @noEscape */ $imgId ?>"
-                 src="<?= $block->escapeUrl($image->setType($type)->getSourceUrl()) ?>?<?= /* @noEscape */ time() ?>"
-                 alt="<?= $block->escapeHtmlAttr($image->getValue()) ?>"
-                 title="<?= $block->escapeHtmlAttr($image->getValue()) ?>"
+                 src="<?= $escaper->escapeUrl($image->setType($type)->getSourceUrl()) ?>?<?= /* @noEscape */ time() ?>"
+                 alt="<?= $escaper->escapeHtmlAttr($image->getValue()) ?>"
+                 title="<?= $escaper->escapeHtmlAttr($image->getValue()) ?>"
                  height="25"
                  class="small-image-preview v-middle"/>
             </a><br/>
@@ -51,29 +56,29 @@
                     '#a_' . $imgId
                 ) ?>
             <input type="file"
-                   name="<?= $block->escapeHtmlAttr($block->getElement()->getName())
-                    ?>_<?= $block->escapeHtmlAttr($type) ?>[<?= $block->escapeHtmlAttr($image->getValueId()) ?>]"
+                   name="<?= $escaper->escapeHtmlAttr($block->getElement()->getName())
+                    ?>_<?= $escaper->escapeHtmlAttr($type) ?>[<?= $escaper->escapeHtmlAttr($image->getValueId()) ?>]"
                    size="1">
             </td>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('vertical-align:bottom;', 'td#' . $typeId) ?>
         <?php endforeach; ?>
         <td class="gallery" align="center" id="<?= /* @noEscape */ $trId . '_td_input' ?>">
             <input type="input"
-                   name="<?= $block->escapeHtmlAttr($block->getElement()->getParentName())
-                    ?>[position][<?= $block->escapeHtmlAttr($image->getValueId()) ?>]"
-                   value="<?= $block->escapeHtmlAttr($image->getPosition()) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($block->getElement()->getParentName())
+                    ?>[position][<?= $escaper->escapeHtmlAttr($image->getValueId()) ?>]"
+                   value="<?= $escaper->escapeHtmlAttr($image->getPosition()) ?>"
                    id="<?= $block->getElement()->getHtmlId()
-                    ?>_position_<?= $block->escapeHtmlAttr($image->getValueId()) ?>"
+                    ?>_position_<?= $escaper->escapeHtmlAttr($image->getValueId()) ?>"
                    size="3"/>
         </td>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('vertical-align:bottom;', $trId . '_td_input') ?>
         <td class="gallery" align="center" id="<?= /* @noEscape */ $trId . '_td_delete' ?>">
             <?= $block->getDeleteButtonHtml($image->getValueId()) ?>
             <input type="hidden"
-                   name="<?= $block->escapeHtmlAttr($block->getElement()->getParentName())
-                    ?>[delete][<?= $block->escapeHtmlAttr($image->getValueId()) ?>]"
+                   name="<?= $escaper->escapeHtmlAttr($block->getElement()->getParentName())
+                    ?>[delete][<?= $escaper->escapeHtmlAttr($image->getValueId()) ?>]"
                    id="<?= $block->getElement()->getHtmlId()
-                    ?>_delete_<?= $block->escapeHtmlAttr($image->getValueId()) ?>"/>
+                    ?>_delete_<?= $escaper->escapeHtmlAttr($image->getValueId()) ?>"/>
         </td>
             <?= /* @noEscape */ $secureRenderer->renderStyleAsTag('vertical-align:bottom;', $trId . '_td_delete') ?>
         </tr>
@@ -110,10 +115,10 @@ window.addNewImage = function()
     num_of_images++;
 script;
 
-    $elementName = $block->escapeHtmlAttr($block->getElement()->getName());
-    $parentName = $block->escapeJs($block->getElement()->getParentName());
+    $elementName = $escaper->escapeHtmlAttr($block->getElement()->getName());
+    $parentName = $escaper->escapeJs($block->getElement()->getParentName());
     $deleteButton = /* @noEscape */ $jsonHelper->jsonEncode($block->getDeleteButtonHtml("this"));
-    $elementNameDel = $block->escapeJs($block->getElement()->getName());
+    $elementNameDel = $escaper->escapeJs($block->getElement()->getName());
     $scriptString .= <<<script
     new_file_input = '<input type="file" name="{$elementName}_%j%[%id%]" size="1">';
 

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/form/renderer/fieldset.phtml
@@ -3,9 +3,13 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/** @var $element \Magento\Framework\Data\Form\Element\Fieldset */
+declare(strict_types=1);
+
+use Magento\Framework\Data\Form\Element\Fieldset;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var Fieldset $element */
 $element = $block->getElement();
 $containerId = $element->getFieldsetContainerId();
 $id = $element->getHtmlId();
@@ -15,6 +19,7 @@ $titleActions = '<div class="actions">' . $element->getHeaderBar() . '</div>';
 $isField = $element->getFieldsetType() == 'field';
 $advancedAfter = $element->getAdvancedPosition() == 'after'; // To place advanced options inside or after fieldset
 $advancedLabel = $element->getAdvancedLabel();
+
 if (!isset($advancedLabel)) {
     $advancedLabel = __('Additional Settings');
 }
@@ -32,87 +37,88 @@ if ($isField) {
  * @todo investigate situations, when the following is needed:
  * echo $element->getHeaderBar();
  * echo $element->getSubFieldsetHtml();
- */ ?>
+ */
+?>
 
 <?php if ($isWrapped): ?>
-    <div class="fieldset-wrapper <?= ($isCollapsable) ? 'admin__collapsible-block-wrapper ' : '' ?>"
-        id="<?=  $block->escapeHtmlAttr($containerId ? $containerId : $id . '-wrapper') ?>"
-        data-role="<?=  $block->escapeHtmlAttr($id) ?>-wrapper">
+    <div class="fieldset-wrapper <?= $isCollapsable ? 'admin__collapsible-block-wrapper ' : ''; ?>"
+        id="<?= $escaper->escapeHtmlAttr($containerId ? $containerId : $id . '-wrapper'); ?>"
+        data-role="<?= $escaper->escapeHtmlAttr($id); ?>-wrapper">
         <div class="fieldset-wrapper-title admin__fieldset-wrapper-title">
-            <strong <?= /* @noEscape */ $isCollapsable ?
-                'class="admin__collapsible-title" data-bs-toggle="collapse" data-bs-target="#' . $id . '-content"' :
-                'class="title"'; ?>>
-                <span><?= $block->escapeHtml($element->getLegend()) ?></span>
+            <strong <?= /* @noEscape */ $isCollapsable
+                ? 'class="admin__collapsible-title" data-bs-toggle="collapse" data-bs-target="#' . $id . '-content"'
+                : 'class="title"'; ?>>
+                <span><?= $escaper->escapeHtml($element->getLegend()); ?></span>
             </strong>
-            <?= /* @noEscape */ $titleActions ?>
+            <?= /* @noEscape */ $titleActions; ?>
         </div>
-        <div class="fieldset-wrapper-content admin__fieldset-wrapper-content<?= ($isCollapsable) ? ' collapse' : '' ?>"
-            id="<?=  $block->escapeHtmlAttr($id) ?>-content"
-            data-role="<?=  $block->escapeHtmlAttr($id) ?>-content">
+        <div class="fieldset-wrapper-content admin__fieldset-wrapper-content<?= ($isCollapsable) ? ' collapse' : ''; ?>"
+             id="<?= $escaper->escapeHtmlAttr($id); ?>-content"
+             data-role="<?= $escaper->escapeHtmlAttr($id); ?>-content">
 <?php endif; ?>
 
-    <?php if (!$element->getNoContainer()): ?>
-        <fieldset class="<?=  $block->escapeHtmlAttr($cssClass) ?>" id="<?=  $block->escapeHtmlAttr($id) ?>">
+<?php if (!$element->getNoContainer()): ?>
+    <fieldset class="<?= $escaper->escapeHtmlAttr($cssClass); ?>" id="<?= $escaper->escapeHtmlAttr($id); ?>">
         <?php if (is_string($element->getBeforeElementHtml()) && strlen($element->getBeforeElementHtml())): ?>
-            <?= $element->getBeforeElementHtml() ?>
-        <?php endif ?>
+            <?= $element->getBeforeElementHtml(); ?>
+        <?php endif; ?>
+
         <?php if ($element->getLegend() && !$isWrapped): ?>
-            <legend class="<?= /* @noEscape */ $isField ? 'label admin__field-label' : 'admin__legend legend' ?>">
-                <span><?= $block->escapeHtml($element->getLegend()) ?></span>
-            </legend><br />
+            <legend class="<?= /* @noEscape */ $isField ? 'label admin__field-label' : 'admin__legend legend'; ?>">
+                <span><?= $escaper->escapeHtml($element->getLegend()); ?></span>
+            </legend>
+            <br />
         <?php endif; ?>
+<?php endif; ?>
+
+
+<div class="messages">
+    <?php if ($element->getComment() && !$isField): ?>
+        <div class="message message-notice"><?= $escaper->escapeHtml($element->getComment()); ?></div>
+    <?php endif; ?>
+</div>
+
+<?= $isField ? '<div class="control admin__field-control">' : ''; ?>
+
+<?php if ($element->hasHtmlContent() && !$isField): ?>
+    <?= $element->getHtmlContent(); ?>
+<?php else: ?>
+
+    <?php if ($isField && $count > 1): ?>
+        <div class="fields-group-<?= /* @noEscape */ $count; ?>">
     <?php endif; ?>
 
+    <?= $element->getBasicChildrenHtml(); ?>
 
-    <div class="messages">
-        <?php if ($element->getComment() && !$isField): ?>
-            <div class="message message-notice"><?= $block->escapeHtml($element->getComment()) ?></div>
-        <?php endif; ?>
-    </div>
+    <?= ($isField && $count > 1) ? '</div>' : ''; ?>
 
+    <?php if ($element->getComment() && $isField): ?>
+        <div class="note"><?= $escaper->escapeHtml($element->getComment()); ?></div>
+    <?php endif; ?>
 
-    <?= ($isField) ? '<div class="control admin__field-control">' : '' ?>
-
-    <?php if ($element->hasHtmlContent() && !$isField): ?>
-        <?= $element->getHtmlContent() ?>
-    <?php else: ?>
-
-        <?php if ($isField && $count > 1): ?>
-            <div class="fields-group-<?= /* @noEscape */ $count ?>">
-        <?php endif; ?>
-
-        <?= $element->getBasicChildrenHtml() ?>
-
-        <?= ($isField && $count > 1) ? '</div>' : '' ?>
-
-        <?php if ($element->getComment() && $isField): ?>
-            <div class="note"><?= $block->escapeHtml($element->getComment()) ?></div>
-        <?php endif; ?>
-
-        <?php if ($element->hasAdvanced() && !$isField): ?>
-            <?= (!$element->getNoContainer() && $advancedAfter)  ? '</fieldset>' : '' ?>
-            <details class="details admin__collapsible-block-wrapper" id="details<?= /* @noEscape */ $id ?>">
-                <summary class="details-summary admin__collapsible-title" id="details-summary<?= /* @noEscape */ $id?>">
-                    <span><?= $block->escapeHtml($advancedLabel) ?></span>
-                </summary>
-                <div class="details-content admin__fieldset" id="details-content<?= /* @noEscape */ $id ?>">
-                    <?= $element->getAdvancedChildrenHtml() ?>
-                </div>
-            </details>
-        <?php elseif ($element->hasAdvanced() && $isField): ?>
-            <div class="nested" id="nested<?= /* @noEscape */ $id ?>">
-                <?= $element->getAdvancedChildrenHtml() ?>
+    <?php if ($element->hasAdvanced() && !$isField): ?>
+        <?= (!$element->getNoContainer() && $advancedAfter)  ? '</fieldset>' : ''; ?>
+        <details class="details admin__collapsible-block-wrapper" id="details<?= /* @noEscape */ $id; ?>">
+            <summary class="details-summary admin__collapsible-title" id="details-summary<?= /* @noEscape */ $id; ?>">
+                <span><?= $escaper->escapeHtml($advancedLabel); ?></span>
+            </summary>
+            <div class="details-content admin__fieldset" id="details-content<?= /* @noEscape */ $id; ?>">
+                <?= $element->getAdvancedChildrenHtml(); ?>
             </div>
-        <?php endif; ?>
-
-        <?= ($isField) ? '</div>' : '' ?>
-
+        </details>
+    <?php elseif ($element->hasAdvanced() && $isField): ?>
+        <div class="nested" id="nested<?= /* @noEscape */ $id; ?>">
+            <?= $element->getAdvancedChildrenHtml(); ?>
+        </div>
     <?php endif; ?>
 
+    <?= $isField ? '</div>' : ''; ?>
+<?php endif; ?>
 
-    <?php if (!$element->getNoContainer() && !$advancedAfter): ?>
-        </fieldset>
-    <?php endif; ?>
+
+<?php if (!$element->getNoContainer() && !$advancedAfter): ?>
+    </fieldset>
+<?php endif; ?>
 
 <?php if ($isWrapped): ?>
         </div>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid.phtml
@@ -3,9 +3,16 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-?>
-<?php
+use Magento\Backend\Block\Widget\Grid;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Grid $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 /**
  * Template for \Magento\Backend\Block\Widget\Grid
  *
@@ -16,24 +23,25 @@
  *  getVarNamePage()
  *
  */
-/* @var $block \Magento\Backend\Block\Widget\Grid */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
 
-$numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
+$numColumns = $block->getColumns() !== null ? count($block->getColumns()) : 0;
 ?>
 <?php if ($block->getCollection()): ?>
-
     <?php if ($block->canDisplayContainer()): ?>
-<div id="<?= $block->escapeHtml($block->getId()) ?>" data-grid-id="<?= $block->escapeHtml($block->getId()) ?>">
+        <div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>"
+             data-grid-id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>">
     <?php else: ?>
         <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
     <?php endif; ?>
 
         <div class="admin__data-grid-header admin__data-grid-toolbar">
-            <?php $massActionAvailable = $block->getChildBlock('grid.massaction') &&
-                $block->getChildBlock('grid.massaction')->isAvailable() ?>
-            <?php if ($block->getPagerVisibility() || $block->getExportTypes() ||
-                $block->getChildBlock('grid.columnSet')->getFilterVisibility() || $massActionAvailable): ?>
+            <?php $massActionAvailable = $block->getChildBlock('grid.massaction')
+                && $block->getChildBlock('grid.massaction')->isAvailable() ?>
+
+            <?php if ($block->getPagerVisibility()
+                || $block->getExportTypes()
+                || $block->getChildBlock('grid.columnSet')->getFilterVisibility()
+                || $massActionAvailable): ?>
             <div class="admin__data-grid-header-row">
                 <?php if ($massActionAvailable): ?>
                     <?= $block->getMainButtonsHtml() ? '<div class="admin__filter-actions">' .
@@ -54,20 +62,21 @@ $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
                 <?php endif; ?>
                     <?php $countRecords = $block->getCollection()->getSize(); ?>
                     <div class="admin__control-support-text">
-                        <span id="<?= $block->escapeHtml($block->getHtmlId()) ?>-total-count"
+                        <span id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-total-count"
                             <?= /* @noEscape */ $block->getUiId('total-count') ?>>
                             <?= /* @noEscape */ $countRecords ?>
                         </span>
-                        <?= $block->escapeHtml(__('records found')) ?>
-                        <span id="<?= $block->escapeHtml($block->getHtmlId()) ?>_massaction-count"
-                              class="mass-select-info _empty"><strong data-role="counter">0</strong>
-                            <span><?= $block->escapeHtml(__('selected')) ?></span>
+                        <?= $escaper->escapeHtml(__('records found')) ?>
+                        <span id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_massaction-count"
+                              class="mass-select-info _empty">
+                            <strong data-role="counter">0</strong>
+                            <span><?= $escaper->escapeHtml(__('selected')) ?></span>
                         </span>
                     </div>
                 <?php if ($block->getPagerVisibility()): ?>
                     <div class="admin__data-grid-pager-wrap">
-                        <select name="<?= $block->escapeHtmlAttr($block->getVarNameLimit()) ?>"
-                                id="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-limit"
+                        <select name="<?= $escaper->escapeHtmlAttr($block->getVarNameLimit()) ?>"
+                                id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-limit"
                                 onchange="<?= /* @noEscape */ $block->getJsObjectName() ?>.loadByElement(this)"
                             <?= /* @noEscape */ $block->getUiId('per-page') ?>
                                 class="admin__control-select">
@@ -87,33 +96,35 @@ $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
                                 selected="selected"<?php endif; ?>>200
                             </option>
                         </select>
-                        <label for="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-limit"
-                            class="admin__control-support-text"><?= $block->escapeHtml(__('per page')) ?></label>
+                        <label for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-limit"
+                            class="admin__control-support-text">
+                            <?= $escaper->escapeHtml(__('per page')) ?>
+                        </label>
                         <div class="admin__data-grid-pager">
                             <?php $_curPage = $block->getCollection()->getCurPage() ?>
                             <?php $_lastPage = $block->getCollection()->getLastPageNumber() ?>
 
                             <?php if ($_curPage > 1): ?>
                                 <button class="action-previous" type="button">
-                                    <span><?= $block->escapeHtml(__('Previous page')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Previous page')) ?></span>
                                 </button>
                                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                     'onclick',
                                     /* @noEscape */ $block->getJsObjectName() . '.setPage(\'' .
                                         /* @noEscape */ ($_curPage - 1) . '\');event.preventDefault();',
-                                    'div#' . $block->escapeJs($block->getId()) .
+                                    'div#' . $escaper->escapeJs($block->getId()) .
                                     ' .admin__data-grid-pager button.action-previous:not(.disabled)'
                                 ) ?>
                             <?php else: ?>
                                 <button type="button" class="action-previous disabled">
-                                    <span><?= $block->escapeHtml(__('Previous page')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Previous page')) ?></span>
                                 </button>
                             <?php endif; ?>
 
                             <input type="text"
-                                   id="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-current"
-                                   name="<?= $block->escapeHtmlAttr($block->getVarNamePage()) ?>"
-                                   value="<?= $block->escapeHtmlAttr($_curPage) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-current"
+                                   name="<?= $escaper->escapeHtmlAttr($block->getVarNamePage()) ?>"
+                                   value="<?= $escaper->escapeHtmlAttr($_curPage) ?>"
                                    class="admin__control-text"
                                    <?= /* @noEscape */ $block->getUiId('current-page') ?> />
 
@@ -121,29 +132,30 @@ $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
                                 'onkeypress',
                                 /* @noEscape */ $block->getJsObjectName() . '.inputPage(event, \'' .
                                 /* @noEscape */ $_lastPage . '\')',
-                                '#' . $block->escapeHtml($block->getHtmlId()) . '_page-current'
+                                '#' . $escaper->escapeHtml($block->getHtmlId()) . '_page-current'
                             ) ?>
 
-                            <label class="admin__control-support-text" for="<?= $block->escapeHtml($block->getHtmlId())
-                            ?>_page-current">
+                            <label class="admin__control-support-text"
+                                   for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-current">
                                 <?= /* @noEscape */ __('of %1', '<span>' .
                                     $block->getCollection()->getLastPageNumber() . '</span>') ?>
                             </label>
                             <?php if ($_curPage < $_lastPage): ?>
-                                <button type="button" title="<?= $block->escapeHtmlAttr(__('Next page')) ?>"
+                                <button type="button"
+                                        title="<?= $escaper->escapeHtmlAttr(__('Next page')) ?>"
                                         class="action-next">
-                                    <span><?= $block->escapeHtml(__('Next page')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Next page')) ?></span>
                                 </button>
                                 <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                     'onclick',
                                     /* @noEscape */ $block->getJsObjectName() . '.setPage(\'' .
                                     /* @noEscape */ ($_curPage + 1) . '\');event.preventDefault();',
-                                    'div#' . $block->escapeJs($block->getId()) .
+                                    'div#' . $escaper->escapeJs($block->getId()) .
                                     ' .admin__data-grid-pager button.action-next:not(.disabled)'
                                 ) ?>
                             <?php else: ?>
                                 <button type="button" class="action-next disabled">
-                                    <span><?= $block->escapeHtml(__('Next page')) ?></span>
+                                    <span><?= $escaper->escapeHtml(__('Next page')) ?></span>
                                 </button>
                             <?php endif; ?>
                         </div>
@@ -153,14 +165,14 @@ $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
         </div>
         <div class="admin__data-grid-wrap admin__data-grid-wrap-static">
         <?php if ($block->getGridCssClass()): ?>
-            <table class="<?= $block->escapeHtmlAttr($block->getGridCssClass()) ?> data-grid"
-                   id="<?= $block->escapeHtml($block->getId()) ?>_table">
+            <table class="<?= $escaper->escapeHtmlAttr($block->getGridCssClass()) ?> data-grid"
+                   id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_table">
                 <!-- Rendering column set -->
                 <?= $block->getChildHtml('grid.columnSet') ?>
             </table>
         <?php else: ?>
 
-            <table class="data-grid" id="<?= $block->escapeHtml($block->getId()) ?>_table">
+            <table class="data-grid" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_table">
                 <!-- Rendering column set -->
                 <?= $block->getChildHtml('grid.columnSet') ?>
             </table>
@@ -191,44 +203,44 @@ $numColumns = $block->getColumns() !== null ? count($block->getColumns()): 0;
 require(deps, function('. ($block->getDependencyJsObject() ? 'registry' : '') .'){' . PHP_EOL;
         //TODO: getJsObjectName and getRowClickCallback has unexpected behavior. Should be removed
         if ($block->getDependencyJsObject()) {
-            $scriptString .= 'registry.get(\'' . $block->escapeJs($block->getDependencyJsObject()) .
-                '\', function ('. $block->escapeJs($block->getDependencyJsObject()) . ') {' . PHP_EOL;
+            $scriptString .= 'registry.get(\'' . $escaper->escapeJs($block->getDependencyJsObject()) .
+                '\', function ('. $escaper->escapeJs($block->getDependencyJsObject()) . ') {' . PHP_EOL;
         }
 
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . ' = new varienGrid(\'' .
-            $block->escapeJs($block->getId()) . '\', \'' . $block->escapeJs($block->getGridUrl()) . '\', \'' .
-            $block->escapeJs($block->getVarNamePage()) .'\', \'' .
-            $block->escapeJs($block->getVarNameSort()) . '\', \'' .
-            $block->escapeJs($block->getVarNameDir()) . '\', \'' . $block->escapeJs($block->getVarNameFilter()) .'\');
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . ' = new varienGrid(\'' .
+            $escaper->escapeJs($block->getId()) . '\', \'' . $escaper->escapeJs($block->getGridUrl()) . '\', \'' .
+            $escaper->escapeJs($block->getVarNamePage()) .'\', \'' .
+            $escaper->escapeJs($block->getVarNameSort()) . '\', \'' .
+            $escaper->escapeJs($block->getVarNameDir()) . '\', \'' . $escaper->escapeJs($block->getVarNameFilter()) .'\');
 ' . PHP_EOL;
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.useAjax = ' .
-            (/* @noEscape */ $block->escapeJs($block->getUseAjax()) ? 'true' : 'false') . ';' . PHP_EOL;
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.useAjax = ' .
+            (/* @noEscape */ $escaper->escapeJs($block->getUseAjax()) ? 'true' : 'false') . ';' . PHP_EOL;
         if ($block->getRowClickCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.rowClickCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.rowClickCallback = ' .
                 /* @noEscape */ $block->getRowClickCallback() . ';' . PHP_EOL;
         }
 
         if ($block->getCheckboxCheckCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.checkboxCheckCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.checkboxCheckCallback = ' .
                 /* @noEscape */ $block->getCheckboxCheckCallback() . ';' . PHP_EOL;
         }
 
         if ($block->getSortableUpdateCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.sortableUpdateCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.sortableUpdateCallback = ' .
                 /* @noEscape */ $block->getSortableUpdateCallback() . ';' . PHP_EOL;
         }
 
         if ($block->getFilterKeyPressCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.filterKeyPressCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.filterKeyPressCallback = ' .
                 /* @noEscape */ $block->getFilterKeyPressCallback() . ';' . PHP_EOL;
         }
 
-        $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.bindSortable();' . PHP_EOL;
+        $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.bindSortable();' . PHP_EOL;
 
         if ($block->getRowInitCallback()) {
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '.initRowCallback = ' .
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '.initRowCallback = ' .
                 /* @noEscape */ $block->getRowInitCallback() . ';' . PHP_EOL;
-            $scriptString .= $block->escapeJs($block->getJsObjectName()) . '..initGridRows();' . PHP_EOL;
+            $scriptString .= $escaper->escapeJs($block->getJsObjectName()) . '..initGridRows();' . PHP_EOL;
         }
 
         if ($block->getChildBlock('grid.massaction') &&

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/column_set.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/column_set.phtml
@@ -3,13 +3,17 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * Template for \Magento\Backend\Block\Widget\Grid\ColumnSet
- * @var $block \Magento\Backend\Block\Widget\Grid\ColumnSet
- */
+declare(strict_types=1);
+
+use Magento\Backend\Block\Widget\Grid\Column;
+use Magento\Backend\Block\Widget\Grid\ColumnSet;
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
+/** @var ColumnSet $block */
 $numColumns = count($block->getColumns());
+
+// phpcs:disable Generic.Files.LineLength
 ?>
 <?php if ($block->getCollection()) : ?>
     <?php
@@ -17,26 +21,27 @@ $numColumns = count($block->getColumns());
     /* foreach ($block->getColumns() as $_column): ?>
         <col <?= $_column->getHtmlProperty() ?> />
     <?php endforeach; */ ?>
-    <?php if ($block->isHeaderVisible()) : ?>
+    <?php if ($block->isHeaderVisible()): ?>
         <thead>
-            <?php if ($block->isHeaderVisible() || $block->getFilterVisibility()) : ?>
+            <?php if ($block->isHeaderVisible() || $block->getFilterVisibility()): ?>
                 <tr>
-                <?php foreach ($block->getColumns() as $_column) : ?>
-                    <?php /* @var $_column \Magento\Backend\Block\Widget\Grid\Column */ ?>
+                <?php foreach ($block->getColumns() as $_column): ?>
+                    <?php /* @var Column $_column */ ?>
                     <?php if ($_column->getHeaderHtml() == '&nbsp;') :?>
-                        <th class="data-grid-th" data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                            <?= $_column->getHeaderHtmlProperty() ?>>&nbsp;</th>
+                        <th class="data-grid-th" data-column="<?= $escaper->escapeHtmlAttr($_column->getId()); ?>"
+                            <?= $_column->getHeaderHtmlProperty(); ?>>&nbsp;</th>
                     <?php else : ?>
-                        <?= $_column->getHeaderHtml() ?>
+                        <?= $_column->getHeaderHtml(); ?>
                     <?php endif; ?>
                 <?php endforeach; ?>
                 </tr>
             <?php endif; ?>
-            <?php if ($block->isFilterVisible()) : ?>
+            <?php if ($block->isFilterVisible()): ?>
                 <tr class="data-grid-filters" data-role="filter-form">
-                    <?php $i = 0; foreach ($block->getColumns() as $_column) : ?>
-                        <td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>" <?= $_column->getHeaderHtmlProperty() ?>>
-                            <?= $_column->getFilterHtml() ?>
+                    <?php $i = 0; foreach ($block->getColumns() as $_column): ?>
+                        <td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                            <?= $_column->getHeaderHtmlProperty(); ?>>
+                            <?= $_column->getFilterHtml(); ?>
                         </td>
                     <?php endforeach; ?>
                 </tr>
@@ -50,20 +55,20 @@ $numColumns = count($block->getColumns());
             <?php foreach ($block->getCollection() as $_index => $_item) : ?>
                 <?php if ($block->hasMultipleRows($_item)) :?>
                     <?php $block->updateItemByFirstMultiRow($_item); ?>
-                <tr title="<?= $block->escapeHtmlAttr($block->getRowUrl($_item)) ?>" data-role="row"
-                    <?php if ($_class = $block->getRowClass($_item)) :?> class="<?= $block->escapeHtmlAttr($_class) ?>"<?php endif;?>
+                <tr title="<?= $escaper->escapeHtmlAttr($block->getRowUrl($_item)) ?>" data-role="row"
+                    <?php if ($_class = $block->getRowClass($_item)) :?> class="<?= $escaper->escapeHtmlAttr($_class) ?>"<?php endif;?>
                 ><?php $i = 0; foreach ($block->getColumns() as $_column) :
                     if ($block->shouldRenderCell($_item, $_column)) :
                             $_rowspan = $block->getRowspan($_item, $_column);
-                        ?><td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
+                        ?><td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
                                 <?= /* @noEscape */ ($_rowspan ? 'rowspan="' . $_rowspan . '" ' : '') ?>
-                                class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
+                                class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
                             >
                                 <?= /* @noEscape */ (($_html = $_column->getRowField($_item)) != '' ? $_html : '&nbsp;') ?>
                             </td><?php
                             if ($block->shouldRenderEmptyCell($_item, $_column)) :?>
-                                <td colspan="<?= $block->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>" class="last">
-                                <?= $block->escapeHtml($block->getEmptyCellLabel()) ?>
+                                <td colspan="<?= $escaper->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>" class="last">
+                                <?= $escaper->escapeHtml($block->getEmptyCellLabel()) ?>
                                 </td><?php
                             endif;
                         endif;
@@ -79,8 +84,8 @@ $numColumns = count($block->getColumns());
                         ?>
                     <tr data-role="row">
                         <?php $i = 0; foreach ($block->getMultipleRowColumns($_i) as $_column) :
-                            ?><td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                            class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns-1 ? 'last' : '' ?>"
+                            ?><td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                            class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns-1 ? 'last' : '' ?>"
                         >
                             <?= /* @noEscape */ (($_html = $_column->getRowField($_i)) != '' ? $_html : '&nbsp;') ?>
                         </td><?php
@@ -91,31 +96,31 @@ $numColumns = count($block->getColumns());
                     <?php if ($block->shouldRenderSubTotal($_item)) : ?>
                     <tr class="subtotals">
                         <?php $i = 0; foreach ($block->getMultipleRowColumns() as $_column) : ?>
-                            <td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                                class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
+                            <td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                                class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
                             >
-                                <?= /* @noEscape */ $_column->hasSubtotalsLabel() ? $block->escapeHtml($_column->getSubtotalsLabel()) : $_column->getRowField($block->getSubTotals($_item)) ?>
+                                <?= /* @noEscape */ $_column->hasSubtotalsLabel() ? $escaper->escapeHtml($_column->getSubtotalsLabel()) : $_column->getRowField($block->getSubTotals($_item)) ?>
                             </td>
                         <?php endforeach; ?>
                     </tr>
                 <?php endif; ?>
             <?php else : ?>
-                <tr data-role="row" title="<?= $block->escapeHtmlAttr($block->getRowUrl($_item)) ?>"<?php if ($_class = $block->getRowClass($_item)) : ?>
-                    class="<?= $block->escapeHtmlAttr($_class) ?>"<?php endif;?>
+                <tr data-role="row" title="<?= $escaper->escapeHtmlAttr($block->getRowUrl($_item)) ?>"<?php if ($_class = $block->getRowClass($_item)) : ?>
+                    class="<?= $escaper->escapeHtmlAttr($_class) ?>"<?php endif;?>
                 >
                     <?php $i = 0; foreach ($block->getColumns() as $_column) : ?>
                         <?php if ($block->shouldRenderCell($_item, $_column)) : ?>
-                            <td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                                class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
+                            <td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                                class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?> <?= /* @noEscape */ $_column->getId() == 'massaction' ? 'data-grid-checkbox-cell': '' ?> <?= ++$i == $numColumns ? 'last' : '' ?>"
                             >
                                 <?= /* @noEscape */ (($_html = $_column->getRowField($_item)) != '' ? $_html : '&nbsp;') ?>
                             </td>
                             <?php if ($block->shouldRenderEmptyCell($_item, $_column)) : ?>
-                                <td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                                    colspan="<?= $block->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>"
-                                    class="col-no-records <?= $block->escapeHtmlAttr($block->getEmptyTextClass()) ?> last"
+                                <td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                                    colspan="<?= $escaper->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>"
+                                    class="col-no-records <?= $escaper->escapeHtmlAttr($block->getEmptyTextClass()) ?> last"
                                 >
-                                    <?= $block->escapeHtml($block->getEmptyCellLabel()) ?>
+                                    <?= $escaper->escapeHtml($block->getEmptyCellLabel()) ?>
                                 </td>
                             <?php endif;?>
                         <?php endif;?>
@@ -125,8 +130,8 @@ $numColumns = count($block->getColumns());
         <?php endforeach; ?>
         <?php elseif ($block->getEmptyText()) : ?>
             <tr class="data-grid-tr-no-data" data-role="row">
-                <td class="<?= $block->escapeHtmlAttr($block->getEmptyTextClass()) ?>"
-                    colspan="<?= $block->escapeHtmlAttr($numColumns) ?>"><?= $block->escapeHtml($block->getEmptyText()) ?></td>
+                <td class="<?= $escaper->escapeHtmlAttr($block->getEmptyTextClass()) ?>"
+                    colspan="<?= $escaper->escapeHtmlAttr($numColumns) ?>"><?= $escaper->escapeHtml($block->getEmptyText()) ?></td>
             </tr>
         <?php endif; ?>
     </tbody>
@@ -135,10 +140,10 @@ $numColumns = count($block->getColumns());
     <tfoot>
         <tr class="totals" data-role="row">
             <?php foreach ($block->getColumns() as $_column) : ?>
-                <th data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
-                    class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?>"
+                <th data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
+                    class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?>"
                 >
-                    <?= /* @noEscape */ ($_column->hasTotalsLabel()) ? $block->escapeHtml($_column->getTotalsLabel()) : $_column->getRowField($block->getTotals()) ?>
+                    <?= /* @noEscape */ ($_column->hasTotalsLabel()) ? $escaper->escapeHtml($_column->getTotalsLabel()) : $_column->getRowField($block->getTotals()) ?>
                 </th>
             <?php endforeach; ?>
         </tr>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/export.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/export.phtml
@@ -3,14 +3,23 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <div class="admin__data-grid-export">
-    <label for="<?= $block->escapeHtmlAttr($block->getId()) ?>_export" class="admin__control-support-text">
-        <?= $block->escapeHtml(__('Export to:')) ?>
+    <label for="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export" class="admin__control-support-text">
+        <?= $escaper->escapeHtml(__('Export to:')) ?>
     </label>
-    <select name="<?= $block->escapeHtmlAttr($block->getId()) ?>_export" id="<?= $block->escapeHtmlAttr($block->getId()) ?>_export" class="admin__control-select">
+    <select name="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export"
+            id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export"
+            class="admin__control-select">
         <?php foreach ($block->getExportTypes() as $_type) : ?>
-            <option value="<?= $block->escapeHtmlAttr($_type->getUrl()) ?>"><?= $block->escapeHtml($_type->getLabel()) ?></option>
+            <option value="<?= $escaper->escapeHtmlAttr($_type->getUrl()) ?>">
+                <?= $escaper->escapeHtml($_type->getLabel()) ?>
+            </option>
         <?php endforeach; ?>
     </select>
     <?= $block->getExportButtonHtml() ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/extended.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/extended.phtml
@@ -3,11 +3,19 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
+use Magento\Backend\Block\Widget\Grid\Extended;
+use Magento\Backend\ViewModel\LimitTotalNumberOfProductsInGrid;
+use Magento\Framework\Escaper;
 use Magento\Catalog\Ui\DataProvider\Product\ProductCollection;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
-?>
-<?php
+/** @var Extended $block */
+/** @var LimitTotalNumberOfProductsInGrid $viewModel */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 /**
  * Template for \Magento\Backend\Block\Widget\Grid
  *
@@ -18,19 +26,14 @@ use Magento\Catalog\Ui\DataProvider\Product\ProductCollection;
  *  getVarNamePage()
  */
 
-/**
- * @var \Magento\Backend\Block\Widget\Grid\Extended $block
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- * @var \Magento\Backend\ViewModel\LimitTotalNumberOfProductsInGrid $viewModel
- */
 $numColumns = count($block->getColumns());
 $viewModel = $block->getViewModel();
-
 ?>
 <?php if ($block->getCollection()): ?>
     <?php if ($block->canDisplayContainer()): ?>
 
-    <div id="<?= $block->escapeHtml($block->getId()) ?>" data-grid-id="<?= $block->escapeHtml($block->getId()) ?>">
+    <div id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>"
+        data-grid-id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>">
     <?php else: ?>
         <?= $block->getLayout()->getMessagesBlock()->getGroupedHtml() ?>
     <?php endif; ?>
@@ -47,15 +50,15 @@ $viewModel = $block->getViewModel();
                 <div class="admin__data-grid-export">
                     <label
                         class="admin__control-support-text"
-                        for="<?= $block->escapeHtml($block->getId()) ?>_export">
-                        <?= $block->escapeHtml(__('Export to:')) ?>
+                        for="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export">
+                        <?= $escaper->escapeHtml(__('Export to:')) ?>
                     </label>
-                    <select name="<?= $block->escapeHtml($block->getId()) ?>_export"
-                            id="<?= $block->escapeHtml($block->getId()) ?>_export"
+                    <select name="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export"
+                            id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_export"
                             class="admin__control-select">
                         <?php foreach ($block->getExportTypes() as $_type): ?>
-                            <option value="<?= $block->escapeHtmlAttr($_type->getUrl()) ?>">
-                                <?= $block->escapeHtml($_type->getLabel()) ?>
+                            <option value="<?= $escaper->escapeHtmlAttr($_type->getUrl()) ?>">
+                                <?= $escaper->escapeHtml($_type->getLabel()) ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
@@ -76,23 +79,23 @@ $viewModel = $block->getViewModel();
                     <?php if (!$block->getCollection() instanceof ProductCollection
                         || !$viewModel->limitTotalNumberOfProducts()
                         || $countRecords < $viewModel->getRecordsLimit()): ?>
-                        <span id="<?= $block->escapeHtml($block->getHtmlId()) ?>-total-count"
+                        <span id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-total-count"
                             <?= /* @noEscape */ $block->getUiId('total-count') ?>>
                             <?= /* @noEscape */ $countRecords ?>
                         </span>
-                        <?= $block->escapeHtml(__('records found')) ?>
+                        <?= $escaper->escapeHtml(__('records found')) ?>
                     <?php endif; ?>
-                    <span id="<?= $block->escapeHtml($block->getHtmlId()) ?>_massaction-count"
+                    <span id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_massaction-count"
                           class="mass-select-info _empty">
                         <strong data-role="counter">0</strong>
-                        <span><?= $block->escapeHtml(__('selected')) ?></span>
+                        <span><?= $escaper->escapeHtml(__('selected')) ?></span>
                     </span>
                 </div>
 
             <?php if ($block->getPagerVisibility()): ?>
                 <div class="admin__data-grid-pager-wrap">
-                    <select name="<?= $block->escapeHtmlAttr($block->getVarNameLimit()) ?>"
-                            id="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-limit"
+                    <select name="<?= $escaper->escapeHtmlAttr($block->getVarNameLimit()) ?>"
+                            id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-limit"
                             onchange="<?= /* @noEscape */ $block->getJsObjectName() ?>.loadByElement(this)"
                             class="admin__control-select">
                         <option value="20"<?php if ($block->getCollection()->getPageSize() == 20): ?>
@@ -111,65 +114,65 @@ $viewModel = $block->getViewModel();
                             selected="selected"<?php endif; ?>>200
                         </option>
                     </select>
-                    <label for="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-limit"
-                        class="admin__control-support-text"><?= $block->escapeHtml(__('per page')) ?></label>
+                    <label for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-limit"
+                        class="admin__control-support-text"><?= $escaper->escapeHtml(__('per page')) ?></label>
 
                     <div class="admin__data-grid-pager">
                         <?php $_curPage = $block->getCollection()->getCurPage() ?>
                         <?php $_lastPage = $block->getCollection()->getLastPageNumber() ?>
                         <?php if ($_curPage > 1): ?>
                             <button class="action-previous" type="button">
-                                <span><?= $block->escapeHtml(__('Previous page')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Previous page')) ?></span>
                             </button>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 /* @noEscape */ $block->getJsObjectName() . '.setPage(\'' .
                                 /* @noEscape */ ($_curPage - 1) . '\');event.preventDefault();',
-                                'div#' . $block->escapeJs($block->getId()) .
+                                'div#' . $escaper->escapeJs($block->getId()) .
                                 ' .admin__data-grid-pager button.action-previous:not(.disabled)'
                             ) ?>
                         <?php else: ?>
                             <button type="button" class="action-previous disabled">
-                                <span><?= $block->escapeHtml(__('Previous page')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Previous page')) ?></span>
                             </button>
                         <?php endif; ?>
                         <?php if (!$block->getCollection() instanceof ProductCollection
                             || !$viewModel->limitTotalNumberOfProducts()
                             || $countRecords < $viewModel->getRecordsLimit()): ?>
                             <input type="text"
-                                   id="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-current"
-                                   name="<?= $block->escapeHtmlAttr($block->getVarNamePage()) ?>"
-                                   value="<?= $block->escapeHtmlAttr($_curPage) ?>"
+                                   id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-current"
+                                   name="<?= $escaper->escapeHtmlAttr($block->getVarNamePage()) ?>"
+                                   value="<?= $escaper->escapeHtmlAttr($_curPage) ?>"
                                    class="admin__control-text"
                                    <?= /* @noEscape */ $block->getUiId('current-page') ?> />
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onkeypress',
                                 /* @noEscape */ $block->getJsObjectName() . '.inputPage(event, \'' .
                                 /* @noEscape */ $_lastPage . '\')',
-                                '#' . $block->escapeHtml($block->getHtmlId()) . '_page-current'
+                                '#' . $escaper->escapeHtml($block->getHtmlId()) . '_page-current'
                             ) ?>
                             <label class="admin__control-support-text"
-                                   for="<?= $block->escapeHtml($block->getHtmlId()) ?>_page-current">
+                                   for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>_page-current">
                                 <?= /* @noEscape */ __('of %1', '<span>' .
                                     $block->getCollection()->getLastPageNumber() . '</span>') ?>
                             </label>
                         <?php endif; ?>
                         <?php if ($_curPage < $_lastPage): ?>
                             <button type="button"
-                                    title="<?= $block->escapeHtmlAttr(__('Next page')) ?>"
+                                    title="<?= $escaper->escapeHtmlAttr(__('Next page')) ?>"
                                     class="action-next">
-                                <span><?= $block->escapeHtml(__('Next page')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Next page')) ?></span>
                             </button>
                             <?= /* @noEscape */ $secureRenderer->renderEventListenerAsTag(
                                 'onclick',
                                 /* @noEscape */ $block->getJsObjectName() . '.setPage(\'' .
                                 /* @noEscape */ ($_curPage + 1) . '\');event.preventDefault();',
-                                'div#' . $block->escapeJs($block->getId()) .
+                                'div#' . $escaper->escapeJs($block->getId()) .
                                 ' .admin__data-grid-pager button.action-next:not(.disabled)'
                             ) ?>
                         <?php else: ?>
                             <button type="button" class="action-next disabled">
-                                <span><?= $block->escapeHtml(__('Next page')) ?></span>
+                                <span><?= $escaper->escapeHtml(__('Next page')) ?></span>
                             </button>
                         <?php endif; ?>
                     </div>
@@ -180,7 +183,7 @@ $viewModel = $block->getViewModel();
     <?php endif; ?>
 
     <div class="admin__data-grid-wrap admin__data-grid-wrap-static">
-        <table class="data-grid" id="<?= $block->escapeHtml($block->getId()) ?>_table">
+        <table class="data-grid" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>_table">
             <?php
             /* This part is commented to remove all <col> tags from the code. */
             /* foreach ($block->getColumns() as $_column): ?>
@@ -193,7 +196,8 @@ $viewModel = $block->getViewModel();
                     <tr>
                         <?php foreach ($block->getColumns() as $_column): ?>
                             <?php if ($_column->getHeaderHtml() == '&nbsp;'): ?>
-                                <th class="data-grid-th" data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
+                                <th class="data-grid-th"
+                                    data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
                                     <?= $_column->getHeaderHtmlProperty() ?>>&nbsp;</th>
                             <?php else: ?>
                                 <?= $_column->getHeaderHtml() ?>
@@ -205,7 +209,7 @@ $viewModel = $block->getViewModel();
                     <tr class="data-grid-filters" data-role="filter-form">
                         <?php $i = 0;
                         foreach ($block->getColumns() as $_column): ?>
-                            <td data-column="<?= $block->escapeHtmlAttr($_column->getId()) ?>"
+                            <td data-column="<?= $escaper->escapeHtmlAttr($_column->getId()) ?>"
                                 <?= $_column->getHeaderHtmlProperty() ?>>
                                 <?= $_column->getFilterHtml() ?>
                             </td>
@@ -218,9 +222,9 @@ $viewModel = $block->getViewModel();
                 <tfoot>
                 <tr class="totals">
                     <?php foreach ($block->getColumns() as $_column): ?>
-                        <th class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?>">
+                        <th class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?>">
                             <?= /* @noEscape */ ($_column->hasTotalsLabel()) ?
-                                $block->escapeHtml($_column->getTotalsLabel()) :
+                                $escaper->escapeHtml($_column->getTotalsLabel()) :
                                 $_column->getRowField($_column->getGrid()->getTotals()) ?>
                         </th>
                     <?php endforeach; ?>
@@ -231,9 +235,9 @@ $viewModel = $block->getViewModel();
             <tbody>
             <?php if (($block->getCollection()->getSize() > 0) && (!$block->getIsCollapsed())): ?>
                 <?php foreach ($block->getCollection() as $_index => $_item): ?>
-                    <tr title="<?= $block->escapeHtmlAttr($block->getRowUrl($_item)) ?>"
+                    <tr title="<?= $escaper->escapeHtmlAttr($block->getRowUrl($_item)) ?>"
                         <?php if ($_class = $block->getRowClass($_item)): ?>
-                        class="<?= $block->escapeHtmlAttr($_class) ?>"
+                        class="<?= $escaper->escapeHtmlAttr($_class) ?>"
                         <?php endif; ?>>
                         <?php
                         $i = 0;
@@ -242,7 +246,7 @@ $viewModel = $block->getViewModel();
                                 $_rowspan = $block->getRowspan($_item, $_column);
                                 ?>
                             <td <?= /* @noEscape */ ($_rowspan ? 'rowspan="' . $_rowspan . '" ' : '') ?>
-                                class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?>
+                                class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?>
                                         <?= /* @noEscape */ $_column->getId() == 'massaction' ?
                                         'data-grid-checkbox-cell': '' ?>">
                                 <?= /* @noEscape */ (($_html = $_column->getRowField($_item)) != '' ?
@@ -250,8 +254,8 @@ $viewModel = $block->getViewModel();
                                 </td><?php
                                 if ($block->shouldRenderEmptyCell($_item, $_column)):
                                     ?>
-                                    <td colspan="<?= $block->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>"
-                                        class="last"><?= $block->escapeHtml($block->getEmptyCellLabel()) ?></td><?php
+                                    <td colspan="<?= $escaper->escapeHtmlAttr($block->getEmptyCellColspan($_item)) ?>"
+                                        class="last"><?= $escaper->escapeHtml($block->getEmptyCellLabel()) ?></td><?php
                                 endif;
                             endif;
                         endforeach; ?>
@@ -261,7 +265,7 @@ $viewModel = $block->getViewModel();
                             <tr>
                                 <?php $i = 0;
                                 foreach ($block->getMultipleRowColumns($_i) as $_column): ?>
-                                    <td class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?>
+                                    <td class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?>
                                         <?= /* @noEscape */ $_column->getId() == 'massaction' ?
                                         'data-grid-checkbox-cell': '' ?>">
                                         <?= /* @noEscape */ (($_html = $_column->getRowField($_i)) != '' ?
@@ -276,11 +280,11 @@ $viewModel = $block->getViewModel();
                         <tr class="subtotals">
                             <?php $i = 0;
                             foreach ($block->getSubTotalColumns() as $_column): ?>
-                                <td class="<?= $block->escapeHtmlAttr($_column->getCssProperty()) ?>
+                                <td class="<?= $escaper->escapeHtmlAttr($_column->getCssProperty()) ?>
                                 <?= /* @noEscape */ $_column->getId() == 'massaction' ?
                                     'data-grid-checkbox-cell': '' ?>">
                                     <?= /* @noEscape */ $_column->hasSubtotalsLabel() ?
-                                        $block->escapeHtml($_column->getSubtotalsLabel()) :
+                                        $escaper->escapeHtml($_column->getSubtotalsLabel()) :
                                         $_column->getRowField($block->getSubTotalItem($_item)) ?>
                                 </td>
                             <?php endforeach; ?>
@@ -289,9 +293,9 @@ $viewModel = $block->getViewModel();
                 <?php endforeach; ?>
             <?php elseif ($block->getEmptyText()): ?>
                 <tr class="data-grid-tr-no-data">
-                    <td class="<?= $block->escapeHtmlAttr($block->getEmptyTextClass()) ?>"
-                        colspan="<?= $block->escapeHtmlAttr($numColumns) ?>"><?=
-                        $block->escapeHtml($block->getEmptyText()) ?></td>
+                    <td class="<?= $escaper->escapeHtmlAttr($block->getEmptyTextClass()) ?>"
+                        colspan="<?= $escaper->escapeHtmlAttr($numColumns) ?>"><?=
+                        $escaper->escapeHtml($block->getEmptyText()) ?></td>
                 </tr>
             <?php endif; ?>
             </tbody>
@@ -330,7 +334,7 @@ script;
             foreach ($block->getRequireJsDependencies() as $dependency):
                 $scriptString .= <<<script
 
-            deps.push('{$block->escapeJs($dependency)}');
+            deps.push('{$escaper->escapeJs($dependency)}');
 script;
             endforeach;
         endif;
@@ -349,51 +353,51 @@ script;
         if ($block->getDependencyJsObject()):
             $scriptString .= <<<script
 
-        registry.get('{$block->escapeJs($block->getDependencyJsObject())}',
-         function ({$block->escapeJs($block->getDependencyJsObject())}) {
+        registry.get('{$escaper->escapeJs($block->getDependencyJsObject())}',
+         function ({$escaper->escapeJs($block->getDependencyJsObject())}) {
 script;
         endif;
         $encodedId = /* @noEscape */ $jsonHelper->jsonEncode($block->getId());
         $scriptString .= <<<script
 
-    {$block->escapeJs($block->getJsObjectName())} = new varienGrid({$encodedId},
-         '{$block->escapeJs($block->getGridUrl())}',
-         '{$block->escapeJs($block->getVarNamePage())}',
-         '{$block->escapeJs($block->getVarNameSort())}',
-         '{$block->escapeJs($block->getVarNameDir())}',
-         '{$block->escapeJs($block->getVarNameFilter())}'
+    {$escaper->escapeJs($block->getJsObjectName())} = new varienGrid({$encodedId},
+         '{$escaper->escapeJs($block->getGridUrl())}',
+         '{$escaper->escapeJs($block->getVarNamePage())}',
+         '{$escaper->escapeJs($block->getVarNameSort())}',
+         '{$escaper->escapeJs($block->getVarNameDir())}',
+         '{$escaper->escapeJs($block->getVarNameFilter())}'
          );
 
-        {$block->escapeJs($block->getJsObjectName())}.useAjax = '{$block->escapeJs($block->getUseAjax())}';
+        {$escaper->escapeJs($block->getJsObjectName())}.useAjax = '{$escaper->escapeJs($block->getUseAjax())}';
 
 script;
         if ($block->getRowClickCallback()):
             $rowClickCallback = /* @noEscape */ $block->getRowClickCallback();
             $scriptString .= <<<script
 
-            {$block->escapeJs($block->getJsObjectName())}.rowClickCallback = {$rowClickCallback};
+            {$escaper->escapeJs($block->getJsObjectName())}.rowClickCallback = {$rowClickCallback};
 script;
         endif;
         if ($block->getCheckboxCheckCallback()):
             $checkboxCheckCallback = /* @noEscape */ $block->getCheckboxCheckCallback();
             $scriptString .= <<<script
 
-            {$block->escapeJs($block->getJsObjectName())}.checkboxCheckCallback = {$checkboxCheckCallback};
+            {$escaper->escapeJs($block->getJsObjectName())}.checkboxCheckCallback = {$checkboxCheckCallback};
 script;
         endif;
         if ($block->getFilterKeyPressCallback()):
             $filterKeyPressCallback = /* @noEscape */ $block->getFilterKeyPressCallback();
             $scriptString .= <<<script
 
-            {$block->escapeJs($block->getJsObjectName())}.filterKeyPressCallback = {$filterKeyPressCallback};
+            {$escaper->escapeJs($block->getJsObjectName())}.filterKeyPressCallback = {$filterKeyPressCallback};
 script;
         endif;
         if ($block->getRowInitCallback()):
             $rowInitCallback = /* @noEscape */ $block->getRowInitCallback();
             $scriptString .= <<<script
 
-            {$block->escapeJs($block->getJsObjectName())}.initRowCallback = {$rowInitCallback};
-            {$block->escapeJs($block->getJsObjectName())}.initGridRows();
+            {$escaper->escapeJs($block->getJsObjectName())}.initRowCallback = {$rowInitCallback};
+            {$escaper->escapeJs($block->getJsObjectName())}.initGridRows();
 
 script;
         endif;

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/massaction.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/massaction.phtml
@@ -3,40 +3,47 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+// phpcs:disable Generic.Files.LineLength
 ?>
 <?= /* @noEscape */ $block->getSomething() ?>
-<div id="<?= $block->getHtmlId() ?>" class="admin__grid-massaction">
-
+<div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>" class="admin__grid-massaction">
     <?php if ($block->getHideFormElement() !== true): ?>
-    <form action="" id="<?= $block->getHtmlId() ?>-form" method="post">
+        <form action="" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-form" method="post">
     <?php endif ?>
         <div class="admin__grid-massaction-form">
     <?= $block->getBlockHtml('formkey') ?>
-            <select
-                id="<?= $block->getHtmlId() ?>-select"
-                class="required-entry local-validation admin__control-select"
-                <?= /* @noEscape */ $block->getUiId('select') ?>>
-                <option class="admin__control-select-placeholder" value="" selected>
-                    <?= $block->escapeHtml(__('Actions')) ?></option>
-                <?php foreach ($block->getItems() as $_item): ?>
-                    <option value="<?= $block->escapeHtmlAttr($_item->getId()) ?>"
-                        <?= ($_item->getSelected() ? ' selected="selected"' : '') ?>>
-                        <?= $block->escapeHtml($_item->getLabel()) ?>
-                    </option>
-                <?php endforeach; ?>
-            </select>
-            <span class="outer-span" id="<?= $block->getHtmlId() ?>-form-hiddens"></span>
-            <span class="outer-span" id="<?= $block->getHtmlId() ?>-form-additional"></span>
-            <?= $block->getApplyButtonHtml() ?>
-        </div>
+        <select
+            id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-select"
+            class="required-entry local-validation admin__control-select"
+            <?= /* @noEscape */ $block->getUiId('select') ?>>
+            <option class="admin__control-select-placeholder" value="" selected>
+                <?= $escaper->escapeHtml(__('Actions')) ?>
+            </option>
+            <?php foreach ($block->getItems() as $_item): ?>
+                <option value="<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
+                    <?= ($_item->getSelected() ? ' selected="selected"' : '') ?>>
+                    <?= $escaper->escapeHtml($_item->getLabel()) ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <span class="outer-span" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-form-hiddens"></span>
+        <span class="outer-span" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-form-additional"></span>
+        <?= $block->getApplyButtonHtml() ?>
+    </div>
     <?php if ($block->getHideFormElement() !== true):?>
-    </form>
+        </form>
     <?php endif ?>
     <div class="no-display">
     <?php foreach ($block->getItems() as $_item): ?>
-        <div id="<?= $block->getHtmlId() ?>-item-<?= /* @noEscape */ $_item->getId() ?>-block">
+        <div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-item-<?= $escaper->escapeHtmlAttr($_item->getId()) ?>-block">
             <?php if ('' != $_item->getBlockName()):?>
                 <?= $block->getChildHtml($_item->getBlockName()) ?>
             <?php endif;?>
@@ -46,29 +53,29 @@
 
     <div class="mass-select-wrap">
         <select
-            id="<?= $block->getHtmlId() ?>-mass-select"
+            id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select"
             class="action-select-multiselect _disabled"
             disabled="disabled"
             data-menu="grid-mass-select">
-            <optgroup label="<?= $block->escapeHtmlAttr(__('Mass Actions')) ?>">
+            <optgroup label="<?= $escaper->escapeHtmlAttr(__('Mass Actions')) ?>">
                 <option disabled selected></option>
                 <?php if ($block->getUseSelectAll()):?>
                     <option value="selectAll">
-                        <?= $block->escapeHtml(__('Select All')) ?>
+                        <?= $escaper->escapeHtml(__('Select All')) ?>
                     </option>
                     <option value="unselectAll">
-                        <?= $block->escapeHtml(__('Unselect All')) ?>
+                        <?= $escaper->escapeHtml(__('Unselect All')) ?>
                     </option>
                 <?php endif; ?>
                 <option value="selectVisible">
-                    <?= $block->escapeHtml(__('Select Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Select Visible')) ?>
                 </option>
                 <option value="unselectVisible">
-                    <?= $block->escapeHtml(__('Unselect Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Unselect Visible')) ?>
                 </option>
             </optgroup>
         </select>
-        <label for="<?= $block->getHtmlId() ?>-mass-select"></label>
+        <label for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select"></label>
     </div>
 
 <?php $scriptString = <<<script
@@ -87,26 +94,26 @@ script;
 if ($block->getUseSelectAll()):
     $scriptString .= '
                 case \'selectAll\':
-                    return ' . $block->escapeJs($block->getJsObjectName()) . '.selectAll();
+                    return ' . $escaper->escapeJs($block->getJsObjectName()) . '.selectAll();
                     break;
                 case \'unselectAll\':
-                    return ' . $block->escapeJs($block->getJsObjectName()) . '.unselectAll();
+                    return ' . $escaper->escapeJs($block->getJsObjectName()) . '.unselectAll();
                     break;';
 endif;
     $scriptString .= '
                 case \'selectVisible\':
-                    return  ' . $block->escapeJs($block->getJsObjectName()) . '.selectVisible();
+                    return  ' . $escaper->escapeJs($block->getJsObjectName()) . '.selectVisible();
                     break;
                 case \'unselectVisible\':
-                    return ' . $block->escapeJs($block->getJsObjectName()) . '.unselectVisible();
+                    return ' . $escaper->escapeJs($block->getJsObjectName()) . '.unselectVisible();
                     break;
             }
         });
     });';
 
 if (!$block->getParentBlock()->canDisplayContainer()):
-    $scriptString .= $block->escapeJs($block->getJsObjectName()) .
-        '.setGridIds(\'' . $block->escapeJs($block->getGridIdsJson()) .'\');';
+    $scriptString .= $escaper->escapeJs($block->getJsObjectName()) .
+        '.setGridIds(\'' . $escaper->escapeJs($block->getGridIdsJson()) .'\');';
 endif;
 ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false); ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/massaction_extended.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/massaction_extended.phtml
@@ -3,31 +3,37 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
+// phpcs:disable Generic.Files.LineLength
 ?>
-<div id="<?= $block->getHtmlId() ?>" class="admin__grid-massaction">
-
+<div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>" class="admin__grid-massaction">
     <?php if ($block->getHideFormElement() !== true): ?>
-    <form action="" id="<?= $block->getHtmlId() ?>-form" method="post">
+        <form action="" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-form" method="post">
     <?php endif ?>
         <div class="admin__grid-massaction-form">
         <?= $block->getBlockHtml('formkey') ?>
             <select
-                id="<?= $block->getHtmlId() ?>-select"
+                id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-select"
                 class="required-entry local-validation admin__control-select">
                 <option class="admin__control-select-placeholder" value="" selected>
-                    <?= $block->escapeHtml(__('Actions')) ?>
+                    <?= $escaper->escapeHtml(__('Actions')) ?>
                 </option>
                 <?php foreach ($block->getItems() as $_item): ?>
-                    <option value="<?= $block->escapeHtmlAttr($_item->getId()) ?>"
+                    <option value="<?= $escaper->escapeHtmlAttr($_item->getId()) ?>"
                         <?= ($_item->getSelected() ? ' selected="selected"' : '') ?>>
-                        <?= $block->escapeHtml($_item->getLabel()) ?>
+                        <?= $escaper->escapeHtml($_item->getLabel()) ?>
                     </option>
                 <?php endforeach; ?>
             </select>
-            <span class="outer-span" id="<?= $block->getHtmlId() ?>-form-hiddens"></span>
-            <span class="outer-span" id="<?= $block->getHtmlId() ?>-form-additional"></span>
+            <span class="outer-span" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>-form-hiddens"></span>
+            <span class="outer-span" id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>-form-additional"></span>
             <?= $block->getApplyButtonHtml() ?>
         </div>
     <?php if ($block->getHideFormElement() !== true): ?>
@@ -35,59 +41,59 @@
     <?php endif ?>
     <div class="no-display">
         <?php foreach ($block->getItems() as $_item): ?>
-            <div id="<?= $block->getHtmlId() ?>-item-<?= /* @noEscape */ $_item->getId() ?>-block">
+            <div id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>-item-<?= $escaper->escapeHtmlAttr($_item->getId()); ?>-block">
                 <?= $_item->getAdditionalActionBlockHtml() ?>
             </div>
         <?php endforeach; ?>
     </div>
     <div class="mass-select-wrap">
         <select
-            id="<?= $block->getHtmlId() ?>-mass-select"
+            id="<?= $escaper->escapeHtmlAttr($block->getHtmlId()); ?>-mass-select"
             class="action-select-multiselect"
             data-menu="grid-mass-select">
-            <optgroup label="<?= $block->escapeHtml(__('Mass Actions')) ?>">
+            <optgroup label="<?= $escaper->escapeHtmlAttr(__('Mass Actions')) ?>">
                 <option disabled selected></option>
             <?php if ($block->getUseSelectAll()): ?>
                 <option value="selectAll">
-                    <?= $block->escapeHtml(__('Select All')) ?>
+                    <?= $escaper->escapeHtml(__('Select All')) ?>
                 </option>
                 <option value="unselectAll">
-                    <?= $block->escapeHtml(__('Unselect All')) ?>
+                    <?= $escaper->escapeHtml(__('Unselect All')) ?>
                 </option>
             <?php endif; ?>
                 <option value="selectVisible">
-                    <?= $block->escapeHtml(__('Select Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Select Visible')) ?>
                 </option>
                 <option value="unselectVisible">
-                    <?= $block->escapeHtml(__('Unselect Visible')) ?>
+                    <?= $escaper->escapeHtml(__('Unselect Visible')) ?>
                 </option>
             </optgroup>
         </select>
-        <label for="<?= $block->getHtmlId() ?>-mass-select"></label>
+        <label for="<?= $escaper->escapeHtmlAttr($block->getHtmlId()) ?>-mass-select"></label>
     </div>
     <?php $scriptString = <<<script
     require(['jquery'], function($){
         'use strict';
-        $('#{$block->getHtmlId()}-mass-select').change(function () {
+        $('#{$escaper->escapeHtmlAttr($block->getHtmlId())}-mass-select').change(function () {
             var massAction = $('option:selected', this).val();
             switch (massAction) {
 script;
     if ($block->getUseSelectAll()):
         $scriptString .= <<<script
                 case 'selectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectAll();
                     break;
                 case 'unselectAll':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectAll();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectAll();
                     break;
 script;
 endif;
     $scriptString .= <<<script
                 case 'selectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.selectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.selectVisible();
                     break;
                 case 'unselectVisible':
-                    return {$block->escapeJs($block->getJsObjectName())}.unselectVisible();
+                    return {$escaper->escapeJs($block->getJsObjectName())}.unselectVisible();
                     break;
             }
             this.blur();
@@ -97,7 +103,7 @@ script;
     if (!$block->getParentBlock()->canDisplayContainer()):
         $gridIdsJson = /* @noEscape */ $block->getGridIdsJson();
         $scriptString .= <<<script
-        {$block->escapeJs($block->getJsObjectName())}.setGridIds('{$gridIdsJson}');
+        {$escaper->escapeJs($block->getJsObjectName())}.setGridIds('{$gridIdsJson}');
 script;
     endif;
     ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/serializer.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/grid/serializer.phtml
@@ -3,18 +3,20 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
-?>
-<?php
-/**
- * @var $block \Magento\Backend\Block\Widget\Grid\Serializer
- * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
- */
-?>
-<?php
+declare(strict_types=1);
+
+use Magento\Backend\Block\Widget\Grid\Serializer;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Serializer $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
+
 // phpcs:ignore
 $_id = 'id_' . md5(microtime());
+$formId = $block->getFormId();
 ?>
-<?php $formId = $block->getFormId()?>
 <?php if (!empty($formId)): ?>
     <?php $scriptString = <<<script
     require([
@@ -24,13 +26,13 @@ $_id = 'id_' . md5(microtime());
         Event.observe(window, "load", function(){
             var serializeInput  = document.createElement('input');
             serializeInput.type = 'hidden';
-            serializeInput.name = '{$block->escapeJs($block->getInputElementName())}';
+            serializeInput.name = '{$escaper->escapeJs($block->getInputElementName())}';
             serializeInput.id   = '{$_id}';
             try {
-                document.getElementById('{$block->escapeJs($formId)}').appendChild(serializeInput);
+                document.getElementById('{$escaper->escapeJs($formId)}').appendChild(serializeInput);
                 new serializerController('{$_id}', {$block->getDataAsJSON()}, {$block->getColumnInputNames(true)},
-                 {$block->escapeJs($block->getGridBlock()->getJsObjectName())},
-                 '{$block->escapeJs($block->getReloadParamName())}');
+                 {$escaper->escapeJs($block->getGridBlock()->getJsObjectName())},
+                 '{$escaper->escapeJs($block->getReloadParamName())}');
             } catch(e) {
                 //Error add serializer
             }
@@ -40,15 +42,17 @@ script;
     ?>
     <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 <?php else:?>
-<input type="hidden" name="<?= $block->escapeHtmlAttr($block->getInputElementName()) ?>"  value=""
+<input type="hidden"
+       name="<?= $escaper->escapeHtmlAttr($block->getInputElementName()) ?>"
+       value=""
        id="<?= /* @noEscape */ $_id ?>" />
     <?php $scriptString = <<<script
     require([
         'mage/adminhtml/grid'
     ], function(){
         new serializerController('{$_id}', {$block->getDataAsJSON()}, {$block->getColumnInputNames(true)},
-         {$block->escapeJs($block->getGridBlock()->getJsObjectName())},
-         '{$block->escapeJs($block->getReloadParamName())}');
+         {$escaper->escapeJs($block->getGridBlock()->getJsObjectName())},
+         '{$escaper->escapeJs($block->getReloadParamName())}');
     });
 script;
     ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/tabs.phtml
@@ -3,16 +3,21 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
-/** @var $block \Magento\Backend\Block\Widget\Tabs */
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+use Magento\Backend\Block\Widget\Tabs;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+/** @var Tabs $block */
+/** @var Escaper $escaper */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
 <?php if (!empty($tabs)): ?>
-
-<div class="admin__page-nav" data-role="container" id="<?=  $block->escapeHtmlAttr($block->getId()) ?>">
+<div class="admin__page-nav" data-role="container" id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>">
     <?php if ($block->getTitle()): ?>
         <div class="admin__page-nav-title" data-role="title" <?= /* @noEscape */ $block->getUiId('title') ?>>
-            <strong><?= $block->escapeHtml($block->getTitle()) ?></strong>
+            <strong><?= $escaper->escapeHtml($block->getTitle()) ?></strong>
             <span data-role="title-messages" class="admin__page-nav-title-messages"></span>
         </div>
     <?php endif ?>
@@ -31,23 +36,24 @@
             <?php $_tabHref = $block->getTabUrl($_tab) == '#' ? '#' . $block->getTabId($_tab) . '_content' :
                 $block->getTabUrl($_tab) ?>
 
-            <li class="admin__page-nav-item no-display" id="<?= $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
+            <li class="admin__page-nav-item no-display"
+                id="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab)) ?>"
                 <?= /* @noEscape */ $block->getUiId('tab', 'item', $_tab->getId()) ?>>
-                <a href="<?=  $block->escapeUrl($_tabHref) ?>"
-                   id="<?=  $block->escapeHtmlAttr($block->getTabId($_tab)) ?>"
-                   name="<?=  $block->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
-                   title="<?=  $block->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
-                   class="admin__page-nav-link <?= $block->escapeHtmlAttr($_tabClass) ?>"
-                   data-tab-type="<?=  $block->escapeHtmlAttr($_tabType) ?>"
+                <a href="<?= $escaper->escapeUrl($_tabHref) ?>"
+                   id="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab)) ?>"
+                   name="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab, false)) ?>"
+                   title="<?= $escaper->escapeHtmlAttr($block->getTabTitle($_tab)) ?>"
+                   class="admin__page-nav-link <?= $escaper->escapeHtmlAttr($_tabClass) ?>"
+                   data-tab-type="<?= $escaper->escapeHtmlAttr($_tabType) ?>"
                    <?= /* @noEscape */ $block->getUiId('tab', 'link', $_tab->getId()) ?>>
 
-                   <span><?= $block->escapeHtml($block->getTabLabel($_tab)) ?></span>
+                   <span><?= $escaper->escapeHtml($block->getTabLabel($_tab)) ?></span>
 
                    <span class="admin__page-nav-item-messages" data-role="item-messages">
                        <span class="admin__page-nav-item-message _changed">
                            <span class="admin__page-nav-item-message-icon"></span>
                            <span class="admin__page-nav-item-message-tooltip">
-                               <?= $block->escapeHtml(__(
+                               <?= $escaper->escapeHtml(__(
                                    'Changes have been made to this section that have not been saved.'
                                )) ?>
                            </span>
@@ -55,7 +61,7 @@
                        <span class="admin__page-nav-item-message _error">
                            <span class="admin__page-nav-item-message-icon"></span>
                            <span class="admin__page-nav-item-message-tooltip">
-                               <?= $block->escapeHtml(__(
+                               <?= $escaper->escapeHtml(__(
                                    'This tab contains invalid data. Please resolve this before saving.'
                                )) ?>
                            </span>
@@ -68,13 +74,13 @@
                        </span>
                    </span>
                 </a>
-                <div id="<?=  $block->escapeHtmlAttr($block->getTabId($_tab)) ?>_content"
+                <div id="<?= $escaper->escapeHtmlAttr($block->getTabId($_tab)) ?>_content"
                     <?= /* @noEscape */ $block->getUiId('tab', 'content', $_tab->getId()) ?>>
                     <?= /* @noEscape */ $block->getTabContent($_tab) ?>
                 </div>
                 <?= /* @noEscape */ $secureRenderer->renderStyleAsTag(
                     'display:none',
-                    'div#' . $block->escapeJs($block->getTabId($_tab)) . '_content'
+                    'div#' . $escaper->escapeJs($block->getTabId($_tab)) . '_content'
                 ); ?>
             </li>
             <?php $scriptString = <<<script
@@ -83,12 +89,12 @@
 script;
             if ($block->getTabIsHidden($_tab)):
                 $scriptString .= <<<script
-        $('li.admin__page-nav-item#{$block->escapeJs($block->getTabId($_tab))}').css('display', 'none');
+        $('li.admin__page-nav-item#{$escaper->escapeJs($block->getTabId($_tab))}').css('display', 'none');
 script;
             endif;
 
             $scriptString .= <<<script
-        $('li.admin__page-nav-item#{$block->escapeJs($block->getTabId($_tab))}').removeClass('no-display');
+        $('li.admin__page-nav-item#{$escaper->escapeJs($block->getTabId($_tab))}').removeClass('no-display');
     })
 script;
             ?>

--- a/app/code/Magento/Backend/view/adminhtml/templates/widget/tabsleft.phtml
+++ b/app/code/Magento/Backend/view/adminhtml/templates/widget/tabsleft.phtml
@@ -3,18 +3,24 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+
+/** @var Escaper $escaper */
 ?>
 <dl id="dl-<?= /* @noEscape */ $id ?>" class="accordion">
 <?php foreach ($sections as $sectionId => $section) : ?>
     <dt id="dt-<?= /* @noEscape */ $id ?>-<?= /* @noEscape */ $sectionId ?>">
-        <strong><?= $block->escapeHtml($section['title']) ?></strong>
+        <strong><?= $escaper->escapeHtml($section['title']) ?></strong>
     </dt>
-    <dd id="dd-<?= /* @noEscape */ $id ?>-<?= /* @noEscape */ $section['id'] ?>" class="section-menu <?= !empty($section['active']) ? 'open' : '' ?>">
+    <dd id="dd-<?= /* @noEscape */ $id ?>-<?= /* @noEscape */ $section['id'] ?>"
+        class="section-menu <?= !empty($section['active']) ? 'open' : '' ?>">
         <ul>
         <?php foreach ($section['children'] as $menuId => $menuItem) : ?>
             <li id="li-<?= /* @noEscape */ $id ?>-<?= /* @noEscape */ $sectionId ?>-<?= /* @noEscape */ $menuId ?>">
-                <a href="#" title="<?= $block->escapeHtmlAttr($menuItem['title']) ?>">
-                    <span><?= $block->escapeHtml($menuItem['label']) ?></span>
+                <a href="#" title="<?= $escaper->escapeHtmlAttr($menuItem['title']) ?>">
+                    <span><?= $escaper->escapeHtml($menuItem['label']) ?></span>
                 </a>
             </li>
         <?php endforeach ?>


### PR DESCRIPTION
### Description (*)
Refactors the `Magento_Backend` module to replace `$block` escaping functions with `$escaper` escaping functions.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37099: Chore: Backend - Replace Block Escaping with Escaper