### PR TITLE
Add UpToDateThemes validator to setup:db:status

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Patch/UpToDateThemes.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/UpToDateThemes.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\Setup\Patch;
+
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\RuntimeException;
+use Magento\Framework\Setup\UpToDateValidatorInterface;
+use Magento\Theme\Model\Config\Importer;
+
+class UpToDateThemes implements UpToDateValidatorInterface
+{
+    private Importer $themeImporter;
+
+    private DeploymentConfig $deploymentConfig;
+
+    /**
+     * UpToDateThemes constructor.
+     *
+     * @param Importer         $themeImporter
+     * @param DeploymentConfig $deploymentConfig
+     */
+    public function __construct(
+        Importer $themeImporter,
+        DeploymentConfig $deploymentConfig,
+    ) {
+        $this->themeImporter = $themeImporter;
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNotUpToDateMessage() : string
+    {
+        return 'Themes are not up to date';
+    }
+
+    /**
+     * @return bool
+     * @throws FileSystemException
+     * @throws RuntimeException
+     */
+    public function isUpToDate() : bool
+    {
+        return !count($this->themeImporter->getWarningMessages($this->deploymentConfig->getConfigData('themes')));
+    }
+}

--- a/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
+++ b/setup/src/Magento/Setup/Console/Command/DbStatusCommand.php
@@ -11,6 +11,7 @@ use Magento\Framework\Setup\Declaration\Schema\UpToDateDeclarativeSchema;
 use Magento\Framework\Setup\OldDbValidator;
 use Magento\Framework\Setup\Patch\UpToDateData;
 use Magento\Framework\Setup\Patch\UpToDateSchema;
+use Magento\Framework\Setup\Patch\UpToDateThemes;
 use Magento\Framework\Setup\UpToDateValidatorInterface;
 use Magento\Setup\Model\ObjectManagerProvider;
 use Symfony\Component\Console\Input\InputInterface;
@@ -64,6 +65,7 @@ class DbStatusCommand extends AbstractSetupCommand
             $this->objectManagerProvider->get()->get(UpToDateSchema::class),
             $this->objectManagerProvider->get()->get(UpToDateData::class),
             $this->objectManagerProvider->get()->get(OldDbValidator::class),
+            $this->objectManagerProvider->get()->get(UpToDateThemes::class),
         ];
         parent::__construct();
     }


### PR DESCRIPTION
### Description (*)
Running `bin/magento setup:db:status` right now does not check whether there is a theme update. If the only change in the deploy is a theme being added, `bin/magento setup:db:status` will now show;

```
$ bin/magento setup:db:status
All modules are up to date.
```

However if you were to run `bin/magento setup:upgrade`, you'd get this message;

```
$ bin/magento setup:upgrade
Processing configurations data from configuration file...
The following themes will be registered: frontend/Hyva/Elgentos
Do you want to continue [yes/no]?
```

With the change in this MR, we'll get this output from `setup:db:status`;

```
$ bin/magento setup:db:status
Themes are not up to date
Run 'setup:upgrade' to update your DB schema and data.
```

Since we rely on the output of `setup:db:status` to decide whether or not to run `setup:upgrade` in our deployment pipeline (to make near-zero downtime deployments possible), this is tripping us up from time to time.

This PR aims to add a validator to check whether there are theme changes, forcing `setup:upgrade` to run.

Thanks to @johnorourke for pointing this out.

### Resolved issues:
1. [x] resolves magento/magento2#39385: Add UpToDateThemes validator to setup:db:status