### PR TITLE
[Issue-39831] Resolve Calendar popup opens over display

### DIFF
--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -102,12 +102,13 @@ define([
             }
         },
 
-        _overwriteFindPos: function () {
+       _overwriteFindPos: function () {
             $.datepicker.constructor.prototype._findPos = function (obj) {
-                var rect = obj.getBoundingClientRect();
-                var docEl = document.documentElement;
-                var left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0);
-                var top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
+                var rect = obj.getBoundingClientRect(),
+                    docEl = document.documentElement,
+                    left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0),
+                    top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
+
                 return [left, top];
             };
         },

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -104,9 +104,11 @@ define([
 
         _overwriteFindPos: function () {
             $.datepicker.constructor.prototype._findPos = function (obj) {
-                let domPosition = obj.getBoundingClientRect();
-
-                return [domPosition.left, domPosition.top];
+                var rect = obj.getBoundingClientRect();
+                var docEl = document.documentElement;
+                var left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0);
+                var top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
+                return [left, top];
             };
         },
 

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -104,15 +104,15 @@ define([
 
         _overwriteFindPos: function () {
             $.datepicker.constructor.prototype._findPos = function (obj) {
-                if (!obj || typeof obj.getBoundingClientRect !== 'function') {
-                    // Return a default position or throw a descriptive error
-                    return [0, 0];
-                }
                 var rect = obj.getBoundingClientRect(),
                     docEl = document.documentElement,
                     left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0),
                     top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
 
+                if (!obj || typeof obj.getBoundingClientRect !== 'function') {
+                    // Return a default position or throw a descriptive error
+                    return [0, 0];
+                }
                 return [left, top];
             };
         },

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -103,12 +103,12 @@ define([
         },
 
         _overwriteFindPos: function () {
-            var rect = obj.getBoundingClientRect(),
+            $.datepicker.constructor.prototype._findPos = function (obj) {
+                var rect = obj.getBoundingClientRect(),
                     docEl = document.documentElement,
                     left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0),
                     top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
                     
-            $.datepicker.constructor.prototype._findPos = function (obj) {
                 if (!obj || typeof obj.getBoundingClientRect !== 'function') {
                     return [0, 0];
                 }                

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -104,6 +104,10 @@ define([
 
         _overwriteFindPos: function () {
             $.datepicker.constructor.prototype._findPos = function (obj) {
+                if (!obj || typeof obj.getBoundingClientRect !== 'function') {
+                    // Return a default position or throw a descriptive error
+                    return [0, 0];
+                }
                 var rect = obj.getBoundingClientRect(),
                     docEl = document.documentElement,
                     left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0),

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -1,6 +1,6 @@
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
  */
 
 /*eslint max-depth: 0*/

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -102,7 +102,7 @@ define([
             }
         },
 
-       _overwriteFindPos: function () {
+        _overwriteFindPos: function () {
             $.datepicker.constructor.prototype._findPos = function (obj) {
                 var rect = obj.getBoundingClientRect(),
                     docEl = document.documentElement,

--- a/lib/web/mage/calendar.js
+++ b/lib/web/mage/calendar.js
@@ -103,16 +103,15 @@ define([
         },
 
         _overwriteFindPos: function () {
-            $.datepicker.constructor.prototype._findPos = function (obj) {
-                var rect = obj.getBoundingClientRect(),
+            var rect = obj.getBoundingClientRect(),
                     docEl = document.documentElement,
                     left = rect.left + (window.pageXOffset || docEl.scrollLeft || 0),
                     top = rect.top + (window.pageYOffset || docEl.scrollTop || 0);
-
+                    
+            $.datepicker.constructor.prototype._findPos = function (obj) {
                 if (!obj || typeof obj.getBoundingClientRect !== 'function') {
-                    // Return a default position or throw a descriptive error
                     return [0, 0];
-                }
+                }                
                 return [left, top];
             };
         },


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This pull request addresses a UI issue where the calendar popup (used in various date fields) displays incorrectly when the page is scrolled. The issue occurs because `getBoundingClientRect` returns coordinates relative to the viewport, whereas the expected behavior is based on the full document scroll. The fix adjusts the position calculation to ensure the popup displays in the correct location regardless of scroll position.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#39831

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

#### Case 1: Orders Grid in Admin Panel
1. Navigate to **Sales > Orders** in the Magento Admin.
2. Expand the **Filters** section.
3. Scroll the page so that the **"Purchase Date"** field is at the top of the viewport.
4. Click the calendar icon for the **"Purchase Date From"** field.

**Expected Result:**  
The calendar popup appears correctly below the input field.

**Actual Result (Before Fix):**  
The calendar popup appears offset or overlays other parts of the screen incorrectly.

#### Case 2: Product Attribute Date Field
1. Navigate to **Stores > Product** attribute with a **Date** input type.
2. Edit or create an attribute using a Date input.
3. Scroll to the input field and click the calendar icon.

**Expected Result:**  
Calendar appears correctly relative to the input field.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
- This issue affects both Adminhtml and Storefront areas.
- The fix ensures popup positioning accounts for scroll offset relative to the document, not just the viewport.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)

---

### Preconditions and environment
- Magento version: 2.4.8
