### PR TITLE
Added a method to remove an attribute from a group in EavSetup

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -1347,6 +1347,43 @@ class EavSetup
         return $this;
     }
 
+    /**
+     * Remove an attribute from a group and an attribute set.
+     *
+     * @return $this
+     */
+    public function removeAttributeFromGroup(int|string $entityTypeId, int|string $setId, int|string $groupId, int|string $attributeId): static
+    {
+        $entityTypeId = $this->getEntityTypeId($entityTypeId);
+        $setId = $this->getAttributeSetId($entityTypeId, $setId);
+        $groupId = $this->getAttributeGroupId($entityTypeId, $setId, $groupId);
+        $attributeId = $this->getAttributeId($entityTypeId, $attributeId);
+
+        $table = $this->setup->getTable('eav_entity_attribute');
+        $select = $this->setup->getConnection()->select()->from($table)
+            ->where('entity_type_id = :entity_type_id')
+            ->where('attribute_set_id = :attribute_set_id')
+            ->where('attribute_group_id = :attribute_group_id')
+            ->where('attribute_id = :attribute_id');
+
+        $row = $this->setup->getConnection()->fetchRow($select, [
+            'entity_type_id' => $entityTypeId,
+            'attribute_set_id' => $setId,
+            'attribute_group_id' => $groupId,
+            'attribute_id' => $attributeId,
+        ]);
+
+        if (false === $row) {
+            return $this;
+        }
+
+        $this->setup->getConnection()->delete($table, [
+            'entity_attribute_id = ?' => $row['entity_attribute_id'],
+        ]);
+
+        return $this;
+    }
+
     /******************* BULK INSTALL *****************/
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
  */
-
 namespace Magento\Eav\Setup;
 
 use Magento\TestFramework\Fixture\AppIsolation;
@@ -15,8 +14,6 @@ use Magento\TestFramework\Fixture\AppIsolation;
 class EavSetupTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Eav setup.
-     *
      * @var \Magento\Eav\Setup\EavSetup
      */
     private $eavSetup;
@@ -105,7 +102,8 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
     public function testAddInvalidAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field,');
+        $this->expectExceptionMessage('Please use only letters (a-z or A-Z), ' .
+            'numbers (0-9) or underscore (_) in this field,');
 
         $attributeData = $this->getAttributeData();
         $this->eavSetup->addAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode, $attributeData);

--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Eav\Setup;
 
+use Magento\TestFramework\Fixture\AppIsolation;
+
 /**
  * Test class for Magento\Eav\Setup\EavSetup.
  * @magentoDbIsolation enabled
@@ -66,6 +68,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider addAttributeThrowExceptionDataProvider
      */
+    #[AppIsolation(true)]
     public function testAddAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
@@ -98,6 +101,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider addInvalidAttributeThrowExceptionDataProvider
      */
+    #[AppIsolation(true)]
     public function testAddInvalidAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);


### PR DESCRIPTION
### Description (*)

The EavSetup class provides methods to add EAV attributes, groups and sets. There are also corresponding methods to remove those records. But there is no opposite to `addAttributeToGroup`. This commit adds a `removeAttributeFromGroup` method, which fixes this lack.

An integration test which ensures that the method works, was added, too.

### Related Pull Requests

1. This PR depends on #39617

### Fixed Issues (if relevant)

1. Fixes magento/community-features#346

### Manual testing scenarios (*)
1. Add a data upgrade setup script with the following content:
```
$eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
$eavSetup->addAttribute(Product::ENTITY, 'test_attribute', [
    'type' => 'varchar',
    'label' => 'Test attribute',
    'input' => 'text',
    'required' => false,
    'global' => ScopedAttributeInterface::SCOPE_GLOBAL,
]);
$eavSetup->addAttributeToGroup(Product::ENTITY, 'Default', 'General', 'test_attribute');
$eavSetup->removeAttributeFromGroup(Product::ENTITY, 'Default', 'General', 'test_attribute');
```
2. Check if the attribute was correctly removed from the group (`eav_entity_attribute` table)

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
