### PR TITLE
fix: aria-labelledby error with multiples elements + $escaper

### DIFF
--- a/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
+++ b/app/code/Magento/Theme/view/frontend/templates/html/title.phtml
@@ -6,23 +6,24 @@
 
 /**
  * @var $block \Magento\Theme\Block\Html\Title
+ * @var $escaper \Magento\Framework\Escaper
  */
 $cssClass = $block->getCssClass() ? ' ' . $block->getCssClass() : '';
 $titleHtml = '';
 if (trim($block->getPageHeading())) {
     $titleHtml = '<span class="base" data-ui-id="page-title-wrapper" '
-        . $block->getAddBaseAttribute()
+        . $escaper->getAddBaseAttribute()
         . '>'
-        . $block->escapeHtml($block->getPageHeading())
+        . $escaper->escapeHtml($block->getPageHeading())
         . '</span>';
 }
 ?>
 <?php if ($titleHtml) : ?>
-<div class="page-title-wrapper<?= $block->escapeHtmlAttr($cssClass) ?>">
+<div class="page-title-wrapper<?= $escaper->escapeHtmlAttr($cssClass) ?>">
     <h1 class="page-title"
-        <?php if ($block->getId()) : ?> id="<?= $block->escapeHtmlAttr($block->getId()) ?>" <?php endif; ?>
+        <?php if ($block->getId()) : ?> id="<?= $escaper->escapeHtmlAttr($block->getId()) ?>" <?php endif; ?>
         <?php if ($block->getAddBaseAttributeAria()) : ?>
-            aria-labelledby="<?= $block->escapeHtmlAttr($block->getAddBaseAttributeAria()) ?>"
+            aria-labelledby="<?= $escaper->escapeHtml($block->getAddBaseAttributeAria()) ?>"
         <?php endif; ?>>
         <?= /* @noEscape */ $titleHtml ?>
     </h1>


### PR DESCRIPTION
### Description (*)
Reported in **Magento_Theme**

The use of `escapeHtmlAttr` function encode spaces with special characters which unvalidated the ARIA target(s).
Indeed `$block->getAddBaseAttributeAria()` can export multiples elements CSS classes.

I attached a screenshot when I passed Magento 2 with W3C Html Checker.

I took advantage of this PR to replace $block function by $escaper ( \Magento\Framework\Escaper) for all escaper's functions

<img width="1305" alt="Capture d’écran 2023-07-21 à 13 57 58" src="https://github.com/magento/magento2/assets/2975845/3a59dc66-b88c-42e6-95ce-7e0303cd4c73">