### PR TITLE
Magento 2.4.8: Fixed missing screen-l styles added using .media-width mixin

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/blank/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -32,7 +32,7 @@
 @checkout-shipping-item-mobile__active__padding: 15px (@indent__l + 5px) 15px 18px;
 
 @checkout-shipping-item-before__border-color: @color-gray80;
-@checkout-shipping-item-before__height: calc(~'100% - 20px');
+@checkout-shipping-item-before__height: ~"calc(100% - 20px)";
 
 @checkout-shipping-method__border: @checkout-step-title__border;
 @checkout-shipping-method__padding: @indent__base;

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/_shipping.less
@@ -32,7 +32,7 @@
 @checkout-shipping-item-mobile__active__padding: 15px (@indent__l + 5px) 15px 18px;
 
 @checkout-shipping-item-before__border-color: @color-gray80;
-@checkout-shipping-item-before__height: calc(~'100% - 20px');
+@checkout-shipping-item-before__height: ~"calc(100% - 20px)";
 
 @checkout-shipping-method__border: @checkout-step-title__border;
 @checkout-shipping-method__padding: @indent__base;

--- a/lib/web/css/source/lib/_responsive.less
+++ b/lib/web/css/source/lib/_responsive.less
@@ -74,6 +74,11 @@
         .media-width('max', @screen__l);
     }
 
+    @media all and (min-width: (@screen__l)),
+    print {
+        .media-width('min', @screen__l);
+    }
+
     @media all and (min-width: @screen__xl),
     print {
         .media-width('min', @screen__xl);


### PR DESCRIPTION
### Description
This PR fixes completely missing screen-l styles in Magento 2.4.8.
This commit https://github.com/magento/magento2/commit/438f9782d85fe6a2694ccc01c97f2a4c2a81f5bb causes the issue

### Fixed Issues
- Fixes https://github.com/magento/magento2/issues/39817

### Manual testing scenarios
Open category page on large screen (>1024) and see products columns count.

Without PR | With PR
----------------|---------------
![image](https://github.com/user-attachments/assets/d7a8a64f-2ec4-4c6d-a57f-15b563ea2f8a) | ![image](https://github.com/user-attachments/assets/05b5e8cd-53a9-4a82-9d48-a8bc5becae95)

### Questions or comments
While this PR fully fixes the issue, I would like to hear your thoughts on the code added in [commit that caused](https://github.com/magento/magento2/commit/438f9782d85fe6a2694ccc01c97f2a4c2a81f5bb) the issue. This code was added instead of old mixin:

```less
@media all and (max-width: (@screen__l - 1)),
print {
    .media-width('max', @screen__l);
}
```

I believe this code should be removed? I can't find out if it's used. Can somebody from Magento confirm that this code is needed and used by magento?

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
