### PR TITLE
L2 cache refactor load method

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/RemoteSynchronizedCache.php
@@ -231,20 +231,9 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
      */
     public function save($data, $id, $tags = [], $specificLifetime = false)
     {
-        $dataToSave = $data;
-        $remHash = $this->loadRemoteDataVersion($id);
-        $isRemoteUpToDate = false;
-        if ($remHash !== false && $this->getDataVersion($data) === $remHash) {
-            $remoteData = $this->remote->load($id);
-            if ($remoteData !== false && $this->getDataVersion($data) === $this->getDataVersion($remoteData)) {
-                $isRemoteUpToDate = true;
-                $dataToSave = $remoteData;
-            }
-        }
-        if (!$isRemoteUpToDate) {
-            $this->remote->save($data, $id, $tags, $specificLifetime);
-            $this->saveRemoteDataVersion($data, $id, $tags, $specificLifetime);
-        }
+
+        $this->remote->save($data, $id, $tags, $specificLifetime);
+        $this->saveRemoteDataVersion($data, $id, $tags, $specificLifetime);
 
         if ($this->_options['use_stale_cache']) {
             $this->unlock($id);
@@ -258,7 +247,7 @@ class RemoteSynchronizedCache extends \Zend_Cache_Backend implements \Zend_Cache
 
         // Local cache doesn't save tags intentionally since it will cause inconsistency after flushing the cache
         // in multinode environment
-        return $this->local->save($dataToSave, $id, [], $specificLifetime);
+        return $this->local->save($data, $id, [], $specificLifetime);
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
