### PR TITLE
fix(filesystem): add flags parameter to getPathInfo method

### DIFF
--- a/lib/internal/Magento/Framework/Filesystem/Io/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/File.php
@@ -910,10 +910,11 @@ class File extends AbstractIo
      * Get path info
      *
      * @param string $path
+     * @param int|null $flags
      * @return mixed
      */
-    public function getPathInfo($path)
+    public function getPathInfo($path, $flags = null)
     {
-        return pathinfo($path);
+        return $flags === null ? pathinfo($path) : pathinfo($path, $flags);
     }
 }

--- a/lib/internal/Magento/Framework/Filesystem/Io/File.php
+++ b/lib/internal/Magento/Framework/Filesystem/Io/File.php
@@ -910,10 +910,11 @@ class File extends AbstractIo
      * Get path info
      *
      * @param string $path
-     * @param int|null $flags
-     * @return mixed
+     * @param int|null $flags One of PATHINFO_DIRNAME, PATHINFO_BASENAME, PATHINFO_EXTENSION or PATHINFO_FILENAME
+     * @return array|string
+     * @since 101.1.0
      */
-    public function getPathInfo($path, $flags = null)
+    public function getPathInfo(string $path, ?int $flags = null): array|string
     {
         return $flags === null ? pathinfo($path) : pathinfo($path, $flags);
     }


### PR DESCRIPTION
### Description (*)

The `getPathInfo()` method in `Magento\Framework\Filesystem\Io\File` was ignoring the second parameter (flags) that callers were passing.

This broke the `captcha_delete_expired_images` cron job because the condition:
```php
$this->_fileInfo->getPathInfo($filePath, PATHINFO_EXTENSION) == 'png'
```
always returned `false` since the method returned an array instead of a string.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40192

### Manual testing scenarios (*)
1. Enable captcha on frontend
2. Generate some captcha images
3. Wait for expiration time to pass
4. Run cron `captcha_delete_expired_images`
5. Verify expired captcha images are deleted from `/media/captcha/base`

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)
