### PR TITLE
35820 - Do not persist remote file metadata cache

### DIFF
--- a/app/code/Magento/RemoteStorage/Driver/Adapter/Cache/Generic.php
+++ b/app/code/Magento/RemoteStorage/Driver/Adapter/Cache/Generic.php
@@ -73,7 +73,6 @@ class Generic implements CacheInterface
     {
         foreach ($this->cachePathPurgeQueue as $path) {
             unset($this->cacheData[$path]);
-            $this->cacheAdapter->remove($this->prefix . $path);
         }
     }
 
@@ -83,14 +82,6 @@ class Generic implements CacheInterface
     public function updateMetadata(string $path, array $objectMetadata, bool $persist = false): void
     {
         $this->cacheData[$path] = array_merge($this->pathUtil->pathInfo($path), $objectMetadata);
-        if ($persist) {
-            $this->cacheAdapter->save(
-                $this->serializer->serialize([$path => $this->cacheData[$path]]),
-                $this->prefix . $path,
-                [self::CACHE_TAG]
-            );
-        }
-
         $this->ensureParentDirectories($path);
     }
 
@@ -100,11 +91,6 @@ class Generic implements CacheInterface
     public function storeFileNotExists(string $path): void
     {
         $this->cacheData[$path] = false;
-        $this->cacheAdapter->save(
-            $this->serializer->serialize([$path => $this->cacheData[$path]]),
-            $this->prefix . $path,
-            [self::CACHE_TAG]
-        );
     }
 
     /**
@@ -113,13 +99,7 @@ class Generic implements CacheInterface
     public function exists(string $path): ?bool
     {
         if (!isset($this->cacheData[$path])) {
-            $fileMeta = $this->cacheAdapter->load($this->prefix . $path);
-
-            if ($fileMeta === false) {
-                return null;
-            }
-
-            $this->setFromStorage($fileMeta);
+            return null;
         }
 
         return array_key_exists($path, $this->cacheData) ? $this->cacheData[$path] !== false : null;
@@ -137,11 +117,6 @@ class Generic implements CacheInterface
             $object['path'] = $newpath;
             $object = array_merge($object, $this->pathUtil->pathInfo($newpath));
             $this->cacheData[$newpath] = $object;
-            $this->cacheAdapter->save(
-                $this->serializer->serialize([$newpath => $this->cacheData[$newpath]]),
-                $this->prefix . $newpath,
-                [self::CACHE_TAG]
-            );
             $this->purgeQueue();
         }
     }
@@ -190,17 +165,7 @@ class Generic implements CacheInterface
         if (isset($this->cacheData[$path]['type'])) {
             return $this->cacheData[$path];
         } else {
-            $meta = $this->cacheAdapter->load($this->prefix . $path);
-            if (!$meta) {
-                return null;
-            }
-            $meta = $this->serializer->unserialize($meta);
-
-            if (empty($meta[$path])) {
-                return null;
-            }
-            $this->cacheData[$path] = $meta[$path];
-            return $this->cacheData[$path];
+            return null;
         }
     }
 
@@ -210,7 +175,6 @@ class Generic implements CacheInterface
     public function flushCache(): void
     {
         $this->cacheData = [];
-        $this->cacheAdapter->clean([self::CACHE_TAG]);
     }
 
     /**

--- a/app/code/Magento/RemoteStorage/Driver/Adapter/CachedAdapter.php
+++ b/app/code/Magento/RemoteStorage/Driver/Adapter/CachedAdapter.php
@@ -158,7 +158,7 @@ class CachedAdapter implements CachedAdapterInterface
             $this->cache->storeFileNotExists($path);
         } else {
             $cacheEntry = is_array($exists) ? $exists : ['path' => $path];
-            $this->cache->updateMetadata($path, $cacheEntry, true);
+            $this->cache->updateMetadata($path, $cacheEntry, false);
         }
 
         return $exists;

--- a/app/code/Magento/RemoteStorage/Driver/Adapter/MetadataProvider.php
+++ b/app/code/Magento/RemoteStorage/Driver/Adapter/MetadataProvider.php
@@ -112,7 +112,7 @@ class MetadataProvider implements MetadataProviderInterface
         if (isset($extraMetadata['Metadata']['image-width']) && isset($extraMetadata['Metadata']['image-height'])) {
             $data['extra'] = $extraMetadata['Metadata'];
         }
-        $this->cache->updateMetadata($path, $data, true);
+        $this->cache->updateMetadata($path, $data, false);
         return $data;
     }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#35820

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
