### PR TITLE
fix(pagecache): improve Varnish cache normalization for better hit ratio

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -22,6 +22,14 @@ acl purge {
 }
 
 sub vcl_recv {
+    # Remove empty query strings (e.g. /index.html?)
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header for consistent cache keys
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
     # Sorting query string parameters
     if (req.url ~ "\?.+&.+") {
         set req.url = std.querysort(req.url);

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -23,6 +23,14 @@ acl purge {
 }
 
 sub vcl_recv {
+    # Remove empty query strings (e.g. /index.html?)
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header for consistent cache keys
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
     # Sorting query string parameters
     if (req.url ~ "\?.+&.+") {
         set req.url = std.querysort(req.url);

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -27,6 +27,14 @@ sub vcl_recv {
         set req.hash_always_miss = true;
     }
 
+    # Remove empty query strings (e.g. /index.html?)
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header for consistent cache keys
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
     # Sorting query string parameters
     if (req.url ~ "\?.+&.+") {
         set req.url = std.querysort(req.url);

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -27,6 +27,14 @@ sub vcl_recv {
         set req.hash_always_miss = true;
     }
 
+    # Remove empty query strings (e.g. /index.html?)
+    if (req.url ~ "\?$") {
+        set req.url = regsub(req.url, "\?$", "");
+    }
+
+    # Remove port number from host header for consistent cache keys
+    set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+
     # Sorting query string parameters
     if (req.url ~ "\?.+&.+") {
         set req.url = std.querysort(req.url);


### PR DESCRIPTION
## Description

Add two cache normalization rules to `vcl_recv` in all Varnish VCL templates:

1. **Strip trailing empty query strings** — URLs like `/page?` are normalized to `/page` so they share the same cache entry
2. **Remove port numbers from Host header** — Requests to `example.com` and `example.com:443` now hit the same cache object instead of creating separate entries

Both changes improve cache hit ratio without affecting functionality.

## Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl`
- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`
