### PR TITLE
Lazy load data source data for list UI components

### DIFF
--- a/app/code/Magento/Ui/Component/Listing.php
+++ b/app/code/Magento/Ui/Component/Listing.php
@@ -35,6 +35,13 @@ class Listing extends AbstractComponent
      */
     public function getDataSourceData()
     {
-        return ['data' => $this->getContext()->getDataProvider()->getData()];
+        // Only load data in an ajax (json) request for better performance
+        if($this->getContext()->getAcceptType() == 'json') {
+            return ['data' => $this->getContext()->getDataProvider()->getData()];
+        }
+        else {
+            // build out default array keys to revent null erros, in case some module expects this
+            return ['data' => ['items' => [], 'totalRecords' => 0]];
+        }
     }
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If a page has listing UI component, the data source collection of the component is loaded and added to the page DOM in the generated component js tag. However this data collection is never rendered and always refreshed via ajax immediately after page load. It is waste of resource and slows down initial page load. 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#37190

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. open any admin listing page that is built using uiCompnennt, e.g. customers listing page

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
I think this is a quite exciting performance improvement for many admin pages that has listing component. In my local testing, the TTFB imporved from about 570ms - 420ms

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
