### PR TITLE
Fix: Stock Status and Saleable Quantity Not Updated When Product Quantity is Set to 0 (#3364)

### DIFF
--- a/app/code/Magento/CatalogInventory/Plugin/MassUpdateProductAttribute.php
+++ b/app/code/Magento/CatalogInventory/Plugin/MassUpdateProductAttribute.php
@@ -185,9 +185,33 @@ class MassUpdateProductAttribute
             $this->dataObjectHelper->populateWithArray($stockItemDo, $inventoryData, StockItemInterface::class);
             $stockItemDo->setItemId($stockItemId);
             $this->stockItemRepository->save($stockItemDo);
+            
+            // New logic to check and update stock status
+            $this->updateStockStatus($productId, $websiteId, $stockItemDo);
+    
             $this->processParents($product);
         }
         $this->stockIndexerProcessor->reindexList($productIds);
+    }
+    
+    /**
+     * Update stock status based on inventory data
+     *
+     * @param int $productId
+     * @param int $websiteId
+     * @param StockItemInterface $stockItemDo
+     *
+     * @return void
+     */
+    private function updateStockStatus(int $productId, int $websiteId, StockItemInterface $stockItemDo): void
+    {
+        // Check if product quantity is 0 and set stock status accordingly
+        $qty = $stockItemDo->getQty();
+        $isInStock = $qty > 0 ? 1 : 0;
+    
+        // Set stock status based on quantity
+        $stockItemDo->setIsInStock($isInStock);
+        $this->stockItemRepository->save($stockItemDo);
     }
 
     /**


### PR DESCRIPTION
**Description**
This pull request addresses the issue where the stock status and saleable quantity do not update correctly when a product’s quantity is set to 0 in Magento Inventory.

**Problem:**

When a product is updated with qty = 0 and the stock status is set to 'out of stock', the expected behavior is that the stock status should switch to 'in stock' if the product becomes available and the saleable quantity should match the set quantity.
Currently, the stock status remains 'out of stock' and the saleable quantity does not update, leading to incorrect inventory data.
**Root Cause:**

The issue occurs due to the order of operations within the SetDataToLegacyCatalogInventory::updateSourceItems method. The stock status is being fetched from the cataloginventory_stock_status table before the new values are updated, causing old values to be reused.
**Solution**
The solution involves modifying the logic to ensure that stock status and saleable quantity are correctly updated based on the product's quantity. Here’s the implemented fix:

**Updated updateInventoryInProducts Method:**

Added logic to explicitly check and update the stock status based on the quantity.
If the quantity is greater than 0, the stock status is set to 'in stock'; otherwise, it is set to 'out of stock'.
**New Method updateStockStatus:**

This method checks the product’s quantity and updates the stock status accordingly.
Ensures that the stock status is synchronized with the actual inventory data.
Changes Made
Modified the updateInventoryInProducts method to include logic for updating stock status.
Added the updateStockStatus method to encapsulate the stock status update logic based on product quantity.
**Preconditions**
Magento Inventory 1.2.3 (issue present in recent versions).
No backorders enabled.
Steps to Reproduce the Issue
Update a product with qty = 0 and stock_status = 'out of stock'.
**Expected Result**
Stock status should switch to 'in stock' if applicable, and the saleable quantity should be equal to the product quantity.
**Actual Result**
Stock status remains 'out of stock'.
Saleable quantity stays at 0.
**Additional Information**
The issue was traced through the following functions and classes:
\Magento\Inventory\Model\SourceItem\Command\SourceItemsSave::execute
\Magento\InventoryCatalog\Plugin\InventoryApi\SetDataToLegacyCatalogInventoryAtSourceItemsSavePlugin::afterExecute
\Magento\InventoryCatalog\Model\SourceItemsSaveSynchronization\SetDataToLegacyCatalogInventory::updateSourceItems
\Magento\InventorySales\Model\AreProductsSalable::execute
And others listed in the detailed debug trace.
**Testing**
Ensure to test thoroughly by updating products with varying quantities to verify the stock status and saleable quantity updates correctly.