### PR TITLE
'Report-To' header is deprecated and no longer recommended

### DIFF
--- a/app/code/Magento/Csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
+++ b/app/code/Magento/Csp/Model/Policy/Renderer/SimplePolicyHeaderRenderer.php
@@ -45,17 +45,9 @@ class SimplePolicyHeaderRenderer implements PolicyRendererInterface
             $header = 'Content-Security-Policy';
         }
         $value = $policy->getId() .' ' .$policy->getValue() .';';
-        if ($config->getReportUri() && !$response->getHeader('Report-To')) {
-            $reportToData = [
-                'group' => 'report-endpoint',
-                'max_age' => 10886400,
-                'endpoints' => [
-                    ['url' => $config->getReportUri()]
-                ]
-            ];
-            $value .= ' report-uri ' .$config->getReportUri() .';';
-            $value .= ' report-to '. $reportToData['group'] .';';
-            $response->setHeader('Report-To', json_encode($reportToData), true);
+        if ($config->getReportUri()) {
+            $value .= ' report-uri ' . $config->getReportUri() .';';
+            $value .= ' report-to '. $config->getReportUri() .';';
         }
         if ($existing = $response->getHeader($header)) {
             $value = $value .' ' .$existing->getFieldValue();


### PR DESCRIPTION
### Description (*)
As reported in this [document](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Report-To), 'Report-To' header is deprecated and no longer recommended to report CSP violations.
And, in any case, it is not possible to add "report-to <goup-name>" in the 'Content-Security-Policy-Report-Only' header. 

### Manual testing scenarios (*)
1. Set CSP in "report-only"
2. Compile 'Report URI' fields in Configuration > Security > Content Security Policy (CSP) page
3. Navigate the website in a page that contains some CSP violations
4. It must be a POST call to Report URI.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39288: 'Report-To' header is deprecated and no longer recommended