### PR TITLE
Ensure the widget chooser saves the cms block id in the widget parameter

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
@@ -100,7 +100,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         $js = '
             function (grid, event) {
                 var trElement = Event.findElement(event, "tr");
-                var blockId = trElement.down("td").next().next().innerHTML.replace(/^\s+|\s+$/g,"");
+                var blockId = trElement.down("td").innerHTML.replace(/^\s+|\s+$/g,"");
                 var blockTitle = trElement.down("td").next().innerHTML;
                 ' .
             $chooserJsObject .


### PR DESCRIPTION
## Ensure the widget chooser saves the cms block id in the widget parameter

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The widget chooser selects the block identifier from the grid data that are displayed within the widget chooser ui. The first column is the block id. Therefore, the PR change consists in stopping the chooser to move the dom using the next() javascript method to set the widget parameter information

### Related Pull Requests


### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38801

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a new cms block
Create a new cms widget 
Assign the newly cms block to the widget
Save the widget
Check in the database the block id is assigned to the widget data 
2. Select an existing cms widget that has a blcok title in the data
Select a new cms block for the widget
Save the widget
Check in the database the block id is assigned to the widget data 

### Questions or comments


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
