### PR TITLE
Added null check in DataFixtureSetup for the scope

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixtureSetup.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Annotation/DataFixtureSetup.php
@@ -46,6 +46,9 @@ class DataFixtureSetup
         $factory = $this->dataFixtureFactory->create($fixture['factory']);
         if (isset($fixture['scope'])) {
             $scope = DataFixtureStorageManager::getStorage()->get($fixture['scope']);
+            if (null === $scope) {
+                throw new \RuntimeException(sprintf('Scope "%s" does not exist.', $fixture['scope']));
+            }
             $fromScope = $this->scopeSwitcher->switch($scope);
             try {
                 $result = $factory->apply($data);

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DataFixtureSetupTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/Annotation/DataFixtureSetupTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace integration\framework\tests\unit\testsuite\Magento\Test\Annotation;
+
+use Magento\Framework\Registry;
+use Magento\TestFramework\Annotation\DataFixtureSetup;
+use Magento\TestFramework\Fixture\DataFixtureFactory;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\ScopeSwitcherInterface;
+use PHPUnit\Framework\TestCase;
+
+class DataFixtureSetupTest extends TestCase
+{
+    private ?DataFixtureSetup $object;
+
+    private ?Registry $registry;
+    private ?DataFixtureFactory $dataFixtureFactory;
+    private ?ScopeSwitcherInterface $scopeSwitcher;
+
+    protected function setUp(): void
+    {
+        $this->registry = $this->createMock(Registry::class);
+        $this->dataFixtureFactory = $this->createMock(DataFixtureFactory::class);
+        $this->scopeSwitcher = $this->createMock(ScopeSwitcherInterface::class);
+        $this->object = new DataFixtureSetup($this->registry, $this->dataFixtureFactory, $this->scopeSwitcher);
+    }
+
+    public function testApplyWithArbitraryScopeThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Scope "non_existing_scope" does not exist.');
+
+        $storage = new DataFixtureStorage();
+        DataFixtureStorageManager::setStorage($storage);
+
+        $this->object->apply([
+            'data' => [],
+            'factory' => 'DummyFixtureClass',
+            'scope' => 'non_existing_scope',
+        ]);
+    }
+}


### PR DESCRIPTION
### Description (*)
The scope defined in a data fixture could be an arbitrary string. If there is no corresponding value in the storage manager null is returned.

In this case null is passed to the scope switcher which leads to a `TypeError`, because it requires an object of type `ScopeInterface`.

The `TypeError` is now prevented by throwing a `RuntimeException` with a more specific message.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39427: Added null check in DataFixtureSetup for the scope