### PR TITLE
Add optional parameter to cache:clean and cache:flush to exclude type(s)

### DIFF
--- a/app/code/Magento/Backend/Console/Command/AbstractCacheManageCommand.php
+++ b/app/code/Magento/Backend/Console/Command/AbstractCacheManageCommand.php
@@ -8,6 +8,7 @@ namespace Magento\Backend\Console\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * @api
@@ -20,6 +21,8 @@ abstract class AbstractCacheManageCommand extends AbstractCacheCommand
      */
     const INPUT_KEY_TYPES = 'types';
 
+    const EXCLUDE_KEY_TYPES = 'exclude';
+
     /**
      * {@inheritdoc}
      */
@@ -29,6 +32,12 @@ abstract class AbstractCacheManageCommand extends AbstractCacheCommand
             self::INPUT_KEY_TYPES,
             InputArgument::IS_ARRAY,
             'Space-separated list of cache types or omit to apply to all cache types.'
+        );
+        $this->addOption(
+            self::EXCLUDE_KEY_TYPES,
+            'e',
+            InputOption::VALUE_OPTIONAL,
+            'Comma separated list of cache types to omit'
         );
         parent::configure();
     }
@@ -46,8 +55,16 @@ abstract class AbstractCacheManageCommand extends AbstractCacheCommand
             $requestedTypes = $input->getArgument(self::INPUT_KEY_TYPES);
             $requestedTypes = array_filter(array_map('trim', $requestedTypes), 'strlen');
         }
+        $excludeTypes = $input->getOption(self::EXCLUDE_KEY_TYPES);
         if (empty($requestedTypes)) {
-            return $this->cacheManager->getAvailableTypes();
+            $cacheTypes = $this->cacheManager->getAvailableTypes();
+            if (!empty($excludeTypes)) {
+                foreach (explode(',', $excludeTypes) as $item) {
+                    unset($cacheTypes[array_search($item, $cacheTypes)]);
+                }
+                $cacheTypes = array_values($cacheTypes);
+            }
+            return $cacheTypes;
         } else {
             $availableTypes = $this->cacheManager->getAvailableTypes();
             $unsupportedTypes = array_diff($requestedTypes, $availableTypes);
@@ -56,6 +73,12 @@ abstract class AbstractCacheManageCommand extends AbstractCacheCommand
                     "The following requested cache types are not supported: '" . join("', '", $unsupportedTypes)
                     . "'." . PHP_EOL . 'Supported types: ' . join(", ", $availableTypes)
                 );
+            }
+            if (!empty($excludeTypes)) {
+                foreach (explode(',', $excludeTypes) as $item) {
+                    unset($availableTypes[array_search($item, $availableTypes)]);
+                }
+                $availableTypes = array_values($availableTypes);
             }
             return array_values(array_intersect($availableTypes, $requestedTypes));
         }

--- a/app/code/Magento/Backend/Console/Command/AbstractCacheManageCommand.php
+++ b/app/code/Magento/Backend/Console/Command/AbstractCacheManageCommand.php
@@ -10,21 +10,17 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
-/**
- * @api
- * @since 100.0.2
- */
 abstract class AbstractCacheManageCommand extends AbstractCacheCommand
 {
     /**
      * Input argument types
      */
-    const INPUT_KEY_TYPES = 'types';
+    public const INPUT_KEY_TYPES = 'types';
 
-    const EXCLUDE_KEY_TYPES = 'exclude';
+    public const EXCLUDE_KEY_TYPES = 'exclude';
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function configure()
     {

--- a/app/code/Magento/Backend/Console/Command/AbstractCacheTypeManageCommand.php
+++ b/app/code/Magento/Backend/Console/Command/AbstractCacheTypeManageCommand.php
@@ -64,6 +64,13 @@ abstract class AbstractCacheTypeManageCommand extends AbstractCacheManageCommand
         $this->performAction($types);
         $output->writeln($this->getDisplayMessage());
         $output->writeln(join(PHP_EOL, $types));
+        $excludeTypes = $input->getOption(self::EXCLUDE_KEY_TYPES);
+        if (!empty($excludeTypes)) {
+            $output->writeln('Excluded Cache Type');
+            foreach (explode(',', $excludeTypes) as $type) {
+                $output->writeln($type);
+            }
+        }
 
         return Cli::RETURN_SUCCESS;
     }


### PR DESCRIPTION
Provided the feature to exclude cache type while cleaning the cache.

Description (*)
In order to facilitate the admin to clear all caches excluding a particular cache, added an input option to take from the admin and exclude it from available types using the below command.

Getting the option from the admin
```
$this->addOption(
            self::EXCLUDE_KEY_TYPES,
            'e',
            InputOption::VALUE_OPTIONAL,
            'Comma separated list of cache types to omit'
        );
```

Excluding from cache type
```
$excludeTypes = $input->getOption(self::EXCLUDE_KEY_TYPES);
        if (empty($requestedTypes)) {
            $cacheTypes = $this->cacheManager->getAvailableTypes();
            if (!empty($excludeTypes)) {
                foreach (explode(',', $excludeTypes) as $item) {
                    unset($cacheTypes[array_search($item, $cacheTypes)]);
                }
                $cacheTypes = array_values($cacheTypes);
            }
            return $cacheTypes;
        }
```

Fixed Issues (if relevant)
Fixes https://github.com/magento/magento2/issues/35847
Manual testing scenarios (*)
Run the command bin/magento c:c --exclude=config or shorthand notation using bin/magento c:c -e config to exclude the cache from not being cleared.

If you want to exclude multiple cache from being cleaned use this bin/magento c:c --exclude=config,layout

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
