### PR TITLE
fix(mftf): resolve Add Products button timing flakiness MC-15861

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/ActionGroup/AddSimpleProductToOrderActionGroup.xml
+++ b/app/code/Magento/Sales/Test/Mftf/ActionGroup/AddSimpleProductToOrderActionGroup.xml
@@ -17,6 +17,7 @@
             <argument name="productQty" defaultValue="1" type="string"/>
         </arguments>
 
+        <waitForElementClickable selector="{{AdminOrderFormItemsSection.addProducts}}" stepKey="waitForAddProductsButton"/>
         <click selector="{{AdminOrderFormItemsSection.addProducts}}" stepKey="clickAddProducts"/>
         <fillField selector="{{AdminOrderFormItemsSection.skuFilter}}" userInput="{{product.sku}}" stepKey="fillSkuFilter"/>
         <click selector="{{AdminOrderFormItemsSection.search}}" stepKey="clickSearch"/>


### PR DESCRIPTION
## Description

The "Add Products" button on the Admin Create Order page is dynamically injected by JavaScript (`Magento_Sales/order/create/scripts.js`). The button is added to `#order-items .admin__page-section-title .actions` via `itemsArea.onLoad` callback.

When `AddSimpleProductToOrderActionGroup` runs immediately after `AdminNavigateToNewOrderPageExistingCustomerActionGroup`, the button may not exist yet, causing:

```
CSS or XPath element with //section[@id='order-items']/div/div/button/span[text() = 'Add Products'] was not found.
```

## Solution

Add `waitForElementClickable` before the click, following the pattern used in `AddConfigurableProductToOrderActionGroup` and `CreateOrderInStoreActionGroup`.

## Fixed Issues

- Fixes flaky test **MC-15861: Create Credit Memo for Offline Payment Methods (partial refund)** (`AdminCreateCreditMemoPartialRefundTest`) observed in EE functional test suite.
- Flaky tests in #40479 

## Testing

- Affected action group is used by multiple Sales MFTF tests.
- The wait ensures the button is present and clickable before interaction.
