### PR TITLE
Fix Magento install error: "Attribute with ID: 'url_key' does not exist"

### DIFF
--- a/app/code/Magento/Catalog/Setup/Patch/Data/UpdateProductUrlKeyBackendModel.php
+++ b/app/code/Magento/Catalog/Setup/Patch/Data/UpdateProductUrlKeyBackendModel.php
@@ -42,7 +42,10 @@ class UpdateProductUrlKeyBackendModel implements DataPatchInterface, PatchRevert
      */
     public static function getDependencies()
     {
-        return [];
+        return [
+            UpdateProductAttributes::class,
+            \Magento\CatalogUrlRewrite\Setup\Patch\Data\CreateUrlAttributes::class
+        ];
     }
 
     /**


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes a Magento installation failure: 'Unable to apply data patch Magento\Catalog\Setup\Patch\Data\UpdateProductUrlKeyBackendModel for module Magento_Catalog. Original exception message: Attribute with ID: "url_key" does not exist'
<img width="1920" height="914" alt="Screenshot from 2025-11-26 20-06-06" src="https://github.com/user-attachments/assets/156bb4d1-2e00-479b-b1fa-683cecda860a" />

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Perform a standard Magento installation process.
2. Verify that the installation completes successfully without any errors.

Expected Result:
Magento installs successfully and no error related to the url_key attribute or data patches appears.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)



### Resolved issues:
1. [x] resolves magento/magento2#40332: Fix Magento install error: "Attribute with ID: 'url_key' does not exist"