### PR TITLE
Change GA4 purchase event data values to numbers

### DIFF
--- a/app/code/Magento/GoogleGtag/Block/Ga.php
+++ b/app/code/Magento/GoogleGtag/Block/Ga.php
@@ -149,16 +149,16 @@ class Ga extends Template
                 $result['products'][] = [
                     'item_id' => $this->escapeJsQuote($item->getSku()),
                     'item_name' =>  $this->escapeJsQuote($item->getName()),
-                    'price' => number_format((float) $item->getPrice(), 2),
+                    'price' => round((float) $item->getPrice(), 2),
                     'quantity' => (int)$item->getQtyOrdered(),
                 ];
             }
             $result['orders'][] = [
                 'transaction_id' =>  $order->getIncrementId(),
                 'affiliation' => $this->escapeJsQuote($this->_storeManager->getStore()->getFrontendName()),
-                'value' => number_format((float) $order->getGrandTotal(), 2),
-                'tax' => number_format((float) $order->getTaxAmount(), 2),
-                'shipping' => number_format((float) $order->getShippingAmount(), 2),
+                'value' => round((float) $order->getGrandTotal(), 2),
+                'tax' => round((float) $order->getTaxAmount(), 2),
+                'shipping' => round((float) $order->getShippingAmount(), 2),
             ];
             $result['currency'] = $order->getOrderCurrencyCode();
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

GA4 purchase event requires certain values (order total, tax, delivery cost, product prices) to be numbers. Existing implementation uses `number_format` function that in some locales adds commas to numbers (1000 -> "1,000"), which makes it an incorrect for GA4.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2##37708

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
