### PR TITLE
Fixed widget category tree jquery.jstree.js handleOpenNode function

### DIFF
--- a/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/widget/tree.phtml
+++ b/app/code/Magento/Catalog/view/adminhtml/templates/catalog/category/widget/tree.phtml
@@ -124,29 +124,34 @@ require(['jquery', 'jquery/jstree/jquery.jstree'], function($) {
 
     function handleOpenNode(e, data) {
         let parentNode = data.node;
+        if (parentNode && parentNode.children.length > 0) {
 
-        if (parentNode.children.length > 0) {
-            let childNode = data.instance.get_node(parentNode.children, false);
+            parentNode.children.forEach(function(childId) {
 
-            // Check if the child node has no children (is not yet loaded)
-            if (childNode.children && childNode.children.length === 0
-                && childNode.original && !childNode.original.lastNode) {
-                $.ajax({
-                    url: '{$block->escapeJs($block->escapeUrl($block->getLoadTreeUrl()))}',
-                    data: {
-                        id: childNode.original.id,
-                        store: childNode.original.store,
-                        form_key: FORM_KEY
-                    },
-                    dataType: 'json',
-                    success: function (response) {
-                        handleSuccessResponse(response, childNode, data);
-                    },
-                    error: function (jqXHR, status, error) {
-                        console.log(status + ': ' + error + 'Response text:' + jqXHR.responseText);
-                    }
-                });
-            }
+                let childNode = data.instance.get_node(childId, false);
+
+                // Check if the child node has no children (is not yet loaded)
+                if (childNode.children && childNode.children.length === 0
+                    && childNode.original && !childNode.original.lastNode) {
+
+                    $.ajax({
+                        url: '{$block->escapeJs($block->escapeUrl($block->getLoadTreeUrl()))}',
+                        type: "POST",
+                        data: {
+                            id: childNode.original.id,
+                            store: childNode.original.store,
+                            form_key: FORM_KEY
+                        },
+                        dataType: 'json',
+                        success: function (response) {
+                            handleSuccessResponse(response, childNode, data);
+                        },
+                        error: function (jqXHR, status, error) {
+                            console.log(status + ': ' + error);
+                        }
+                    });
+                }
+            });
         }
     }
 


### PR DESCRIPTION
If you have deeper category levels, like till level 5 or 6, if you open an widget, place the widget on Anchor Categories, specific categories, the category tree in there, will not render more than 3 level due to incorrect handleOpenNode function.

This fix (https://github.com/magento/magento2/issues/39008) is a copy paste from the working handleOpenNode function from there: vendor/magento/module-catalog/view/adminhtml/templates/catalog/category/tree.phtml


Example tree before the fix:
![image](https://github.com/user-attachments/assets/9e259183-ddbe-4b80-9316-ef22928e4fb1)

Example tree after the fix:
![image](https://github.com/user-attachments/assets/439d9bd2-3ded-46f6-b277-dd2238a78ab3)

Fixes https://github.com/magento/magento2/issues/39008