### PR TITLE
UI grid editing : Add textarea and multiselects types to editor

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/editing/record.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/editing/record.js
@@ -43,9 +43,18 @@ define([
                         template: 'ui/form/element/date',
                         dateFormat: 'MMM d, y h:mm:ss a'
                     },
+                    textarea: {
+                        component: 'Magento_Ui/js/form/element/textarea',
+                        template: 'ui/form/element/textarea'
+                    },
                     select: {
                         component: 'Magento_Ui/js/form/element/select',
                         template: 'ui/form/element/select',
+                        options: '${ JSON.stringify($.$data.column.options) }'
+                    },
+                    multiselect: {
+                        component: 'Magento_Ui/js/form/element/multiselect',
+                        template: 'ui/form/element/multiselect',
                         options: '${ JSON.stringify($.$data.column.options) }'
                     }
                 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

In UI Grid editor, we cannot have textarea or multiselect fields. This PR add support for those two types.



### Resolved issues:
1. [x] resolves magento/magento2#38807: UI grid editing : Add textarea and multiselects types to editor