### PR TITLE
fix(config): handle missing data/metadata keys in Initial config

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/Initial.php
+++ b/lib/internal/Magento/Framework/App/Config/Initial.php
@@ -58,8 +58,8 @@ class Initial
         } else {
             $data = $this->serializer->unserialize($data);
         }
-        $this->_data = $data['data'];
-        $this->_metadata = $data['metadata'];
+        $this->_data = $data['data'] ?? [];
+        $this->_metadata = $data['metadata'] ?? [];
     }
 
     /**


### PR DESCRIPTION
### Description (*)

Added null coalescing operators to prevent "Undefined array key" warnings when accessing `$data['data']` and `$data['metadata']` in `Magento\Framework\App\Config\Initial::__construct()`.

This can occur when the config cache contains invalid or incomplete data structure, particularly during integration test execution.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40234

### Manual testing scenarios (*)
1. Run integration tests on a fresh Magento 2.4.9-alpha3 installation
2. Verify no "Undefined array key 'data'" warning is thrown
3. Clear config cache and verify normal operation continues

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
