### PR TITLE
Do not reapply patches in case it got already applied with one of it's aliases

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
+++ b/lib/internal/Magento/Framework/Setup/Patch/PatchApplier.php
@@ -153,6 +153,19 @@ class PatchApplier
                     new Phrase("Patch %1 should implement DataPatchInterface", [get_class($dataPatch)])
                 );
             }
+            /**
+             * If the patch was already applied before with a name from its aliases,we fix the new name as well but
+             * skip it's installation, otherwise we fix the alias name in history.
+             */
+            foreach ($dataPatch->getAliases() as $patchAlias) {
+                if ($this->patchHistory->isApplied($patchAlias)) {
+                    $this->patchHistory->fixPatch(get_class($dataPatch));
+
+                    continue 2;
+                }
+
+                $this->patchHistory->fixPatch($patchAlias);
+            }
             if ($dataPatch instanceof NonTransactionableInterface) {
                 $dataPatch->apply();
                 $this->patchHistory->fixPatch(get_class($dataPatch));
@@ -161,11 +174,6 @@ class PatchApplier
                     $this->moduleDataSetup->getConnection()->beginTransaction();
                     $dataPatch->apply();
                     $this->patchHistory->fixPatch(get_class($dataPatch));
-                    foreach ($dataPatch->getAliases() as $patchAlias) {
-                        if (!$this->patchHistory->isApplied($patchAlias)) {
-                            $this->patchHistory->fixPatch($patchAlias);
-                        }
-                    }
                     $this->moduleDataSetup->getConnection()->commit();
                 } catch (\Exception $e) {
                     $this->moduleDataSetup->getConnection()->rollBack();
@@ -240,13 +248,23 @@ class PatchApplier
                  * @var SchemaPatchInterface $schemaPatch
                  */
                 $schemaPatch = $this->patchFactory->create($schemaPatch, ['schemaSetup' => $this->schemaSetup]);
+
+                /**
+                 * If the patch was already applied before with a name from its aliases, we fix the new name as well but
+                 * skip it's installation, otherwise we fix the alias name in history.
+                 */
+                foreach ($schemaPatch->getAliases() as $patchAlias) {
+                    if ($this->patchHistory->isApplied($patchAlias)) {
+                        $this->patchHistory->fixPatch(get_class($schemaPatch));
+
+                        continue 2;
+                    }
+
+                    $this->patchHistory->fixPatch($patchAlias);
+                }
+
                 $schemaPatch->apply();
                 $this->patchHistory->fixPatch(get_class($schemaPatch));
-                foreach ($schemaPatch->getAliases() as $patchAlias) {
-                    if (!$this->patchHistory->isApplied($patchAlias)) {
-                        $this->patchHistory->fixPatch($patchAlias);
-                    }
-                }
             } catch (\Exception $e) {
                 $schemaPatchClass = is_object($schemaPatch) ? get_class($schemaPatch) : $schemaPatch;
                 throw new SetupException(


### PR DESCRIPTION
### Description (*)
In case a patch has defined aliases in `getAliases` it should be checked, if one of those aliases already got applied before and is fixed in `patch_list` DB table.  
In case it is, the patch must not be reapplied as it just got renamed / moved for some reason, but we still want to make sure the new name is also fixed in `patch_list` DB table.

### Related Pull Requests
1. https://github.com/magento/magento2/pull/31635

### Fixed Issues (if relevant)

1. Fixes magento/magento2#23031
2. Fixes magento/magento2#31396

### Manual testing scenarios (*)
1. Create a data and a schema patch
2. Apply the patches by running `bin/magento setup:upgrade`
3. Create a new data and schema patch having the respective patches from above defined in `getAliases`
4. Apply the patches by running `bin/magento setup:upgrade`
5. Verify that the new patches weren't re-applied but fixed in the `patch_list` DB table

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
