### PR TITLE
Fix currency format and precision

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Currency.php
+++ b/lib/internal/Magento/Framework/Locale/Currency.php
@@ -22,6 +22,8 @@ class Currency implements \Magento\Framework\Locale\CurrencyInterface
     const CURRENCY_OPTION_NAME = 'name';
 
     const CURRENCY_OPTION_DISPLAY = 'display';
+    
+    const CURRENCY_OPTION_PRECISION = 'precision';
 
     /**
      * @var array
@@ -88,6 +90,9 @@ class Currency implements \Magento\Framework\Locale\CurrencyInterface
                 $options[self::CURRENCY_OPTION_CURRENCY] = $currency;
                 $options[self::CURRENCY_OPTION_SYMBOL] = $currency;
             }
+            
+            $numberFormatter = new NumberFormatter('@currency=' . $currency, NumberFormatter::CURRENCY);
+            $options[self::CURRENCY_OPTION_PRECISION] = $numberFormatter->getAttribute(NumberFormatter::MAX_FRACTION_DIGITS);
 
             $options = new \Magento\Framework\DataObject($options);
             $this->_eventManager->dispatch(

--- a/lib/internal/Magento/Framework/Locale/Format.php
+++ b/lib/internal/Magento/Framework/Locale/Format.php
@@ -102,16 +102,22 @@ class Format implements \Magento\Framework\Locale\FormatInterface
                 $value = str_replace(',', '', $value);
             }
         } elseif ($separatorComa !== false) {
-            $locale = $this->_localeResolver->getLocale();
-            /**
-             * It's hard code for Japan locale.
-             * Comma separator uses as group separator: 4,000 saves as 4,000.00
-             */
-            $value = str_replace(
-                ',',
-                $locale === self::JAPAN_LOCALE_CODE ? '' : '.',
-                $value
-            );
+            /** Some currencies have a precision of 0 with no decimals. We shouldn't convert them as decimal points. */
+            if (substr_count($value, ',') === 1) {
+                $locale = $this->_localeResolver->getLocale();
+                /**
+                 * It's hard code for Japan locale.
+                 * Comma separator uses as group separator: 4,000 saves as 4,000.00
+                 * @ToDo: List all locales with no decimals in their currencies.
+                 */
+                $value = str_replace(
+                    ',',
+                    $locale === self::JAPAN_LOCALE_CODE ? '' : '.',
+                    $value
+                );
+            } else {
+                $value = str_replace(',', '', $value);
+            }
         }
 
         return (float)$value;


### PR DESCRIPTION
<!---
### Description (*)
Many currencies are not displayed correctly, there's even a project about that: https://github.com/magento/magento2-jp

Currencies like JPY, FCFA or many other are not displayed correctly within Magento. This PR aims to fix that by removing the decimals for those cases.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
