### PR TITLE
Fix incorrect condition check and method name typo for `\Magento\Framework\Escaper`

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
  */
 declare(strict_types=1);
 
@@ -280,7 +280,7 @@ class Escaper
             $translateInline = $this->getTranslateInline();
 
             return $translateInline->isAllowed()
-                ? $this->inlineSensitiveEscapeHthmlAttr($string)
+                ? $this->inlineSensitiveEscapeHtmlAttr($string)
                 : $this->getEscaper()->escapeHtmlAttr($string);
         }
 
@@ -407,12 +407,12 @@ class Escaper
     private function escapeScriptIdentifiers(string $data): string
     {
         $filteredData = preg_replace('/[\x00-\x1F\x7F\xA0]/u', '', $data);
-        if ($filteredData === false || $filteredData === '') {
+        if ($filteredData === null || $filteredData === '') {
             return '';
         }
 
         $filteredData = preg_replace(self::$xssFiltrationPattern, ':', $filteredData);
-        if ($filteredData === false) {
+        if ($filteredData === null) {
             return '';
         }
 
@@ -518,7 +518,7 @@ class Escaper
      * @param string $text
      * @return string
      */
-    private function inlineSensitiveEscapeHthmlAttr(string $text): string
+    private function inlineSensitiveEscapeHtmlAttr(string $text): string
     {
         $escaper = $this->getEscaper();
         $textLength = strlen($text);


### PR DESCRIPTION
Fixed incorrect condition check and method name typo for `\Magento\Framework\Escaper`.

### Description (*)

 - Fixed incorrect condition check in `\Magento\Framework\Escaper::escapeScriptIdentifiers`
 - Fixed `\Magento\Framework\Escaper::inlineSensitiveEscapeHthmlAttr` method name typo

### Related Pull Requests

N/A

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40195

### Manual testing scenarios (*)

N/A

### Questions or comments

If you care about the unit test, it is not possible to let `preg_replace` return `NULL` with the given valid regular expression [here](https://github.com/magento/magento2/blob/4baea6d63e6cc645e7417998e930117d590c88a2/lib/internal/Magento/Framework/Escaper.php#L409) and [here](https://github.com/magento/magento2/blob/4baea6d63e6cc645e7417998e930117d590c88a2/lib/internal/Magento/Framework/Escaper.php#L57).

The check for `NULL` is just a "safeguard".

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
