### PR TITLE
Change status filter to state to allow cancel expired orders with all…

### DIFF
--- a/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
+++ b/app/code/Magento/Sales/Model/CronJob/CleanExpiredOrders.php
@@ -60,7 +60,7 @@ class CleanExpiredOrders
             /** @var $orders \Magento\Sales\Model\ResourceModel\Order\Collection */
             $orders = $this->orderCollectionFactory->create();
             $orders->addFieldToFilter('store_id', $storeId);
-            $orders->addFieldToFilter('status', Order::STATE_PENDING_PAYMENT);
+            $orders->addFieldToFilter('state', Order::STATE_PENDING_PAYMENT);
             $orders->getSelect()->where(
                 new \Zend_Db_Expr('TIME_TO_SEC(TIMEDIFF(CURRENT_TIMESTAMP, `updated_at`)) >= ' . $lifetime * 60)
             );


### PR DESCRIPTION


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Clean Expired Orders only works with the default pending_payment status. It should work with all the statuses related to the pending_payment state


### Manual testing scenarios (*)
1. Create a new status related to the pending_payment state
2. Configure the status in any payment method (It can be an online payment)
3. Place an order
4. Wait the time configured in the sales/orders/delete_pending_after configuration param

Expected Result
- Order is cancelled

Actual Result
- Order is not cancelled

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [X] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38913: Change status filter to state to allow cancel expired orders with all…