### PR TITLE
fix(import): handle zero values for stock use_config fields during product import (#39780)

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -3101,7 +3101,7 @@ class Product extends AbstractEntity
 
             if (isset($this->defaultStockData[$key])
                 && isset($this->defaultStockData[$useConfigName])
-                && !empty($value)
+                && $value !== null && $value !== ''
                 && empty($rowData[$useConfigName])
             ) {
                 $useConfigFields[$useConfigName] = ($value == self::INVENTORY_USE_CONFIG) ? 1 : 0;


### PR DESCRIPTION
### Description (*)

The `_setStockUseConfigFieldsValues()` method in the product import used `!empty($value)` to check if a stock field had been explicitly set in the import CSV. However, `!empty(0)` returns `false` in PHP, causing fields with a valid value of `0` (e.g. `allow_backorders = 0` meaning "No Backorders") to be ignored.

As a result, `use_config_backorders` was never set to `0`, so the imported product continued to use the system configuration default even when the CSV explicitly specified `allow_backorders = 0`. The same bug affects other stock fields that can have `0` as a valid value.

**Fix:** Changed `!empty($value)` to `$value !== null && $value !== ''` to correctly treat numeric `0` as a valid explicit value while still skipping truly empty entries (null or empty string).

### Related Pull Requests

_No related pull requests_

### Fixed Issues

Fixes magento/magento2#39780

### Manual testing scenarios (*)

1. Set the system default "Backorders" to "Allow Qty Below 0"
2. Create a CSV import file with `allow_backorders = 0` (No Backorders) for a product
3. Run the product import
4. Verify the imported product has "Backorders" set to "No Backorders" (not using the system default)

### Questions or comments

_No questions or comments_

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
