### PR TITLE
Fix DivisionByZeroError in creditmemo tax when base shipping amount is zero (#40492)

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -106,7 +106,7 @@ class Tax extends AbstractTotal
         $baseOrderShippingAmount = (float)$order->getBaseShippingAmount();
         if ($invoice = $creditmemo->getInvoice()) {
             // recalculate tax amounts in case if refund shipping value was changed
-            if ($baseOrderShippingAmount && $creditmemo->getBaseShippingAmount() !== null) {
+            if ($baseOrderShippingAmount > 0 && $creditmemo->getBaseShippingAmount() !== null) {
                 $taxFactor = $creditmemo->getBaseShippingAmount() / $baseOrderShippingAmount;
                 $shippingTaxAmount = $invoice->getShippingTaxAmount() * $taxFactor;
                 $baseShippingTaxAmount = $invoice->getBaseShippingTaxAmount() * $taxFactor;
@@ -134,7 +134,7 @@ class Tax extends AbstractTotal
             $baseShippingDiscountTaxCompensationAmount = 0;
             $shippingDelta = $baseOrderShippingAmount - $baseOrderShippingRefundedAmount;
 
-            if ($orderShippingAmount > 0 && ($shippingDelta > $creditmemo->getBaseShippingAmount() ||
+            if ($orderShippingAmount > 0 && $baseOrderShippingAmount > 0 && ($shippingDelta > $creditmemo->getBaseShippingAmount() ||
                 $this->isShippingIncludeTaxWithTaxAfterDiscount($order->getStoreId()))) {
                 $part = $creditmemo->getShippingAmount() / $orderShippingAmount;
                 $basePart = $creditmemo->getBaseShippingAmount() / $baseOrderShippingAmount;

--- a/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo/Total/Tax.php
@@ -134,8 +134,11 @@ class Tax extends AbstractTotal
             $baseShippingDiscountTaxCompensationAmount = 0;
             $shippingDelta = $baseOrderShippingAmount - $baseOrderShippingRefundedAmount;
 
-            if ($orderShippingAmount > 0 && $baseOrderShippingAmount > 0 && ($shippingDelta > $creditmemo->getBaseShippingAmount() ||
-                $this->isShippingIncludeTaxWithTaxAfterDiscount($order->getStoreId()))) {
+            if ($orderShippingAmount > 0
+                && $baseOrderShippingAmount > 0
+                && ($shippingDelta > $creditmemo->getBaseShippingAmount()
+                    || $this->isShippingIncludeTaxWithTaxAfterDiscount($order->getStoreId()))
+            ) {
                 $part = $creditmemo->getShippingAmount() / $orderShippingAmount;
                 $basePart = $creditmemo->getBaseShippingAmount() / $baseOrderShippingAmount;
                 $shippingTaxAmount = $order->getShippingTaxAmount() * $part;

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/TaxTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Creditmemo/Total/TaxTest.php
@@ -921,6 +921,100 @@ class TaxTest extends TestCase
     }
 
     /**
+     * Test that credit memo with invoice and zero base shipping amount does not throw DivisionByZeroError
+     *
+     * @see https://github.com/magento/magento2/issues/40492
+     */
+    public function testCollectWithZeroBaseShippingAmountDoesNotThrowDivisionByZero(): void
+    {
+        $orderData = [
+            'base_shipping_amount' => 0,
+            'shipping_amount' => 0,
+            'shipping_tax_amount' => 0,
+            'base_shipping_tax_amount' => 0,
+            'shipping_discount_tax_compensation_amount' => 0,
+            'base_shipping_discount_tax_compensation_amount' => 0,
+            'tax_invoiced' => 10.00,
+            'base_tax_invoiced' => 10.00,
+            'tax_refunded' => 0,
+            'base_tax_refunded' => 0,
+        ];
+
+        $invoiceMock = $this->createInvoiceMock([
+            'tax_amount' => 10.00,
+            'base_tax_amount' => 10.00,
+            'shipping_tax_amount' => 0,
+            'base_shipping_tax_amount' => 0,
+            'shipping_discount_tax_compensation_amount' => 0,
+            'base_shipping_discount_tax_compensation_amount' => 0,
+        ]);
+
+        $this->resourceInvoice->expects($this->any())
+            ->method('calculateRefundedAmount')
+            ->willReturn(0.0);
+
+        $creditmemoData = [
+            'items' => [
+                'item_1' => [
+                    'order_item' => [
+                        'qty_invoiced' => 1,
+                        'tax_invoiced' => 10.00,
+                        'tax_refunded' => 0,
+                        'base_tax_invoiced' => 10.00,
+                        'base_tax_refunded' => 0,
+                        'discount_tax_compensation_amount' => 0,
+                        'base_discount_tax_compensation_amount' => 0,
+                        'qty_refunded' => 0,
+                    ],
+                    'is_last' => true,
+                    'qty' => 1,
+                ],
+            ],
+            'is_last' => true,
+            'data_fields' => [
+                'grand_total' => 100.00,
+                'base_grand_total' => 100.00,
+                'base_shipping_amount' => 0,
+                'shipping_amount' => 0,
+                'tax_amount' => 0,
+                'base_tax_amount' => 0,
+                'invoice' => $invoiceMock,
+            ],
+        ];
+
+        foreach ($orderData as $key => $value) {
+            $this->order->setData($key, $value);
+        }
+
+        $creditmemoItems = [];
+        foreach ($creditmemoData['items'] as $itemKey => $creditmemoItemData) {
+            $creditmemoItems[$itemKey] = $this->getCreditmemoItem($creditmemoItemData);
+        }
+        $this->creditmemo->expects($this->once())
+            ->method('getAllItems')
+            ->willReturn($creditmemoItems);
+        $this->creditmemo->expects($this->any())
+            ->method('isLast')
+            ->willReturn($creditmemoData['is_last']);
+        $this->creditmemo->expects($this->any())
+            ->method('getInvoice')
+            ->willReturn($invoiceMock);
+        foreach ($creditmemoData['data_fields'] as $key => $value) {
+            if ($key !== 'invoice') {
+                $this->creditmemo->setData($key, $value);
+            }
+        }
+        $this->creditmemo->expects($this->any())
+            ->method('roundPrice')
+            ->willReturnArgument(0);
+
+        $this->model->collect($this->creditmemo);
+
+        $this->assertEqualsWithDelta(0, $this->creditmemo->getShippingTaxAmount(), self::EPSILON);
+        $this->assertEqualsWithDelta(0, $this->creditmemo->getBaseShippingTaxAmount(), self::EPSILON);
+    }
+
+    /**
      * Test that invoice-based credit memo correctly accounts for tax refunded in order based credit memo
      */
     public function testInvoiceBasedCreditMemoAccountsForOrderBasedRefund()


### PR DESCRIPTION
### Description (*)
Add explicit `$baseOrderShippingAmount > 0` guard before division in `Magento\Sales\Model\Order\Creditmemo\Total\Tax::collect()` to prevent DivisionByZeroError when creating a credit memo for orders with zero base shipping amount (e.g. free shipping, shipping covered by cart rule).

Without this guard, the expression `$creditmemo->getBaseShippingAmount() / $baseOrderShippingAmount` throws when base order shipping is 0.

### Fixed Issues (if relevant)
Fixes magento/magento2#40492

### Manual testing scenarios (*)
1. Create an order with free shipping (or shipping fully discounted by cart rule)
2. Invoice the order
3. Create a credit memo from the invoice
4. Verify credit memo is created successfully without DivisionByZeroError
5. Verify tax amounts are calculated correctly (shipping tax remains 0)

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
