### PR TITLE
Improved error handling when rendering templates, so no html leaks wh…

### DIFF
--- a/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
+++ b/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
@@ -70,7 +70,7 @@ class Php implements TemplateEngineInterface
             extract($dictionary, EXTR_SKIP);
             include $fileName;
             $this->_currentBlock = $tmpBlock;
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             ob_end_clean();
             throw $exception;
         }

--- a/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
+++ b/lib/internal/Magento/Framework/View/TemplateEngine/Php.php
@@ -16,15 +16,11 @@ use Magento\Framework\View\TemplateEngineInterface;
 class Php implements TemplateEngineInterface
 {
     /**
-     * Current block
-     *
      * @var BlockInterface
      */
     protected $_currentBlock;
 
     /**
-     * Helper factory
-     *
      * @var \Magento\Framework\ObjectManagerInterface
      */
     protected $_helperFactory;


### PR DESCRIPTION
…en a php error occurs.

### Description (*)
We noticed that Magento only catches exceptions and not php errors when rendering templates.
When it catches exceptions, the rendered output so-far gets discarded using the `ob_end_clean` php function. This didn't happen for PHP errors yet. If we change the try catch to catch a `Throwable` instead of an `Exception` this gets fixed.

This was found while writing a little module to run over all the cms pages of a very content-heavy webshop and we are trying to render those in the backoffice so we can display which pages have errors, so the merchant can see at a glance which cms content is broken. We noticed that when a fatal php error happened while rendering a frontend cms page, it outputted part of the html before the error to the browser already, this doesn't happen if an exception gets thrown.
So we align this behavior in this PR.

This builds further on https://github.com/magento/magento2/pull/25250 where similar changes got done.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Simulate both an exception and a PHP error in the frontend
    - An easy way is to temporarily change the template file `app/code/Magento/Search/view/frontend/templates/form.mini.phtml`
    - And either put the following at the **end** of the file (it's important it's at the end, not at the beginning!)
        - first time: `<?php throw new \Exception('test');`
        - second time: `<?php $quickSearchUrl->doSomethingThatDoesnExist();`
2. Validate the results on the frontend in both cases, try it both in `production` and `developer` mode and see the differences and if they make sense or not
3. Validate that a developer can still find useful info about the exception/error in the log files

In the case of a php error in production mode, this is the difference in the browser.
Before this PR:
![Screenshot 2023-11-08 at 16 16 35](https://github.com/magento/magento2/assets/85479/5ee16666-1df4-4799-9922-40e600aa3404)

After this PR:
![Screenshot 2023-11-08 at 16 14 30](https://github.com/magento/magento2/assets/85479/429fe94e-eb17-4f86-a480-9a76b910fc3a)

### Questions or comments
I couldn't find unit tests for this part of core Magento, so I have nothing to base new automated testing on, so I'll just skip this otherwise it's going to take me too long to figure out how to write tests for this. So if somebody could help out with this part, that would be appreciated!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38166: Improved error handling when rendering templates, so no html leaks wh…