### PR TITLE
Fix #39376: correct LoginAsCustomer admin ID key and ScopeResolver phpdoc

### DIFF
--- a/app/code/Magento/LoginAsCustomer/Model/GetLoggedAsCustomerAdminId.php
+++ b/app/code/Magento/LoginAsCustomer/Model/GetLoggedAsCustomerAdminId.php
@@ -35,6 +35,12 @@ class GetLoggedAsCustomerAdminId implements GetLoggedAsCustomerAdminIdInterface
      */
     public function execute(): int
     {
-        return (int)$this->session->getLoggedAsCustomerAdmindId();
+        $adminId = $this->session->getLoggedAsCustomerAdminId();
+        if ($adminId === null) {
+            // Backward compatibility for session values written with the previous typo.
+            $adminId = $this->session->getLoggedAsCustomerAdmindId();
+        }
+
+        return (int)$adminId;
     }
 }

--- a/app/code/Magento/LoginAsCustomer/Model/SetLoggedAsCustomerAdminId.php
+++ b/app/code/Magento/LoginAsCustomer/Model/SetLoggedAsCustomerAdminId.php
@@ -35,6 +35,8 @@ class SetLoggedAsCustomerAdminId implements SetLoggedAsCustomerAdminIdInterface
      */
     public function execute(int $adminId): void
     {
+        $this->session->setLoggedAsCustomerAdminId($adminId);
+        // Backward compatibility for code reading the legacy typo-based session key.
         $this->session->setLoggedAsCustomerAdmindId($adminId);
     }
 }

--- a/app/code/Magento/LoginAsCustomer/Test/Unit/Model/GetLoggedAsCustomerAdminIdTest.php
+++ b/app/code/Magento/LoginAsCustomer/Test/Unit/Model/GetLoggedAsCustomerAdminIdTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2025 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
@@ -14,9 +14,9 @@ use PHPUnit\Framework\TestCase;
 class GetLoggedAsCustomerAdminIdTest extends TestCase
 {
     /**
-     * @var Session
+     * @var Session&\PHPUnit\Framework\MockObject\MockObject
      */
-    private Session $sessionMock;
+    private $sessionMock;
 
     /**
      * @var GetLoggedAsCustomerAdminId
@@ -25,7 +25,10 @@ class GetLoggedAsCustomerAdminIdTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->sessionMock = $this->createMock(Session::class);
+        $this->sessionMock = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getLoggedAsCustomerAdminId', 'getLoggedAsCustomerAdmindId'])
+            ->getMock();
         $this->model = new GetLoggedAsCustomerAdminId($this->sessionMock);
     }
 

--- a/app/code/Magento/LoginAsCustomer/Test/Unit/Model/GetLoggedAsCustomerAdminIdTest.php
+++ b/app/code/Magento/LoginAsCustomer/Test/Unit/Model/GetLoggedAsCustomerAdminIdTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\LoginAsCustomer\Test\Unit\Model;
+
+use Magento\Customer\Model\Session;
+use Magento\LoginAsCustomer\Model\GetLoggedAsCustomerAdminId;
+use PHPUnit\Framework\TestCase;
+
+class GetLoggedAsCustomerAdminIdTest extends TestCase
+{
+    /**
+     * @var Session
+     */
+    private Session $sessionMock;
+
+    /**
+     * @var GetLoggedAsCustomerAdminId
+     */
+    private GetLoggedAsCustomerAdminId $model;
+
+    protected function setUp(): void
+    {
+        $this->sessionMock = $this->createMock(Session::class);
+        $this->model = new GetLoggedAsCustomerAdminId($this->sessionMock);
+    }
+
+    public function testExecuteUsesCorrectedSessionGetter(): void
+    {
+        $this->sessionMock->expects($this->once())
+            ->method('getLoggedAsCustomerAdminId')
+            ->willReturn('123');
+
+        $this->sessionMock->expects($this->never())
+            ->method('getLoggedAsCustomerAdmindId');
+
+        $this->assertSame(123, $this->model->execute());
+    }
+
+    public function testExecuteFallsBackToLegacySessionGetter(): void
+    {
+        $this->sessionMock->expects($this->once())
+            ->method('getLoggedAsCustomerAdminId')
+            ->willReturn(null);
+
+        $this->sessionMock->expects($this->once())
+            ->method('getLoggedAsCustomerAdmindId')
+            ->willReturn('456');
+
+        $this->assertSame(456, $this->model->execute());
+    }
+}

--- a/app/code/Magento/LoginAsCustomer/Test/Unit/Model/SetLoggedAsCustomerAdminIdTest.php
+++ b/app/code/Magento/LoginAsCustomer/Test/Unit/Model/SetLoggedAsCustomerAdminIdTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2025 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
@@ -14,9 +14,9 @@ use PHPUnit\Framework\TestCase;
 class SetLoggedAsCustomerAdminIdTest extends TestCase
 {
     /**
-     * @var Session
+     * @var Session&\PHPUnit\Framework\MockObject\MockObject
      */
-    private Session $sessionMock;
+    private $sessionMock;
 
     /**
      * @var SetLoggedAsCustomerAdminId
@@ -25,7 +25,10 @@ class SetLoggedAsCustomerAdminIdTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->sessionMock = $this->createMock(Session::class);
+        $this->sessionMock = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setLoggedAsCustomerAdminId', 'setLoggedAsCustomerAdmindId'])
+            ->getMock();
         $this->model = new SetLoggedAsCustomerAdminId($this->sessionMock);
     }
 

--- a/app/code/Magento/LoginAsCustomer/Test/Unit/Model/SetLoggedAsCustomerAdminIdTest.php
+++ b/app/code/Magento/LoginAsCustomer/Test/Unit/Model/SetLoggedAsCustomerAdminIdTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\LoginAsCustomer\Test\Unit\Model;
+
+use Magento\Customer\Model\Session;
+use Magento\LoginAsCustomer\Model\SetLoggedAsCustomerAdminId;
+use PHPUnit\Framework\TestCase;
+
+class SetLoggedAsCustomerAdminIdTest extends TestCase
+{
+    /**
+     * @var Session
+     */
+    private Session $sessionMock;
+
+    /**
+     * @var SetLoggedAsCustomerAdminId
+     */
+    private SetLoggedAsCustomerAdminId $model;
+
+    protected function setUp(): void
+    {
+        $this->sessionMock = $this->createMock(Session::class);
+        $this->model = new SetLoggedAsCustomerAdminId($this->sessionMock);
+    }
+
+    public function testExecuteWritesBothCorrectAndLegacySessionKeys(): void
+    {
+        $adminId = 789;
+
+        $this->sessionMock->expects($this->once())
+            ->method('setLoggedAsCustomerAdminId')
+            ->with($adminId);
+
+        $this->sessionMock->expects($this->once())
+            ->method('setLoggedAsCustomerAdmindId')
+            ->with($adminId);
+
+        $this->model->execute($adminId);
+    }
+}

--- a/lib/internal/Magento/Framework/App/ScopeResolver.php
+++ b/lib/internal/Magento/Framework/App/ScopeResolver.php
@@ -10,7 +10,7 @@ use Magento\Framework\ObjectManagerInterface;
 class ScopeResolver implements ScopeResolverInterface
 {
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 


### PR DESCRIPTION
### Description (*)
This PR addresses `magento/magento2#39376` by fixing two developer-experience issues in core code:

1. Corrected the PHPDoc type for `Magento\Framework\App\ScopeResolver::$objectManager` to `ObjectManagerInterface`.
2. Corrected Login As Customer admin-id session key usage in a backward-compatible way:
   - read from `getLoggedAsCustomerAdminId()` first
   - fallback to legacy typo key `getLoggedAsCustomerAdmindId()`
   - write both keys in setter to preserve compatibility for existing integrations/session data

Also added unit tests for the getter and setter behavior.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#39376

### Manual testing scenarios (*)
1. Run unit tests for LoginAsCustomer model tests.
2. Verify `GetLoggedAsCustomerAdminId::execute()` returns value from corrected key when present.
3. Verify fallback to legacy typo key still works.
4. Verify `SetLoggedAsCustomerAdminId::execute()` writes both corrected and legacy keys.

### Questions or comments
Unable to run Magento test suite in this environment because PHP runtime is unavailable in the execution container.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [ ] All automated tests passed successfully (all builds are green)
