### PR TITLE
Removed replacing two dots with empty string in media file names on media cache generation

### DIFF
--- a/app/code/Magento/MediaStorage/Model/File/Storage/Request.php
+++ b/app/code/Magento/MediaStorage/Model/File/Storage/Request.php
@@ -21,7 +21,7 @@ class Request
      */
     public function __construct(HttpRequest $request)
     {
-        $this->pathInfo = str_replace('..', '', ltrim($request->getPathInfo(), '/'));
+        $this->pathInfo = ltrim($request->getPathInfo(), '/');
     }
 
     /**


### PR DESCRIPTION
### Description (*)
This change removes replacing two dots with empty string. I have no clue why this was implemented, but if it's needed in some specific file storage setting then we should check for that specific situation before removing dots. Since I'm not aware about those scenarios for now, I suggest removing it completely.

In my case the problem occured with file like "test.....media.....file.jpg", which was replaced with "test.media.file.jpg".
### Related Pull Requests

### Fixed Issues (if relevant)
1. Fixes magento/magento2#38641

### Manual testing scenarios (*)
1. Upload image with name containing two dots to product media gallery
2. Thumbnails and media cache should be generated

### Questions or comments
1. Is there any specific file storage setting where two dots should be removed?

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
