### PR TITLE
fix(graphql): include catalog-only products when filtering by url_key (#40451)

### DIFF
--- a/app/code/Magento/CatalogGraphQl/DataProvider/Product/SearchCriteriaBuilder.php
+++ b/app/code/Magento/CatalogGraphQl/DataProvider/Product/SearchCriteriaBuilder.php
@@ -100,7 +100,12 @@ class SearchCriteriaBuilder
             $this->addDefaultSortOrder($searchCriteria, $args, $isSearch);
         }
         $this->addEntityIdSort($searchCriteria);
-        $this->addVisibilityFilter($searchCriteria, $isSearch, !empty($args['filter']['category_id']));
+        $this->addVisibilityFilter(
+            $searchCriteria,
+            $isSearch,
+            !empty($args['filter']['category_id']),
+            !empty($args['filter']['url_key'])
+        );
 
         return $searchCriteria;
     }
@@ -169,15 +174,22 @@ class SearchCriteriaBuilder
      * @param SearchCriteriaInterface $searchCriteria
      * @param bool $isSearch
      * @param bool $isFilter
+     * @param bool $hasUrlKeyFilter When true, include catalog-only products (e.g. configurable children)
      */
-    private function addVisibilityFilter(SearchCriteriaInterface $searchCriteria, bool $isSearch, bool $isFilter): void
-    {
+    private function addVisibilityFilter(
+        SearchCriteriaInterface $searchCriteria,
+        bool $isSearch,
+        bool $isFilter,
+        bool $hasUrlKeyFilter = false
+    ): void {
         if ($isFilter && $isSearch) {
             // Index already contains products filtered by visibility: catalog, search, both
             return;
         }
         $visibilityIds = $isSearch
-            ? $this->visibility->getVisibleInSearchIds()
+            ? ($hasUrlKeyFilter
+                ? $this->visibility->getVisibleInSiteIds()
+                : $this->visibility->getVisibleInSearchIds())
             : $this->visibility->getVisibleInCatalogIds();
 
         $this->addFilter($searchCriteria, 'visibility', $visibilityIds, 'in');


### PR DESCRIPTION
### Description (*)
When the products GraphQL query has a `url_key` filter (e.g. PDP lookup by URL key), use `getVisibleInSiteIds()` for the visibility filter so that configurable children with Visibility=Catalog are included in results. Previously `getVisibleInSearchIds()` was used for search, which excluded catalog-only products.

### Fixed Issues (if relevant)
Fixes magento/magento2#40451

### Manual testing scenarios (*)
1. Create a configurable product with Visibility=Catalog.
2. Create 2 children with Visibility=Catalog (same as configurable).
3. Run: `products(search: "{child_sku}", filter: { url_key: { eq: "{child_url_key}" } })`.
4. Expected: child product is returned. Before fix: no results.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)
