### PR TITLE
[2.4] Developer Experience: Make getAdditionalConfig extensible for Configurable Swatches (#30787)

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -222,6 +222,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
      *
      * @return array
      * @api
+     * @since 100.4.9
      */
     public function getAdditionalConfig(): array
     {

--- a/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
+++ b/app/code/Magento/ConfigurableProduct/Block/Product/View/Type/Configurable.php
@@ -205,11 +205,27 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
     /**
      * Returns additional values for js config, can be overridden by descendants
      *
+     * @deprecated 100.2.0 Use composition approach to extend the configuration (plugin for getAdditionalConfig method)
+     * @see getAdditionalConfig to apply `after` plugin and extend an array
      * @return array
      */
     protected function _getAdditionalConfig()
     {
         return [];
+    }
+
+    /**
+     * Returns additional values for js config.
+     *
+     * Enables plugins to extend swatch configuration without class inheritance.
+     * Use an `after` plugin on this method to add custom data to the config array.
+     *
+     * @return array
+     * @api
+     */
+    public function getAdditionalConfig(): array
+    {
+        return $this->_getAdditionalConfig();
     }
 
     /**
@@ -244,7 +260,7 @@ class Configurable extends \Magento\Catalog\Block\Product\View\AbstractView
             $config['defaultValues'] = $attributesData['defaultValues'];
         }
 
-        $config = array_merge($config, $this->_getAdditionalConfig());
+        $config = array_merge($config, $this->getAdditionalConfig());
 
         return $this->jsonEncoder->encode($config);
     }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Block/Product/View/Type/ConfigurableTest.php
@@ -256,6 +256,14 @@ class ConfigurableTest extends TestCase
     }
 
     /**
+     * Test that getAdditionalConfig() returns result of _getAdditionalConfig() and is extensible via plugins
+     */
+    public function testGetAdditionalConfigReturnsEmptyArrayByDefault(): void
+    {
+        $this->assertSame([], $this->block->getAdditionalConfig());
+    }
+
+    /**
      * Check that getJsonConfig() method returns expected value
      */
     public function testGetJsonConfig(): void


### PR DESCRIPTION
### Description (*)

Fixes magento/magento2#30787

Revival of #30718, retargeted to **2.4-develop** (2.5-develop is no longer active).

Currently when you need to add extra data to Configurable Swatches config, you must either:
- Inherit the class and add custom elements
- Use a plugin on `getJsonConfig` and decode/encode the JSON

This change adds a public `getAdditionalConfig()` method that delegates to `_getAdditionalConfig()`, enabling extensions to use an `after` plugin on `getAdditionalConfig()` to add custom data without class inheritance or JSON manipulation.

### Changes
- Add public `getAdditionalConfig(): array` method (marked `@api`)
- Mark `_getAdditionalConfig()` as `@deprecated 100.2.0`
- Update `getJsonConfig()` to use `getAdditionalConfig()` instead of `_getAdditionalConfig()`
- Add unit test `testGetAdditionalConfigReturnsEmptyArrayByDefault`

### Manual testing scenarios (*)
1. Create a plugin for `Magento\ConfigurableProduct\Block\Product\View\Type\Configurable::getAdditionalConfig()` with `after` method
2. In the plugin, merge custom data into the result array
3. Verify the custom data appears in the swatch JSON config on the product page

### Backward compatibility
- Fully backward compatible: `_getAdditionalConfig()` remains for descendants
- No breaking changes to existing plugins on `getJsonConfig` (e.g. Weee module)

### Related
- Original PR: #30718 (closed, was for 2.5-develop)
- Issue: #30787
