### PR TITLE
Allow some SalesSequence data to be retrieved by extensions for customisatioons

### DIFF
--- a/app/code/Magento/SalesSequence/Model/Meta.php
+++ b/app/code/Magento/SalesSequence/Model/Meta.php
@@ -11,6 +11,10 @@ use Magento\Framework\Model\AbstractModel;
  * Class Meta
  *
  * @api
+ * @method Profile getActiveProfile()
+ * @method string getEntityType()
+ * @method int getStoreId()
+ * @method string getSequenceTable()
  * @since 100.0.2
  */
 class Meta extends AbstractModel

--- a/app/code/Magento/SalesSequence/Model/Profile.php
+++ b/app/code/Magento/SalesSequence/Model/Profile.php
@@ -11,6 +11,10 @@ use Magento\Framework\Model\AbstractModel;
  * Class Profile
  *
  * @api
+ * @method string getPrefix()
+ * @method string getSuffix()
+ * @method int getStartValue()
+ * @method int getStep()
  * @since 100.0.2
  */
 class Profile extends AbstractModel

--- a/app/code/Magento/SalesSequence/Model/Sequence.php
+++ b/app/code/Magento/SalesSequence/Model/Sequence.php
@@ -90,7 +90,7 @@ class Sequence implements SequenceInterface
      *
      * @return string
      */
-    private function calculateCurrentValue(): string
+    public function calculateCurrentValue(): string
     {
         return ($this->lastIncrementId - $this->meta->getActiveProfile()->getStartValue())
         * $this->meta->getActiveProfile()->getStep() + $this->meta->getActiveProfile()->getStartValue();
@@ -104,6 +104,16 @@ class Sequence implements SequenceInterface
     public function getEntityType(): string
     {
         return $this->meta->getEntityType();
+    }
+
+    /**
+     * Retrieve the current store id
+     *
+     * @return int
+     */
+    public function getStoreId(): int
+    {
+        return $this->meta->getStoreId();
     }
 
     /**

--- a/app/code/Magento/SalesSequence/Model/Sequence.php
+++ b/app/code/Magento/SalesSequence/Model/Sequence.php
@@ -49,7 +49,7 @@ class Sequence implements SequenceInterface
     public function __construct(
         Meta $meta,
         AppResource $resource,
-        $pattern = self::DEFAULT_PATTERN
+        string $pattern = self::DEFAULT_PATTERN
     ) {
         $this->meta = $meta;
         $this->connection = $resource->getConnection('sales');
@@ -59,9 +59,9 @@ class Sequence implements SequenceInterface
     /**
      * Retrieve current value
      *
-     * @return string
+     * @return ?string
      */
-    public function getCurrentValue()
+    public function getCurrentValue(): ?string
     {
         if (!isset($this->lastIncrementId)) {
             return null;
@@ -76,11 +76,9 @@ class Sequence implements SequenceInterface
     }
 
     /**
-     * Retrieve next value
-     *
-     * @return string
+     * @inheritdoc
      */
-    public function getNextValue()
+    public function getNextValue(): string
     {
         $this->connection->insert($this->meta->getSequenceTable(), []);
         $this->lastIncrementId = $this->connection->lastInsertId($this->meta->getSequenceTable());
@@ -92,9 +90,29 @@ class Sequence implements SequenceInterface
      *
      * @return string
      */
-    private function calculateCurrentValue()
+    private function calculateCurrentValue(): string
     {
         return ($this->lastIncrementId - $this->meta->getActiveProfile()->getStartValue())
         * $this->meta->getActiveProfile()->getStep() + $this->meta->getActiveProfile()->getStartValue();
+    }
+
+    /**
+     * Retrieve the current entity type
+     *
+     * @return string
+     */
+    public function getEntityType(): string
+    {
+        return $this->meta->getEntityType();
+    }
+
+    /**
+     * Retrieve the currently active meta profile
+     *
+     * @return Profile
+     */
+    public function getMetaProfile(): Profile
+    {
+        return $this->meta->getActiveProfile();
     }
 }

--- a/app/code/Magento/SalesSequence/Test/Unit/Model/SequenceTest.php
+++ b/app/code/Magento/SalesSequence/Test/Unit/Model/SequenceTest.php
@@ -49,7 +49,7 @@ class SequenceTest extends TestCase
     protected function setUp(): void
     {
         $this->meta = $this->getMockBuilder(Meta::class)
-            ->addMethods(['getSequenceTable', 'getActiveProfile'])
+            ->addMethods(['getSequenceTable', 'getActiveProfile', 'getStoreId', 'getEntityType'])
             ->disableOriginalConstructor()
             ->getMock();
         $this->profile = $this->getMockBuilder(Profile::class)
@@ -83,6 +83,30 @@ class SequenceTest extends TestCase
     public function testSequenceInitialNull(): void
     {
         $this->assertNull($this->sequence->getCurrentValue());
+    }
+
+    /**
+     * Test that the meta getters return values as expected
+     *
+     * @return void
+     */
+    public function testMetaGetters(): void
+    {
+        $exampleEntityType = 'order';
+        $exampleStoreId = 0;
+        $this->meta->expects($this->atLeastOnce())
+            ->method('getActiveProfile')
+            ->willReturn($this->profile);
+
+        $this->meta->expects($this->atLeastOnce())
+            ->method('getStoreId')
+            ->willReturn($exampleStoreId);
+        $this->meta->expects($this->atLeastOnce())
+            ->method('getEntityType')
+            ->willReturn($exampleEntityType);
+
+        $this->assertEquals($exampleEntityType, $this->sequence->getEntityType());
+        $this->assertEquals($exampleStoreId, $this->sequence->getStoreId());
     }
 
     /**

--- a/lib/internal/Magento/Framework/DB/Sequence/SequenceInterface.php
+++ b/lib/internal/Magento/Framework/DB/Sequence/SequenceInterface.php
@@ -17,14 +17,14 @@ interface SequenceInterface
     /**
      * Retrieve current value
      *
-     * @return string
+     * @return ?string
      */
-    public function getCurrentValue();
+    public function getCurrentValue(): ?string;
 
     /**
      * Retrieve next value
      *
      * @return string
      */
-    public function getNextValue();
+    public function getNextValue(): string;
 }

--- a/lib/internal/Magento/Framework/EntityManager/Sequence/Sequence.php
+++ b/lib/internal/Magento/Framework/EntityManager/Sequence/Sequence.php
@@ -36,8 +36,8 @@ class Sequence implements SequenceInterface
      */
     public function __construct(
         ResourceConnection $resource,
-        $connectionName,
-        $sequenceTable
+        string $connectionName,
+        string $sequenceTable
     ) {
         $this->resource = $resource;
         $this->connectionName = $connectionName;
@@ -47,7 +47,7 @@ class Sequence implements SequenceInterface
     /**
      * @inheritdoc
      */
-    public function getNextValue()
+    public function getNextValue(): string
     {
         $this->resource->getConnection($this->connectionName)
             ->insert($this->resource->getTableName($this->sequenceTable), []);
@@ -58,7 +58,7 @@ class Sequence implements SequenceInterface
     /**
      * @inheritdoc
      */
-    public function getCurrentValue()
+    public function getCurrentValue(): string
     {
         $select = $this->resource->getConnection($this->connectionName)->select();
         $select->from($this->resource->getTableName($this->sequenceTable));


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

Being able to change the sequence generation for a specific entity type is a reasonably common request. The objective of this PR is to allow extensions to more easily modify this: currently, it is impossible without overriding the whole model (read: copy and paste, since everything is private).

This PR will allow extensions or vendors to change the format, for instance with an `after` plugin:
```php
public function afterGetNextValue(
    \Magento\SalesSequence\Model\Sequence $subject,
    string $result
) {
    //If we're generating for an order, set its sequence to ECOM{STORE_ID}#{4 DIGIT INC. ID}
    if ('order' === $subject->getEntityType()) {
        return \sprintf('ECOM%d#%\'.04d', $subject->getStoreId(), $subject->calculateCurrentValue());
    }
    
    //Otherwise, passthrough
    return $result;
}
```

NB: this would probably be a good use case for some sort of expansion (having some di-defined array for entity types to calculate their values), but this is a good first step IMO.

### Related Pull Requests
<!-- related pull request placeholder -->

N/A

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

N/A

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

This is a transparent API change: it should not change anything. Perhaps trying an after plugin like mentioned above.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

Unsure re: unit tests. I've added some, but they seem superfluous.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40252: Allow some SalesSequence data to be retrieved by extensions for customisatioons