### PR TITLE
Fix Category::getUrl by using only auto-generated URL rewrite

### DIFF
--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -615,6 +615,7 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
                     UrlRewrite::ENTITY_ID => $this->getId(),
                     UrlRewrite::ENTITY_TYPE => CategoryUrlRewriteGenerator::ENTITY_TYPE,
                     UrlRewrite::STORE_ID => $this->getStoreId(),
+                    UrlRewrite::REDIRECT_TYPE => 0,
                 ]
             );
             if ($rewrite) {

--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -109,6 +109,7 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
      *
      * @var \Magento\UrlRewrite\Model\UrlRewrite
      * @deprecated 102.0.0
+     * @see $urlFinder
      */
     protected $_urlRewrite;
 
@@ -315,6 +316,7 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
      * @throws \Magento\Framework\Exception\LocalizedException
      * @return \Magento\Catalog\Model\ResourceModel\Category
      * @deprecated 102.0.6 because resource models should be used directly
+     * @see parent::_getResource
      * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod
      * @since 102.0.6
      */


### PR DESCRIPTION
Just like this works for products, the URL rewrite fetched in this method should only be of `redirect_type` `0`. Otherwise on old URL key that have a 301, will be used to determine the category URL.

### Fixed Issues

1. Fixes: https://github.com/magento/magento2/issues/38152

### Manual testing scenarios (*)

Can be tested manually by:
1. Creating a Category in the admin
2. Changing it's URL Key in the admin
3. Enabling canonical URLs (which makes use of `Category::getUrl()`)
4. Verifying that the canonical URL is the same as the new category URL Key in the frontend

### Comment

May contain regression bugs as I am not familiar with the original train-of-though for the current implementation of this method. There are also no tests for the scenario of changing a category URL key - which brings this bug to light.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
