### PR TITLE
Fix cart price rule not applied in Sweden when postal code contains space (#40379)

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -625,6 +625,7 @@
     <zip countryCode="PL">
         <codes>
             <code id="pattern_1" active="true" example="12-345">^[0-9]{2}-[0-9]{3}$</code>
+            <code id="pattern_2" active="true" example="12345">^[0-9]{5}$</code>
         </codes>
     </zip>
     <zip countryCode="PM">

--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -686,6 +686,7 @@
     <zip countryCode="SE">
         <codes>
             <code id="pattern_1" active="true" example="123 45">^[0-9]{3}\s[0-9]{2}$</code>
+            <code id="pattern_2" active="true" example="12345">^[0-9]{5}$</code>
         </codes>
     </zip>
     <zip countryCode="SG">

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
@@ -189,8 +189,8 @@ class Address extends \Magento\Rule\Model\Condition\AbstractCondition
     }
 
     /**
-     * Validate postcode attribute with normalized values for formats that use spaces (e.g. Sweden "100 00").
-     * Ensures cart price rules match regardless of space in postal code.
+     * Validate postcode attribute with normalized values for formats that use spaces, hyphens or dots.
+     * Ensures cart price rules match regardless of formatting (e.g. Sweden "100 00", Poland "56-500").
      *
      * @param object|array|int|string|float|bool|null $validatedValue
      * @return bool
@@ -222,14 +222,15 @@ class Address extends \Magento\Rule\Model\Condition\AbstractCondition
     }
 
     /**
-     * Normalize postcode by removing whitespace for consistent comparison.
-     * Handles formats like Swedish "100 00" and Czech "123 45".
+     * Normalize postcode by removing whitespace, hyphens and dots for consistent comparison.
+     * Handles formats like: Swedish "100 00", Polish "56-500", Czech "123 45".
+     * Formatting characters (space, hyphen, dot) are optional in many countries.
      *
      * @param string $postcode
      * @return string
      */
     private function normalizePostcode(string $postcode): string
     {
-        return preg_replace('/\s+/', '', $postcode);
+        return preg_replace('/[\s.\-]+/', '', $postcode);
     }
 }

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
@@ -187,4 +187,49 @@ class Address extends \Magento\Rule\Model\Condition\AbstractCondition
 
         return parent::validate($address);
     }
+
+    /**
+     * Validate postcode attribute with normalized values for formats that use spaces (e.g. Sweden "100 00").
+     * Ensures cart price rules match regardless of space in postal code.
+     *
+     * @param object|array|int|string|float|bool|null $validatedValue
+     * @return bool
+     */
+    public function validateAttribute($validatedValue)
+    {
+        if ($this->getAttribute() === 'postcode' && is_scalar($validatedValue)) {
+            $normalizedValidated = $this->normalizePostcode((string) $validatedValue);
+            $originalValue = $this->getValueParsed();
+            if (is_array($originalValue)) {
+                $normalizedValue = array_map(
+                    function ($item) {
+                        return $this->normalizePostcode((string) $item);
+                    },
+                    $originalValue
+                );
+            } else {
+                $normalizedValue = $this->normalizePostcode((string) $originalValue);
+            }
+            $this->setData('value_parsed', $normalizedValue);
+            try {
+                return parent::validateAttribute($normalizedValidated);
+            } finally {
+                $this->setData('value_parsed', $originalValue);
+            }
+        }
+
+        return parent::validateAttribute($validatedValue);
+    }
+
+    /**
+     * Normalize postcode by removing whitespace for consistent comparison.
+     * Handles formats like Swedish "100 00" and Czech "123 45".
+     *
+     * @param string $postcode
+     * @return string
+     */
+    private function normalizePostcode(string $postcode): string
+    {
+        return preg_replace('/\s+/', '', $postcode);
+    }
 }

--- a/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
+++ b/app/code/Magento/SalesRule/Model/Rule/Condition/Address.php
@@ -190,6 +190,7 @@ class Address extends \Magento\Rule\Model\Condition\AbstractCondition
 
     /**
      * Validate postcode attribute with normalized values for formats that use spaces, hyphens or dots.
+     *
      * Ensures cart price rules match regardless of formatting (e.g. Sweden "100 00", Poland "56-500").
      *
      * @param object|array|int|string|float|bool|null $validatedValue

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Condition/AddressTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Condition/AddressTest.php
@@ -100,4 +100,59 @@ class AddressTest extends TestCase
             'Postcode "100 00" should match rule value "10000" (normalized)'
         );
     }
+
+    /**
+     * Test that Polish postcode with hyphen matches without hyphen (e.g. "56-500" vs "56500")
+     *
+     * @return void
+     */
+    public function testValidateAttributePostcodePolishWithHyphenMatchesWithoutHyphen(): void
+    {
+        $this->model->setAttribute('postcode');
+        $this->model->setOperator('==');
+        $this->model->setValueParsed('56-500');
+
+        $this->assertTrue(
+            $this->model->validateAttribute('56-500'),
+            'Postcode "56-500" should match rule value "56-500"'
+        );
+        $this->assertTrue(
+            $this->model->validateAttribute('56500'),
+            'Postcode "56500" should match rule value "56-500" (normalized)'
+        );
+    }
+
+    /**
+     * Test that postcode rule without hyphen matches address with hyphen (Polish format)
+     *
+     * @return void
+     */
+    public function testValidateAttributePostcodeRuleWithoutHyphenMatchesAddressWithHyphen(): void
+    {
+        $this->model->setAttribute('postcode');
+        $this->model->setOperator('==');
+        $this->model->setValueParsed('56500');
+
+        $this->assertTrue(
+            $this->model->validateAttribute('56-500'),
+            'Postcode "56-500" should match rule value "56500" (normalized)'
+        );
+    }
+
+    /**
+     * Test that postcode with dot is normalized (e.g. "12.345" or "56.500")
+     *
+     * @return void
+     */
+    public function testValidateAttributePostcodeWithDotNormalized(): void
+    {
+        $this->model->setAttribute('postcode');
+        $this->model->setOperator('==');
+        $this->model->setValueParsed('56500');
+
+        $this->assertTrue(
+            $this->model->validateAttribute('56.500'),
+            'Postcode "56.500" should match rule value "56500" (dot normalized)'
+        );
+    }
 }

--- a/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Condition/AddressTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/Rule/Condition/AddressTest.php
@@ -62,4 +62,42 @@ class AddressTest extends TestCase
         $this->model->loadAttributeOptions();
         $this->assertEquals($attributes, array_keys($this->model->getAttributeOption()));
     }
+
+    /**
+     * Test that postcode with space matches postcode without space (e.g. Swedish format "100 00")
+     *
+     * @return void
+     */
+    public function testValidateAttributePostcodeWithSpaceMatchesWithoutSpace(): void
+    {
+        $this->model->setAttribute('postcode');
+        $this->model->setOperator('==');
+        $this->model->setValueParsed('100 00');
+
+        $this->assertTrue(
+            $this->model->validateAttribute('100 00'),
+            'Postcode "100 00" should match rule value "100 00"'
+        );
+        $this->assertTrue(
+            $this->model->validateAttribute('10000'),
+            'Postcode "10000" should match rule value "100 00" (normalized)'
+        );
+    }
+
+    /**
+     * Test that postcode rule without space matches address with space
+     *
+     * @return void
+     */
+    public function testValidateAttributePostcodeRuleWithoutSpaceMatchesAddressWithSpace(): void
+    {
+        $this->model->setAttribute('postcode');
+        $this->model->setOperator('==');
+        $this->model->setValueParsed('10000');
+
+        $this->assertTrue(
+            $this->model->validateAttribute('100 00'),
+            'Postcode "100 00" should match rule value "10000" (normalized)'
+        );
+    }
 }


### PR DESCRIPTION
## Description

Fixes #40379

When applying a Cart Price Rule in the Sweden store view, the discount was not applied correctly if the postal code contained a space (e.g. "100 00"). Additionally, entering a Swedish postal code without a space (e.g. "10000") triggered a validation warning.

## Changes

1. **zip_codes.xml**:
   - **Sweden (SE)**: Added pattern to accept postal codes without space (`^[0-9]{5}$`), so both "100 00" and "10000" are valid.
   - **Poland (PL)**: Added pattern to accept postal codes without hyphen (`^[0-9]{5}$`), so both "56-500" and "56500" are valid.

2. **SalesRule Address condition**: Normalize postcode values before comparison when validating the Shipping Postcode condition. Removes **whitespace**, **hyphens** and **dots** so cart price rules match regardless of formatting:
   - **Sweden**: "100 00" ↔ "10000"
   - **Poland**: "56-500" ↔ "56500"
   - **Czech/Slovak**: "123 45" ↔ "12345"

3. **Unit tests**: Added tests for Swedish, Polish and dot-separated formats.

## Design decision: why ignore `.` and `-`?

Many countries use optional formatting characters in postal codes:
- **Poland (PL)**: Official format `XX-XXX` (e.g. 56-500) but users often enter `56500`
- **Brazil (BR)**: `12345-678` or `12345678`
- **Portugal (PT)**: `1234-567` or `1234567`

Magento's `zip_codes.xml` already defines patterns that accept both formats for some countries (e.g. NL, CA). For cart price rules, we normalize before comparison so the rule matches regardless of how the admin or customer entered the postcode. This avoids the same class of issues as Sweden (#40379) for other countries.

## Testing

- Unit tests pass: `Magento\SalesRule\Test\Unit\Model\Rule\Condition\AddressTest`
