### PR TITLE
Fix case insensitive SQL fiter(where) condition

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -3190,6 +3190,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface, Rese
 
         $query = '';
         if (is_array($condition)) {
+            $condition = array_change_key_case($condition, CASE_LOWER);
             $key = key(array_intersect_key($condition, $conditionKeyMap));
 
             if (isset($condition['from']) || isset($condition['to'])) {


### PR DESCRIPTION
or you can also make this for edge case: 
           $key = key(array_intersect_key($condition, $conditionKeyMap));
            if(!$key) {
                $condition = array_change_key_case($condition, CASE_LOWER);
                $key = key(array_intersect_key($condition, $conditionKeyMap));
            }

Even like this will be even better: 

            $key = key(array_intersect_key($condition, $conditionKeyMap));
            if(!$key) {
                $condition = array_change_key_case($condition, CASE_LOWER);
                $key = key(array_intersect_key($condition, $conditionKeyMap));
            }
            if(!$key && isset($condition[0]) && key($condition) !== 0) {
                throw new \InvalidArgumentException('Invalid SQL condition: ' . print_r($condition, true));
            }