### PR TITLE
Make integration test settings overridable per ENV

### DIFF
--- a/dev/tests/integration/framework/bootstrap.php
+++ b/dev/tests/integration/framework/bootstrap.php
@@ -30,7 +30,10 @@ try {
     setCustomErrorHandler();
 
     /* Bootstrap the application */
-    $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, get_defined_constants());
+    $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, array_replace(
+        get_defined_constants(),
+        getenv()
+    ));
 
     $testFrameworkDir = __DIR__;
     require_once 'deployTestModules.php';


### PR DESCRIPTION
### Description (*)
In the `bootstrap.php` of the integration test framework several settings are derived from the defined constants.

    $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, get_defined_constants());

But this is very static and unflexible. This PR improves the situation by replacing the values of the constants by environment variables.

    $settings = new \Magento\TestFramework\Bootstrap\Settings($testsBaseDir, array_replace(
        get_defined_constants(),
        getenv()
    ));

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40525

### Manual testing scenarios (*)
1. Make sure that the `TESTS_CLEANUP` is set to `enabled` in your phpunit.xml.dist
2. Run `TESTS_CLEANUP=disabled vendor/bin/phpunit -c dev/tests/integration/phpunit.xml.dist`

This should not trigger a re-installation of Magento in the test database.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (not applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
