### PR TITLE
Fix storeCode is graphql issue

### DIFF
--- a/app/code/Magento/Store/App/Request/StorePathInfoValidator.php
+++ b/app/code/Magento/Store/App/Request/StorePathInfoValidator.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\Request\PathInfo;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
+use Magento\Framework\App\Area;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreIsInactiveException;
@@ -87,7 +88,12 @@ class StorePathInfoValidator implements ResetAfterRequestInterface
         }
         $storeCode = $this->getStoreCode($pathInfo);
 
-        if (empty($storeCode) || $storeCode === Store::ADMIN_CODE || !$this->storeCodeValidator->isValid($storeCode)) {
+        if (
+            empty($storeCode)
+            || $storeCode === Area::AREA_GRAPHQL
+            || $storeCode === Store::ADMIN_CODE
+            || !$this->storeCodeValidator->isValid($storeCode)
+        ) {
             return null;
         }
 


### PR DESCRIPTION

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
### Fix the case - when $storeCode === Area::AREA_GRAPHQL
```
 Magento\Store\Model\StoreRepository->get($code = 'graphql')
``` 
The issue provided by the request:
```
curl 'https://your-magento-test-host.com/graphql' -H 'accept: */*' -H 'accept-language: en-US,en;q=0.9' -H 'authorization;' -H 'cache-control: no-cache' -H 'content-type: application/json' -b 'SID=94638c7c90fa603674e1df25068d13d6; _ga=GA1.1.1738941708.1742491653; pwaProMore=1; cookie_accepted=true; cf_clearance=FwzcQkb_y5TxCmAatAQ22oOun9jzGow1XWdB8QA7VL0-1742536421-1.2.1.1-pQ_1vRuHXNR.t34JcS9EFcH.k1B54Hmkjaom_W.AmIcaCP1ycv39jwrMDu8RDR3rmr58YasLwU4ZURrJRVma7JsmhMljnCeNJ7oIeCYQbllqJSm43aQygaghKXQQ11Z_AgpFKtcVfz08AKDXYvyXzLVAmNxZW5pdlKu4wLe_kvI3Ss3GFDgOkLpPL1iwgzg_5WWCzFVyxD8mAvOvNzrSG6GqwrYnoI7wEz7JRRYCJm1N.UWw8YxFop4RqykGFQhLkmsyQVu9up.7RYaWoZAKvi_kHwbv_XMhGYybPe6se7eLdtoGBoGRHrjV7lprVwsKyek9WKgj2k0NzUFCbr6ByFRLZSmyCglFkfXgp_Wd4_o; _ga_LWFKYRLFVB=GS1.1.1742536422.5.0.1742536422.0.0.0' -H 'origin: https://your-magento-test-host.com' -H 'pragma: no-cache' -H 'priority: u=1, i' -H 'referer: https://your-magento-test-host.com/en_us/' -H 'sec-ch-ua: "Not:A-Brand";v="24", "Chromium";v="134"' -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Linux"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-origin' -H 'store: en_us' -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' -H 'x-magento-cache-id: b665ee02f24c915afc32f00f3697beb351eea255490f62b3e93dbdaf4ba1bff6' --data-raw '{"operationName":"createCart","variables":{},"query":"mutation createCart {\n  cartId: createEmptyCart\n}\n"}';
```
The above request is part of the magento pwa-studio requests.
The request executing e.g. during opening the home page. 

Affected to the Case:

Store::XML_PATH_STORE_IN_URL

Core config data value 'web/url/use_store' === 1
```
select * from core_config_data where path='web/url/use_store';
+-----------+---------+----------+-------------------+-------+---------------------+
| config_id | scope   | scope_id | path              | value | updated_at          |
+-----------+---------+----------+-------------------+-------+---------------------+
|       523 | default |        0 | web/url/use_store | 1     | 2024-08-29 20:49:29 |
+-----------+---------+----------+-------------------+-------+---------------------+

```


<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The fix appended additional verification for the case:
$storeCode === Area::AREA_GRAPHQL

To the method:
```
public function getValidStoreCode(Http $request, string $pathInfo = '') : ?string
```


### Related Commit:
[Merge branch 'ACP2E-3447' into PR-11-14-2024](https://github.com/magento/magento2/commit/87bc610555e48d9c1e20c3e8dc4cd2128462aa7f)
<!-- related pull request placeholder -->

### Fixed Issue
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes the firs part: related to the storeCode === Area::AREA_GRAPHQL issue magento/magento2#39742

```
Magento\Framework\Exception\NoSuchEntityException: The store that was requested wasn't found. Verify the store and try again.  in vendor/magento/module-store/Model/StoreRepository.php on line 75

Call Stack:
    0.0001     507288   1. {main}() pub/index.php:0
    0.0110    2907496   2. Magento\Framework\App\Bootstrap->run($application = class Magento\Framework\App\Http { ... }) pub/index.php:35
    0.0111    2919104   3. Magento\Framework\App\Http->launch() vendor/magento/framework/App/Bootstrap.php:264
    0.0111    2919104   4. Magento\Framework\App\Request\Http->getFrontName() vendor/magento/framework/App/Http.php:111
    0.0111    2919104   5. Magento\Framework\App\Request\Http->getPathInfo() vendor/magento/framework/App/Request/Http.php:219
    0.0111    2919104   6. Magento\Framework\App\Request\Http->getOriginalPathInfo() vendor/magento/framework/App/Request/Http.php:169
    0.0111    2919144   7. Magento\Backend\App\Request\PathInfoProcessor\Proxy->process($request = class Magento\Framework\App\Request\Http { ... }, $pathInfo = '/graphql') vendor/magento/framework/App/Request/Http.php:154
    0.0121    2927000   8. Magento\Backend\App\Request\PathInfoProcessor->process($request = class Magento\Framework\App\Request\Http { ... }, $pathInfo = '/graphql') generated/code/Magento/Backend/App/Request/PathInfoProcessor/Proxy.php:105
    0.0140    3653080   9. Magento\Store\App\Request\PathInfoProcessor->process($request = class Magento\Framework\App\Request\Http { ... }, $pathInfo = '/graphql') vendor/magento/module-backend/App/Request/PathInfoProcessor.php:55
    0.0140    3653080  10. Magento\Store\App\Request\StorePathInfoValidator->getValidStoreCode($request = class Magento\Framework\App\Request\Http { ... }, $pathInfo = '/graphql') vendor/magento/module-store/App/Request/PathInfoProcessor.php:42
    0.0143    3818928  11. Magento\Store\Model\StoreRepository->getActiveStoreByCode($code = 'graphql') vendor/magento/module-store/App/Request/StorePathInfoValidator.php:99
    0.0143    3818928  12. Magento\Store\Model\StoreRepository->get($code = 'graphql') vendor/magento/module-store/Model/StoreRepository.php:89

```

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. After fix: the issue related to $storeCode === Area::AREA_GRAPHQL disappeared
2. Empty xdebug output - related to the case of the request:
```
curl 'https://your-magento-test-host.com/graphql' -H 'accept: */*' -H 'accept-language: en-US,en;q=0.9' -H 'authorization;' -H 'cache-control: no-cache' -H 'content-type: application/json' -b 'SID=94638c7c90fa603674e1df25068d13d6; _ga=GA1.1.1738941708.1742491653; pwaProMore=1; cookie_accepted=true; cf_clearance=FwzcQkb_y5TxCmAatAQ22oOun9jzGow1XWdB8QA7VL0-1742536421-1.2.1.1-pQ_1vRuHXNR.t34JcS9EFcH.k1B54Hmkjaom_W.AmIcaCP1ycv39jwrMDu8RDR3rmr58YasLwU4ZURrJRVma7JsmhMljnCeNJ7oIeCYQbllqJSm43aQygaghKXQQ11Z_AgpFKtcVfz08AKDXYvyXzLVAmNxZW5pdlKu4wLe_kvI3Ss3GFDgOkLpPL1iwgzg_5WWCzFVyxD8mAvOvNzrSG6GqwrYnoI7wEz7JRRYCJm1N.UWw8YxFop4RqykGFQhLkmsyQVu9up.7RYaWoZAKvi_kHwbv_XMhGYybPe6se7eLdtoGBoGRHrjV7lprVwsKyek9WKgj2k0NzUFCbr6ByFRLZSmyCglFkfXgp_Wd4_o; _ga_LWFKYRLFVB=GS1.1.1742536422.5.0.1742536422.0.0.0' -H 'origin: https://your-magento-test-host.com' -H 'pragma: no-cache' -H 'priority: u=1, i' -H 'referer: https://your-magento-test-host.com/en_us/' -H 'sec-ch-ua: "Not:A-Brand";v="24", "Chromium";v="134"' -H 'sec-ch-ua-mobile: ?0' -H 'sec-ch-ua-platform: "Linux"' -H 'sec-fetch-dest: empty' -H 'sec-fetch-mode: cors' -H 'sec-fetch-site: same-origin' -H 'store: en_us' -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' -H 'x-magento-cache-id: b665ee02f24c915afc32f00f3697beb351eea255490f62b3e93dbdaf4ba1bff6' --data-raw '{"operationName":"createCart","variables":{},"query":"mutation createCart {\n  cartId: createEmptyCart\n}\n"}';
```

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
But, the second part the issue related to the "infinite loop" still exists.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
