### PR TITLE
Fix directory path served as file in `\Magento\MediaStorage\App\Media`

### DIFF
--- a/app/code/Magento/MediaStorage/App/Media.php
+++ b/app/code/Magento/MediaStorage/App/Media.php
@@ -192,7 +192,9 @@ class Media implements AppInterface
         try {
             $this->createLocalCopy();
 
-            if ($this->directoryPub->isReadable($this->relativeFileName)) {
+            if ($this->directoryPub->isReadable($this->relativeFileName)
+                && $this->directoryPub->isFile($this->relativeFileName)
+            ) {
                 $this->response->setFilePath($this->directoryPub->getAbsolutePath($this->relativeFileName));
             } else {
                 $this->setPlaceholderImage();
@@ -214,7 +216,9 @@ class Media implements AppInterface
         $synchronizer = $this->syncFactory->create(['directory' => $this->directoryPub]);
         $synchronizer->synchronize($this->relativeFileName);
 
-        if ($this->directoryPub->isReadable($this->relativeFileName)) {
+        if ($this->directoryPub->isReadable($this->relativeFileName)
+            && $this->directoryPub->isFile($this->relativeFileName)
+        ) {
             return;
         }
 

--- a/app/code/Magento/MediaStorage/Test/Unit/App/MediaTest.php
+++ b/app/code/Magento/MediaStorage/Test/Unit/App/MediaTest.php
@@ -132,6 +132,10 @@ class MediaTest extends TestCase
             ->method('isReadable')
             ->with(self::RELATIVE_FILE_PATH)
             ->willReturn(true);
+        $this->directoryPubMock->expects(self::exactly(2))
+            ->method('isFile')
+            ->with(self::RELATIVE_FILE_PATH)
+            ->willReturn(true);
         $this->responseMock->expects(self::once())
             ->method('setFilePath')
             ->with($filePath);
@@ -156,6 +160,10 @@ class MediaTest extends TestCase
             ->willReturn(self::MEDIA_DIRECTORY);
         $this->directoryPubMock->expects(self::exactly(2))
             ->method('isReadable')
+            ->with(self::RELATIVE_FILE_PATH)
+            ->willReturn(true);
+        $this->directoryPubMock->expects(self::exactly(2))
+            ->method('isFile')
             ->with(self::RELATIVE_FILE_PATH)
             ->willReturn(true);
         $this->directoryPubMock->expects(self::exactly(2))
@@ -184,6 +192,34 @@ class MediaTest extends TestCase
             ->willReturn(self::MEDIA_DIRECTORY);
         $this->directoryPubMock->expects(self::exactly(2))
             ->method('isReadable')
+            ->with(self::RELATIVE_FILE_PATH)
+            ->willReturn(false);
+        $this->directoryPubMock->expects(self::never())
+            ->method('isFile');
+        $this->configMock->expects($this->once())
+            ->method('getMediaDirectory')
+            ->willReturn('');
+        $this->directoryPubMock->method('getAbsolutePath')->willReturn('');
+
+        self::assertSame($this->responseMock, $this->mediaModel->launch());
+    }
+
+    public function testProcessRequestReturnsPlaceholderForDirectoryPath(): void
+    {
+        $this->mediaModel = $this->createMediaModel();
+
+        $this->sync->method('synchronize')
+            ->with(self::RELATIVE_FILE_PATH);
+        $this->directoryMediaMock->expects(self::once())
+            ->method('getAbsolutePath')
+            ->with(null)
+            ->willReturn(self::MEDIA_DIRECTORY);
+        $this->directoryPubMock->expects(self::atLeastOnce())
+            ->method('isReadable')
+            ->with(self::RELATIVE_FILE_PATH)
+            ->willReturn(true);
+        $this->directoryPubMock->expects(self::exactly(2))
+            ->method('isFile')
             ->with(self::RELATIVE_FILE_PATH)
             ->willReturn(false);
         $this->configMock->expects($this->once())


### PR DESCRIPTION
### Description

`Magento\MediaStorage\App\Media::launch()` does not check whether the requested path is a file before serving it. When a directory path is requested (e.g., `/media/email/logo/websites/1/`), it passes `isReadable()` but reaches `Magento\Framework\File\Transfer\Adapter\Http::send()` which throws:

```
Exception: File '/path/pub/media/email/logo/websites/1/' does not exists.
```

The same bug was previously fixed in `pub/get.php` (line [70](https://github.com/magento/magento2/blob/2.4-develop/pub/get.php#L70)) with an `is_dir()` guard, but the equivalent check was never added to `Media::launch()`.

This PR adds `isFile()` checks alongside existing `isReadable()` checks in two places:
- `launch()` - before setting the response file path
- `createLocalCopy()` - before returning early for already-synced files

Sentry Catch:
<img width="2736" height="1868" alt="image" src="https://github.com/user-attachments/assets/6b21aedc-c418-4916-b169-93ce78f5edd9" />


### Related Pull Requests

- magento/magento2#296 - original `is_dir()` fix for `pub/get.php` (same bug, different code path)

### Manual testing scenarios
1. Configure an email logo at `Stores > Configuration > Sales > Sales Emails > Email Logo Image`
2. Clear the resource config cache (`var/resource_config.json`)
3. Send a request to the directory path without filename:
   ```
   curl -X OPTIONS https://your-store.com/media/email/logo/websites/1/
   ```
4. **Before fix**: Exception thrown - `File '...' does not exists.`
5. **After fix**: Placeholder image returned (no exception)

Alternative scenario:
1. Request any media directory path (e.g., `/media/catalog/product/m/a/`) when `var/resource_config.json` is expired or missing
2. **Before fix**: Exception in `Http::send()`
3. **After fix**: Placeholder image returned gracefully

### Questions or comments
The `is_dir()` guard in `pub/get.php` (line 55) was added to fix magento/magento2#296, but only covers the fast-path when the resource config cache is valid. When the cache is expired or missing, `get.php` falls through to `Media::launch()` which lacks this check.

**Real-world trigger**: Microsoft Outlook sends `OPTIONS` preflight requests to directory paths before loading email logo images. Access log example:

```
"OPTIONS /media/email/logo/websites/1/ HTTP/1.1" 200 20 "-" "Microsoft Office Outlook 2014" ← directory path, triggers the bug
[02/Feb/2026:14:25:54 -0500] "GET /media/email/logo/websites/1/logo.png HTTP/1.1" 200 2997 "-" "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"  ← actual file, works fine
146.75.146.1 - - [02/Feb/2026:23:09:09 -0500] "GET /media/email/logo/websites/1/logo.png HTTP/1.1" 200 2997 "-" "Mozilla/5.0"   ← actual file, works fine

```

Outlook's `OPTIONS` request targets the parent directory URL (without the filename), which passes through `get.php` to `Media::launch()` and causes the exception. This is reproducible with any email client that sends preflight requests to media URLs.


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40520: Fix directory path served as file in `\Magento\MediaStorage\App\Media`