### PR TITLE
Cleanup of some non-existing classes from some unit tests code in the…

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ExcludeFilterTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ExcludeFilterTest.php
@@ -52,8 +52,8 @@ class ExcludeFilterTest extends TestCase
 
         foreach ($files as $file) {
             $item = $this->getMockBuilder(
-                \SplFileInfoClass::class
-            )->setMethods(['__toString', 'getFilename'])->getMock();
+                \SplFileInfo::class
+            )->disableOriginalConstructor()->setMethods(['__toString', 'getFilename'])->getMock();
             $item->expects($this->any())->method('__toString')->willReturn($file);
             $item->expects($this->any())->method('getFilename')->willReturn('notDots');
             yield $item;

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ExcludeFilterTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/File/ExcludeFilterTest.php
@@ -32,6 +32,7 @@ class ExcludeFilterTest extends TestCase
             ]
         );
 
+        $result = [];
         foreach ($iterator as $i) {
             $result[] = $i;
         }

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php
@@ -299,14 +299,12 @@ class CompiledTest extends TestCase
                 '_vac_' => [
                     'array_value' => 'value',
                     'array_configured_instance' => [
-                        '_i_' => \Magento\Framework\ObjectManager\Test\Unit::class
-                            . '\Factory\Fixture\Compiled\DependencySharedTesting',
+                        '_i_' => DependencySharedTesting::class,
                     ],
                     'array_configured_array' => [
                         'array_array_value' => 'value',
                         'array_array_configured_instance' => [
-                            '_ins_' => \Magento\Framework\ObjectManager::class
-                                . '\Test\Unit\Factory\Fixture\Compiled\DependencyTesting',
+                            '_ins_' => DependencyTesting::class,
                         ],
                     ],
                     'array_global_argument' => [

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Helper/SortItemsTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Helper/SortItemsTest.php
@@ -13,11 +13,6 @@ use PHPUnit\Framework\TestCase;
 class SortItemsTest extends TestCase
 {
     /**
-     * @var MockObject|InterpreterInterface
-     */
-    protected InterpreterInterface $_itemInterpreter;
-
-    /**
      * @var SortItemsHelper
      */
     protected SortItemsHelper $_model;

--- a/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/PriceBoxTest.php
+++ b/lib/internal/Magento/Framework/Pricing/Test/Unit/Render/PriceBoxTest.php
@@ -74,11 +74,8 @@ class PriceBoxTest extends TestCase
         $scopeConfigMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
         $cacheState = $this->getMockBuilder(StateInterface::class)
             ->getMockForAbstractClass();
-        $storeConfig = $this->getMockBuilder(\Magento\Store\Model\Store\Config::class)
-            ->disableOriginalConstructor()
-            ->getMock();
         $this->context = $this->getMockBuilder(Context::class)
-            ->setMethods(['getLayout', 'getEventManager', 'getStoreConfig', 'getScopeConfig', 'getCacheState'])
+            ->setMethods(['getLayout', 'getEventManager', 'getScopeConfig', 'getCacheState'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->context->expects($this->any())
@@ -87,9 +84,6 @@ class PriceBoxTest extends TestCase
         $this->context->expects($this->any())
             ->method('getEventManager')
             ->willReturn($eventManager);
-        $this->context->expects($this->any())
-            ->method('getStoreConfig')
-            ->willReturn($storeConfig);
         $this->context->expects($this->any())
             ->method('getScopeConfig')
             ->willReturn($scopeConfigMock);

--- a/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
+++ b/lib/internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Helper class for basic object retrieving, such as blocks, models etc...
  *
  * @deprecated Class under test should be instantiated with `new` keyword with explicit dependencies declaration
+ * @see https://github.com/magento/magento2/pull/29272
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class ObjectManager
@@ -29,8 +30,6 @@ class ObjectManager
     ];
 
     /**
-     * Test object
-     *
      * @var \PHPUnit\Framework\TestCase
      */
     protected $_testObject;
@@ -158,10 +157,7 @@ class ObjectManager
      */
     public function getObject($className, array $arguments = [])
     {
-        // phpstan:ignore
-        if (is_subclass_of($className, \Magento\Framework\Api\AbstractSimpleObjectBuilder::class)
-            || is_subclass_of($className, \Magento\Framework\Api\Builder::class)
-        ) {
+        if (is_subclass_of($className, \Magento\Framework\Api\AbstractSimpleObjectBuilder::class)) {
             return $this->getBuilder($className, $arguments);
         }
         $constructArguments = $this->getConstructArguments($className, $arguments);

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/DeserializerFactoryTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/DeserializerFactoryTest.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * Test Webapi Json Deserializer Request Rest Controller.
- *
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/DeserializerFactoryTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/DeserializerFactoryTest.php
@@ -62,7 +62,7 @@ class DeserializerFactoryTest extends TestCase
     {
         $expectedMetadata = ['text_xml' => ['type' => 'text/xml', 'model' => 'Xml']];
         $invalidInterpreter = $this->getMockBuilder(
-            \Magento\Framework\Webapi\Response\Rest\Renderer\Json::class
+            \Magento\Framework\Webapi\Rest\Response\Renderer\Json::class
         )->disableOriginalConstructor()
         ->getMock();
 


### PR DESCRIPTION
… Magento framework.

### Description (*)
In an attempt at slowly fixing phpstan reported issues in the entire Magento codebase, I took a look today at the Framework code and searched for classes used that don't exist (any more). I've only found some fixes for some unit tests in the Framework code. This fixes 7 errors out of 173 phpstan errors found in total when scanning on level 0 on the Framework code.

Errors fixed:
```
 ------ ---------------------------------------------------------------------------- 
  Line   internal/Magento/Framework/Filesystem/Test/Unit/File/ExcludeFilterTest.php  
 ------ ---------------------------------------------------------------------------- 
  55     Class SplFileInfoClass not found.                                           
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols         
 ------ ---------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   internal/Magento/Framework/ObjectManager/Test/Unit/Factory/CompiledTest.php  
 ------ ----------------------------------------------------------------------------- 
  302    Class Magento\Framework\ObjectManager\Test\Unit not found.                   
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols          
  308    Class Magento\Framework\ObjectManager not found.                             
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols          
 ------ ----------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   internal/Magento/Framework/ObjectManager/Test/Unit/Helper/SortItemsTest.php                                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  18     Property Magento\Framework\ObjectManager\Test\Unit\Helper\SortItemsTest::$_itemInterpreter has unknown class Magento\Framework\ObjectManager\Test\Unit\Helper\InterpreterInterface as its type.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

------ ---------------------------------------------------------------------- 
  Line   internal/Magento/Framework/Pricing/Test/Unit/Render/PriceBoxTest.php  
 ------ ---------------------------------------------------------------------- 
  77     Class Magento\Store\Model\Store\Config not found.                     
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ ---------------------------------------------------------------------- 

------ ------------------------------------------------------------------------ 
  Line   internal/Magento/Framework/TestFramework/Unit/Helper/ObjectManager.php  
 ------ ------------------------------------------------------------------------ 
  163    Class Magento\Framework\Api\Builder not found.                          
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols     
 ------ ------------------------------------------------------------------------ 

------ -------------------------------------------------------------------------------------- 
  Line   internal/Magento/Framework/Webapi/Test/Unit/Rest/Request/DeserializerFactoryTest.php  
 ------ -------------------------------------------------------------------------------------- 
  65     Class Magento\Framework\Webapi\Response\Rest\Renderer\Json not found.                 
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                   
 ------ -------------------------------------------------------------------------------------- 
```

### Related Pull Requests
None

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
1. Run: `vendor/bin/phpstan clear-result-cache && bin/magento setup:di:compile && composer dump-autoload`
2. Run: `vendor/bin/phpstan analyse --level=0 lib/`
3. After applying the changes from this PR and re-running steps 1 and 2 from above, you should have 7 fewer errors.
4. Also check if after these changes, all unit tests keep running correctly (but the automated tests on github should take care of testing this).

### Questions or comments
It is my hope that it's Adobe's goal one day to have zero issues that phpstan finds on level 0, since those are the most important ones to fix usually. If we finally have level 0 tackled across the entire codebase, we can slowly go up one by one which would also allow the checks in pull requests here to be made against a higher level than only 0, which in the end should hopefully result in a lot more stable code then what we have right now.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37636: Cleanup of some non-existing classes from some unit tests code in the…