### PR TITLE
Added: New events for account management in Magento_Customer

### DIFF
--- a/app/code/Magento/Customer/Model/AccountManagement.php
+++ b/app/code/Magento/Customer/Model/AccountManagement.php
@@ -628,16 +628,28 @@ class AccountManagement implements AccountManagementInterface
 
         $customerId = $customer->getId();
         if ($this->authentication->isLocked($customerId)) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_locked',
+                ['email' => $username]
+            );
             throw new UserLockedException(__('The account is locked.'));
         }
         try {
             $this->authentication->authenticate($customerId, $password);
         } catch (InvalidEmailOrPasswordException $e) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_failed',
+                ['email' => $username]
+            );
             throw new InvalidEmailOrPasswordException(__('Invalid login or password.'));
         }
 
         if ($customer->getConfirmation()
             && ($this->isConfirmationRequired($customer) || $this->isEmailChangedConfirmationRequired($customer))) {
+            $this->eventManager->dispatch(
+                'customer_authenticate_inactive',
+                ['email' => $username]
+            );
             throw new EmailNotConfirmedException(__("This account isn't confirmed. Verify and try again."));
         }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Missing events added to allow developers to implement additional logging or notifications with much less effort and code.

1. `customer_authenticate_failed`
2. `customer_authenticate_locked`
3. `customer_authenticate_inactive`

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)

This can only be tested by creating a module with minimal requirements.

1. Create a module and add a global `events.xml` file ( or `frontend` folder )
2. Add the following content to the `events.xml` file

```
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
    <event name="customer_authenticate_failed">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
    <event name="customer_authenticate_locked">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
    <event name="customer_authenticate_inactive">
        <observer name="customer_log_observer" instance="MyCustomer\Log\Observer\MyObserver" />
    </event>
</config>
```

4. Create an observer with the following content

```
public function execute(\Magento\Framework\Event\Observer $observer)
{
    // Receive event name ( e.g customer_authenticate_failed or customer_authenticate_inactive )
    $eventName = $observer->getEvent()->getName();

    // Get the email address
    $email = $observer->getEvent()->getData('email');

    // Do something with it ...
}
```

### Questions or comments
While working on new monitoring features I've noticed that the module `Magento_Customer` does have a number of events for successful events such as `customer_login` or `customer_session_init` - but not a single event to track failed login attempts, locked or inactive customers.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
