### PR TITLE
Improve backoffice category display performance

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -374,20 +374,22 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     private function getCountFromCategoryTableBulk(
         array $categoryIds,
         int $websiteId
-    ) : array {
-        $subSelect = clone $this->_conn->select();
-        $subSelect->from(['ce2' => $this->getTable('catalog_category_entity')], 'ce2.entity_id')
-            ->where("ce2.path LIKE CONCAT(ce.path, '/%') OR ce2.path = ce.path");
-
+    ): array {
         $select = clone $this->_conn->select();
         $select->from(
             ['ce' => $this->getTable('catalog_category_entity')],
             'ce.entity_id'
         );
-        $joinCondition =  new \Zend_Db_Expr("cp.category_id IN ({$subSelect})");
+
+        $select->joinLeft(
+            ['ce2' => $this->getTable('catalog_category_entity')],
+            new \Zend_Db_Expr("ce2.path LIKE CONCAT(ce.path, '/%') OR ce2.path = ce.path"),
+            []
+        );
+
         $select->joinLeft(
             ['cp' => $this->getProductTable()],
-            $joinCondition,
+            'cp.category_id = ce2.entity_id',
             'COUNT(DISTINCT cp.product_id) AS product_count'
         );
         if ($websiteId) {


### PR DESCRIPTION
This PR improvement performance of categroy display in BO. It fixes #39829

### Description
This PR change a time consuming subselect in SQL query for a fast join.

### Fixed Issues
Fixes magento/magento2#39829

### Manual testing scenarios
Connect to BO
Go on Catalog -> Category
Check that numbers in parenthesis near category names are corresponding to number of category products

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
