### PR TITLE
[WIP] Updated wikimedia/less.php from v3 to v5

### DIFF
--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -1219,7 +1219,7 @@
 & when (@media-common = true) {
     .abs-field-date-input {
         margin-right: @indent__s;
-        width: calc(~'100% -' @icon-calendar__font-size + @indent__s);
+        width: calc(~'100% -' @icon-calendar__font-size - @indent__s);
     }
 }
 
@@ -1234,7 +1234,7 @@
 
         input {
             margin-right: @indent__s;
-            width: calc(~'100% -' @checkout-tooltip-icon__font-size + @indent__s + @indent__xs);
+            width: calc(~'100% -' @checkout-tooltip-icon__font-size - @indent__s - @indent__xs);
         }
     }
 }

--- a/app/design/frontend/Magento/luma/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/luma/web/css/source/_extends.less
@@ -1639,7 +1639,7 @@
 & when (@media-common = true) {
     .abs-field-date-input {
         .lib-css(margin-right, @indent__s);
-        width: calc(~'100% -' @icon-calendar__font-size + @indent__s);
+        width: calc(~'100% -' @icon-calendar__font-size - @indent__s);
     }
 }
 
@@ -1654,7 +1654,7 @@
 
         input {
             .lib-css(margin-right, @indent__s);
-            width: calc(~'100% -' @checkout-tooltip-icon__font-size + @indent__s + @indent__xs);
+            width: calc(~'100% -' @checkout-tooltip-icon__font-size - @indent__s - @indent__xs);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "tubalmartin/cssmin": "^4.1",
         "web-token/jwt-framework": "^3.1",
         "webonyx/graphql-php": "^15.0",
-        "wikimedia/less.php": "^3.2"
+        "wikimedia/less.php": "^3.2 || ^5.0"
     },
     "require-dev": {
         "allure-framework/allure-phpunit": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d174ef5374078e24b312404e0e87755",
+    "content-hash": "60f9d8b378c01c707283f38e0b4d97a4",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1072,7 +1072,7 @@
             "version": "v7.17.2",
             "source": {
                 "type": "git",
-                "url": "git@github.com:elastic/elasticsearch-php.git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
                 "reference": "2d302233f2bb0926812d82823bb820d405e130fc"
             },
             "dist": {
@@ -1631,12 +1631,12 @@
             "version": "v5.2.13",
             "source": {
                 "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "reference": "fbbe7e5d79f618997bc3332a6f49246036c45793",
                 "shasum": ""
             },
@@ -9330,28 +9330,28 @@
         },
         {
             "name": "wikimedia/less.php",
-            "version": "v3.2.1",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/less.php.git",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559"
+                "reference": "1ed8afc79c726ffe3c29754d87b0717d8882cdaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/0d5b30ba792bdbf8991a646fc9c30561b38a5559",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/1ed8afc79c726ffe3c29754d87b0717d8882cdaa",
+                "reference": "1ed8afc79c726ffe3c29754d87b0717d8882cdaa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.9"
+                "php": ">=7.4.3"
             },
             "require-dev": {
-                "mediawiki/mediawiki-codesniffer": "40.0.1",
-                "mediawiki/mediawiki-phan-config": "0.12.0",
-                "mediawiki/minus-x": "1.1.1",
+                "mediawiki/mediawiki-codesniffer": "43.0.0",
+                "mediawiki/mediawiki-phan-config": "0.14.0",
+                "mediawiki/minus-x": "1.1.3",
                 "php-parallel-lint/php-console-highlighter": "1.0.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpunit/phpunit": "^8.5"
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpunit/phpunit": "9.6.16"
             },
             "bin": [
                 "bin/lessc"
@@ -9399,9 +9399,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wikimedia/less.php/issues",
-                "source": "https://github.com/wikimedia/less.php/tree/v3.2.1"
+                "source": "https://github.com/wikimedia/less.php/tree/v5.0.0"
             },
-            "time": "2023-02-03T06:43:41+00:00"
+            "time": "2024-06-27T22:34:11+00:00"
         }
     ],
     "packages-dev": [

--- a/lib/internal/Magento/Framework/composer.json
+++ b/lib/internal/Magento/Framework/composer.json
@@ -52,7 +52,7 @@
         "symfony/process": "^6.4",
         "tedivm/jshrink": "^1.4",
         "webonyx/graphql-php": "^15.0",
-        "wikimedia/less.php": "^3.2"
+        "wikimedia/less.php": "^3.2 || ^5.0"
     },
     "archive": {
         "exclude": [


### PR DESCRIPTION
### Description (*)

Will update description later

TODO's:
- describe PR
- benchmark speed differences (with PHP 8.1 is around ~1 second faster, with PHP 8.2 is ~0.3 seconds faster, sidenote: the difference between 8.1 & 8.2 is insane, never expected this)
- show diff of compiled css and try to explain it (still figuring part of this out)
- complain about Magento's silly coding standards (again)
- B2B Edition contains more differences than Magento Open Source - need to double check:
```diff
# both in Magento/blank & Magento/luma frontend themes:

 .negotiable-quote-quote-print .quote-block-content {
-  width: calc(44%);
+  width: calc(100% * 0.5 - 6rem);
 }

# both in Magento/backend & Magento/spectrum backend themes:

 .accordion .config input[name*='expiration_period'] + label {
   position: static;
   top: 5.5rem;
-  width: calc(96%);
+  width: calc(100% - 4rem);
 }
 .quotes-quote-print .quote-negotiated-price {
   float: right;
-  width: calc(44%);
+  width: calc((100%) * 0.5 - 6rem);
 }
 .quotes-quote-print .quote-catalog-price {
   float: left;
-  width: calc(44%);
+  width: calc((100%) * 0.5 - 6rem);
 }

```
- PageBuilder also has one change - need to double check:
```diff
# in Magento/backend backend theme

 .focus-options .pagebuilder-options .pagebuilder-options-wrapper:after {
   background: #ffffff;
   border: 1px solid rgba(153, 153, 153, 0.7);
   bottom: -6px;
   content: '';
   display: block;
   height: 12px;
-  left: calc(49%);
+  left: calc(50% - 1px);
   position: absolute;
   transform: rotate(45deg) translateX(-50%);
   width: 12px;
   z-index: 1;
 }
```

_Update_: This looks like a fix, because `50% - 1px` is not equal to `49%`, so it seems like this is a bug that gets fixed

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#37841

### Manual testing scenarios (*)
1. TODO !!!

### Questions or comments
I've chosen to keep the constraints open so that version 3 is also still available to install, the changes in the `calc` compilation might be problematic for some shops, so this way we give an opportunity to let people stay at version 3. However, the 2 fixes in core magento themes will then cause issues for them...

In case of any protest about potential backwards compatibility breakage: we'll have to move to v4 anyways one day in the future (v3 will probably get abandoned and probably won't support newer PHP versions).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
