### PR TITLE
Fix #40361 - Customer address telephone validation does not work if there is no allowed characters

### DIFF
--- a/app/code/Magento/Customer/Model/Validator/Telephone.php
+++ b/app/code/Magento/Customer/Model/Validator/Telephone.php
@@ -24,7 +24,7 @@ class Telephone extends AbstractValidator
      * \d: Digits (0-9).
      */
     private const PATTERN_TELEPHONE = '/(?:[\d\s\+\-\()]{1,20})/u';
-    
+
     /**
      * Validate telephone fields.
      *
@@ -50,12 +50,10 @@ class Telephone extends AbstractValidator
      */
     private function isValidTelephone($telephoneValue)
     {
-        if ($telephoneValue != null) {
-            if (preg_match(self::PATTERN_TELEPHONE, (string) $telephoneValue, $matches)) {
-                return $matches[0] == $telephoneValue;
-            }
+        if ($telephoneValue === null) {
+            return true;
         }
 
-        return true;
+        return (bool) preg_match(self::PATTERN_TELEPHONE, (string) $telephoneValue);
     }
 }


### PR DESCRIPTION
### Description (*)
The function which in charge of the customer address telephone does not work as intended, see issue #40361.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40361

### Manual testing scenarios (*)
- Create a customer account
- Go to address book and create an adress
- Enter `aaaa` as Telephone
- You should have an error message telling you the telephone is invalid

### Contribution checklist (*)
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [X] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
