### PR TITLE
Removes deprecated syntax usage in less files.

### DIFF
--- a/app/design/adminhtml/Magento/backend/Magento_AdminNotification/web/css/source/_module.less
+++ b/app/design/adminhtml/Magento/backend/Magento_AdminNotification/web/css/source/_module.less
@@ -109,7 +109,7 @@
     margin: @message-system-short__padding-vertical 0;
     position: relative;
 
-    .action-toggle-triangle (
+    .action-toggle-triangle(
         @_dropdown__padding-right: @message-system-triangle__padding-right;
         @_triangle__height: @message-system-triangle__height;
         @_triangle__width: @message-system-triangle__width;

--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_file-uploader.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_file-uploader.less
@@ -115,7 +115,7 @@
 .file-uploader-preview {
     .action-remove {
         &:extend(.abs-action-reset all);
-        .lib-icon-font (
+        .lib-icon-font(
         @icon-delete__content,
         @_icon-font: @icons-admin__font-name,
         @_icon-font-size: @file-uploader-delete-icon__font-size,
@@ -377,7 +377,7 @@
         height: @data-grid-file-uploader-upload-icon__line-height;
         text-align: center;
 
-        .lib-icon-font (
+        .lib-icon-font(
             @icon-plus__content,
             @_icon-font: @icons-admin__font-name,
             @_icon-font-size: 1.3rem,

--- a/app/design/adminhtml/Magento/backend/web/css/source/components/_slider.less
+++ b/app/design/adminhtml/Magento/backend/web/css/source/components/_slider.less
@@ -49,7 +49,7 @@
     }
 
     .ui-slider-handle {
-        .data-slider-handle;
+        .data-slider-handle();
     }
 }
 

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/fields/_file-uploader.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/checkout/fields/_file-uploader.less
@@ -132,7 +132,7 @@
 
     .file-uploader-preview {
         .action-remove {
-            .lib-icon-font (
+            .lib-icon-font(
                 @icon-delete__content,
                 @_icon-font: @icons__font-name,
                 @_icon-font-size: @file-uploader-delete-icon__font-size,
@@ -395,7 +395,7 @@
             height: @data-grid-file-uploader-upload-icon__line-height;
             text-align: center;
 
-            .lib-icon-font (
+            .lib-icon-font(
                 @icon-file__content,
                 @_icon-font: @icons__font-name,
                 @_icon-font-size: 1.3rem,

--- a/dev/tests/static/testsuite/Magento/Test/Less/_files/blacklist/old.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Less/_files/blacklist/old.txt
@@ -1,3 +1,4 @@
+app/design/adminhtml/Magento/backend/Magento_AdminNotification/web/css/source/_module.less
 app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/_module-old.less
 app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_header.less
 app/design/adminhtml/Magento/backend/Magento_Backend/web/css/source/module/_menu.less

--- a/lib/web/css/source/lib/_buttons.less
+++ b/lib/web/css/source/lib/_buttons.less
@@ -77,7 +77,7 @@
     box-sizing: border-box;
     vertical-align: middle;
 
-    ._lib-button-icon (
+    ._lib-button-icon(
         @_button-icon-use: @_button-icon-use,
         @_icon-font-content: @_button-font-content,
         @_icon-font: @_button-icon-font,
@@ -383,7 +383,7 @@
 //  Inner buttons mixins
 //  ---------------------------------------------
 
-._lib-button-icon (
+._lib-button-icon(
     @_button-icon-use: @button-icon__use,
     @_icon-font-content: @button-icon__content,
     @_icon-font: @button-icon__font,
@@ -397,7 +397,7 @@
     @_icon-font-position: @button-icon__position,
     @_icon-font-text-hide: @button-icon__text-hide
 ) when (@_button-icon-use = true) {
-    .lib-button-icon (
+    .lib-button-icon(
         @_icon-font-content: @_icon-font-content,
         @_icon-font: @_icon-font,
         @_icon-font-size: @_icon-font-size,
@@ -412,7 +412,7 @@
     );
 }
 
-.lib-button-icon (
+.lib-button-icon(
     @_icon-font-content,
     @_icon-font: @button-icon__font,
     @_icon-font-size: @button-icon__font-size,

--- a/lib/web/css/source/lib/_pages.less
+++ b/lib/web/css/source/lib/_pages.less
@@ -272,7 +272,7 @@
         }
 
         &.next {
-            ._lib-pager-icon (
+            ._lib-pager-icon(
                 @_icon-font-content: @_pager-icon-next-content,
                 @_pager-icon-use: @_pager-icon-use,
                 @_icon-font: @_pager-icon-font,
@@ -290,7 +290,7 @@
         }
 
         &.previous {
-            ._lib-pager-icon (
+            ._lib-pager-icon(
                 @_icon-font-content: @_pager-icon-previous-content,
                 @_pager-icon-use: @_pager-icon-use,
                 @_icon-font: @_pager-icon-font,
@@ -373,7 +373,7 @@
     }
 }
 
-._lib-pager-icon (
+._lib-pager-icon(
     @_pager-icon-use,
     @_icon-font-content,
     @_icon-font,
@@ -415,7 +415,7 @@
     );
 }
 
-._lib-pager-icon (
+._lib-pager-icon(
     @_icon-font-content,
     @_pager-icon-use,
     @_icon-font,

--- a/lib/web/css/source/lib/_rating.less
+++ b/lib/web/css/source/lib/_rating.less
@@ -174,8 +174,8 @@
         .loopingClass(@_index - 1);
     }
 
-    .loopingClass (0) {}
-    .loopingClass (@_icon-count);
+    .loopingClass(0) {}
+    .loopingClass(@_icon-count);
 }
 
 ._lib-rating-icon-defalt(


### PR DESCRIPTION
### Description (*)
Some syntax in `.less` files [is being deprecated](https://github.com/less/less.js/pull/4319). Magento uses some of them. This PR fixes this.
Here's an overview:
```
DEPRECATED WARNING: Calling a mixin without parentheses is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/components/_slider.less on line 52, column 28
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/components/_file-uploader.less on line 118, column 24
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/components/_file-uploader.less on line 380, column 24
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/lib/_buttons.less on line 400, column 22
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/lib/_buttons.less on line 80, column 23
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/lib/_pages.less on line 275, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/lib/_pages.less on line 293, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/css/source/lib/_rating.less on line 178, column 19
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/adminhtml/Magento/backend/en_US/Magento_AdminNotification/css/source/_module.less on line 112, column 29
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/source/lib/_buttons.less on line 400, column 22
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/source/lib/_buttons.less on line 80, column 23
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/source/lib/_pages.less on line 275, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/source/lib/_pages.less on line 293, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/blank/en_US/css/source/lib/_rating.less on line 178, column 19
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/source/lib/_buttons.less on line 400, column 22
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/source/lib/_buttons.less on line 80, column 23
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/source/lib/_pages.less on line 275, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/source/lib/_pages.less on line 293, column 30
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/css/source/lib/_rating.less on line 178, column 19
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/Magento_Checkout/css/source/module/checkout/fields/_file-uploader.less on line 135, column 28
DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in var/view_preprocessed/pub/static/frontend/Magento/luma/en_US/Magento_Checkout/css/source/module/checkout/fields/_file-uploader.less on line 398, column 28
```

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Setup clean Magento
2. Run these commands to set everything up:

  ```
  $ rm -Rf package-lock.json node_modules/ var/view_preprocessed/ pub/static/adminhtml/ pub/static/frontend/
  $ cp package.json.sample package.json
  $ npm install
  $ composer require baldwin/magento2-module-less-js-compiler:dev-v1-develop
  $ bin/magento setup:upgrade
  $ bin/magento setup:static-content:deploy en_US -f
  $ cp -r pub/static /tmp/magento-static-files-before-changes
  ```

4. Now upgrade less.js to latest version, as [it has no more false positives in deprecated warnings](https://github.com/less/less.js/issues/4339#issuecomment-3240161698), to do so, apply this change to the `package.json` file:

  ```diff
       "grunt-template-jasmine-requirejs": "~0.2.3",
       "grunt-text-replace": "~0.4.0",
       "imagemin-svgo": "~9.0.0",
  -    "less": "4.2.2",
  +    "less": "4.6.4",
       "load-grunt-config": "~4.0.1",
       "morgan": "~1.10.0",
       "node-minify": "~3.6.0",
  ```

5. Run these commands:

  ```
  $ rm -Rf package-lock.json node_modules/ var/log/system.log var/view_preprocessed/ pub/static/adminhtml/ pub/static/frontend/
  $ npm install
  $ bin/magento setup:static-content:deploy en_US -f
  $ grep 'deprecated' var/log/system.log
  ```

6. Notice that the `grep` command reveals ~93 deprecated warnings from the less compiler

7. Apply the changes from this PR

8. Run these commands:

  ```
  $ rm -Rf var/log/system.log var/view_preprocessed/ pub/static/adminhtml/ pub/static/frontend/
  $ bin/magento setup:static-content:deploy en_US -f
  $ cp -r pub/static /tmp/magento-static-files-after-changes
  $ grep 'deprecated' var/log/system.log
  ```
  
9. Verify no deprecated warnings from the `grep` command anymore

10. Also verify that no important changes happened in the outputted css files by diffing, only the `deployed_version.txt` file shows up with a change, but that's expected:

  ```
  $ diff -ur /tmp/magento-static-files-before-changes/ /tmp/magento-static-files-after-changes/
  ```

### Questions or comments
Should Adobe Commerce / B2B also be checked for the same? I don't have access to those codebases, so I can't help with those.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
