### PR TITLE
Add return  for setters of Magento\Sales\Model\Order\Invoice\ItemCreation class.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
@@ -42,6 +42,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     public function setOrderItemId($orderItemId)
     {
         $this->orderItemId = $orderItemId;
+        return $this;
     }
 
     /**
@@ -58,6 +59,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     public function setQty($qty)
     {
         $this->qty = $qty;
+        return $this;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
+++ b/app/code/Magento/Sales/Model/Order/Invoice/ItemCreation.php
@@ -29,7 +29,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     private $extensionAttributes;
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getOrderItemId()
     {
@@ -37,7 +37,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setOrderItemId($orderItemId)
     {
@@ -46,7 +46,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getQty()
     {
@@ -54,7 +54,7 @@ class ItemCreation implements InvoiceItemCreationInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function setQty($qty)
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
I added `return $this` to the setters of Magento\Sales\Model\Order\Invoice\ItemCreation class. This allows to chain calls and prevents unexpected errors.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Make an order with checkmo payment method
2. Create an invoice for the order in the admin interface

Note that a visual inspection of the code should be enough.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
