### PR TITLE
fix(config): capture config value before beforeSave() transforms it for lock-env (#39836)

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigSet/LockProcessor.php
+++ b/app/code/Magento/Config/Console/Command/ConfigSet/LockProcessor.php
@@ -78,9 +78,15 @@ class LockProcessor implements ConfigSetProcessorInterface
 
     /**
      * Processes lock flow of config:set command.
+     *
      * Requires read access to filesystem.
      *
-     * {@inheritdoc}
+     * @param string $path The configuration path in format group/section/field_name
+     * @param string $value The configuration value
+     * @param string $scope The configuration scope
+     * @param string $scopeCode The scope code
+     * @return void
+     * @throws CouldNotSaveException An exception on processing error
      */
     public function process($path, $value, $scope, $scopeCode)
     {
@@ -94,10 +100,16 @@ class LockProcessor implements ConfigSetProcessorInterface
                  * for storing system configuration into database and configuration files.
                  */
                 $backendModel->validateBeforeSave();
-                $backendModel->beforeSave();
 
+                /**
+                 * Capture the value before beforeSave() is called, since backend models
+                 * may transform the value in beforeSave() for database serialization
+                 * (e.g. converting a string to an array). The env.php lock storage
+                 * requires the validated scalar value, not the DB-serialized form.
+                 */
                 $value = $backendModel->getValue();
 
+                $backendModel->beforeSave();
                 $backendModel->afterSave();
 
                 /**

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigSet/LockEnvProcessorTest.php
@@ -162,6 +162,59 @@ class LockEnvProcessorTest extends TestCase
         ];
     }
 
+    /**
+     * Tests that the value is captured before beforeSave() to prevent backend models
+     * from transforming the value for database storage (e.g. converting string to array)
+     * being saved to env.php instead of the original scalar value.
+     */
+    public function testProcessUsesValueBeforeBeforeSaveTransformation(): void
+    {
+        $path = 'test/test/test';
+        $originalValue = 'google';
+        $callOrder = [];
+
+        $this->preparedValueFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->valueMock);
+        $this->configPathResolver->expects($this->once())
+            ->method('resolve')
+            ->willReturn('system/default/test/test/test');
+
+        $this->valueMock->method('validateBeforeSave')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'validateBeforeSave';
+            });
+        $this->valueMock->method('getValue')
+            ->willReturnCallback(function () use (&$callOrder, $originalValue) {
+                $callOrder[] = 'getValue';
+                return $originalValue;
+            });
+        $this->valueMock->method('beforeSave')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'beforeSave';
+            });
+        $this->valueMock->method('afterSave')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'afterSave';
+            });
+
+        $this->arrayManagerMock->method('set')->willReturn([]);
+        $this->deploymentConfigWriterMock->method('saveConfig');
+
+        $this->model->process($path, $originalValue, ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null);
+
+        $getValueIndex = array_search('getValue', $callOrder);
+        $beforeSaveIndex = array_search('beforeSave', $callOrder);
+
+        $this->assertNotFalse($getValueIndex, 'getValue() should be called');
+        $this->assertNotFalse($beforeSaveIndex, 'beforeSave() should be called');
+        $this->assertLessThan(
+            $beforeSaveIndex,
+            $getValueIndex,
+            'getValue() must be called before beforeSave() to capture the value before DB serialization'
+        );
+    }
+
     public function testProcessNotReadableFs()
     {
         $this->expectException('Magento\Framework\Exception\LocalizedException');

--- a/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Console/Command/ConfigSetCommandTest.php
@@ -24,6 +24,7 @@ use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\TestFramework\Fixture\DbIsolation;
 use PHPUnit\Framework\MockObject\MockObject as Mock;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\InputInterface;
@@ -308,6 +309,52 @@ class ConfigSetCommandTest extends \PHPUnit\Framework\TestCase
     public static function runExtendedDataProvider()
     {
         return self::runLockDataProvider();
+    }
+
+    /**
+     * Tests that --lock-env preserves the original value in env.php even when a backend model
+     * transforms it in beforeSave() (e.g. Encrypted backend encrypts the value for DB storage).
+     *
+     * @see https://github.com/magento/magento2/issues/39836
+     */
+    #[DbIsolation(true)]
+    public function testLockEnvPreservesValueBeforeBackendModelTransformation()
+    {
+        $path = 'system/smtp/password';
+        $value = 'my_secret_password';
+        $scope = ScopeConfigInterface::SCOPE_TYPE_DEFAULT;
+        $scopeCode = null;
+
+        $this->inputMock->expects($this->any())
+            ->method('getArgument')
+            ->willReturnMap([
+                [ConfigSetCommand::ARG_PATH, $path],
+                [ConfigSetCommand::ARG_VALUE, $value]
+            ]);
+        $this->inputMock->expects($this->any())
+            ->method('getOption')
+            ->willReturnMap([
+                [ConfigSetCommand::OPTION_LOCK_ENV, true],
+                [ConfigSetCommand::OPTION_SCOPE, $scope],
+                [ConfigSetCommand::OPTION_SCOPE_CODE, $scopeCode]
+            ]);
+        $this->outputMock->expects($this->once())
+            ->method('writeln')
+            ->with('<info>Value was saved in app/etc/env.php and locked.</info>');
+
+        /** @var ConfigSetCommand $command */
+        $command = $this->objectManager->create(ConfigSetCommand::class);
+        /** @var ConfigPathResolver $resolver */
+        $resolver = $this->objectManager->get(ConfigPathResolver::class);
+
+        $status = $command->run($this->inputMock, $this->outputMock);
+        $this->appConfig->reinit();
+
+        $configPath = $resolver->resolve($path, $scope, $scopeCode, 'system');
+        $storedValue = $this->arrayManager->get($configPath, $this->loadConfig());
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $status);
+        $this->assertSame($value, $storedValue, 'env.php must store the original value, not the encrypted form');
     }
 
     /**


### PR DESCRIPTION
### Description (*)

When using `bin/magento config:set --lock-env`, the `LockProcessor` was capturing the configuration value **after** calling `beforeSave()` on the backend model. Some backend models transform the value in `beforeSave()` for database serialization (e.g. converting a comma-separated string to an array). This caused the DB-serialized form (e.g. an array) to be written to `env.php`, making subsequent reads return the wrong type.

**Example error:**
```
Type Error occurred when creating object: Magento\TwoFactorAuth\Model\Provider\Engine\DuoSecurity
explode(): Argument #2 ($string) must be of type string, array given
```

**Root cause:** After `bin/magento config:set --lock-env twofactorauth/general/force_providers google`, `env.php` incorrectly stored `['google']` (array) instead of `'google'` (string) because `ForceProviders::beforeSave()` transforms the value for database storage.

**Fix:** Capture the value **before** `beforeSave()` is called. The `beforeSave()` lifecycle hook is intended for database serialization and should not affect what is stored in `env.php`. The `validateBeforeSave()` call remains first to still run all validations.

### Related Pull Requests

_No related pull requests_

### Fixed Issues

Fixes magento/magento2#39836

### Manual testing scenarios (*)

1. Run `bin/magento config:set --lock-env twofactorauth/general/force_providers google`
2. Verify `env.php` contains `'force_providers' => 'google'` (string, not array)
3. Run `bin/magento` and confirm no errors about `explode()` receiving array instead of string

### Questions or comments

_No questions or comments_

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
