### PR TITLE
clearing the Global default welcome text will cause a NULL parameter CRASH

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -436,6 +436,7 @@ class Escaper
      */
     public function escapeQuote($data, $addSlashes = false)
     {
+        if (empty($data)) return "";
         if ($addSlashes === true) {
             $data = addslashes($data);
         }


### PR DESCRIPTION
### Description (*)
Clearing the Global default Welcome Text will cause a NULL parameter to be passed to Escaper.php.   
Added a parameter sanity check to avoid the site crash.

```
[2024-12-20T17:21:42.186669+00:00] main.CRITICAL: TypeError: addslashes(): Argument #1 ($string) must be of type string, null given in /home/jetrails/encircle.markets/html/vendor/magento/framework/Escaper.php:440
Stack trace:
#0 /home/jetrails/encircle.markets/html/vendor/magento/framework/Escaper.php(440): addslashes(NULL)
#1 /home/jetrails/encircle.markets/html/vendor/magento/module-theme/Block/Html/Header.php(62): Magento\Framework\Escaper->escapeQuote(NULL, true)
#2 /home/jetrails/encircle.markets/html/vendor/magento/module-theme/view/frontend/templates/html/header.phtml(11): Magento\Theme\Block\Html\Header->getWelcome()
```
### Related Pull Requests
none
### Fixed Issues (if relevant)
none
### Manual testing scenarios (*)
1. add a website to the 'All Stores' configuration page `./admin/system_store/index/key/…`
2. remove the Global default Welcome Text from the first item in the **Content | Design/Configuration** list `./theme/design_config/index/key/…`
*1. remove the **Welcome Text** from the **[Header]** section of the Global default.
3. restart the web server; reload the home page for the newly added website [BOOM].

I have a two website configuration and removed the global default in favor of the configuration for the specific websites, causing my site to crash.  I think the issue is that the newly added website started with no value set for the **Welcome Text**.

### Questions or comments
### Contribution checklist (*)
 - [ √ ] Pull request has a meaningful description of its purpose
 - [ √ ] All commits are accompanied by meaningful commit messages
 - [ - ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ - ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ - ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39507: clearing the Global default welcome text will cause a NULL parameter CRASH