### PR TITLE
Fix: propagate stock validation message in QuantityValidator error info

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
+++ b/app/code/Magento/CatalogInventory/Model/Quote/Item/QuantityValidator.php
@@ -158,8 +158,9 @@ class QuantityValidator
                     || $parentStockStatus && $parentStockStatus->getStockStatus() == Stock::STOCK_OUT_OF_STOCK
                 || (int) $quoteItem->getProduct()->getStatus() !== Status::STATUS_ENABLED
             ) {
-                $hasError = $quoteItem->getStockStateResult()
-                    ? $quoteItem->getStockStateResult()->getHasError() : false;
+                $stockResult = $quoteItem->getStockStateResult();
+                $hasError = $stockResult
+                    ? $stockResult->getHasError() : false;
                 if (!$hasError) {
                     $quoteItem->addErrorInfo(
                         'cataloginventory',
@@ -167,7 +168,11 @@ class QuantityValidator
                         __('This product is out of stock.')
                     );
                 } else {
-                    $quoteItem->addErrorInfo(null, Data::ERROR_QTY);
+                    $quoteItem->addErrorInfo(
+                        null,
+                        Data::ERROR_QTY,
+                        $stockResult->getMessage() ?? __('This product is out of stock.')
+                    );
                 }
                 $quoteItem->getQuote()->addErrorInfo(
                     'stock',


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)

  - Fix missing error message when QuantityValidator reports a stock error that already has a stockStateResult with hasError = true
  - Previously, addErrorInfo() was called without a message, causing silent errors in consumers like the GraphQL cart mutations
  - Now propagates $stockResult->getMessage() with a fallback to the default "out of stock" message

### Manual testing scenarios (*)

  - Add an out-of-stock product to cart via GraphQL and verify the error response contains a descriptive message
  - Verify standard storefront "out of stock" behavior is unchanged
  - Run existing CatalogInventory unit/integration tests

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40569: Fix: propagate stock validation message in QuantityValidator error info