### PR TITLE
fix(salesrule): preserve cart price rule discount when editing order in admin

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -631,6 +631,10 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
             $quote->setCouponCode($orderCouponCode);
         }
 
+        if ($order->getAppliedRuleIds() && !$order->getReordered()) {
+            $quote->setData('original_order_applied_rule_ids', $order->getAppliedRuleIds());
+        }
+
         if ($quote->getCouponCode()) {
             $quote->collectTotals();
         }

--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -111,7 +111,9 @@ class Utility
             $ruleCustomer = $this->customerFactory->create();
             $ruleCustomer->loadByCustomerRule($customerId, $ruleId);
             if ($ruleCustomer->getId()) {
-                if ($ruleCustomer->getTimesUsed() >= $rule->getUsesPerCustomer()) {
+                $timesUsed = $ruleCustomer->getTimesUsed();
+                $timesUsed -= $this->getOriginalOrderRuleUsageCount($address, (int)$ruleId);
+                if ($timesUsed >= $rule->getUsesPerCustomer()) {
                     $rule->setIsValidForAddress($address, false);
                     return false;
                 }
@@ -142,6 +144,25 @@ class Utility
          */
         $rule->setIsValidForAddress($address, true);
         return true;
+    }
+
+    /**
+     * Get the number of times a rule was used in the original order being edited.
+     *
+     * During admin order edits, the original order's usage should not count against the limit
+     * because it will be canceled after the new order is placed.
+     *
+     * @param Address $address
+     * @param int $ruleId
+     * @return int
+     */
+    private function getOriginalOrderRuleUsageCount(Address $address, int $ruleId): int
+    {
+        $originalRuleIds = $address->getQuote()->getData('original_order_applied_rule_ids');
+        if ($originalRuleIds && in_array((string)$ruleId, explode(',', $originalRuleIds))) {
+            return 1;
+        }
+        return 0;
     }
 
     /**

--- a/app/code/Magento/SalesRule/Model/ValidateCoupon.php
+++ b/app/code/Magento/SalesRule/Model/ValidateCoupon.php
@@ -26,6 +26,25 @@ class ValidateCoupon
     }
 
     /**
+     * Get usage offset for order edit context.
+     *
+     * When editing an order, the original order's coupon/rule usage should not count
+     * against the limit because the original order will be canceled after the new one is placed.
+     *
+     * @param Address $address
+     * @param Rule $rule
+     * @return int
+     */
+    private function getOrderEditUsageOffset(Address $address, Rule $rule): int
+    {
+        $originalRuleIds = $address->getQuote()->getData('original_order_applied_rule_ids');
+        if ($originalRuleIds && in_array((string)$rule->getId(), explode(',', $originalRuleIds))) {
+            return 1;
+        }
+        return 0;
+    }
+
+    /**
      * Validate coupon rule
      *
      * @param Rule $rule
@@ -50,8 +69,12 @@ class ValidateCoupon
             return false;
         }
 
+        $orderEditOffset = $this->getOrderEditUsageOffset($address, $rule);
+
         // check entire usage limit
-        if ($coupon->getUsageLimit() && $coupon->getTimesUsed() >= $coupon->getUsageLimit()) {
+        if ($coupon->getUsageLimit()
+            && $coupon->getTimesUsed() - $orderEditOffset >= $coupon->getUsageLimit()
+        ) {
             $rule->setIsValidForAddress($address, false);
             return false;
         }
@@ -67,8 +90,8 @@ class ValidateCoupon
             $customerId,
             $coupon->getId()
         );
-        if ($couponUsage->getCouponId() &&
-            $couponUsage->getTimesUsed() >= $coupon->getUsagePerCustomer()
+        if ($couponUsage->getCouponId()
+            && $couponUsage->getTimesUsed() - $orderEditOffset >= $coupon->getUsagePerCustomer()
         ) {
             $rule->setIsValidForAddress($address, false);
             return false;

--- a/app/code/Magento/SalesRule/Test/Mftf/Test/AdminEditOrderPreservesCartPriceRuleWithUsageLimitTest.xml
+++ b/app/code/Magento/SalesRule/Test/Mftf/Test/AdminEditOrderPreservesCartPriceRuleWithUsageLimitTest.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminEditOrderPreservesCartPriceRuleWithUsageLimitTest">
+        <annotations>
+            <features value="SalesRule"/>
+            <stories value="Cart price rule discount is preserved when editing an order in admin"/>
+            <title value="Admin order edit preserves cart price rule discount when rule has usage limit"/>
+            <description value="Verify that when a cart price rule with 'Uses per Customer = 1' is applied to an order
+                and the admin edits that order, the discount remains applied to the edited order."/>
+            <severity value="CRITICAL"/>
+            <testCaseId value="AC-16671"/>
+            <useCaseId value="40624"/>
+            <group value="salesRule"/>
+        </annotations>
+        <before>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+            <!-- Create product and customer -->
+            <createData entity="SimpleProduct2" stepKey="createProduct"/>
+            <createData entity="Simple_US_Customer" stepKey="createCustomer"/>
+
+            <!-- Create cart price rule with coupon and uses_per_customer=1 -->
+            <actionGroup ref="AdminOpenCartPriceRulesPageActionGroup" stepKey="goToCartPriceRules"/>
+            <click selector="{{AdminCartPriceRulesSection.addNewRuleButton}}" stepKey="clickAddNewRule"/>
+            <fillField selector="{{AdminCartPriceRulesFormSection.ruleName}}" userInput="TestUsageLimitRule" stepKey="fillRuleName"/>
+            <selectOption selector="{{AdminCartPriceRulesFormSection.websites}}" userInput="Main Website" stepKey="selectWebsite"/>
+            <selectOption selector="{{AdminCartPriceRulesFormSection.customerGroups}}" parameterArray="['General', 'NOT LOGGED IN']" stepKey="selectCustomerGroups"/>
+            <selectOption selector="{{AdminCartPriceRulesFormSection.coupon}}" userInput="Specific Coupon" stepKey="selectCouponType"/>
+            <fillField selector="{{AdminCartPriceRulesFormSection.couponCode}}" userInput="TESTLIMIT1" stepKey="fillCouponCode"/>
+            <fillField selector="{{AdminCartPriceRulesFormSection.userPerCustomer}}" userInput="1" stepKey="fillUsesPerCustomer"/>
+            <!-- Set discount action -->
+            <click selector="{{AdminCartPriceRulesFormSection.actionsHeader}}" stepKey="expandActions"/>
+            <selectOption selector="{{AdminCartPriceRulesFormSection.apply}}" userInput="Percent of product price discount" stepKey="selectApplyType"/>
+            <fillField selector="{{AdminCartPriceRulesFormSection.discountAmount}}" userInput="50" stepKey="fillDiscountAmount"/>
+            <click selector="{{AdminCartPriceRulesFormSection.save}}" stepKey="saveRule"/>
+            <waitForPageLoad stepKey="waitForRuleSave"/>
+
+            <!-- Create order in admin with the coupon applied -->
+            <amOnPage stepKey="navigateToNewOrderPage" url="{{AdminOrderCreatePage.url}}"/>
+            <waitForPageLoad stepKey="waitForNewOrderPageOpened"/>
+            <click stepKey="chooseCustomer" selector="{{AdminOrdersGridSection.customerInOrdersSection('$$createCustomer.firstname$$')}}"/>
+            <waitForPageLoad stepKey="waitForStoresPageOpened"/>
+            <conditionalClick selector="{{AdminOrderFormStoreSelectorSection.defaultStoreViewButton}}"
+                              dependentSelector="{{AdminOrderFormStoreSelectorSection.storeSelectorContainer}}"
+                              visible="true"
+                              stepKey="selectDefaultStoreView"/>
+            <waitForPageLoad stepKey="waitForAddProductPageOpened"/>
+            <click selector="{{OrdersGridSection.addProducts}}" stepKey="clickOnAddProducts"/>
+            <waitForPageLoad stepKey="waitForProductsListForOrder"/>
+            <click selector="{{AdminOrdersGridSection.productForOrder('$$createProduct.sku$$')}}" stepKey="chooseTheProduct"/>
+            <waitForPageLoad stepKey="waitForClickProduct"/>
+            <click selector="{{AdminOrderFormItemsSection.addSelected}}" stepKey="addSelectedProductToOrder"/>
+            <waitForPageLoad stepKey="waitForProductAddedInOrder"/>
+            <actionGroup ref="AdminApplyCouponToOrderActionGroup" stepKey="applyCoupon">
+                <argument name="couponCode" value="TESTLIMIT1"/>
+            </actionGroup>
+            <click selector="{{AdminInvoicePaymentShippingSection.getShippingMethodAndRates}}" stepKey="openShippingMethod"/>
+            <waitForPageLoad stepKey="waitForShippingMethods"/>
+            <click selector="{{AdminInvoicePaymentShippingSection.shippingMethod}}" stepKey="chooseShippingMethod"/>
+            <waitForPageLoad stepKey="waitForShippingMethodsThickened"/>
+            <click selector="{{OrdersGridSection.submitOrder}}" stepKey="submitOrder"/>
+            <waitForPageLoad stepKey="waitForSubmitOrder"/>
+            <see stepKey="seeSuccessMessageForOrder" userInput="You created the order."/>
+        </before>
+        <after>
+            <actionGroup ref="DeleteCartPriceRuleByName" stepKey="deleteRule">
+                <argument name="ruleName" value="TestUsageLimitRule"/>
+            </actionGroup>
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="StorefrontCustomerLogoutActionGroup" stepKey="logoutCustomer"/>
+            <deleteData createDataKey="createCustomer" stepKey="deleteCustomer"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="adminLogout"/>
+        </after>
+
+        <!-- Grab the original order ID -->
+        <grabTextFrom selector="{{AdminOrderDetailsInformationSection.orderId}}" stepKey="grabOriginalOrderId"/>
+
+        <!-- Open the order and edit it -->
+        <actionGroup ref="OpenOrderByIdActionGroup" stepKey="openOrder">
+            <argument name="orderId" value="{$grabOriginalOrderId}"/>
+        </actionGroup>
+        <waitForElementClickable selector="{{AdminOrderDetailsMainActionsSection.edit}}" stepKey="waitForEditButton"/>
+        <click selector="{{AdminOrderDetailsMainActionsSection.edit}}" stepKey="clickEditOrder"/>
+        <waitForElementClickable selector="{{AdminOrderDetailsMainActionsSection.ok}}" stepKey="waitForConfirmModal"/>
+        <click selector="{{AdminOrderDetailsMainActionsSection.ok}}" stepKey="confirmEditOrder"/>
+        <waitForPageLoad stepKey="waitForEditPage"/>
+
+        <!-- Verify the coupon code is still present on the edit page -->
+        <seeInField selector="input[name='order[coupon][code]']" userInput="TESTLIMIT1" stepKey="verifyCouponCodePreserved"/>
+
+        <!-- Submit the edited order -->
+        <waitForElementClickable selector="{{OrdersGridSection.submitOrder}}" stepKey="waitForSubmitButton"/>
+        <click selector="{{OrdersGridSection.submitOrder}}" stepKey="submitEditedOrder"/>
+        <waitForPageLoad stepKey="waitForOrderCreation"/>
+
+        <!-- Verify the new order was created successfully -->
+        <see selector="{{AdminOrderDetailsMessagesSection.successMessage}}" userInput="You created the order." stepKey="seeOrderCreatedSuccess"/>
+    </test>
+</tests>

--- a/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
@@ -273,6 +273,39 @@ class UtilityTest extends TestCase
     }
 
     /**
+     * Verify rule is allowed during admin order edit when usage limit was reached by the original order.
+     *
+     * @return void
+     */
+    public function testCanProcessRuleAllowsUsageDuringOrderEdit(): void
+    {
+        $customerId = 1;
+        $usageLimit = 1;
+        $timesUsed = 1;
+        $ruleId = 4;
+        $this->rule->setId($ruleId);
+        $this->rule->setUsesPerCustomer($usageLimit);
+        $this->quote->setCustomerId($customerId);
+        $this->quote->setData('original_order_applied_rule_ids', (string)$ruleId);
+        $this->address->expects($this->atLeastOnce())
+            ->method('getQuote')
+            ->willReturn($this->quote);
+        $this->customer->setId($customerId);
+        $this->customer->setTimesUsed($timesUsed);
+        $this->customerFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->customer);
+
+        $this->validateCoupon->method('execute')
+            ->willReturn(true);
+
+        $this->rule->expects($this->once())->method('afterLoad');
+        $this->rule->expects($this->once())->method('validate')->willReturn(true);
+
+        $this->assertTrue($this->utility->canProcessRule($this->rule, $this->address));
+    }
+
+    /**
      * Quote does not meet rule's conditions
      *
      * @return void

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/CouponUsageLimitOrderEditTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/CouponUsageLimitOrderEditTest.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\SalesRule\Model;
+
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\Checkout\Test\Fixture\PlaceOrder as PlaceOrderFixture;
+use Magento\Checkout\Test\Fixture\SetBillingAddress as SetBillingAddressFixture;
+use Magento\Checkout\Test\Fixture\SetDeliveryMethod as SetDeliveryMethodFixture;
+use Magento\Checkout\Test\Fixture\SetPaymentMethod as SetPaymentMethodFixture;
+use Magento\Checkout\Test\Fixture\SetShippingAddress as SetShippingAddressFixture;
+use Magento\Customer\Test\Fixture\Customer as CustomerFixture;
+use Magento\Framework\Registry;
+use Magento\Quote\Test\Fixture\AddProductToCart as AddProductToCartFixture;
+use Magento\Quote\Test\Fixture\ApplyCoupon as ApplyCouponFixture;
+use Magento\Quote\Test\Fixture\CustomerCart;
+use Magento\Sales\Model\AdminOrder\Create;
+use Magento\Sales\Model\AdminOrder\EmailSender;
+use Magento\SalesRule\Model\Rule as SalesRule;
+use Magento\SalesRule\Test\Fixture\Rule as RuleFixture;
+use Magento\SalesRule\Test\Fixture\RuleCoupon as CouponFixture;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\AppIsolation;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for cart price rule usage limit handling during admin order edit.
+ *
+ * @see https://github.com/magento/magento2/issues/40624
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class CouponUsageLimitOrderEditTest extends TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->fixtures = $this->objectManager->get(DataFixtureStorageManager::class)->getStorage();
+    }
+
+    /**
+     * Verify that a rule with usage limit is still applied when editing the order that used it.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        AppArea('adminhtml'),
+        DataFixture(
+            RuleFixture::class,
+            [
+                'simple_action' => SalesRule::BY_PERCENT_ACTION,
+                'discount_amount' => 10,
+                'coupon_type' => SalesRule::COUPON_TYPE_SPECIFIC,
+                'uses_per_customer' => 1,
+            ],
+            'rule'
+        ),
+        DataFixture(
+            CouponFixture::class,
+            ['rule_id' => '$rule.id$', 'code' => 'LIMITED1', 'usage_limit' => 1, 'usage_per_customer' => 1],
+            'coupon'
+        ),
+        DataFixture(CustomerFixture::class, ['email' => 'customer@example.com'], 'customer'),
+        DataFixture(ProductFixture::class, ['price' => 100], 'product'),
+        DataFixture(CustomerCart::class, ['customer_id' => '$customer.id$'], 'cart'),
+        DataFixture(
+            AddProductToCartFixture::class,
+            ['cart_id' => '$cart.id$', 'product_id' => '$product.id$', 'qty' => 1]
+        ),
+        DataFixture(ApplyCouponFixture::class, ['cart_id' => '$cart.id$', 'coupon_codes' => ['LIMITED1']]),
+        DataFixture(SetBillingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetShippingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetDeliveryMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetPaymentMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(PlaceOrderFixture::class, ['cart_id' => '$cart.id$'], 'order'),
+    ]
+    public function testRuleWithUsageLimitIsPreservedWhenEditingOrder(): void
+    {
+        $order = $this->fixtures->get('order');
+        $this->assertNotEmpty($order->getAppliedRuleIds(), 'Order must have applied rules');
+        $this->assertEquals('LIMITED1', $order->getCouponCode());
+
+        $emailSenderMock = $this->createMock(EmailSender::class);
+        $orderCreateModel = $this->objectManager->create(
+            Create::class,
+            ['emailSender' => $emailSenderMock]
+        );
+
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $orderCreateModel->initFromOrder($order);
+
+        $quote = $orderCreateModel->getQuote();
+
+        $this->assertEquals(
+            'LIMITED1',
+            $quote->getCouponCode(),
+            'Coupon code should be preserved on the new quote during order edit'
+        );
+        $this->assertNotEmpty(
+            $quote->getAppliedRuleIds(),
+            'Applied rule IDs should not be empty — the discount must be preserved during order edit'
+        );
+    }
+
+    /**
+     * Verify that original_order_applied_rule_ids is set on the quote during order edit.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        AppArea('adminhtml'),
+        DataFixture(
+            RuleFixture::class,
+            [
+                'simple_action' => SalesRule::BY_PERCENT_ACTION,
+                'discount_amount' => 10,
+                'coupon_type' => SalesRule::COUPON_TYPE_SPECIFIC,
+                'uses_per_customer' => 1,
+            ],
+            'rule'
+        ),
+        DataFixture(
+            CouponFixture::class,
+            ['rule_id' => '$rule.id$', 'code' => 'LIMITED2', 'usage_limit' => 1, 'usage_per_customer' => 1],
+            'coupon'
+        ),
+        DataFixture(CustomerFixture::class, ['email' => 'customer2@example.com'], 'customer'),
+        DataFixture(ProductFixture::class, ['price' => 100], 'product'),
+        DataFixture(CustomerCart::class, ['customer_id' => '$customer.id$'], 'cart'),
+        DataFixture(
+            AddProductToCartFixture::class,
+            ['cart_id' => '$cart.id$', 'product_id' => '$product.id$', 'qty' => 1]
+        ),
+        DataFixture(ApplyCouponFixture::class, ['cart_id' => '$cart.id$', 'coupon_codes' => ['LIMITED2']]),
+        DataFixture(SetBillingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetShippingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetDeliveryMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetPaymentMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(PlaceOrderFixture::class, ['cart_id' => '$cart.id$'], 'order'),
+    ]
+    public function testOriginalOrderRuleIdsAreSetOnQuoteDuringEdit(): void
+    {
+        $order = $this->fixtures->get('order');
+
+        $emailSenderMock = $this->createMock(EmailSender::class);
+        $orderCreateModel = $this->objectManager->create(
+            Create::class,
+            ['emailSender' => $emailSenderMock]
+        );
+
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+        $orderCreateModel->initFromOrder($order);
+
+        $quote = $orderCreateModel->getQuote();
+
+        $this->assertEquals(
+            $order->getAppliedRuleIds(),
+            $quote->getData('original_order_applied_rule_ids'),
+            'Quote should carry the original order applied rule IDs for usage limit offset'
+        );
+    }
+}


### PR DESCRIPTION
## Description

When a Cart Price Rule with limited usage (e.g., "Uses per Customer = 1") was applied to an order and the admin edited that order, the discount was incorrectly removed. Magento re-validated rule usage on the new quote without accounting for the fact that the original order (which will be canceled) had already consumed one usage slot.

### Root Cause

`Utility::canProcessRule()` checks `timesUsed >= usesPerCustomer` during `collectTotals()` on the new quote. Since the original order already incremented `timesUsed`, the rule is rejected. The same issue affected coupon validation in `ValidateCoupon::execute()` for both total usage limits and per-customer coupon limits.

### Fix

1. **`AdminOrder\Create::initFromOrder()`** — passes the original order's `applied_rule_ids` to the quote via data attribute before totals collection
2. **`Utility::canProcessRule()`** — offsets `timesUsed` by 1 when the rule was applied in the original order being edited
3. **`ValidateCoupon::execute()`** — applies the same offset to both coupon usage limit and per-customer coupon limit checks

The original order is canceled in `afterSubmit()` after the new order is placed, so excluding its usage during validation is correct.

Fixes magento/magento2#40624

## Files Changed

- `app/code/Magento/Sales/Model/AdminOrder/Create.php` — set original order context on quote
- `app/code/Magento/SalesRule/Model/Utility.php` — offset rule usage for order edits
- `app/code/Magento/SalesRule/Model/ValidateCoupon.php` — offset coupon usage for order edits
- `app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php` — new test for order edit scenario

## Manual Testing Scenarios

1. Create a Cart Price Rule with **Uses per Customer = 1** and a discount (e.g., 50%)
2. Place an order on the storefront using this rule (usage limit now reached)
3. In Admin, go to Sales > Orders, open the order, click **Edit**
4. Modify the order (e.g., change quantity)
5. **Expected**: The discount remains applied to the edited order
6. **Before fix**: The discount was removed because the usage limit was re-validated
