### PR TITLE
Fixes xsd schema to work with libxml 2.12 and higher.

### DIFF
--- a/app/code/Magento/Elasticsearch/etc/esconfig.xsd
+++ b/app/code/Magento/Elasticsearch/etc/esconfig.xsd
@@ -11,14 +11,21 @@
 <xs:element name="config" type="configType" />
 <xs:complexType name="configType" mixed="true">
     <xs:choice maxOccurs="unbounded" minOccurs="1">
-        <xs:element name="stemmer" type="mixedDataType" />
-        <xs:element name="stopwords_file" type="mixedDataType" />
+        <xs:element name="stemmer" type="stemmerDataType" />
+        <xs:element name="stopwords_file" type="stopwordsDataType" />
     </xs:choice>
 </xs:complexType>
-<xs:complexType name="mixedDataType">
-    <xs:choice maxOccurs="unbounded" minOccurs="1">
-        <xs:element type="xs:string" name="default" minOccurs="1" maxOccurs="1" />
-        <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded" />
-    </xs:choice>
+<xs:complexType name="stemmerDataType">
+    <xs:sequence>
+        <xs:element type="xs:string" name="type" minOccurs="1" maxOccurs="1"/>
+        <xs:element type="xs:string" name="default" minOccurs="1" maxOccurs="1"/>
+        <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+</xs:complexType>
+<xs:complexType name="stopwordsDataType">
+    <xs:sequence>
+        <xs:element type="xs:string" name="default" minOccurs="1" maxOccurs="1"/>
+        <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
 </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
### Description (*)
The latest libxml2 library (2.12.*) contains more strict requirements for xsd schema files:
> Several bugs in the regex determinism checks were fixed. Invalid XML Schemas which previous versions erroneously accepted will now be rejected.
Source: https://www.linuxcompatible.org/story/libxml2-2120-released/

There is one xsd file in Magento which now fails these more stricter checks: [`app/code/Magento/Elasticsearch/etc/esconfig.xsd`](https://github.com/magento/magento2/blob/488c103401f7b04bfea0a339d25107ada11bd2da/app/code/Magento/Elasticsearch/etc/esconfig.xsd)

When using any Magento version with libxml2 version 2.12.* in **developer** mode, whenever an xml file with `esconfig.xsd` schema is being loaded, it will now fail with this error:

```
Exception #0 (Magento\Framework\Config\Dom\ValidationSchemaException): Processed schema file: vendor/magento/module-elasticsearch/etc/esconfig.xsd
complex type 'mixedDataType': The content model is not determinist.
Line: 18
```

This PR fixes this. It should be mostly backwards compatible. With the exception that it now always expect the `type` element to be in front of the `default` element in the `stemmer` section, but that matches how Magento's xml files are already setup:
- [Magento/Elasticsearch/etc/esconfig.xml](https://github.com/magento/magento2/blob/488c103401f7b04bfea0a339d25107ada11bd2da/app/code/Magento/Elasticsearch/etc/esconfig.xml)
- [Magento/Elasticsearch/Test/Unit/Model/Adapter/Index/Config/_files/esconfig_test.xml](https://github.com/magento/magento2/blob/488c103401f7b04bfea0a339d25107ada11bd2da/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/Index/Config/_files/esconfig_test.xml)

This PR fixes an additional problem - by splitting out the types for `stemmer` and `stopwords_file`. Previously, there was no requirement on `type` element, even though [the code that parses this xml file requires the `type` to exist](https://github.com/magento/magento2/blob/488c103401f7b04bfea0a339d25107ada11bd2da/app/code/Magento/Elasticsearch/Model/Adapter/Index/Builder.php#L185-L194). That's been fixed by no longer using `mixedDataType` for both `stemmer` and `stopwords_file` elements, but splitting it out in 2 distinct types where the one for `stemmer` now requires a `type` element to exist.

I've tested these changes with libxml2 versions 2.9.14 and 2.12.6 and both work correctly.

### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/38254

### Manual testing scenarios (*)
1. Have php being compiled with libxml2 using a version lower than 2.12.0
1. Have a `test-xsd.php` file in the root of the magento project with this contents:
```php
<?php

echo sprintf("Libxml version: %s\n\n", getLibXmlVersion());

$xmlFiles = [
    sprintf('%s/app/code/Magento/Elasticsearch/etc/esconfig.xml', __DIR__),
    sprintf('%s/app/code/Magento/Elasticsearch/Test/Unit/Model/Adapter/Index/Config/_files/esconfig_test.xml', __DIR__),
];
$schemaFile = sprintf('%s/app/code/Magento/Elasticsearch/etc/esconfig.xsd', __DIR__);

foreach ($xmlFiles as $xmlFile) {
    $xml = file_get_contents($xmlFile);

    $dom = new \DOMDocument();
    $dom->loadXML($xml);

    $result = $dom->schemaValidate($schemaFile);

    var_dump($result);
}

function getLibXmlVersion(): string
{
    $reflector = new \ReflectionExtension('libxml');
    ob_start();
    $reflector->info();
    $output = strip_tags(ob_get_clean());
    preg_match('/^libXML Loaded Version (?:=>)?(.*)$/m', $output, $matches);

    return $matches[1];
}
```
1. Execute that file via cli: `php test-xsd.php`, expected is to see no errors
1. Have php being compiled with libxml2 using a version higher than or equal to 2.12.0
1. Execute that file via cli: `php test-xsd.php`, expected is to see no errors

Alternative steps:
1. Have php being compiled with libxml2 using a version higher than or equal to 2.12.0
1. Have Magento run in developer mode
1. Run `bin/magento indexer:reindex catalogsearch_fulltext`, expect to get no errors

### Questions or comments
I haven't found time or energy to add/update unit tests, if this is required, it would be appreciated if somebody could lend a hand.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
