### PR TITLE
fix: handle null itemId in getItemById method

### DIFF
--- a/app/code/Magento/Sales/Model/Order.php
+++ b/app/code/Magento/Sales/Model/Order.php
@@ -1614,7 +1614,7 @@ class Order extends AbstractModel implements EntityInterface, OrderInterface
     /**
      * Gets order item by given ID.
      *
-     * @param int $itemId
+     * @param int|null $itemId
      * @return \Magento\Framework\DataObject|null
      */
     public function getItemById($itemId)


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Fix PHPStan violation in `Order::getItemById()`: the `@param` type was declared as `int`, causing PHPStan to flag the `$itemId ??= ''` as unnecessary since a non-nullable value can never be `null`. Updated the annotation to `int|null` to accurately reflect that `null` is a valid input, making the null-coalescing assignment intentional and correct. No type hint was added to preserve backward compatibility.

### Related Pull Requests
https://github.com/magento/magento2/pull/39572#pullrequestreview-4082375571

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://public-results-storage-prod.magento-testing-service.engineering/reports/magento/magento2/pull/39572/a953b3be6eab7a170c2d5cbb50b9a43c/Statics/allure-report-b2b/index.html#categories/d59386462ddc895d48599f20ad1e18c3/956345d9fe66c6a0/
2. Requested via https://github.com/magento/magento2/pull/39572#pullrequestreview-4082375571

### Questions or comments

```
PHPStan detected violation(s):
 ------ -------------------------------------------------------------- 
  Line   app/code/Magento/Sales/Model/Order.php                        
 ------ -------------------------------------------------------------- 
  1623   Variable $itemId on left side of ?? always exists and is not  
         nullable.                                                     
 ------ -------------------------------------------------------------- 
```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40754: fix: handle null itemId in getItemById method