### PR TITLE
Avoid re-rendering already loaded grid for Product Options (SwiftOtter's SOP-348)

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Form/Modifier/CustomOptions.php
@@ -658,16 +658,13 @@ class CustomOptions extends AbstractModifier
                     'config' => [
                         'addButtonLabel' => __('Add Value'),
                         'componentType' => DynamicRows::NAME,
-                        'component' => 'Magento_Catalog/js/components/dynamic-rows-per-page',
-                        'template' => 'Magento_Catalog/components/dynamic-rows-per-page',
+                        'component' => 'Magento_Ui/js/dynamic-rows/dynamic-rows',
+                        'template' => 'ui/dynamic-rows/templates/default',
                         'additionalClasses' => 'admin__field-wide',
                         'deleteProperty' => static::FIELD_IS_DELETE,
                         'deleteValue' => '1',
                         'renderDefaultRecord' => false,
-                        'sortOrder' => $sortOrder,
-                        'sizesConfig' => [
-                            'enabled' => true
-                        ]
+                        'sortOrder' => $sortOrder
                     ],
                 ],
             ],


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

In the Product Edit Page, when you open the “Customizable Options” bar, all the Product Options are visible. Suddenly, the loader icon pops up and all the options are rendered again.

The bug was introduced in 2022, and is affecting Product Edit page especiall with a big subsets of options.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. When I open “Customizable Options” section on Edit Product page, and the values of the options are rendered, the loader doesn’t appear afterwards, and the content is not re-rendered.
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38741: Avoid re-rendering already loaded grid for Product Options (SwiftOtter's SOP-348)