### PR TITLE
fix(dhl): use getGatewayURL() for sandbox mode support in _getQuotes

### DIFF
--- a/app/code/Magento/Dhl/Model/Carrier.php
+++ b/app/code/Magento/Dhl/Model/Carrier.php
@@ -1089,7 +1089,7 @@ class Carrier extends AbstractDhl implements CarrierInterface
                 $deferredResponses[] = [
                     'deferred' => $this->httpClient->request(
                         new Request(
-                            (string)$this->getConfigData('gateway_xml_url'),
+                            $this->getGatewayURL(),
                             Request::METHOD_POST,
                             ['Content-Type' => 'application/xml'],
                             mb_convert_encoding($request, 'UTF-8')


### PR DESCRIPTION
### Description (*)

The `_getQuotes()` method was using hardcoded `gateway_xml_url` config value instead of `getGatewayURL()` method which properly handles sandbox mode.

This caused DHL to always return "Validation Failure: Site Id is wrong" when sandbox mode was enabled, because requests were still being sent to the production URL.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40249

### Manual testing scenarios (*)
1. Enable DHL shipping method in admin
2. Enable sandbox mode for DHL
3. Configure sandbox credentials
4. Request shipping rates
5. Verify requests are sent to sandbox URL instead of production URL

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
