### PR TITLE
Trim deployment version in Version\\Storage\\File::load()

### DIFF
--- a/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/Version/Storage/FileTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/Version/Storage/FileTest.php
@@ -45,6 +45,22 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('123', $this->object->load());
     }
 
+    /**
+     * Trailing newline in deployed_version.txt must not be part of the version (breaks static URLs / JSON).
+     */
+    public function testLoadTrimsWhitespaceFromFileContents()
+    {
+        $this->directory->expects($this->once())
+            ->method('isReadable')
+            ->with('fixture_file.txt')
+            ->willReturn(true);
+        $this->directory->expects($this->once())
+            ->method('readFile')
+            ->with('fixture_file.txt')
+            ->willReturn("1774318753872\n");
+        $this->assertSame('1774318753872', $this->object->load());
+    }
+
     public function testSave()
     {
         $this->directory

--- a/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/Version/Storage/FileTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/View/Deployment/Version/Storage/FileTest.php
@@ -46,9 +46,13 @@ class FileTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Trailing newline in deployed_version.txt must not be part of the version (breaks static URLs / JSON).
+     * Whitespace around the version in deployed_version.txt must be stripped (URLs / JSON embed this value).
+     *
+     * @param string $rawFromFile
+     * @param string $expectedVersion
+     * @dataProvider loadTrimsWhitespaceDataProvider
      */
-    public function testLoadTrimsWhitespaceFromFileContents()
+    public function testLoadTrimsWhitespaceFromFileContents($rawFromFile, $expectedVersion)
     {
         $this->directory->expects($this->once())
             ->method('isReadable')
@@ -57,8 +61,30 @@ class FileTest extends \PHPUnit\Framework\TestCase
         $this->directory->expects($this->once())
             ->method('readFile')
             ->with('fixture_file.txt')
-            ->willReturn("1774318753872\n");
-        $this->assertSame('1774318753872', $this->object->load());
+            ->willReturn($rawFromFile);
+        $this->assertSame($expectedVersion, $this->object->load());
+    }
+
+    /**
+     * Cases match PHP trim(): spaces, tabs, CR/LF, NUL, vertical tab at start/end only.
+     *
+     * @return array
+     */
+    public static function loadTrimsWhitespaceDataProvider()
+    {
+        $v = '1774318753872';
+
+        return [
+            'trailing LF' => [$v . "\n", $v],
+            'trailing CRLF' => [$v . "\r\n", $v],
+            'leading LF' => ["\n" . $v, $v],
+            'leading and trailing CR' => ["\r" . $v . "\r", $v],
+            'spaces around' => ['  ' . $v . '  ', $v],
+            'tabs around' => ["\t" . $v . "\t", $v],
+            'mixed space tab newline' => [" \t\n\r" . $v . "\r\n\t ", $v],
+            'vertical tabs' => ["\x0B" . $v . "\x0B", $v],
+            'null bytes on edges' => ["\0" . $v . "\0", $v],
+        ];
     }
 
     public function testSave()

--- a/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
+++ b/lib/internal/Magento/Framework/App/View/Deployment/Version/Storage/File.php
@@ -41,7 +41,7 @@ class File implements \Magento\Framework\App\View\Deployment\Version\StorageInte
     public function load()
     {
         if ($this->directory->isReadable($this->fileName)) {
-            return $this->directory->readFile($this->fileName);
+            return trim((string) $this->directory->readFile($this->fileName));
         }
         return false;
     }


### PR DESCRIPTION
## Description

`pub/static/deployed_version.txt` is read verbatim in `Version\Storage\File::load()`. A trailing newline (common when the file is written with a shell redirect or some editors) becomes part of the deployment version string and breaks static view URLs (`/static/version…/…`), including JSON that embeds those URLs (e.g. `body` `data-mage-init` for the loader icon).

## Manual testing scenarios

- `deployed_version.txt` contains only digits + trailing `\n` → static URLs and `JSON.parse` on `data-mage-init` succeed.
- No `deployed_version.txt` / file unreadable → unchanged (`false`).

Fixes #40620