### PR TITLE
RequireJS mixins.js causes duplicate script loading for all deps modules #40527

### DIFF
--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -229,6 +229,8 @@ require([
      * that way it is able to respect any changes done after mixins module has initialized.
      */
     defContext.configure = function (cfg) {
+        var unbundledCfg = {},
+            key;
         originalContextConfigure(cfg);
 
         for (key in cfg) {

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -230,7 +230,12 @@ require([
      */
     defContext.configure = function (cfg) {
         originalContextConfigure(cfg);
-        unbundledContext.configure(cfg);
+
+        for (key in cfg) {
+            if (cfg.hasOwnProperty(key) && key !== 'deps' && key !== 'callback') {
+                unbundledCfg[key] = cfg[key];
+            }
+        }
     };
 
     /**

--- a/lib/web/mage/requirejs/mixins.js
+++ b/lib/web/mage/requirejs/mixins.js
@@ -236,6 +236,8 @@ require([
                 unbundledCfg[key] = cfg[key];
             }
         }
+        
+        unbundledContext.configure(unbundledCfg);
     };
 
     /**


### PR DESCRIPTION
### Preconditions and environment

Issue: [40527](https://github.com/magento/magento2/issues/40527)

#### Summary

The `defContext.configure` wrapper in `lib/web/mage/requirejs/mixins.js` forwards the complete config object (including deps and callback) to the unbundled `$` RequireJS context. Since `RequireJS.configure()` calls               
`context.require(cfg.deps)` when deps is present (require.js:1403-1404), every module listed in a deps array is loaded in both the default `_` context and the unbundled `$` context, resulting in duplicate <script> tags.

### Steps to reproduce

Steps to reproduce (it hard to reproduce, but 1 request from 10-20 reproduce this issue)
 
1. Install clean Magento 2.4.8-p3
2. Open product page
3. Open browser DevTools → Network tab
4. Filter by JS

### Expected result

Each script is loaded once.

### Actual result

The following scripts appear twice (one load per RequireJS context):

- mage/common.js
- mage/dataPost.js
- mage/bootstrap.js
- Magento_Ui/js/core/app.js
- Magento_PageCache/js/form-key-provider.js
- Magento_Translation/js/mage-translation-dictionary.js
- Magento_Theme/js/theme.js

![Image](https://github.com/user-attachments/assets/fac31b48-13da-40f5-966e-cd2638acdf19)

Every duplicated script corresponds exactly to a deps entry in the generated requirejs-config.js.

Additionally, the double execution of `mage/bootstrap.js` and `mage/common.js` can corrupt `jQuery` plugin state, causing intermittent `$fotoramaElement.fotorama` is not a function errors on product pages (gallery.js:310).

![Image](https://github.com/user-attachments/assets/436c00f6-b68b-4b23-9cb4-254259813b63)

### Additional information

#### Root cause analysis

Introduced in commit [bf705b031d1c4ea63f19ff14036d9d1ffd4f8304](https://github.com/magento/magento2/commit/bf705b031d1c4ea63f19ff14036d9d1ffd4f8304), which changed the script loading order so `mixins.js` loads before `requirejs-config.js`. To compensate, a `defContext.configure` wrapper was added to keep the
unbundled `$` context in sync:

// lib/web/mage/requirejs/mixins.js — L229-232
```javascript
defContext.configure = function (cfg) {
    originalContextConfigure(cfg);
    unbundledContext.configure(cfg);  // ← forwards deps, triggering loads in '$' context
};
```
The unbundled `$` context exists solely for `toUrl()` path resolution — it should never load modules. But `unbundledContext.configure(cfg)` processes `cfg.deps` and calls `context.require(cfg.deps)` internally (require.js
L1403-1404), creating duplicate <script> tags for every deps entry.

#### Environment
- Magento version: 2.4.7 / 2.4.8 (all affected)
- Reproducible on clean install with Luma theme, no custom modules required

### Release note

_No response_

### Triage and priority

- [x] Severity: **S0** _- Affects critical data or functionality and leaves users without workaround._
- [ ] Severity: **S1** _- Affects critical data or functionality and forces users to employ a workaround._
- [ ] Severity: **S2** _- Affects non-critical data or functionality and forces users to employ a workaround._
- [ ] Severity: **S3** _- Affects non-critical data or functionality and does not force users to employ a workaround._
- [ ] Severity: **S4** _- Affects aesthetics, professional look and feel, “quality” or “usability”._