### PR TITLE
Fix table render of DiInfoCommand

### DIFF
--- a/app/code/Magento/Developer/Console/Command/DiInfoCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DiInfoCommand.php
@@ -93,7 +93,7 @@ class DiInfoCommand extends Command
             $paramsTableArray[] = $parameterRow;
         }
         $paramsTable->setRows($paramsTableArray);
-        $output->writeln($paramsTable->render());
+        $paramsTable->render();
     }
 
     /**


### PR DESCRIPTION
When running the DiInfoCommand under Magento 2.4.7 and PHP 8.3, line 96 mentions to pass the output of `$paramsTable->render()` to the `$output`. However, because of typing issues, this causes a Fatal Error. According the Symfony docs (since a long time) the `render()` method is already giving output, so the output should not be passed to `$output->writeln()` anyway. This PR fixes things.



### Resolved issues:
1. [x] resolves magento/magento2#38820: Fix table render of DiInfoCommand