### PR TITLE
set item_id as id on the request object

### DIFF
--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -1820,6 +1820,7 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         $params->setCurrentConfig($item->getBuyRequest());
         $buyRequest = $this->_catalogProduct->addParamsToBuyRequest($buyRequest, $params);
 
+        $buyRequest->setData('id', $item->getId());
         $buyRequest->setResetCount(true);
         $resultItem = $this->addProduct($product, $buyRequest);
 


### PR DESCRIPTION
### Description (*)
Use the item_id as id on the request object to make `reset_count` work in: `\Magento\Quote\Model\Quote\Item\Processor::prepare`

### Fixed Issues (if relevant)
1. Fixes magento/magento2#38949

### Manual testing scenarios (*)
1. Create guest cart with rest api: 
Post to `https://11bfd466f8c258a1113feb50fd641584.instances-prod.magento-community.engineering/rest/V1/guest-carts/` and use that masked id.

2. Get the guest cart to determine quote id:
Get to `https://11bfd466f8c258a1113feb50fd641584.instances-prod.magento-community.engineering/rest/V1/guest-carts/{{masked_id}}`

3. Add just 1 configurable to cart:
Post to: `https://11bfd466f8c258a1113feb50fd641584.instances-prod.magento-community.engineering/rest/V1/guest-carts/{{masked_id}}/items` with body:
```
{
  "cartItem": {
    "sku": "MH02",
    "qty": 1,
    "quote_id": "{{quote_id}}",
    "product_option": {
      "extension_attributes": {
        "configurable_item_options": [
          {
            "option_id": "93",
            "option_value": 49
          },
          {
            "option_id": "142",
            "option_value": 166
          }
        ]
      }
    },
    "extension_attributes": {}
  }
}

```

4. Update the qty to 100 (default stock for a simple of a configurable product)
![image](https://github.com/user-attachments/assets/4c4a63bc-3fe9-4494-bfc9-84421d280ec6)

Note: Use the item_id of the configurable type (not the simple)

PUT to `https://11bfd466f8c258a1113feb50fd641584.instances-prod.magento-community.engineering/rest/V1/guest-carts/{{masked_id}}/items/{{item_id}}` with body:
```
{
  "cartItem": {
    "sku": "MH02",
    "qty": 100,
    "quote_id": "{{quote_id}}",
    "product_option": {
      "extension_attributes": {
        "configurable_item_options": [
          {
            "option_id": "93",
            "option_value": 49
          },
          {
            "option_id": "142",
            "option_value": 166
          }
        ]
      }
    },
    "extension_attributes": {}
  }
}
```

Now the response of the call is:  
```
{
    "message": "The requested qty is not available"
}
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
