### PR TITLE
Fix REST API getVideoProvider() on null when fetching configurable children with video (#40401)

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
+++ b/app/code/Magento/ConfigurableProduct/Model/LinkManagement.php
@@ -123,18 +123,23 @@ class LinkManagement implements LinkManagementInterface
             $attributes = [];
             foreach ($child->getAttributes() as $attribute) {
                 $attrCode = $attribute->getAttributeCode();
+                if ($attrCode === 'media_gallery_entries') {
+                    continue;
+                }
                 $value = $child->getDataUsingMethod($attrCode) ?: $child->getData($attrCode);
                 if (null !== $value) {
                     $attributes[$attrCode] = $value;
                 }
             }
             $attributes['store_id'] = $child->getStoreId();
+            /** @var \Magento\Catalog\Api\Data\ProductInterface $productDataObject */
             $productDataObject = $this->productFactory->create();
             $this->dataObjectHelper->populateWithArray(
-                $productDataObject->setMediaGalleryEntries($child->getMediaGalleryEntries()),
+                $productDataObject,
                 $attributes,
                 ProductInterface::class
             );
+            $productDataObject->setMediaGalleryEntries($child->getMediaGalleryEntries());
             $childrenList[] = $productDataObject;
         }
         return $childrenList;


### PR DESCRIPTION
### Description (*)

This PR fixes the "Call to a member function getVideoProvider() on null" error that occurs when calling the REST API endpoint `/rest/V1/configurable-products/{sku}/children` for a configurable product whose simple child has a YouTube video in the media gallery.

**Root cause:** The `LinkManagement::getChildren()` method was passing `media_gallery_entries` through `populateWithArray()` using data derived from `getMediaEntries()`, which converts raw gallery data. For external videos, this conversion path triggers `ExternalVideoEntryConverter::convertFrom()` with incomplete data, causing a null reference when calling `getVideoProvider()`.

**Solution:**
- Exclude `media_gallery_entries` from the attributes array to prevent conversion via the deprecated `getMediaEntries()` path
- Use `setMediaGalleryEntries($child->getMediaGalleryEntries())` after `populateWithArray()` to set properly hydrated media gallery entry objects directly from the child product

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40401

### Manual testing scenarios (*)
1. Create a configurable product with a simple child product
2. Add a YouTube video to the child product's media gallery (no other images required)
3. Save and verify the video appears in the admin
4. Generate OAuth keys in System > Integrations
5. Call `GET /rest/V1/configurable-products/{configSku}/children` with OAuth authentication
6. Verify the response returns child products with media gallery entries populated correctly, without errors in logs

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files are updated if required
- [ ] All automated tests passed successfully
