### PR TITLE
#40213 - Handle no entity exception for attribute set

### DIFF
--- a/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
+++ b/app/code/Magento/Catalog/Controller/Adminhtml/Product/Set/Edit.php
@@ -55,7 +55,15 @@ class Edit extends Set implements HttpGetActionInterface
     public function execute()
     {
         $this->_setTypeId();
-        $attributeSet = $this->attributeSetRepository->get($this->getRequest()->getParam('id'));
+
+        try {
+            $attributeSet = $this->attributeSetRepository->get($this->getRequest()->getParam('id'));
+        } catch (NoSuchEntityException $e) {
+            $this->messageManager->addErrorMessage(__('Could not load attribute set.'));
+
+            return $this->_redirect('*/*/');
+        }
+
         if (!$attributeSet->getId()) {
             return $this->resultRedirectFactory->create()->setPath('catalog/*/index');
         }


### PR DESCRIPTION
Logical improvement for edit attribute set entity

### Description (*)
Pull request contain exception handling for attribute set entity. When controller can't find entity for attribute set, code catch this runtime moment, set relevant moment and redirect to default attribute set page

### Manual testing scenarios (*)
Please sign-in to admin panel next go to Stores > Attributes > Attribute Set
1. Open Default attribute set
2. Change parameter in url to non existing attribute set eg. 85
3. You should be redirected to default attribute set page with relevant message
<img width="1886" height="564" alt="image" src="https://github.com/user-attachments/assets/5fde46fc-f46b-42a2-b379-ebd717394728" />

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)
