### PR TITLE
Quote is loaded without totals

### DIFF
--- a/app/code/Magento/Checkout/Model/Session.php
+++ b/app/code/Magento/Checkout/Model/Session.php
@@ -263,34 +263,27 @@ class Session extends \Magento\Framework\Session\SessionManager
                         $quote = $this->quoteRepository->getActive($this->getQuoteId());
                     }
 
-                    $customerId = $this->_customer
-                        ? $this->_customer->getId()
-                        : $this->_customerSession->getCustomerId();
-
-                    if ($quote->getData('customer_id') && (int)$quote->getData('customer_id') !== (int)$customerId) {
+                    $customerId = $this->_customer?->getId() ?? $this->_customerSession->getCustomerId();
+                    if ($quote->getCustomerId() && (int)$quote->getCustomerId() !== (int)$customerId) {
                         $quote = $this->quoteFactory->create();
                         $this->setQuoteId(null);
                     }
 
                     /**
                      * If current currency code of quote is not equal current currency code of store,
-                     * need recalculate totals of quote. It is possible if customer use currency switcher or
+                     * need recalculate totals of quote. It is possible if a customer uses currency switcher or
                      * store switcher.
                      */
-                    if ($quote->getQuoteCurrencyCode() != $this->_storeManager->getStore()->getCurrentCurrencyCode()) {
+                    if ($quote->getQuoteCurrencyCode() !== $this->_storeManager->getStore()->getCurrentCurrencyCode()) {
                         $quote->setStore($this->_storeManager->getStore());
-                        $this->quoteRepository->save($quote->collectTotals());
-                        /*
-                         * We mast to create new quote object, because collectTotals()
-                         * can to create links with other objects.
-                         */
-                        $quote = $this->quoteRepository->get($this->getQuoteId());
+                        $quote->setTriggerRecollect(1);
+                        $this->quoteRepository->save($quote);
+                        $quote = $this->quoteRepository->get($quote->getId());
                     }
-
-                    if ($quote->getTotalsCollectedFlag() === false) {
-                        $quote->collectTotals();
-                    }
-                } catch (NoSuchEntityException $e) {
+                    // Totals may have already been collected here if needed: `\Magento\Quote\Model\Quote::_afterLoad`
+                    // The collectTotals method already check for the internal flag `getTotalsCollectedFlag`
+                    $quote->collectTotals();
+                } catch (NoSuchEntityException) {
                     $this->setQuoteId(null);
                 }
             }
@@ -305,6 +298,7 @@ class Session extends \Magento\Framework\Session\SessionManager
                 } else {
                     $quote->setIsCheckoutCart(true);
                     $quote->setCustomerIsGuest(1);
+                    $quote->setCustomerId(null);
                     $this->_eventManager->dispatch('checkout_quote_init', ['quote' => $quote]);
                 }
             }
@@ -354,7 +348,7 @@ class Session extends \Magento\Framework\Session\SessionManager
     /**
      * Set the current session's quote id
      *
-     * @param int $quoteId
+     * @param int|null $quoteId
      * @return void
      * @codeCoverageIgnore
      */
@@ -399,13 +393,9 @@ class Session extends \Magento\Framework\Session\SessionManager
                 $quote = $this->getQuote();
                 $quote->setCustomerIsGuest(0);
                 $this->quoteRepository->save(
-                    $customerQuote->merge($quote)->collectTotals()
+                    $customerQuote->merge($quote)->setTotalsCollectedFlag(false)->collectTotals()
                 );
-                $newQuote = $this->quoteRepository->get($customerQuote->getId());
-                $this->quoteRepository->save(
-                    $newQuote->collectTotals()
-                );
-                $customerQuote = $newQuote;
+                $customerQuote = $this->quoteRepository->get($customerQuote->getId());
             }
 
             $this->setQuoteId($customerQuote->getId());
@@ -415,13 +405,14 @@ class Session extends \Magento\Framework\Session\SessionManager
             }
             $this->_quote = $customerQuote;
         } else {
-            $this->getQuote()->getBillingAddress();
-            $this->getQuote()->getShippingAddress();
-            $this->getQuote()->setCustomer($this->_customerSession->getCustomerDataObject())
+            $quote = $this->getQuote();
+            $quote->getBillingAddress();
+            $quote->getShippingAddress();
+            $quote->setCustomer($this->_customerSession->getCustomerDataObject())
                 ->setCustomerIsGuest(0)
                 ->setTotalsCollectedFlag(false)
                 ->collectTotals();
-            $this->quoteRepository->save($this->getQuote());
+            $this->quoteRepository->save($quote);
         }
         return $this;
     }
@@ -611,13 +602,11 @@ class Session extends \Magento\Framework\Session\SessionManager
      */
     private function getQuoteByCustomer(): ?CartInterface
     {
-        $customerId = $this->_customer
-            ? $this->_customer->getId()
-            : $this->_customerSession->getCustomerId();
+        $customerId = $this->_customer?->getId() ?? $this->_customerSession->getCustomerId();
 
         try {
             $quote = $this->quoteRepository->getActiveForCustomer($customerId);
-        } catch (NoSuchEntityException $e) {
+        } catch (NoSuchEntityException) {
             $quote = null;
         }
 

--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -2498,7 +2498,8 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
     {
         // collect totals and save me, if required
         if (1 == $this->getTriggerRecollect()) {
-            $this->collectTotals()
+            $this->setTotalsCollectedFlag(false)
+                ->collectTotals()
                 ->setTriggerRecollect(0)
                 ->save();
         }

--- a/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteInfiniteLoopTest.php
+++ b/dev/tests/integration/testsuite/Magento/Quote/Model/QuoteInfiniteLoopTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2018 Adobe
+ * All Rights Reserved.
  */
 declare(strict_types=1);
 
@@ -31,6 +31,7 @@ class QuoteInfiniteLoopTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
+        // @phpstan-ignore class.notFound
         $this->config = $this->objectManager->get(\Magento\TestModuleQuoteTotalsObserver\Model\Config::class);
         $this->config->disableObserver();
     }
@@ -51,7 +52,7 @@ class QuoteInfiniteLoopTest extends \PHPUnit\Framework\TestCase
      * @param $observerEnabled
      * @return void
      */
-    public function testLoadQuoteSuccessfully($triggerRecollect, $observerEnabled): void
+    public function testLoadQuote($triggerRecollect, $observerEnabled): void
     {
         $originalQuote = $this->generateQuote($triggerRecollect);
         $quoteId = $originalQuote->getId();
@@ -64,6 +65,8 @@ class QuoteInfiniteLoopTest extends \PHPUnit\Framework\TestCase
         );
 
         if ($observerEnabled) {
+            $this->expectException(\LogicException::class);
+            $this->expectExceptionMessage('Infinite loop detected, review the trace for the looping path');
             $this->config->enableObserver();
         }
 
@@ -73,8 +76,19 @@ class QuoteInfiniteLoopTest extends \PHPUnit\Framework\TestCase
         $session->setQuoteId($quoteId);
 
         $quote = $session->getQuote();
-        $this->assertEquals($quoteId, $quote->getId(), "The loaded quote should have the same ID as the initial quote");
-        $this->assertEquals(0, $quote->getTriggerRecollect(), "trigger_recollect should be unset after a quote reload");
+
+        if (!$observerEnabled) {
+            $this->assertEquals(
+                $quoteId,
+                $quote->getId(),
+                'The loaded quote should have the same ID as the initial quote'
+            );
+            $this->assertEquals(
+                0,
+                $quote->getTriggerRecollect(),
+                'trigger_recollect should be unset after a quote reload'
+            );
+        }
     }
 
     /**
@@ -86,34 +100,8 @@ class QuoteInfiniteLoopTest extends \PHPUnit\Framework\TestCase
             [0, false],
             [0, true],
             [1, false],
-            //[1, true], this combination of trigger recollect and third party code causes the loop, tested separately
+            [1, true],
         ];
-    }
-
-    /**
-     *
-     * @return void
-     */
-    public function testLoadQuoteWithTriggerRecollectInfiniteLoop(): void
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Infinite loop detected, review the trace for the looping path');
-
-        $originalQuote = $this->generateQuote();
-        $quoteId = $originalQuote->getId();
-
-        $this->assertGreaterThan(0, $quoteId, "The quote should have a database id");
-        $this->assertEquals(1, $originalQuote->getTriggerRecollect(), "The quote has trigger_recollect set");
-
-        // Enable an observer which gets the quote from the session
-        // The observer hooks into part of the collect totals process for an easy demonstration of the loop.
-        $this->config->enableObserver();
-
-        /** @var  $session \Magento\Checkout\Model\Session */
-        $this->objectManager->removeSharedInstance(\Magento\Checkout\Model\Session::class);
-        $session = $this->objectManager->get(\Magento\Checkout\Model\Session::class);
-        $session->setQuoteId($quoteId);
-        $session->getQuote();
     }
 
     /**

--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
     scanDirectories:
         - %rootDir%/../../../dev/tests/static/framework/tests/unit/testsuite/Magento
         - %rootDir%/../../../dev/tests/integration/framework/tests/unit/testsuite/Magento
+        - %rootDir%/../../../dev/tests/integration/_files/Magento
         - %rootDir%/../../../dev/tests/api-functional/_files/Magento
     bootstrapFiles:
             - %rootDir%/../../../dev/tests/static/framework/autoload.php


### PR DESCRIPTION
### Description (*)
For exemple, when we load the quote on the checkout cart page, some fields are missing on the items because the totals have not been collected. For exemple the original price is missing.
It results in weird scenarios (for exempleif you want to print the diff between the final price and the original one on a quote item, an original price is 0).

### Manual testing scenarios (*)
1. Load quote from session
2. use getOriginalPrice method on quote items

### Questions or comments
Not sure why originally the check was forced to checking "false" when in almost every case the Magento core checkout for true (which is set when the totals are collected).
Also the collectTotals method is already proof as it already checks for the flag.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39205: Quote is loaded without totals