### PR TITLE
Revert change from 42577bc that introduced side effect in ConfigurableWYSIWYGValidator, function validateConfigured()

### DIFF
--- a/lib/internal/Magento/Framework/Validator/HTML/ConfigurableWYSIWYGValidator.php
+++ b/lib/internal/Magento/Framework/Validator/HTML/ConfigurableWYSIWYGValidator.php
@@ -110,7 +110,6 @@ class ConfigurableWYSIWYGValidator implements WYSIWYGValidatorInterface
     private function validateConfigured(\DOMXPath $xpath): void
     {
         //Validating tags
-        $this->allowedTags = array_merge($this->allowedTags, ["body", "html"]);
         $found = $xpath->query(
             '//*['
             . implode(
@@ -119,7 +118,7 @@ class ConfigurableWYSIWYGValidator implements WYSIWYGValidatorInterface
                     function (string $tag): string {
                         return "name() != '$tag'";
                     },
-                    $this->allowedTags
+                    array_merge($this->allowedTags, ['body', 'html'])
                 )
             )
             .']'


### PR DESCRIPTION
### Description (*)
Commit 42577bc5ab88ce74706d16356825440c9cdce9ba introduced a side effect in `validateConfigured()` function of `ConfigurableWYSIWYGValidator` class. `validateConfigured()` function now permanently modifies `allowedTags` property with adding/merging `['body', 'html']` to the list of allowed tags on each invocation. This results in an ever growing list of allowed tags for the lifetime of the object of class `ConfigurableWYSIWYGValidator`.

This hit us really hard since we have some long running PHP processes, that go trough HTML validation, calling `validateConfigured()` hundred of thousand of times. In the process, `allowedTags` list grew huge, with an ever increasing size. We saw out PHP process worked increasingly more slow with CPU being at 100% all the time.

### Related Pull Requests
Unknown.

### Fixed Issues (if relevant)
No reported issue found.

### Manual testing scenarios (*)
1. Create a long running PHP process that calls `validateConfigured()` multiple times. It will run increasingly more slowly.

### Questions or comments
No Questions

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39459: Revert change from 42577bc that introduced side effect in ConfigurableWYSIWYGValidator, function validateConfigured()