### PR TITLE
Typecast incrementId variables always to a string

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -559,7 +559,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
      */
     public function loadByIncrementId($incrementId)
     {
-        return $this->loadByAttribute('increment_id', $incrementId);
+        return $this->loadByAttribute('increment_id', (string) $incrementId);
     }
 
     /**
@@ -573,7 +573,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     {
         $orderCollection = $this->getSalesOrderCollection(
             [
-                'increment_id' => $incrementId,
+                'increment_id' => (string) $incrementId,
                 'store_id' => $storeId
             ]
         );


### PR DESCRIPTION
### Description (*)
Ensure our calls to the sales_order table for the increment_id field are called with a string type and not an int type. When a module passed through an int variable, a full table scan occurs since the increment_id index can not be utilized.

### Manual testing scenarios (*)
Create a small module and call the loadByIncrementId with an integer and see that this query is not hitting any index without this change.

### Resolved issues:
1. [x] resolves magento/magento2#39458: Typecast incrementId variables always to a string