### PR TITLE
required_options not updating correctly

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -875,7 +875,7 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
         $this->getTypeInstance()->beforeSave($this);
 
         $hasOptions = $this->getData('has_options') === "1" && $this->isProductHasOptions();
-        $hasRequiredOptions = $this->getData('required_options') === "1" && $this->isProductHasOptions();
+        $hasRequiredOptions = false;
 
         /**
          * $this->_canAffectOptions - set by type instance only


### PR DESCRIPTION

### Description (*)
When a product no longer has a required option this isn't reflected in the DB / frontend.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Create a product, with custom options.
2. Make one or more of the options required.
3. Save the product. 
4. run `select * from catalog_product_entity where entity_id = ENTITY_ID;` , validate `required_options` == 1
5. Make all the custom options _not_ required.
6. Save the product
7. run `select * from catalog_product_entity where entity_id = ENTITY_ID;`  again.
  **IF BROKEN:** `required_options` will still be 1
  **IF FIXED:** `required_options` will be 0

### Questions or comments
Haven't tested this via the API only via the MAP. Have validated that when the product doesn't have any required custom options `required_options` isn't passed in the payload. (So it's not the UI that's broken)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38720: required_options not updating correctly