### PR TITLE
Fix "Cannot return null for non-nullable field \"AppliedCoupon.code\"" error

### DIFF
--- a/app/code/Magento/SalesGraphQl/Model/Formatter/Order.php
+++ b/app/code/Magento/SalesGraphQl/Model/Formatter/Order.php
@@ -57,7 +57,7 @@ class Order
             'shipping_address' => $this->orderAddress->getOrderShippingAddress($orderModel),
             'billing_address' => $this->orderAddress->getOrderBillingAddress($orderModel),
             'payment_methods' => $this->orderPayments->getOrderPaymentMethod($orderModel),
-            'applied_coupons' => $orderModel->getCouponCode() ? ['code' => $orderModel->getCouponCode()] : [],
+            'applied_coupons' => $orderModel->getCouponCode() ? [['code' => $orderModel->getCouponCode()]] : [],
             'model' => $orderModel,
             'comments' => $this->getOrderComments($orderModel)
         ];


### PR DESCRIPTION
Fix #39830

### Description
Fix GraphQL unexpected error when you query customer order applied_coupons.code node

### Fixed Issues
Fixes magento/magento2#39830

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
