### PR TITLE
Modify createClassDefinition to include application mode

### DIFF
--- a/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
+++ b/lib/internal/Magento/Framework/App/ObjectManagerFactory.php
@@ -168,7 +168,8 @@ class ObjectManagerFactory
             $this->directoryList->getPath(AppDirectoryList::GENERATED_CODE)
         );
 
-        $definitions = $definitionFactory->createClassDefinition();
+        $mode = $arguments[State::PARAM_MODE] ?? State::MODE_DEFAULT;
+        $definitions = $definitionFactory->createClassDefinition($mode);
         $relations = $definitionFactory->createRelations();
 
         /** @var EnvironmentFactory $envFactory */

--- a/lib/internal/Magento/Framework/ObjectManager/DefinitionFactory.php
+++ b/lib/internal/Magento/Framework/ObjectManager/DefinitionFactory.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\ObjectManager;
 
 use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\App\State;
 use Magento\Framework\ObjectManager\Definition\Runtime;
 use Magento\Framework\Code\Generator\Autoloader;
 
@@ -45,17 +46,20 @@ class DefinitionFactory
         $this->_generationDir = $generationDir;
     }
 
-    /**
-     * Create class definitions
-     *
-     * @return DefinitionInterface
-     */
-    public function createClassDefinition()
-    {
-        $autoloader = new Autoloader($this->getCodeGenerator());
-        spl_autoload_register([$autoloader, 'load']);
+     /**
+      * Create class definitions
+      *
+      * @param string|null $mode Application mode. When production, Generator Autoloader is not registered.
+      * @return DefinitionInterface
+      */
+     public function createClassDefinition($mode = null)
+     {
+        if ($mode !== State::MODE_PRODUCTION) {
+            $autoloader = new Autoloader($this->getCodeGenerator());
+            spl_autoload_register([$autoloader, 'load']);
+        }
         return new Runtime();
-    }
+     }
 
     /**
      * Create plugin definitions


### PR DESCRIPTION
# Disable runtime code generation in production mode

## Description

This patch stops Magento from generating Interceptors, Factories, and Proxies at runtime when running in production mode.

In production, all generated classes must be created beforehand by `bin/magento setup:di:compile`. If they are missing (for example after `generated/code` is cleared during deployment), Magento should fail with a clear error instead of generating them on the fly.

## Changes

- **DefinitionFactory**: Registers the Generator Autoloader only when the application mode is not `production`.
- **ObjectManagerFactory**: Passes the application mode from deployment config into `createClassDefinition()`.

## Behaviour

| Mode       | Generator Autoloader | Runtime generation |
|-----------|----------------------|--------------------|
| developer | Registered           | Yes                |
| default   | Registered           | Yes                |
| production| Not registered       | No                 |

## Requirements

- Run `bin/magento setup:di:compile` during deployment before serving traffic.
- Ensure `generated/code` is populated before going live.

### Resolved issues:
1. [x] resolves magento/magento2#40571: Modify createClassDefinition to include application mode