### PR TITLE
Only add 24h to toTimeStamp if no time has been given

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/Timezone.php
@@ -274,7 +274,7 @@ class Timezone implements TimezoneInterface
         $scopeTimeStamp = $this->scopeTimeStamp($scope);
         $fromTimeStamp = strtotime($dateFrom);
         $toTimeStamp = strtotime($dateTo);
-        if ($dateTo) {
+        if ($toTimeStamp % 86400 === 0) {
             // fix date YYYY-MM-DD 00:00:00 to YYYY-MM-DD 23:59:59
             $toTimeStamp += 86400;
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR updates the dateTo check to check wether the timestamp is 00:00:00 before adding 24 hours.
Ensuring the old behaviour works as expected. However allowing passing in a time without 24 hours being forced onto the date.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Execute isScopeDateInInterval() with the scope, from day, and to date only being a date
2. Check that 24 hours has been added to the ToDate
3. Execute isScopeDateInInterval() with the scope, from day, and to date being a date with a time
4. Check that 24 hours has not been added and it matches the exact time given

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
