### PR TITLE
Don't allow to inject '%' characters in sprintf through an image file…

### DIFF
--- a/app/code/Magento/Catalog/Model/View/Asset/Image.php
+++ b/app/code/Magento/Catalog/Model/View/Asset/Image.php
@@ -275,8 +275,7 @@ class Image implements LocalInterface
         $data = implode('_', $this->convertToReadableFormat($this->miscParams));
 
         $pathTemplate = $this->getModule()
-            . DIRECTORY_SEPARATOR . "%s" . DIRECTORY_SEPARATOR
-            . $this->getFilePath();
+            . DIRECTORY_SEPARATOR . '%s' . DIRECTORY_SEPARATOR . '%s';
 
         /**
          * New paths are generated without dependency on
@@ -285,7 +284,7 @@ class Image implements LocalInterface
         return preg_replace(
             '|\Q' . DIRECTORY_SEPARATOR . '\E+|',
             DIRECTORY_SEPARATOR,
-            sprintf($pathTemplate, hash(self::HASH_ALGORITHM, $data))
+            sprintf($pathTemplate, hash(self::HASH_ALGORITHM, $data), $this->getFilePath())
         );
     }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/View/Asset/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/View/Asset/ImageTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Test\Unit\Model\View\Asset;
+
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Catalog\Model\Config\CatalogMediaConfig;
+use Magento\Catalog\Model\Product\Image\ConvertImageMiscParamsToReadableFormat;
+use Magento\Catalog\Model\Product\Media\ConfigInterface;
+use Magento\Catalog\Model\View\Asset\Image as ImageAsset;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\View\Asset\ContextInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ImageTest extends TestCase
+{
+    /** @var ConfigInterface */
+    private ConfigInterface $mediaConfig;
+    /** @var ContextInterface */
+    private ContextInterface $context;
+    /** @var EncryptorInterface */
+    private EncryptorInterface $encryptor;
+    /** @var ImageHelper */
+    private ImageHelper $imageHelper;
+    /** @var CatalogMediaConfig */
+    private CatalogMediaConfig $catalogMediaConfig;
+    /** @var StoreManagerInterface */
+    private StoreManagerInterface $storeManager;
+    /** @var ConvertImageMiscParamsToReadableFormat */
+    private ConvertImageMiscParamsToReadableFormat $convertImageMiscParamsToReadableFormat;
+
+    protected function setUp(): void
+    {
+        $this->mediaConfig = $this->createStub(ConfigInterface::class);
+        $this->context = $this->createStub(ContextInterface::class);
+        $this->encryptor = $this->createStub(EncryptorInterface::class);
+        $this->imageHelper = $this->createStub(ImageHelper::class);
+        $this->catalogMediaConfig = $this->createStub(CatalogMediaConfig::class);
+        $this->storeManager = $this->createStub(StoreManagerInterface::class);
+        $this->convertImageMiscParamsToReadableFormat =
+            $this->createStub(ConvertImageMiscParamsToReadableFormat::class);
+    }
+
+    public function testGetPath(): void
+    {
+        $filePath = 'i/m/image.jpg';
+        $miscParams = [];
+
+        $imageAsset = new ImageAsset(
+            $this->mediaConfig,
+            $this->context,
+            $this->encryptor,
+            $filePath,
+            $miscParams,
+            $this->imageHelper,
+            $this->catalogMediaConfig,
+            $this->storeManager,
+            $this->convertImageMiscParamsToReadableFormat,
+        );
+
+        $this->assertStringEndsWith($filePath, $imageAsset->getPath());
+    }
+
+    public function testGetPathWithPercentageCharacter(): void
+    {
+        $filePath = 'i/m/im%age.jpg';
+        $miscParams = [];
+
+        $imageAsset = new ImageAsset(
+            $this->mediaConfig,
+            $this->context,
+            $this->encryptor,
+            $filePath,
+            $miscParams,
+            $this->imageHelper,
+            $this->catalogMediaConfig,
+            $this->storeManager,
+            $this->convertImageMiscParamsToReadableFormat,
+        );
+
+        $this->assertStringEndsWith($filePath, $imageAsset->getPath());
+    }
+}


### PR DESCRIPTION
…name.

### Description (*)
Before this fix, it was possible to inject `%` characters into the first argument of the `sprintf` function by having `%` character in a product images filename, which then caused the code to crash as it only expected one placeholder:

```
ArgumentCountError: 3 arguments are required, 2 given in app/code/Magento/Catalog/Model/View/Asset/Image.php:288
```

You can't easily trigger this by using Magento in a normal way, because Magento will replace `%` characters in an product image's filename when uploading it. But if you use a module to do fast product imports that will directly write to the database without much validation, it's possible to insert such filenames with a  `%` character into the database. And then later on when loading backoffice or frontend, a crash can occur for such products.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Setup empty Magento shop
2. Create a category
3. Create a product and assign it to the category
4. Add an image to the product
5. Now we need to do some 'hacking' to trigger the problem, so find the table `catalog_product_entity_varchar` in the database and find the entry for the 'small_image' product attribute (for me it's `attribute_id` 88) for the product created in step 3, now edit this row's `value` and insert a `%` character in the filename, so you get for example `/s/o/some%file.png` instead of `/s/o/some_file.png`.
6. Do a reindex & cache flush
7. Visit the category created in step 2 on the frontend
8. Before this PR, you should see a crash with the error mentioned above
9. You can also run the unit test provided in this PR before and after the fix, and see it fails before the fix

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
