### PR TITLE
Add custom attribute values to the origData property to prevent unnecessary db inserts and updates when saving the customer entity

### DIFF
--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -1416,4 +1416,25 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     {
         $this->_errors = [];
     }
+
+    /**
+     * @param $key
+     *
+     * @return array|mixed|null
+     */
+    public function getOrigData($key = null)
+    {
+        $customAttributes = $this->_origData['custom_attributes'] ?? null;
+        if ($customAttributes) {
+            foreach ($customAttributes as $customAttribute) {
+                $attributeCode = $customAttribute['attribute_code'] ?? null;
+                $value = $customAttribute['value'] ?? null;
+                if ($attributeCode && $value) {
+                    $this->_origData[$attributeCode] = $value;
+                }
+            }
+        }
+
+        return parent::getOrigData($key);
+    }
 }

--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -1418,7 +1418,9 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     }
 
     /**
-     * @param $key
+     * Get object original data
+     *
+     * @param string $key
      *
      * @return array|mixed|null
      */


### PR DESCRIPTION
### Description (*)
Prevents the creation and execution of unnecessary db inserts/updates when saving a customer entity when non-static customer custom attribute exist.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#38753

### Manual testing scenarios (*)
1. Create a non-static customer custom attribute (e.g. `my_custom_attribute`)
2. Set `my_custom_attribute` to any value and save
3. Enable DB profiling
4. Load up the customer using the Customer Repository (`\Magento\Customer\Api\CustomerRepositoryInterface`)
5. Without changing any value save the customer using the Customer Repository (`\Magento\Customer\Api\CustomerRepositoryInterface::save()`)
6. Check DB profiling results
7. Notice there is no longer a query to insert the value that was already saved and set for your custom attribute `my_custom_attribute` since the original value does not differ from the new value


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
