### PR TITLE
Clarified Attribute Option already exists response

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2378,7 +2378,7 @@ class Product extends AbstractEntity
     /**
      * Uploading files into the "catalog/product" media folder.
      *
-     * Return a new file name if the same file is already exists.
+     * Return a new file name if the same file already exists.
      *
      * @param string $fileName
      * @param bool $renameFileOff [optional] boolean to pass.

--- a/app/code/Magento/DownloadableImportExport/Model/Import/Product/Type/Downloadable.php
+++ b/app/code/Magento/DownloadableImportExport/Model/Import/Product/Type/Downloadable.php
@@ -1036,7 +1036,7 @@ class Downloadable extends \Magento\CatalogImportExport\Model\Import\Product\Typ
     /**
      * Uploading files into the "downloadable/files" media folder.
      *
-     * Return a new file name if the same file is already exists.
+     * Return a new file name if the same file already exists.
      *
      * @param string $fileName
      * @param string $type

--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -68,7 +68,7 @@ class OptionManagement implements AttributeOptionManagementInterface, AttributeO
         if ($attribute->getSource()->getOptionId($label) !== null) {
             throw new InputException(
                 __(
-                    'Admin store attribute option label "%1" is already exists.',
+                    'Admin store attribute option label "%1" already exists.',
                     $option->getLabel()
                 )
             );
@@ -110,7 +110,7 @@ class OptionManagement implements AttributeOptionManagementInterface, AttributeO
         if (!empty($optionIdByLabel) && (int)$optionIdByLabel !== (int)$optionId) {
             throw new InputException(
                 __(
-                    'Admin store attribute option label \'%1\' is already exists.',
+                    'Admin store attribute option label \'%1\' already exists.',
                     $option->getLabel()
                 )
             );

--- a/app/code/Magento/Eav/i18n/en_US.csv
+++ b/app/code/Magento/Eav/i18n/en_US.csv
@@ -143,4 +143,4 @@ hello,hello
 "The value of attribute not valid","The value of attribute not valid"
 "EAV types and attributes","EAV types and attributes"
 "Entity types declaration cache","Entity types declaration cache"
-"Admin store attribute option label ""%1"" is already exists.","Admin store attribute option label ""%1"" is already exists."
+"Admin store attribute option label ""%1"" already exists.","Admin store attribute option label ""%1"" already exists."

--- a/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionUpdateInterfaceTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Catalog/Api/ProductAttributeOptionUpdateInterfaceTest.php
@@ -76,7 +76,7 @@ class ProductAttributeOptionUpdateInterfaceTest extends WebapiAbstract
      */
     public function testUpdateWithAlreadyExistsException()
     {
-        $this->expectExceptionMessage("Admin store attribute option label '%1' is already exists.");
+        $this->expectExceptionMessage("Admin store attribute option label '%1' already exists.");
         $testAttributeCode = 'select_attribute';
 
         $newOptionData = [

--- a/lib/internal/Magento/Framework/File/Uploader.php
+++ b/lib/internal/Magento/Framework/File/Uploader.php
@@ -806,7 +806,7 @@ class Uploader
     }
 
     /**
-     * Get new file name if the same is already exists
+     * Get new file name if the same already exists
      *
      * @param string $destinationFile
      * @return string


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Replaced the awkward phrase "Get new file name if the same is already exists" with a clearer and grammatically correct version: "Get a new file name if one already exists." This improves readability and user understanding.
Same for the attribute option response.

### Manual testing scenarios (*)
1. pushing an already existing attribute option to the attribute option api endpoint.

### Questions or comments
First time PR to Magento. Please let me know if i need to do something else.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
