### PR TITLE
Commercial destination should not be treated as residential

### DIFF
--- a/app/code/Magento/Ups/Model/Carrier.php
+++ b/app/code/Magento/Ups/Model/Carrier.php
@@ -1118,8 +1118,7 @@ XMLRequest;
                             "AddressLine" => ["{$params['49_residential']}"],
                             "StateProvinceCode" => "{$params['destRegionCode']}",
                             "PostalCode" => "{$params['19_destPostal']}",
-                            "CountryCode" => "{$params['22_destCountry']}",
-                            "ResidentialAddressIndicator" => "{$residentialAddressIndicator}"
+                            "CountryCode" => "{$params['22_destCountry']}"
                         ]
                     ],
                     "ShipFrom" => [
@@ -1133,6 +1132,11 @@ XMLRequest;
                 ]
             ]
         ];
+
+        if ($params['49_residential'] === '01') {
+            $rateParams['RateRequest']['Shipment']['ShipTo']['Address']['ResidentialAddressIndicator']
+                = $residentialAddressIndicator;
+        }
 
         if ($this->getConfigFlag('negotiated_active')) {
             $rateParams['RateRequest']['Shipment']['ShipmentRatingOptions']['TPFCNegotiatedRatesIndicator'] = "Y";


### PR DESCRIPTION
### Description (*)
The UPS REST rate request builder in `\Magento\Ups\Model\Carrier` always includes the `ResidentialAddressIndicator` field in the `ShipTo.Address` section, even when the destination type is commercial (`49_residential = "02"`).

According to UPS API behavior, the mere presence of the `ResidentialAddressIndicator` tag (even with an empty value) makes the shipment be treated as **residential**, which results in “Demand Surcharge - Residential” being applied and higher rates being returned for commercial destinations.

This pull request updates the REST request payload builder so that:

- `ResidentialAddressIndicator` is **only included** when `49_residential === "01"` (residential).
- For non-residential (e.g. `"02"` commercial) requests, the `ResidentialAddressIndicator` field is **not added** to the payload at all.

This aligns the REST implementation with the existing XML implementation, which already adds `ResidentialAddressIndicator` conditionally based on `49_residential`.

### Manual testing scenarios (*)

#### Scenario 1: Commercial destination should not be treated as residential

1. Configure UPS shipping in Magento with valid UPS credentials and enable the REST API integration (US → US shipment).
2. Create a quote/cart with:
   - Origin in the US (e.g. Miami, FL 33127).
   - Destination in the US with a **commercial** destination type (`49_residential = "02"`).
   - A package weight of approximately 20.8 lbs.
3. Request shipping rates (via storefront checkout or REST API).
4. **Before the fix**:
   - Inspect the UPS REST request (debug/logs):
     - `ShipTo.Address.ResidentialAddressIndicator` is present with an empty value.
   - UPS returns rates that include “Demand Surcharge - Residential is applied on Package 0” and higher total charges.
5. **After the fix**:
   - Inspect the UPS REST request again:
     - `ShipTo.Address` does **not** contain the `ResidentialAddressIndicator` field for `49_residential = "02"`.
   - UPS returns commercial rates (no “Demand Surcharge - Residential” message), and totals match expected commercial pricing.

#### Scenario 2: Residential destination still behaves as residential

1. Using the same configuration, create a quote/cart with a **residential** destination (`49_residential = "01"`).
2. Request shipping rates.
3. Verify that:
   - `ShipTo.Address.ResidentialAddressIndicator` **is present** in the UPS REST request.
   - UPS returns rates that include residential surcharge (e.g. “Demand Surcharge - Residential is applied on Package 0”).
   - Behavior matches previous residential handling and the XML-based UPS rates.