### PR TITLE
fix(mftf): resolve PayPal login flaky test AC-5004 - multiple password fields

### DIFF
--- a/app/code/Magento/Paypal/Test/Mftf/Section/PayPalExpressCheckoutConfigSection/PayPalPaymentSection.xml
+++ b/app/code/Magento/Paypal/Test/Mftf/Section/PayPalExpressCheckoutConfigSection/PayPalPaymentSection.xml
@@ -12,7 +12,7 @@
         <element name="loginSection" type="input" selector=" #main&gt;#login"/>
         <element name="existingAccountLoginBtn" type="input" selector="#loginSection a"/>
         <element name="email" type="input" selector="//input[contains(@name, 'email') and not(contains(@style, 'display:none'))]"/>
-        <element name="password" type="input" selector="//input[contains(@name, 'password') and not(contains(@style, 'display:none'))]"/>
+        <element name="password" type="input" selector="(//input[contains(@name, 'password') and not(contains(@style, 'display:none'))])[1]"/>
         <element name="loginBtn" type="input" selector="//button[normalize-space(text())='Log In']"/>
         <element name="reviewUserInfo" type="text" selector="[data-testid=personalized-banner-content]"/>
         <element name="cartIcon" type="text" selector="[data-testid='header-show-cart-dropdown-btn']"/>


### PR DESCRIPTION
## Description

When the PayPal sandbox login page shows multiple password input elements (e.g., passkey/biometric + traditional password flow), the `conditionalClick` in `StorefrontLoginToPayPalPaymentAccountTwoStepActionGroup` throws:

```
more than one element matches selector //input[contains(@name, 'password') and not(contains(@style, 'display:none'))]
```

The MagentoWebDriver `conditionalClick` method throws when `_findElements(dependentSelector)` returns more than one element.

## Solution

Add `[1]` positional predicate to the password selector in `PayPalPaymentSection.xml` so it always resolves to at most one element (the first visible password field).

## Fixed Issues

- Fixes flaky test **AC-5004: Void order placed within Billing Agreement** (`AdminVoidSalesOrderWithPaypalBillingAgreementTest`) observed in B2B functional test suite.
- Flaky tests in #40479 
- 
## Testing

- Affected tests use `StorefrontLoginToPayPalPaymentAccountTwoStepActionGroup` (PayPal sandbox login).
- The fix ensures `conditionalClick` does not throw when multiple password fields exist in DOM.
