### PR TITLE
Incorrect Scope Assigned to Price Attributes at Creation

### DIFF
--- a/app/code/Magento/Catalog/Observer/ChangePriceAttributeScopeOnCreate.php
+++ b/app/code/Magento/Catalog/Observer/ChangePriceAttributeScopeOnCreate.php
@@ -30,7 +30,7 @@ class ChangePriceAttributeScopeOnCreate implements ObserverInterface
     /**
      * Change scope for price attribute when create
      *
-     * @param   \EventObserver $observer
+     * @param   EventObserver $observer
      * @return  $this
      */
     public function execute(EventObserver $observer)

--- a/app/code/Magento/Catalog/Observer/ChangePriceAttributeScopeOnCreate.php
+++ b/app/code/Magento/Catalog/Observer/ChangePriceAttributeScopeOnCreate.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Observer;
+
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Helper\Data;
+use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Store\Model\Store;
+
+/**
+ * Observer is responsible for changing scope for new price attributes in system
+ * depending on 'Catalog Price Scope' configuration parameter
+ */
+class ChangePriceAttributeScopeOnCreate implements ObserverInterface
+{
+    /**
+     * @param Data $catalogData
+     */
+    public function __construct(
+        private Data $catalogData
+    ) {
+    }
+
+    /**
+     * Change scope for price attribute when create
+     *
+     * @param   \EventObserver $observer
+     * @return  $this
+     */
+    public function execute(EventObserver $observer)
+    {
+        $attribute = $observer->getEvent()->getAttribute();
+        if (empty($attribute->getId) && $attribute->getFrontendInput() == 'price') {
+            $scope = $this->catalogData->getPriceScope();
+            $scope = ($scope == Store::PRICE_SCOPE_WEBSITE)
+                ? ProductAttributeInterface::SCOPE_WEBSITE_TEXT
+                : ProductAttributeInterface::SCOPE_GLOBAL_TEXT;
+            $attribute->setScope($scope);
+        }
+        return $this;
+    }
+}

--- a/app/code/Magento/Catalog/etc/events.xml
+++ b/app/code/Magento/Catalog/etc/events.xml
@@ -70,4 +70,7 @@
     <event name="admin_system_config_changed_section_general">
         <observer name="move_store_level_catalog_data_to_website_scope_on_single_store_mode" instance="Magento\Catalog\Observer\MoveStoreLevelCatalogDataToWebsiteScopeOnSingleStoreMode" />
     </event>
+    <event name="catalog_entity_attribute_save_before">
+        <observer name="catalog_attribute_price_scope" instance="Magento\Catalog\Observer\ChangePriceAttributeScopeOnCreate" />
+    </event>
 </config>

--- a/app/code/Magento/Catalog/etc/events.xml
+++ b/app/code/Magento/Catalog/etc/events.xml
@@ -71,6 +71,6 @@
         <observer name="move_store_level_catalog_data_to_website_scope_on_single_store_mode" instance="Magento\Catalog\Observer\MoveStoreLevelCatalogDataToWebsiteScopeOnSingleStoreMode" />
     </event>
     <event name="catalog_entity_attribute_save_before">
-        <observer name="catalog_attribute_price_scope" instance="Magento\Catalog\Observer\ChangePriceAttributeScopeOnCreate" />
+        <observer name="catalog_attribute_price_scope_change" instance="Magento\Catalog\Observer\ChangePriceAttributeScopeOnCreate" />
     </event>
 </config>

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Save/AttributePriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Save/AttributePriceTest.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2019 Adobe
+ * All Rights Reserved.
  */
 declare(strict_types=1);
 
 namespace Magento\Catalog\Model\Product\Attribute\Save;
 
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use Magento\Eav\Model\Entity\Attribute\Exception;
 
 /**
@@ -49,6 +50,18 @@ class AttributePriceTest extends AbstractAttributeTest
     public function testDefaultValue(string $productSku): void
     {
         // product price attribute does not support default value
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_decimal_attribute.php
+     * @magentoConfigFixture current_store catalog/price/scope 1
+     */
+    public function testScopePriceAttribute()
+    {
+        $this->assertEquals(
+            $this->getAttribute()->getIsGlobal(),
+            ProductAttributeInterface::SCOPE_WEBSITE_TEXT
+        );
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Save/AttributePriceTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Product/Attribute/Save/AttributePriceTest.php
@@ -58,10 +58,7 @@ class AttributePriceTest extends AbstractAttributeTest
      */
     public function testScopePriceAttribute()
     {
-        $this->assertEquals(
-            $this->getAttribute()->getIsGlobal(),
-            ProductAttributeInterface::SCOPE_WEBSITE_TEXT
-        );
+        $this->assertTrue($this->getAttribute()->isScopeWebsite());
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#39986
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#39986

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
