### PR TITLE
Tailwindui css layout support - Add more htmlClasses

### DIFF
--- a/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
+++ b/lib/internal/Magento/Framework/View/Layout/etc/elements.xsd
@@ -119,7 +119,7 @@
 
     <xs:simpleType name="htmlClassType">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z\d\-_/:.\[\]&amp;@() ]*"/>
+            <xs:pattern value="[a-zA-Z\d\-_/:.\[\]&amp;@()! ]*"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Supports classes with !important as used in Tailwind 3 
https://tailwindcss.com/docs/configuration#important-modifier

`<p class="font-bold md:!font-medium">`

Follow-up on https://github.com/magento/magento2/pull/36452

### Related Pull Requests
https://github.com/magento/magento2-page-builder/pull/791

### Resolved issues:
1. [x] resolves magento/magento2#37568: Tailwindui css layout support - Add more htmlClasses