### PR TITLE
Fix REST API attribute update without attribute_id in payload

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Repository.php
@@ -140,6 +140,16 @@ class Repository implements \Magento\Catalog\Api\ProductAttributeRepositoryInter
                 ->getEntityType(\Magento\Catalog\Api\Data\ProductAttributeInterface::ENTITY_TYPE_CODE)
                 ->getId()
         );
+        // When attribute_id is missing but attribute_code is provided, load existing attribute for update
+        if (!$attribute->getAttributeId() && $attribute->getAttributeCode()) {
+            try {
+                $existingAttribute = $this->get($attribute->getAttributeCode());
+                $attribute->setAttributeId($existingAttribute->getAttributeId());
+            // phpcs:ignore Magento2.CodeAnalysis.EmptyBlock.DetectedCatch
+            } catch (NoSuchEntityException $e) {
+                // Attribute doesn't exist, proceed with new attribute creation
+            }
+        }
         if ($attribute->getAttributeId()) {
             $existingModel = $this->get($attribute->getAttributeCode());
 


### PR DESCRIPTION
### Description (*)
When PUT request to `/V1/products/attributes/{attributeCode}` includes `attribute_code` in payload but omits `attribute_id`, the API incorrectly returns 400 "Attribute with the same code already exists". This fix loads the existing attribute by code when `attribute_id` is missing but `attribute_code` is provided, allowing the update to proceed.

### Fixed Issues (if relevant)
Fixes magento/magento2#40458

### Manual testing scenarios (*)
1. Send PUT to `/V1/products/attributes/color` with payload containing `attribute_code` but no `attribute_id`
2. Verify API returns 200 and attribute is updated (not 400)

### Contribution checklist (*)
- [x] Pull request has a meaningful description
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests
- [ ] README.md files for modified modules are updated
