### PR TITLE
fix(sales): cast creditmemo item qty to float to prevent TypeError in QuantityValidator

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Validation/QuantityValidator.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Validation/QuantityValidator.php
@@ -133,7 +133,7 @@ class QuantityValidator implements ValidatorInterface
         }
         $orderItem = $orderItemsById[$item->getOrderItemId()];
 
-        if (!$this->isValidDecimalRefundQty($orderItem->getIsQtyDecimal(), $item->getQty())) {
+        if (!$this->isValidDecimalRefundQty($orderItem->getIsQtyDecimal(), (float) $item->getQty())) {
             return __(
                 'We found an invalid quantity to refund item "%1".',
                 $orderItem->getSku()


### PR DESCRIPTION
### Description (*)
When creating credit memo via API, item qty can be passed as string (e.g. `"1.0"`). PHP 8.4 strict typing causes `TypeError` in `isValidDecimalRefundQty()` when the method receives a string for `$itemQty` parameter.

**Fix:** Cast `$item->getQty()` to `(float)` before passing to `isValidDecimalRefundQty()`.

### Fixed Issues
Fixes magento/magento2#40302

### Manual testing scenarios (*)
1. Create order with shippable item
2. Create credit memo via API with qty as string (e.g. `"1.0"`)
3. Verify credit memo is created without TypeError
