### PR TITLE
Magento/Search: Remove scopeConfig, already defined in AbstractHelper

### DIFF
--- a/app/code/Magento/Search/Helper/Data.php
+++ b/app/code/Magento/Search/Helper/Data.php
@@ -5,7 +5,6 @@
  */
 namespace Magento\Search\Helper;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Escaper;
@@ -36,14 +35,6 @@ class Data extends AbstractHelper
     protected $string;
 
     /**
-     * Core store config
-     *
-     * @var ScopeConfigInterface
-     * @since 100.1.0
-     */
-    protected $scopeConfig;
-
-    /**
      * @var Escaper
      * @since 100.1.0
      */
@@ -70,7 +61,6 @@ class Data extends AbstractHelper
         StoreManagerInterface $storeManager
     ) {
         $this->string = $string;
-        $this->scopeConfig = $context->getScopeConfig();
         $this->escaper = $escaper;
         $this->storeManager = $storeManager;
         parent::__construct($context);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
`scopeConfig` is already part of the parent constructor `AbstractHelper` and doesn't need to be defined again in the constructor. Therefore `$this->scopeConfig = $context->getScopeConfig();` can safely be removed.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
N/A

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
