### PR TITLE
fix for synchronizing quote in cart model with checkout session

### DIFF
--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -223,8 +223,9 @@ class Cart extends DataObject implements CartInterface
         }
 
         $quote = $this->_getData('quote');
-
-        if ($this->_checkoutSession->getQuoteId() != $quote->getId()) {
+        $sessionQuoteId = $this->_checkoutSession->getQuoteId();
+        
+        if ($sessionQuoteId && $sessionQuoteId != $quote->getId()) {
             $this->setData('quote', $this->_checkoutSession->getQuote());
         }
         

--- a/app/code/Magento/Checkout/Model/Cart.php
+++ b/app/code/Magento/Checkout/Model/Cart.php
@@ -221,6 +221,13 @@ class Cart extends DataObject implements CartInterface
         if (!$this->hasData('quote')) {
             $this->setData('quote', $this->_checkoutSession->getQuote());
         }
+
+        $quote = $this->_getData('quote');
+
+        if ($this->_checkoutSession->getQuoteId() != $quote->getId()) {
+            $this->setData('quote', $this->_checkoutSession->getQuote());
+        }
+        
         return $this->_getData('quote');
     }
 


### PR DESCRIPTION
Magento\Checkout\Model\Cart::getQuote() Returns Incorrect Quote After Using \Magento\Checkout\Model\Session::replaceQuote($quote) (ISSUE:#38027)