### PR TITLE
Product Detail Page Layout Fixes 

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
+++ b/app/code/Magento/Bundle/view/frontend/layout/catalog_product_view_type_bundle.xml
@@ -68,7 +68,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.media"/>
+            <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.main"/>
         </referenceContainer>
         <referenceContainer name="product.info.type">
             <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="Magento_Bundle::catalog/product/view/type/bundle.phtml"/>

--- a/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
+++ b/app/code/Magento/Downloadable/view/frontend/layout/catalog_product_view_type_downloadable.xml
@@ -29,7 +29,7 @@
         <referenceBlock name="head.components">
             <block class="Magento\Framework\View\Element\Js\Components" name="downloadable_page_head_components" template="Magento_Downloadable::js/components.phtml"/>
         </referenceBlock>
-        <move element="product.info" destination="content" after="product.info.media" />
+        <move element="product.info" destination="content" after="product.info.main" />
         <move element="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
     </body>
 </page>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_bundle.xml
@@ -71,7 +71,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.media"/>
+            <container name="bundle.options.container" htmlTag="div" htmlClass="bundle-options-container" after="product.info.main"/>
         </referenceContainer>
         <referenceContainer name="product.info.type">
             <block class="Magento\Bundle\Block\Catalog\Product\View\Type\Bundle" name="product.info.bundle" as="product_type_data" template="Magento_Bundle::catalog/product/view/type/bundle.phtml"/>

--- a/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
+++ b/app/code/Magento/Wishlist/view/frontend/layout/wishlist_index_configure_type_downloadable.xml
@@ -41,7 +41,7 @@
                 </arguments>
             </block>
         </referenceContainer>
-        <move element="product.info" destination="content" after="product.info.media" />
+        <move element="product.info" destination="content" after="product.info.main" />
         <move element="product.info.social" destination="product.info.options.wrapper.bottom" after="-" />
     </body>
 </page>


### PR DESCRIPTION
Description (*)
This PR fixes the broken layout on the bundle and downloadable product pages

Related Pull Requests
PR that caused the issue: https://github.com/magento/magento2/commit/9b224ac45e6c7a5df924a0bc377064a0537a7044

Manual testing scenarios (*)
Open the bundle and downloadable product page and check the layout on the desktop
Contribution checklist (*)
 Pull request has a meaningful description of its purpose
 All commits are accompanied by meaningful commit messages
 All new or changed code is covered with unit/integration tests (if applicable)
 README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 All automated tests passed successfully (all builds are green)