### PR TITLE
[TestFramework] Stopped marking transaction in integration tests as inactive although they're still active

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php
@@ -111,7 +111,6 @@ class Transaction
                 $this->_eventManager->fireEvent('startTransaction', [$test]);
                 restore_error_handler();
             } catch (\Exception $e) {
-                $this->_isTransactionActive = false;
                 $test->getTestResultObject()->addFailure(
                     $test,
                     new \PHPUnit\Framework\AssertionFailedError((string)$e),


### PR DESCRIPTION
### Description (*)
Before an integration test is started the testing framework [begins][1] a new database transaction so that all changes to the database can be reverted after the test is completed.

The testing framework also offers a way to easily load data fixtures during this transaction with the help of the `Magento\TestFramework\Fixture\DataFixture` attribute. But in case of faulty fixtures an exception or error can occur. Currently this will prevent the  `endTest` event from rolling back the transaction and so the tests fail with the error message:

> Fatal error: Some transactions have not been committed or rolled back in /var/www/html/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php on line 4169

instead of showing the real reason of the error.

The reason why the transaction is not rolled back correctly is that the catch block in the Transaction event marks the transaction as 'inactive' (see [here][2]) so that it won't be rolled back at the end of the test (see [here][3]), although the transaction is still open.

This PR fixes this behaviour so that the transaction is rolled back after the test execution and the correct error messages is shown in the console output.

### Manual testing scenarios (*)

Add an integration test to your own test suite that uses a data fixture with an invalid config. For example:

```php
<?php

namespace MyVendor\MyModule\Test\Integration;

use Magento\Catalog\Test\Fixture\Product as ProductFixture;
use Magento\TestFramework\Fixture\DataFixture;
use Magento\TestFramework\Fixture\DbIsolation;
use PHPUnit\Framework\TestCase;

class SynchronizerTest extends TestCase
{
    #[DbIsolation(true)]
    #[DataFixture(
        ProductFixture::class,
        ['sku' => 'test', 'name' => 'Test', 'price' => '7.77'],
        'test',
        'invalid_scope_key' // this line results in an error
    )]
    public function testSynchronize(): void
    {
        // can be empty
    }
}
```
Now, run the test and you should get this output:

> PHPUnit 9.6.21 by Sebastian Bergmann and contributors.
> 
> FRolled back transaction has not been completed correctly.
>
> === Memory Usage System Stats ===
> Memory usage (OS):      91.20M (188.03% of 48.50M reported by PHP)
> Estimated memory leak:  42.70M (46.82% of used memory)
> 
> Fatal error: Some transactions have not been committed or rolled back in /var/www/html/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php on line 4169

After applying this PR the output of phpunit shows the following:

> PHPUnit 9.6.21 by Sebastian Bergmann and contributors.
> 
> F..                                                                                                                                                                      3 / 3 (100%)
>
> Time: 00:18.394, Memory: 48.00 MB
>
> There was 1 failure:
>
> 1) MyVendor\MyModule\Test\Integration\SynchronizerTest::testSynchronize
> PHPUnit\Framework\Exception: Unable to apply fixture: Magento\Catalog\Test\Fixture\Product (test)
> #0 /var/www/html/app/code/MyVendor/MyModule/Test/Integration/Synchronizer.php(51): MyVendor\MyModule\Test\Integration\SynchronizerTest->testSynchronize()
> 
> Caused By: ... rest of the exception with backtrace

This helps the developer to find the real issue. The previous message 'Some transactions have not been committed or rolled back' does not help.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

[1]: https://github.com/magento/magento2/blob/88660e79f04867bb236ddf3caf0921f3ce68ca4c/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php#L95
[2]: https://github.com/magento/magento2/blob/88660e79f04867bb236ddf3caf0921f3ce68ca4c/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php#L114
[3]: https://github.com/magento/magento2/blob/88660e79f04867bb236ddf3caf0921f3ce68ca4c/dev/tests/integration/framework/Magento/TestFramework/Event/Transaction.php#L114

### Resolved issues:
1. [x] resolves magento/magento2#39460: [TestFramework] Stopped marking transaction in integration tests as inactive although they're still active