### PR TITLE
Fix setup:db:status not recognizing JSON type in MariaDB

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Db/MySQL/DbSchemaReader.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\Setup\Declaration\Schema\Db\MySQL;
 
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\SqlVersionProvider;
 use Magento\Framework\DB\Sql\Expression;
 use Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface;
 use Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator;
@@ -34,17 +35,26 @@ class DbSchemaReader implements DbSchemaReaderInterface
     private $definitionAggregator;
 
     /**
+     * @var SqlVersionProvider
+     */
+    private $sqlVersionProvider;
+
+    /**
      * Constructor.
      *
      * @param ResourceConnection $resourceConnection
      * @param DefinitionAggregator $definitionAggregator
+     * @param SqlVersionProvider|null $sqlVersionProvider
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        DefinitionAggregator $definitionAggregator
+        DefinitionAggregator $definitionAggregator,
+        ?SqlVersionProvider $sqlVersionProvider = null
     ) {
         $this->resourceConnection = $resourceConnection;
         $this->definitionAggregator = $definitionAggregator;
+        $this->sqlVersionProvider = $sqlVersionProvider
+            ?? \Magento\Framework\App\ObjectManager::getInstance()->get(SqlVersionProvider::class);
     }
 
     /**
@@ -120,12 +130,69 @@ class DbSchemaReader implements DbSchemaReaderInterface
 
         $columnsDefinition = $adapter->fetchAssoc($stmt);
 
+        // In MariaDB, JSON columns are stored as LONGTEXT internally.
+        // Detect JSON columns by checking for json_valid CHECK constraints.
+        $jsonColumns = $this->getJsonColumnsFromCheckConstraints($tableName, $resource);
+
         foreach ($columnsDefinition as $columnDefinition) {
+            // If this is a MariaDB JSON column reported as longtext, correct the type
+            if (isset($jsonColumns[$columnDefinition['name']]) && $columnDefinition['type'] === 'longtext') {
+                $columnDefinition['type'] = 'json';
+            }
             $column = $this->definitionAggregator->fromDefinition($columnDefinition);
             $columns[$column['name']] = $column;
         }
 
         return $columns;
+    }
+
+    /**
+     * Get columns that have json_valid CHECK constraints (indicating JSON type in MariaDB).
+     *
+     * MariaDB stores JSON columns as LONGTEXT internally but adds a json_valid() CHECK constraint.
+     * This method detects such columns so they can be properly identified as JSON type.
+     *
+     * @param string $tableName
+     * @param string $resource
+     * @return array Column names that are JSON type (as keys)
+     */
+    private function getJsonColumnsFromCheckConstraints(string $tableName, string $resource): array
+    {
+        $jsonColumns = [];
+
+        try {
+            if (!$this->sqlVersionProvider->isMariaDbEngine()) {
+                return $jsonColumns;
+            }
+        } catch (\Exception $e) {
+            // If we can't determine the engine, assume not MariaDB
+            return $jsonColumns;
+        }
+
+        $adapter = $this->resourceConnection->getConnection($resource);
+        $dbName = $this->resourceConnection->getSchemaName($resource);
+
+        // Query CHECK_CONSTRAINTS to find json_valid constraints
+        // MariaDB adds constraints like: json_valid(`column_name`)
+        $stmt = $adapter->select()
+            ->from(
+                'information_schema.CHECK_CONSTRAINTS',
+                ['CHECK_CLAUSE']
+            )
+            ->where('CONSTRAINT_SCHEMA = ?', $dbName)
+            ->where('TABLE_NAME = ?', $tableName)
+            ->where('CHECK_CLAUSE LIKE ?', 'json_valid(%');
+
+        $checkConstraints = $adapter->fetchCol($stmt);
+
+        foreach ($checkConstraints as $checkClause) {
+            // Extract column name from json_valid(`column_name`) or json_valid(column_name)
+            if (preg_match('/json_valid\s*\(\s*`?([^`\)]+)`?\s*\)/i', $checkClause, $matches)) {
+                $jsonColumns[$matches[1]] = true;
+            }
+        }
+
+        return $jsonColumns;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Db/MySQL/DbSchemaReaderTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Db/MySQL/DbSchemaReaderTest.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Setup\Test\Unit\Declaration\Schema\Db\MySQL;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Adapter\SqlVersionProvider;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Setup\Declaration\Schema\Db\DefinitionAggregator;
+use Magento\Framework\Setup\Declaration\Schema\Db\MySQL\DbSchemaReader;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for DbSchemaReader
+ */
+class DbSchemaReaderTest extends TestCase
+{
+    /**
+     * @var DbSchemaReader
+     */
+    private $dbSchemaReader;
+
+    /**
+     * @var ResourceConnection|MockObject
+     */
+    private $resourceConnectionMock;
+
+    /**
+     * @var DefinitionAggregator|MockObject
+     */
+    private $definitionAggregatorMock;
+
+    /**
+     * @var SqlVersionProvider|MockObject
+     */
+    private $sqlVersionProviderMock;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->resourceConnectionMock = $this->createMock(ResourceConnection::class);
+        $this->definitionAggregatorMock = $this->createMock(DefinitionAggregator::class);
+        $this->sqlVersionProviderMock = $this->createMock(SqlVersionProvider::class);
+        $this->adapterMock = $this->createMock(AdapterInterface::class);
+
+        $this->dbSchemaReader = $this->objectManager->getObject(
+            DbSchemaReader::class,
+            [
+                'resourceConnection' => $this->resourceConnectionMock,
+                'definitionAggregator' => $this->definitionAggregatorMock,
+                'sqlVersionProvider' => $this->sqlVersionProviderMock,
+            ]
+        );
+    }
+
+    /**
+     * Test that JSON columns are correctly detected in MariaDB
+     *
+     * MariaDB stores JSON columns as LONGTEXT internally but adds a json_valid CHECK constraint.
+     * The readColumns method should detect this and convert the type back to 'json'.
+     */
+    public function testReadColumnsDetectsJsonColumnsInMariaDb(): void
+    {
+        $tableName = 'test_table';
+        $resource = 'default';
+        $dbName = 'test_db';
+
+        // Mock MariaDB engine detection
+        $this->sqlVersionProviderMock->expects($this->once())
+            ->method('isMariaDbEngine')
+            ->willReturn(true);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getConnection')
+            ->with($resource)
+            ->willReturn($this->adapterMock);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getSchemaName')
+            ->with($resource)
+            ->willReturn($dbName);
+
+        // Mock column query results - returns 'longtext' for a JSON column in MariaDB
+        $columnsSelect = $this->createMock(Select::class);
+        $checkConstraintsSelect = $this->createMock(Select::class);
+
+        $this->adapterMock->expects($this->exactly(2))
+            ->method('select')
+            ->willReturnOnConsecutiveCalls($columnsSelect, $checkConstraintsSelect);
+
+        $columnsSelect->expects($this->any())->method('from')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('where')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('order')->willReturnSelf();
+
+        $checkConstraintsSelect->expects($this->any())->method('from')->willReturnSelf();
+        $checkConstraintsSelect->expects($this->any())->method('where')->willReturnSelf();
+
+        // Simulate column data with a JSON column reported as longtext
+        $columnData = [
+            'json_data' => [
+                'name' => 'json_data',
+                'default' => null,
+                'type' => 'longtext',
+                'nullable' => true,
+                'definition' => 'longtext',
+                'extra' => '',
+                'comment' => null,
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci'
+            ],
+            'other_column' => [
+                'name' => 'other_column',
+                'default' => null,
+                'type' => 'varchar',
+                'nullable' => true,
+                'definition' => 'varchar(255)',
+                'extra' => '',
+                'comment' => null,
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci'
+            ]
+        ];
+
+        // Simulate CHECK constraint for json_valid
+        $checkConstraints = ['json_valid(`json_data`)'];
+
+        $this->adapterMock->expects($this->once())
+            ->method('fetchAssoc')
+            ->willReturn($columnData);
+
+        $this->adapterMock->expects($this->once())
+            ->method('fetchCol')
+            ->willReturn($checkConstraints);
+
+        // The definitionAggregator should receive 'json' type for the json_data column
+        $this->definitionAggregatorMock->expects($this->exactly(2))
+            ->method('fromDefinition')
+            ->willReturnCallback(function ($data) {
+                // Verify that json_data column has type 'json', not 'longtext'
+                if ($data['name'] === 'json_data') {
+                    $this->assertEquals('json', $data['type'], 'JSON column should have type corrected to json');
+                }
+                return $data;
+            });
+
+        $this->dbSchemaReader->readColumns($tableName, $resource);
+    }
+
+    /**
+     * Test that MySQL (non-MariaDB) columns are not modified
+     */
+    public function testReadColumnsDoesNotModifyColumnsForMySql(): void
+    {
+        $tableName = 'test_table';
+        $resource = 'default';
+        $dbName = 'test_db';
+
+        // Mock MySQL engine (not MariaDB)
+        $this->sqlVersionProviderMock->expects($this->once())
+            ->method('isMariaDbEngine')
+            ->willReturn(false);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getConnection')
+            ->with($resource)
+            ->willReturn($this->adapterMock);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getSchemaName')
+            ->with($resource)
+            ->willReturn($dbName);
+
+        $columnsSelect = $this->createMock(Select::class);
+
+        // Only one select call for columns (no CHECK constraints query for MySQL)
+        $this->adapterMock->expects($this->once())
+            ->method('select')
+            ->willReturn($columnsSelect);
+
+        $columnsSelect->expects($this->any())->method('from')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('where')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('order')->willReturnSelf();
+
+        $columnData = [
+            'json_data' => [
+                'name' => 'json_data',
+                'default' => null,
+                'type' => 'json',
+                'nullable' => true,
+                'definition' => 'json',
+                'extra' => '',
+                'comment' => null,
+                'charset' => null,
+                'collation' => null
+            ]
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('fetchAssoc')
+            ->willReturn($columnData);
+
+        // fetchCol should not be called for MySQL (no CHECK constraint query)
+        $this->adapterMock->expects($this->never())
+            ->method('fetchCol');
+
+        $this->definitionAggregatorMock->expects($this->once())
+            ->method('fromDefinition')
+            ->with($this->callback(function ($data) {
+                // Verify type is unchanged
+                return $data['type'] === 'json';
+            }))
+            ->willReturnArgument(0);
+
+        $this->dbSchemaReader->readColumns($tableName, $resource);
+    }
+
+    /**
+     * Test that longtext columns without json_valid CHECK constraint remain as longtext
+     */
+    public function testReadColumnsKeepsLongtextWithoutJsonConstraint(): void
+    {
+        $tableName = 'test_table';
+        $resource = 'default';
+        $dbName = 'test_db';
+
+        // Mock MariaDB engine detection
+        $this->sqlVersionProviderMock->expects($this->once())
+            ->method('isMariaDbEngine')
+            ->willReturn(true);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getConnection')
+            ->with($resource)
+            ->willReturn($this->adapterMock);
+
+        $this->resourceConnectionMock->expects($this->any())
+            ->method('getSchemaName')
+            ->with($resource)
+            ->willReturn($dbName);
+
+        $columnsSelect = $this->createMock(Select::class);
+        $checkConstraintsSelect = $this->createMock(Select::class);
+
+        $this->adapterMock->expects($this->exactly(2))
+            ->method('select')
+            ->willReturnOnConsecutiveCalls($columnsSelect, $checkConstraintsSelect);
+
+        $columnsSelect->expects($this->any())->method('from')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('where')->willReturnSelf();
+        $columnsSelect->expects($this->any())->method('order')->willReturnSelf();
+
+        $checkConstraintsSelect->expects($this->any())->method('from')->willReturnSelf();
+        $checkConstraintsSelect->expects($this->any())->method('where')->willReturnSelf();
+
+        // Regular longtext column (not JSON)
+        $columnData = [
+            'description' => [
+                'name' => 'description',
+                'default' => null,
+                'type' => 'longtext',
+                'nullable' => true,
+                'definition' => 'longtext',
+                'extra' => '',
+                'comment' => null,
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci'
+            ]
+        ];
+
+        // No json_valid CHECK constraints
+        $checkConstraints = [];
+
+        $this->adapterMock->expects($this->once())
+            ->method('fetchAssoc')
+            ->willReturn($columnData);
+
+        $this->adapterMock->expects($this->once())
+            ->method('fetchCol')
+            ->willReturn($checkConstraints);
+
+        // Type should remain longtext since there's no json_valid constraint
+        $this->definitionAggregatorMock->expects($this->once())
+            ->method('fromDefinition')
+            ->with($this->callback(function ($data) {
+                return $data['type'] === 'longtext';
+            }))
+            ->willReturnArgument(0);
+
+        $this->dbSchemaReader->readColumns($tableName, $resource);
+    }
+}


### PR DESCRIPTION
### Description (*)
Fixes `bin/magento setup:db:status` incorrectly reporting schema mismatches for JSON columns when using MariaDB.

**Root Cause:** When reading column definitions from `information_schema.COLUMNS`, MariaDB reports JSON columns with `DATA_TYPE = 'longtext'` instead of `json`. This causes the schema comparison to always fail because the declared schema says `json` but the actual database reports `longtext`.

**Solution:** Query `information_schema.CHECK_CONSTRAINTS` to find columns with `json_valid()` CHECK constraints (which MariaDB automatically adds for JSON columns) and correct their type from `longtext` to `json` before comparison.

### Related Pull Requests
<!-- No related PRs -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#38278

### Manual testing scenarios (*)
1. Set up a Magento installation with MariaDB
2. Create or use a table with JSON columns (e.g., `quote` table has JSON columns in recent versions)
3. Run `bin/magento setup:db:status`
4. Verify no false positive schema mismatch errors for JSON columns

### Questions or comments
<!-- None -->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
