### PR TITLE
Customer account confirm - StateException should not be logged as critical error

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/Confirm.php
+++ b/app/code/Magento/Customer/Controller/Account/Confirm.php
@@ -191,7 +191,7 @@ class Confirm extends AbstractAccount implements HttpGetActionInterface
             $resultRedirect->setUrl($this->getSuccessRedirect());
             return $resultRedirect;
         } catch (StateException $e) {
-            $this->messageManager->addException($e, __('This confirmation key is invalid or has expired.'));
+            $this->messageManager->addErrorMessage($e->getMessage());
         } catch (\Exception $e) {
             $this->messageManager->addException($e, __('There was an error confirming the account'));
         }


### PR DESCRIPTION
### Description (*)
The error "The account is already active," etc., should not be logged as a critical exception since it is more of a user error rather than a programming issue that needs to be addressed.
Instead of using "addException" which logs the StateExpection I changed to to a normal error message.

### Manual testing scenarios (*)
- Create a customer account
- Confirm
- Confrm again

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39487: Customer account confirm - StateException should not be logged as critical error