### PR TITLE
customer not reset in local storage issue solved

### DIFF
--- a/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
+++ b/app/code/Magento/Customer/view/frontend/web/js/customer-data.js
@@ -35,7 +35,6 @@ define([
      */
     invalidateCacheBySessionTimeOut = function (invalidateOptions) {
         var date;
-
         if (new Date($.localStorage.get('mage-cache-timeout')) < new Date()) {
             storage.removeAll();
         }
@@ -46,10 +45,11 @@ define([
     /**
      * Invalidate Cache By Close Cookie Session
      */
-    invalidateCacheByCloseCookieSession = function () {
+        invalidateCacheByCloseCookieSession = function () {
         if (!$.cookieStorage.isSet('mage-cache-sessid')) {
             storage.removeAll();
         }
+            $.localStorage.set('mage-cache-storage', {})
 
         $.cookieStorage.set('mage-cache-sessid', true);
     };


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
Customer Data not reset when session file is lost.

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The 'mage-cache-storage' local storage object contains the customer data and hence even after the session file is lost customer data is not being reset. So, 'mage-cache-storage' has to be cleared in :
app/code/Magento/Customer/view/frontend/web/js/customer-data.js.

Changes made: 
$.localStorage.set('mage-cache-storage', {})

### Related Pull Requests
<!-- related pull request placeholder -->


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#36391

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
