### PR TITLE
Checking nullability of test properties before setting to null in integration test framework cleanup

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/TestCaseProperties.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Workaround/Cleanup/TestCaseProperties.php
@@ -35,7 +35,7 @@ class TestCaseProperties
 
                 if (is_array($property->getDefaultValue())) {
                     $property->setValue($test, []);
-                } else {
+                } elseif (!$property->hasType() || $property->getType()->allowsNull()) {
                     $property->setValue($test, null);
                 }
             }

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest.php
@@ -6,9 +6,9 @@
 
 namespace Magento\Test\Workaround\Cleanup;
 
+use Magento\TestFramework\Workaround\Cleanup\TestCaseProperties;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
-use Magento\TestFramework\Workaround\Cleanup\TestCaseProperties;
 
 /**
  * Test class for \Magento\TestFramework\Workaround\Cleanup\TestCaseProperties.
@@ -19,16 +19,18 @@ class TestCasePropertiesTest extends TestCase
      * @var array
      */
     protected $fixtureProperties = [
-        'testPublic' => ['name' => 'testPublic', 'is_static' => false],
-        '_testPrivate' => ['name' => '_testPrivate', 'is_static' => false],
-        '_testPropertyBoolean' => ['name' => '_testPropertyBoolean', 'is_static' => false],
-        '_testPropertyInteger' => ['name' => '_testPropertyInteger', 'is_static' => false],
-        '_testPropertyFloat' => ['name' => '_testPropertyFloat', 'is_static' => false],
-        '_testPropertyString' => ['name' => '_testPropertyString', 'is_static' => false],
-        '_testPropertyArray' => ['name' => '_testPropertyArray', 'is_static' => false],
-        'testPublicStatic' => ['name' => 'testPublicStatic', 'is_static' => true],
-        '_testProtectedStatic' => ['name' => '_testProtectedStatic', 'is_static' => true],
-        '_testPrivateStatic' => ['name' => '_testPrivateStatic', 'is_static' => true]
+        'testPublic' => ['name' => 'testPublic', 'is_static' => false, 'nullable' => true],
+        '_testPrivate' => ['name' => '_testPrivate', 'is_static' => false, 'nullable' => true],
+        '_testPropertyBoolean' => ['name' => '_testPropertyBoolean', 'is_static' => false, 'nullable' => true],
+        '_testPropertyInteger' => ['name' => '_testPropertyInteger', 'is_static' => false, 'nullable' => true],
+        '_testPropertyFloat' => ['name' => '_testPropertyFloat', 'is_static' => false, 'nullable' => true],
+        '_testPropertyString' => ['name' => '_testPropertyString', 'is_static' => false, 'nullable' => true],
+        '_testPropertyArray' => ['name' => '_testPropertyArray', 'is_static' => false, 'nullable' => true],
+        '_testTypedNonNullable' => ['name' => '_testTypedNonNullable', 'is_static' => false, 'nullable' => false],
+        '_testTypedNullable' => ['name' => '_testTypedNullable', 'is_static' => false, 'nullable' => true],
+        'testPublicStatic' => ['name' => 'testPublicStatic', 'is_static' => true, 'nullable' => true],
+        '_testProtectedStatic' => ['name' => '_testProtectedStatic', 'is_static' => true, 'nullable' => true],
+        '_testPrivateStatic' => ['name' => '_testPrivateStatic', 'is_static' => true, 'nullable' => true]
     ];
 
     /**
@@ -61,7 +63,13 @@ class TestCasePropertiesTest extends TestCase
             if (in_array($property->getName(), $fixturePropertiesNames)) {
                 $property->setAccessible(true);
                 $value = $property->getValue($testSuite);
-                $this->assertNull($value);
+                $isNullable = $this->fixtureProperties[$property->getName()]['nullable'];
+
+                if ($isNullable) {
+                    $this->assertNull($value);
+                } else {
+                    $this->assertNotNull($value);
+                }
             }
         }
     }

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest/DummyTestCase.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Workaround/Cleanup/TestCasePropertiesTest/DummyTestCase.php
@@ -47,6 +47,10 @@ class DummyTestCase extends \PHPUnit\Framework\TestCase
      */
     protected $_testPropertyObject;
 
+    private string $_testTypedNonNullable;
+
+    private ?string $_testTypedNullable;
+
     /**
      * @var string
      */
@@ -71,6 +75,8 @@ class DummyTestCase extends \PHPUnit\Framework\TestCase
         $this->_testPropertyFloat = 1.97;
         $this->_testPropertyString = 'string';
         $this->_testPropertyArray = ['test', 20];
+        $this->_testTypedNonNullable = 'typed non nullable';
+        $this->_testTypedNullable = 'typed nullable';
         self::$testPublicStatic = 'static public';
         self::$_testProtectedStatic = 'static protected';
         self::$_testPrivateStatic = 'static private';


### PR DESCRIPTION
### Description (*)

Previously an error occured if a non-nullable typed property was used in a test case. The error message was something like

> Cannot assign null to property MyVendor\MyModule\Test\Integration\MyTest::$objectManager of type Magento\Framework\ObjectManagerInterface

### Manual testing scenarios (*)
1. Add a non-nullable typed property to an integration test (like the one in the `DummyTestCase` in this PR)
2. Run the test
3. In the test result there will occur an error message looking like the above one.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39245: Checking nullability of test properties before setting to null in integration test framework cleanup