### PR TITLE
Remove the "required" UI setting because it is not being used

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
@@ -169,12 +169,10 @@
                 <dataType>string</dataType>
                 <label translate="true">Category Image</label>
                 <visible>true</visible>
-                <required>false</required>
             </settings>
             <formElements>
                 <imageUploader>
                     <settings>
-                        <required>false</required>
                         <uploaderConfig>
                             <param xsi:type="url" name="url" path="catalog/category_image/upload"/>
                         </uploaderConfig>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml
@@ -52,7 +52,6 @@
         </container>
         <field name="name" sortOrder="10" formElement="input">
             <settings>
-                <required>true</required>
                 <validation>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
                 </validation>

--- a/app/code/Magento/Catalog/view/adminhtml/ui_component/product_attribute_add_form.xml
+++ b/app/code/Magento/Catalog/view/adminhtml/ui_component/product_attribute_add_form.xml
@@ -60,7 +60,6 @@
                 </item>
             </argument>
             <settings>
-                <required>true</required>
                 <validation>
                     <rule name="required-entry" xsi:type="boolean">true</rule>
                     <rule name="validate-no-html-tags" xsi:type="boolean">true</rule>

--- a/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
+++ b/app/code/Magento/Customer/view/base/ui_component/customer_form.xml
@@ -171,7 +171,6 @@
                     </item>
                 </argument>
                 <settings>
-                    <required>true</required>
                     <dataType>number</dataType>
                 </settings>
             </field>

--- a/app/code/Magento/Swatches/view/adminhtml/ui_component/product_attribute_add_form.xml
+++ b/app/code/Magento/Swatches/view/adminhtml/ui_component/product_attribute_add_form.xml
@@ -170,7 +170,6 @@
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Admin</label>
-                        <required>true</required>
                         <validation>
                             <rule name="required-entry" xsi:type="boolean">true</rule>
                         </validation>
@@ -296,7 +295,6 @@
                     <settings>
                         <dataType>text</dataType>
                         <label translate="true">Admin</label>
-                        <required>true</required>
                         <validation>
                             <rule name="required-entry" xsi:type="boolean">true</rule>
                         </validation>

--- a/app/code/Magento/Ui/view/base/ui_component/etc/definition/ui_settings.xsd
+++ b/app/code/Magento/Ui/view/base/ui_component/etc/definition/ui_settings.xsd
@@ -960,13 +960,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="required" type="translatableString">
-                <xs:annotation>
-                    <xs:documentation>
-                        Defines whether the rendered field is required.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="validation" type="validationType">
                 <xs:annotation>
                     <xs:documentation>


### PR DESCRIPTION
This pull request removes the `required` UI setting because it is not being used.

The `required` node within the `settings` node was introduced in Magento 2.2.0 https://github.com/magento/magento2/commit/5affd8aa4c44f2f137bb171887af000b9ef27d09#diff-8aee8246d682b388c846bcfd4c2b9191c18af2fa9fea845324805421d62b579f
Its purpose was to define whether the rendered field is required. However, this functionality is already covered by the `validation` setting. The `required-entry` rule node within the `validation` node determines whether the field is required or not.
For example,
```
<field name="name" sortOrder="10" formElement="input">
    <settings>
        <validation>
            <rule name="required-entry" xsi:type="boolean">true</rule>
        </validation>
    </settings>
</field>
```
We can refer to the `initObservable` and `_setClasses` functions in the `Magento_Ui/js/form/element/abstract` JS component located in the [vendor/magento/module-ui/view/base/web/js/form/element/abstract.js](https://github.com/magento/magento2/blob/2.2.0/app/code/Magento/Ui/view/base/web/js/form/element/abstract.js#L102) file.

Since the `required` node within the `settings` node is not being used, it should be removed from the Magento codebase.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->
N/A
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new category or edit an existing category > remove the category image if exists > Save the category.
Expected result: The category is saved without an error or notice indicating the category image is required.
Related file:
- app/code/Magento/Catalog/view/adminhtml/ui_component/category_form.xml
2. Create a new category > save the category without filling in the **Category Name** field.
Expected result: The category can not be saved since the  **Category Name** field is required. This field is required because the `required-entry` rule node within the `validation` node is set to `true`.
Related file:
- app/code/Magento/Catalog/view/adminhtml/ui_component/new_category_form.xml
3. Create a new product or edit an existing product > Click the **Add Attribute** button > Click the **Create New Attribute** button > Save the attribute without filling in the **Attribute Label** field.
Expected result: The product attribute can not be saved since the  **AttributeDefault Label** field is required. This field is required because the `required-entry` rule node within the `validation` node is set to `true`.
Related file:
- app/code/Magento/Catalog/view/adminhtml/ui_component/product_attribute_add_form.xml
4. Since the "Customer Group ID" field always has value in the Customer edit page in the admin, removing the `required` setting in the `app/code/Magento/Customer/view/base/ui_component/customer_form.xml` file does not affect anything. Therefore, no manual testing is needed.
Related file:
- app/code/Magento/Customer/view/base/ui_component/customer_form.xml
5. Create a new product or edit an existing product > Click the **Add Attribute** button > Click the **Create New Attribute** button > In the **Catalog Input Type for Store Owner** field, select "Text Swatch" > Click the **Add Swatch** button > Save the attribute without filling in the **Admin** field.
Expected result: The product attribute can not be saved since the  **Admin** field is required. This field is required because the `required-entry` rule node within the `validation` node is set to `true`.
Related file:
- app/code/Magento/Swatches/view/adminhtml/ui_component/product_attribute_add_form.xml

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38184: Remove the "required" UI setting because it is not being used