### PR TITLE
#38365: Fixed wrong type for `InvalidArgumentException` to avoid fatal error

### DIFF
--- a/app/code/Magento/Store/Model/StoreResolver.php
+++ b/app/code/Magento/Store/Model/StoreResolver.php
@@ -15,7 +15,7 @@ class StoreResolver implements \Magento\Store\Api\StoreResolverInterface
     /**
      * Cache tag
      */
-    const CACHE_TAG = 'store_relations';
+    public const CACHE_TAG = 'store_relations';
 
     /**
      * @var \Magento\Store\Api\StoreRepositoryInterface
@@ -107,7 +107,9 @@ class StoreResolver implements \Magento\Store\Api\StoreResolverInterface
 
         if (is_array($storeCode)) {
             if (!isset($storeCode['_data']['code'])) {
-                throw new \InvalidArgumentException(__('Invalid store parameter.'));
+                throw new \InvalidArgumentException(
+                    __('Invalid store parameter.')->render()
+                );
             }
             $storeCode = $storeCode['_data']['code'];
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request (PR) provides fixes for store resolver to avoid fatal error when system tries to throw InvalidArgumentException with message: "Invalid store parameter."

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38365

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. You need to have the $_COOKIE['store'] to be an array and not contain a valid store code. For example: `$_COOKIE['store'] = ['test'];`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
