### PR TITLE
Fix return type in phpdoc

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1556,7 +1556,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Gets order item by given ID.
      *
      * @param int $itemId
-     * @return \Magento\Framework\DataObject|null
+     * @return \Magento\Sales\Api\Data\OrderItemInterface|null
      */
     public function getItemById($itemId)
     {
@@ -1573,7 +1573,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      * Get item by quote item id
      *
      * @param mixed $quoteItemId
-     * @return \Magento\Framework\DataObject|null
+     * @return \Magento\Sales\Api\Data\OrderItemInterface|null
      */
     public function getItemByQuoteItemId($quoteItemId)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The method does return a `\Magento\Sales\Api\Data\OrderItemInterface` and it should be typed as such. `\Magento\Sales\Model\Order::getItems` is called to get the item and in its phpdoc the return type is `\Magento\Sales\Api\Data\OrderItemInterface[]`, so it only makes sense to return `\Magento\Sales\Api\Data\OrderItemInterface` it in these methods


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
No Issue created.

### Manual testing scenarios (*)
No manual testing steps necessary this should be logical in the review.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40853: Fix return type in phpdoc