### PR TITLE
fix(pagecache): improve Varnish backend response handling

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -142,6 +142,12 @@ sub process_graphql_headers {
 }
 
 sub vcl_backend_response {
+    # Do not cache error responses (403, 404, 5xx)
+    if (beresp.status == 403 || beresp.status == 404 || beresp.status >= 500) {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 120s;
+        return (deliver);
+    }
 
     set beresp.grace = 3d;
 
@@ -149,7 +155,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text|javascript|json|css") {
         set beresp.do_gzip = true;
     }
 
@@ -157,10 +163,10 @@ sub vcl_backend_response {
         set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
     }
 
-    # cache only successfully responses and 404s
-    if (beresp.status != 200 && beresp.status != 404) {
-        set beresp.ttl = 120s;
+    # Do not cache responses marked as private
+    if (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
+        set beresp.ttl = 86400s;
         return (deliver);
     } elsif (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -143,6 +143,12 @@ sub process_graphql_headers {
 }
 
 sub vcl_backend_response {
+    # Do not cache error responses (403, 404, 5xx)
+    if (beresp.status == 403 || beresp.status == 404 || beresp.status >= 500) {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 120s;
+        return (deliver);
+    }
 
     set beresp.grace = 3d;
 
@@ -150,7 +156,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text|javascript|json|css") {
         set beresp.do_gzip = true;
     }
 
@@ -158,8 +164,8 @@ sub vcl_backend_response {
         set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
     }
 
-    # cache only successfully responses and 404s that are not marked as private
-    if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
+    # Do not cache responses marked as private
+    if (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
         set beresp.ttl = 86400s;
         return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -147,6 +147,12 @@ sub process_graphql_headers {
 }
 
 sub vcl_backend_response {
+    # Do not cache error responses (403, 404, 5xx)
+    if (beresp.status == 403 || beresp.status == 404 || beresp.status >= 500) {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 120s;
+        return (deliver);
+    }
 
     set beresp.grace = 3d;
 
@@ -154,7 +160,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text|javascript|json|css") {
         set beresp.do_gzip = true;
     }
 
@@ -162,8 +168,8 @@ sub vcl_backend_response {
         set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
     }
 
-    # cache only successfully responses and 404s that are not marked as private
-    if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
+    # Do not cache responses marked as private
+    if (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
         set beresp.ttl = 86400s;
         return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -147,6 +147,12 @@ sub process_graphql_headers {
 }
 
 sub vcl_backend_response {
+    # Do not cache error responses (403, 404, 5xx)
+    if (beresp.status == 403 || beresp.status == 404 || beresp.status >= 500) {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 120s;
+        return (deliver);
+    }
 
     set beresp.grace = 3d;
 
@@ -154,7 +160,7 @@ sub vcl_backend_response {
         set beresp.do_esi = true;
     }
 
-    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text|javascript|json|css") {
         set beresp.do_gzip = true;
     }
 
@@ -162,8 +168,8 @@ sub vcl_backend_response {
         set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
     }
 
-    # cache only successfully responses and 404s that are not marked as private
-    if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
+    # Do not cache responses marked as private
+    if (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
         set beresp.ttl = 86400s;
         return (deliver);


### PR DESCRIPTION
## Description

Three improvements to `vcl_backend_response` in all Varnish VCL templates:

### 1. Make error responses explicitly uncacheable
403, 404, and 5xx responses are now marked uncacheable with a short 120s TTL. Previously, 404s were cached alongside 200s, which could cause stale "not found" pages to persist after the underlying issue is resolved.

### 2. Extend gzip compression to JSON and CSS
The `do_gzip` condition now matches `text|javascript|json|css` content types instead of just `text`. This reduces bandwidth for REST API JSON responses and CSS stylesheets served through Varnish.

### 3. Simplify cacheable response check
The combined status + `Cache-Control: private` check is split: error statuses are handled by the early return above, and the remaining check only looks at `Cache-Control: private`.

## Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl`
- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`
