### PR TITLE
Fixes incorrect classes being referenced in Magento modules.

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -813,7 +813,7 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     {
         if (!$this->collectionProcessor) {
             $this->collectionProcessor = \Magento\Framework\App\ObjectManager::getInstance()->get(
-                // phpstan:ignore "Class Magento\Catalog\Model\Api\SearchCriteria\ProductCollectionProcessor not found."
+                // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
                 \Magento\Catalog\Model\Api\SearchCriteria\ProductCollectionProcessor::class
             );
         }

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
@@ -199,8 +199,8 @@ class Full extends AbstractAction
                         $connection->query($query);
                     }
                 }
+                $this->activeTableSwitcher->switchTable($indexer->getConnection(), [$indexer->getMainTable()]);
             }
-            $this->activeTableSwitcher->switchTable($indexer->getConnection(), [$indexer->getMainTable()]);
         } catch (\Exception $e) {
             throw new LocalizedException(__($e->getMessage()), $e);
         }

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
@@ -148,6 +148,7 @@ class Full extends AbstractAction
             $entityMetadata = $this->metadataPool->getMetadata(ProductInterface::class);
 
             $columns = array_keys($this->_getConnection()->describeTable($this->_getIdxTable()));
+            $indexerTables = [];
 
             /** @var DefaultStock $indexer */
             foreach ($this->_getTypeIndexers() as $indexer) {
@@ -199,8 +200,12 @@ class Full extends AbstractAction
                         $connection->query($query);
                     }
                 }
-                $this->activeTableSwitcher->switchTable($indexer->getConnection(), [$indexer->getMainTable()]);
+
+                $indexerTables[] = $indexer->getMainTable();
             }
+
+            $indexerTables = array_unique($indexerTables);
+            $this->activeTableSwitcher->switchTable($this->_getConnection(), $indexerTables);
         } catch (\Exception $e) {
             throw new LocalizedException(__($e->getMessage()), $e);
         }

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
@@ -1,7 +1,5 @@
 <?php
 /**
- * @category    Magento
- * @package     Magento_CatalogInventory
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
@@ -11,24 +9,24 @@ declare(strict_types=1);
 namespace Magento\CatalogInventory\Model\Indexer\Stock\Action;
 
 use Magento\Catalog\Api\Data\ProductInterface;
-use Magento\Catalog\Model\ResourceModel\Indexer\ActiveTableSwitcher;
-use Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock;
-use Magento\Framework\App\ResourceConnection;
-use Magento\CatalogInventory\Model\ResourceModel\Indexer\StockFactory;
 use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Catalog\Model\ResourceModel\Indexer\ActiveTableSwitcher;
+use Magento\CatalogInventory\Model\Indexer\Stock\AbstractAction;
+use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
+use Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock;
+use Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\StockInterface;
+use Magento\CatalogInventory\Model\ResourceModel\Indexer\StockFactory;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Query\BatchIteratorInterface;
 use Magento\Framework\DB\Query\Generator as QueryGenerator;
-use Magento\Framework\Indexer\CacheContext;
-use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\EntityManager\MetadataPool;
-use Magento\Framework\Indexer\BatchSizeManagementInterface;
-use Magento\Framework\Indexer\BatchProviderInterface;
-use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\CatalogInventory\Model\Indexer\Stock\AbstractAction;
-use Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\StockInterface;
-use Magento\Framework\App\DeploymentConfig;
-use Magento\CatalogInventory\Model\Indexer\Stock\Processor;
+use Magento\Framework\Indexer\BatchProviderInterface;
+use Magento\Framework\Indexer\BatchSizeManagementInterface;
+use Magento\Framework\Indexer\CacheContext;
 
 /**
  * Class Full reindex action
@@ -40,7 +38,7 @@ class Full extends AbstractAction
     /**
      * Action type representation
      */
-    const ACTION_TYPE = 'full';
+    public const ACTION_TYPE = 'full';
 
     /**
      * @var MetadataPool
@@ -164,7 +162,7 @@ class Full extends AbstractAction
                     )
                 );
 
-                if (is_null($batchRowCount)) {
+                if ($batchRowCount === null) {
                     $batchRowCount = isset($this->batchRowsCount[$indexer->getTypeId()])
                         ? $this->batchRowsCount[$indexer->getTypeId()]
                         : $this->batchRowsCount['default'];

--- a/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
+++ b/app/code/Magento/CatalogInventory/Model/Indexer/Stock/Action/Full.php
@@ -12,7 +12,6 @@ namespace Magento\CatalogInventory\Model\Indexer\Stock\Action;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Indexer\ActiveTableSwitcher;
-use Magento\CatalogInventory\Model\Indexer\Stock\BatchSizeManagement;
 use Magento\CatalogInventory\Model\ResourceModel\Indexer\Stock\DefaultStock;
 use Magento\Framework\App\ResourceConnection;
 use Magento\CatalogInventory\Model\ResourceModel\Indexer\StockFactory;
@@ -125,7 +124,7 @@ class Full extends AbstractAction
         $this->metadataPool = $metadataPool ?: ObjectManager::getInstance()->get(MetadataPool::class);
         $this->batchProvider = $batchProvider ?: ObjectManager::getInstance()->get(BatchProviderInterface::class);
         $this->batchSizeManagement = $batchSizeManagement ?: ObjectManager::getInstance()->get(
-            BatchSizeManagement::class
+            BatchSizeManagementInterface::class
         );
         $this->batchRowsCount = $batchRowsCount;
         $this->activeTableSwitcher = $activeTableSwitcher ?: ObjectManager::getInstance()

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Rule.php
@@ -132,6 +132,7 @@ class Rule extends \Magento\Rule\Model\ResourceModel\AbstractResource
             // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             ->get(\Magento\CatalogRule\Model\ResourceModel\Rule\AssociatedEntityMap::class)
             ->getData();
+
         parent::__construct($context, $connectionName);
     }
 
@@ -216,12 +217,8 @@ class Rule extends \Magento\Rule\Model\ResourceModel\AbstractResource
     }
 
     /**
-     * Load an object
+     * @inheritDoc
      *
-     * @param \Magento\Framework\Model\AbstractModel $object
-     * @param mixed $value
-     * @param string $field
-     * @return $this
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function load(\Magento\Framework\Model\AbstractModel $object, $value, $field = null)

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Rule.php
@@ -129,7 +129,7 @@ class Rule extends \Magento\Rule\Model\ResourceModel\AbstractResource
         $this->priceCurrency = $priceCurrency;
         $this->entityManager = $entityManager ?? ObjectManager::getInstance()->get(EntityManager::class);
         $this->_associatedEntitiesMap = $associatedEntityMap ?? ObjectManager::getInstance()
-            // phpstan:ignore this is a virtual class
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             ->get(\Magento\CatalogRule\Model\ResourceModel\Rule\AssociatedEntityMap::class)
             ->getData();
         parent::__construct($context, $connectionName);

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Rule/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Rule/Collection.php
@@ -159,6 +159,7 @@ class Collection extends \Magento\Rule\Model\ResourceModel\Rule\Collection\Abstr
      *
      * @return array
      * @deprecated 100.1.0
+     * @see https://github.com/magento/magento2/commit/d063251cf0ce6717795fdb646a534cc0c2b22c05
      */
     private function getAssociatedEntitiesMap()
     {

--- a/app/code/Magento/CatalogRule/Model/ResourceModel/Rule/Collection.php
+++ b/app/code/Magento/CatalogRule/Model/ResourceModel/Rule/Collection.php
@@ -164,7 +164,7 @@ class Collection extends \Magento\Rule\Model\ResourceModel\Rule\Collection\Abstr
     {
         if (!$this->_associatedEntitiesMap) {
             $this->_associatedEntitiesMap = \Magento\Framework\App\ObjectManager::getInstance()
-                // phpstan:ignore
+                // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
                 ->get(\Magento\CatalogRule\Model\ResourceModel\Rule\AssociatedEntityMap::class)
                 ->getData();
         }

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -289,9 +289,8 @@ class PageRepository implements PageRepositoryInterface
     private function getCollectionProcessor()
     {
         if (!$this->collectionProcessor) {
-            // phpstan:ignore "Class Magento\Cms\Model\Api\SearchCriteria\PageCollectionProcessor not found."
-            $this->collectionProcessor = ObjectManager::getInstance()
-                ->get(PageCollectionProcessor::class);
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
+            $this->collectionProcessor = ObjectManager::getInstance()->get(PageCollectionProcessor::class);
         }
         return $this->collectionProcessor;
     }

--- a/app/code/Magento/Cms/Model/PageRepository.php
+++ b/app/code/Magento/Cms/Model/PageRepository.php
@@ -285,6 +285,7 @@ class PageRepository implements PageRepositoryInterface
      *
      * @deprecated 102.0.0
      * @return CollectionProcessorInterface
+     * @see https://github.com/magento/magento2/commit/eacac63d35b97961e3304dc007cd6b78519a93d0
      */
     private function getCollectionProcessor()
     {

--- a/app/code/Magento/Paypal/Observer/AddPaypalShortcutsObserver.php
+++ b/app/code/Magento/Paypal/Observer/AddPaypalShortcutsObserver.php
@@ -57,9 +57,13 @@ class AddPaypalShortcutsObserver implements ObserverInterface
             SmartButton::class => PaypalConfig::METHOD_WPS_EXPRESS,
             \Magento\Paypal\Block\Express\Shortcut::class => PaypalConfig::METHOD_WPP_EXPRESS,
             \Magento\Paypal\Block\Bml\Shortcut::class => PaypalConfig::METHOD_WPP_EXPRESS,
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             \Magento\Paypal\Block\WpsExpress\Shortcut::class => PaypalConfig::METHOD_WPS_EXPRESS,
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             \Magento\Paypal\Block\WpsBml\Shortcut::class => PaypalConfig::METHOD_WPS_EXPRESS,
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             \Magento\Paypal\Block\PayflowExpress\Shortcut::class => PaypalConfig::METHOD_WPP_PE_EXPRESS,
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             \Magento\Paypal\Block\Payflow\Bml\Shortcut::class => PaypalConfig::METHOD_WPP_PE_EXPRESS
         ];
         foreach ($blocks as $blockInstanceName => $paymentMethodCode) {

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
@@ -5,11 +5,12 @@
  */
 namespace Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo;
 
-use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResponseInterface;
 use Magento\Sales\Api\CreditmemoRepositoryInterface;
 
-class PrintAction extends \Magento\Backend\App\Action
+class PrintAction extends \Magento\Backend\App\Action implements HttpGetActionInterface
 {
     /**
      * Authorization level of a basic admin session

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
@@ -16,7 +16,7 @@ class PrintAction extends \Magento\Backend\App\Action
      *
      * @see _isAllowed()
      */
-    const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
+    public const ADMIN_RESOURCE = 'Magento_Sales::sales_creditmemo';
 
     /**
      * @var \Magento\Framework\App\Response\Http\FileFactory
@@ -52,6 +52,8 @@ class PrintAction extends \Magento\Backend\App\Action
     }
 
     /**
+     * Execute action based on request and return result
+     *
      * @return ResponseInterface|\Magento\Backend\Model\View\Result\Forward
      * @throws \Exception
      */

--- a/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
@@ -73,7 +73,7 @@ class PrintAction extends \Magento\Backend\App\Action
                 $fileContent = ['type' => 'string', 'value' => $pdf->render(), 'rm' => true];
 
                 return $this->_fileFactory->create(
-                    \creditmemo::class . $date . '.pdf',
+                    'creditmemo' . $date . '.pdf',
                     $fileContent,
                     DirectoryList::VAR_DIR,
                     'application/pdf'

--- a/app/code/Magento/Sales/Test/Unit/Helper/ReorderTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Helper/ReorderTest.php
@@ -31,7 +31,7 @@ class ReorderTest extends TestCase
     protected $scopeConfigMock;
 
     /**
-     * @var MockObject|\Magento\Sales\Model\Store
+     * @var MockObject|\Magento\Store\Model\Store
      */
     protected $storeParam;
 
@@ -78,7 +78,7 @@ class ReorderTest extends TestCase
             $this->repositoryMock
         );
 
-        $this->storeParam = $this->getMockBuilder(\Magento\Sales\Model\Store::class)
+        $this->storeParam = $this->getMockBuilder(\Magento\Store\Model\Store::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule.php
@@ -84,7 +84,7 @@ class Rule extends AbstractResource
         $this->string = $string;
         $this->_resourceCoupon = $resourceCoupon;
         $associatedEntitiesMapInstance = $associatedEntityMapInstance ?: ObjectManager::getInstance()->get(
-            // phpstan:ignore "Class Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap not found."
+            // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
             \Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap::class
         );
         $this->_associatedEntitiesMap = $associatedEntitiesMapInstance->getData();

--- a/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php
+++ b/app/code/Magento/SalesRule/Model/ResourceModel/Rule/Collection.php
@@ -463,7 +463,7 @@ class Collection extends \Magento\Rule\Model\ResourceModel\Rule\Collection\Abstr
     {
         if (!$this->_associatedEntitiesMap) {
             $this->_associatedEntitiesMap = \Magento\Framework\App\ObjectManager::getInstance()
-                // phpstan:ignore "Class Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap not found."
+                // @phpstan-ignore-next-line - this is a virtual type defined in di.xml
                 ->get(\Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap::class)
                 ->getData();
         }


### PR DESCRIPTION
### Description (*)
These were found by running phpstan with level 0 on all code in `app/code/Magento`

The first commit deals with the description here, further commits are to fix failing tests.

### Related Pull Requests
Similar fixes as in https://github.com/magento/magento2/pull/37629 (but that was for code in `lib/internal/Magento/Framework`)

### Fixed Issues (if relevant)

### Manual testing scenarios (*)
1. Run: `vendor/bin/phpstan clear-result-cache && bin/magento setup:di:compile && composer dump-autoload`
2. Run: `vendor/bin/phpstan analyse --level=0 -c ./dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon app/code/Magento/` (if you don't use a very modern computer with a very good processor and enough memory, it might take a long time to run, or even crash)
3. After applying the changes from this PR and re-running steps 1 and 2 from above, you should have 16 fewer errors.
4. Try printing a creditmemo as pdf file in the backoffice, the filename you get should be `creditmemo{current-date}.pdf`
5. Make sure reindexing of stocks still works as expected
6. All automated tests should keep running correctly I hope

### Questions or comments

Changes include:
- properly ignoring phpstan errors for classes that don't exist in the codebase but are declared as a `virtualType` (which phpstan doesn't know about)
- fixing non existing classes in unit tests to existing classes (shows that all this mocking of classes in phpunit doesn't assure anything)
- a real bugfix in `Magento\CatalogInventory\Model\Indexer\Stock\Action\FullAction` where if you inherit from the class, and call the parent constructor and do not provide a value for `$batchSizeManagement`, it will try to load a non-existing class and crash
- a real bugfix in `Magento\Sales\Controller\Adminhtml\Creditmemo\AbstractCreditmemo\PrintAction` to fix the filename for creditmemo pdf files, it seems like this bug was accidentally introduced in https://github.com/magento/magento2/commit/d7ff74d07e49b81f172044e81a7348008ea75b08#diff-b6974c4da004f8f764ba347774b2f3dbfeebab760c91f2f4c647dff63fcb6bfe
- implementing `HttpGetActionInterface` interface `PrintAction` class (revealed by failing static test in this PR)
- fixing extra phpstan failures around `activeTableSwitcher->switchTable` line where the variables `$indexer` aren't guaranteed to exist
- a bunch of static test failure fixes

This fixes the following phpstan errors:
```
 ------ --------------------------------------------------------------------------------------
  Line   Catalog/Model/ProductRepository.php
 ------ --------------------------------------------------------------------------------------
  809    Class Magento\Catalog\Model\Api\SearchCriteria\ProductCollectionProcessor not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------
  Line   Catalog/Test/Unit/Model/ResourceModel/AttributeTest.php
 ------ ---------------------------------------------------------------------
  82     Class Magento\ResourceConnections\DB\Select not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------
  Line   CatalogInventory/Model/Indexer/Stock/Action/Full.php
 ------ -----------------------------------------------------------------------------------
  128    Class Magento\CatalogInventory\Model\Indexer\Stock\BatchSizeManagement not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  206    Variable $indexer might not be defined.
  206    Variable $indexer might not be defined.
 ------ -----------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------
  Line   CatalogRule/Model/ResourceModel/Rule.php
 ------ -----------------------------------------------------------------------------------
  266    Class Magento\CatalogRule\Model\ResourceModel\Rule\AssociatedEntityMap not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ -----------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------
  Line   CatalogRule/Model/ResourceModel/Rule/Collection.php
 ------ -----------------------------------------------------------------------------------
  168    Class Magento\CatalogRule\Model\ResourceModel\Rule\AssociatedEntityMap not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ -----------------------------------------------------------------------------------

------ -------------------------------------------------------------------------------
  Line   Cms/Model/PageRepository.php
 ------ -------------------------------------------------------------------------------
  294    Class Magento\Cms\Model\Api\SearchCriteria\PageCollectionProcessor not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ -------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------
  Line   Paypal/Observer/AddPaypalShortcutsObserver.php
 ------ ---------------------------------------------------------------------
  60     Class Magento\Paypal\Block\WpsExpress\Shortcut not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  61     Class Magento\Paypal\Block\WpsBml\Shortcut not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  62     Class Magento\Paypal\Block\PayflowExpress\Shortcut not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  63     Class Magento\Paypal\Block\Payflow\Bml\Shortcut not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------

 ------ --------------------------------------------------------------------------
  Line   Sales/Controller/Adminhtml/Creditmemo/AbstractCreditmemo/PrintAction.php
 ------ --------------------------------------------------------------------------
  76     Class creditmemo not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ --------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------
  Line   Sales/Test/Unit/Helper/ReorderTest.php
 ------ ---------------------------------------------------------------------
  81     Class Magento\Sales\Model\Store not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------
  Line   SalesRule/Model/ResourceModel/Rule.php
 ------ ---------------------------------------------------------------------------------
  88     Class Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------
  Line   SalesRule/Model/ResourceModel/Rule/Collection.php
 ------ ---------------------------------------------------------------------------------
  456    Class Magento\SalesRule\Model\ResourceModel\Rule\AssociatedEntityMap not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------
  Line   Theme/Test/Unit/Model/Config/ValidatorTest.php
 ------ ---------------------------------------------------------------------
  77     Class Magento\Email\Model\TemplateInterface not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
  122    Class Magento\Email\Model\TemplateInterface not found.
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 ------ ---------------------------------------------------------------------
```

I won't be adding more automated tests, unless it's really expected, but I might need some help for that...

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39126: Fixes incorrect classes being referenced in Magento modules.