### PR TITLE
fix(dhl): use getGatewayURL() for sandbox mode support in XML quotes (#40249)

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -1089,7 +1089,7 @@ class Carrier extends AbstractDhl implements CarrierInterface
                 $deferredResponses[] = [
                     'deferred' => $this->httpClient->request(
                         new Request(
-                            (string)$this->getConfigData('gateway_xml_url'),
+                            $this->getGatewayURL(),
                             Request::METHOD_POST,
                             ['Content-Type' => 'application/xml'],
                             mb_convert_encoding($request, 'UTF-8')


### PR DESCRIPTION
### Description

Replace hardcoded `gateway_xml_url` config with `getGatewayURL()` method call in `_getQuotes()`. 

The `getGatewayURL()` method correctly handles sandbox mode by checking `sandbox_mode` config and returning the appropriate URL:
- Production: `gateway_xml_url`
- Sandbox: `sandbox_xml_url`

**Root cause:** Line 1092 in `_getQuotes()` used `$this->getConfigData('gateway_xml_url')` directly, bypassing the sandbox mode logic in `getGatewayURL()`.

### Related Pull Requests

None

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40249

### Manual testing scenarios

1. Enable DHL shipping method in Admin > Stores > Configuration > Sales > Shipping Methods > DHL
2. Enable **Sandbox Mode** and configure sandbox credentials
3. Add a product to cart and proceed to checkout
4. Enter shipping address and request shipping rates
5. **Before fix:** DHL returns "Validation Failure: Site Id is wrong" (production URL used with sandbox credentials)
6. **After fix:** DHL returns valid shipping rates from sandbox environment

### Questions or comments

The `getGatewayURL()` method already exists and handles sandbox mode correctly for other DHL operations. This fix ensures `_getQuotes()` uses the same logic.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
