### PR TITLE
fix(customer): cast website and store ids to int in EmailNotification (#40469)

### DIFF
--- a/app/code/Magento/Customer/Model/EmailNotification.php
+++ b/app/code/Magento/Customer/Model/EmailNotification.php
@@ -339,10 +339,10 @@ class EmailNotification implements EmailNotificationInterface
     private function getWebsiteStoreId($customer, $defaultStoreId = null): int
     {
         if ($customer->getWebsiteId() != 0 && empty($defaultStoreId)) {
-            $storeIds = $this->storeManager->getWebsite($customer->getWebsiteId())->getStoreIds();
+            $storeIds = $this->storeManager->getWebsite((int) $customer->getWebsiteId())->getStoreIds();
             $defaultStoreId = reset($storeIds);
         }
-        return $defaultStoreId;
+        return (int) $defaultStoreId;
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Cast website and store IDs to `int` in `EmailNotification::getWebsiteStoreId()` so the return value matches the declared `int` return type when StoreManager/Website return IDs as strings.

### Fixed Issues (if relevant)
Fixes magento/magento2#40469

### Manual testing scenarios (*)
1. Create a custom module that sends welcome email via `Magento\Customer\Model\EmailNotification::newAccount($customer)`.
2. Trigger welcome email (e.g. after customer registration or programmatically).
3. Verify no type error: "Return value must be of type int, string returned" and that the email is sent.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)
