### PR TITLE
Fix shipping rates used to determine instant purchase cheapest shipping

### DIFF
--- a/app/code/Magento/InstantPurchase/Model/QuoteManagement/QuoteCreation.php
+++ b/app/code/Magento/InstantPurchase/Model/QuoteManagement/QuoteCreation.php
@@ -57,9 +57,11 @@ class QuoteCreation
         $quote->setCustomer($customer->getDataModel());
         $quote->setCustomerIsGuest(0);
         $quote->getShippingAddress()
-            ->importCustomerAddressData($shippingAddress->getDataModel());
+            ->importCustomerAddressData($shippingAddress->getDataModel())
+            ->setCollectShippingRates(true);
         $quote->getBillingAddress()
-            ->importCustomerAddressData($billingAddress->getDataModel());
+            ->importCustomerAddressData($billingAddress->getDataModel())
+            ->setCollectShippingRates(true);
         $quote->setInventoryProcessed(false);
         return $quote;
     }

--- a/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/CheapestMethodDeferredChooser.php
+++ b/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/CheapestMethodDeferredChooser.php
@@ -20,16 +20,29 @@ class CheapestMethodDeferredChooser implements DeferredShippingMethodChooserInte
      */
     public function choose(Address $address)
     {
-        $address->setCollectShippingRates(true);
-        $address->collectShippingRates();
-        $shippingRates = $address->getAllShippingRates();
-
+        $shippingRates = $this->getShippingRates($address);
         if (empty($shippingRates)) {
             return null;
         }
 
         $cheapestRate = $this->selectCheapestRate($shippingRates);
         return $cheapestRate->getCode();
+    }
+
+    /**
+     * Retrieves previously collected shipping rates or computes new ones.
+     *
+     * @param Address $address
+     * @return Rate[]
+     */
+    private function getShippingRates(Address $address) : array {
+        if (!empty($shippingRates = $address->getAllShippingRates())) {
+            // Favour previously collected rates over recomputing.
+            return $shippingRates;
+        }
+        $address->setCollectShippingRates(true);
+        $address->collectShippingRates();
+        return $address->getAllShippingRates();
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

The shipping rates used to determine the cheapest shipping method for instant purchases are incorrect for products where the item quantity does not equal the "sendable" item quantity, such as configurable products. The incorrect rates cause some "cheapest shipping" instant purchases to be incorrectly placed with non-cheapest shipping methods, as in the scenario described in https://github.com/magento/magento2/issues/38811. In short, the root cause of this issue goes as follows (see [comment](https://github.com/magento/magento2/issues/38811#issuecomment-2159874274) for details):

* While shipping rates are normally computed correctly as part of quote totals collection, we do not set the "collect shipping rates" flag before collecting quote totals for instant purchase orders in [Magento​\InstantPurchase​\Model​\PlaceOrder​::placeOrder](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/InstantPurchase/Model/PlaceOrder.php#L115), thereby preventing shipping rates from being computed at that stage.

* Instead, we set the "collect shipping rates" further down the pipeline when choosing the cheapest shipping method in [Magento​\InstantPurchase​\Model​\ShippingMethodChoose​\CheapestMethodDeferredChooser​::choose](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/CheapestMethodDeferredChooser.php#L23-L25), and then collect the shipping rates not by collecting quote totals but by directly calling `$address->collectShippingRates()`.

* However, while shipping rate calculation for total shipping computation sets the "address item quantity" (and some other magic fields) before calling `$address->collectShippingRates()` in [Magento​\Quote​\Model​\Quote​\Address​\Total​\Shipping​::collect](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/Quote/Model/Quote/Address/Total/Shipping.php#L87-L92), we do not set these fields before collecting shipping rates for determining the cheapest shipping method in [Magento​\InstantPurchase​\Model​\ShippingMethodChoose​\CheapestMethodDeferredChooser​::choose](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/CheapestMethodDeferredChooser.php#L23-L25).

* Incorrect item quantities cause shipping rate calculation to be incorrect when determining the cheapest shipping method, which, in turn, causes the determined cheapest shipping method to not always be the actual cheapest shipping method, hence the issue we are trying to solve.

This pull request proposes to fix this issue by:

1. Updating [Magento\InstantPurchase\Model\QuoteManagement\QuoteCreation::createQuote](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/InstantPurchase/Model/QuoteManagement/QuoteCreation.php) to set the "collect shipping rates" flags to true from the get-go so that we compute correct shipping rates upfront, as part of quote totals collection in [Magento​\InstantPurchase​\Model​\PlaceOrder​::placeOrder](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/InstantPurchase/Model/PlaceOrder.php#L115).

2. Updating [Magento​\InstantPurchase​\Model​\ShippingMethodChoose​\CheapestMethodDeferredChooser​::choose](https://github.com/magento/magento2/blob/e81f28e4e6739924594c266b011c68b08a227c2d/app/code/Magento/InstantPurchase/Model/ShippingMethodChoose/CheapestMethodDeferredChooser.php) to leverage previously collected shipping rates, should those be available—which should be always the case, as deferred cheapest method choosing happens after totals collection.

<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38811

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
See steps in https://github.com/magento/magento2/issues/38811. With the changes proposed in this pull request, the instant purchase order of the "Chaz Kangeroo Hoodie" product is successfully placed using per-item flat rate shipping, which is the cheapest shipping method.

#### Before

![#38811-fix-before](https://github.com/magento/magento2/assets/12563382/e9f8c35e-cd0d-4dcb-bb7c-2c46c03b6f6a)

#### After

![#38811-fix-after-frontend](https://github.com/magento/magento2/assets/12563382/ef8106e6-8e5a-455c-bccc-76f3544dd3fc)

![#38811-fix-after-admin](https://github.com/magento/magento2/assets/12563382/e78ebc5e-7319-4543-a55a-fe808c548dc8)

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
