### PR TITLE
Adds Catalog Price Rules to Custom Options

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
+++ b/app/code/Magento/Catalog/Block/Product/View/Options/AbstractOptions.php
@@ -195,6 +195,17 @@ abstract class AbstractOptions extends \Magento\Framework\View\Element\Template
         $customOptionPrice = $this->getProduct()->getPriceInfo()->getPrice('custom_option_price');
         $isPercent = (bool) $value['is_percent'];
 
+        if (!$isPercent) {
+            $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+                $this->getProduct(),
+                (float)$value['pricing_value'],
+                $isPercent
+            );
+            if ($catalogPriceValue !== null) {
+                $value['pricing_value'] = $catalogPriceValue;
+            }
+        }
+
         $context = [CustomOptionPriceInterface::CONFIGURATION_OPTION_FLAG => true];
         $optionAmount = $isPercent
             ? $this->calculator->getAmount(

--- a/app/code/Magento/Catalog/Model/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Option.php
@@ -163,11 +163,11 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
         Option\Validator\Pool $validatorPool,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = [],
         ProductCustomOptionValuesInterfaceFactory $customOptionValuesFactory = null,
-        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
         array $optionGroups = [],
         array $optionTypesToGroups = [],
-        array $data = []
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null
     ) {
         $this->productOptionValue = $productOptionValue;
         $this->optionTypeFactory = $optionFactory;

--- a/app/code/Magento/Catalog/Model/Product/Option.php
+++ b/app/code/Magento/Catalog/Model/Product/Option.php
@@ -16,8 +16,10 @@ use Magento\Catalog\Model\Product\Option\Type\DefaultType;
 use Magento\Catalog\Model\Product\Option\Type\File;
 use Magento\Catalog\Model\Product\Option\Type\Select;
 use Magento\Catalog\Model\Product\Option\Type\Text;
+use Magento\Catalog\Model\Product\Option\Value;
 use Magento\Catalog\Model\ResourceModel\Product\Option\Value\Collection;
 use Magento\Catalog\Pricing\Price\BasePrice;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
@@ -129,6 +131,11 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
     private $customOptionValuesFactory;
 
     /**
+     * @var CalculateCustomOptionCatalogRule
+     */
+    private $calculateCustomOptionCatalogRule;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -156,10 +163,11 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
         Option\Validator\Pool $validatorPool,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        array $data = [],
         ProductCustomOptionValuesInterfaceFactory $customOptionValuesFactory = null,
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
         array $optionGroups = [],
-        array $optionTypesToGroups = []
+        array $optionTypesToGroups = [],
+        array $data = []
     ) {
         $this->productOptionValue = $productOptionValue;
         $this->optionTypeFactory = $optionFactory;
@@ -167,6 +175,8 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
         $this->validatorPool = $validatorPool;
         $this->customOptionValuesFactory = $customOptionValuesFactory ?:
             ObjectManager::getInstance()->get(ProductCustomOptionValuesInterfaceFactory::class);
+        $this->calculateCustomOptionCatalogRule = $calculateCustomOptionCatalogRule ??
+            ObjectManager::getInstance()->get(CalculateCustomOptionCatalogRule::class);
         $this->optionGroups = $optionGroups ?: [
             self::OPTION_GROUP_DATE => Date::class,
             self::OPTION_GROUP_FILE => File::class,
@@ -468,10 +478,21 @@ class Option extends AbstractExtensibleModel implements ProductCustomOptionInter
      */
     public function getPrice($flag = false)
     {
-        if ($flag && $this->getPriceType() == self::$typePercent) {
-            $basePrice = $this->getProduct()->getPriceInfo()->getPrice(BasePrice::PRICE_CODE)->getValue();
-            return $basePrice * ($this->_getData(self::KEY_PRICE) / 100);
+        if ($flag && $this->getPriceType() === self::$typePercent) {
+            $price = $this->calculateCustomOptionCatalogRule->execute(
+                $this->getProduct(),
+                (float)$this->getData(self::KEY_PRICE),
+                $this->getPriceType() === Value::TYPE_PERCENT
+            );
+
+            if ($price === null) {
+                $basePrice = $this->getProduct()->getPriceInfo()->getPrice(BasePrice::PRICE_CODE)->getValue();
+                $price = $basePrice * ($this->_getData(self::KEY_PRICE) / 100);
+            }
+
+            return $price;
         }
+
         return $this->_getData(self::KEY_PRICE);
     }
 

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/DefaultType.php
@@ -14,6 +14,8 @@ use Magento\Catalog\Model\Product\Configuration\Item\Option\OptionInterface;
 use Magento\Catalog\Model\Product\Configuration\Item\ItemInterface;
 use Magento\Catalog\Model\Product\Option\Value;
 use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Catalog product option default type
@@ -57,21 +59,30 @@ class DefaultType extends \Magento\Framework\DataObject implements ResetAfterReq
      */
     protected $_checkoutSession;
 
+     /**
+     * @var CalculateCustomOptionCatalogRule
+     */
+    private $calculateCustomOptionCatalogRule;
+
     /**
      * Construct
      *
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param CalculateCustomOptionCatalogRule|null $calculateCustomOptionCatalogRule
      * @param array $data
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        array $data = []
+        array $data = [],
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null
     ) {
         $this->_checkoutSession = $checkoutSession;
         parent::__construct($data);
         $this->_scopeConfig = $scopeConfig;
+        $this->calculateCustomOptionCatalogRule = $calculateCustomOptionCatalogRule 
+            ?? ObjectManager::getInstance()->get(CalculateCustomOptionCatalogRule::class);
     }
 
     /**
@@ -338,11 +349,20 @@ class DefaultType extends \Magento\Framework\DataObject implements ResetAfterReq
     {
         $option = $this->getOption();
 
-        return $this->_getChargeableOptionPrice(
-            $option->getPrice(),
-            $option->getPriceType() === Value::TYPE_PERCENT,
-            $basePrice
+        $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+            $option->getProduct(),
+            (float)$option->getPrice(),
+            $option->getPriceType() === Value::TYPE_PERCENT
         );
+        if ($catalogPriceValue !== null) {
+            return $catalogPriceValue;
+        } else {
+            return $this->_getChargeableOptionPrice(
+                $option->getPrice(),
+                $option->getPriceType() === Value::TYPE_PERCENT,
+                $basePrice
+            );
+        }
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -7,7 +7,10 @@
 namespace Magento\Catalog\Model\Product\Option\Type;
 
 use Magento\Catalog\Model\Product\Option\Value;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Catalog\Model\Product\Option;
 
 /**
  * Catalog product option select type
@@ -39,6 +42,11 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
     private $singleSelectionTypes;
 
     /**
+     * @var CalculateCustomOptionCatalogRule
+     */
+    private $calculateCustomOptionCatalogRule;
+
+    /**
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\Stdlib\StringUtils $string
@@ -51,8 +59,9 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Stdlib\StringUtils $string,
         \Magento\Framework\Escaper $escaper,
-        array $data = [],
-        array $singleSelectionTypes = []
+        array $singleSelectionTypes = [],
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
+        array $data = []
     ) {
         $this->string = $string;
         $this->_escaper = $escaper;
@@ -62,6 +71,10 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
             'drop_down' => \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_DROP_DOWN,
             'radio' => \Magento\Catalog\Api\Data\ProductCustomOptionInterface::OPTION_TYPE_RADIO,
         ];
+
+        $this->calculateCustomOptionCatalogRule = 
+            $calculateCustomOptionCatalogRule ?? ObjectManager::getInstance()
+                ->get(CalculateCustomOptionCatalogRule::class);
     }
 
     /**
@@ -253,11 +266,7 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
             foreach (explode(',', (string)$optionValue) as $value) {
                 $_result = $option->getValueById($value);
                 if ($_result) {
-                    $result += $this->_getChargeableOptionPrice(
-                        $_result->getPrice(),
-                        $_result->getPriceType() === Value::TYPE_PERCENT,
-                        $basePrice
-                    );
+                    $result += $this->getCalculatedOptionValue($option, $_result, $basePrice);
                 } else {
                     if ($this->getListener()) {
                         $this->getListener()->setHasError(true)->setMessage($this->_getWrongConfigurationMessage());
@@ -268,11 +277,20 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         } elseif ($this->_isSingleSelection()) {
             $_result = $option->getValueById($optionValue);
             if ($_result) {
-                $result = $this->_getChargeableOptionPrice(
-                    $_result->getPrice(),
-                    $_result->getPriceType() === Value::TYPE_PERCENT,
-                    $basePrice
+                $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+                    $option->getProduct(),
+                    (float)$_result->getPrice(),
+                    $_result->getPriceType() === Value::TYPE_PERCENT
                 );
+                if ($catalogPriceValue !== null) {
+                    $result = $catalogPriceValue;
+                } else {
+                    $result = $this->_getChargeableOptionPrice(
+                        $_result->getPrice(),
+                        $_result->getPriceType() == 'percent',
+                        $basePrice
+                    );
+                }
             } else {
                 if ($this->getListener()) {
                     $this->getListener()->setHasError(true)->setMessage($this->_getWrongConfigurationMessage());
@@ -333,5 +351,32 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
     protected function _isSingleSelection()
     {
         return in_array($this->getOption()->getType(), $this->singleSelectionTypes, true);
+    }
+
+    /**
+     * Returns calculated price of option
+     *
+     * @param Option $option
+     * @param Option\Value $result
+     * @param float $basePrice
+     * @return float
+     */
+    protected function getCalculatedOptionValue(Option $option, Value $result, float $basePrice) : float
+    {
+        $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+            $option->getProduct(),
+            (float)$result->getPrice(),
+            $result->getPriceType() === Value::TYPE_PERCENT
+        );
+        if ($catalogPriceValue !== null) {
+            $optionCalculatedValue = $catalogPriceValue;
+        } else {
+            $optionCalculatedValue = $this->_getChargeableOptionPrice(
+                $result->getPrice(),
+                $result->getPriceType() === Value::TYPE_PERCENT,
+                $basePrice
+            );
+        }
+        return $optionCalculatedValue;
     }
 }

--- a/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/Select.php
@@ -59,9 +59,9 @@ class Select extends \Magento\Catalog\Model\Product\Option\Type\DefaultType
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Stdlib\StringUtils $string,
         \Magento\Framework\Escaper $escaper,
+        array $data = [],
         array $singleSelectionTypes = [],
-        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
-        array $data = []
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null
     ) {
         $this->string = $string;
         $this->_escaper = $escaper;

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -10,6 +10,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Option;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Catalog\Pricing\Price\BasePrice;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 use Magento\Catalog\Pricing\Price\CustomOptionPriceCalculator;
 use Magento\Catalog\Pricing\Price\RegularPrice;
 use Magento\Framework\App\ObjectManager;
@@ -71,13 +72,19 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     private $customOptionPriceCalculator;
 
     /**
+     * @var CalculateCustomOptionCatalogRule
+     */
+    private $calculateCustomOptionCatalogRule;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Catalog\Model\ResourceModel\Product\Option\Value\CollectionFactory $valueCollectionFactory
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
-     * @param array $data
      * @param CustomOptionPriceCalculator|null $customOptionPriceCalculator
+     * @param CalculateCustomOptionCatalogRule|null $calculateCustomOptionCatalogRule
+     * @param array $data
      */
     public function __construct(
         \Magento\Framework\Model\Context $context,
@@ -85,12 +92,15 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         \Magento\Catalog\Model\ResourceModel\Product\Option\Value\CollectionFactory $valueCollectionFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        CustomOptionPriceCalculator $customOptionPriceCalculator = null,
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
         array $data = [],
-        CustomOptionPriceCalculator $customOptionPriceCalculator = null
     ) {
         $this->_valueCollectionFactory = $valueCollectionFactory;
         $this->customOptionPriceCalculator = $customOptionPriceCalculator
             ?? ObjectManager::getInstance()->get(CustomOptionPriceCalculator::class);
+        $this->calculateCustomOptionCatalogRule = $calculateCustomOptionCatalogRule
+            ?? ObjectManager::getInstance()->get(CalculateCustomOptionCatalogRule::class);
 
         parent::__construct(
             $context,
@@ -254,7 +264,16 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
     public function getPrice($flag = false)
     {
         if ($flag) {
-            return $this->customOptionPriceCalculator->getOptionPriceByPriceCode($this);
+            $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+                $this->getProduct(),
+                (float)$this->getData(self::KEY_PRICE),
+                $this->getPriceType() === self::TYPE_PERCENT
+            );
+            if ($catalogPriceValue!==null) {
+                return $catalogPriceValue;
+            } else {
+                return $this->customOptionPriceCalculator->getOptionPriceByPriceCode($this, BasePrice::PRICE_CODE);
+            }
         }
         return $this->_getData(self::KEY_PRICE);
     }

--- a/app/code/Magento/Catalog/Model/Product/Option/Value.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Value.php
@@ -92,9 +92,9 @@ class Value extends AbstractModel implements \Magento\Catalog\Api\Data\ProductCu
         \Magento\Catalog\Model\ResourceModel\Product\Option\Value\CollectionFactory $valueCollectionFactory,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        CustomOptionPriceCalculator $customOptionPriceCalculator = null,
-        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null,
         array $data = [],
+        CustomOptionPriceCalculator $customOptionPriceCalculator = null,
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule = null
     ) {
         $this->_valueCollectionFactory = $valueCollectionFactory;
         $this->customOptionPriceCalculator = $customOptionPriceCalculator

--- a/app/code/Magento/Catalog/Pricing/Price/CalculateCustomOptionCatalogRule.php
+++ b/app/code/Magento/Catalog/Pricing/Price/CalculateCustomOptionCatalogRule.php
@@ -9,6 +9,7 @@ namespace Magento\Catalog\Pricing\Price;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\PriceModifierInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 
 /**
@@ -20,25 +21,25 @@ use Magento\Framework\Pricing\PriceCurrencyInterface;
 class CalculateCustomOptionCatalogRule
 {
     /**
-     * @var PriceCurrencyInterface
-     */
-    private $priceCurrency;
-
-    /**
      * @var PriceModifierInterface
      */
     private $priceModifier;
 
     /**
-     * @param PriceCurrencyInterface $priceCurrency
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * @param PriceModifierInterface $priceModifier
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        PriceCurrencyInterface $priceCurrency,
-        PriceModifierInterface $priceModifier
+        PriceModifierInterface $priceModifier,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
     ) {
         $this->priceModifier = $priceModifier;
-        $this->priceCurrency = $priceCurrency;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -62,7 +63,10 @@ class CalculateCustomOptionCatalogRule
             $product
         );
         // Apply catalog price rules to product options only if catalog price rules are applied to product.
-        if ($catalogRulePrice < $regularPrice) {
+        if (($catalogRulePrice < $regularPrice) 
+            && $this->scopeConfig->isSetFlag('catalog/catalog_price_rules/apply_to_custom_options',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
+            
             $optionPrice = $this->getOptionPriceWithoutPriceRule($optionPriceValue, $isPercent, $regularPrice);
             $totalCatalogRulePrice = $this->priceModifier->modifyPrice(
                 $regularPrice + $optionPrice,

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/ValueTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Option/ValueTest.php
@@ -16,7 +16,7 @@ use Magento\Framework\Pricing\Price\PriceInterface;
 use Magento\Framework\Pricing\PriceInfoInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\TestCase;
-use Magento\Catalog\Pricing\Price\CustomOptionPriceCalculator;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -30,9 +30,9 @@ class ValueTest extends TestCase
     private $model;
 
     /**
-     * @var CustomOptionPriceCalculator|MockObject
+     * @var CalculateCustomOptionCatalogRule|MockObject
      */
-    private $customOptionPriceCalculatorMock;
+    private $calculateCustomOptionCatalogRule;
 
     /**
      * @inheritDoc
@@ -42,8 +42,8 @@ class ValueTest extends TestCase
         $mockedResource = $this->getMockedResource();
         $mockedCollectionFactory = $this->getMockedValueCollectionFactory();
 
-        $this->customOptionPriceCalculatorMock = $this->createMock(
-            CustomOptionPriceCalculator::class
+        $this->calculateCustomOptionCatalogRule = $this->createMock(
+            CalculateCustomOptionCatalogRule::class
         );
 
         $helper = new ObjectManager($this);
@@ -52,7 +52,7 @@ class ValueTest extends TestCase
             [
                 'resource' => $mockedResource,
                 'valueCollectionFactory' => $mockedCollectionFactory,
-                'customOptionPriceCalculator' => $this->customOptionPriceCalculatorMock
+                'calculateCustomOptionCatalogRule' => $this->calculateCustomOptionCatalogRule
             ]
         );
         $this->model->setOption($this->getMockedOption());
@@ -80,8 +80,8 @@ class ValueTest extends TestCase
         $this->assertEquals($price, $this->model->getPrice(false));
 
         $percentPrice = 100.0;
-        $this->customOptionPriceCalculatorMock->expects($this->atLeastOnce())
-            ->method('getOptionPriceByPriceCode')
+        $this->calculateCustomOptionCatalogRule->expects($this->atLeastOnce())
+            ->method('execute')
             ->willReturn($percentPrice);
         $this->assertEquals($percentPrice, $this->model->getPrice(true));
     }

--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -138,6 +138,14 @@
                     <hide_in_single_store_mode>1</hide_in_single_store_mode>
                 </field>
             </group>
+            <group id="catalog_price_rules" translate="label" type="text" sortOrder="450" showInDefault="1">
+                <label>Catalog Price Rules</label>
+                <field id="apply_to_custom_options" translate="label comment" type="select" sortOrder="1" showInDefault="1">
+                    <label>Apply to Custom Options</label>
+                    <comment><![CDATA[Determines whether catalog price rules should also apply to the custom option prices.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
             <group id="layered_navigation">
                 <field id="display_category" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Display Category Filter</label>

--- a/app/code/Magento/Catalog/etc/config.xml
+++ b/app/code/Magento/Catalog/etc/config.xml
@@ -54,6 +54,9 @@
                 <time_format>12h</time_format>
                 <forbidden_extensions>php,exe</forbidden_extensions>
             </custom_options>
+            <catalog_price_rules>
+                <apply_to_custom_options>0</apply_to_custom_options>
+            </catalog_price_rules>
             <layered_navigation>
                 <display_category>1</display_category>
             </layered_navigation>


### PR DESCRIPTION
Adds a config option to allow the Catalog Price Rules to discount Custom Options

### Description (*)
This is a PR that basically reverts this commit https://github.com/magento/magento2/commit/a1aa4af82c39d8f0445eb8fcf023e7c2cf0bdade but adds a config option to give the choice to the tore owner as whether or not the catalog price rules should discount the custom options.

### Manual testing scenarios (*)

- Create a product
- Add some custom options
- Save the product
- Navigate to Catalog Price Rules - Marketing > Catalog Price Rules
- Add new rule, making sure to set it to active with an action of 10% discount - apply as percentage of the original
- Save and apply the new rule
- Visit the product in the front end
- Select one of the options
- The discount is applied to the product price only
- Navigate to Stores > Configuration > Catalog > Catalog > Catalog Price Rules
- Set "Apply to Custom Options" to Yes
- Navigate back to the product
- Select an option
- Notice the discount is applied to the overall price (product price + custom option)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
