### PR TITLE
Ensure order state handles with partial shipment

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -881,6 +881,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $qtyToShip = !$item->getParentItem() || $item->getParentItem()->getProductType() !== Type::TYPE_BUNDLE ?
                 $item->getQtyToShip() : $item->getSimpleQtyToShip();
 
+            $qtyToShip -= $item->getQtyRefunded();
+
             if ($qtyToShip > 0 && !$item->getIsVirtual() &&
                 !$item->getLockedDoShip() && !$this->isRefunded($item)) {
                 return true;

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -881,8 +881,6 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             $qtyToShip = !$item->getParentItem() || $item->getParentItem()->getProductType() !== Type::TYPE_BUNDLE ?
                 $item->getQtyToShip() : $item->getSimpleQtyToShip();
 
-            $qtyToShip -= $item->getQtyRefunded();
-
             if ($qtyToShip > 0 && !$item->getIsVirtual() &&
                 !$item->getLockedDoShip() && !$this->isRefunded($item)) {
                 return true;

--- a/app/code/Magento/Sales/Model/Order/Item.php
+++ b/app/code/Magento/Sales/Model/Order/Item.php
@@ -232,7 +232,7 @@ class Item extends AbstractModel implements OrderItemInterface
      */
     public function getSimpleQtyToShip()
     {
-        $qty = $this->getQtyOrdered() - max($this->getQtyShipped(), $this->getQtyRefunded()) - $this->getQtyCanceled();
+        $qty = $this->getQtyOrdered() - $this->getQtyShipped() - $this->getQtyRefunded() - $this->getQtyCanceled();
         return max(round($qty, 8), 0);
     }
 

--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Sales\Model\ResourceModel\Order\Handler;
 
+use Magento\Catalog\Model\Product\Type;
 use Magento\Sales\Model\Order;
 
 /**
@@ -60,11 +61,28 @@ class State
     {
         $isPartiallyRefundedOrderShipped = false;
         if ($this->getShippedItems($order) > 0
-            && $order->getTotalQtyOrdered() <= $this->getRefundedItems($order) + $this->getShippedItems($order)) {
+            && $this->getQtyItemsToShip($order) <= $this->getRefundedItems($order) + $this->getShippedItems($order)) {
             $isPartiallyRefundedOrderShipped = true;
         }
 
         return $isPartiallyRefundedOrderShipped;
+    }
+
+    /**
+     * Get all refunded items number
+     *
+     * @param Order $order
+     * @return int
+     */
+    private function getQtyItemsToShip(Order $order): int
+    {
+        $numOfItemsToShip = 0;
+        foreach ($order->getAllItems() as $item) {
+            if ($item->getProductType() == Type::TYPE_SIMPLE) { // only simple products are accountable for the order qty
+                $numOfItemsToShip += (int)$item->getQtyOrdered();
+            }
+        }
+        return $numOfItemsToShip;
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/ItemTest.php
@@ -323,6 +323,13 @@ class ItemTest extends TestCase
                 ],
                 'expectedResult' => ['to_ship' => 7.0, 'to_invoice' => 0.0]
             ],
+            'partially_refunded_partially_shipped_refund_lower_than_ship' => [
+                'options' => [
+                    'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 2, 'qty_shipped' => 4,
+                    'qty_canceled' => 0
+                ],
+                'expectedResult' => ['to_ship' => 8.0, 'to_invoice' => 0.0]
+            ],
             'complete' => [
                 'options' => [
                     'qty_ordered' => 12, 'qty_invoiced' => 12, 'qty_refunded' => 0, 'qty_shipped' => 12,
@@ -350,7 +357,8 @@ class ItemTest extends TestCase
                     'qty_canceled' => 0.4
                 ],
                 'expectedResult' => ['to_ship' => 0.0, 'to_invoice' => 0.0]
-            ]
+            ],
+
         ];
     }
 


### PR DESCRIPTION
The order flow will set the order to complete only once the order items are dealt with shipment, refund, cancellation. Yet, some edge case with virtual items and with partial shipment, partial refund, partial cancellation can make this flow faulty. 

### Description (*)
The change in this PR makes the `qty to ship` calculation to remove the qty refunded, qty cancelled and qty shipped already

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38547

### Manual testing scenarios (*)
**Test 1:** place an order with only physical items
validate the order gets complete when the invoice and shipment are processed and all the items are shipped
**Test 2:** place an order with only physical items and partial refund
validate the order gets complete when the invoice, refund and shipment are processed and all the items are shipped or refund or cancelled
**Test 3:** place an order with a mix of configurable, physical items and virtual items
validate the order gets complete when the invoice, refund and shipment are processed and all the items are shipped or refund or cancelled

### Questions or comments
This change is not backward compliant. However, like @digitalpianism mentions, the current behaviour is not consistent when the order has only physical items. The latest change in the model `\Magento\Sales\Model\ResourceModel\Order\Handler\State` is what makes the experience consistent as per the requirements of the issue we are dealing with.

Currently, it is possible to refund an item that has not been shipped or just as well refund an item that has already been shipped without being able to trace either scenarios. Yet, the logic in the method `\Magento\Sales\Model\ResourceModel\Order\Handler\State::isPartiallyRefundedOrderShipped` assumes the refund and the shipping are separate information that can be cumulated

I have added some changes in the method` \Magento\Sales\Model\Order\Item::getSimpleQtyToShip`. These turn out to do the same as before. However, I would like to encourage to keep these changes (I am not precious but think they improve the readability of the logic in this method)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
