### PR TITLE
Added CDATA to catalog/catalog/fields_masks field comments

### DIFF
--- a/app/code/Magento/Catalog/etc/adminhtml/system.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/system.xml
@@ -22,19 +22,19 @@
                 <label>Product Fields Auto-Generation</label>
                 <field id="sku" translate="label comment" type="text" sortOrder="10" showInDefault="1" canRestore="1">
                     <label>Mask for SKU</label>
-                    <comment>Use {{name}} as Product Name placeholder</comment>
+                    <comment><![CDATA[Use {{name}} as Product Name placeholder]]></comment>
                 </field>
                 <field id="meta_title" translate="label comment" type="text" sortOrder="20" showInDefault="1" canRestore="1">
                     <label>Mask for Meta Title</label>
-                    <comment>Use {{name}} as Product Name placeholder</comment>
+                    <comment><![CDATA[Use {{name}} as Product Name placeholder]]></comment>
                 </field>
                 <field id="meta_keyword" translate="label comment" type="text" sortOrder="30" showInDefault="1" canRestore="1">
                     <label>Mask for Meta Keywords</label>
-                    <comment>Use {{name}} as Product Name or {{sku}} as Product SKU placeholders</comment>
+                    <comment><![CDATA[Use {{name}} as Product Name or {{sku}} as Product SKU placeholders]]></comment>
                 </field>
                 <field id="meta_description" translate="label comment" type="text" sortOrder="40" showInDefault="1" canRestore="1">
                     <label>Mask for Meta Description</label>
-                    <comment>Use {{name}} and {{description}} as Product Name and Product Description placeholders</comment>
+                    <comment><![CDATA[Use {{name}} and {{description}} as Product Name and Product Description placeholders]]></comment>
                 </field>
             </group>
             <group id="recently_products" translate="label" type="text" sortOrder="350" showInDefault="1" showInWebsite="1">


### PR DESCRIPTION
### Added CDATA to Product Fields Auto-Generation Mask fields comments

The change adds CDATA to the `<comment>` xml tag to correctly display the _field_masks_ group field comments

### Description (*)
Adds CDATA to the `<comment>` xml tag for the mask fields to properly escape the text containing curly brackets, like 
`{{name}}` `{{sku}}`

### Related Pull Requests

### Fixed Issues
1. Fixes magento/magento2#38531

### Manual testing scenarios (*)
1. Go to Stores -> Configuration -> Catalog -> Catalog -> Product Fields Auto-Generation
2. The comments for the `Mask for SKU`, `Mask for Meta Title`, `Mask for Meta Keywords` and `Mask for Meta Description` fields now show the correct text.
![image](https://github.com/user-attachments/assets/716bc545-abbf-48d1-82e8-c7f901b510c7)


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
