### PR TITLE
fix(catalog-url-rewrite): delete URL rewrites when import sets visibility to not visible (#40533)

### DIFF
--- a/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
+++ b/app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php
@@ -406,9 +406,31 @@ class AfterImportDataObserver implements ObserverInterface
     private function addProductToImport(Product $product, string $storeId, array &$products) : void
     {
         if ($product->getVisibility() == (string)Visibility::getOptionArray()[Visibility::VISIBILITY_NOT_VISIBLE]) {
+            $this->deleteUrlRewrites($product, (int)$storeId);
             return;
         }
         $products[$product->getId()][$storeId] = $product;
+    }
+
+    /**
+     * Delete URL rewrites for a product in a given store.
+     *
+     * Called when product visibility changes to "Not Visible Individually" during import,
+     * to ensure stale URL rewrite records are removed.
+     *
+     * @param Product $product
+     * @param int $storeId
+     * @return void
+     */
+    private function deleteUrlRewrites(Product $product, int $storeId): void
+    {
+        $this->urlPersist->deleteByData(
+            [
+                UrlRewrite::ENTITY_ID => $product->getId(),
+                UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+                UrlRewrite::STORE_ID => $storeId,
+            ]
+        );
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_visibility_not_visible.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_visibility_not_visible.csv
@@ -1,0 +1,2 @@
+sku,store_view_code,attribute_set_code,product_type,name,price,product_websites,visibility,url_key
+simple,,Default,simple,Simple Product,10,base,"Not Visible Individually",simple-product

--- a/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_visibility_visible.csv
+++ b/dev/tests/integration/testsuite/Magento/CatalogImportExport/Model/Import/_files/products_to_import_with_visibility_visible.csv
@@ -1,0 +1,2 @@
+sku,store_view_code,attribute_set_code,product_type,name,price,product_websites,visibility,url_key
+simple,,Default,simple,Simple Product,10,base,"Catalog, Search",simple-product

--- a/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserverVisibilityTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserverVisibilityTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewrite\Observer;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\CatalogImportExport\Model\Import\Product;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+
+/**
+ * Integration test for URL rewrite cleanup when product visibility changes via CSV import.
+ *
+ * @see https://github.com/magento/magento2/issues/40533
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation disabled
+ */
+class AfterImportDataObserverVisibilityTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    private $objectManager;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoAppIsolation enabled
+     */
+    public function testUrlRewritesDeletedWhenVisibilityChangedToNotVisibleViaImport(): void
+    {
+        $productId = (int)$this->getProductRepository()->get('simple')->getId();
+
+        $rewritesBeforeImport = $this->getProductUrlRewrites($productId);
+        $this->assertGreaterThan(0, count($rewritesBeforeImport));
+
+        $this->runImport('products_to_import_with_visibility_not_visible.csv');
+
+        $rewritesAfterImport = $this->getProductUrlRewrites($productId);
+        $this->assertCount(0, $rewritesAfterImport);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Catalog/_files/product_simple.php
+     * @magentoAppIsolation enabled
+     */
+    public function testUrlRewritesPreservedWhenVisibilityRemainsVisible(): void
+    {
+        $productId = (int)$this->getProductRepository()->get('simple')->getId();
+
+        $rewritesBeforeImport = $this->getProductUrlRewrites($productId);
+        $this->assertGreaterThan(0, count($rewritesBeforeImport));
+
+        $this->runImport('products_to_import_with_visibility_visible.csv');
+
+        $rewritesAfterImport = $this->getProductUrlRewrites($productId);
+        $this->assertGreaterThan(0, count($rewritesAfterImport));
+    }
+
+    /**
+     * Run CSV product import.
+     *
+     * @param string $fileName
+     * @return void
+     */
+    private function runImport(string $fileName): void
+    {
+        $filesystem = $this->objectManager->create(Filesystem::class);
+        $directory = $filesystem->getDirectoryWrite(DirectoryList::ROOT);
+        $source = $this->objectManager->create(
+            \Magento\ImportExport\Model\Import\Source\Csv::class,
+            [
+                'file' => __DIR__ . '/../../CatalogImportExport/Model/Import/_files/' . $fileName,
+                'directory' => $directory,
+            ]
+        );
+        $importModel = $this->objectManager->create(Product::class);
+        $importModel->setParameters(
+            [
+                'behavior' => \Magento\ImportExport\Model\Import::BEHAVIOR_APPEND,
+                'entity' => 'catalog_product',
+            ]
+        );
+        $importModel->setSource($source);
+        $errors = $importModel->validateData();
+        $this->assertTrue($errors->getErrorsCount() == 0, 'Import validation failed');
+        $importModel->importData();
+    }
+
+    /**
+     * Get all URL rewrites for a given product.
+     *
+     * @param int $productId
+     * @return array
+     */
+    private function getProductUrlRewrites(int $productId): array
+    {
+        /** @var UrlFinderInterface $urlFinder */
+        $urlFinder = $this->objectManager->get(UrlFinderInterface::class);
+
+        return $urlFinder->findAllByData(
+            [
+                UrlRewrite::ENTITY_TYPE => 'product',
+                UrlRewrite::ENTITY_ID => $productId,
+            ]
+        );
+    }
+
+    /**
+     * @return ProductRepositoryInterface
+     */
+    private function getProductRepository(): ProductRepositoryInterface
+    {
+        return $this->objectManager->get(ProductRepositoryInterface::class);
+    }
+}


### PR DESCRIPTION
## Description

When product visibility is changed to "Not Visible Individually" via CSV import, existing URL rewrite records are **not deleted** from the `url_rewrite` table. This causes stale routes to remain accessible via GraphQL `route` queries and can lead to incorrect 301 redirects on the storefront.

### Root Cause

The admin UI handles this correctly via `ProcessUrlRewriteOnChangeProductVisibilityObserver` (triggered by `catalog_product_attribute_update_before` event), which calls `AdaptUrlRewritesToVisibilityAttribute::execute()` to delete URL rewrites.

However, the import path in `AfterImportDataObserver::addProductToImport()` only **skips URL rewrite generation** for not-visible products — it does not clean up existing records:

```php
// Before fix
if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
    return; // Skips generation but leaves stale records
}
```

### Fix

When a product's visibility is "Not Visible Individually" during import, explicitly delete its URL rewrite records for the affected store before returning:

```php
// After fix
if ($product->getVisibility() == Visibility::VISIBILITY_NOT_VISIBLE) {
    $this->deleteUrlRewrites($product, (int)$storeId); // Clean up stale records
    return;
}
```

Fixes magento/magento2#40533

## Files Changed

- `app/code/Magento/CatalogUrlRewrite/Observer/AfterImportDataObserver.php` — delete URL rewrites when visibility is NOT_VISIBLE

## Manual Testing Scenarios

1. Create a product with visibility "Catalog, Search"
2. Verify the product is accessible on the storefront (no 404)
3. Prepare a CSV import file changing the product's visibility to "Not Visible Individually"
4. Run the import
5. **Expected**: The product URL now returns 404 on storefront, and GraphQL `route` query returns `null`
6. **Before fix**: The product URL still resolves (stale URL rewrite record remains)
