### PR TITLE
Fix for corrupted sri-hashes.json file due to race condition that breaks checkout

### DIFF
--- a/app/code/Magento/Csp/Model/SubresourceIntegrity/Storage/File.php
+++ b/app/code/Magento/Csp/Model/SubresourceIntegrity/Storage/File.php
@@ -243,7 +243,7 @@ class File implements StorageInterface
         $allHashes = array_merge($existingHashes, $newHashes);
 
         if ($allHashes !== $existingHashes) {
-            $staticDir->writeFile($filePath, $this->serializer->serialize($allHashes), 'w');
+            $staticDir->writeFile($filePath, $this->serializer->serialize($allHashes), 'w', true);
         }
     }
 }

--- a/app/code/Magento/Csp/Model/SubresourceIntegrityRepository.php
+++ b/app/code/Magento/Csp/Model/SubresourceIntegrityRepository.php
@@ -155,13 +155,37 @@ class SubresourceIntegrityRepository
         if ($this->data === null) {
             $rawData = $this->storage->load($this->context);
 
-            $this->data = $rawData ? $this->serializer->unserialize($rawData) : [];
-
+            if ($rawData) {
+                try {
+                    $this->data = $this->serializer->unserialize($rawData);
+                } catch (\Throwable $e) {
+                    $this->data = [];
+                    $this->safeRemove($this->context);
+                }
+            } else {
+                $this->data = [];
+            }
             foreach ($this->data as $path => $hash) {
                 $this->data[$path] = new SubresourceIntegrity(["path" => $path, "hash" => $hash]);
             }
         }
 
         return $this->data;
+    }
+
+    /**
+     * Safely removes sri-hashes.json file from storage.
+     *
+     * @param string|null $context
+     *
+     * @return bool
+     */
+    private function safeRemove(?string $context): bool
+    {
+        try {
+            return $this->storage->remove($context);
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 }

--- a/app/code/Magento/Csp/Test/Unit/Model/SubresourceIntegrityRepositoryTest.php
+++ b/app/code/Magento/Csp/Test/Unit/Model/SubresourceIntegrityRepositoryTest.php
@@ -166,4 +166,130 @@ class SubresourceIntegrityRepositoryTest extends TestCase
             $this->subresourceIntegrityRepository->saveBunch($bunch)
         );
     }
+
+    /**
+     * Test that getByPath returns null when storage data is corrupted and safeRemove succeeds
+     *
+     * @return void
+     */
+    public function testGetByPathWithCorruptedDataAndSuccessfulRemove(): void
+    {
+        $corruptedData = 'invalid-json-data';
+
+        $this->storage->expects($this->once())
+            ->method('load')
+            ->with($this->context)
+            ->willReturn($corruptedData);
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($corruptedData)
+            ->willThrowException(new \InvalidArgumentException('Invalid data'));
+
+        // safeRemove should be called and succeed
+        $this->storage->expects($this->once())
+            ->method('remove')
+            ->with($this->context)
+            ->willReturn(true);
+
+        // Should return null for non-existent path after corruption cleanup
+        $result = $this->subresourceIntegrityRepository->getByPath('js/jquery.js');
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test that getByPath returns null when storage data is corrupted and safeRemove fails
+     *
+     * @return void
+     */
+    public function testGetByPathWithCorruptedDataAndFailedRemove(): void
+    {
+        $corruptedData = 'invalid-json-data';
+
+        $this->storage->expects($this->once())
+            ->method('load')
+            ->with($this->context)
+            ->willReturn($corruptedData);
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($corruptedData)
+            ->willThrowException(new \InvalidArgumentException('Invalid data'));
+
+        // safeRemove should be called but fail with an exception
+        $this->storage->expects($this->once())
+            ->method('remove')
+            ->with($this->context)
+            ->willThrowException(new \RuntimeException('Cannot remove file'));
+
+        // Should still return null and not propagate the exception
+        $result = $this->subresourceIntegrityRepository->getByPath('js/jquery.js');
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test that getAll returns empty array when storage data is corrupted and safeRemove succeeds
+     *
+     * @return void
+     */
+    public function testGetAllWithCorruptedDataAndSuccessfulRemove(): void
+    {
+        $corruptedData = 'corrupted-serialized-data';
+
+        $this->storage->expects($this->once())
+            ->method('load')
+            ->with($this->context)
+            ->willReturn($corruptedData);
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($corruptedData)
+            ->willThrowException(new \InvalidArgumentException('Unserialize failed'));
+
+        // safeRemove should be called and succeed
+        $this->storage->expects($this->once())
+            ->method('remove')
+            ->with($this->context)
+            ->willReturn(true);
+
+        // Should return empty array after corruption cleanup
+        $result = $this->subresourceIntegrityRepository->getAll();
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test that multiple calls to getByPath only trigger safeRemove once due to data caching
+     *
+     * @return void
+     */
+    public function testGetByPathWithCorruptedDataCachesResult(): void
+    {
+        $corruptedData = 'invalid-data';
+
+        // Storage load should only be called once
+        $this->storage->expects($this->once())
+            ->method('load')
+            ->with($this->context)
+            ->willReturn($corruptedData);
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($corruptedData)
+            ->willThrowException(new \InvalidArgumentException('Invalid data'));
+
+        // safeRemove should only be called once
+        $this->storage->expects($this->once())
+            ->method('remove')
+            ->with($this->context)
+            ->willReturn(true);
+
+        // First call
+        $result1 = $this->subresourceIntegrityRepository->getByPath('js/jquery.js');
+        $this->assertNull($result1);
+
+        // Second call should use cached empty data, not call storage again
+        $result2 = $this->subresourceIntegrityRepository->getByPath('js/test.js');
+        $this->assertNull($result2);
+    }
 }


### PR DESCRIPTION
### Description (*)
This PR is to fix an issue where the sri-hashes.json file can become corrupt due to a race condition that breaks checkout. The issue can happen randomly without warning, and currently the only way to fix it is to regenerate the sri-hashes.json file through redeploying static content. The proposed fix locks the sri-hashes.json to keep multiple processes from writing to the file, and also includes a check to remove the file if its corrupt. The fix comes from code written here: https://gist.github.com/hryvinskyi/3df14e684d67bd8f7d278f4340ab133b

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
NOTE: This is difficult to test because it is a race condition that happens randomly. Some ways that this can happen are:
1. When a customer access a page that requires hash generation while using concurrent requests.
2. High volume traffic that requires hash generation to happen.

### Questions or comments
Since this is difficult to test, I'm unsure about how to include testing instructions for this. I had originally reached out to Adobe support about this issue and asked about a patch for this issue that someone else wrote, but was told I needed to make a PR to get the Magento development team to review it.

Code from community: https://gist.github.com/hryvinskyi/3df14e684d67bd8f7d278f4340ab133b

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40568: Fix for corrupted sri-hashes.json file due to race condition that breaks checkout