### PR TITLE
fix(review): prevent product state modification in Review block (#40168)

### DIFF
--- a/app/code/Magento/Review/Block/Product/View.php
+++ b/app/code/Magento/Review/Block/Product/View.php
@@ -87,8 +87,6 @@ class View extends \Magento\Catalog\Block\Product\View
             return '';
         }
 
-        $product->setShortDescription(null);
-
         return parent::_toHtml();
     }
 

--- a/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
+++ b/app/code/Magento/Review/view/frontend/layout/review_product_list.xml
@@ -8,6 +8,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="catalog_product_view"/>
     <body>
+        <referenceBlock name="product.info.overview" remove="true"/>
         <referenceContainer name="product.info.main">
             <block class="Magento\Review\Block\Product\View\Other" name="product.info.other" as="other" template="Magento_Review::product/view/other.phtml" before="product.info.addto" ifconfig="catalog/review/active"/>
         </referenceContainer>


### PR DESCRIPTION
### Description (*)

Removed `$product->setShortDescription(null);` from `Magento\Review\Block\Product\View::_toHtml()`.

This line was modifying the product object stored in the registry, causing side effects for any subsequent code that accessed the product - they would see `null` for `short_description` instead of the actual value.

The short description block is now hidden via layout XML (`remove="true"`) on the review page, achieving the same visual result without mutating the model.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40168

### Manual testing scenarios (*)
1. Visit product page with reviews - short description should display normally
2. Navigate to reviews page (`/review/product/list/id/{product_id}`) - short description should be hidden
3. Verify product's `short_description` attribute retains its value when accessed from other blocks/code

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
