### PR TITLE
Only load attributes from attribute set of given entity type

### DIFF
--- a/app/code/Magento/Eav/Model/AttributeManagement.php
+++ b/app/code/Magento/Eav/Model/AttributeManagement.php
@@ -182,7 +182,9 @@ class AttributeManagement implements \Magento\Eav\Api\AttributeManagementInterfa
             throw NoSuchEntityException::singleField('attributeSetId', $attributeSetId);
         }
         $attributeCollection = $this->attributeCollectionFactory->create();
-        $attributeCollection->setAttributeSetFilter($attributeSet->getAttributeSetId())->load();
+        $attributeCollection->setAttributeSetFilter($attributeSet->getAttributeSetId())
+            ->addFieldToFilter('entity_attribute.entity_type_id', $requiredEntityTypeId)
+            ->load();
 
         return $attributeCollection->getItems();
     }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
The `eav_entity_attribute` table can contain attributes of different entity types (from third parties), next to the `catalog_product` entity type attributes. These attributes can possibly have the same attribute set IDs as the `catalog_product` entity attribute set IDs.
This can cause issues when loading the attributes by attribute set for a product.

For example: when switching a product's attribute set to a different attribute set, the following snippet will try to delete the data of the product of the old attribute set:
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/Model/ResourceModel/Product.php#L344-L355

This will result in the following error:
```
Call to a member function getBackendTable() on bool
```
On: https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Catalog/Model/ResourceModel/Product.php#L373:

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Create a custom entity type, or install a third party extension which adds custom entity types (like https://mirasvit.com/magento-2-extensions/blog.html, which adds `blog_post` and `blog_category` entity types), and make sure you have a product attribute set ID with the same attribute set ID of the custom entity type.
2. Try to switch the attribute set of an existing product, which currently has a product attribute set ID which is the same as one of the custom entity type IDs.
3. When trying to save the product, the following error will appear:
```Call to a member function getBackendTable() on bool```

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39815: Only load attributes from attribute set of given entity type