### PR TITLE
Fix Magento bug #34464

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Config.php
@@ -265,7 +265,7 @@ class Config implements ConfigInterface
                             $this->_mergedArguments = [];
                         }
                         if (isset($this->_arguments[$key])) {
-                            $this->_arguments[$key] = array_replace($this->_arguments[$key], $curConfig['arguments']);
+                            $this->_arguments[$key] = array_replace_recursive($this->_arguments[$key], $curConfig['arguments']);
                         } else {
                             $this->_arguments[$key] = $curConfig['arguments'];
                         }


### PR DESCRIPTION
# Change: In Magento\Framework\ObjectManager\Config\Config::_mergeConfiguration(), replace array_replace with array_replace_recursive so array arguments are merged instead of overwritten across areas

### Description (*)

In `Magento\Framework\ObjectManager\Config\Config::_mergeConfiguration()`, array arguments are merged using `array_replace()`. When a type is configured in global `etc/di.xml` with array arguments (e.g. `collections`), and the same type is modified in area-specific `etc/adminhtml/di.xml` (e.g. adding a plugin or more arguments), the entire array value is replaced instead of merged. Global entries are lost, causing "Not registered handle" errors on admin grids (e.g. CMS Blocks, Pages).

**Change:** Replace `array_replace` with `array_replace_recursive` so nested array arguments are merged by key. This preserves both global and area-specific items.

**File:** `ObjectManager/Config/Config.php` (line ~261)


### Fixed Issues (if relevant)
Bug in DI generation: array arguments got replaced instead of merging when modified from different area #34464
1. Fixes magento/magento2#34464

### Manual testing scenarios (*)

1. Create a custom module with global `etc/di.xml` adding a `collections` item to `Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory`.
2. Add `etc/adminhtml/di.xml` in the same module with a plugin on `CollectionFactory` and an additional `collections` item.
3. In admin area, verify `CollectionFactory::getReport('cms_block_listing_data_source')` succeeds (no "Not registered handle" exception).
4. Open Content > Blocks and Content > Pages in admin; both grids should load without errors.
5. Open Sales > Orders; order grid should load without errors.

### Questions or comments

`array_replace_recursive` preserves existing behavior when no nested keys overlap. When keys overlap, the second value wins (same as `array_replace` for that key), but sibling keys are now merged instead of lost.

