### PR TITLE
Fixed PHP 8.2 deprecation warnings: 'creation of dynamic property'.

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -117,13 +117,6 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
     protected $_productTypeModels = [];
 
     /**
-     * Array of pairs store ID to its code.
-     *
-     * @var array
-     */
-    protected $_storeIdToCode = [];
-
-    /**
      * Array of Website ID-to-code.
      *
      * @var array

--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -116,13 +116,6 @@ class Carrier extends AbstractDhl implements CarrierInterface
     protected $_request;
 
     /**
-     * Rate result data
-     *
-     * @var Result|null
-     */
-    protected $_result;
-
-    /**
      * Countries parameters data
      *
      * @var Element|null

--- a/app/code/Magento/Fedex/Model/Carrier.php
+++ b/app/code/Magento/Fedex/Model/Carrier.php
@@ -81,13 +81,6 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
     protected $_request = null;
 
     /**
-     * Rate result data
-     *
-     * @var Result|null
-     */
-    protected $_result = null;
-
-    /**
      * Path to wsdl file of rate service
      *
      * @var string

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -146,9 +146,11 @@ abstract class AbstractEntity
     protected $_storeManager;
 
     /**
+     * Array of pairs store ID to its code.
+     *
      * @var array
      */
-    private $_storeIdToCode = [];
+    protected $_storeIdToCode = [];
 
     /**
      * @var array

--- a/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
+++ b/app/code/Magento/ImportExport/Model/Export/Entity/AbstractEntity.php
@@ -146,6 +146,16 @@ abstract class AbstractEntity
     protected $_storeManager;
 
     /**
+     * @var array
+     */
+    private $_storeIdToCode = [];
+
+    /**
+     * @var array
+     */
+    private $_invalidRows = [];
+
+    /**
      * @param \Magento\Framework\Stdlib\DateTime\TimezoneInterface $localeDate
      * @param \Magento\Eav\Model\Config $config
      * @param ResourceConnection $resource
@@ -172,10 +182,8 @@ abstract class AbstractEntity
     protected function _initStores()
     {
         foreach ($this->_storeManager->getStores(true) as $store) {
-            // phpstan:ignore "Access to an undefined property"
             $this->_storeIdToCode[$store->getId()] = $store->getCode();
         }
-        // phpstan:ignore "Access to an undefined property"
         ksort($this->_storeIdToCode);
         // to ensure that 'admin' store (ID is zero) goes first
 
@@ -350,7 +358,6 @@ abstract class AbstractEntity
         $errorCode = (string)$errorCode;
         $this->_errors[$errorCode][] = $errorRowNum + 1;
         // one added for human readability
-        // phpstan:ignore "Access to an undefined property"
         $this->_invalidRows[$errorRowNum] = true;
         $this->_errorsCount++;
 
@@ -508,7 +515,6 @@ abstract class AbstractEntity
      */
     public function getInvalidRowsCount()
     {
-        // phpstan:ignore "Access to an undefined property"
         return count($this->_invalidRows);
     }
 

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -47,9 +47,11 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
     protected $_isFixed = false;
 
     /**
-     * @var ?RateResult
+     * Rate result data
+     *
+     * @var RateResult|null
      */
-    private $_result;
+    protected $_result = null;
 
     /**
      * @var string[]

--- a/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
+++ b/app/code/Magento/Shipping/Model/Carrier/AbstractCarrier.php
@@ -7,6 +7,7 @@
 namespace Magento\Shipping\Model\Carrier;
 
 use Magento\Quote\Model\Quote\Address\RateResult\Error;
+use Magento\Shipping\Model\Rate\Result as RateResult;
 use Magento\Shipping\Model\Shipment\Request;
 
 /**
@@ -44,6 +45,11 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      * @var bool
      */
     protected $_isFixed = false;
+
+    /**
+     * @var ?RateResult
+     */
+    private $_result;
 
     /**
      * @var string[]
@@ -331,7 +337,7 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
      * @param \Magento\Framework\DataObject $request
      * @return $this|bool|\Magento\Framework\DataObject
      * @deprecated 100.2.6
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @see processAdditionalValidation()
      */
     public function proccessAdditionalValidation(\Magento\Framework\DataObject $request)
     {
@@ -426,7 +432,6 @@ abstract class AbstractCarrier extends \Magento\Framework\DataObject implements 
             return;
         }
         $freeRateId = false;
-        // phpstan:ignore
         if (is_object($this->_result)) {
             foreach ($this->_result->getAllRates() as $i => $item) {
                 if ($item->getMethod() == $freeMethod) {

--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -87,13 +87,6 @@ class Carrier extends AbstractCarrierOnline implements CarrierInterface
     protected $_request;
 
     /**
-     * Rate result data
-     *
-     * @var Result
-     */
-    protected $_result;
-
-    /**
      * @var float
      */
     protected $_baseCurrencyRate;

--- a/app/code/Magento/Usps/Model/Carrier.php
+++ b/app/code/Magento/Usps/Model/Carrier.php
@@ -94,13 +94,6 @@ class Carrier extends AbstractCarrierOnline implements \Magento\Shipping\Model\C
     protected $_request = null;
 
     /**
-     * Rate result data
-     *
-     * @var Result|null
-     */
-    protected $_result = null;
-
-    /**
      * Default cgi gateway url
      *
      * @var string

--- a/dev/tests/integration/testsuite/Magento/Setup/Fixtures/FixturesAsserts/SimpleProductsAssert.php
+++ b/dev/tests/integration/testsuite/Magento/Setup/Fixtures/FixturesAsserts/SimpleProductsAssert.php
@@ -13,13 +13,17 @@ use Magento\Setup\Fixtures\SimpleProductsFixture;
  * Class performs assertion that generated simple products are valid
  * after running setup:performance:generate-fixtures command
  */
-#[\AllowDynamicProperties]
 class SimpleProductsAssert
 {
     /**
      * @var \Magento\Catalog\Api\ProductRepositoryInterface
      */
     private $productRepository;
+
+    /**
+     * @var \Magento\ConfigurableProduct\Api\OptionRepositoryInterface
+     */
+    private $optionRepository;
 
     /**
      * @var \Magento\Setup\Fixtures\FixturesAsserts\ProductAssert

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -111,6 +111,21 @@ class Processor
     public $reportUrl;
 
     /**
+     * @var string
+     */
+    public $_reportDir;
+
+    /**
+     * @var string
+     */
+    public $_indexDir;
+
+    /**
+     * @var string
+     */
+    public $_errorDir;
+
+    /**
      * Server script name
      *
      * @var string
@@ -154,21 +169,6 @@ class Processor
      * @var DocumentRoot
      */
     private $documentRoot;
-
-    /**
-     * @var string
-     */
-    private $_errorDir;
-
-    /**
-     * @var string
-     */
-    private $_reportDir;
-
-    /**
-     * @var string
-     */
-    private $_indexDir;
 
     /**
      * @param Http $response

--- a/pub/errors/processor.php
+++ b/pub/errors/processor.php
@@ -20,7 +20,6 @@ use Magento\Framework\App\Response\Http;
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * phpcs:ignoreFile
  */
-#[\AllowDynamicProperties]
 class Processor
 {
     const MAGE_ERRORS_LOCAL_XML = 'local.xml';
@@ -155,6 +154,21 @@ class Processor
      * @var DocumentRoot
      */
     private $documentRoot;
+
+    /**
+     * @var string
+     */
+    private $_errorDir;
+
+    /**
+     * @var string
+     */
+    private $_reportDir;
+
+    /**
+     * @var string
+     */
+    private $_indexDir;
 
     /**
      * @param Http $response


### PR DESCRIPTION
### Description (*)
This fixes PHP 8.2 deprecated usage of 'creation of dynamic property': https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties

The phpstan tool is able to find these problems, here's a copy paste from https://github.com/magento/adobe-commerce-beta/issues/61 where I've reported this a few months ago during the Magento 2.4.6 beta period:

```
  172    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  173    Access to an undefined property Magento\Framework\Error\Processor::$_reportDir.
  186    Access to an undefined property Magento\Framework\Error\Processor::$_indexDir.
  268    Access to an undefined property Magento\Framework\Error\Processor::$_indexDir.
  269    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  454    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  472    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  475    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  611    Access to an undefined property Magento\Framework\Error\Processor::$_reportDir.
  732    Access to an undefined property Magento\Framework\Error\Processor::$_errorDir.
  176    Access to an undefined property Magento\ImportExport\Model\Export\Entity\AbstractEntity::$_storeIdToCode.
  179    Access to an undefined property Magento\ImportExport\Model\Export\Entity\AbstractEntity::$_storeIdToCode.
  354    Access to an undefined property Magento\ImportExport\Model\Export\Entity\AbstractEntity::$_invalidRows.
  512    Access to an undefined property Magento\ImportExport\Model\Export\Entity\AbstractEntity::$_invalidRows.
  430    Access to an undefined property Magento\Shipping\Model\Carrier\AbstractCarrier::$_result.
  40     Access to an undefined property Magento\Setup\Fixtures\FixturesAsserts\SimpleProductsAssert::$optionRepository.
```

### Related Pull Requests
- https://github.com/magento/magento-zend-loader/pull/1
- https://github.com/magento/magento-zend-db/pull/1
- https://github.com/magento/magento-zend-pdf/pull/1
- https://github.com/magento/magento2-functional-testing-framework/pull/905

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/adobe-commerce-beta/issues/61

In the wild, we've only ran into problems with deprecations in the `magento/magento-zend-pdf` library so far, none of the others we've triggered yet, but that doesn't mean you can't trigger them.

### Manual testing scenarios (*)
- Run `vendor/bin/phpstan analyse --level=0 {some-path}  | grep 'Access to an undefined property'` on all Magento code, it should not output anything (don't run this on the root the M2 codebase, otherwise it will take hours and might crash your computer if you don't have at least 32 GB of memory)
- Test all affected code and make sure that everything keeps working as expected (I'm assuming the automated tests will take care of this)

### Questions or comments
<del>I've used `protected` scoped members here and there, because I wanted to stay consistent with the existing members in the classes, but not sure if that's recommended and I should maybe change them to `private`?</del>
<del>_Update_: changed them to `private` because the semantic version check failed otherwise.</del>
_Update 2_: integration tests fail when `_storeIdToCode` is a `private` member in `AbstractEntity.php`, so changed it back to `protected` which solved the integration tests, however now the Semantic Version check fails again, but in my opinion, this one should be allowed...
_Update 3_: Same thing for the `$_result` in `AbstractCarrier`, had to change it back to `protected` to solve more integration tests.

The `public` scopes in `pub/errors/processor.php` are needed for the integration tests, they directly call those, so we can't make them `private`.

I won't write new automated tests, because I think that's not relevant in scope of this PR.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
