### PR TITLE
Feature: CLI cache warmup (cache:flush/clean --warmup, cache:warmup)

### DIFF
--- a/app/code/Magento/Backend/Console/Command/AbstractCacheTypeManageCommand.php
+++ b/app/code/Magento/Backend/Console/Command/AbstractCacheTypeManageCommand.php
@@ -6,11 +6,13 @@
 
 namespace Magento\Backend\Console\Command;
 
+use Magento\Backend\Model\Cache\WarmupRunner;
+use Magento\Framework\App\Cache\Manager;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Magento\Framework\App\Cache\Manager;
 
 /**
  * phpcs:disable Magento2.Classes.AbstractApi
@@ -25,15 +27,38 @@ abstract class AbstractCacheTypeManageCommand extends AbstractCacheManageCommand
     protected $eventManager;
 
     /**
+     * @var WarmupRunner
+     */
+    private $cacheWarmupRunner;
+
+    /**
      * @param Manager $cacheManager
      * @param EventManagerInterface $eventManager
+     * @param WarmupRunner $cacheWarmupRunner
      */
     public function __construct(
         Manager $cacheManager,
-        EventManagerInterface $eventManager
+        EventManagerInterface $eventManager,
+        WarmupRunner $cacheWarmupRunner
     ) {
         $this->eventManager = $eventManager;
+        $this->cacheWarmupRunner = $cacheWarmupRunner;
         parent::__construct($cacheManager);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->addOption(
+            'warmup',
+            'w',
+            InputOption::VALUE_NONE,
+            'After this operation, send HTTP GET requests to warm full-page cache '
+            . '(Stores > Configuration > Advanced > Developer > CLI Cache Warmup).'
+        );
     }
 
     /**
@@ -64,6 +89,10 @@ abstract class AbstractCacheTypeManageCommand extends AbstractCacheManageCommand
         $this->performAction($types);
         $output->writeln($this->getDisplayMessage());
         $output->writeln(join(PHP_EOL, $types));
+
+        if ($input->getOption('warmup')) {
+            $this->cacheWarmupRunner->run($output);
+        }
 
         return Cli::RETURN_SUCCESS;
     }

--- a/app/code/Magento/Backend/Console/Command/CacheWarmupCommand.php
+++ b/app/code/Magento/Backend/Console/Command/CacheWarmupCommand.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Console\Command;
+
+use Magento\Backend\Model\Cache\WarmupRunner;
+use Magento\Framework\Console\Cli;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Standalone CLI: warm full-page cache via HTTP GET without flushing or cleaning.
+ */
+class CacheWarmupCommand extends Command
+{
+    public const NAME = 'cache:warmup';
+
+    /**
+     * @param WarmupRunner $warmupRunner
+     */
+    public function __construct(
+        private readonly WarmupRunner $warmupRunner
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure(): void
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Sends HTTP GET requests to warm full-page cache (see Stores > Configuration > Advanced > Developer > CLI Cache Warmup).');
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->warmupRunner->run($output);
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/app/code/Magento/Backend/Model/Cache/WarmupRunner.php
+++ b/app/code/Magento/Backend/Model/Cache/WarmupRunner.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Model\Cache;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Sends HTTP GET requests to warm full-page cache after CLI cache operations.
+ */
+class WarmupRunner
+{
+    private const XML_PATH_URLS = 'dev/cache_warmup/urls';
+
+    private const XML_PATH_TIMEOUT = 'dev/cache_warmup/timeout';
+
+    /**
+     * @param Curl $curl
+     * @param ScopeConfigInterface $scopeConfig
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        private readonly Curl $curl,
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly StoreManagerInterface $storeManager
+    ) {
+    }
+
+    /**
+     * Run configured warmup URLs.
+     *
+     * @param OutputInterface $output
+     * @return int Number of successfully warmed URLs (HTTP 2xx/3xx)
+     */
+    public function run(OutputInterface $output): int
+    {
+        $urls = $this->resolveUrls();
+        $toWarm = [];
+        foreach ($urls as $url) {
+            $url = trim($url);
+            if ($url !== '') {
+                $toWarm[] = $url;
+            }
+        }
+        if ($toWarm === []) {
+            $output->writeln(
+                '<comment>No warmup URLs configured. Set Stores > Configuration > Advanced > Developer > '
+                . 'CLI Cache Warmup > Warmup URLs (one per line), or leave empty to use the storefront base URL.'
+                . '</comment>'
+            );
+            return 0;
+        }
+
+        $total = count($toWarm);
+        $output->writeln(sprintf('<comment>Cache warmup: in progress (%d stage(s))…</comment>', $total));
+
+        $timeout = (int) $this->scopeConfig->getValue(self::XML_PATH_TIMEOUT);
+        if ($timeout < 1) {
+            $timeout = 30;
+        }
+
+        $this->curl->setOptions([CURLOPT_TIMEOUT => $timeout, CURLOPT_FOLLOWLOCATION => true]);
+        $ok = 0;
+
+        foreach ($toWarm as $index => $url) {
+            $stage = $index + 1;
+            $output->writeln(sprintf('<comment>Stage %d/%d:</comment> %s', $stage, $total, $url));
+            try {
+                $this->curl->get($url);
+                $status = (int) $this->curl->getStatus();
+                if ($status >= 200 && $status < 400) {
+                    $output->writeln(sprintf('<info>[%d]</info> %s', $status, $url));
+                    $ok++;
+                } else {
+                    $output->writeln(sprintf('<error>[%d]</error> %s', $status, $url));
+                }
+            } catch (\Throwable $e) {
+                $output->writeln(sprintf('<error>%s</error> — %s', $url, $e->getMessage()));
+            }
+        }
+
+        $output->writeln(sprintf('<info>Cache warmup finished: %d/%d URLs OK.</info>', $ok, $total));
+
+        return $ok;
+    }
+
+    /**
+     * Resolve URLs from configuration or default storefront base URL.
+     *
+     * @return string[]
+     */
+    private function resolveUrls(): array
+    {
+        $raw = (string) $this->scopeConfig->getValue(self::XML_PATH_URLS, ScopeInterface::SCOPE_STORE);
+        $lines = preg_split('/\r\n|\r|\n/', $raw) ?: [];
+        $configured = array_values(array_filter(array_map('trim', $lines), 'strlen'));
+
+        if ($configured !== []) {
+            return $configured;
+        }
+
+        try {
+            $base = $this->storeManager->getStore()->getBaseUrl();
+            return $base !== '' ? [rtrim($base, '/') . '/'] : [];
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+}

--- a/app/code/Magento/Backend/Test/Unit/Console/Command/AbstractCacheManageCommandTestCase.php
+++ b/app/code/Magento/Backend/Test/Unit/Console/Command/AbstractCacheManageCommandTestCase.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Backend\Test\Unit\Console\Command;
 
+use Magento\Backend\Model\Cache\WarmupRunner;
 use Magento\Framework\Event\ManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -19,9 +20,13 @@ abstract class AbstractCacheManageCommandTestCase extends AbstractCacheCommandTe
     /** @var  ManagerInterface|MockObject */
     protected $eventManagerMock;
 
+    /** @var WarmupRunner|MockObject */
+    protected $warmupRunnerMock;
+
     protected function setUp(): void
     {
         $this->eventManagerMock = $this->createMock(ManagerInterface::class);
+        $this->warmupRunnerMock = $this->createMock(WarmupRunner::class);
         parent::setUp();
     }
 
@@ -57,6 +62,7 @@ abstract class AbstractCacheManageCommandTestCase extends AbstractCacheCommandTe
         $this->expectException('InvalidArgumentException');
         $this->expectExceptionMessage('The following requested cache types are not supported:');
         $this->cacheManagerMock->expects($this->once())->method('getAvailableTypes')->willReturn(['A', 'B', 'C']);
+        $this->warmupRunnerMock->expects($this->never())->method('run');
         $param = ['types' => ['A', 'D']];
         $commandTester = new CommandTester($this->command);
         $commandTester->execute($param);

--- a/app/code/Magento/Backend/Test/Unit/Console/Command/CacheCleanCommandTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Console/Command/CacheCleanCommandTest.php
@@ -17,7 +17,11 @@ class CacheCleanCommandTest extends AbstractCacheManageCommandTestCase
     {
         $this->cacheEventName = 'adminhtml_cache_flush_system';
         parent::setUp();
-        $this->command = new CacheCleanCommand($this->cacheManagerMock, $this->eventManagerMock);
+        $this->command = new CacheCleanCommand(
+            $this->cacheManagerMock,
+            $this->eventManagerMock,
+            $this->warmupRunnerMock
+        );
     }
 
     /**
@@ -40,6 +44,8 @@ class CacheCleanCommandTest extends AbstractCacheManageCommandTestCase
             $this->eventManagerMock->expects($this->never())->method('dispatch');
         }
 
+        $this->warmupRunnerMock->expects($this->never())->method('run');
+
         $commandTester = new CommandTester($this->command);
         $commandTester->execute($param);
 
@@ -55,5 +61,27 @@ class CacheCleanCommandTest extends AbstractCacheManageCommandTestCase
     public static function getExpectedExecutionOutput(array $types)
     {
         return 'Cleaned cache types:' . PHP_EOL . implode(PHP_EOL, $types) . PHP_EOL;
+    }
+
+    public function testExecuteWithWarmupOption(): void
+    {
+        $this->cacheManagerMock->expects($this->once())->method('getAvailableTypes')->willReturn([
+            'A', 'B', 'C', 'full_page'
+        ]);
+        $this->cacheManagerMock->expects($this->once())->method('clean')->with(['A', 'B', 'C', 'full_page']);
+        $this->eventManagerMock->expects($this->once())->method('dispatch')->with($this->cacheEventName);
+        $this->warmupRunnerMock->expects($this->once())->method('run')->willReturnCallback(
+            function ($output) {
+                $output->writeln('warmup_output_marker');
+                return 1;
+            }
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['--warmup' => true]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('Cleaned cache types:', $display);
+        $this->assertStringContainsString('warmup_output_marker', $display);
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Console/Command/CacheFlushCommandTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Console/Command/CacheFlushCommandTest.php
@@ -17,7 +17,11 @@ class CacheFlushCommandTest extends AbstractCacheManageCommandTestCase
     {
         $this->cacheEventName = 'adminhtml_cache_flush_all';
         parent::setUp();
-        $this->command = new CacheFlushCommand($this->cacheManagerMock, $this->eventManagerMock);
+        $this->command = new CacheFlushCommand(
+            $this->cacheManagerMock,
+            $this->eventManagerMock,
+            $this->warmupRunnerMock
+        );
     }
 
     /**
@@ -52,5 +56,27 @@ class CacheFlushCommandTest extends AbstractCacheManageCommandTestCase
     public static function getExpectedExecutionOutput(array $types)
     {
         return 'Flushed cache types:' . PHP_EOL . implode(PHP_EOL, $types) . PHP_EOL;
+    }
+
+    public function testExecuteWithWarmupOption(): void
+    {
+        $this->cacheManagerMock->expects($this->once())->method('getAvailableTypes')->willReturn([
+            'A', 'B', 'C', 'full_page'
+        ]);
+        $this->cacheManagerMock->expects($this->once())->method('flush')->with(['A', 'B', 'C', 'full_page']);
+        $this->eventManagerMock->expects($this->once())->method('dispatch')->with($this->cacheEventName);
+        $this->warmupRunnerMock->expects($this->once())->method('run')->willReturnCallback(
+            function ($output) {
+                $output->writeln('warmup_output_marker');
+                return 1;
+            }
+        );
+
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute(['--warmup' => true]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertStringContainsString('Flushed cache types:', $display);
+        $this->assertStringContainsString('warmup_output_marker', $display);
     }
 }

--- a/app/code/Magento/Backend/Test/Unit/Console/Command/CacheWarmupCommandTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Console/Command/CacheWarmupCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Test\Unit\Console\Command;
+
+use Magento\Backend\Console\Command\CacheWarmupCommand;
+use Magento\Backend\Model\Cache\WarmupRunner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CacheWarmupCommandTest extends TestCase
+{
+    public function testExecuteRunsWarmupRunner(): void
+    {
+        $warmupRunner = $this->createMock(WarmupRunner::class);
+        $warmupRunner->expects($this->once())->method('run')->willReturn(2);
+
+        $command = new CacheWarmupCommand($warmupRunner);
+        $tester = new CommandTester($command);
+        $exit = $tester->execute([]);
+
+        $this->assertSame(0, $exit);
+    }
+}

--- a/app/code/Magento/Backend/Test/Unit/Model/Cache/WarmupRunnerTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Cache/WarmupRunnerTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Backend\Test\Unit\Model\Cache;
+
+use Magento\Backend\Model\Cache\WarmupRunner;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class WarmupRunnerTest extends TestCase
+{
+    public function testRunOutputsProgressAndFinished(): void
+    {
+        $curl = $this->createMock(Curl::class);
+        $curl->expects($this->once())->method('setOptions');
+        $curl->expects($this->once())->method('get')->with('http://example.test/');
+        $curl->method('getStatus')->willReturn(200);
+
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnCallback(
+            static function (string $path, ?string $scope = null, ?string $scopeCode = null) {
+                if ($path === 'dev/cache_warmup/urls') {
+                    return 'http://example.test/';
+                }
+                if ($path === 'dev/cache_warmup/timeout') {
+                    return 30;
+                }
+                return null;
+            }
+        );
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+
+        $runner = new WarmupRunner($curl, $scopeConfig, $storeManager);
+        $output = new BufferedOutput();
+        $ok = $runner->run($output);
+        $text = $output->fetch();
+
+        $this->assertSame(1, $ok);
+        $this->assertStringContainsString('Cache warmup: in progress', $text);
+        $this->assertStringContainsString('Stage 1/1:', $text);
+        $this->assertStringContainsString('Cache warmup finished', $text);
+    }
+
+    public function testRunNoUrlsWhenStoreUnavailable(): void
+    {
+        $curl = $this->createMock(Curl::class);
+        $curl->expects($this->never())->method('get');
+
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnCallback(
+            static function (string $path, ?string $scope = null, ?string $scopeCode = null) {
+                if ($path === 'dev/cache_warmup/urls' && $scope === ScopeInterface::SCOPE_STORE) {
+                    return '';
+                }
+                return null;
+            }
+        );
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willThrowException(new \RuntimeException('no store'));
+
+        $runner = new WarmupRunner($curl, $scopeConfig, $storeManager);
+        $output = new BufferedOutput();
+        $ok = $runner->run($output);
+
+        $this->assertSame(0, $ok);
+        $this->assertStringContainsString('No warmup URLs configured', $output->fetch());
+    }
+}

--- a/app/code/Magento/Backend/etc/adminhtml/system.xml
+++ b/app/code/Magento/Backend/etc/adminhtml/system.xml
@@ -172,6 +172,17 @@
                     <comment>Translate, blocks and other output caches should be disabled for both Storefront and Admin inline translations.</comment>
                 </field>
             </group>
+            <group id="cache_warmup" translate="label" type="text" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>CLI Cache Warmup</label>
+                <field id="urls" translate="label comment" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Warmup URLs</label>
+                    <comment>One URL per line. Used by bin/magento cache:flush --warmup, cache:clean --warmup, and cache:warmup. If empty, the storefront base URL is used.</comment>
+                </field>
+                <field id="timeout" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>HTTP Timeout (seconds)</label>
+                    <validate>validate-digits validate-greater-than-zero</validate>
+                </field>
+            </group>
             <group id="js" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>JavaScript Settings</label>
                 <field id="merge_files" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">

--- a/app/code/Magento/Backend/etc/config.xml
+++ b/app/code/Magento/Backend/etc/config.xml
@@ -22,6 +22,9 @@
             <js>
                 <defer_non_critical>0</defer_non_critical>
             </js>
+            <cache_warmup>
+                <timeout>30</timeout>
+            </cache_warmup>
         </dev>
         <system>
             <media_storage_configuration>

--- a/app/code/Magento/Backend/etc/di.xml
+++ b/app/code/Magento/Backend/etc/di.xml
@@ -150,6 +150,7 @@
                 <item name="cacheFlushCommand" xsi:type="object">Magento\Backend\Console\Command\CacheFlushCommand</item>
                 <item name="cacheCleanCommand" xsi:type="object">Magento\Backend\Console\Command\CacheCleanCommand</item>
                 <item name="cacheStatusCommand" xsi:type="object">Magento\Backend\Console\Command\CacheStatusCommand</item>
+                <item name="cacheWarmupCommand" xsi:type="object">Magento\Backend\Console\Command\CacheWarmupCommand</item>
                 <item name="maintenanceAllowIps" xsi:type="object">Magento\Backend\Console\Command\MaintenanceAllowIpsCommand</item>
                 <item name="maintenanceDisable" xsi:type="object">Magento\Backend\Console\Command\MaintenanceDisableCommand</item>
                 <item name="maintenanceEnableCommand" xsi:type="object">Magento\Backend\Console\Command\MaintenanceDisableCommand</item>


### PR DESCRIPTION
Fixes #40636

## Description
Adds optional full-page cache warmup from the CLI after `cache:flush` and `cache:clean`, plus a standalone `cache:warmup` command.

- **`cache:flush --warmup` / `-w`** and **`cache:clean --warmup` / `-w`**: after the cache operation, runs HTTP GET against configured URLs (or the storefront base URL if none configured).
- **`bin/magento cache:warmup`**: warms caches without flushing or cleaning.
- **Admin configuration**: _Stores > Configuration > Advanced > Developer > CLI Cache Warmup_ — multiline URLs and HTTP timeout (default 30s).

Implementation: `Magento\Backend\Model\Cache\WarmupRunner` (reuses `Magento\Framework\HTTP\Client\Curl`).

## Manual testing scenarios
1. Leave **Warmup URLs** empty; run `bin/magento cache:warmup` — should GET the storefront base URL and print stage/progress and summary.
2. Set one or more URLs; run `bin/magento cache:flush --warmup` — should flush, then warm each URL.
3. Run `bin/magento cache:clean -w full_page` with warmup enabled — same behavior for clean.

## Unit tests
- `Magento\Backend\Test\Unit\Model\Cache\WarmupRunnerTest`
- `Magento\Backend\Test\Unit\Console\Command\CacheWarmupCommandTest`
- Extended `CacheFlushCommandTest` / `CacheCleanCommandTest` for `--warmup`

Run:
`./vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Backend/Test/Unit/Model/Cache/WarmupRunnerTest.php app/code/Magento/Backend/Test/Unit/Console/Command/CacheWarmupCommandTest.php app/code/Magento/Backend/Test/Unit/Console/Command/CacheFlushCommandTest.php app/code/Magento/Backend/Test/Unit/Console/Command/CacheCleanCommandTest.php`
