### PR TITLE
fix Column 'customer_id' in where clause is ambiguous,

### DIFF
--- a/app/code/Magento/Customer/Model/ResourceModel/Online/Grid/Collection.php
+++ b/app/code/Magento/Customer/Model/ResourceModel/Online/Grid/Collection.php
@@ -100,7 +100,7 @@ class Collection extends SearchResult
     public function addFieldToFilter($field, $condition = null): Collection
     {
         if ($field == 'visitor_type') {
-            $field = 'customer_id';
+            $field = 'main_table.customer_id';
             if (is_array($condition) && isset($condition['eq'])) {
                 $condition = $condition['eq'] == Visitor::VISITOR_TYPE_CUSTOMER ? ['gt' => 0] : ['null' => true];
             }


### PR DESCRIPTION
### Description (*)
Add main_table to select for customer online filter.

### Fixed Issues (if relevant)
When we try to filter the online customer grid we have an issue : 

```Integrity constraint violation: 1052 Column 'customer_id' in where clause is ambiguous, query was: SELECT `main_table`.*, `customer`.`email`, `customer`.`firstname`, `customer`.`lastname`, IF(main_table.customer_id IS NOT NULL AND main_table.customer_id != 0, 'c', 'v') AS `visitor_type`, `company_customer`.`company_id`, `company`.`company_name` FROM `customer_visitor` AS `main_table`
 LEFT JOIN `customer_entity` AS `customer` ON customer.entity_id = main_table.customer_id
 LEFT JOIN `company_advanced_customer_entity` AS `company_customer` ON main_table.customer_id = company_customer.customer_id
 LEFT JOIN `company` ON company.entity_id = company_customer.company_id WHERE (main_table.last_visit_at >= '2023-07-28 09:34:09') AND (((`customer_id` > 0))) ORDER BY customer_id ASC
 LIMIT 20 in /app/vendor/magento/framework/DB/Statement/Pdo/Mysql.php:109```

### Manual testing scenarios (*)
1. In admin Navigate to customers -> Now Online
2. Try to filter "type" -> value "customer"
3. Enjoy

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
