### PR TITLE
Fix unnecessary loading of directory data for config directives

### DIFF
--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\State;
 use Magento\Framework\Css\PreProcessor\Adapter\CssInliner;
+use Magento\Framework\DataObject;
 use Magento\Framework\Escaper;
 use Magento\Framework\Exception\MailException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -105,6 +106,11 @@ class Filter extends Template
      * @var bool
      */
     private $plainTemplateMode = false;
+
+    /**
+     * @var null|DataObject
+     */
+    private $storeInformationObject = null;
 
     /**
      * @var Repository
@@ -854,25 +860,38 @@ class Filter extends Template
     {
         $configValue = '';
         $params = $this->getParameters($construction[2]);
-        $storeId = $this->getStoreId();
-        $store = $this->_storeManager->getStore($storeId);
-        $storeInformationObj = $this->storeInformation
-            ->getStoreInformationObject($store);
         if (isset($params['path']) && $this->isAvailableConfigVariable($params['path'])) {
+            $storeId = $this->getStoreId();   
             $configValue = $this->_scopeConfig->getValue(
                 $params['path'],
                 ScopeInterface::SCOPE_STORE,
                 $storeId
             );
             if ($params['path'] == $this->storeInformation::XML_PATH_STORE_INFO_COUNTRY_CODE) {
-                $configValue = $storeInformationObj->getData('country');
+                $configValue = $this->getStoreInformationObject($storeId)->getData('country');
             } elseif ($params['path'] == $this->storeInformation::XML_PATH_STORE_INFO_REGION_CODE) {
-                $configValue = $storeInformationObj->getData('region') ?
-                    $storeInformationObj->getData('region') :
-                    $configValue;
+                $region = $this->getStoreInformationObject($storeId)->getData('region');
+                $configValue = $region ?: $configValue;
             }
         }
         return $configValue;
+    }
+
+    /**
+     * Get store information object
+     *
+     * @param int $storeId
+     * @return DataObject
+     */
+    private function getStoreInformationObject($storeId)
+    {
+        if ($this->storeInformationObject === null) {
+            $store = $this->_storeManager->getStore($storeId);            
+            $this->storeInformationObject = $this->storeInformation
+                ->getStoreInformationObject($store);
+        }
+
+        return $this->storeInformationObject;
     }
 
     /**


### PR DESCRIPTION
### Description

This pull request optimizes the `configDirective()` method in `Magento\Email\Model\Template\Filter` by eliminating redundant calls to retrieve the store information object.

Previously, `getStoreInformationObject()` was executed every time the directive was processed, even within the same request scope. This resulted in unnecessary repeated instantiation and data fetching.

The change introduces a private cache (`$storeInformationObject`) along with a dedicated accessor method `getStoreInformationObject($storeId)` that lazily loads and reuses the object.

Additionally:

* Store information retrieval is now deferred until it is actually needed.
* Minor readability improvements were applied (e.g., simplifying region fallback logic).
* Avoided redundant `$store` and `$storeInformationObj` initialization when not required.

This improves performance and reduces overhead when processing email templates with multiple `config` directives.

---

### Related Pull Requests

N/A

---

### Fixed Issues

N/A

---

### Manual testing scenarios

1. Configure store information in admin panel:

   * Stores → Configuration → General → Store Information
   * Set values for country and region.

2. Create or modify an email template containing:

   ```
   {{config path="general/store_information/country_id"}}
   {{config path="general/store_information/region_id"}}
   ```

3. Trigger an email that uses this template (e.g. order confirmation).

4. Verify that:

   * Country and region values are correctly rendered.
   * Region fallback works correctly when region is not explicitly set.

5. (Optional) Add logging or use profiler to confirm:

   * `getStoreInformationObject()` is executed only once per filter instance.

---

### Questions or comments

This change assumes that `storeInformationObject` can be safely reused within a single `Filter` instance lifecycle. Please confirm that there are no edge cases where multiple store contexts could be processed within the same instance.

---

### Contribution checklist

* [x] Pull request has a meaningful description of its purpose
* [x] All commits are accompanied by meaningful commit messages
* [ ] All new or changed code is covered with unit/integration tests (if applicable)
* [ ] README.md files for modified modules are updated and included in the pull request if any required sections need an update
* [ ] All automated tests passed successfully (all builds are green)