### PR TITLE
Correct colspan in visual swatch admin

### DIFF
--- a/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/app/code/Magento/Swatches/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -27,7 +27,7 @@ $stores = $block->getStoresSortedBySortOrder();
                         <span><?= $escaper->escapeHtml($_store->getName()) ?></span>
                     </th>
                 <?php endforeach; ?>
-                <?php $colTotal = count($stores) * 2 + 3; ?>
+                <?php $colTotal = count($stores) + 4; ?>
                 <th class="col-delete">&nbsp;</th>
             </tr>
             </thead>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
The colspan is incorrect. Probably based on the text.phtml file, but there is only 1 `th` per store + 4 additional, as you can see in the code.


### Manual testing scenarios (*)
Edit a visual swatch and look at the tfoot of the swatches table. The number does not match the number of columns if the number of storeviews is > 1 . For 1 storeview, the number still matches (1 * 2 + 3 = 5 and 1 + 4 = 5), but otherwise it will be too high.

(As far as I can tell, this doesn't have any effect because the number of stores is at least 1 so the colspan will always be high

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39360: Correct colspan in visual swatch admin