### PR TITLE
Fix incorrect free_shipping flag for virtual products

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
+++ b/app/code/Magento/OfflineShipping/Model/Quote/Address/FreeShipping.php
@@ -43,6 +43,8 @@ class FreeShipping implements FreeShippingInterface
         $this->calculator->initFromQuote($quote);
         $shippingAddress = $quote->getShippingAddress();
         $shippingAddress->setFreeShipping(0);
+        $billingAddress = $quote->getBillingAddress();
+        $billingAddress->setFreeShipping(0);
         /** @var \Magento\Quote\Api\Data\CartItemInterface $item */
         foreach ($items as $item) {
             if ($item->getNoDiscount()) {


### PR DESCRIPTION
This fixes the incorrect free_shipping flag for virtual products described in #40184 

### Description (*)
The fix resets the billing address free_shipping flag in the same way it is done for the shipping address.

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/40184

### Manual testing scenarios (*)
1. Go through steps to reproduce from issue, on step 8 the free_shipping flag for item test2 is 1 after adding this fix.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
