### PR TITLE
fix: undefined special price map key lookup

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
@@ -154,11 +154,12 @@ class FinalPriceBox extends BasePriceBox
     public function hasSpecialPrice()
     {
         if ($this->isProductList()) {
-            if (!$this->getData('special_price_map')) {
+            if (!is_array($this->getData('special_price_map'))) {
                 return false;
             }
 
-            return (bool)$this->getData('special_price_map')[$this->saleableItem->getId()];
+            return array_key_exists($this->saleableItem->getId(), $this->getData('special_price_map'))
+                && (bool)$this->getData('special_price_map')[$this->saleableItem->getId()];
         } else {
             $displayRegularPrice = $this->getPriceType(Price\RegularPrice::PRICE_CODE)->getAmount()->getValue();
             $displayFinalPrice = $this->getPriceType(Price\FinalPrice::PRICE_CODE)->getAmount()->getValue();


### PR DESCRIPTION
### Description (*)
After upgrading from Magento 2.4.4 to 2.4.8, we started seeing repeated Undefined array key warnings coming from `FinalPriceBox::hasSpecialPrice()` when rendering product lists.

This PR replaces the blind lookup, with a `array_key_exists` call to safely verify the product ID exists in the map without generating errors/warnings.

This prevents unnecessary warnings in the logs while preserving the existing pricing logic.

```
[2026-02-24T16:25:26.304197+00:00] main.CRITICAL: Exception: Warning: Undefined array key 7391 in /var/www/vhosts/prod.xxx.co.uk/htdocs/releases/xxx/vendor/magento/module-catalog/Pricing/Render/FinalPriceBox.php on line 161
```

### Fixed Issues (if relevant)
1. Fixes #40547 

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
