### PR TITLE
Added app isolation attribute to tests in EavSetupTest

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
  */
-
 namespace Magento\Eav\Setup;
 
 use Magento\TestFramework\Fixture\AppIsolation;
@@ -15,8 +14,6 @@ use Magento\TestFramework\Fixture\AppIsolation;
 class EavSetupTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Eav setup.
-     *
      * @var \Magento\Eav\Setup\EavSetup
      */
     private $eavSetup;
@@ -105,7 +102,8 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
     public function testAddInvalidAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field,');
+        $this->expectExceptionMessage('Please use only letters (a-z or A-Z), ' .
+            'numbers (0-9) or underscore (_) in this field,');
 
         $attributeData = $this->getAttributeData();
         $this->eavSetup->addAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode, $attributeData);

--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Eav\Setup;
 
+use Magento\TestFramework\Fixture\AppIsolation;
+
 /**
  * Test class for Magento\Eav\Setup\EavSetup.
  * @magentoDbIsolation enabled
@@ -66,6 +68,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider addAttributeThrowExceptionDataProvider
      */
+    #[AppIsolation(true)]
     public function testAddAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
@@ -98,6 +101,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider addInvalidAttributeThrowExceptionDataProvider
      */
+    #[AppIsolation(true)]
     public function testAddInvalidAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);


### PR DESCRIPTION
### Description (*)

The proposed changes add AppIsolation attributes to two tests of the `EavSetupTest`, because they affect global state (adding error messages to the `Magento\Eav\Model\Validator\Attribute\Code` service) which will affect further tests that try to add EAV attributes.

### Related Pull Requests
-

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39616.


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
