### PR TITLE
magento/magento2#38017: Coupon for single use can be used multiple ti…

### DIFF
--- a/app/code/Magento/Quote/Model/ValidationRules/CouponUsageValidationRule.php
+++ b/app/code/Magento/Quote/Model/ValidationRules/CouponUsageValidationRule.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model\ValidationRules;
+
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Validation\ValidationResultFactory;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\SalesRule\Api\CouponRepositoryInterface;
+use Magento\SalesRule\Api\Data\CouponInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @inheritdoc
+ */
+class CouponUsageValidationRule implements QuoteValidationRuleInterface
+{
+    /**
+     * @var string
+     */
+    private $generalMessage;
+
+    /**
+     * @var string
+     */
+    private $wrongCouponCodeMessage;
+
+    /**
+     * @var ValidationResultFactory
+     */
+    private $validationResultFactory;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var CouponRepositoryInterface
+     */
+    private $couponRepository;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param CouponRepositoryInterface $couponRepository
+     * @param LoggerInterface $logger
+     * @param OrderRepositoryInterface $orderRepository
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param ValidationResultFactory $validationResultFactory
+     * @param string $generalMessage
+     * @param string $wrongCouponCodeMessage
+     */
+    public function __construct(
+        CouponRepositoryInterface $couponRepository,
+        LoggerInterface $logger,
+        OrderRepositoryInterface $orderRepository,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        ValidationResultFactory $validationResultFactory,
+        string $generalMessage = '',
+        string $wrongCouponCodeMessage = ''
+    ) {
+        $this->couponRepository = $couponRepository;
+        $this->logger = $logger;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->orderRepository = $orderRepository;
+        $this->validationResultFactory = $validationResultFactory;
+        $this->generalMessage = $generalMessage;
+        $this->wrongCouponCodeMessage = $wrongCouponCodeMessage;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function validate(Quote $quote): array
+    {
+        $validationErrors = [];
+
+        $appliedCouponCode = $quote->getCouponCode();
+        if ($appliedCouponCode === '') {
+            return [$this->validationResultFactory->create(['errors' => $validationErrors])];
+        }
+
+        $couponData = $this->getCouponDataByCode($appliedCouponCode);
+        if (!$couponData) {
+            $validationErrors = [__($this->wrongCouponCodeMessage)];
+            return [$this->validationResultFactory->create(['errors' => $validationErrors])];
+        }
+
+        foreach ($couponData as $coupon) {
+            $usageLimit = $coupon->getUsageLimit();
+            if (!$usageLimit) {
+                continue;
+            }
+
+            $used = $coupon->getTimesUsed();
+            $ordersWithAppliedCoupon = $this->getOrdersWithAppliedCouponCode($appliedCouponCode);
+            if ($used >= $usageLimit ||
+                $used >= $ordersWithAppliedCoupon ||
+                $ordersWithAppliedCoupon >= $usageLimit
+            ) {
+                $validationErrors = [__($this->generalMessage)];
+            }
+        }
+
+        return [$this->validationResultFactory->create(['errors' => $validationErrors])];
+    }
+
+    /**
+     * Get sale rules with a target coupon code
+     *
+     * @param string $couponCode
+     * @return CouponInterface[]|null
+     */
+    private function getCouponDataByCode(string $couponCode): ?array
+    {
+        $couponData = null;
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('code', $couponCode)
+            ->create();
+
+        try {
+            $couponList = $this->couponRepository->getList($searchCriteria);
+            if ($couponList->getTotalCount()) {
+                $couponData = $couponList->getItems();
+            }
+        } catch (LocalizedException $e) {
+            $this->logger->error($e->getMessage());
+        }
+
+        return $couponData;
+    }
+
+    /**
+     * Get orders qty with applied target coupon code
+     *
+     * @param string $couponCode
+     * @return int
+     */
+    private function getOrdersWithAppliedCouponCode(string $couponCode): int
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('coupon_code', $couponCode)
+            ->create();
+
+        return $this->orderRepository->getList($searchCriteria)->getTotalCount();
+    }
+}

--- a/app/code/Magento/Quote/etc/adminhtml/di.xml
+++ b/app/code/Magento/Quote/etc/adminhtml/di.xml
@@ -14,6 +14,7 @@
                 <item name="ShippingMethodValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\ShippingMethodValidationRule</item>
                 <item name="BillingAddressValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\BillingAddressValidationRule</item>
                 <item name="PaymentMethodValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\PaymentMethodValidationRule</item>
+                <item name="CouponUsageValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\CouponUsageValidationRule</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/Quote/etc/di.xml
+++ b/app/code/Magento/Quote/etc/di.xml
@@ -116,6 +116,7 @@
                 <item name="BillingAddressValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\BillingAddressValidationRule</item>
                 <item name="PaymentMethodValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\PaymentMethodValidationRule</item>
                 <item name="MinimumAmountValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\MinimumAmountValidationRule</item>
+                <item name="CouponUsageValidationRule" xsi:type="object">Magento\Quote\Model\ValidationRules\CouponUsageValidationRule</item>
             </argument>
         </arguments>
     </type>
@@ -142,6 +143,12 @@
     <type name="Magento\Quote\Model\ValidationRules\PaymentMethodValidationRule">
         <arguments>
             <argument name="generalMessage" xsi:type="string" translatable="true">Enter a valid payment method and try again.</argument>
+        </arguments>
+    </type>
+    <type name="Magento\Quote\Model\ValidationRules\CouponUsageValidationRule">
+        <arguments>
+            <argument name="wrongCouponCodeMessage" xsi:type="string" translatable="true">Enter a valid coupon code and try again.</argument>
+            <argument name="generalMessage" xsi:type="string" translatable="true">The coupon code is not valid.</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\App\Backpressure\SlidingWindow\CompositeLimitConfigManager">


### PR DESCRIPTION
…mes - fixed issue with multiple usage limited coupon by adding coupon usage validator to quote submitting

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The issue was related to the ability to multiple coupon codes with limited usage if the cron job for setting coupon usage has not been executed yet

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
Added an additional coupon usage validator for submitting quotes which check is qty of orders with the same coupon code less than the usage limit

1. Fixes magento/magento2#38017

### Manual testing scenarios (*)
1. Create a cart rule with coupon usage and usage per coupon = 1
2. Generate coupon code (after generating it must be: used is no, used times is 0)
3. Open browser 1, apply the coupon code, and go to the last checkout page
4. Open browser 2 (or incognito tab), apply the same coupon code and go to the last checkout page
5. Place order in browsers 1 and 2 simultaneously (a few seconds might be ok)
The first order will be a success, the second place order must return the error: "The coupon code is not valid."

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
