### PR TITLE
fix items getChilderen returns empty array for parent cart items when…

### DIFF
--- a/app/code/Magento/Checkout/Block/Cart/Grid.php
+++ b/app/code/Magento/Checkout/Block/Cart/Grid.php
@@ -6,6 +6,10 @@
 
 namespace Magento\Checkout\Block\Cart;
 
+use Magento\Quote\Model\ResourceModel\Quote\Item\Collection;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Theme\Block\Html\Pager;
+
 /**
  * Block on checkout/cart/index page to display a pager on the  cart items grid
  * The pager will be displayed if items quantity in the shopping cart > than number from
@@ -23,7 +27,7 @@ class Grid extends \Magento\Checkout\Block\Cart
     const XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER = 'checkout/cart/number_items_to_display_pager';
 
     /**
-     * @var \Magento\Quote\Model\ResourceModel\Quote\Item\Collection
+     * @var Collection
      */
     private $itemsCollection;
 
@@ -110,29 +114,53 @@ class Grid extends \Magento\Checkout\Block\Cart
         if ($this->isPagerDisplayedOnPage()) {
             $availableLimit = (int)$this->_scopeConfig->getValue(
                 self::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                ScopeInterface::SCOPE_STORE
             );
             $itemsCollection = $this->getItemsForGrid();
-            /** @var  \Magento\Theme\Block\Html\Pager $pager */
-            $pager = $this->getLayout()->createBlock(\Magento\Theme\Block\Html\Pager::class);
+            /** @var  Pager $pager */
+            $pager = $this->getLayout()->createBlock(Pager::class);
             $pager->setAvailableLimit([$availableLimit => $availableLimit])->setCollection($itemsCollection);
             $this->setChild('pager', $pager);
+            $this->updateCollectionWithQuoteItems($itemsCollection);
             $itemsCollection->load();
             $this->prepareItemUrls();
         }
         return $this;
     }
 
+    private function updateCollectionWithQuoteItems(
+        Collection $itemsCollection
+    ) {
+        foreach ($itemsCollection->getItems() as $key => $collectionItem) {
+            $quote      = $this->getQuote();
+            $quoteItems = $quote->getItems();
+            foreach ($quoteItems as $quoteItem) {
+                if ($quoteItem->getSku() === $collectionItem->getSku()) {
+                    $itemsCollection->removeItemByKey($key);
+                    try {
+                        $itemsCollection->addItem($quoteItem);
+                    } catch (\Exception $e) {
+                        // No action, item id removed
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return $itemsCollection;
+    }
+
     /**
      * Prepare quote items collection for pager
      *
-     * @return \Magento\Quote\Model\ResourceModel\Quote\Item\Collection
+     * @return Collection
      * @since 100.1.7
      */
     public function getItemsForGrid()
     {
         if (!$this->itemsCollection) {
-            /** @var \Magento\Quote\Model\ResourceModel\Quote\Item\Collection $itemCollection */
+            /** @var Collection $itemCollection */
             $itemCollection = $this->itemCollectionFactory->create();
 
             $itemCollection->setQuote($this->getQuote());
@@ -167,7 +195,7 @@ class Grid extends \Magento\Checkout\Block\Cart
         if (!$this->isPagerDisplayed) {
             $availableLimit = (int)$this->_scopeConfig->getValue(
                 self::XPATH_CONFIG_NUMBER_ITEMS_TO_DISPLAY_PAGER,
-                \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+                ScopeInterface::SCOPE_STORE
             );
             $this->isPagerDisplayed = !$this->getCustomItems() && $availableLimit < $this->getItemsCount();
         }


### PR DESCRIPTION
### Description (*)
This pull request addresses a known issue in Magento Checkout where child products are not displayed correctly when the cart contains more than 20 products and pagination is enabled. the issue is that `$_item->getHasChildren()` returns `NULL` and `$_item->getChilderen()` returns `NULL` for configurable products when the cart is paginated. 

To fix this, I've implemented the following changes:

1. **Added `updateCollectionWithQuoteItems` Method**: This method iterates over the items in the collection and updates them with the corresponding quote items. It ensures that the correct items are displayed in the cart, even when pagination is active.

These changes ensure that `$_item->getHasChildren()` returns `true` for configurable products, and `$_item->getChildren()` returns the correct array of child items, regardless of pagination status. This resolves the issue described in [#34507](https://github.com/magento/magento2/issues/34507) and improves the reliability of the checkout process.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#34507

### Related Pull Requests
[35739](https://github.com/magento/magento2/pull/35739)

### Manual testing scenarios (*)
1. Add both configurable and non-configurable products to the cart.
3. Print the `$_item->getHasChildren()` property in the `Magento_Checkout/cart/item/default.phtml` template.
4. Observe the function output with and without pagination in the cart.

#### Expected result
The cart should behave as expected even when underlying code is calling for childeren of a products i.e.  `$_item->getHasChildren()` and `$_item->getChilderen()`.

![image](https://github.com/user-attachments/assets/5601324a-3db0-4083-a5a7-b83572558d4b)

