### PR TITLE
Issue 39665 Return empty meta data if data provider is for cms block …

### DIFF
--- a/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/DataProviderTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Ui/Component/Listing/DataProviderTest.php
@@ -175,7 +175,12 @@ class DataProviderTest extends TestCase
 
         $this->assertEquals(
             $metadata,
-            $this->dataProvider->prepareMetadata()
+            $this->dataProvider->prepareMetadata($this->name)
+        );
+
+        $this->assertEquals(
+            [],
+            $this->dataProvider->prepareMetadata(DataProvider::CMS_BLOCK_LISTING_DATA_SOURCE)
         );
     }
 }

--- a/app/code/Magento/Cms/Ui/Component/DataProvider.php
+++ b/app/code/Magento/Cms/Ui/Component/DataProvider.php
@@ -20,6 +20,8 @@ use Magento\Ui\Component\Container;
  */
 class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider
 {
+    public const CMS_BLOCK_LISTING_DATA_SOURCE = 'cms_block_listing_data_source';
+
     /**
      * @var AuthorizationInterface
      */
@@ -77,8 +79,7 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
             $meta,
             $data
         );
-
-        $this->meta = array_replace_recursive($meta, $this->prepareMetadata());
+        $this->meta = array_replace_recursive($meta, $this->prepareMetadata($name));
         $this->additionalFilterPool = $additionalFilterPool;
     }
 
@@ -101,10 +102,14 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
     /**
      * Prepares Meta
      *
+     * @param string $name
      * @return array
      */
-    public function prepareMetadata()
+    public function prepareMetadata(string $name): array
     {
+        if ($name === self::CMS_BLOCK_LISTING_DATA_SOURCE) {
+            return [];
+        }
         $metadata = [];
 
         if (!$this->getAuthorizationInstance()->isAllowed('Magento_Cms::save')) {
@@ -123,7 +128,6 @@ class DataProvider extends \Magento\Framework\View\Element\UiComponent\DataProvi
                 ]
             ];
         }
-
         if (!$this->getAuthorizationInstance()->isAllowed('Magento_Cms::save_design')) {
 
             foreach ($this->pageLayoutColumns as $column) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Removed the unnecessary metadata which don't require for cms block listing data provider


### Fixed Issues (if relevant)

1. Fixes #39665 

### Manual testing scenarios (*)

1. Add Admin user with restricted permissions for merchandising only (allowed only to manage categories, products, cms blocks, cms pages). Important: you need to un-select "Edit Page Design" under "Save Page"
2. login into the admin
3. navigate to CMS Block
4. CMS Block listing page should be displayed without any error


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
