### PR TITLE
Fix misleading phpdocs return types for Customer Address

### DIFF
--- a/app/code/Magento/Customer/Model/Customer.php
+++ b/app/code/Magento/Customer/Model/Customer.php
@@ -679,7 +679,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     /**
      * Get customer default billing address
      *
-     * @return Address
+     * @return Address|false
      */
     public function getPrimaryBillingAddress()
     {
@@ -689,7 +689,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     /**
      * Get customer default billing address
      *
-     * @return Address
+     * @return Address|false
      */
     public function getDefaultBillingAddress()
     {
@@ -699,7 +699,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     /**
      * Get default customer shipping address
      *
-     * @return Address
+     * @return Address|false
      */
     public function getPrimaryShippingAddress()
     {
@@ -709,7 +709,7 @@ class Customer extends \Magento\Framework\Model\AbstractModel implements ResetAf
     /**
      * Get default customer shipping address
      *
-     * @return Address
+     * @return Address|false
      */
     public function getDefaultShippingAddress()
     {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR fixes missleading PHPDocs return types for Customer Address related methods

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40769: Fix misleading phpdocs return types for Customer Address