### PR TITLE
Improve Configurable Products Extensibility

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Model/Product/Type/Configurable.php
@@ -81,7 +81,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType impl
      *
      * @var string
      */
-    protected $_usedProducts = '_cache_instance_products';
+    public $_usedProducts = '_cache_instance_products';
 
     /**
      * Cache key for salable used products
@@ -1435,7 +1435,7 @@ class Configurable extends \Magento\Catalog\Model\Product\Type\AbstractType impl
      * @return \Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Product\Collection
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    private function getConfiguredUsedProductCollection(
+    public function getConfiguredUsedProductCollection(
         \Magento\Catalog\Model\Product $product,
         $skipStockFilter = true,
         $requiredAttributeIds = null


### PR DESCRIPTION
### Description (*)
Make $_usedProducts & getConfiguredUsedProductCollection() public so that around plugins can be created on getUsedProducts, an already public function.

### Manual testing scenarios (*)

- Create a new local module
- Create a around plugin for getUsedProducts function
	- Make alterations to children products 
```
	 foreach ($usedProducts as $product) {
                $collection->getItemByColumnValue('position', $product->getSku());
     } 
```
- Create before/after/around plugin for getConfiguredUsedProductCollection function
- Configure the plugin in etc/di.xml
- Enable the module
- Enable and configure Xdebug and add breakpoints in your plugin(s)
- Load the configurable product `$product->getTypeInstance()->getUsedProducts($product);` and ensure changes to children products are present.


### Questions or comments
I don't know why these were originally declared private functions so if there's a reason this change cannot be made, please let me know.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
