### PR TITLE
[WIP] Fixes some wrong usages of ignoring coding standards in less files.

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Analytics/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Analytics/web/css/source/_module.less
@@ -115,7 +115,7 @@
 }
 
 .advanced-reports-subscription-modal {
-    h1:first-of-type {
+    h1::first-of-type {
         background: url("Magento_Analytics::images/analytics-icon.svg") no-repeat;
         background-size: 55px 49.08px;
         padding: 1.5rem 0 2rem 7rem;
@@ -158,9 +158,7 @@
     margin-top: 1rem;
 }
 
-/**
- * @codingStandardsIgnoreStart
- */
+/* @codingStandardsIgnoreStart */
 #row_analytics_general_vertical {
     >td.config-vertical-label {
         >label.admin__field-label {
@@ -168,3 +166,4 @@
         }
     }
 }
+/* @codingStandardsIgnoreEnd */

--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_menu.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_menu.less
@@ -53,10 +53,6 @@
 //  Utilities
 //  ---------------------------------------------
 
-/**
- * @codingStandardsIgnoreStart
- */
-
 .admin__menu-link() {
     color: @menu-item__color;
     display: block;
@@ -161,9 +157,7 @@
 
         .logo-img {
             height: @menu-logo-img__height;
-            transition: -webkit-filter .2s linear,
-            filter .2s linear,
-            transform .1s linear;
+            transition: -webkit-filter .2s linear, filter .2s linear, transform .1s linear;
             width: @menu-logo-img__width;
         }
     }

--- a/app/design/adminhtml/Magento/backend/Magento_Rma/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Rma/web/css/source/_module.less
@@ -6,22 +6,19 @@
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .rma-request-details,
     .rma-wrapper .order-shipping-address {
-        float: left;
-        /**
-         * @codingStandardsIgnoreStart
-         */
+        /* @codingStandardsIgnoreStart */
         #mix-grid .width(6, 12);
-        //@codingStandardsIgnoreEnd
+        /* @codingStandardsIgnoreEnd */
+        float: left;
     }
 
     .rma-confirmation,
-    .rma-wrapper .order-return-address, .rma-wrapper .order-shipping-method {
-        float: right;
-        /**
-        * @codingStandardsIgnoreStart
-        */
+    .rma-wrapper .order-return-address,
+    .rma-wrapper .order-shipping-method {
+        /* @codingStandardsIgnoreStart */
         #mix-grid .width(6, 12);
-        //@codingStandardsIgnoreEnd
+        /* @codingStandardsIgnoreEnd */
+        float: right;
     }
 }
 

--- a/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Tax/web/css/source/_module.less
@@ -3,9 +3,6 @@
 //  * See COPYING.txt for license details.
 //  */
 
-/**
- * @codingStandardsIgnoreStart
- */
 .block-footer .action-add {
     -webkit-appearance: none;
     &:extend(.action-default, button all);
@@ -40,4 +37,3 @@
         }
     }
 }
-//@codingStandardsIgnoreEnd

--- a/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Ui/web/css/source/module/_data-grid.less
@@ -12,9 +12,6 @@
 //  _____________________________________________
 
 //  Data Grid Change Indicator
-/**
- * @codingStandardsIgnoreStart
- */
 @data-grid-row-changed__icon: @icon-edit__content;
 @data-grid-row-changed-tooltip__background: @color-white-fog2;
 
@@ -1088,7 +1085,7 @@ body._in-resize {
 
     //  Content Hierarchy specific
     .adminhtml-cms-hierarchy-index & {
-        .data-grid-actions-cell:first-child {
+        .data-grid-actions-cell::first-child {
             padding: 0;
         }
     }

--- a/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-dropdown.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-dropdown.less
@@ -168,15 +168,12 @@
     width: auto;
     z-index: 1;
 
-    /**
-     * @codingStandardsIgnoreStart
-     */
     &:hover {
-        &:extend(.abs-form-control-pattern:hover);
+        &:extend(.abs-form-control-pattern::hover);
     }
 
     &._focus {
-        &:extend(.abs-form-control-pattern:focus);
+        &:extend(.abs-form-control-pattern::focus);
     }
 
     &._active {
@@ -261,7 +258,7 @@
 
     .selectmenu:hover & {
         &:before {
-            &:extend(.abs-form-control-pattern:hover);
+            &:extend(.abs-form-control-pattern::hover);
         }
     }
 
@@ -270,7 +267,7 @@
     }
 
     .selectmenu._focus &:before {
-        &:extend(.abs-form-control-pattern:focus);
+        &:extend(.abs-form-control-pattern::focus);
     }
 
     body._keyfocus &:focus {
@@ -355,7 +352,7 @@
     white-space: nowrap;
     z-index: 1;
 
-    li:last-child & {
+    li::last-child & {
         padding-right: .4rem;
     }
 

--- a/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-multiselect.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/actions/_actions-multiselect.less
@@ -11,9 +11,6 @@
 //  Variables
 //  _____________________________________________
 
-/**
- * @codingStandardsIgnoreStart
- */
 @action-multiselect-menu-item__padding: 1rem;
 @action-multiselect-menu-item__hover__background-color: @color-gray89;
 @action-multiselect-menu-item__selected__background-color: @color-blue-clear-sky;

--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_media-gallery.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_media-gallery.less
@@ -90,9 +90,7 @@
         height: @image-gallery-placeholder__height;
 
         .product-image-wrapper {
-            /**
-            * @codingStandardsIgnoreStart
-            */
+            /* @codingStandardsIgnoreStart */
             .lib-icon-font(
                 @icon-camera__content,
                 @_icon-font: @icons-admin__font-name,
@@ -100,7 +98,7 @@
                 @_icon-font-color: @image-gallery-placeholder-icon__color,
                 @_icon-font-text-hide: true
             );
-            //@codingStandardsIgnoreEnd
+            /* @codingStandardsIgnoreEnd */
 
             &:before {
                 left: 0;

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_controls.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_controls.less
@@ -31,6 +31,7 @@
     width: auto;
 }
 
+/* @codingStandardsIgnoreStart */
 .__form-control-pattern__hover() {
     border-color: @field-control__hover__border-color;
 }
@@ -48,6 +49,7 @@
     cursor: not-allowed;
     opacity: @disabled__opacity;
 }
+/* @codingStandardsIgnoreEnd */
 
 //  Input text styles
 .admin__control-text {
@@ -134,12 +136,9 @@ option:empty {
     &:before {
         &:extend(.abs-form-control-pattern);
 
-        .admin__control-file:active + &,
-        .admin__control-file:focus + & {
-            /**
-             * @codingStandardsIgnoreStart
-             */
-            &:extend(.abs-form-control-pattern:focus);
+        .admin__control-file::active + &,
+        .admin__control-file::focus + & {
+            &:extend(.abs-form-control-pattern::focus);
         }
 
         .admin__control-file[disabled] + & {
@@ -168,14 +167,14 @@ option:empty {
 //  Support text. Can be used on label or plain text to align controls & actions
 //  ---------------------------------------------
 
-.admin__control-support-text { // ToDo UI: should be renamed to .admin__control-text
+.admin__control-support-text { /* ToDo UI: should be renamed to .admin__control-text */
     border: @field-control__border-width solid transparent;
     display: inline-block;
     font-size: @field-control__font-size;
     line-height: @field-control__line-height;
+    margin-left: @action__outer-indent;
     padding-bottom: @field-control__padding-bottom;
     padding-top: @field-control__padding-top;
-    margin-left: @action__outer-indent;
 
     + [class*='admin__control-'] {
         margin-left: @action__outer-indent;
@@ -288,11 +287,11 @@ option:empty {
         }
 
         &:focus ~ [class*='admin__addon-']:last-child:before {
-            &:extend(.abs-form-control-pattern:focus);
+            &:extend(.abs-form-control-pattern::focus);
         }
 
         &:hover ~ [class*='admin__addon-']:last-child:before {
-            &:extend(.abs-form-control-pattern:hover);
+            &:extend(.abs-form-control-pattern::hover);
         }
     }
 }

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_fields.less
@@ -59,11 +59,9 @@
 }
 
 .abs-field-no-label {
-    /**
-     *@codingStandardsIgnoreStart
-     */
+    /* @codingStandardsIgnoreStart */
     #mix-grid .return_length(@field-label-grid__column, @field-grid__columns, '+');
-    //@codingStandardsIgnoreEnd
+    /* @codingStandardsIgnoreEnd */
     margin-left: @_length;
 }
 
@@ -121,7 +119,7 @@
 
         > .admin__field-control {
             #mix-grid .column(@field-control-grid__column, @field-grid__columns);
-            input[type="checkbox"] {
+            input[type='checkbox'] {
                 margin-top: @indent__s;
             }
         }
@@ -191,9 +189,11 @@
     .admin__control-textarea {
         width: 100%;
         &.disabled {
+            /* @codingStandardsIgnoreStart */
             background-color: #e9e9e9;
             border-color: #adadad;
             color: #303030;
+            /* @codingStandardsIgnoreEnd */
             cursor: not-allowed;
             opacity: .5;
         }
@@ -235,7 +235,9 @@
         white-space: nowrap;
 
         &:before {
+            /* @codingStandardsIgnoreStart */
             .appearing__off();
+            /* @codingStandardsIgnoreEnd */
             content: '.';
             margin-left: -7px;
             overflow: hidden;
@@ -328,7 +330,9 @@
     //  Till that time they'll be disabled by commenting pseudo-element content property.
     &[data-config-scope] {
         &:before {
+            /* @codingStandardsIgnoreStart */
             #mix-grid .return_length(@field-label-grid__column + @field-control-grid__column, @field-grid__columns);
+            /* @codingStandardsIgnoreEnd */
             color: @field-scope__color;
             content: attr(data-config-scope);
             display: inline-block;
@@ -349,8 +353,8 @@
     }
 
     &._error {
-        .admin__field-control [class*='admin__control-'] [class*='admin__addon-']:before,
-        .admin__field-control [class*='admin__addon-']:before,
+        .admin__field-control [class*='admin__control-'] [class*='admin__addon-']::before,
+        .admin__field-control [class*='admin__addon-']::before,
         .admin__field-control > [class*='admin__control-'] {
             border-color: @field-error-control__border-color;
         }
@@ -364,9 +368,11 @@
         outline: inherit;
 
         .admin__action-multiselect-wrap {
+            /* @codingStandardsIgnoreStart */
             .admin__action-multiselect {
                 .__form-control-pattern__disabled();
             }
+            /* @codingStandardsIgnoreEnd */
         }
     }
 
@@ -620,7 +626,7 @@
         &.admin__field-large {
             width: 1px;
 
-            + .admin__field:last-child {
+            + .admin__field::last-child {
                 width: auto;
             }
         }
@@ -666,8 +672,8 @@
         &.admin__field {
             > .admin__field-control {
                 &:extend(.abs-field-size-small all);
-                position: relative;
                 display: inline-block;
+                position: relative;
             }
         }
 
@@ -763,7 +769,7 @@
     margin: @indent__s 0 @indent__l;
     padding-left: @indent__s;
 
-    .admin__field:not(._hidden) + & {
+    .admin__field::not(._hidden) + & {
         margin-top: 3rem;
     }
 
@@ -809,7 +815,7 @@
 //  _____________________________________________
 
 .admin__legend {
-    //  ToDo UI: add form legend styles. Check if they doon't conflict with create order page form legend styles
+    /* ToDo UI: add form legend styles. Check if they doon't conflict with create order page form legend styles */
     float: left;
     position: static;
     width: 100%;

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/_temp.less
@@ -155,6 +155,8 @@
 
     .action-delete {
         .lib-button-reset();
+
+        /* @codingStandardsIgnoreStart */
         .lib-icon-font(
             @icon-remove-small__content,
             @icons-admin__font-name,
@@ -164,6 +166,7 @@
             @_icon-font-position: after,
             @_icon-font-color: @color-brown-darker
         );
+        /* @codingStandardsIgnoreEnd */
 
         span {
             max-height: 1px;
@@ -408,18 +411,15 @@ label.mage-error {
             width: 16px;
             z-index: 1;
 
-            /**
-             * @codingStandardsIgnoreStart
-             */
             &:before {
-                &:extend(.admin__control-checkbox + label:before);
+                &:extend(.admin__control-checkbox + label::before);
                 left: 0;
                 position: absolute;
                 top: 0;
             }
 
             &:after {
-                &:extend(.action-multicheck-wrap .action-multicheck-toggle:after);
+                &:extend(.action-multicheck-wrap .action-multicheck-toggle::after);
                 top: 40% !important;
             }
         }
@@ -427,7 +427,7 @@ label.mage-error {
         &:focus {
             + label {
                 &:after {
-                    &:extend(.action-multicheck-wrap .action-multicheck-toggle._active:after);
+                    &:extend(.action-multicheck-wrap .action-multicheck-toggle._active::after);
                 }
             }
         }
@@ -435,9 +435,8 @@ label.mage-error {
         &._checked {
             + label {
                 &:before {
-                    &:extend(.admin__control-checkbox:checked + label:before);
+                    &:extend(.admin__control-checkbox::checked + label::before);
                 }
-                //  @codingStandardsIgnoreEnd
             }
 
             &._indeterminate {
@@ -464,8 +463,8 @@ label.mage-error {
 
 .admin__data-grid-toolbar {
     *,
-    *:before,
-    *:after {
+    *::before,
+    *::after {
         box-sizing: border-box;
     }
 

--- a/app/design/adminhtml/Magento/backend/web/css/source/forms/fields/_control-table.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/forms/fields/_control-table.less
@@ -6,9 +6,6 @@
 //
 //  Variables
 //  ---------------------------------------------
-/**
- * @codingStandardsIgnoreStart
- */
 @control-table__dragging__outline-color: @color-blue-pure;
 
 @control-table-row__dragging__background-color: @color-light-gray0;
@@ -239,6 +236,7 @@
     }
 }
 
+/* @codingStandardsIgnoreStart */
 .product_form_product_form_advanced_pricing_modal .admin__fieldset > .admin__field > .admin__field-label,
 .product_form_product_form_advanced_pricing_modal [class*='admin__control-grouped'] > .admin__field:first-child > .admin__field-label {
     margin-left: 0;
@@ -257,3 +255,4 @@
     overflow-x: visible;
     overflow-y: visible;
 }
+/* @codingStandardsIgnoreEnd */

--- a/app/design/frontend/Magento/blank/web/css/source/_extends.less
+++ b/app/design/frontend/Magento/blank/web/css/source/_extends.less
@@ -11,9 +11,7 @@
 //  List default styles reset
 //  ---------------------------------------------
 
-/**
- * @codingStandardsIgnoreStart
- */
+/* @codingStandardsIgnoreStart */
 & when (@media-common = true) {
     .abs-reset-list {
         .lib-list-reset-styles();
@@ -1457,4 +1455,4 @@
         }
     }
 }
-//@codingStandardsIgnoreEnd
+/* @codingStandardsIgnoreEnd */

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_payments.less
@@ -67,13 +67,11 @@
                     }
                 }
             }
-            /**
-             * @codingStandardsIgnoreStart
-             */
+            /* @codingStandardsIgnoreStart */
             #po_number {
                 margin-bottom: 20px;
             }
-            //  @codingStandardsIgnoreEnd
+            /* @codingStandardsIgnoreEnd */
         }
 
         .payment-method-title {
@@ -138,7 +136,7 @@
                 .lib-css(padding, @checkout-billing-address-details__padding);
             }
 
-            input[type="checkbox"] {
+            input[type='checkbox'] {
                 vertical-align: top;
             }
         }


### PR DESCRIPTION
### Description (*)
New Magento coding standards v32 came with fix for [ignoring underscore usage in less files](https://github.com/magento/magento-coding-standard/issues/409), I tried looking to remove some of the ignores that got added in less files over the last couple of months that ran into this false positive.
However, while trying to remove those now obsolete ignores, I ran into a bunch more problems, where I discovered that the syntax `//@codingStandardsIgnoreEnd` wasn't even working, it should have been used as `/* @codingStandardsIgnoreEnd */`.
While fixing those, ran into a bunch more problems, like:
- coding standards tripping over the syntax `:first-child` and similar ones, solved that by using 2 colons (`::first-child`), [which is considered the way of the future](https://stackoverflow.com/a/28527928), but it might also be considered [a bug in coding standards](https://github.com/magento/magento-coding-standard/issues/395)?.
- sort order of certain properties was not alphabetical
- double quotes replaced with single quotes
- ...

I'm considering this WIP, still TODO:
- compare if the resulting css files contain no changes (or only a few changes and see if those make sense).
- explain changes in more detail
- write out manual testing scenario's if resulting css files are different then before

### Related Pull Requests

### Fixed Issues (if relevant)
1. None

### Manual testing scenarios (*)
1. Entire frontend should still look identical as before

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
