### PR TITLE
Fix: Force current currency reload on currency code change

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -911,6 +911,9 @@ class Store extends AbstractExtensibleModel implements
                 : $this->_storeManager->getWebsite()->getDefaultStore()->getDefaultCurrency()->getCode();
 
             $this->_httpContext->setValue(Context::CONTEXT_CURRENCY, $code, $defaultCode);
+            
+            // Force reload of current currency on currency code change
+            $this->unsetData('current_currency');
         }
         return $this;
     }

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -820,6 +820,107 @@ class StoreTest extends TestCase
     }
 
     /**
+     * Test that setCurrentCurrencyCode clears cached currency
+     *
+     * @return void
+     */
+    public function testSetCurrentCurrencyCodeClearsCachedCurrency(): void
+    {
+        $currencyCodeFirst = 'USD';
+        $currencyCodeSecond = 'EUR';
+        
+        $sessionMock = $this->getMockBuilder(SessionManagerInterface::class)
+            ->getMockForAbstractClass();
+        $sessionMock->expects($this->exactly(2))
+            ->method('setCurrencyCode')
+            ->willReturnCallback(function ($code) use ($currencyCodeFirst, $currencyCodeSecond) {
+                static $callCount = 0;
+                $callCount++;
+                if ($callCount === 1) {
+                    $this->assertEquals($currencyCodeFirst, $code);
+                } else {
+                    $this->assertEquals($currencyCodeSecond, $code);
+                }
+            });
+        
+        $httpContextMock = $this->getMockBuilder(\Magento\Framework\App\Http\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $currencyFactoryMock = $this->getMockBuilder(CurrencyFactory::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $currencyMockFirst = $this->getMockBuilder(Currency::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $currencyMockFirst->expects($this->any())
+            ->method('getCode')
+            ->willReturn($currencyCodeFirst);
+            
+        $currencyMockSecond = $this->getMockBuilder(Currency::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $currencyMockSecond->expects($this->any())
+            ->method('getCode')
+            ->willReturn($currencyCodeSecond);
+        
+        $storeManagerMock = $this->getMockBuilder(StoreManagerInterface::class)
+            ->getMockForAbstractClass();
+        $storeManagerMock->expects($this->any())
+            ->method('getStore')
+            ->willReturn(null);
+            
+        $websiteMock = $this->getMockBuilder(WebsiteInterface::class)
+            ->getMockForAbstractClass();
+        $websiteMock->expects($this->any())
+            ->method('getDefaultStore')
+            ->willReturnSelf();
+        $websiteMock->expects($this->any())
+            ->method('getDefaultCurrency')
+            ->willReturn($currencyMockFirst);
+            
+        $storeManagerMock->expects($this->any())
+            ->method('getWebsite')
+            ->willReturn($websiteMock);
+        
+        $storeMock = $this->getMockBuilder(Store::class)
+            ->setConstructorArgs([
+                $this->createMock(\Magento\Framework\Model\Context::class),
+                $this->createMock(\Magento\Framework\Registry::class),
+                $this->createMock(\Magento\Framework\App\Cache\Type\Config::class),
+                $this->createMock(\Magento\Framework\Url::class),
+                $this->requestMock,
+                $this->createMock(\Magento\Config\Model\ResourceModel\Config\Data::class),
+                $this->configMock,
+                $storeManagerMock,
+                $this->filesystemMock,
+                $this->createMock(\Magento\Framework\Url\ModifierInterface::class),
+                $sessionMock,
+                $httpContextMock,
+                $this->createMock(\Magento\Framework\App\Config::class),
+                $currencyFactoryMock
+            ])
+            ->onlyMethods(['getAvailableCurrencyCodes', 'getData', 'unsetData', 'setData'])
+            ->getMock();
+        
+        $storeMock->expects($this->any())
+            ->method('getAvailableCurrencyCodes')
+            ->willReturn([$currencyCodeFirst, $currencyCodeSecond]);
+        
+        // Expect unsetData to be called when currency code changes
+        $storeMock->expects($this->exactly(2))
+            ->method('unsetData')
+            ->with('current_currency');
+        
+        // First currency change
+        $storeMock->setCurrentCurrencyCode($currencyCodeFirst);
+        
+        // Second currency change - should clear cached currency
+        $storeMock->setCurrentCurrencyCode($currencyCodeSecond);
+    }
+
+    /**
      * @param Store $model
      */
     private function setUrlModifier(Store $model)


### PR DESCRIPTION
### Description (*)

Fixed an issue where calling `setCurrentCurrencyCode()` multiple times did not update the currency returned by `getCurrentCurrency()` due to internal caching.

**Root Cause:**
`getCurrentCurrency()` caches the currency object using the `'current_currency'` key. When `setCurrentCurrencyCode()` changed the currency code, it didn't clear this cache, causing `getCurrentCurrency()` to return stale data.

**Solution:**
Added `unsetData('current_currency')` in `setCurrentCurrencyCode()` to clear the cached currency when the currency code changes, forcing `getCurrentCurrency()` to reload the currency based on the new code.

**Changes:**
- Updated `Store::setCurrentCurrencyCode()` to clear cached currency
- Added unit test `testSetCurrentCurrencyCodeClearsCachedCurrency()`

### Related Pull Requests
None

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40333

### Manual testing scenarios (*)
1. Create a store with multiple available currencies (USD, EUR)
2. Call `$store->setCurrentCurrencyCode('USD')`
3. Verify `$store->getCurrentCurrency()->getCode()` returns `'USD'`
4. Call `$store->setCurrentCurrencyCode('EUR')`
5. Verify `$store->getCurrentCurrency()->getCode()` returns `'EUR'` (without this fix, it would still return `'USD'`)

### Questions or comments
None

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)