### PR TITLE
Disable javascript minifying of TinyMCE 7 library, to fix a bug with…

### DIFF
--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -22,6 +22,7 @@
                 <minify_files>0</minify_files>
                 <minify_exclude>
                     <tiny_mce>/tiny_mce/</tiny_mce>
+                    <tiny_mce_7>/tiny_mce_7/</tiny_mce_7>
                 </minify_exclude>
             </js>
             <css>


### PR DESCRIPTION
… loading language files from it.

### Description (*)
I've seen it happening on Magento 2.4.7-p3 where TinyMCE v5 was updated to v7, but it also happens on `2.4-develop` branch.

It's a minor bug, nothing really important I think, just making sure people can read the help section of the TinyMCE editor while using it.

So, when Magento has JS minification enabled, during SCD* it will transform any .js file it finds that doesn't already end its filename with `.min.js` to a minified version of that and rename the file from `xxx.js` to `xxx.min.js`.
However, in case of the TinyMCE 7 library, when it tries to load its language files [from here](https://github.com/magento/magento2/tree/2.4.7-p3/lib/web/tiny_mce_7/plugins/help/js/i18n/keynav), it doesn't expect them to have the filename of `{language-code}.min.js` and fails to load them.

In this PR, we prevent this from happening and disallow minification of js files whenever the pattern `/tiny_mce_7/` is found in a path when the SCD* process processes js files.

*SCD = static content deploy

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
None at the moment

### Manual testing scenarios (*)
1. Setup clean Magento shop (I'm using one without pagebuilder as its easier to showcase the bug, but you can trigger part of the bug also with pagebuilder enabled)
2. Enable JS minification: `bin/magento config:set dev/js/minify_files 1`
3. Remove all generated frontend files (if any) and flush caches, easiest is just to run `bin/magento setup:upgrade`
4. Now switch to production mode, as JS minification only works in production mode: `bin/magento deploy:mode:set production`
5. Go in the backoffice
6. Create a new cms page
7. Open your browsers inspector
8. Click open the 'Content' tab
9. Click inside the wysiwyg editor and try to launch the help with the keyboard shortcut mentioned at the bottom of the editor: alt/option+0

Currently at step 8 you see these error messages:
```
GET .../adminhtml/Magento/backend/en_US/tiny_mce_7/plugins/help/js/i18n/keynav/en.js net::ERR_ABORTED 404 (Not Found)
Refused to execute script from '.../adminhtml/Magento/backend/en_US/tiny_mce_7/plugins/help/js/i18n/keynav/en.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.
Uncaught (in promise) Script at URL ".../adminhtml/Magento/backend/en_US/tiny_mce_7/plugins/help/js/i18n/keynav/en.js" failed to load
```
And at step 9 the help doesn't open and you get another error message:
```
Uncaught (in promise) Script at URL ".../adminhtml/Magento/backend/en_US/tiny_mce_7/plugins/help/js/i18n/keynav/en.js" failed to load
```

With the fix from this PR, that's all solved.

### Questions or comments
Adding automated tests for this will be hard, so I'm not doing it, hopefully that's okay, if not, please write them yourselves, I won't have the time to put into this task.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39263: Disable javascript minifying of TinyMCE 7 library, to fix a bug with…