### PR TITLE
[WIP] perf(scd): skip redundant per-file deploy for inherited locale/theme variants via bulk copy

### DIFF
--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -20,6 +20,11 @@ use Psr\Log\LoggerInterface;
 class DeployPackage
 {
     /**
+     * Minimum ratio of inherited files required before a bulk directory copy is attempted.
+     * Below this threshold the per-file loop is used instead to avoid unnecessary overhead.
+     */
+    private const BULK_COPY_THRESHOLD = 0.5;
+    /**
      * Application state object
      *
      * Allows to switch between different application areas
@@ -119,6 +124,17 @@ class DeployPackage
     {
         $this->count = 0;
         $this->errorsCount = 0;
+
+        $parentPackage = $package->getParent();
+        $parentBulkCopied = false;
+        if ($parentPackage && $this->shouldBulkCopy($package, $parentPackage)) {
+            $copiedCount = $this->deployStaticFile->copyTree(
+                $parentPackage->getPath(),
+                $package->getPath()
+            );
+            $parentBulkCopied = ($copiedCount > 0);
+        }
+
         $this->register($package, null, $skipLogging);
 
         /** @var PackageFile $file */
@@ -131,7 +147,7 @@ class DeployPackage
             }
 
             try {
-                $this->processFile($file, $package);
+                $this->processFile($file, $package, $parentBulkCopied);
             } catch (ContentProcessorException $exception) {
                 $errorMessage = __(
                     'Compilation from source: %1',
@@ -161,15 +177,12 @@ class DeployPackage
     }
 
     /**
-     * Apply proper deployment action
-     *
-     * File can be created if content is already provided, or copied from parent package or published
-     *
      * @param PackageFile $file
      * @param Package $package
+     * @param bool $parentBulkCopied
      * @return void
      */
-    private function processFile(PackageFile $file, Package $package)
+    private function processFile(PackageFile $file, Package $package, bool $parentBulkCopied = false)
     {
         if ($file->getContent()) {
             $this->deployStaticFile->writeFile(
@@ -177,26 +190,98 @@ class DeployPackage
                 $package->getPath(),
                 $file->getContent()
             );
-        } else {
-            $parentPackage = $package->getParent();
-            if ($this->checkIfCanCopy($file, $package, $parentPackage)) {
-                $this->deployStaticFile->copyFile(
-                    $file->getDeployedFileId(),
-                    $parentPackage->getPath(),
-                    $package->getPath()
-                );
-            } else {
-                $this->deployStaticFile->deployFile(
-                    $file->getFileName(),
-                    [
-                        'area' => $package->getArea(),
-                        'theme' => $package->getTheme(),
-                        'locale' => $package->getLocale(),
-                        'module' => $file->getModule(),
-                    ]
-                );
+            return;
+        }
+
+        $parentPackage = $package->getParent();
+
+        if ($parentBulkCopied && $this->isInheritedFile($file, $package, $parentPackage)) {
+            return;
+        }
+
+        if (!$parentBulkCopied && $this->checkIfCanCopy($file, $package, $parentPackage)) {
+            $this->deployStaticFile->copyFile(
+                $file->getDeployedFileId(),
+                $parentPackage->getPath(),
+                $package->getPath()
+            );
+            return;
+        }
+
+        $this->deployStaticFile->deployFile(
+            $file->getFileName(),
+            [
+                'area' => $package->getArea(),
+                'theme' => $package->getTheme(),
+                'locale' => $package->getLocale(),
+                'module' => $file->getModule(),
+            ]
+        );
+    }
+
+    /**
+     * Check if file is inherited from a parent package.
+     *
+     * A file is inherited when it originates from a different scope (area/theme/locale) AND
+     * exists in the parent's deployed file list. The parent file list check is required because
+     * a scope mismatch alone is not enough — theme-specific files (e.g. critical.css in luma)
+     * also have a locale mismatch but are not present in the parent theme's output.
+     *
+     * @param PackageFile $file
+     * @param Package $package
+     * @param Package|null $parentPackage
+     * @return bool
+     */
+    private function isInheritedFile(PackageFile $file, Package $package, ?Package $parentPackage = null): bool
+    {
+        return $parentPackage
+            && $file->getOrigPackage() !== $package
+            && (
+                $file->getArea() !== $package->getArea()
+                || $file->getTheme() !== $package->getTheme()
+                || $file->getLocale() !== $package->getLocale()
+            )
+            && isset($parentPackage->getFiles()[$file->getFileId()]);
+    }
+
+    /**
+     * Check if a bulk directory copy is worth doing for this package.
+     *
+     * copyTree() is only faster than per-file copies when a large proportion of the package's
+     * files are inherited — otherwise the directory traversal overhead exceeds the savings.
+     * This uses the in-memory file lists to count without any filesystem calls.
+     *
+     * @param Package $package
+     * @param Package $parentPackage
+     * @return bool
+     */
+    private function shouldBulkCopy(Package $package, Package $parentPackage): bool
+    {
+        $packageFiles = $package->getFiles();
+        $total = count($packageFiles);
+        if ($total === 0) {
+            return false;
+        }
+
+        $parentFiles = $parentPackage->getFiles();
+        $inherited = 0;
+        foreach ($packageFiles as $file) {
+            if ($file->getContent()) {
+                continue;
+            }
+            if ($file->getOrigPackage() !== $package
+                && (
+                    $file->getArea() !== $package->getArea()
+                    || $file->getTheme() !== $package->getTheme()
+                    || $file->getLocale() !== $package->getLocale()
+                )
+                && isset($parentFiles[$file->getFileId()])
+            ) {
+                $inherited++;
             }
         }
+
+        return ($inherited / $total) >= self::BULK_COPY_THRESHOLD;
     }
 
     /**
@@ -216,8 +301,7 @@ class DeployPackage
                 || $file->getTheme() !== $package->getTheme()
                 || $file->getLocale() !== $package->getLocale()
             )
-            && $file->getOrigPackage() === $parentPackage
-            && $this->deployStaticFile->readFile($file->getDeployedFileId(), $parentPackage->getPath());
+            && $this->deployStaticFile->fileExists($file->getDeployedFileId(), $parentPackage->getPath());
     }
 
     /**

--- a/app/code/Magento/Deploy/Service/DeployStaticFile.php
+++ b/app/code/Magento/Deploy/Service/DeployStaticFile.php
@@ -144,6 +144,56 @@ class DeployStaticFile
     }
 
     /**
+     * Check if a resolved file exists in pub static directory
+     *
+     * @param string $fileName
+     * @param string $filePath
+     * @return bool
+     */
+    public function fileExists(string $fileName, string $filePath): bool
+    {
+        $fileName = $this->minification->addMinifiedSign($fileName);
+        $relativePath = $filePath . DIRECTORY_SEPARATOR . $this->resolveFile($fileName);
+        return $this->pubStaticDir->isFile($relativePath);
+    }
+
+    /**
+     * Recursively copy all files from source path to target path.
+     *
+     * @param string $sourcePath Relative path within pub/static
+     * @param string $targetPath Relative path within pub/static
+     * @return int Number of files copied
+     */
+    public function copyTree(string $sourcePath, string $targetPath): int
+    {
+        if (!$this->pubStaticDir->isExist($sourcePath)) {
+            return 0;
+        }
+
+        $sourceAbsPath = $this->pubStaticDir->getAbsolutePath($sourcePath);
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($sourceAbsPath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        $count = 0;
+        foreach ($iterator as $item) {
+            $relSubPath = $iterator->getSubPathName();
+            if ($item->isDir()) {
+                $this->pubStaticDir->create($targetPath . DIRECTORY_SEPARATOR . $relSubPath);
+            } else {
+                $this->pubStaticDir->copyFile(
+                    $sourcePath . DIRECTORY_SEPARATOR . $relSubPath,
+                    $targetPath . DIRECTORY_SEPARATOR . $relSubPath
+                );
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
      * Open static file
      *
      * @param string $fileName

--- a/app/code/Magento/Deploy/Strategy/QuickDeploy.php
+++ b/app/code/Magento/Deploy/Strategy/QuickDeploy.php
@@ -71,11 +71,29 @@ class QuickDeploy implements StrategyInterface
         $includeThemesMap = array_flip($options[Options::THEME] ?? []);
         $excludeThemesMap = array_flip($options[Options::EXCLUDE_THEME] ?? []);
 
+        // Pre-compute which packages will be queued so we can safely resolve parent dependencies.
+        // A parent is only a valid queue dependency if it will actually be queued — passing a
+        // dependency that is never queued causes Queue::process() to wait forever (deadlock).
+        $queuedPaths = [];
         foreach ($groupedPackages as $levelPackages) {
             foreach ($levelPackages as $package) {
                 if ($parentCompilationRequested
                     || $this->canDeployTheme($package->getTheme(), $includeThemesMap, $excludeThemesMap)) {
-                    $this->queue->add($package);
+                    $queuedPaths[$package->getPath()] = true;
+                }
+            }
+        }
+
+        foreach ($groupedPackages as $levelPackages) {
+            foreach ($levelPackages as $package) {
+                if ($parentCompilationRequested
+                    || $this->canDeployTheme($package->getTheme(), $includeThemesMap, $excludeThemesMap)) {
+                    $parentPackage = $package->getParent();
+                    $parentQueued = $parentPackage && isset($queuedPaths[$parentPackage->getPath()]);
+                    $this->queue->add(
+                        $package,
+                        $parentQueued ? [$parentPackage->getPath() => $parentPackage] : []
+                    );
                     $deployPackages[] = $package;
                 }
             }

--- a/app/code/Magento/Deploy/Strategy/StandardDeploy.php
+++ b/app/code/Magento/Deploy/Strategy/StandardDeploy.php
@@ -61,14 +61,35 @@ class StandardDeploy implements StrategyInterface
             $deployedPackages[] = $package;
         }
 
+        // For each area/theme, the first locale becomes the base. Subsequent locales are set as
+        // children of the base so DeployPackage can bulk-copy the already-deployed output rather
+        // than re-running LESS compilation for every locale variant independently.
+        $baseLocalePackages = [];
+        foreach ($deployedPackages as $package) {
+            $packageId = $package->getArea() . '/' . $package->getTheme();
+            if (!isset($baseLocalePackages[$packageId])) {
+                $baseLocalePackages[$packageId] = $package;
+            } else {
+                $package->setParent($baseLocalePackages[$packageId]);
+            }
+        }
+
         $parentCompilationRequested = $options[Options::NO_PARENT] !== true;
         $includeThemesMap = array_flip($options[Options::THEME] ?? []);
         $excludeThemesMap = array_flip($options[Options::EXCLUDE_THEME] ?? []);
 
+        // Sort so base packages (no locale parent) come before their variants.
+        // This guarantees the source directory exists when copyTree runs for each variant.
+        usort($deployedPackages, fn($a, $b) => ($a->getParent() !== null) <=> ($b->getParent() !== null));
+
         foreach ($deployedPackages as $package) {
             if ($parentCompilationRequested
                 || $this->canDeployTheme($package->getTheme(), $includeThemesMap, $excludeThemesMap)) {
-                $this->queue->add($package);
+                $parentPackage = $package->getParent();
+                $this->queue->add(
+                    $package,
+                    $parentPackage ? [$parentPackage->getPath() => $parentPackage] : []
+                );
             }
         }
 

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployPackageTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployPackageTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Copyright 2024 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Service;
+
+use Magento\Deploy\Package\Package;
+use Magento\Deploy\Package\PackageFile;
+use Magento\Deploy\Service\DeployPackage;
+use Magento\Deploy\Service\DeployStaticFile;
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * @see DeployPackage
+ */
+class DeployPackageTest extends TestCase
+{
+    private DeployPackage $service;
+
+    /** @var Package|MockObject */
+    private MockObject $package;
+
+    /** @var Package|MockObject */
+    private MockObject $parentPackage;
+
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+        $this->service = $objectManager->getObject(DeployPackage::class, [
+            'appState'       => $this->createMock(AppState::class),
+            'localeResolver' => $this->createMock(LocaleResolver::class),
+            'deployStaticFile' => $this->createMock(DeployStaticFile::class),
+            'logger'         => $this->createMock(LoggerInterface::class),
+        ]);
+
+        $this->package = $this->createMock(Package::class);
+        $this->package->method('getArea')->willReturn('frontend');
+        $this->package->method('getTheme')->willReturn('Magento/blank');
+        $this->package->method('getLocale')->willReturn('en_US');
+
+        $this->parentPackage = $this->createMock(Package::class);
+        $this->parentPackage->method('getArea')->willReturn('frontend');
+        $this->parentPackage->method('getTheme')->willReturn('Magento/blank');
+        $this->parentPackage->method('getLocale')->willReturn('en_GB');
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldBulkCopy
+    // -------------------------------------------------------------------------
+
+    public function testShouldBulkCopyReturnsFalseForEmptyPackage(): void
+    {
+        $this->package->method('getFiles')->willReturn([]);
+        $this->assertFalse($this->invokeShouldBulkCopy($this->package, $this->parentPackage));
+    }
+
+    public function testShouldBulkCopyReturnsFalseWhenFewerThanHalfInherited(): void
+    {
+        $parentFiles = [];
+
+        // 2 own files (not in parent)
+        $own1 = $this->makeFile('a.css', $this->package, 'frontend', 'Magento/blank', 'en_US');
+        $own2 = $this->makeFile('b.css', $this->package, 'frontend', 'Magento/blank', 'en_US');
+
+        // 1 inherited file (in parent, scope mismatch)
+        $inherited = $this->makeFile('c.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $parentFiles['c.css'] = $inherited;
+
+        $this->parentPackage->method('getFiles')->willReturn($parentFiles);
+        $this->package->method('getFiles')->willReturn([$own1, $own2, $inherited]);
+
+        $this->assertFalse($this->invokeShouldBulkCopy($this->package, $this->parentPackage));
+    }
+
+    public function testShouldBulkCopyReturnsTrueWhenMajorityInherited(): void
+    {
+        $parentFiles = [];
+
+        // 1 own file
+        $own = $this->makeFile('a.css', $this->package, 'frontend', 'Magento/blank', 'en_US');
+
+        // 3 inherited files
+        $parentFiles['b.css'] = $this->makeFile('b.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $parentFiles['c.css'] = $this->makeFile('c.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $parentFiles['d.css'] = $this->makeFile('d.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+
+        $this->parentPackage->method('getFiles')->willReturn($parentFiles);
+        $this->package->method('getFiles')->willReturn(
+            array_merge([$own], array_values($parentFiles))
+        );
+
+        $this->assertTrue($this->invokeShouldBulkCopy($this->package, $this->parentPackage));
+    }
+
+    public function testShouldBulkCopyExcludesContentFilesFromInheritedCount(): void
+    {
+        // Content files (pre-set content, e.g. inline CSS) are never bulk-copied and
+        // should not count toward the inherited ratio.
+        $parentFiles = [];
+
+        $contentFile = $this->makeFile(
+            'inline.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB', 'body{}'
+        );
+        $parentFiles['inline.css'] = $contentFile;
+
+        $inherited = $this->makeFile('b.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $parentFiles['b.css'] = $inherited;
+
+        $own = $this->makeFile('c.css', $this->package, 'frontend', 'Magento/blank', 'en_US');
+
+        $this->parentPackage->method('getFiles')->willReturn($parentFiles);
+        // 1 content file + 1 inherited + 1 own = 3 total; only 1 counts as inherited (33%)
+        $this->package->method('getFiles')->willReturn([$contentFile, $inherited, $own]);
+
+        $this->assertFalse($this->invokeShouldBulkCopy($this->package, $this->parentPackage));
+    }
+
+    // -------------------------------------------------------------------------
+    // isInheritedFile
+    // -------------------------------------------------------------------------
+
+    public function testIsInheritedFileReturnsFalseWithNoParent(): void
+    {
+        $file = $this->makeFile('a.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $this->assertFalse($this->invokeIsInheritedFile($file, $this->package, null));
+    }
+
+    public function testIsInheritedFileReturnsFalseWhenFileOriginatesFromPackage(): void
+    {
+        // File originated from this package — should never be skipped
+        $file = $this->makeFile('override.css', $this->package, 'frontend', 'Magento/blank', 'en_US');
+        $this->parentPackage->method('getFiles')->willReturn(['override.css' => $file]);
+
+        $this->assertFalse($this->invokeIsInheritedFile($file, $this->package, $this->parentPackage));
+    }
+
+    public function testIsInheritedFileReturnsFalseWhenNotInParentFileList(): void
+    {
+        // Scope mismatch but the parent did not deploy this file (e.g. theme-specific critical.css)
+        $file = $this->makeFile('critical.css', $this->parentPackage, 'frontend', 'Magento/luma', 'en_GB');
+        $this->parentPackage->method('getFiles')->willReturn([]); // not in parent
+
+        $this->assertFalse($this->invokeIsInheritedFile($file, $this->package, $this->parentPackage));
+    }
+
+    public function testIsInheritedFileReturnsTrueForScopeMismatchPresentInParent(): void
+    {
+        $file = $this->makeFile('styles.css', $this->parentPackage, 'frontend', 'Magento/blank', 'en_GB');
+        $this->parentPackage->method('getFiles')->willReturn(['styles.css' => $file]);
+
+        $this->assertTrue($this->invokeIsInheritedFile($file, $this->package, $this->parentPackage));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeFile(
+        string $fileId,
+        Package $origPackage,
+        string $area,
+        string $theme,
+        string $locale,
+        ?string $content = null
+    ): MockObject {
+        $file = $this->createMock(PackageFile::class);
+        $file->method('getFileId')->willReturn($fileId);
+        $file->method('getDeployedFileId')->willReturn($fileId);
+        $file->method('getOrigPackage')->willReturn($origPackage);
+        $file->method('getArea')->willReturn($area);
+        $file->method('getTheme')->willReturn($theme);
+        $file->method('getLocale')->willReturn($locale);
+        $file->method('getContent')->willReturn($content);
+        return $file;
+    }
+
+    private function invokeShouldBulkCopy(Package $package, Package $parent): bool
+    {
+        $method = new ReflectionMethod(DeployPackage::class, 'shouldBulkCopy');
+        $method->setAccessible(true);
+        return $method->invoke($this->service, $package, $parent);
+    }
+
+    private function invokeIsInheritedFile(PackageFile $file, Package $package, ?Package $parent): bool
+    {
+        $method = new ReflectionMethod(DeployPackage::class, 'isInheritedFile');
+        $method->setAccessible(true);
+        return $method->invoke($this->service, $file, $package, $parent);
+    }
+}

--- a/app/code/Magento/Deploy/Test/Unit/Strategy/QuickDeployTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Strategy/QuickDeployTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright 2024 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Strategy;
+
+use Magento\Deploy\Console\DeployStaticOptions as Options;
+use Magento\Deploy\Package\Package;
+use Magento\Deploy\Package\PackagePool;
+use Magento\Deploy\Process\Queue;
+use Magento\Deploy\Strategy\QuickDeploy;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see QuickDeploy
+ */
+class QuickDeployTest extends TestCase
+{
+    private QuickDeploy $strategy;
+
+    /** @var PackagePool|MockObject */
+    private MockObject $packagePool;
+
+    /** @var Queue|MockObject */
+    private MockObject $queue;
+
+    protected function setUp(): void
+    {
+        $this->packagePool = $this->createMock(PackagePool::class);
+        $this->queue = $this->createMock(Queue::class);
+        $this->strategy = new QuickDeploy($this->packagePool, $this->queue);
+    }
+
+    /**
+     * When all packages are being deployed (no theme filtering), a package whose parent is also in
+     * the queue must declare that parent as a queue dependency so parallel workers don't race.
+     */
+    public function testParentInQueueIsPassedAsDependency(): void
+    {
+        $parentPath = 'frontend/Magento/blank/en_GB';
+        $childPath  = 'frontend/Magento/blank/en_US';
+
+        $parent = $this->makePackage('frontend', 'Magento/blank', 'en_GB', $parentPath, 1, null);
+        $child  = $this->makePackage('frontend', 'Magento/blank', 'en_US', $childPath, 2, $parent, [$parent]);
+
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$parent, $child]);
+
+        $calls = [];
+        $this->queue->method('add')->willReturnCallback(function ($pkg, $deps) use (&$calls) {
+            $calls[] = [$pkg, $deps];
+        });
+        $this->queue->expects($this->exactly(2))->method('add');
+        $this->queue->expects($this->once())->method('process');
+
+        $options = [
+            Options::NO_PARENT    => false,
+            Options::THEME        => [],
+            Options::EXCLUDE_THEME => [],
+        ];
+        $this->strategy->deploy($options);
+
+        // Parent added first with no dependency
+        $this->assertSame($parent, $calls[0][0]);
+        $this->assertSame([], $calls[0][1]);
+
+        // Child added with parent as explicit queue dependency
+        $this->assertSame($child, $calls[1][0]);
+        $this->assertSame([$parentPath => $parent], $calls[1][1]);
+    }
+
+    /**
+     * When a theme-hierarchy parent (e.g. blank as parent of luma) is filtered out by PackagePool
+     * (e.g. because --theme Magento/luma was passed), it is never in groupedPackages and therefore
+     * never in queuedPaths. Passing it as a queue dependency would cause Queue::process() to wait
+     * forever for a package that will never be deployed (deadlock). The child must be queued with
+     * no dependencies in that case.
+     *
+     * This matches real-world behaviour: PackagePool::getPackagesForDeployment() filters by theme,
+     * so blank is absent from the returned list even though luma's theme-hierarchy parent IS blank.
+     * preparePackages() still calls setParent() on luma pointing at the blank Package object (via
+     * getParentPackages()), but that object is not in queuedPaths.
+     */
+    public function testParentNotInQueueDueToThemeFilterIsNotPassedAsDependency(): void
+    {
+        $blankPath = 'frontend/Magento/blank/en_GB';
+        $lumaPath  = 'frontend/Magento/luma/en_GB';
+
+        // blank is a theme-hierarchy Package known to luma via getParentPackages(), but it is NOT
+        // returned by PackagePool (filtered by --theme Magento/luma) — so not in groupedPackages.
+        $blank = $this->makePackage('frontend', 'Magento/blank', 'en_GB', $blankPath, 1, null);
+
+        // luma: level 2 in the theme hierarchy (inherits from blank). getParent() returns blank
+        // because preparePackages() would call setParent(blank) via the getParentPackages() path.
+        $luma = $this->makePackage('frontend', 'Magento/luma', 'en_GB', $lumaPath, 2, $blank, [$blank]);
+
+        // Pool returns ONLY luma — blank is absent (filtered by PackagePool for --theme Magento/luma)
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$luma]);
+
+        $calls = [];
+        $this->queue->method('add')->willReturnCallback(function ($pkg, $deps) use (&$calls) {
+            $calls[] = [$pkg, $deps];
+        });
+
+        $options = [
+            Options::NO_PARENT    => true,
+            Options::THEME        => ['Magento/luma'],
+            Options::EXCLUDE_THEME => [],
+        ];
+        $this->strategy->deploy($options);
+
+        // Only luma should be queued
+        $this->assertCount(1, $calls);
+        $this->assertSame($luma, $calls[0][0]);
+        // blank is not in queuedPaths → no dependency, no deadlock
+        $this->assertSame([], $calls[0][1]);
+    }
+
+    public function testVirtualPackagesAreSkipped(): void
+    {
+        $virtual = $this->makePackage('frontend', 'Magento/blank', 'en_GB', 'v/path', 1, null, [], true);
+
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$virtual]);
+
+        // Nothing should be added to the queue
+        $this->queue->expects($this->never())->method('add');
+        $this->queue->expects($this->once())->method('process');
+
+        $options = [
+            Options::NO_PARENT    => false,
+            Options::THEME        => [],
+            Options::EXCLUDE_THEME => [],
+        ];
+        $this->strategy->deploy($options);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param string $area
+     * @param string $theme
+     * @param string $locale
+     * @param string $path
+     * @param int $inheritanceLevel Used by getInheritanceLevel() to assign groupedPackages level
+     * @param Package|null $parent  Returned by getParent() — set as if preparePackages already ran
+     * @param Package[] $parentPackages Returned by getParentPackages()
+     * @param bool $virtual
+     */
+    private function makePackage(
+        string $area,
+        string $theme,
+        string $locale,
+        string $path,
+        int $inheritanceLevel = 1,
+        ?Package $parent = null,
+        array $parentPackages = [],
+        bool $virtual = false
+    ): MockObject {
+        $pkg = $this->createMock(Package::class);
+        $pkg->method('isVirtual')->willReturn($virtual);
+        $pkg->method('getArea')->willReturn($area);
+        $pkg->method('getTheme')->willReturn($theme);
+        $pkg->method('getLocale')->willReturn($locale);
+        $pkg->method('getPath')->willReturn($path);
+        $pkg->method('getInheritanceLevel')->willReturn($inheritanceLevel);
+        $pkg->method('getParent')->willReturn($parent);
+        $pkg->method('getParentPackages')->willReturn($parentPackages);
+        $pkg->method('aggregate')->willReturn(null);
+        return $pkg;
+    }
+}

--- a/app/code/Magento/Deploy/Test/Unit/Strategy/StandardDeployTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Strategy/StandardDeployTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Copyright 2024 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Strategy;
+
+use Magento\Deploy\Console\DeployStaticOptions as Options;
+use Magento\Deploy\Package\Package;
+use Magento\Deploy\Package\PackagePool;
+use Magento\Deploy\Process\Queue;
+use Magento\Deploy\Strategy\StandardDeploy;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see StandardDeploy
+ */
+class StandardDeployTest extends TestCase
+{
+    private StandardDeploy $strategy;
+
+    /** @var PackagePool|MockObject */
+    private MockObject $packagePool;
+
+    /** @var Queue|MockObject */
+    private MockObject $queue;
+
+    private array $defaultOptions;
+
+    protected function setUp(): void
+    {
+        $this->packagePool = $this->createMock(PackagePool::class);
+        $this->queue = $this->createMock(Queue::class);
+        $this->strategy = new StandardDeploy($this->packagePool, $this->queue);
+        $this->defaultOptions = [
+            Options::NO_PARENT    => false,
+            Options::THEME        => [],
+            Options::EXCLUDE_THEME => [],
+        ];
+    }
+
+    public function testVirtualPackagesAreSkipped(): void
+    {
+        $virtual = $this->makePackage('frontend', 'Magento/blank', 'en_GB', 'path/v', true);
+        $real    = $this->makePackage('frontend', 'Magento/blank', 'en_US', 'path/r', false);
+
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$virtual, $real]);
+
+        // Only the real package should be added
+        $this->queue->expects($this->once())->method('add')->with($real, $this->anything());
+        $this->queue->expects($this->once())->method('process');
+
+        $result = $this->strategy->deploy($this->defaultOptions);
+
+        $this->assertNotContains($virtual, $result);
+        $this->assertContains($real, $result);
+    }
+
+    public function testFirstLocalePerThemeHasNoParentAndNoQueueDependency(): void
+    {
+        $base = $this->makePackage('frontend', 'Magento/blank', 'en_GB', 'frontend/Magento/blank/en_GB');
+
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$base]);
+
+        // Base locale should be queued with empty dependencies
+        $this->queue->expects($this->once())->method('add')->with($base, []);
+        $this->queue->expects($this->once())->method('process');
+
+        $this->strategy->deploy($this->defaultOptions);
+    }
+
+    public function testSecondLocalePerThemeGetsParentSetAndQueuedWithDependency(): void
+    {
+        $basePath    = 'frontend/Magento/blank/en_GB';
+        $variantPath = 'frontend/Magento/blank/en_US';
+
+        $base    = $this->makePackage('frontend', 'Magento/blank', 'en_GB', $basePath);
+        $variant = $this->makePackage('frontend', 'Magento/blank', 'en_US', $variantPath);
+
+        $this->packagePool->method('getPackagesForDeployment')->willReturn([$base, $variant]);
+
+        // Variant should have setParent() called with the base package
+        $variant->expects($this->once())->method('setParent')->with($base);
+
+        // Variant's getParent() returns base (as set by setParent)
+        $variant->method('getParent')->willReturn($base);
+        $base->method('getParent')->willReturn(null);
+
+        // Base queued with no dependency; variant queued with base as dependency
+        $calls = [];
+        $this->queue->method('add')->willReturnCallback(function ($pkg, $deps) use (&$calls) {
+            $calls[] = [$pkg, $deps];
+        });
+        $this->queue->expects($this->exactly(2))->method('add');
+        $this->queue->expects($this->once())->method('process');
+
+        $this->strategy->deploy($this->defaultOptions);
+
+        // Base is first with no dependencies
+        $this->assertSame($base, $calls[0][0]);
+        $this->assertSame([], $calls[0][1]);
+
+        // Variant is second with base as dependency
+        $this->assertSame($variant, $calls[1][0]);
+        $this->assertSame([$basePath => $base], $calls[1][1]);
+    }
+
+    public function testBasePackagesQueuedBeforeVariants(): void
+    {
+        $base1    = $this->makePackage('frontend', 'Magento/blank', 'en_GB', 'frontend/Magento/blank/en_GB');
+        $variant1 = $this->makePackage('frontend', 'Magento/blank', 'en_US', 'frontend/Magento/blank/en_US');
+        $base2    = $this->makePackage('frontend', 'Magento/luma', 'en_GB', 'frontend/Magento/luma/en_GB');
+        $variant2 = $this->makePackage('frontend', 'Magento/luma', 'en_US', 'frontend/Magento/luma/en_US');
+
+        // Pool returns interleaved order: base1, base2, variant1, variant2
+        $this->packagePool->method('getPackagesForDeployment')
+            ->willReturn([$base1, $base2, $variant1, $variant2]);
+
+        $variant1->method('setParent')->with($base1);
+        $variant1->method('getParent')->willReturn($base1);
+        $base1->method('getParent')->willReturn(null);
+
+        $variant2->method('setParent')->with($base2);
+        $variant2->method('getParent')->willReturn($base2);
+        $base2->method('getParent')->willReturn(null);
+
+        $order = [];
+        $this->queue->method('add')->willReturnCallback(function ($pkg) use (&$order) {
+            $order[] = $pkg;
+        });
+        $this->queue->expects($this->exactly(4))->method('add');
+
+        $this->strategy->deploy($this->defaultOptions);
+
+        // All base packages appear before any variant
+        $this->assertSame($base1, $order[0]);
+        $this->assertSame($base2, $order[1]);
+        $this->assertSame($variant1, $order[2]);
+        $this->assertSame($variant2, $order[3]);
+    }
+
+    public function testDifferentThemesHaveSeparateBaseLocales(): void
+    {
+        // blank/en_GB and luma/en_GB are both base locales (different themes)
+        $blankBase    = $this->makePackage('frontend', 'Magento/blank', 'en_GB', 'frontend/Magento/blank/en_GB');
+        $blankVariant = $this->makePackage('frontend', 'Magento/blank', 'en_US', 'frontend/Magento/blank/en_US');
+        $lumaBase     = $this->makePackage('frontend', 'Magento/luma', 'en_GB', 'frontend/Magento/luma/en_GB');
+
+        $this->packagePool->method('getPackagesForDeployment')
+            ->willReturn([$blankBase, $blankVariant, $lumaBase]);
+
+        $blankVariant->method('setParent')->with($blankBase);
+        $blankVariant->method('getParent')->willReturn($blankBase);
+        $blankBase->method('getParent')->willReturn(null);
+        // lumaBase is first for its theme, so no setParent expected
+        $lumaBase->expects($this->never())->method('setParent');
+        $lumaBase->method('getParent')->willReturn(null);
+
+        $this->queue->expects($this->exactly(3))->method('add');
+
+        $this->strategy->deploy($this->defaultOptions);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makePackage(
+        string $area,
+        string $theme,
+        string $locale,
+        string $path,
+        bool $virtual = false
+    ): MockObject {
+        $pkg = $this->createMock(Package::class);
+        $pkg->method('isVirtual')->willReturn($virtual);
+        $pkg->method('getArea')->willReturn($area);
+        $pkg->method('getTheme')->willReturn($theme);
+        $pkg->method('getLocale')->willReturn($locale);
+        $pkg->method('getPath')->willReturn($path);
+        $pkg->method('aggregate')->willReturn(null);
+        return $pkg;
+    }
+}


### PR DESCRIPTION
### Description (*)

When deploying locale/theme variant packages, the vast majority of files are inherited unchanged from a parent package. Currently both the quick and standard strategies re-run the full LESS pipeline for every file in every variant, even though LESS output does not vary by locale and the files are identical to the parent.

This PR replaces per-file deploy operations with a single recursive directory copy for packages whose files are predominantly inherited, across both the quick and standard deploy strategies.

**Performance results** (5 locales: en\_GB en\_US fr\_FR de\_DE nl\_NL, cold static dir, serial mode):

| Store | Themes | Strategy | Before | After | Improvement |
|---|---|---|---|---|---|
| Store 1 (2.4.8-p4, PHP 8.3) | 4 | quick | 65.2s | 16.4s | **75% faster** |
| Store 1 | 4 | standard | 62.8s | 22.7s | **64% faster** |
| Store 2 (2.4.8-p3, PHP 8.3) | 7 | quick | 104.8s | 20.0s | **81% faster** |
| Store 2 | 7 | standard | 98.6s | 30.7s | **69% faster** |
| Store 3 (2.4.8-p4, PHP 8.3) | 11 | quick | 176.7s | 19.8s | **89% faster** |
| Store 3 | 11 | standard | 169.2s | 45.7s | **73% faster** |

The compact strategy is unaffected (~2% noise) — it pre-compiles LESS once then copies cheaply, so `shouldBulkCopy()` correctly returns false.

#### Breakdown

**Root cause - quick strategy (dead code):**
`checkIfCanCopy()` contained the condition `$file->getOrigPackage() === $parentPackage`. `origPackage` is set to the deepest ancestor virtual package (e.g. `blank/default`), not the locale parent assigned by the strategy. This condition virtually never passed, so every file fell through to `deployFile()` regardless of whether a copy was valid.

**Root cause - standard strategy:**
The standard strategy had no parent-package concept at all. Every locale of a theme was deployed fully independently, re-running LESS compilation for each.

**Parallel safety:**
`copyTree()` requires the parent locale directory to be fully deployed before a variant worker begins copying. Without explicit queue dependencies, `-j N` workers can fork a variant before the base locale finishes. Both strategies now pass the parent as an explicit queue dependency.

**Deadlock fix (quick strategy):**
`QuickDeploy::preparePackages()` assigns `setParent()` for both locale parents and theme-hierarchy parents (e.g. blank as parent of luma). When `--no-parent` or `--theme` filters exclude theme-hierarchy parents from the package pool, passing them as queue dependencies causes `Queue::process()` to wait indefinitely. The fix pre-computes `$queuedPaths` and only uses parents present in that set as dependencies.

### Manual testing scenarios (*)

**Basic deploy (all strategies):**
1. Clear `pub/static/`: `rm -rf pub/static/frontend pub/static/adminhtml pub/static/base`
2. Run: `php bin/magento setup:static-content:deploy -f en_GB en_US fr_FR -s quick`
3. Verify deploy completes without errors and file count matches a stock deploy
4. Repeat with `-s standard`

**Parallel deploy:**
1. Clear `pub/static/`
2. Run: `php bin/magento setup:static-content:deploy -f en_GB en_US fr_FR -s quick -j 4`
3. Verify no race conditions, file counts match serial deploy
4. Repeat with `-s standard -j 4`

**Filter options (deadlock regression):**
1. Run: `php bin/magento setup:static-content:deploy -f en_GB en_US --theme Magento/luma --no-parent -s quick`
2. Verify deploy completes (does not hang waiting for Magento/blank which is absent from queue)

**Output correctness:**
1. Deploy with stock code, capture: `find pub/static -type f | sort > /tmp/stock.txt`
2. Deploy with this PR, capture: `find pub/static -type f | sort > /tmp/patched.txt`
3. Verify: `diff -r /tmp/stock.txt /tmp/patched.txt` produces no output

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)