### PR TITLE
fix(catalog): restore self-reference in category product count query

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -408,7 +408,7 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
             )
             ->joinInner(
                 ['ce2' => $this->getTable('catalog_category_entity')],
-                'ce2.path LIKE CONCAT(ce.path, \'/%\')',
+                'ce2.path LIKE CONCAT(ce.path, \'/%\') OR ce2.entity_id = ce.entity_id',
                 []
             )
             ->where('ce.entity_id IN (?)', $categoryIds);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Category/CollectionTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Category/CollectionTest.php
@@ -220,7 +220,7 @@ class CollectionTest extends TestCase
         $this->select->expects($this->once())->method('joinInner')
             ->with(
                 ['ce2' => null],
-                'ce2.path LIKE CONCAT(ce.path, \'/%\')',
+                'ce2.path LIKE CONCAT(ce.path, \'/%\') OR ce2.entity_id = ce.entity_id',
                 []
             )->willReturnSelf();
         $this->select->method('where')->willReturnSelf();

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Category/CollectionProductCountTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Category/CollectionProductCountTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Model\ResourceModel\Category;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Model\Category;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for category product count functionality.
+ *
+ * Tests the fix for magento/magento2#40263 - product count shows 0 for
+ * anchor categories without children (leaf anchor categories).
+ *
+ * @see \Magento\Catalog\Model\ResourceModel\Category\Collection::loadProductCount()
+ * @see \Magento\Catalog\Model\ResourceModel\Category\Collection::getCountFromCategoryTableBulk()
+ */
+class CollectionProductCountTest extends TestCase
+{
+    private ObjectManagerInterface $objectManager;
+    private CollectionFactory $collectionFactory;
+    private CategoryRepositoryInterface $categoryRepository;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->collectionFactory = $this->objectManager->get(CollectionFactory::class);
+        $this->categoryRepository = $this->objectManager->get(CategoryRepositoryInterface::class);
+    }
+
+    /**
+     * Test that anchor categories without children correctly count products assigned directly to them.
+     *
+     * This is the main regression test for magento/magento2#40263.
+     * Without the fix, leaf anchor categories would show 0 products.
+     *
+     * @magentoDataFixture Magento/Catalog/_files/category_anchor_without_children_with_product.php
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     */
+    public function testLeafAnchorCategoryProductCount(): void
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addIdFilter([555, 556]);
+        $collection->setLoadProductCount(true);
+        $collection->load();
+
+        /** @var Category $category555 */
+        $category555 = $collection->getItemById(555);
+        /** @var Category $category556 */
+        $category556 = $collection->getItemById(556);
+
+        $this->assertNotNull($category555, 'Category 555 should exist');
+        $this->assertNotNull($category556, 'Category 556 should exist');
+
+        // Without the fix, these would be 0
+        $this->assertEquals(
+            1,
+            $category555->getProductCount(),
+            'Leaf anchor category 555 should count 1 product assigned directly to it'
+        );
+        $this->assertEquals(
+            1,
+            $category556->getProductCount(),
+            'Leaf anchor category 556 should count 1 product assigned directly to it'
+        );
+    }
+
+    /**
+     * Test that the bulk processing method correctly includes self-references without causing duplicate entry errors.
+     *
+     * This tests that the fix doesn't reintroduce the ACP2E-4159 regression (duplicate entry errors).
+     *
+     * @magentoDataFixture Magento/Catalog/_files/category_anchor_without_children_with_product.php
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     */
+    public function testBulkQueryDoesNotCauseDuplicateEntryError(): void
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+
+        /** @var AdapterInterface $connection */
+        $connection = $collection->getConnection();
+
+        $categoryIds = [555, 556];
+        $tempTableName = 'temp_category_descendants_test_' . uniqid();
+
+        try {
+            // Create temp table matching the structure in getCountFromCategoryTableBulk
+            $tempTable = $connection->newTable($tempTableName)
+                ->addColumn(
+                    'category_id',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                    null,
+                    ['unsigned' => true, 'nullable' => false],
+                    'Category ID'
+                )
+                ->addColumn(
+                    'descendant_id',
+                    \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+                    null,
+                    ['unsigned' => true, 'nullable' => false],
+                    'Descendant ID'
+                )
+                ->addIndex(
+                    $connection->getIndexName($tempTableName, ['category_id', 'descendant_id']),
+                    ['category_id', 'descendant_id'],
+                    ['type' => AdapterInterface::INDEX_TYPE_PRIMARY]
+                );
+            $connection->createTemporaryTable($tempTable);
+
+            // Build the SELECT with the fix (includes self-reference via OR condition)
+            $selectDescendants = $connection->select()
+                ->from(
+                    ['ce' => $collection->getTable('catalog_category_entity')],
+                    ['category_id' => 'ce.entity_id', 'descendant_id' => 'ce2.entity_id']
+                )
+                ->joinInner(
+                    ['ce2' => $collection->getTable('catalog_category_entity')],
+                    'ce2.path LIKE CONCAT(ce.path, \'/%\') OR ce2.entity_id = ce.entity_id',
+                    []
+                )
+                ->where('ce.entity_id IN (?)', $categoryIds);
+
+            // This should NOT throw a duplicate entry exception
+            $connection->query(
+                $connection->insertFromSelect(
+                    $selectDescendants,
+                    $tempTableName,
+                    ['category_id', 'descendant_id']
+                )
+            );
+
+            // Verify self-references were inserted
+            $rows = $connection->fetchAll("SELECT * FROM {$tempTableName} ORDER BY category_id, descendant_id");
+
+            $selfRefCount = 0;
+            foreach ($rows as $row) {
+                if ($row['category_id'] === $row['descendant_id']) {
+                    $selfRefCount++;
+                }
+            }
+
+            $this->assertEquals(
+                count($categoryIds),
+                $selfRefCount,
+                'Each category should have a self-reference entry in the temp table'
+            );
+        } finally {
+            $connection->dropTemporaryTable($tempTableName);
+        }
+    }
+
+    /**
+     * Test that the LIKE condition and self-reference condition are mutually exclusive.
+     *
+     * This validates our assumption that duplicates cannot occur because:
+     * - 'path/%' never matches the category's own path (LIKE requires chars after /)
+     * - Self-reference only matches the category itself
+     *
+     * @magentoDataFixture Magento/Catalog/_files/category_anchor_without_children_with_product.php
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     */
+    public function testLikeAndSelfReferenceAreMutuallyExclusive(): void
+    {
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+
+        /** @var AdapterInterface $connection */
+        $connection = $collection->getConnection();
+
+        // Test with category 555 (path: 1/2/555)
+        $category = $this->categoryRepository->get(555);
+        $categoryPath = $category->getPath();
+
+        // Query to find rows that match BOTH conditions (should be 0)
+        $select = $connection->select()
+            ->from(
+                ['ce' => $collection->getTable('catalog_category_entity')],
+                ['count' => 'COUNT(*)']
+            )
+            ->joinInner(
+                ['ce2' => $collection->getTable('catalog_category_entity')],
+                // Both conditions must be true (not OR)
+                'ce2.path LIKE CONCAT(ce.path, \'/%\') AND ce2.entity_id = ce.entity_id',
+                []
+            )
+            ->where('ce.entity_id = ?', 555);
+
+        $count = (int) $connection->fetchOne($select);
+
+        $this->assertEquals(
+            0,
+            $count,
+            'LIKE and self-reference conditions should be mutually exclusive - a category cannot be its own descendant'
+        );
+    }
+
+    /**
+     * Test product count for a parent category with children (traditional scenario).
+     *
+     * This ensures the fix doesn't break the existing behavior for categories with children.
+     *
+     * @magentoDataFixture Magento/Catalog/_files/category_anchor.php
+     * @magentoDbIsolation disabled
+     * @magentoAppIsolation enabled
+     */
+    public function testParentAnchorCategoryProductCount(): void
+    {
+        // Category 22 is an anchor with child category 11
+        // Product1 is assigned to category 11 (child)
+        // Product2 is assigned to category 22 (parent)
+
+        /** @var Collection $collection */
+        $collection = $this->collectionFactory->create();
+        $collection->addIdFilter([22]);
+        $collection->setLoadProductCount(true);
+        $collection->load();
+
+        /** @var Category $parentCategory */
+        $parentCategory = $collection->getItemById(22);
+
+        $this->assertNotNull($parentCategory, 'Parent anchor category 22 should exist');
+
+        // Parent anchor category should count products from itself AND its children
+        // Product1 (in child 11) + Product2 (in parent 22) = 2 products
+        $this->assertGreaterThanOrEqual(
+            2,
+            $parentCategory->getProductCount(),
+            'Parent anchor category should count products from itself and descendants'
+        );
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/category_anchor_without_children_with_product.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/category_anchor_without_children_with_product.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * Fixture for testing category product count on anchor categories without children.
+ * This tests the fix for magento/magento2#40263.
+ */
+declare(strict_types=1);
+
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Api\Data\ProductInterfaceFactory;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var StoreManagerInterface $storeManager */
+$storeManager = $objectManager->get(StoreManagerInterface::class);
+$defaultStoreId = (int) $storeManager->getDefaultStoreView()->getId();
+
+/** @var ProductInterfaceFactory $productFactory */
+$productFactory = $objectManager->get(ProductInterfaceFactory::class);
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+
+// Create anchor category WITHOUT children (leaf anchor category) using model directly
+// This is the scenario that breaks without the fix
+/** @var CategoryInterface $leafAnchorCategory */
+$leafAnchorCategory = $objectManager->create(CategoryInterface::class);
+$leafAnchorCategory->isObjectNew(true);
+$leafAnchorCategory
+    ->setId(555)
+    ->setIsAnchor(true)
+    ->setStoreId($defaultStoreId)
+    ->setName('Leaf Anchor Category')
+    ->setParentId(2)
+    ->setPath('1/2/555')
+    ->setLevel(2)
+    ->setAvailableSortBy('name')
+    ->setDefaultSortBy('name')
+    ->setIsActive(true)
+    ->setPosition(1);
+$leafAnchorCategory->save();
+
+// Create a second anchor category without children for bulk testing
+/** @var CategoryInterface $leafAnchorCategory2 */
+$leafAnchorCategory2 = $objectManager->create(CategoryInterface::class);
+$leafAnchorCategory2->isObjectNew(true);
+$leafAnchorCategory2
+    ->setId(556)
+    ->setIsAnchor(true)
+    ->setStoreId($defaultStoreId)
+    ->setName('Leaf Anchor Category 2')
+    ->setParentId(2)
+    ->setPath('1/2/556')
+    ->setLevel(2)
+    ->setAvailableSortBy('name')
+    ->setDefaultSortBy('name')
+    ->setIsActive(true)
+    ->setPosition(2);
+$leafAnchorCategory2->save();
+
+// Create product and assign directly to the leaf anchor category
+$product = $productFactory->create();
+$product
+    ->setTypeId(Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Product in Leaf Anchor')
+    ->setSku('product_in_leaf_anchor')
+    ->setPrice(10)
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 0])
+    ->setCategoryIds([555]);
+$productRepository->save($product);
+
+// Create second product for the second leaf category
+$product2 = $productFactory->create();
+$product2
+    ->setTypeId(Type::TYPE_SIMPLE)
+    ->setAttributeSetId(4)
+    ->setWebsiteIds([1])
+    ->setName('Product in Leaf Anchor 2')
+    ->setSku('product_in_leaf_anchor_2')
+    ->setPrice(20)
+    ->setVisibility(Visibility::VISIBILITY_BOTH)
+    ->setStatus(Status::STATUS_ENABLED)
+    ->setStockData(['use_config_manage_stock' => 0])
+    ->setCategoryIds([556]);
+$productRepository->save($product2);

--- a/dev/tests/integration/testsuite/Magento/Catalog/_files/category_anchor_without_children_with_product_rollback.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/_files/category_anchor_without_children_with_product_rollback.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+use Magento\TestFramework\Helper\Bootstrap;
+
+$objectManager = Bootstrap::getObjectManager();
+
+/** @var Registry $registry */
+$registry = $objectManager->get(Registry::class);
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', true);
+
+/** @var ProductRepositoryInterface $productRepository */
+$productRepository = $objectManager->get(ProductRepositoryInterface::class);
+
+/** @var CategoryRepositoryInterface $categoryRepository */
+$categoryRepository = $objectManager->get(CategoryRepositoryInterface::class);
+
+// Delete products
+$productSkus = ['product_in_leaf_anchor', 'product_in_leaf_anchor_2'];
+foreach ($productSkus as $sku) {
+    try {
+        $product = $productRepository->get($sku);
+        $productRepository->delete($product);
+    } catch (NoSuchEntityException $e) {
+        // Product already deleted
+    }
+}
+
+// Delete categories
+$categoryIds = [555, 556];
+foreach ($categoryIds as $categoryId) {
+    try {
+        $category = $categoryRepository->get($categoryId);
+        $categoryRepository->delete($category);
+    } catch (NoSuchEntityException $e) {
+        // Category already deleted
+    }
+}
+
+$registry->unregister('isSecureArea');
+$registry->register('isSecureArea', false);


### PR DESCRIPTION
### Description

Restore the `OR ce2.entity_id = ce.entity_id` condition in the bulk category product count query (`getCountFromCategoryTableBulk` method).

**Root cause:**
Commit `dba0f6fc57f` (from quality patch ACSD-65848) removed this condition to fix slow category loading. However, this inadvertently broke product count display for categories without child categories.

**Why the condition is needed:**
The query builds a temporary table of (category_id, descendant_id) pairs. Without the self-reference condition (`ce2.entity_id = ce.entity_id`), categories are not included as their own "descendants", so products directly assigned to a category (not through children) are not counted.

**Example:**
- Category A has no child categories
- Product X is assigned directly to Category A
- Without fix: Category A shows (0) products
- With fix: Category A correctly shows (1) product

### Related Pull Requests

- Regression introduced by: commit `dba0f6fc57f933e439f755a6fc6cd854129daf35`

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40263

### Manual testing scenarios

1. Create 401 categories OR temporarily set `BULK_PROCESSING_LIMIT` to 1 in `Magento\Catalog\Model\ResourceModel\Category\Collection`
2. Ensure all categories are anchors: `UPDATE catalog_category_entity_int SET value = 1 WHERE attribute_id = (SELECT attribute_id FROM eav_attribute WHERE attribute_code = 'is_anchor');`
3. Open Admin > Catalog > Categories
4. Select any category without child categories
5. Assign a product to this category
6. Reload the page
7. Verify the category shows the correct product count (1) in the left sidebar

### Questions or comments

This is a regression fix. The original performance optimization is preserved - only the necessary self-reference condition is restored.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
