### PR TITLE
fix(catalog): align getChildren() method signature with caller and Flat implementation (#40257)

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category.php
@@ -836,41 +836,52 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
      * Return children ids of category
      *
      * @param \Magento\Catalog\Model\Category $category
-     * @param boolean $recursive
+     * @param bool $recursive
+     * @param bool $isActive
+     * @param bool $sortByPosition
      * @return array
      */
-    public function getChildren($category, $recursive = true)
+    public function getChildren($category, $recursive = true, $isActive = true, $sortByPosition = false)
     {
         $linkField = $this->getLinkField();
-        $attributeId = $this->getIsActiveAttributeId();
-        $backendTable = $this->getTable([$this->getEntityTablePrefix(), 'int']);
         $connection = $this->getConnection();
-        $checkSql = $connection->getCheckSql('c.value_id > 0', 'c.value', 'd.value');
         $bind = [
-            'attribute_id' => $attributeId,
-            'store_id' => $category->getStoreId(),
-            'scope' => 1,
             'c_path' => $category->getPath() . '/%',
         ];
-        $select = $this->getConnection()->select()->from(
+        $select = $connection->select()->from(
             ['m' => $this->getEntityTable()],
             'entity_id'
-        )->joinLeft(
-            ['d' => $backendTable],
-            "d.attribute_id = :attribute_id AND d.store_id = 0 AND d.{$linkField} = m.{$linkField}",
-            []
-        )->joinLeft(
-            ['c' => $backendTable],
-            "c.attribute_id = :attribute_id AND c.store_id = :store_id AND c.{$linkField} = m.{$linkField}",
-            []
-        )->where(
-            $checkSql . ' = :scope'
         )->where(
             $connection->quoteIdentifier('path') . ' LIKE :c_path'
         );
+
+        if ($isActive) {
+            $attributeId = $this->getIsActiveAttributeId();
+            $backendTable = $this->getTable([$this->getEntityTablePrefix(), 'int']);
+            $checkSql = $connection->getCheckSql('c.value_id > 0', 'c.value', 'd.value');
+            $bind['attribute_id'] = $attributeId;
+            $bind['store_id'] = $category->getStoreId();
+            $bind['scope'] = 1;
+            $select->joinLeft(
+                ['d' => $backendTable],
+                "d.attribute_id = :attribute_id AND d.store_id = 0 AND d.{$linkField} = m.{$linkField}",
+                []
+            )->joinLeft(
+                ['c' => $backendTable],
+                "c.attribute_id = :attribute_id AND c.store_id = :store_id AND c.{$linkField} = m.{$linkField}",
+                []
+            )->where(
+                $checkSql . ' = :scope'
+            );
+        }
+
         if (!$recursive) {
             $select->where($connection->quoteIdentifier('level') . ' <= :c_level');
             $bind['c_level'] = $category->getLevel() + 1;
+        }
+
+        if ($sortByPosition) {
+            $select->order('position ASC');
         }
 
         return $connection->fetchCol($select, $bind);


### PR DESCRIPTION
### Description (*)
Align `ResourceModel\Category::getChildren()` method signature with:
- The Category model's call which passes 4 arguments
- The `ResourceModel\Category\Flat::getChildren()` signature

**Problem:** The Category model calls `$this->getResource()->getChildren($this, $recursive, $isActive, $sortByPosition)` but the resource model only accepted 2 parameters. This caused extra arguments to be silently ignored and inconsistent behavior between flat and non-flat catalog modes.

**Solution:** Add `$isActive` and `$sortByPosition` parameters to match the Flat implementation. Default values maintain full backward compatibility.

### Related Pull Requests
<!-- No related PRs -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40257

### Manual testing scenarios (*)
1. Navigate to Admin > Catalog > Categories
2. Expand a parent category with child categories
3. Verify the category tree displays correctly with all children
4. Test with both flat catalog enabled and disabled

### Questions or comments
<!-- None -->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
