### PR TITLE
fix GraphQL list types not nullable

### DIFF
--- a/lib/internal/Magento/Framework/GraphQl/Config/Data/WrappedTypeProcessor.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Data/WrappedTypeProcessor.php
@@ -95,10 +95,8 @@ class WrappedTypeProcessor
     private function processIsList(FieldInterface $field, ?TypeInterface $object = null) : TypeInterface
     {
         if ($field->isList()) {
-            if ($field instanceof \Magento\Framework\GraphQl\Config\Element\Argument) {
-                if ($field->areItemsRequired()) {
-                    $object = $this->typeFactory->createNonNull($object);
-                }
+            if ($field->areItemsRequired()) {
+                $object = $this->typeFactory->createNonNull($object);
             }
             return $this->typeFactory->createList($object);
         }
@@ -136,10 +134,8 @@ class WrappedTypeProcessor
     ) : \GraphQL\Type\Definition\Type {
         $object = $object ?: $this->scalarTypes->getScalarTypeInstance($field->getTypeName());
         if ($field->isList()) {
-            if ($field instanceof \Magento\Framework\GraphQl\Config\Element\Argument) {
-                if ($field->areItemsRequired()) {
-                    $object = $this->scalarTypes->createNonNull($object);
-                }
+            if ($field->areItemsRequired()) {
+                $object = $this->scalarTypes->createNonNull($object);
             }
             return $this->scalarTypes->createList($object);
         }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/Field.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/Field.php
@@ -61,6 +61,11 @@ class Field implements OutputFieldInterface
     private $deprecated;
 
     /**
+     * @var bool
+     */
+    private bool $itemsRequired;
+
+    /**
      * @param string $name
      * @param string $type
      * @param bool $required
@@ -83,7 +88,8 @@ class Field implements OutputFieldInterface
         string $description = '',
         array $arguments = [],
         array $cache = [],
-        array $deprecated = []
+        array $deprecated = [],
+        bool $itemsRequired = false
     ) {
         $this->name = $name;
         $this->type = $isList ? $itemType : $type;
@@ -94,6 +100,7 @@ class Field implements OutputFieldInterface
         $this->arguments = $arguments;
         $this->cache = $cache;
         $this->deprecated = $deprecated;
+        $this->itemsRequired = $itemsRequired;
     }
 
     /**
@@ -184,5 +191,15 @@ class Field implements OutputFieldInterface
     public function getDeprecated() : array
     {
         return $this->deprecated;
+    }
+
+    /**
+     * Return true if item is a list, and if that list must be populated by at least one item. False otherwise.
+     *
+     * @return bool
+     */
+    public function areItemsRequired() : bool
+    {
+        return $this->itemsRequired;
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldFactory.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldFactory.php
@@ -66,6 +66,7 @@ class FieldFactory
                 'arguments' => $arguments,
                 'cache' => isset($fieldData['cache']) ? $fieldData['cache'] : [],
                 'deprecated' => isset($fieldData['deprecated']) ? $fieldData['deprecated'] : [],
+                'itemsRequired' => isset($fieldData['itemsRequired']) ? $fieldData['itemsRequired'] : false,
             ]
         );
     }

--- a/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldInterface.php
+++ b/lib/internal/Magento/Framework/GraphQl/Config/Element/FieldInterface.php
@@ -31,6 +31,11 @@ interface FieldInterface extends ConfigElementInterface
     public function isList(): bool;
 
     /**
+     * @return bool
+     */
+    public function areItemsRequired() : bool;
+
+    /**
      * Return true if argument is required when invoking the query where the argument is specified. False otherwise.
      *
      * @return bool


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

Non-nullable list item types were not correctly reflected in the generated GraphQL schema for output object types.

For example, the following definition in `schema.graphqls`:

``` graphql
type AddProductsToWishlistOutput @doc(description: "Contains the customer's wish list and any errors encountered.") {
    wishlist: Wishlist! @doc(description: "Contains the wish list with all items that were successfully added.")
    user_errors: [WishListUserInputError!]! @doc(description: "An array of errors encountered while adding products to a wish list.")
}
```

Results in the following type in the stitched schema:

``` graphql
[WishListUserInputError]!
```

Instead of the expected:

``` graphql
[WishListUserInputError!]!
```

This issue affects all output object types. Input argument handling already behaved correctly.

This pull request fixes the schema generation logic to correctly preserve non-nullable list item types.

This same bug applied to tens of other types throughout the Magento GraphQL schema.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1.  Retrieve the GraphQL introspection schema.
2.  Verify that list fields defined as `[Type!]!` in `schema.graphqls`
    are preserved as `[Type!]!` in the stitched schema.
3.  Without this fix, the same fields appear incorrectly as `[Type]!`.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
