### PR TITLE
fix(catalog): use simple anchor product count to avoid slow admin categories (#40456)

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -342,24 +342,10 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             $categoryIds = array_keys($anchor);
             $countSelect = $this->getProductsCountQuery($categoryIds, (bool)$websiteId);
             $categoryProductsCount = $this->_conn->fetchPairs($countSelect);
-            $countFromCategoryTable = [];
-            if (count($categoryIds) > self::BULK_PROCESSING_LIMIT) {
-                $countFromCategoryTable = $this->getCountFromCategoryTableBulk($categoryIds, (int)$websiteId);
-            }
-
             foreach ($anchor as $item) {
-                $productsCount = 0;
-                if (count($categoryIds) > self::BULK_PROCESSING_LIMIT) {
-                    if (isset($categoryProductsCount[$item->getId()])) {
-                        $productsCount = (int)$categoryProductsCount[$item->getId()];
-                    } elseif (isset($countFromCategoryTable[$item->getId()])) {
-                        $productsCount = (int)$countFromCategoryTable[$item->getId()];
-                    }
-                } else {
-                    $productsCount = isset($categoryProductsCount[$item->getId()])
-                        ? (int)$categoryProductsCount[$item->getId()]
-                        : $this->getProductsCountFromCategoryTable($item, $websiteId);
-                }
+                $productsCount = isset($categoryProductsCount[$item->getId()])
+                    ? (int)$categoryProductsCount[$item->getId()]
+                    : $this->getProductsCountFromCategoryTable($item, $websiteId);
                 $item->setProductCount($productsCount);
             }
         }


### PR DESCRIPTION
### Description (*)
Revert anchor categories product count logic in `loadProductCount()` to the simpler 2.4.7-p8 style. The bulk path (when category count > BULK_PROCESSING_LIMIT) causes very slow queries on large catalogs (150K+ products, 800+ categories), preventing admin Catalog > Categories from loading.

### Fixed Issues (if relevant)
Fixes magento/magento2#40456

### Manual testing scenarios (*)
1. Have 150K+ products and 800+ categories.
2. Upgrade from 2.4.7-p8 to 2.4.8-p3.
3. Go to backend Catalog > Categories.
4. Categories should load (no endless spinner).

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)
