### PR TITLE
Fix #13983: Improve custom option matching for multi-store imports

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product/Option.php
@@ -619,10 +619,15 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
                     if (isset($oldCustomOptions[$productId][$customOption->getId()])) {
                         $oldCustomOptions[$productId][$customOption->getId()]['titles'][$storeId] = $customOption
                             ->getTitle();
+                        // Ensure sort_order is set for existing options
+                        if (!isset($oldCustomOptions[$productId][$customOption->getId()]['sort_order'])) {
+                            $oldCustomOptions[$productId][$customOption->getId()]['sort_order'] = $customOption->getSortOrder();
+                        }
                     } else {
                         $oldCustomOptions[$productId][$customOption->getId()] = [
                             'titles' => [$storeId => $customOption->getTitle()],
                             'type' => $customOption->getType(),
+                            'sort_order' => $customOption->getSortOrder(),
                         ];
                     }
                 };
@@ -836,6 +841,15 @@ class Option extends \Magento\ImportExport\Model\Import\Entity\AbstractEntity
             $existingOptions = $this->getOldCustomOptions()[$productId];
             foreach ($existingOptions as $optionId => $optionData) {
                 if ($optionData['type'] == $newOptionData['type']) {
+                    // Primary matching: by sort_order if both are available and non-zero
+                    if (isset($optionData['sort_order']) && isset($newOptionData['sort_order'])
+                        && $optionData['sort_order'] > 0 && $newOptionData['sort_order'] > 0
+                        && $optionData['sort_order'] == $newOptionData['sort_order']
+                    ) {
+                        return $optionId;
+                    }
+                    
+                    // Fallback matching: by exact title match (original behavior for backward compatibility)
                     foreach ($newOptionTitles as $storeId => $title) {
                         if (isset($optionData['titles'][$storeId]) && $optionData['titles'][$storeId] === $title) {
                             return $optionId;


### PR DESCRIPTION
- Modified _initOldCustomOptions() to include sort_order in existing option data
- Enhanced _findExistingOptionId() to match by type + sort_order first, then fallback to title matching
- This ensures options with same structure but different store titles are recognized as translations
- Fixes issue where multi-store CSV imports created duplicate options instead of proper translations

The fix maintains backward compatibility by keeping title-based matching as fallback.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40369: Fix #13983: Improve custom option matching for multi-store imports