### PR TITLE
Race condition that makes a page cacheable in varnish without X-Magen…

### DIFF
--- a/app/code/Magento/PageCache/Model/Layout/LayoutPlugin.php
+++ b/app/code/Magento/PageCache/Model/Layout/LayoutPlugin.php
@@ -41,6 +41,11 @@ class LayoutPlugin
     private $maintenanceMode;
 
     /**
+     * @var bool
+     */
+    private bool $isPublicHeadersSet = false;
+
+    /**
      * @param ResponseInterface $response
      * @param Config $config
      * @param MaintenanceMode $maintenanceMode
@@ -71,6 +76,7 @@ class LayoutPlugin
     {
         if ($subject->isCacheable() && !$this->maintenanceMode->isOn() && $this->config->isEnabled()) {
             $this->response->setPublicHeaders($this->config->getTtl());
+            $this->isPublicHeadersSet = true;
         }
     }
 
@@ -99,6 +105,8 @@ class LayoutPlugin
             $tags = array_unique(array_merge([], ...$tags));
             $tags = $this->pageCacheTagsPreprocessor->process($tags);
             $this->response->setHeader('X-Magento-Tags', implode(',', $tags));
+        } elseif ($this->isPublicHeadersSet) {
+            $this->response->setNoCacheHeaders();
         }
 
         return $result;

--- a/app/code/Magento/PageCache/Test/Unit/Model/Layout/LayoutPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/Layout/LayoutPluginTest.php
@@ -188,4 +188,31 @@ class LayoutPluginTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * Verify that when FPC is disabled mid-request (between afterGenerateElements and afterGetOutput),
+     * the previously set public cache headers are revoked with no-cache headers.
+     *
+     * @return void
+     */
+    public function testAfterGetOutputRevokesPublicHeadersWhenFpcDisabledMidRequest(): void
+    {
+        $maxAge = 180;
+        $callCount = 0;
+
+        $this->layoutMock->method('isCacheable')->willReturn(true);
+        $this->maintenanceModeMock->method('isOn')->willReturn(false);
+        $this->configMock->method('getTtl')->willReturn($maxAge);
+        $this->configMock->method('isEnabled')->willReturnCallback(function () use (&$callCount) {
+            $callCount++;
+            return $callCount <= 1;
+        });
+
+        $this->responseMock->expects($this->once())->method('setPublicHeaders')->with($maxAge);
+        $this->responseMock->expects($this->once())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->model->afterGenerateElements($this->layoutMock);
+        $this->model->afterGetOutput($this->layoutMock, 'html');
+    }
 }


### PR DESCRIPTION
### Description (*)

When `use_stale_cache` is enabled and `RemoteSynchronizedCache::load()` detects stale cache between `LayoutPlugin::afterGenerateElements` and `LayoutPlugin::afterGetOutput`, the `RuntimeStaleCacheStateModifier` disables FPC at runtime. This creates an inconsistent state where:

- `afterGenerateElements` already set public cache headers (`Cache-Control: public, max-age=X, s-maxage=X`) because FPC was enabled at that point
- `afterGetOutput` skips setting `X-Magento-Tags` because FPC is now disabled

The result is a page cached in Varnish with public cache headers but without `X-Magento-Tags`, making it impossible to purge via admin or CLI. These stale pages persist until Varnish TTL expires or Varnish is restarted.

**Fix:** Track whether public headers were set in `afterGenerateElements` using an `$isPublicHeadersSet` flag. In `afterGetOutput`, if FPC has been disabled mid-request but public headers were already applied, override them with no-cache headers (`Cache-Control: no-store, no-cache, must-revalidate, max-age=0`) to prevent Varnish from caching the page.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40281

### Manual testing scenarios (*)

1. Configure Magento with Varnish and `use_stale_cache` enabled
2. Warm up the cache so data exists in both local and Redis cache
3. Flush Redis cache to simulate cache invalidation (data remains in local cache)
4. Simulate a lock failure in `RemoteSynchronizedCache::lock()` (e.g., by temporarily modifying it to return `false`)
5. Load a cacheable page that triggers a cache read from `RemoteSynchronizedCache` during rendering
6. **Before fix:** The response has `Cache-Control: public` headers but no `X-Magento-Tags` header -- Varnish caches the page and it cannot be purged
7. **After fix:** The response has `Cache-Control: no-store, no-cache` headers -- Varnish does not cache the page

### Questions or comments

The fix is minimal and surgical -- it only adds behavior when the specific race condition occurs (public headers set but FPC disabled mid-request). All existing behavior remains unchanged when FPC stays enabled or was never enabled.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
