### PR TITLE
Update definition.map.xml

### DIFF
--- a/app/code/Magento/Ui/view/base/ui_component/etc/definition.map.xml
+++ b/app/code/Magento/Ui/view/base/ui_component/etc/definition.map.xml
@@ -369,6 +369,9 @@
                     <item name="allowedExtensions" type="string" xsi:type="xpath">
                         formElements/*[name(.)=../../@formElement]/settings/allowedExtensions
                     </item>
+                    <item name="isMultipleFiles" type="string" xsi:type="xpath">
+                        formElements/*[name(.)=../../@formElement]/settings/isMultipleFiles
+                    </item>
                     <item name="openDialogTitle" type="string" xsi:type="xpath">
                         formElements/*[name(.)=../../@formElement]/settings/openDialogTitle
                     </item>


### PR DESCRIPTION
fix isMultipleFiles option for fileUploader component

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
isMultipleFiles option settings doesn't work for fileUploader element in the form ui_component xml.
Even if you add <isMultipleFiles>true</isMultipleFiles> it is not read and it remains false as default.

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. create a field with fileUploader element in a form ui component
2. add the <isMultipleFiles>true</isMultipleFiles>
3. visit the page and you could add multiple files

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
