### PR TITLE
Use static const in Magento\Customer\Model\Address\Config

### DIFF
--- a/app/code/Magento/Customer/Model/Address/Config.php
+++ b/app/code/Magento/Customer/Model/Address/Config.php
@@ -121,7 +121,7 @@ class Config extends ConfigData
         if (!isset($this->_types[$storeId])) {
             $this->_types[$storeId] = [];
             foreach ($this->get() as $typeCode => $typeConfig) {
-                $path = sprintf('%s%s', self::XML_PATH_ADDRESS_TEMPLATE, $typeCode);
+                $path = sprintf('%s%s', static::XML_PATH_ADDRESS_TEMPLATE, $typeCode);
                 $type = new DataObject();
                 if (isset($typeConfig['escapeHtml'])) {
                     $escapeHtml = $typeConfig['escapeHtml'] == 'true' || $typeConfig['escapeHtml'] == '1';
@@ -136,7 +136,7 @@ class Config extends ConfigData
 
                 $renderer = isset($typeConfig['renderer']) ? (string)$typeConfig['renderer'] : null;
                 if (!$renderer) {
-                    $renderer = self::DEFAULT_ADDRESS_RENDERER;
+                    $renderer = static::DEFAULT_ADDRESS_RENDERER;
                 }
 
                 $type->setRenderer($this->_addressHelper->getRenderer($renderer)->setType($type));
@@ -167,7 +167,7 @@ class Config extends ConfigData
                 '{{var street}}, {{var city}}, {{var region}} {{var postcode}}, {{var country}}'
             );
 
-            $renderer = $this->_addressHelper->getRenderer(self::DEFAULT_ADDRESS_RENDERER)
+            $renderer = $this->_addressHelper->getRenderer(static::DEFAULT_ADDRESS_RENDERER)
                 ->setType($this->_defaultTypes[$storeId]);
             $this->_defaultTypes[$storeId]->setRenderer($renderer);
         }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

This PR adds the possibility to create a new configuration from a custom path and create a class that extends from `Magento\Customer\Model\Address\Config` without having to duplicate the function `Magento\Customer\Model\Address\Config::getFormats()`

```php
use Magento\Customer\Model\Address\Config;

class ClickAndCollectConfig extends Config
{
    public const XML_PATH_ADDRESS_TEMPLATE = 'click_and_collect/address_templates/';
}
``` 

![Capture d’écran du 2024-08-29 10-16-48](https://github.com/user-attachments/assets/8b0af7b6-332c-4b00-b90f-6c1d087e0d79)

**Workaround**

Today, the only solution to come to do is to duplicate the `getFormats` function ...

```php
use Magento\Customer\Model\Address\Config;

class ClickAndCollectConfig extends Config
{
    public const XML_PATH_ADDRESS_TEMPLATE = 'click_and_collect/address_templates/';

    /**
     * @inheritDoc
     */
    public function getFormats(): ?array
    {
        $store = $this->getStore();
        $storeId = $store->getId();

        if (!isset($this->_types[$storeId])) {
            $this->_types[$storeId] = [];
            foreach ($this->get() as $typeCode => $typeConfig) {
                $path = sprintf('%s%s', self::XML_PATH_ADDRESS_TEMPLATE, $typeCode);
                $type = new DataObject();
                if (isset($typeConfig['escapeHtml'])) {
                    $escapeHtml = $typeConfig['escapeHtml'] == 'true' || $typeConfig['escapeHtml'] == '1';
                } else {
                    $escapeHtml = false;
                }

                $format = $this->_scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $storeId);
                $type->setData('code', $typeCode)
                    ->setData('title', (string)$typeConfig['title'])
                    ->setData('default_format', $format)
                    ->setData('escape_html', $escapeHtml);

                $renderer = isset($typeConfig['renderer']) ? (string)$typeConfig['renderer'] : null;
                if (!$renderer) {
                    $renderer = self::DEFAULT_ADDRESS_RENDERER;
                }

                // @phpstan-ignore-next-line
                $type->setRenderer($this->_addressHelper->getRenderer($renderer)->setType($type));
                $this->_types[$storeId][] = $type;
            }
        }

        return $this->_types[$storeId];
    }
}
```

### Related Pull Requests

None

### Fixed Issues (if relevant)

None

### Manual testing scenarios (*)

- Create new class extend `Magento\Customer\Model\Address\Config`
- Setup `XML_PATH_ADDRESS_TEMPLATE` with custom value

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39135: Use static const in Magento\Customer\Model\Address\Config