### PR TITLE
Fixed deadlock issue with catalog_category_products indexer when using large catalogs

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/Action/Full.php
@@ -139,14 +139,14 @@ class Full extends AbstractAction
     }
 
     /**
-     * Truncates the replica tables
+     * Deletes the data from the replica tables
      *
      * @return void
      */
     private function clearReplicaTables(): void
     {
         foreach ($this->storeManager->getStores() as $store) {
-            $this->connection->truncateTable($this->tableMaintainer->getMainReplicaTable((int)$store->getId()));
+            $this->connection->delete($this->tableMaintainer->getMainReplicaTable((int)$store->getId()));
         }
     }
 


### PR DESCRIPTION
I manage a site with a very large number of products 300,000 and a massive category structure (1000+).

When running the indexer, this always hangs during the catalog_category_products indexer. On reviewing the database process list, this process has a 'Waiting for table metadata lock' status and this never completes.

### Description (*)
The issue seems to lie specifically with the TRUNCATE query. I have changed this query to a DELETE query. This seems to avoid the deadlock issue and indexing completed in under 1 minute.

### Manual testing scenarios (*)
Manual testing might be difficult. You would need to recreate a large product set and a large category structure. Then you could run the indexer.