### PR TITLE
Add default empty array in constructor

### DIFF
--- a/app/code/Magento/Store/Model/Config/Cache/Tag/Strategy/CompositeTagGenerator.php
+++ b/app/code/Magento/Store/Model/Config/Cache/Tag/Strategy/CompositeTagGenerator.php
@@ -23,7 +23,7 @@ class CompositeTagGenerator implements TagGeneratorInterface
      * @param TagGeneratorInterface[] $tagGenerators
      */
     public function __construct(
-        array $tagGenerators
+        array $tagGenerators = []
     ) {
         $this->tagGenerators = $tagGenerators;
     }


### PR DESCRIPTION
### Description (*)

This class its constructor argument `$tagGenerators` is empty by default in PHP, so that via DI argument types in `di.xml` files the array is filled automatically. This actually means that - without any runtime configuration of this argument - the PHP class has a required argument `$tagGenerators`.

In my cases, this is breaking DI compile when the modules `Magento_DirectoryGraphQl` and `Magento_StoreGraphQl` are disabled (and actually a lot of people will disable this module if they are not building a headless shop). This PR is a simple but required fix.

### Related Pull Requests
None

### Fixed Issues (if relevant)
None

### Manual testing scenarios (*)
Install Magento 2. Next, add a composer replacement of `magento/module-store-graph-ql` and `magento/module-directory-graph-ql` and run `composer update` to remove these dependencies. Alternatively, just disable the modules `Magento_DirectoryGraphQl` and `Magento_StoreGraphQl`. Next, run `bin/magento setup:di:compile`. It should fail. With this patch, it should work.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38165: Add default empty array in constructor