### PR TITLE
fix(pagecache): mitigate httpoxy vulnerability in Varnish VCL templates

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -27,6 +27,10 @@ sub vcl_recv {
         set req.url = std.querysort(req.url);
     }
 
+    # Remove the proxy header to mitigate the httpoxy vulnerability
+    # See https://httpoxy.org/
+    unset req.http.proxy;
+
     if (req.method == "PURGE") {
         if (client.ip !~ purge) {
             return (synth(405, "Method not allowed"));

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -28,6 +28,10 @@ sub vcl_recv {
         set req.url = std.querysort(req.url);
     }
 
+    # Remove the proxy header to mitigate the httpoxy vulnerability
+    # See https://httpoxy.org/
+    unset req.http.proxy;
+
     if (req.method == "PURGE") {
         if (client.ip !~ purge) {
             return (synth(405, "Method not allowed"));

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -32,6 +32,10 @@ sub vcl_recv {
         set req.url = std.querysort(req.url);
     }
 
+    # Remove the proxy header to mitigate the httpoxy vulnerability
+    # See https://httpoxy.org/
+    unset req.http.proxy;
+
     if (req.method == "PURGE") {
         if (client.ip !~ purge) {
             return (synth(405, "Method not allowed"));

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -32,6 +32,10 @@ sub vcl_recv {
         set req.url = std.querysort(req.url);
     }
 
+    # Remove the proxy header to mitigate the httpoxy vulnerability
+    # See https://httpoxy.org/
+    unset req.http.proxy;
+
     if (req.method == "PURGE") {
         if (client.ip !~ purge) {
             return (synth(405, "Method not allowed"));


### PR DESCRIPTION
## Description

Unset the `Proxy` header in `vcl_recv` across all Varnish VCL templates (v4-v7) to prevent the [httpoxy vulnerability](https://httpoxy.org/) (CVE-2016-5385) from being exploitable through Varnish-cached requests.

When a request containing a `Proxy` header reaches a PHP backend, CGI-based environments may set the `HTTP_PROXY` environment variable, causing outbound HTTP connections to be redirected through an attacker-controlled proxy.

## Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl`
- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`
