### PR TITLE
Fix DeploymentConfig::getAllEnvOverrides memoization when no MAGENTO_…

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -51,9 +51,9 @@ class DeploymentConfig
     private $overrideData;
 
     /**
-     * @var array
+     * @var array|null
      */
-    private $envOverrides = [];
+    private ?array $envOverrides = null;
 
     /**
      * @var array
@@ -215,7 +215,8 @@ class DeploymentConfig
      */
     private function getAllEnvOverrides(): array
     {
-        if (empty($this->envOverrides)) {
+        if ($this->envOverrides === null) {
+            $this->envOverrides = [];
             // allow reading values from env variables by convention
             // MAGENTO_DC_{path}, like db/connection/default/host =>
             // can be overwritten by MAGENTO_DC_DB__CONNECTION__DEFAULT__HOST


### PR DESCRIPTION
### Description (*)

`DeploymentConfig::getAllEnvOverrides()` has a broken memoization pattern that causes significant performance degradation on every request.

The method uses `empty($this->envOverrides)` to determine whether the environment variable scan has already been performed. However, when no `MAGENTO_DC_*` environment variables exist (which is the common case for most Magento installations), `$this->envOverrides` remains as `[]`, and `empty([])` evaluates to `true` — causing the full `getenv()` loop to execute on **every single call**.

The fix changes the initialization of `$envOverrides` from `[]` to `null` and uses a strict `=== null` check as the guard condition. This ensures the `getenv()` scan runs exactly once per request lifecycle, regardless of whether any `MAGENTO_DC_*` variables are found.

### Manual testing scenarios (*)

1. Deploy a Magento instance **without** any `MAGENTO_DC_*` environment variables set (default setup).
2. Profile a frontend page request using SPX, Blackfire, or Xdebug.
3. Search for `getAllEnvOverrides` in the profile — **before the fix** it will show a lot of calls
4. Apply the patch and profile the same page again.
5. Confirm `getAllEnvOverrides` now shows ~1-2 calls with negligible time.
6. Set a `MAGENTO_DC_*` environment variable (e.g., `MAGENTO_DC_DB__CONNECTION__DEFAULT__HOST=127.0.0.1`).
7. Verify the env override is correctly applied to `DeploymentConfig::get('db/connection/default/host')`.
8. Verify `resetData()` still works correctly (e.g., after `bin/magento app:config:import`).

### Questions or comments

This is a one-line logic fix with meaningful performance impact. The root cause is that `empty()` cannot distinguish between "never scanned" and "scanned but found nothing." Using `null` as the uninitialized sentinel resolves this cleanly.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)