### PR TITLE
fix: login form incorrect password label

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/login.phtml
@@ -35,7 +35,7 @@ $buttonLockManager = $block->getData('button_lock_manager');
                     </div>
                 </div>
                 <div class="field password required">
-                    <label for="pass" class="label"><span><?= $escaper->escapeHtml(__('Password')) ?></span></label>
+                    <label for="password" class="label"><span><?= $escaper->escapeHtml(__('Password')) ?></span></label>
                     <div class="control">
                         <input name="login[password]" type="password"
                             <?php if ($block->isAutocompleteDisabled()): ?> autocomplete="off"<?php endif; ?>


### PR DESCRIPTION
This PR fixes an incorrect "for" attribute, on the password label located on the login page. Currently, with the incorrect attribute, we are not able to target the password field by label associating in E2E testing frameworks like Playwright.

### Manual testing scenarios (*)
Navigate to the customer login page - https://app.magento2.test/customer/account/login
Inspect the password label and input elements.
Note the "for" attribute on the label does not align with any appropriate attribute on the input element.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40353: fix: login form incorrect password label