### PR TITLE
Display backordered quantity if the order item has them

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/items/column/qty.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/items/column/qty.phtml
@@ -11,6 +11,13 @@
             <td><?= (float) $item->getQtyOrdered() ?></td>
         </tr>
 
+        <?php if ((float)$item->getQtyBackordered()) : ?>
+            <tr>
+                <th><?= $block->escapeHtml(__('Backordered')); ?></th>
+                <td><?= (float) $item->getQtyBackordered() ?></td>
+            </tr>
+        <?php endif; ?>
+        
         <?php if ((float)$item->getQtyInvoiced()) : ?>
             <tr>
                 <th><?= $block->escapeHtml(__('Invoiced')); ?></th>


### PR DESCRIPTION
### Description

This PR will show the number of items that are backordered for every order item in the order overview screen. 

### Fixed Issues

1. Fixes magento/magento2#38252

### Manual testing scenarios 
1. Have a product which allows backorders.
2. Create an order with a product that allows backorders and make sure there's no current inventory for that item.
3. Order overview will show the quantity of the product that are in backorder. 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
