### PR TITLE
fix(elasticsearch): add sortOrder to FieldName CompositeResolver items in di.xml (#39895)

### DIFF
--- a/app/code/Magento/Elasticsearch/etc/di.xml
+++ b/app/code/Magento/Elasticsearch/etc/di.xml
@@ -228,12 +228,12 @@
     <type name="Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CompositeResolver">
         <arguments>
             <argument name="items" xsi:type="array">
-                <item name="notEav" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\NotEavAttribute</item>
-                <item name="special" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\SpecialAttribute</item>
-                <item name="price" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\Price</item>
-                <item name="categoryName" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CategoryName</item>
-                <item name="position" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\Position</item>
-                <item name="default" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\DefaultResolver</item>
+                <item name="notEav" xsi:type="object" sortOrder="10">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\NotEavAttribute</item>
+                <item name="special" xsi:type="object" sortOrder="20">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\SpecialAttribute</item>
+                <item name="price" xsi:type="object" sortOrder="30">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\Price</item>
+                <item name="categoryName" xsi:type="object" sortOrder="40">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\CategoryName</item>
+                <item name="position" xsi:type="object" sortOrder="50">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\Position</item>
+                <item name="default" xsi:type="object" sortOrder="100">\Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldName\Resolver\DefaultResolver</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
### Description (*)

The `<type>` configuration for `FieldName\Resolver\CompositeResolver` in `Magento/Elasticsearch/etc/di.xml` was missing `sortOrder` attributes on its items, unlike:
- The `elasticsearchFieldNameResolver` virtualType (which correctly defined `sortOrder` values: 10, 20, 30, 40, 50, 100)
- The `FieldType\Resolver\CompositeResolver` type (which also correctly uses `sortOrder`)

When a third-party module adds a custom field name resolver to `CompositeResolver` via `di.xml` with a `sortOrder` lower than 100 (the default resolver), the sort order was not respected because the existing built-in items had no `sortOrder` to compare against. As a result, custom resolvers were always placed after the `default` resolver and became unreachable — making it impossible to add custom Elasticsearch field resolvers.

**Fix:** Added `sortOrder` attributes (10, 20, 30, 40, 50, 100) to all existing items in the `<type>` configuration, matching the values used in the `elasticsearchFieldNameResolver` virtualType.

### Related Pull Requests

_No related pull requests_

### Fixed Issues

Fixes magento/magento2#39895

### Manual testing scenarios (*)

1. Create a module with a custom `FieldName` resolver and register it in `di.xml` with `sortOrder="31"` (between `price` sortOrder=30 and `categoryName` sortOrder=40)
2. Verify the custom resolver is called when `CompositeResolver::getFieldName()` is invoked for a matching attribute
3. Verify the built-in resolvers still function correctly in their expected order

### Questions or comments

_No questions or comments_

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
