### PR TITLE
Improve performance of the Category page

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -11,6 +11,12 @@
 $width = (int)$block->getWidth();
 $height = (int)$block->getHeight();
 $paddingBottom = $block->getRatio() * 100;
+
+if (!isset($_GET['cat_image'])) {
+    $_GET['cat_image'] = 0;
+}
+$_GET['cat_image']++;
+$isProductPage = ($block->getRequest()->getFullActionName() === 'catalog_product_view');
 ?>
 <span class="product-image-container product-image-container-<?= /* @noEscape */ $block->getProductId() ?>">
     <span class="product-image-wrapper">
@@ -19,7 +25,10 @@ $paddingBottom = $block->getRatio() * 100;
                 <?= $escaper->escapeHtmlAttr($name) ?>="<?= $escaper->escapeHtml($value) ?>"
             <?php endforeach; ?>
             src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
+            <?php if ($_GET['cat_image'] > 1 || $isProductPage) { ?>
             loading="lazy"
+            fetchpriority="low"
+            <?php }?>
             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
             height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
             alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"/></span>

--- a/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
+++ b/app/code/Magento/Catalog/view/frontend/templates/product/image_with_borders.phtml
@@ -12,11 +12,17 @@ $width = (int)$block->getWidth();
 $height = (int)$block->getHeight();
 $paddingBottom = $block->getRatio() * 100;
 
-if (!isset($_GET['cat_image'])) {
-    $_GET['cat_image'] = 0;
+$globalBlock = $block->getLayout()->getBlock('header');
+if ($globalBlock) {
+    $catImage = $globalBlock->getData('cat_image_counter') ?? 0;
+    $catImage++;
+    $globalBlock->setData('cat_image_counter', $catImage);
+} else {
+    $catImage = 10;
 }
-$_GET['cat_image']++;
+
 $isProductPage = ($block->getRequest()->getFullActionName() === 'catalog_product_view');
+$isHomePage = ($block->getFullActionName() === 'cms_index_index');
 ?>
 <span class="product-image-container product-image-container-<?= /* @noEscape */ $block->getProductId() ?>">
     <span class="product-image-wrapper">
@@ -24,11 +30,14 @@ $isProductPage = ($block->getRequest()->getFullActionName() === 'catalog_product
             <?php foreach ($block->getCustomAttributes() as $name => $value): ?>
                 <?= $escaper->escapeHtmlAttr($name) ?>="<?= $escaper->escapeHtml($value) ?>"
             <?php endforeach; ?>
-            src="<?= $escaper->escapeUrl($block->getImageUrl()) ?>"
-            <?php if ($_GET['cat_image'] > 1 || $isProductPage) { ?>
+             src="<?=$escaper->escapeUrl($block->getImageUrl())?>"
+            <?php if ($catImage > 1 || $isProductPage || $isHomePage) { ?>
             loading="lazy"
             fetchpriority="low"
-            <?php }?>
+            <?php } else { ?>
+            loading="eager"
+            fetchpriority="high"
+            <?php } ?>
             width="<?= $escaper->escapeHtmlAttr($block->getWidth()) ?>"
             height="<?= $escaper->escapeHtmlAttr($block->getHeight()) ?>"
             alt="<?= $escaper->escapeHtmlAttr($block->getLabel()) ?>"/></span>


### PR DESCRIPTION
Lazy load all images except 1. Lazy load negatively impacts LCP metric you shouldn't lazy load LCP element for category it is first image if no big image in the description. We are adding global counter



### Resolved issues:
1. [x] resolves magento/magento2#40087: Improve performance of the Category page