### PR TITLE
Document Exceptions in Asset Repository Functions

### DIFF
--- a/lib/internal/Magento/Framework/View/Asset/Repository.php
+++ b/lib/internal/Magento/Framework/View/Asset/Repository.php
@@ -214,6 +214,7 @@ class Repository implements ResetAfterRequestInterface
      * @param array $params
      * @return File
      * @throws LocalizedException
+     * @throws \UnexpectedValueException
      */
     public function createAsset($fileId, array $params = [])
     {
@@ -254,6 +255,7 @@ class Repository implements ResetAfterRequestInterface
      * Get current context for static view files
      *
      * @return \Magento\Framework\View\Asset\File\FallbackContext
+     * @throws \UnexpectedValueException
      */
     public function getStaticViewFileContext()
     {
@@ -413,6 +415,8 @@ class Repository implements ResetAfterRequestInterface
      *
      * @param string $fileId
      * @return string
+     * @throws LocalizedException
+     * @throws \UnexpectedValueException
      */
     public function getUrl($fileId)
     {
@@ -428,6 +432,8 @@ class Repository implements ResetAfterRequestInterface
      * @param string $fileId
      * @param array $params
      * @return string
+     * @throws LocalizedException
+     * @throws \UnexpectedValueException
      * @see getUrl()
      */
     public function getUrlWithParams($fileId, array $params)


### PR DESCRIPTION
### Description (*)
The `updateDesignParams()` function has the capacity to throw the `UnexpectedValueException` but this is not documented in either of the functions that call it. Additionally, the `createAsset()` function has the potential to throw a `LocalizedException` which is not documented by either of the functions that make use of it.

### Manual testing scenarios (*)
1. Create a class that makes use of the modified functions
2. Observe your IDE report the potential for the aforementioned exceptions

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#38988: Document Exceptions in Asset Repository Functions