### PR TITLE
fix(url): resolve incorrect base URLs during store emulation (#39446)

### DIFF
--- a/lib/internal/Magento/Framework/Url.php
+++ b/lib/internal/Magento/Framework/Url.php
@@ -868,9 +868,12 @@ class Url extends \Magento\Framework\DataObject implements \Magento\Framework\Ur
             );
         }
 
-        $cachedParams = $routeParams;
-        if ($isArray) {
-            ksort($cachedParams);
+        $cachedParams = $routeParams ?? [];
+        ksort($cachedParams);
+        if (!isset($cachedParams['_scope'])) {
+            // Always get fresh scope for cache key to handle store emulation correctly
+            $this->setScope(null);
+            $cachedParams['_scope'] = $this->_getScope()->getId();
         }
 
         $cacheKey = sha1($routePath . $this->serializer->serialize($cachedParams));


### PR DESCRIPTION
### Description

Fixes incorrect base URL generation during store emulation. The URL class cached scope and generated URLs without considering store context changes during emulation, causing URLs to use the wrong base URL when processing multiple stores (e.g., in cron jobs sending emails across different store scopes).

### Related Pull Requests

None

### Fixed Issues (if relevant)

1. Fixes #39446

### Changes

1. **`Magento\Framework\Url::_getScope()`** - Added `$useCache` parameter to control when cached scope is used. Cache is only used when `_scope` param was explicitly passed via route params.

2. **URL cache key** - Include scope ID in the cache key to prevent cross-scope cache hits for URLs with identical paths/params.

3. **`Magento\Backend\Model\Url::_getScope()`** - Updated method signature for compatibility with parent class.

### Manual testing scenarios

1. Set up 2+ store views with different base URLs (e.g., `https://store1.test`, `https://store2.test`)
2. Create a script or cron job that emulates multiple stores and generates URLs within each emulation context
3. **Before fix:** URLs from the first emulated scope are incorrectly reused for subsequent scopes
4. **After fix:** Each emulated scope generates URLs with the correct store-specific base URL

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
