### PR TITLE
Bugfix: Check that the option_id is actually set before using it.

### DIFF
--- a/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
+++ b/app/code/Magento/Bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml
@@ -32,7 +32,7 @@ $catalogHelper = $block->getData('catalogHelper');
     <?php $block->setPriceDataObject($_item) ?>
     <?php $attributes = $block->getSelectionAttributes($_item) ?>
     <?php if ($_item->getParentItem()): ?>
-        <?php if ($_prevOptionId != $attributes['option_id']): ?>
+        <?php if (isset($attributes['option_id']) && $_prevOptionId != $attributes['option_id']): ?>
         <tr>
             <td class="col-product">
                 <div class="option-label"><?= $block->escapeHtml($attributes['option_label']) ?></div>


### PR DESCRIPTION
### Description (*)

When the option_id is not set or present this could result in PHP throwing an error. This PR fixes that by checking if the value is actually available to be used.  

`[2023-09-07T14:51:52.725070+00:00] main.CRITICAL: Exception: Warning: Trying to access array offset on value of type null in /path/vendor/magento/module-bundle/view/adminhtml/templates/sales/order/view/items/renderer.phtml on line 35 in /path/vendor/magento/framework/App/ErrorHandler.php:62`

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#37974: Bugfix: Check that the option_id is actually set before using it.