### PR TITLE
Update frontend_label and apply_to in CategoryAttribute Fixture.

### DIFF
--- a/app/code/Magento/Catalog/Test/Fixture/CategoryAttribute.php
+++ b/app/code/Magento/Catalog/Test/Fixture/CategoryAttribute.php
@@ -41,10 +41,10 @@ class CategoryAttribute implements RevertibleDataFixtureInterface
         'entity_type_id' => '3',
         'is_required' => false,
         'is_user_defined' => true,
-        'default_frontend_label' => 'Category Attribute%uniqid%',
+        'frontend_label' => 'Category Attribute%uniqid%',
         'backend_type' => 'varchar',
         'is_unique' => '0',
-        'apply_to' => [],
+        'apply_to' => 'category',
     ];
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

This PR aims to address issues discovered when trying to use the following fixture.  `app/code/Magento/Catalog/Test/Fixture/CategoryAttribute.php` 

1. Using it without setting any values results in the following errror
```
Unable to apply fixture: Magento\Catalog\Test\Fixture\CategoryAttribute (attr)
Caused by
PHPUnit\Framework\Exception: Warning: Array to string conversion in /var/www/html/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php:3337.
```
2. Label does not get set as it's setting it to `default_frontend_label` when the value that it actually saves/loads from is `frontend_label`.

#### Changes

1. Update `apply_to` to have a default of `category` which I took from  `dev/tests/api-functional/testsuite/Magento/GraphQl/CatalogGraphQl/AttributesMetadataTest.php`
2. Update `default_frontend_label` to `frontend_label`

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Create an integration test with using the fixture `app/code/Magento/Catalog/Test/Fixture/CategoryAttribute.php`
2. Confirm that you can create category attribute overriding any of the data such as `apply_to` and no errors should occur.
3. Confirm that the test succeeds as label should not be null as it's set in the default data for given fixture.
4. 
```php
<?php

namespace integration\testsuite\Magento\Catalog;

use Magento\Catalog\Test\Fixture\CategoryAttribute;
use Magento\TestFramework\Fixture\DataFixture;
use Magento\TestFramework\Fixture\DataFixtureStorageManager;
use PHPUnit\Framework\TestCase;

class CategoryLabelFixtureTest extends TestCase
{

    #[
        DataFixture(CategoryAttribute::class, [], as: "attr")
    ]
    public function testCategoryLabelFixture(): void
    {
        $fixture = DataFixtureStorageManager::getStorage();
        $categoryAttribute = $fixture->get('attr');
        $this->assertNotNull($categoryAttribute->getDefaultFrontendLabel());
    }
}

```
5. 


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#39942: Update frontend_label and apply_to in CategoryAttribute Fixture.