### PR TITLE
Fix 'Ship Together' bundle orders stuck in Processing after full shipment

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -890,12 +890,9 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             if (!$item->getParentItem() || $item->getParentItem()->getProductType() !== Type::TYPE_BUNDLE) {
                 $qtyToShip = $item->getQtyToShip();
             } else {
-                if ($item->getParentItem()->getProductType() === Type::TYPE_BUNDLE &&
-                    $item->getParentItem()->getProduct()->getShipmentType() == Type\AbstractType::SHIPMENT_TOGETHER) {
-                    $qtyToShip = $item->getParentItem()->getQtyToShip();
-                } else {
-                    $qtyToShip = $item->getSimpleQtyToShip();
-                }
+                $parentItem = $item->getParentItem();
+                $isShipTogether = $this->isBundleShipTogether($parentItem);
+                $qtyToShip = $isShipTogether ? $parentItem->getQtyToShip() : $item->getSimpleQtyToShip();
             }
 
             if ($qtyToShip > 0 && !$item->getIsVirtual() && !$item->getLockedDoShip()) {
@@ -904,6 +901,30 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
         }
 
         return false;
+    }
+
+    /**
+     * Check if bundle product is configured to ship together.
+     * For "Ship Together" bundles, only the parent's qty_shipped is updated on shipment,
+     * so we must use the parent's getQtyToShip() for children when determining canShip().
+     *
+     * @param OrderItemInterface $parentItem
+     * @return bool
+     */
+    private function isBundleShipTogether(OrderItemInterface $parentItem): bool
+    {
+        try {
+            $product = $parentItem->getProduct();
+            if ($product !== null) {
+                return $product->getShipmentType() == Type\AbstractType::SHIPMENT_TOGETHER;
+            }
+        } catch (\Throwable $e) {
+            // Product may be deleted or unavailable
+        }
+
+        $productOptions = $parentItem->getProductOptions();
+        return isset($productOptions['shipment_type'])
+            && $productOptions['shipment_type'] == Type\AbstractType::SHIPMENT_TOGETHER;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -919,7 +919,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
                 return $product->getShipmentType() == Type\AbstractType::SHIPMENT_TOGETHER;
             }
         } catch (\Throwable $e) {
-            // Product may be deleted or unavailable
+            // phpcs:ignore Generic.CodeAnalysis.EmptyStatement -- Product may be deleted or unavailable
         }
 
         $productOptions = $parentItem->getProductOptions();
@@ -1635,13 +1635,16 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Gets order item by given ID.
      *
-     * @param int $itemId
+     * @param int|null $itemId Order item ID (null in rare edge cases, e.g. legacy data)
      * @return \Magento\Framework\DataObject|null
      */
     public function getItemById($itemId)
     {
+        if ($itemId === null) {
+            return null;
+        }
+
         $items = $this->getItems();
-        $itemId = $itemId ?? '';
 
         if (isset($items[$itemId])) {
             return $items[$itemId];

--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -918,8 +918,8 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
             if ($product !== null) {
                 return $product->getShipmentType() == Type\AbstractType::SHIPMENT_TOGETHER;
             }
+        // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Product may be deleted or unavailable
         } catch (\Throwable $e) {
-            // phpcs:ignore Generic.CodeAnalysis.EmptyStatement -- Product may be deleted or unavailable
         }
 
         $productOptions = $parentItem->getProductOptions();


### PR DESCRIPTION
### Description (*)

For "Ship Together" bundle products, only the parent item's `qty_shipped` is updated when creating a shipment. The children's `qty_shipped` remains 0. The `canShip()` logic incorrectly used `getSimpleQtyToShip()` for bundle children, which returns `qty_ordered` for children (since their `qty_shipped` is never updated), causing `canShip()` to return `true` even when the order is fully shipped.

**Root cause:** In `Order::canShip()`, for bundle children the code used `$item->getSimpleQtyToShip()` which calculates `qty_ordered - qty_shipped - qty_refunded - qty_canceled`. For Ship Together bundle children, `qty_shipped` is never updated (only the parent's is), so this returns a positive value even when fully shipped.

**Solution:** For bundle children with Ship Together configuration, use the parent's `getQtyToShip()` instead of the child's `getSimpleQtyToShip()`. Added `isBundleShipTogether()` helper with fallback to `product_options` when the product is unavailable (e.g. deleted).

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40465

### Manual testing scenarios (*)

1. Create a bundle product with "Ship Together" option
2. Place an order containing this bundle
3. Create an invoice for the order
4. Create a shipment for the order (ship the full quantity)
5. Verify order status transitions to "Complete"
6. Verify `$order->canShip()` returns `false`

### Questions or comments

None.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)
