### PR TITLE
Update Encryption key missing exception message

### DIFF
--- a/lib/internal/Magento/Framework/Encryption/Encryptor.php
+++ b/lib/internal/Magento/Framework/Encryption/Encryptor.php
@@ -260,7 +260,7 @@ class Encryptor implements EncryptorInterface
     public function hash($data, $version = self::HASH_VERSION_SHA256)
     {
         if (empty($this->keys[$this->keyVersion])) {
-            throw new \RuntimeException('No key available');
+            throw new \RuntimeException('No Encryption key available');
         }
         if (!array_key_exists($version, $this->hashVersionMap)) {
             throw new \InvalidArgumentException('Unknown hashing algorithm');


### PR DESCRIPTION
Summary

Improve the exception text thrown by \Magento\Framework\Encryption\Encryptor::hash() when no encryption key is available.
Before: No key available
After: No encryption key available

The previous message was ambiguous (“key” could refer to array/index/API key). The new message explicitly points to the encryption key, making triage faster and reducing confusion in logs/alerts.

What’s changed

Adjusted the exception message in lib/internal/Magento/Framework/Encryption/Encryptor.php to clarify the missing configuration.

Impact / scope

Affects only the human-readable error text; no functional behavior, signatures, or public APIs changed.

Safer, clearer logs during hashing/encryption operations (e.g., setup, auth, sensitive data hashing).

How to reproduce / test

Start Magento with a missing/empty encryption key (e.g., remove/blank app/etc/env.php ['crypt']['key']).

Trigger any code path that calls Encryptor::hash() (login, password set, etc.).

Observe thrown exception now reads “No encryption key available.”

Backward compatibility

BC-safe: string-only change to an exception message.

No changes to error type, code, or stack traces.

Notes / follow-ups (optional)

Future enhancement: include remediation hints such as:

Verify app/etc/env.php → crypt.key exists.

Rotate or set the key:
bin/magento setup:config:set --key="..."

Consider standardizing similar messages across other encryption-related paths for consistency.