### PR TITLE
Fix default store resolution breaking FPC on non-default websites when launching Magento with website runcodes

### DIFF
--- a/app/code/Magento/Store/App/Action/Plugin/Context.php
+++ b/app/code/Magento/Store/App/Action/Plugin/Context.php
@@ -144,6 +144,10 @@ class Context
                 $defaultStoreCode = $request->getServerValue(StoreManager::PARAM_RUN_CODE);
                 $defaultStore = $this->storeManager->getStore($defaultStoreCode);
                 break;
+            case ScopeInterface::SCOPE_WEBSITE == $request->getServerValue(StoreManager::PARAM_RUN_TYPE):
+                $websiteCode = $request->getServerValue(StoreManager::PARAM_RUN_CODE);
+                $defaultStore = $this->storeManager->getWebsite($websiteCode)->getDefaultStore();
+                break;
             default:
                 $defaultStoreCode = $this->storeManager->getDefaultStoreView()->getCode();
                 $defaultStore = $this->storeManager->getStore($defaultStoreCode);


### PR DESCRIPTION

### Description (*)
When launching a non-default website with a MAGE_RUN_TYPE = website this default store resolution logic would fetch the default store of the whole Magento instance, rather than the default store of the requested website. This results in all pages being served as uncacheable, meaning that the whole website bypasses full page cache.

This change fetches the default store view for the requested website based on the MAGE_RUN_CODE provided.

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/magento2/issues/39880

### Manual testing scenarios (*)
1. Create multiple websites
2. Configure server/environment parameters to launch a non-default website with a MAGE_RUN_TYPE of "website" and a MAGE_RUN_CODE of whatever the code of your new website is.
3. Enable full page cache.
4. Load the page in a browser, all pages should be served from full page cache with a cache hit header. Before this change, no pages are served from full page cache.

