### PR TITLE
Rotate encryption key timeout fix 

### DIFF
--- a/app/code/Magento/EncryptionKey/Model/ResourceModel/Key/Change.php
+++ b/app/code/Magento/EncryptionKey/Model/ResourceModel/Key/Change.php
@@ -187,7 +187,7 @@ class Change extends AbstractDb
     protected function _reEncryptCreditCardNumbers()
     {
         $table = $this->getTable('sales_order_payment');
-        $select = $this->getConnection()->select()->from($table, ['entity_id', 'cc_number_enc']);
+        $select = $this->getConnection()->select()->from($table, ['entity_id', 'cc_number_enc'])->where('sales_order_payment.cc_number_enc is not NULL');
 
         $attributeValues = $this->getConnection()->fetchPairs($select);
         // save new values


### PR DESCRIPTION
Fix required for one of the steps after applying Security fix CVE-2024-34102. 
https://experienceleague.adobe.com/en/docs/commerce-knowledge-base/kb/troubleshooting/known-issues-patches-attached/security-update-available-for-adobe-commerce-apsb24-40-revised-to-include-isolated-patch-for-cve-2024-34102
One of the points requests us to rotate the encryption keys (https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/encryption-key)  
Admin sidebar, go to System > Other Settings > Manage Encryption Key. 
This times out admin for some instances if you have a lot of values in sales_order_payment, in our case we had over 1 million rows which were NULL but it was still trying to encrypt them so i've updated the query to ignore those set to NULL.


Steps to replicate
- Have a large amount of rows in the sales_order_payment table (in our case 1639813 rows) most of these had the cc_number_enc set to NULL
- Go to Admin sidebar > Other Settings > Manage Encryption Key, set Auto generate a key to yes and click change encryption key.
