### PR TITLE
fix(newrelic): remove unused magento-composer-installer dependency

### DIFF
--- a/app/code/Magento/NewRelicReporting/composer.json
+++ b/app/code/Magento/NewRelicReporting/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": "~8.3.0||~8.4.0||~8.5.0",
         "magento/framework": "*",
-        "magento/magento-composer-installer": "*",
         "magento/module-backend": "*",
         "magento/module-catalog": "*",
         "magento/module-config": "*",


### PR DESCRIPTION
### Description (*)

Removed unused `magento/magento-composer-installer` dependency from `magento/module-new-relic-reporting`.

This dependency is not used anywhere in the module code and causes unnecessary tight coupling.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40243

### Manual testing scenarios (*)
1. Verify module installs correctly without the dependency
2. Run `composer validate` on the module

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
