### PR TITLE
fix(quote-graphql): inject CartItemFactory via constructor (#40129)

### DIFF
--- a/app/code/Magento/QuoteGraphQl/Model/AddProductsToCart.php
+++ b/app/code/Magento/QuoteGraphQl/Model/AddProductsToCart.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\QuoteGraphQl\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Quote\Api\ErrorInterface;
 use Magento\Quote\Model\Cart\Data\AddProductsToCartOutput;
@@ -25,12 +24,14 @@ class AddProductsToCart
      * @param AddProductsToCartService $addProductsToCartService
      * @param ScopeConfigInterface $scopeConfig
      * @param PrecursorInterface $cartItemPrecursor
+     * @param CartItemFactory $cartItemFactory
      */
     public function __construct(
         private readonly GetCartForUser $getCartForUser,
         private readonly AddProductsToCartService $addProductsToCartService,
         private readonly ScopeConfigInterface $scopeConfig,
-        private readonly PrecursorInterface $cartItemPrecursor
+        private readonly PrecursorInterface $cartItemPrecursor,
+        private readonly CartItemFactory $cartItemFactory
     ) {
     }
 
@@ -53,7 +54,7 @@ class AddProductsToCart
         $cartItemsData = $this->cartItemPrecursor->process($cartItemsData, $context);
         $cartItems = [];
         foreach ($cartItemsData as $cartItemData) {
-            $cartItems[] = (new CartItemFactory())->create($cartItemData);
+            $cartItems[] = $this->cartItemFactory->create($cartItemData);
         }
 
         /** @var AddProductsToCartOutput $addProductsToCartOutput */


### PR DESCRIPTION
### Description (*)

Replaced direct instantiation of `CartItemFactory` with dependency injection in `Magento\QuoteGraphQl\Model\AddProductsToCart`.

The previous `new CartItemFactory()` approach violated OOP principles and prevented the class from being extended via plugins or subclassing.

Also removed unused `ObjectManager` import.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40129

### Manual testing scenarios (*)
1. Verify cart mutation still works correctly (add products to cart via GraphQL)
2. Verify that `CartItemFactory` can now be extended via plugins

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
