### PR TITLE
perf(customer): cache excluded websites in GroupRepository plugin (#40454)

### DIFF
--- a/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
+++ b/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
@@ -28,6 +28,13 @@ class GetByIdCustomerGroupExcludedWebsite
     private $groupExcludedWebsiteRepository;
 
     /**
+     * In-request cache of excluded websites per customer group id
+     *
+     * @var array<int, array>
+     */
+    private $excludedWebsitesCache = [];
+
+    /**
      * @param \Magento\Customer\Api\Data\GroupExtensionInterfaceFactory $groupExtensionInterfaceFactory
      * @param GroupExcludedWebsiteRepository $groupExcludedWebsiteRepository
      */
@@ -55,7 +62,11 @@ class GetByIdCustomerGroupExcludedWebsite
         GroupInterface $result,
         int $id
     ): GroupInterface {
-        $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($id);
+        if (!isset($this->excludedWebsitesCache[$id])) {
+            $this->excludedWebsitesCache[$id] = $this->groupExcludedWebsiteRepository
+                ->getCustomerGroupExcludedWebsites($id);
+        }
+        $excludedWebsites = $this->excludedWebsitesCache[$id];
         if (!empty($excludedWebsites)) {
             $customerGroupExtensionAttributes = $this->groupExtensionInterfaceFactory->create();
             $customerGroupExtensionAttributes->setExcludeWebsiteIds($excludedWebsites);

--- a/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
+++ b/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
@@ -9,14 +9,17 @@ namespace Magento\Customer\Model\Plugin;
 
 use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\GroupRepositoryInterface;
+use Magento\Customer\Model\Cache\GroupExcludedWebsiteCache;
 use Magento\Customer\Model\ResourceModel\GroupExcludedWebsiteRepository;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 
 /**
  * Add excluded websites to customer group as extension attributes while retrieving this group by id.
+ *
+ * Uses shared GroupExcludedWebsiteCache so cache is properly invalidated when excluded websites
+ * are modified by SaveCustomerGroupExcludedWebsite or DeleteCustomerGroupExcludedWebsite.
  */
-class GetByIdCustomerGroupExcludedWebsite implements ResetAfterRequestInterface
+class GetByIdCustomerGroupExcludedWebsite
 {
     /**
      * @var \Magento\Customer\Api\Data\GroupExtensionInterfaceFactory
@@ -29,22 +32,23 @@ class GetByIdCustomerGroupExcludedWebsite implements ResetAfterRequestInterface
     private $groupExcludedWebsiteRepository;
 
     /**
-     * In-request cache of excluded websites per customer group id
-     *
-     * @var array<int, array>
+     * @var GroupExcludedWebsiteCache
      */
-    private $excludedWebsitesCache = [];
+    private $groupExcludedWebsiteCache;
 
     /**
      * @param \Magento\Customer\Api\Data\GroupExtensionInterfaceFactory $groupExtensionInterfaceFactory
      * @param GroupExcludedWebsiteRepository $groupExcludedWebsiteRepository
+     * @param GroupExcludedWebsiteCache $groupExcludedWebsiteCache
      */
     public function __construct(
         \Magento\Customer\Api\Data\GroupExtensionInterfaceFactory $groupExtensionInterfaceFactory,
-        GroupExcludedWebsiteRepository $groupExcludedWebsiteRepository
+        GroupExcludedWebsiteRepository $groupExcludedWebsiteRepository,
+        GroupExcludedWebsiteCache $groupExcludedWebsiteCache
     ) {
         $this->groupExtensionInterfaceFactory = $groupExtensionInterfaceFactory;
         $this->groupExcludedWebsiteRepository = $groupExcludedWebsiteRepository;
+        $this->groupExcludedWebsiteCache = $groupExcludedWebsiteCache;
     }
 
     /**
@@ -63,11 +67,13 @@ class GetByIdCustomerGroupExcludedWebsite implements ResetAfterRequestInterface
         GroupInterface $result,
         int $id
     ): GroupInterface {
-        if (!isset($this->excludedWebsitesCache[$id])) {
-            $this->excludedWebsitesCache[$id] = $this->groupExcludedWebsiteRepository
-                ->getCustomerGroupExcludedWebsites($id);
+        if ($this->groupExcludedWebsiteCache->isCached($id)) {
+            $excludedWebsites = $this->groupExcludedWebsiteCache->getFromCache($id);
+        } else {
+            $excludedWebsites = $this->groupExcludedWebsiteRepository->getCustomerGroupExcludedWebsites($id);
+            // Resource model populates cache when loading from DB
         }
-        $excludedWebsites = $this->excludedWebsitesCache[$id];
+
         if (!empty($excludedWebsites)) {
             $customerGroupExtensionAttributes = $this->groupExtensionInterfaceFactory->create();
             $customerGroupExtensionAttributes->setExcludeWebsiteIds($excludedWebsites);
@@ -75,13 +81,5 @@ class GetByIdCustomerGroupExcludedWebsite implements ResetAfterRequestInterface
         }
 
         return $result;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function _resetState(): void
-    {
-        $this->excludedWebsitesCache = [];
     }
 }

--- a/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
+++ b/app/code/Magento/Customer/Model/Plugin/GetByIdCustomerGroupExcludedWebsite.php
@@ -11,11 +11,12 @@ use Magento\Customer\Api\Data\GroupInterface;
 use Magento\Customer\Api\GroupRepositoryInterface;
 use Magento\Customer\Model\ResourceModel\GroupExcludedWebsiteRepository;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 
 /**
  * Add excluded websites to customer group as extension attributes while retrieving this group by id.
  */
-class GetByIdCustomerGroupExcludedWebsite
+class GetByIdCustomerGroupExcludedWebsite implements ResetAfterRequestInterface
 {
     /**
      * @var \Magento\Customer\Api\Data\GroupExtensionInterfaceFactory
@@ -74,5 +75,13 @@ class GetByIdCustomerGroupExcludedWebsite
         }
 
         return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function _resetState(): void
+    {
+        $this->excludedWebsitesCache = [];
     }
 }


### PR DESCRIPTION
### Description (*)
Cache excluded websites per customer group id within the request in `GetByIdCustomerGroupExcludedWebsite::afterGetById` to avoid N+1 database queries when multiple `getById()` calls are made (e.g. on category/grouped product pages with many customer group checks).

### Fixed Issues (if relevant)
Fixes magento/magento2#40454

### Manual testing scenarios (*)
1. Navigate to a category page that triggers many customer group lookups.
2. Verify page loads and excluded-website logic is unchanged.
3. Compare query count before/after; repeated getById for same group should hit cache.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)
