### PR TITLE
fix 37994: Duplicate query captcha log with same ip

### DIFF
--- a/app/code/Magento/Captcha/Model/Checkout/ConfigProvider.php
+++ b/app/code/Magento/Captcha/Model/Checkout/ConfigProvider.php
@@ -26,6 +26,13 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
     protected $formIds;
 
     /**
+     * List of form require captcha
+     *
+     * @var array
+     */
+    protected $formIsRequired = [];
+
+    /**
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Captcha\Helper\Data $captchaData
      * @param array $formIds
@@ -116,7 +123,10 @@ class ConfigProvider implements \Magento\Checkout\Model\ConfigProviderInterface
      */
     protected function isRequired($formId)
     {
-        return (boolean)$this->getCaptchaModel($formId)->isRequired();
+        if (!array_key_exists($formId, $this->formIsRequired)) {
+            $this->formIsRequired[$formId] = (boolean)$this->getCaptchaModel($formId)->isRequired();
+        }
+        return $this->formIsRequired[$formId];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#37994

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
