### PR TITLE
fix(catalog): correct getCollection() return type docblock (#40152)

### DIFF
--- a/app/code/Magento/Catalog/Ui/DataProvider/Product/Related/AbstractDataProvider.php
+++ b/app/code/Magento/Catalog/Ui/DataProvider/Product/Related/AbstractDataProvider.php
@@ -113,7 +113,9 @@ abstract class AbstractDataProvider extends ProductDataProvider
     abstract protected function getLinkType();
 
     /**
-     * {@inheritdoc}
+     * Get product collection with store and product filters applied
+     *
+     * @return \Magento\Catalog\Model\ResourceModel\Product\Collection
      * @since 101.0.0
      */
     public function getCollection()


### PR DESCRIPTION
### Description (*)

Fixed incorrect return type documentation in `Magento\Catalog\Ui\DataProvider\Product\Related\AbstractDataProvider::getCollection()`.

The method was documented via `@inheritdoc` to return `\Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection`, but it actually returns `\Magento\Catalog\Model\ResourceModel\Product\Collection` which inherits from the EAV collection hierarchy, not the Framework DB collection.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40152

### Manual testing scenarios (*)
1. Verify PHPDoc tools correctly identify the return type
2. Run existing unit tests in `AbstractDataProviderTestCase` - they already assert the correct return type

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
