### PR TITLE
fix(customer): correct virtualType naming typo in di.xml

### DIFF
--- a/app/code/Magento/Customer/etc/adminhtml/di.xml
+++ b/app/code/Magento/Customer/etc/adminhtml/di.xml
@@ -23,7 +23,7 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="CustomerGirdFilterPool" type="Magento\Framework\View\Element\UiComponent\DataProvider\FilterPool">
+    <virtualType name="CustomerGridFilterPool" type="Magento\Framework\View\Element\UiComponent\DataProvider\FilterPool">
         <arguments>
             <argument name="appliers" xsi:type="array">
                 <item name="regular" xsi:type="object">Magento\Framework\View\Element\UiComponent\DataProvider\RegularFilter</item>
@@ -33,7 +33,7 @@
     </virtualType>
     <virtualType name="CustomerGridCollectionReporting" type="Magento\Framework\View\Element\UiComponent\DataProvider\Reporting">
         <arguments>
-            <argument name="filterPool" xsi:type="object">CustomerGirdFilterPool</argument>
+            <argument name="filterPool" xsi:type="object">CustomerGridFilterPool</argument>
         </arguments>
     </virtualType>
     <type name="Magento\Customer\Ui\Component\DataProvider">


### PR DESCRIPTION
### Description

Rename `CustomerGirdFilterPool` to `CustomerGridFilterPool` - fix transposed letters "ir" → "ri" in the word "Grid".

This is a simple naming typo that doesn't affect functionality (since both the definition and reference use the same typo), but correcting it improves code consistency and prevents confusion for developers reading the code.

### Related Pull Requests

- Original PR that introduced this issue was closed: magento/magento2#38244

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40321

### Manual testing scenarios

1. Run `bin/magento setup:di:compile` - should complete without errors
2. Navigate to Admin > Customers > All Customers grid - should load correctly
3. Test customer grid filters - should work as expected

### Questions or comments

This is a cosmetic fix - the code works because both the virtualType definition and its reference use the same typo. However, fixing this improves code quality and developer experience.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
