### PR TITLE
fix(sales): remove limit from IdListBuilder to allow full sales_order_grid sync

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Provider/Query/IdListBuilder.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Provider/Query/IdListBuilder.php
@@ -10,7 +10,6 @@ namespace Magento\Sales\Model\ResourceModel\Provider\Query;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\DB\Select;
-use Magento\Sales\Model\ResourceModel\Grid;
 
 /**
  * Query builder for retrieving list of updated order ids that was not synced to grid table.
@@ -99,7 +98,6 @@ class IdListBuilder
             );
 
         $select->where('grid_table.entity_id IS NULL');
-        $select->limit(Grid::BATCH_SIZE);
         foreach ($this->additionalGridTables as $table) {
             $select->joinLeft(
                 [$table => $table],


### PR DESCRIPTION
### Description (*)
`IdListBuilder::build()` had `limit(Grid::BATCH_SIZE)` which capped `getIds()` at 100. When `refreshBySchedule()` runs, it chunks the IDs in batches anyway, so the provider must return ALL not-synced IDs. The limit caused only 100 items to be synced when truncating `sales_order_grid` or when >100 orders exist between cron runs.

**Fix:** Remove the limit from the select in `IdListBuilder::build()`.

### Fixed Issues
Fixes magento/magento2#39602

### Manual testing scenarios (*)
1. Create >100 orders
2. Truncate `sales_order_grid`
3. Run `sales_grid_order_async_insert` cron
4. Verify all orders appear in the grid
