### PR TITLE
SHIPTONAME can beginn with a leading space

### DIFF
--- a/app/code/Magento/Paypal/Model/Api/Nvp.php
+++ b/app/code/Magento/Paypal/Model/Api/Nvp.php
@@ -1763,7 +1763,7 @@ class Nvp extends \Magento\Paypal\Model\Api\AbstractApi
     private function updateShippingAddressWithShipToName(DataObject $shippingAddress, array $data)
     {
         if (isset($data['SHIPTONAME'])) {
-            $nameParts = explode(' ', $data['SHIPTONAME'], 2);
+            $nameParts = explode(' ', trim($data['SHIPTONAME']), 2);
             $shippingAddress->addData(['firstname' => $nameParts[0]]);
 
             if (isset($nameParts[1])) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
# SHIPTONAME can begin with a leading space
### Description (*)
In the Paypal API the SHIPTONAME can begin with a leading whitespace. I confirmed this in a production setting, obviosuly I can not share a screenshot due to dataprotection laws. 
### Related Pull Requests
<!-- related pull request placeholder -->
Non that I am aware of....

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Maybe, please find out yourself...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
The fix shoulb be obvious not everything needs steps to reproduce ;).

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38011: SHIPTONAME can beginn with a leading space