### PR TITLE
Fix issue #38826 by correcting the validation of coupon code values in the discount and captcha JS components

### DIFF
--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/captcha.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/captcha.js
@@ -21,8 +21,10 @@ define([
         if (totals()) {
             couponCode(totals()['coupon_code']);
         }
+
         //Captcha can only be required for adding a coupon so we need to know if one was added already.
-        isApplied = ko.observable(couponCode() != null);
+        var couponCodeValue = couponCode();
+        isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
 
         return defaultCaptcha.extend({
             /** @inheritdoc */

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/captcha.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/captcha.js
@@ -4,67 +4,66 @@
  */
 
 define([
-        'Magento_Captcha/js/view/checkout/defaultCaptcha',
-        'Magento_Captcha/js/model/captchaList',
-        'Magento_SalesRule/js/action/set-coupon-code',
-        'Magento_SalesRule/js/action/cancel-coupon',
-        'Magento_Checkout/js/model/quote',
-        'ko'
-    ],
-    function (defaultCaptcha, captchaList, setCouponCodeAction, cancelCouponAction, quote, ko) {
-        'use strict';
+    'Magento_Captcha/js/view/checkout/defaultCaptcha',
+    'Magento_Captcha/js/model/captchaList',
+    'Magento_SalesRule/js/action/set-coupon-code',
+    'Magento_SalesRule/js/action/cancel-coupon',
+    'Magento_Checkout/js/model/quote',
+    'ko'
+], function (defaultCaptcha, captchaList, setCouponCodeAction, cancelCouponAction, quote, ko) {
+    'use strict';
 
-        var totals = quote.getTotals(),
-            couponCode = ko.observable(null),
-            isApplied;
+    var totals = quote.getTotals(),
+        couponCode = ko.observable(null),
+        isApplied;
 
-        if (totals()) {
-            couponCode(totals()['coupon_code']);
-        }
+    if (totals()) {
+        couponCode(totals()['coupon_code']);
+    }
 
-        //Captcha can only be required for adding a coupon so we need to know if one was added already.
-        var couponCodeValue = couponCode();
-        isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
+    //Captcha can only be required for adding a coupon so we need to know if one was added already.
+    var couponCodeValue = couponCode();
+    isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
 
-        return defaultCaptcha.extend({
-            /** @inheritdoc */
-            initialize: function () {
-                var self = this,
-                    currentCaptcha;
+    return defaultCaptcha.extend({
+        /** @inheritdoc */
+        initialize: function () {
+            var self = this,
+                currentCaptcha;
 
-                this._super();
-                //Getting coupon captcha model.
-                currentCaptcha = captchaList.getCaptchaByFormId(this.formId);
+            this._super();
+            //Getting coupon captcha model.
+            currentCaptcha = captchaList.getCaptchaByFormId(this.formId);
 
-                if (currentCaptcha != null) {
-                    if (!isApplied()) {
-                        //Show captcha if we don't have a coupon applied.
-                        currentCaptcha.setIsVisible(true);
-                    }
-                    this.setCurrentCaptcha(currentCaptcha);
-                    //Add captcha code to coupon-apply request.
-                    setCouponCodeAction.registerDataModifier(function (headers) {
-                        if (self.isRequired()) {
-                            headers['X-Captcha'] = self.captchaValue()();
-                        }
-                    });
-                    //Refresh captcha after failed request.
-                    setCouponCodeAction.registerFailCallback(function () {
-                        if (self.isRequired()) {
-                            self.refresh();
-                        }
-                    });
-                    //Hide captcha when a coupon has been applied.
-                    setCouponCodeAction.registerSuccessCallback(function () {
-                        self.setIsVisible(false);
-                    });
-                    //Show captcha again if it was canceled.
-                    cancelCouponAction.registerSuccessCallback(function () {
-                        if (self.isRequired()) {
-                            self.setIsVisible(true);
-                        }
-                    });
+            if (currentCaptcha != null) {
+                if (!isApplied()) {
+                    //Show captcha if we don't have a coupon applied.
+                    currentCaptcha.setIsVisible(true);
                 }
+                this.setCurrentCaptcha(currentCaptcha);
+                //Add captcha code to coupon-apply request.
+                setCouponCodeAction.registerDataModifier(function (headers) {
+                    if (self.isRequired()) {
+                        headers['X-Captcha'] = self.captchaValue()();
+                    }
+                });
+                //Refresh captcha after failed request.
+                setCouponCodeAction.registerFailCallback(function () {
+                    if (self.isRequired()) {
+                        self.refresh();
+                    }
+                });
+                //Hide captcha when a coupon has been applied.
+                setCouponCodeAction.registerSuccessCallback(function () {
+                    self.setIsVisible(false);
+                });
+                //Show captcha again if it was canceled.
+                cancelCouponAction.registerSuccessCallback(function () {
+                    if (self.isRequired()) {
+                        self.setIsVisible(true);
+                    }
+                });
             }
-        });
+        }
     });
+});

--- a/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/discount.js
+++ b/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/discount.js
@@ -21,7 +21,9 @@ define([
     if (totals()) {
         couponCode(totals()['coupon_code']);
     }
-    isApplied(couponCode() != null);
+
+    var couponCodeValue = couponCode();
+    isApplied(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
 
     return Component.extend({
         defaults: {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request aims to fix issue #38826 by correcting the validation of coupon code values in the discount and captcha JS files.

### Detailed explanation:

The changes made in commit https://github.com/magento/magento2/commit/79d57b4eb7696bb0fc2ce3aad03f5d6bec1ae275 to  `Magento\SalesRule\Model\Validator` class set the coupon code to **an empty string** when no valid coupons are present. This action causes issues when the cart contains only virtual items (downloadable/virtual):
```
if (empty($validCoupons)) {
    $quote->setCouponCode('');
}
```
This behavior is due to the [`Magento_SalesRule/js/view/payment/discount`](https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/SalesRule/view/frontend/web/js/view/payment/discount.js#L24) JS component comparing the coupon code against `null`.
```
isApplied(couponCode() != null);
```
**Request flow:**
The checkout page initiates the following sequence:
...
\> `onepage.phtml`
\> `Magento\Checkout\Block\Onepage::getSerializedCheckoutConfig()`
\> `Magento\Checkout\Block\Onepage::getCheckoutConfig()`
\> `Magento\Checkout\Model\CompositeConfigProvider::getConfig()`
\> `Magento\Checkout\Model\DefaultConfigProvider::getConfig()`
\> `Magento\Checkout\Model\DefaultConfigProvider::getTotalsData()`
\> `Magento\Quote\Model\Cart\CartTotalRepository::get()`

The following excerpt is from `Magento\Quote\Model\Cart\CartTotalRepository::get()`:
```
if ($quote->isVirtual()) {
    $quote->collectTotals();
    $addressTotalsData = $quote->getBillingAddress()->getData();
    $addressTotals = $quote->getBillingAddress()->getTotals();
} else {
    $addressTotalsData = $quote->getShippingAddress()->getData();
    $addressTotals = $quote->getShippingAddress()->getTotals();
}
```
If the quote is virtual (contains only virtual item(s)), `$quote->collectTotals()` is triggered. This action, in turns, triggers `Magento\SalesRule\Model\Validator::initFromQuote()`, which sets the coupon code to an empty string:
```
$quote->setCouponCode('');
```

Multiple instances where the coupon code value is set to an empty string, including:
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/SalesRule/Observer/CouponCodeValidation.php#L81
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/Quote/Model/Quote/TotalsCollector.php#L205
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/Checkout/Controller/Cart/CouponPost.php lines 69 and 87
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/SalesRule/view/frontend/web/js/action/select-payment-method-mixin.js#L43
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/SalesRule/view/frontend/web/js/model/place-order-mixin.js#L29
- https://github.com/magento/magento2/blob/2.4.7/app/code/Magento/SalesRule/view/frontend/web/js/model/shipping-save-processor-mixin.js#L23
- And possibly more

To address these issues and ensure consistent behavior, I propose the following changes:
- `Magento_SalesRule/js/view/payment/discount` JS component:
```
-        isApplied = ko.observable(couponCode() != null);
+        var couponCodeValue = couponCode();
+        isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
```
- `Magento_SalesRule/js/view/payment/captcha` JS component.
```
-        isApplied = ko.observable(couponCode() != null);
+        var couponCodeValue = couponCode();
+        isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);
```

These changes cover scenarios where the coupon code is `null` or an empty string while ensuring the length of the coupon code is greater than zero. This approach will prevent future issues if the coupon code is set to `null` or empty, preserving the functionality of the coupon code feature on the checkout page.

Additionally, I also updated the formatting of the `Magento_SalesRule/js/view/payment/captcha` JS component to ensure code consistency.

CC: @bl4de @sivaschenko 

### Related Pull Requests
<!-- related pull request placeholder -->
- None

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38826

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a Virtual/Downloadable product.
2. Navigate to storefront.
3. Click “Add to Cart” on the Virtual/Downloadable Product.
4. Open mini shopping cart and click “Proceed to Checkout”.
5. Click "Apply Discount Code" text to expand the coupon code form.
6. Verify that the discount code/coupon input can be filled in, and the button title text displays as "Apply Discount".

### Patches
Until the issue is resolved in the next Magento version, you can apply the patch that I have prepared:
File name: `magento-module-sales-rule-GitHub-PR-38832-checkout-coupon-code-feature-not-working-correctly.composer.patch`
```
commit 788f6ac46c6425f0a3e18dfcf5a2fa89390a81df
Author: Tu Van <vandinhtuit@gmail.com>
Date:   Sun Jun 16 01:12:44 2024 +0700

    Fix incorrect checking coupon code value in discount and captcha JS files
    Update formating for captcha.js in the SalesRule module to ensure code consistency

diff --git a/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/captcha.js b/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/captcha.js
index f289377e482..ad97e6b383f 100644
--- a/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/captcha.js
+++ b/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/captcha.js
@@ -4,65 +4,66 @@
  */

 define([
-        'Magento_Captcha/js/view/checkout/defaultCaptcha',
-        'Magento_Captcha/js/model/captchaList',
-        'Magento_SalesRule/js/action/set-coupon-code',
-        'Magento_SalesRule/js/action/cancel-coupon',
-        'Magento_Checkout/js/model/quote',
-        'ko'
-    ],
-    function (defaultCaptcha, captchaList, setCouponCodeAction, cancelCouponAction, quote, ko) {
-        'use strict';
+    'Magento_Captcha/js/view/checkout/defaultCaptcha',
+    'Magento_Captcha/js/model/captchaList',
+    'Magento_SalesRule/js/action/set-coupon-code',
+    'Magento_SalesRule/js/action/cancel-coupon',
+    'Magento_Checkout/js/model/quote',
+    'ko'
+], function (defaultCaptcha, captchaList, setCouponCodeAction, cancelCouponAction, quote, ko) {
+    'use strict';

-        var totals = quote.getTotals(),
-            couponCode = ko.observable(null),
-            isApplied;
+    var totals = quote.getTotals(),
+        couponCode = ko.observable(null),
+        isApplied;

-        if (totals()) {
-            couponCode(totals()['coupon_code']);
-        }
-        //Captcha can only be required for adding a coupon so we need to know if one was added already.
-        isApplied = ko.observable(couponCode() != null);
+    if (totals()) {
+        couponCode(totals()['coupon_code']);
+    }

-        return defaultCaptcha.extend({
-            /** @inheritdoc */
-            initialize: function () {
-                var self = this,
-                    currentCaptcha;
+    //Captcha can only be required for adding a coupon so we need to know if one was added already.
+    var couponCodeValue = couponCode();
+    isApplied = ko.observable(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);

-                this._super();
-                //Getting coupon captcha model.
-                currentCaptcha = captchaList.getCaptchaByFormId(this.formId);
+    return defaultCaptcha.extend({
+        /** @inheritdoc */
+        initialize: function () {
+            var self = this,
+                currentCaptcha;

-                if (currentCaptcha != null) {
-                    if (!isApplied()) {
-                        //Show captcha if we don't have a coupon applied.
-                        currentCaptcha.setIsVisible(true);
-                    }
-                    this.setCurrentCaptcha(currentCaptcha);
-                    //Add captcha code to coupon-apply request.
-                    setCouponCodeAction.registerDataModifier(function (headers) {
-                        if (self.isRequired()) {
-                            headers['X-Captcha'] = self.captchaValue()();
-                        }
-                    });
-                    //Refresh captcha after failed request.
-                    setCouponCodeAction.registerFailCallback(function () {
-                        if (self.isRequired()) {
-                            self.refresh();
-                        }
-                    });
-                    //Hide captcha when a coupon has been applied.
-                    setCouponCodeAction.registerSuccessCallback(function () {
-                        self.setIsVisible(false);
-                    });
-                    //Show captcha again if it was canceled.
-                    cancelCouponAction.registerSuccessCallback(function () {
-                        if (self.isRequired()) {
-                            self.setIsVisible(true);
-                        }
-                    });
+            this._super();
+            //Getting coupon captcha model.
+            currentCaptcha = captchaList.getCaptchaByFormId(this.formId);
+
+            if (currentCaptcha != null) {
+                if (!isApplied()) {
+                    //Show captcha if we don't have a coupon applied.
+                    currentCaptcha.setIsVisible(true);
                 }
+                this.setCurrentCaptcha(currentCaptcha);
+                //Add captcha code to coupon-apply request.
+                setCouponCodeAction.registerDataModifier(function (headers) {
+                    if (self.isRequired()) {
+                        headers['X-Captcha'] = self.captchaValue()();
+                    }
+                });
+                //Refresh captcha after failed request.
+                setCouponCodeAction.registerFailCallback(function () {
+                    if (self.isRequired()) {
+                        self.refresh();
+                    }
+                });
+                //Hide captcha when a coupon has been applied.
+                setCouponCodeAction.registerSuccessCallback(function () {
+                    self.setIsVisible(false);
+                });
+                //Show captcha again if it was canceled.
+                cancelCouponAction.registerSuccessCallback(function () {
+                    if (self.isRequired()) {
+                        self.setIsVisible(true);
+                    }
+                });
             }
-        });
+        }
     });
+});
diff --git a/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/discount.js b/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/discount.js
index 79e408569e0..ed209c10f65 100644
--- a/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/discount.js
+++ b/vendor/magento/module-sales-rule/view/frontend/web/js/view/payment/discount.js
@@ -21,7 +21,9 @@ define([
     if (totals()) {
         couponCode(totals()['coupon_code']);
     }
-    isApplied(couponCode() != null);
+
+    var couponCodeValue = couponCode();
+    isApplied(typeof couponCodeValue === 'string' && couponCodeValue.length > 0);

     return Component.extend({
         defaults: {

```

To apply patches for Magento Open Source and Adobe Commerce, please refer to the following documentation:
- For Magento open source, learn how to apply a composer patch here: https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/patches/apply.html
    - Target composer package: `magento/module-sales-rule`
    - Path to patch: "patches/composer/magento-module-sales-rule-GitHub-PR-38832-checkout-coupon-code-feature-not-working-correctly.composer.patch"
    - The configuration for applying the patch using the `cweagans/composer-patches` composer patch plugin to address this issue should look like this:
```
"extra": {
    "magento-force": "override",
    "patches": {
        "magento/module-sales-rule": {
            "Github-PR-38832 - Fix the coupon code feature is not working properly on the checkout page": "patches/composer/magento-module-sales-rule-GitHub-PR-38832-checkout-coupon-code-feature-not-working-correctly.composer.patch"
        }
    }
}
```
- For Adobe Commerce on Cloud Infrastructure, instructions on applying a composer patch can be found here https://experienceleague.adobe.com/docs/commerce-knowledge-base/kb/how-to/how-to-apply-a-composer-patch-provided-by-magento.html?lang=en, with more detailed information available here https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/develop/upgrade/apply-patches#:~:text=Toggle%20Text%20Wrapping-,Apply%20a%20custom%20patch,-When%20you%20deploy

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
