### PR TITLE
Include country in order grid shipping and billing address columns

### DIFF
--- a/app/code/Magento/Sales/etc/di.xml
+++ b/app/code/Magento/Sales/etc/di.xml
@@ -781,6 +781,10 @@
                     <item name="tableAlias" xsi:type="string">sales_shipping_address</item>
                     <item name="columnName" xsi:type="string">postcode</item>
                 </item>
+                <item name="country_id" xsi:type="array">
+                    <item name="tableAlias" xsi:type="string">sales_shipping_address</item>
+                    <item name="columnName" xsi:type="string">country_id</item>
+                </item>
             </argument>
             <argument name="separator" xsi:type="string">, </argument>
         </arguments>
@@ -807,6 +811,10 @@
                 <item name="postcode" xsi:type="array">
                     <item name="tableAlias" xsi:type="string">sales_billing_address</item>
                     <item name="columnName" xsi:type="string">postcode</item>
+                </item>
+                <item name="country_id" xsi:type="array">
+                    <item name="tableAlias" xsi:type="string">sales_billing_address</item>
+                    <item name="columnName" xsi:type="string">country_id</item>
                 </item>
             </argument>
             <argument name="separator" xsi:type="string">, </argument>


### PR DESCRIPTION
### Description (*)
Add country_id to ShippingAddressAggregator and BillingAddressAggregator so the Sales->Orders grid address columns display the country for orders shipped to different countries. Previously only street, city, region and postcode were shown.

### Fixed Issues (if relevant)
Fixes magento/magento2#40403

### Manual testing scenarios (*)
1. Create an order with shipping address in a different country than store default
2. Go to Sales->Orders grid
3. Enable Shipping Address column in grid columns
4. Verify country (e.g. US, DE) is displayed in the address

### Contribution checklist (*)
- [x] Pull request has a meaningful description
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests
- [ ] README.md files for modified modules are updated
