### PR TITLE
Improve Bundle Option & Selection Data Extensibility

### DIFF
--- a/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
+++ b/app/code/Magento/Bundle/Block/Catalog/Product/View/Type/Bundle.php
@@ -230,7 +230,7 @@ class Bundle extends AbstractView implements ResetAfterRequestInterface
      *
      * @return array
      */
-    private function getSelectionItemData(Product $product, Product $selection)
+    public function getSelectionItemData(Product $product, Product $selection)
     {
         $qty = ($selection->getSelectionQty() * 1) ?: '1';
 
@@ -340,7 +340,7 @@ class Bundle extends AbstractView implements ResetAfterRequestInterface
      * @param int $position
      * @return array
      */
-    private function getOptionItemData(Option $option, Product $product, $position)
+    public function getOptionItemData(Option $option, Product $product, $position)
     {
         return [
             'selections' => $this->getSelections($option, $product),


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Updated the visibility from `private` to `public` for the following functions in `Magento\Bundle\Block\Catalog\Product\View\Type\Bundle` for improved extensibiility:
- `getOptionItemData()`
- `getSelectionItemData()`

### Manual testing scenarios (*)
1. Create a new local module
2. Create a before/after/around plugin for each of the aforementioned functions
3. Configure the plugin in `etc/di.xml`
4. Enable the module
5. Enable and configure Xdebug and add breakpoints in your plugin(s)
6. Load a bundle product page on the frontend
7. Ensure the plugin(s) breakpoint(s) are hit

### Questions or comments
I don't know why these were originally declared `private` functions so if there's a reason this change cannot be made, please let me know.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#34805: Improve Bundle Option & Selection Data Extensibility