### PR TITLE
Fix infinite loader on cart page after invalid quantity update (MC-42…

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/action/update-shopping-cart.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/action/update-shopping-cart.js
@@ -152,8 +152,7 @@ define([
          * Form validation failed.
          */
         onError: function (response) {
-            var that = this,
-                elm,
+            var elm,
                 responseData = [];
 
             try {
@@ -177,7 +176,7 @@ define([
                     actions: {
                         /** @inheritdoc */
                         always: function () {
-                            that.submitForm();
+                            $(document.body).trigger('processStop');
                         }
                     }
                 });


### PR DESCRIPTION
## Fix infinite loader on cart page after invalid quantity update

### Description (*)

When a user attempts to update a cart item with an invalid quantity (e.g., breaching the minimum order quantity), an error modal is correctly displayed, and the input field reverts to its previous valid state. However, when the user dismisses the alert modal, the `always` callback in the `update-shopping-cart.js` widget unconditionally forces a form submission (`that.submitForm()`).

Because the input data was already reverted to its original valid state, this forced form submission triggers the `processStart` loader but fails to initiate a state change that would trigger `processStop`, causing the UI to freeze with an infinite loader.

This PR replaces `that.submitForm()` with `$(document.body).trigger('processStop')` in the `always` callback. This ensures that when the user acknowledges the error, the loader is explicitly terminated, leaving the reverted cart state intact and the page fully interactive.

### Related Pull Requests

N/A

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40559 (MINE)
2. Fixes magento/magento2#38516 (CLOSED)

### Manual testing scenarios (*)

1. Log into the Magento Admin and configure a product with a **Minimum Qty Allowed in Shopping Cart** set to `5`.
2. Navigate to the storefront and add `5` items of this product to the shopping cart. Please note during my test, the item have Qty increments enabled.
3. Go to the Shopping Cart page.
4. Change the item quantity input to an invalid amount, such as `2`.
5. Click the "Update Shopping Cart" button.
6. Wait for the AJAX validation to fail and the native Magento Alert modal to appear with the error message.
7. Click "OK" or the "X" to close the alert modal.
8. **Expected Result:** The alert modal closes, the input quantity reverts to `5`, the loader disappears, and the user can continue interacting with the cart page.
9. **Actual Result (without PR):** The alert modal closes, the input quantity reverts, but a new `processStart` event is fired. The loader appears and spins infinitely, blocking all further interaction until a hard page refresh.

### Questions or comments

This bug appears to be a regression inadvertently introduced during the implementation of internal ticket **MC-42813**. Applying this fix restores the expected UI behavior without altering the underlying validation logic.

### Contribution checklist (*)

* [x] Pull request has a meaningful description of its purpose
* [x] All commits are accompanied by meaningful commit messages
* [ ] All new or changed code is covered with unit/integration tests (if applicable)
* [ ] README.md files for modified modules are updated and included in the pull request if any [[README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md)](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
* [x] All automated tests passed successfully (all builds are green)