### PR TITLE
Fix bug in GalleryManagement::create method (Issue #37835)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
@@ -141,8 +141,7 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
             }
             $existingMediaGalleryEntries[] = $entry;
         }
-        $product = $this->productInterfaceFactory->create();
-        $product->setSku($sku);
+        $product = $this->productRepository->get($sku);
         $product->setMediaGalleryEntries($existingMediaGalleryEntries);
         try {
             $product = $this->productRepository->save($product);


### PR DESCRIPTION
In the GalleryManagement::create method, there was a bug that caused the name of an existing image to be deleted when adding it to a product via the Magento 2.4.6 REST API. This issue occurred due to incorrect handling of the media gallery entries during the addition process.

To address this issue, I replaced the erroneous code that set the product object before adding the media gallery entries with the correct code that retrieves the product using the product repository before performing the addition. This fix ensures that the name of the existing image is now properly preserved in the product's media gallery entries when added via the REST API.

The root cause of the problem has been resolved, and the product images will retain their names as expected after this fix is applied.

Resolves: #37835

All relevant information is in the issue, it's pretty clear what the issue is in the PR too.

https://github.com/magento/magento2/issues/37835

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
](https://github.com/magento/magento2/issues/37835)