### PR TITLE
Fix: transaction has itself as a parent which causes deadloop on closing

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Payment/Transaction.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Payment/Transaction.php
@@ -153,7 +153,7 @@ class Transaction extends EntityAbstract implements TransactionResourceInterface
                 $transaction->setData('parent_id', $parentId);
             }
         } else {
-            $result = $this->getParentId($orderId);
+            $result = $this->getParentId($orderId, (string)$transaction->getTransactionId());
             if ($result) {
                 $transaction->setData('parent_id', $result[0]['transaction_id']);
                 $transaction->setData('parent_txn_id', $result[0]['parent_txn_id']);
@@ -224,9 +224,10 @@ class Transaction extends EntityAbstract implements TransactionResourceInterface
      * Retrieve transaction by the unique key of order_id
      *
      * @param int $orderId
+     * @param string $currentTransactionId
      * @return array
      */
-    protected function getParentId(int $orderId): array
+    protected function getParentId(int $orderId, string $currentTransactionId): array
     {
         $connection = $this->getConnection();
         $select = $connection->select()->from(
@@ -235,6 +236,9 @@ class Transaction extends EntityAbstract implements TransactionResourceInterface
         )->where(
             'order_id = ?',
             $orderId
+        )->where(
+            'transaction_id <> ?',
+            $currentTransactionId
         )->order('transaction_id', 'ASC')->limit(1);
         return $connection->fetchAll($select);
     }


### PR DESCRIPTION
…

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

Fi for mentioned issue where transaction has itself as a parent transaction which causes deadloop on closing

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
getParentId()

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#39999

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. On the frontend, create an order and complete payment using an Auth transaction.
2. In the Admin panel navigated to Sales > Orders 
3. Select the order from Step 1
4. Open the Invoice tab and click Capture Online [Submit Invoice].
5. Navigate to Transactions from the left menu to view the transaction summary table.
6. Click on a transaction to view its details.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

But the issue i personally faced is when the payment requires authentication (with 3Ds, for example), order is already placed and  payment tries to update the transaction to close it, causing the deadloop as it tries to cloase the parent transaction firstly (which is actually is the current transaction)

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
