### PR TITLE
39586 Submenu group title not appearing in Marketing menu

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_menu.less
+++ b/app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_menu.less
@@ -522,11 +522,6 @@
             }
         }
     }
-
-    //  This part hides Submenu Group Titles only for menus with single groups.
-    .level-0 > .submenu > ul > .level-1:only-of-type > .submenu-group-title {
-        display: none;
-    }
 }
 
 .admin__menu-overlay {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Submenu group title not appearing in Marketing menu - Admin Panel
### Related Pull Requests
<!-- related pull request placeholder -->


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Go to admin panel and review USER CONTENT sub-menu in Marketing menu by clicking Marketing menu.
2. You can see "USER CONTENT" sub-menu title.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
