### PR TITLE
Synchronise store attributes if attribute scope is website

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/AbstractResource.php
@@ -331,7 +331,11 @@ abstract class AbstractResource extends \Magento\Eav\Model\Entity\AbstractEntity
         $storeId = $hasSingleStore
             ? $this->getDefaultStoreId()
             : (int) $this->_storeManager->getStore($object->getStoreId())->getId();
-        if ($valueId > 0 && array_key_exists('store_id', $row) && $storeId === $row['store_id']) {
+
+        $updateExistingEntry = $valueId > 0 && array_key_exists('store_id', $row) && $storeId === $row['store_id'];
+        $needToUpdateMultipleStores = !$hasSingleStore && $attribute->isScopeWebsite();
+
+        if ($updateExistingEntry && !$needToUpdateMultipleStores) {
             $table = $attribute->getBackend()->getTable();
             $connection = $this->getConnection();
             $connection->update(


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
This pull request aims at fixing [https://github.com/magento/magento2/issues/38243](this issue). 
It fixes the synchronisation of a website scoped attribute in a multi store environment. 

### Description (*)

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

I fixed the issue by applying another condition in the _updateAttribute method of the Magento\Catalog\Model\ResourceModel\AbstractResource class. 

A fix made recently on this method brought the bug. This method used to only call the _saveAttributeValue method of that same class. Now it has its own logic is the updated attribute is not new. I added a condition that the updated attribute must not be website scoped in a multi store environment. 

I did not want to add too much code since the modificatoins that were made on this method took place for a specific reason that i do not know.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

1. Fixes magento/magento2#38243

### Manual testing scenarios (*)

1. Create 3 stores, each one of then will have their own store view.
2. Create a Yes/No attribute with the website scope.
3. Add this attribute to the default attribute set
4. Create a simple product, set this Yes/No attribute to false on the scope of a store view.
5. In a custom script : 

```
$product = $this->productRepository->get('some-product-sku', false, 1);
$product->addAttributeUpdate('show_discount', 1, $product->getStoreId());
```
Adapt the sku and the store id to you use case.

6. Check in the DB, the attribute should have the value "1" for all stores. If not, my fix does not work.

### Questions or comments

It doesn't seem i could write an automated test for this use case. Do you confirm ? 
I took time to choose the right approach. I could not rollback the changes that were made on the issue at the origin of this bug even though the code written did not take into account the scope of the attribute. 
So i decided to treat only the very issue I was working on. I had to make so that previous work would still be present and this issue would be fixed. 

I hope you agree with that approach.  

<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
