### PR TITLE
Added: New events for authentication in Magento_Customer

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -608,14 +608,26 @@ class AccountManagement implements AccountManagementInterface
 
         $customerId = $customer->getId();
         if ($this->authentication->isLocked($customerId)) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_locked',
+                ['email' => $username]
+            );
             throw new UserLockedException(__('The account is locked.'));
         }
         try {
             $this->authentication->authenticate($customerId, $password);
         } catch (InvalidEmailOrPasswordException $e) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_failed',
+                ['email' => $username]
+            );
             throw new InvalidEmailOrPasswordException(__('Invalid login or password.'));
         }
         if ($customer->getConfirmation() && $this->isConfirmationRequired($customer)) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_inactive',
+                ['email' => $username]
+            );
             throw new EmailNotConfirmedException(__("This account isn't confirmed. Verify and try again."));
         }
 

--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+declare(strict_types=1);
 
 namespace Magento\Customer\Model;
 
@@ -19,6 +20,7 @@ use Magento\Customer\Model\Config\Share as ConfigShare;
 use Magento\Customer\Model\Customer as CustomerModel;
 use Magento\Customer\Model\Customer\CredentialsValidator;
 use Magento\Customer\Model\ForgotPasswordToken\GetCustomerByToken;
+use Magento\Customer\Model\Logger as CustomerLogger;
 use Magento\Customer\Model\Metadata\Validator;
 use Magento\Customer\Model\ResourceModel\Visitor\CollectionFactory;
 use Magento\Directory\Model\AllowedCountries;
@@ -67,6 +69,11 @@ use Psr\Log\LoggerInterface as PsrLogger;
  */
 class AccountManagement implements AccountManagementInterface
 {
+    /**
+     * System Configuration Path for Enable/Disable Login at Guest Checkout
+     */
+    public const GUEST_CHECKOUT_LOGIN_OPTION_SYS_CONFIG = 'checkout/options/enable_guest_checkout_login';
+
     /**
      * Configuration paths for create account email template
      *
@@ -219,7 +226,7 @@ class AccountManagement implements AccountManagementInterface
     private $customerFactory;
 
     /**
-     * @var \Magento\Customer\Api\Data\ValidationResultsInterfaceFactory
+     * @var ValidationResultsInterfaceFactory
      */
     private $validationResultsDataFactory;
 
@@ -229,7 +236,7 @@ class AccountManagement implements AccountManagementInterface
     private $eventManager;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     private $storeManager;
 
@@ -299,7 +306,7 @@ class AccountManagement implements AccountManagementInterface
     protected $dataProcessor;
 
     /**
-     * @var \Magento\Framework\Registry
+     * @var Registry
      */
     protected $registry;
 
@@ -319,7 +326,7 @@ class AccountManagement implements AccountManagementInterface
     protected $objectFactory;
 
     /**
-     * @var \Magento\Framework\Api\ExtensibleDataObjectConverter
+     * @var ExtensibleDataObjectConverter
      */
     protected $extensibleDataObjectConverter;
 
@@ -339,7 +346,7 @@ class AccountManagement implements AccountManagementInterface
     private $emailNotification;
 
     /**
-     * @var \Magento\Eav\Model\Validator\Attribute\Backend
+     * @var Backend
      */
     private $eavValidator;
 
@@ -389,6 +396,11 @@ class AccountManagement implements AccountManagementInterface
     private $authorization;
 
     /**
+     * @var CustomerLogger
+     */
+    private CustomerLogger $customerLogger;
+
+    /**
      * @param CustomerFactory $customerFactory
      * @param ManagerInterface $eventManager
      * @param StoreManagerInterface $storeManager
@@ -426,6 +438,7 @@ class AccountManagement implements AccountManagementInterface
      * @param AuthorizationInterface|null $authorization
      * @param AuthenticationInterface|null $authentication
      * @param Backend|null $eavValidator
+     * @param CustomerLogger|null $customerLogger
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -469,7 +482,8 @@ class AccountManagement implements AccountManagementInterface
         SessionCleanerInterface $sessionCleaner = null,
         AuthorizationInterface $authorization = null,
         AuthenticationInterface $authentication = null,
-        Backend $eavValidator = null
+        Backend $eavValidator = null,
+        ?CustomerLogger $customerLogger = null
     ) {
         $this->customerFactory = $customerFactory;
         $this->eventManager = $eventManager;
@@ -512,6 +526,7 @@ class AccountManagement implements AccountManagementInterface
         $this->authorization = $authorization ?? $objectManager->get(AuthorizationInterface::class);
         $this->authentication = $authentication ?? $objectManager->get(AuthenticationInterface::class);
         $this->eavValidator = $eavValidator ?? $objectManager->get(Backend::class);
+        $this->customerLogger = $customerLogger ?? $objectManager->get(CustomerLogger::class);
     }
 
     /**
@@ -562,9 +577,9 @@ class AccountManagement implements AccountManagementInterface
     /**
      * Activate a customer account using a key that was sent in a confirmation email.
      *
-     * @param \Magento\Customer\Api\Data\CustomerInterface $customer
+     * @param CustomerInterface $customer
      * @param string $confirmationKey
-     * @return \Magento\Customer\Api\Data\CustomerInterface
+     * @return CustomerInterface
      * @throws InputException
      * @throws InputMismatchException
      * @throws InvalidTransitionException
@@ -586,12 +601,17 @@ class AccountManagement implements AccountManagementInterface
         // No need to validate customer and customer address while activating customer
         $this->setIgnoreValidationFlag($customer);
         $this->customerRepository->save($customer);
-        $this->getEmailNotification()->newAccount(
-            $customer,
-            'confirmed',
-            '',
-            $this->storeManager->getStore()->getId()
-        );
+
+        $customerLastLoginAt = $this->customerLogger->get((int)$customer->getId())->getLastLoginAt();
+        if (!$customerLastLoginAt) {
+            $this->getEmailNotification()->newAccount(
+                $customer,
+                'confirmed',
+                '',
+                $this->storeManager->getStore()->getId()
+            );
+        }
+
         return $customer;
     }
 
@@ -623,7 +643,9 @@ class AccountManagement implements AccountManagementInterface
             );
             throw new InvalidEmailOrPasswordException(__('Invalid login or password.'));
         }
-        if ($customer->getConfirmation() && $this->isConfirmationRequired($customer)) {
+
+        if ($customer->getConfirmation()
+            && ($this->isConfirmationRequired($customer) || $this->isEmailChangedConfirmationRequired($customer))) {
             $this->eventManager->dispatch(
                 'customer_authenticate_inactive',
                 ['email' => $username]
@@ -640,6 +662,21 @@ class AccountManagement implements AccountManagementInterface
         $this->eventManager->dispatch('customer_data_object_login', ['customer' => $customer]);
 
         return $customer;
+    }
+
+    /**
+     * Checks if account confirmation is required if the email address has been changed
+     *
+     * @param CustomerInterface $customer
+     * @return bool
+     */
+    private function isEmailChangedConfirmationRequired(CustomerInterface $customer): bool
+    {
+        return $this->accountConfirmation->isEmailChangedConfirmationRequired(
+            (int)$customer->getWebsiteId(),
+            (int)$customer->getId(),
+            $customer->getEmail()
+        );
     }
 
     /**
@@ -699,7 +736,7 @@ class AccountManagement implements AccountManagementInterface
         throw new InputException(
             __(
                 'Invalid value of "%value" provided for the %fieldName field. '
-                    . 'Possible values: %template1 or %template2.',
+                . 'Possible values: %template1 or %template2.',
                 [
                     'value' => $template,
                     'fieldName' => 'template',
@@ -716,8 +753,8 @@ class AccountManagement implements AccountManagementInterface
     public function resetPassword($email, $resetToken, $newPassword)
     {
         if (!$email) {
-            $customer = $this->getByToken->execute($resetToken);
-            $email = $customer->getEmail();
+            $params = ['fieldName' => 'email'];
+            throw new InputException(__('"%fieldName" is required. Enter and try again.', $params));
         } else {
             $customer = $this->customerRepository->get($email);
         }
@@ -727,7 +764,7 @@ class AccountManagement implements AccountManagementInterface
         $this->setIgnoreValidationFlag($customer);
 
         //Validate Token and new password strength
-        $this->validateResetPasswordToken($customer->getId(), $resetToken);
+        $this->validateResetPasswordToken((int)$customer->getId(), $resetToken);
         $this->credentialsValidator->checkPasswordDifferentFromEmail(
             $email,
             $newPassword
@@ -738,6 +775,9 @@ class AccountManagement implements AccountManagementInterface
         $customerSecure->setRpToken(null);
         $customerSecure->setRpTokenCreatedAt(null);
         $customerSecure->setPasswordHash($this->createPasswordHash($newPassword));
+        $customerSecure->setFailuresNum(0);
+        $customerSecure->setFirstFailure(null);
+        $customerSecure->setLockExpires(null);
         $this->sessionCleaner->clearFor((int)$customer->getId());
         $this->customerRepository->save($customer);
 
@@ -771,7 +811,8 @@ class AccountManagement implements AccountManagementInterface
                 )
             );
         }
-        if ($this->stringHelper->strlen(trim($password)) != $length) {
+        $trimmedPassLength = $this->stringHelper->strlen($password === null ? '' : trim($password));
+        if ($trimmedPassLength != $length) {
             throw new InputException(
                 __("The password can't begin or end with a space. Verify the password and try again.")
             );
@@ -801,17 +842,19 @@ class AccountManagement implements AccountManagementInterface
         $requiredNumber = $this->scopeConfig->getValue(self::XML_PATH_REQUIRED_CHARACTER_CLASSES_NUMBER);
         $return = 0;
 
-        if (preg_match('/[0-9]+/', $password)) {
-            $counter++;
-        }
-        if (preg_match('/[A-Z]+/', $password)) {
-            $counter++;
-        }
-        if (preg_match('/[a-z]+/', $password)) {
-            $counter++;
-        }
-        if (preg_match('/[^a-zA-Z0-9]+/', $password)) {
-            $counter++;
+        if ($password !== null) {
+            if (preg_match('/[0-9]+/', $password)) {
+                $counter++;
+            }
+            if (preg_match('/[A-Z]+/', $password)) {
+                $counter++;
+            }
+            if (preg_match('/[a-z]+/', $password)) {
+                $counter++;
+            }
+            if (preg_match('/[^a-zA-Z0-9]+/', $password)) {
+                $counter++;
+            }
         }
 
         if ($counter < $requiredNumber) {
@@ -838,13 +881,10 @@ class AccountManagement implements AccountManagementInterface
     {
         // load customer by id
         $customer = $this->customerRepository->getById($customerId);
-        if ($this->isConfirmationRequired($customer)) {
-            if (!$customer->getConfirmation()) {
-                return self::ACCOUNT_CONFIRMED;
-            }
-            return self::ACCOUNT_CONFIRMATION_REQUIRED;
-        }
-        return self::ACCOUNT_CONFIRMATION_NOT_REQUIRED;
+
+        return $this->isConfirmationRequired($customer)
+            ? $customer->getConfirmation() ? self::ACCOUNT_CONFIRMATION_REQUIRED : self::ACCOUNT_CONFIRMED
+            : self::ACCOUNT_CONFIRMATION_NOT_REQUIRED;
     }
 
     /**
@@ -854,11 +894,6 @@ class AccountManagement implements AccountManagementInterface
      */
     public function createAccount(CustomerInterface $customer, $password = null, $redirectUrl = '')
     {
-        $groupId = $customer->getGroupId();
-        if (isset($groupId) && !$this->authorization->isAllowed(self::ADMIN_RESOURCE)) {
-            $customer->setGroupId(null);
-        }
-
         if ($password !== null) {
             $this->checkPasswordStrength($password);
             $customerEmail = $customer->getEmail();
@@ -1102,7 +1137,7 @@ class AccountManagement implements AccountManagementInterface
         $result = $this->eavValidator->isValid($customerModel);
         if ($result === false && is_array($this->eavValidator->getMessages())) {
             return $validationResults->setIsValid(false)->setMessages(
-                // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
                 call_user_func_array(
                     'array_merge',
                     array_values($this->eavValidator->getMessages())
@@ -1114,9 +1149,24 @@ class AccountManagement implements AccountManagementInterface
 
     /**
      * @inheritdoc
+     *
+     * @param string $customerEmail
+     * @param int|null $websiteId
+     * @return bool
+     * @throws LocalizedException
      */
     public function isEmailAvailable($customerEmail, $websiteId = null)
     {
+        $guestLoginConfig = $this->scopeConfig->getValue(
+            self::GUEST_CHECKOUT_LOGIN_OPTION_SYS_CONFIG,
+            ScopeInterface::SCOPE_WEBSITE,
+            $websiteId
+        );
+
+        if (!$guestLoginConfig) {
+            return true;
+        }
+
         try {
             if ($websiteId === null) {
                 $websiteId = $this->storeManager->getStore()->getWebsiteId();
@@ -1175,9 +1225,9 @@ class AccountManagement implements AccountManagementInterface
      * @throws NoSuchEntityException If customer doesn't exist
      * @SuppressWarnings(PHPMD.LongVariable)
      */
-    private function validateResetPasswordToken($customerId, $resetPasswordLinkToken)
+    private function validateResetPasswordToken(int $customerId, string $resetPasswordLinkToken): bool
     {
-        if ($customerId !== null && $customerId <= 0) {
+        if (!$customerId) {
             throw new InputException(
                 __(
                     'Invalid value of "%value" provided for the %fieldName field.',
@@ -1185,14 +1235,7 @@ class AccountManagement implements AccountManagementInterface
                 )
             );
         }
-
-        if ($customerId === null) {
-            //Looking for the customer.
-            $customerId = $this->getByToken
-                ->execute($resetPasswordLinkToken)
-                ->getId();
-        }
-        if (!is_string($resetPasswordLinkToken) || empty($resetPasswordLinkToken)) {
+        if (!$resetPasswordLinkToken) {
             $params = ['fieldName' => 'resetPasswordLinkToken'];
             throw new InputException(__('"%fieldName" is required. Enter and try again.', $params));
         }
@@ -1232,6 +1275,7 @@ class AccountManagement implements AccountManagementInterface
      * @return $this
      * @throws LocalizedException
      * @deprecated 100.1.0
+     * @see EmailNotification::newAccount()
      */
     protected function sendNewAccountEmail(
         $customer,
@@ -1275,6 +1319,7 @@ class AccountManagement implements AccountManagementInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @deprecated 100.1.0
+     * @see EmailNotification::credentialsChanged()
      */
     protected function sendPasswordResetNotificationEmail($customer)
     {
@@ -1288,6 +1333,7 @@ class AccountManagement implements AccountManagementInterface
      * @param int|string|null $defaultStoreId
      * @return int
      * @deprecated 100.1.0
+     * @see StoreManagerInterface::getWebsite()
      * @throws LocalizedException
      */
     protected function getWebsiteStoreId($customer, $defaultStoreId = null)
@@ -1305,6 +1351,7 @@ class AccountManagement implements AccountManagementInterface
      *
      * @return array
      * @deprecated 100.1.0
+     * @see EmailNotification::TEMPLATE_TYPES
      */
     protected function getTemplateTypes()
     {
@@ -1338,6 +1385,7 @@ class AccountManagement implements AccountManagementInterface
      * @return $this
      * @throws MailException
      * @deprecated 100.1.0
+     * @see EmailNotification::sendEmailTemplate()
      */
     protected function sendEmailTemplate(
         $customer,
@@ -1406,7 +1454,7 @@ class AccountManagement implements AccountManagementInterface
      */
     protected function canSkipConfirmation($customer)
     {
-        if (!$customer->getId()) {
+        if (!$customer->getId() || $customer->getEmail() === null) {
             return false;
         }
 
@@ -1463,7 +1511,7 @@ class AccountManagement implements AccountManagementInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function changeResetPasswordLinkToken($customer, $passwordLinkToken)
+    public function changeResetPasswordLinkToken(CustomerInterface $customer, string $passwordLinkToken): bool
     {
         if (!is_string($passwordLinkToken) || empty($passwordLinkToken)) {
             throw new InputException(
@@ -1472,15 +1520,15 @@ class AccountManagement implements AccountManagementInterface
                     ['value' => $passwordLinkToken, 'fieldName' => 'password reset token']
                 )
             );
+        } else {
+            $customerSecure = $this->customerRegistry->retrieveSecureData($customer->getId());
+            $customerSecure->setRpToken($passwordLinkToken);
+            $customerSecure->setRpTokenCreatedAt(
+                $this->dateTimeFactory->create()->format(DateTime::DATETIME_PHP_FORMAT)
+            );
+            $this->setIgnoreValidationFlag($customer);
+            $this->customerRepository->save($customer);
         }
-        $customerSecure = $this->customerRegistry->retrieveSecureData($customer->getId());
-        $customerSecure->setRpToken($passwordLinkToken);
-        $customerSecure->setRpTokenCreatedAt(
-            $this->dateTimeFactory->create()->format(DateTime::DATETIME_PHP_FORMAT)
-        );
-        $this->setIgnoreValidationFlag($customer);
-        $this->customerRepository->save($customer);
-
         return true;
     }
 
@@ -1492,6 +1540,7 @@ class AccountManagement implements AccountManagementInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @deprecated 100.1.0
+     * @see EmailNotification::passwordReminder()
      */
     public function sendPasswordReminderEmail($customer)
     {
@@ -1521,6 +1570,7 @@ class AccountManagement implements AccountManagementInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      * @deprecated 100.1.0
+     * @see EmailNotification::passwordResetConfirmation()
      */
     public function sendPasswordResetConfirmationEmail($customer)
     {
@@ -1566,6 +1616,7 @@ class AccountManagement implements AccountManagementInterface
      * @return Data\CustomerSecure
      * @throws NoSuchEntityException
      * @deprecated 100.1.0
+     * @see EmailNotification::getFullCustomerObject()
      */
     protected function getFullCustomerObject($customer)
     {
@@ -1574,7 +1625,7 @@ class AccountManagement implements AccountManagementInterface
         $mergedCustomerData = $this->customerRegistry->retrieveSecureData($customer->getId());
         $customerData = $this->dataProcessor->buildOutputDataArray(
             $customer,
-            \Magento\Customer\Api\Data\CustomerInterface::class
+            CustomerInterface::class
         );
         $mergedCustomerData->addData($customerData);
         $mergedCustomerData->setData('name', $this->customerViewHelper->getCustomerName($customer));
@@ -1610,7 +1661,6 @@ class AccountManagement implements AccountManagementInterface
      * Get email notification
      *
      * @return EmailNotificationInterface
-     * @deprecated 100.1.0
      */
     private function getEmailNotification()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
New events provided in the PR will add missing events that will allow developers to implement additional logging or notifications with much less effort and code.

1. `customer_authenticate_failed`
2. `customer_authenticate_locked`
3. `customer_authenticate_inactive`

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)

This can only be tested by creating a module with minimal requirements.

1. Create a module and add a global `events.xml` file ( or `frontend` folder )
2. Add the following content to the `events.xml` file

```
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
    <event name="customer_authenticate_failed">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
    <event name="customer_authenticate_locked">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
    <event name="customer_authenticate_inactive">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
</config>
```

4. Create an observer with the following content

```
public function execute(\Magento\Framework\Event\Observer $observer)
{
    // Receive event name ( e.g customer_authenticate_failed or customer_authenticate_inactive )
    $eventName = $observer->getEvent()->getName();

    // Get the email address
    $email = $observer->getEvent()->getData('email');

    // Get customer by email address
    $customer = $this->customerRepository->get($email);

    // Do something with it ...
}
```

### Questions or comments
While working on new monitoring features I've noticed that the module `Magento_Customer` does have a number of events for successful events such as `customer_login` or `customer_session_init` - but not a single event to track failed login attempts, locked or inactive customers.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
