### PR TITLE
fix(developer): detect locked config in template hints enable/disable commands (#40523)

### DIFF
--- a/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php
@@ -7,7 +7,11 @@
 namespace Magento\Developer\Console\Command;
 
 use InvalidArgumentException;
+use Magento\Config\App\Config\Type\System;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ConfigPathResolver;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,20 +23,37 @@ class TemplateHintsDisableCommand extends Command
 
     public const SUCCESS_MESSAGE = "Template hints disabled. Refresh cache types";
 
+    private const CONFIG_PATH = 'dev/debug/template_hints_storefront';
+
     /**
      * @var ConfigInterface
      */
     private $resourceConfig;
 
     /**
-     * Initialize dependencies.
-     *
-     * @param ConfigInterface $resourceConfig
+     * @var DeploymentConfig
      */
-    public function __construct(ConfigInterface $resourceConfig)
-    {
+    private $deploymentConfig;
+
+    /**
+     * @var ConfigPathResolver
+     */
+    private $configPathResolver;
+
+    /**
+     * @param ConfigInterface $resourceConfig
+     * @param DeploymentConfig|null $deploymentConfig
+     * @param ConfigPathResolver|null $configPathResolver
+     */
+    public function __construct(
+        ConfigInterface $resourceConfig,
+        ?DeploymentConfig $deploymentConfig = null,
+        ?ConfigPathResolver $configPathResolver = null
+    ) {
         parent::__construct();
         $this->resourceConfig = $resourceConfig;
+        $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(DeploymentConfig::class);
+        $this->configPathResolver = $configPathResolver ?: ObjectManager::getInstance()->get(ConfigPathResolver::class);
     }
 
     /**
@@ -53,9 +74,28 @@ class TemplateHintsDisableCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->resourceConfig->saveConfig('dev/debug/template_hints_storefront', 0, 'default', 0);
-        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
+        if ($this->isConfigLocked()) {
+            $output->writeln('<error>The value you set has already been locked.'
+                . ' To change the value, modify app/etc/env.php or app/etc/config.php directly.</error>');
+
+            return Cli::RETURN_FAILURE;
+        }
+
+        $this->resourceConfig->saveConfig(self::CONFIG_PATH, 0, 'default', 0);
+        $output->writeln("<info>" . self::SUCCESS_MESSAGE . "</info>");
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Check if the configuration path is locked in deployment config.
+     *
+     * @return bool
+     */
+    private function isConfigLocked(): bool
+    {
+        $scopePath = $this->configPathResolver->resolve(self::CONFIG_PATH, 'default', null, System::CONFIG_TYPE);
+
+        return $this->deploymentConfig->get($scopePath) !== null;
     }
 }

--- a/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
+++ b/app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php
@@ -7,7 +7,11 @@
 namespace Magento\Developer\Console\Command;
 
 use InvalidArgumentException;
+use Magento\Config\App\Config\Type\System;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ConfigPathResolver;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Console\Cli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,20 +23,37 @@ class TemplateHintsEnableCommand extends Command
 
     public const SUCCESS_MESSAGE = "Template hints enabled.";
 
+    private const CONFIG_PATH = 'dev/debug/template_hints_storefront';
+
     /**
      * @var ConfigInterface
      */
     private $resourceConfig;
 
     /**
-     * Initialize dependencies.
-     *
-     * @param ConfigInterface $resourceConfig
+     * @var DeploymentConfig
      */
-    public function __construct(ConfigInterface $resourceConfig)
-    {
+    private $deploymentConfig;
+
+    /**
+     * @var ConfigPathResolver
+     */
+    private $configPathResolver;
+
+    /**
+     * @param ConfigInterface $resourceConfig
+     * @param DeploymentConfig|null $deploymentConfig
+     * @param ConfigPathResolver|null $configPathResolver
+     */
+    public function __construct(
+        ConfigInterface $resourceConfig,
+        ?DeploymentConfig $deploymentConfig = null,
+        ?ConfigPathResolver $configPathResolver = null
+    ) {
         parent::__construct();
         $this->resourceConfig = $resourceConfig;
+        $this->deploymentConfig = $deploymentConfig ?: ObjectManager::getInstance()->get(DeploymentConfig::class);
+        $this->configPathResolver = $configPathResolver ?: ObjectManager::getInstance()->get(ConfigPathResolver::class);
     }
 
     /**
@@ -53,9 +74,28 @@ class TemplateHintsEnableCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->resourceConfig->saveConfig('dev/debug/template_hints_storefront', 1, 'default', 0);
-        $output->writeln("<info>". self::SUCCESS_MESSAGE . "</info>");
+        if ($this->isConfigLocked()) {
+            $output->writeln('<error>The value you set has already been locked.'
+                . ' To change the value, modify app/etc/env.php or app/etc/config.php directly.</error>');
+
+            return Cli::RETURN_FAILURE;
+        }
+
+        $this->resourceConfig->saveConfig(self::CONFIG_PATH, 1, 'default', 0);
+        $output->writeln("<info>" . self::SUCCESS_MESSAGE . "</info>");
 
         return Cli::RETURN_SUCCESS;
+    }
+
+    /**
+     * Check if the configuration path is locked in deployment config.
+     *
+     * @return bool
+     */
+    private function isConfigLocked(): bool
+    {
+        $scopePath = $this->configPathResolver->resolve(self::CONFIG_PATH, 'default', null, System::CONFIG_TYPE);
+
+        return $this->deploymentConfig->get($scopePath) !== null;
     }
 }

--- a/app/code/Magento/Developer/Test/Fixture/LockedTemplateHintsConfig.php
+++ b/app/code/Magento/Developer/Test/Fixture/LockedTemplateHintsConfig.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Developer\Test\Fixture;
+
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\DeploymentConfig\FileReader;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\DataObject;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Filesystem;
+use Magento\TestFramework\Fixture\RevertibleDataFixtureInterface;
+
+class LockedTemplateHintsConfig implements RevertibleDataFixtureInterface
+{
+    /**
+     * @var FileReader
+     */
+    private FileReader $reader;
+
+    /**
+     * @var Writer
+     */
+    private Writer $writer;
+
+    /**
+     * @var Filesystem
+     */
+    private Filesystem $filesystem;
+
+    /**
+     * @var ConfigFilePool
+     */
+    private ConfigFilePool $configFilePool;
+
+    /**
+     * @var ReinitableConfigInterface
+     */
+    private ReinitableConfigInterface $appConfig;
+
+    /**
+     * @var DataObjectFactory
+     */
+    private DataObjectFactory $dataObjectFactory;
+
+    /**
+     * @param FileReader $reader
+     * @param Writer $writer
+     * @param Filesystem $filesystem
+     * @param ConfigFilePool $configFilePool
+     * @param ReinitableConfigInterface $appConfig
+     * @param DataObjectFactory $dataObjectFactory
+     */
+    public function __construct(
+        FileReader $reader,
+        Writer $writer,
+        Filesystem $filesystem,
+        ConfigFilePool $configFilePool,
+        ReinitableConfigInterface $appConfig,
+        DataObjectFactory $dataObjectFactory
+    ) {
+        $this->reader = $reader;
+        $this->writer = $writer;
+        $this->filesystem = $filesystem;
+        $this->configFilePool = $configFilePool;
+        $this->appConfig = $appConfig;
+        $this->dataObjectFactory = $dataObjectFactory;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function apply(array $data = []): ?DataObject
+    {
+        $previousConfig = $this->reader->load(ConfigFilePool::APP_ENV);
+        $this->writer->saveConfig(
+            [
+                ConfigFilePool::APP_ENV => [
+                    'system' => [
+                        'default' => [
+                            'dev' => [
+                                'debug' => [
+                                    'template_hints_storefront' => $data['value'] ?? '1'
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        );
+        $this->appConfig->reinit();
+
+        return $this->dataObjectFactory->create(['data' => ['previous_config' => $previousConfig]]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function revert(DataObject $data): void
+    {
+        $this->filesystem->getDirectoryWrite(DirectoryList::CONFIG)->writeFile(
+            $this->configFilePool->getPath(ConfigFilePool::APP_ENV),
+            "<?php\n return array();\n"
+        );
+        $this->writer->saveConfig([ConfigFilePool::APP_ENV => $data->getData('previous_config')]);
+        $this->appConfig->reinit();
+    }
+}

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsDisableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsDisableCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Developer\Test\Unit\Console\Command;
+
+use Magento\Developer\Console\Command\TemplateHintsDisableCommand;
+use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ConfigPathResolver;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Console\Cli;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TemplateHintsDisableCommandTest extends TestCase
+{
+    /**
+     * @var ConfigInterface|MockObject
+     */
+    private $resourceConfig;
+
+    /**
+     * @var DeploymentConfig|MockObject
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var ConfigPathResolver|MockObject
+     */
+    private $configPathResolver;
+
+    /**
+     * @var TemplateHintsDisableCommand
+     */
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->resourceConfig = $this->createMock(ConfigInterface::class);
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+        $this->configPathResolver = $this->createMock(ConfigPathResolver::class);
+
+        $this->configPathResolver->method('resolve')
+            ->willReturn('system/default/dev/debug/template_hints_storefront');
+
+        $this->command = new TemplateHintsDisableCommand(
+            $this->resourceConfig,
+            $this->deploymentConfig,
+            $this->configPathResolver
+        );
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $this->deploymentConfig->method('get')->willReturn(null);
+
+        $this->resourceConfig->expects($this->once())
+            ->method('saveConfig')
+            ->with('dev/debug/template_hints_storefront', 0, 'default', 0);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with('<info>Template hints disabled. Refresh cache types</info>');
+
+        $this->assertEquals(Cli::RETURN_SUCCESS, $this->command->run($input, $output));
+    }
+
+    public function testExecuteFailsWhenConfigIsLocked(): void
+    {
+        $this->deploymentConfig->method('get')->willReturn('1');
+
+        $this->resourceConfig->expects($this->never())->method('saveConfig');
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('already been locked'));
+
+        $this->assertEquals(Cli::RETURN_FAILURE, $this->command->run($input, $output));
+    }
+
+    public function testConstructorKeepsAdditionalDependenciesOptional(): void
+    {
+        $constructor = new ReflectionMethod(TemplateHintsDisableCommand::class, '__construct');
+
+        $this->assertSame(1, $constructor->getNumberOfRequiredParameters());
+    }
+}

--- a/app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsEnableCommandTest.php
+++ b/app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsEnableCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Developer\Test\Unit\Console\Command;
+
+use Magento\Developer\Console\Command\TemplateHintsEnableCommand;
+use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
+use Magento\Framework\App\Config\ConfigPathResolver;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\Console\Cli;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TemplateHintsEnableCommandTest extends TestCase
+{
+    /**
+     * @var ConfigInterface|MockObject
+     */
+    private $resourceConfig;
+
+    /**
+     * @var DeploymentConfig|MockObject
+     */
+    private $deploymentConfig;
+
+    /**
+     * @var ConfigPathResolver|MockObject
+     */
+    private $configPathResolver;
+
+    /**
+     * @var TemplateHintsEnableCommand
+     */
+    private $command;
+
+    protected function setUp(): void
+    {
+        $this->resourceConfig = $this->createMock(ConfigInterface::class);
+        $this->deploymentConfig = $this->createMock(DeploymentConfig::class);
+        $this->configPathResolver = $this->createMock(ConfigPathResolver::class);
+
+        $this->configPathResolver->method('resolve')
+            ->willReturn('system/default/dev/debug/template_hints_storefront');
+
+        $this->command = new TemplateHintsEnableCommand(
+            $this->resourceConfig,
+            $this->deploymentConfig,
+            $this->configPathResolver
+        );
+    }
+
+    public function testExecuteSuccess(): void
+    {
+        $this->deploymentConfig->method('get')->willReturn(null);
+
+        $this->resourceConfig->expects($this->once())
+            ->method('saveConfig')
+            ->with('dev/debug/template_hints_storefront', 1, 'default', 0);
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with('<info>Template hints enabled.</info>');
+
+        $this->assertEquals(Cli::RETURN_SUCCESS, $this->command->run($input, $output));
+    }
+
+    public function testExecuteFailsWhenConfigIsLocked(): void
+    {
+        $this->deploymentConfig->method('get')->willReturn('0');
+
+        $this->resourceConfig->expects($this->never())->method('saveConfig');
+
+        $input = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+        $output->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('already been locked'));
+
+        $this->assertEquals(Cli::RETURN_FAILURE, $this->command->run($input, $output));
+    }
+
+    public function testConstructorKeepsAdditionalDependenciesOptional(): void
+    {
+        $constructor = new ReflectionMethod(TemplateHintsEnableCommand::class, '__construct');
+
+        $this->assertSame(1, $constructor->getNumberOfRequiredParameters());
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Developer/Console/Command/TemplateHintsCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Developer/Console/Command/TemplateHintsCommandTest.php
@@ -9,13 +9,8 @@ namespace Magento\Developer\Console\Command;
 
 use Magento\Developer\Test\Fixture\LockedTemplateHintsConfig;
 use Magento\Framework\App\Config\ReinitableConfigInterface;
-use Magento\Framework\App\DeploymentConfig\FileReader;
-use Magento\Framework\App\DeploymentConfig\Writer;
-use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ResourceConnection;
-use Magento\Framework\Config\File\ConfigFilePool;
 use Magento\Framework\Console\Cli;
-use Magento\Framework\Filesystem;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use Magento\TestFramework\Fixture\DataFixture;
@@ -39,21 +34,6 @@ class TemplateHintsCommandTest extends TestCase
     private ObjectManagerInterface $objectManager;
 
     /**
-     * @var Writer
-     */
-    private Writer $writer;
-
-    /**
-     * @var Filesystem
-     */
-    private Filesystem $filesystem;
-
-    /**
-     * @var ConfigFilePool
-     */
-    private ConfigFilePool $configFilePool;
-
-    /**
      * @var ReinitableConfigInterface
      */
     private ReinitableConfigInterface $appConfig;
@@ -63,33 +43,13 @@ class TemplateHintsCommandTest extends TestCase
      */
     private ResourceConnection $resourceConnection;
 
-    /**
-     * @var array
-     */
-    private array $envConfig;
-
     protected function setUp(): void
     {
         $this->objectManager = Bootstrap::getObjectManager();
-        $reader = $this->objectManager->get(FileReader::class);
-        $this->writer = $this->objectManager->get(Writer::class);
-        $this->filesystem = $this->objectManager->get(Filesystem::class);
-        $this->configFilePool = $this->objectManager->get(ConfigFilePool::class);
         $this->appConfig = $this->objectManager->get(ReinitableConfigInterface::class);
         $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
 
-        $this->envConfig = $reader->load(ConfigFilePool::APP_ENV);
         $this->deleteConfigValue();
-        $this->appConfig->reinit();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->filesystem->getDirectoryWrite(DirectoryList::CONFIG)->writeFile(
-            $this->configFilePool->getPath(ConfigFilePool::APP_ENV),
-            "<?php\n return array();\n"
-        );
-        $this->writer->saveConfig([ConfigFilePool::APP_ENV => $this->envConfig]);
         $this->appConfig->reinit();
     }
 

--- a/dev/tests/integration/testsuite/Magento/Developer/Console/Command/TemplateHintsCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Developer/Console/Command/TemplateHintsCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Developer\Console\Command;
+
+use Magento\Developer\Test\Fixture\LockedTemplateHintsConfig;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\DeploymentConfig\FileReader;
+use Magento\Framework\App\DeploymentConfig\Writer;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Console\Cli;
+use Magento\Framework\Filesystem;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\Fixture\DataFixture;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Integration tests for template hints CLI commands with locked config detection.
+ *
+ * @see https://github.com/magento/magento2/issues/40523
+ * @magentoDbIsolation enabled
+ * @magentoAppIsolation enabled
+ */
+class TemplateHintsCommandTest extends TestCase
+{
+    private const CONFIG_PATH = 'dev/debug/template_hints_storefront';
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    private ObjectManagerInterface $objectManager;
+
+    /**
+     * @var Writer
+     */
+    private Writer $writer;
+
+    /**
+     * @var Filesystem
+     */
+    private Filesystem $filesystem;
+
+    /**
+     * @var ConfigFilePool
+     */
+    private ConfigFilePool $configFilePool;
+
+    /**
+     * @var ReinitableConfigInterface
+     */
+    private ReinitableConfigInterface $appConfig;
+
+    /**
+     * @var ResourceConnection
+     */
+    private ResourceConnection $resourceConnection;
+
+    /**
+     * @var array
+     */
+    private array $envConfig;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $reader = $this->objectManager->get(FileReader::class);
+        $this->writer = $this->objectManager->get(Writer::class);
+        $this->filesystem = $this->objectManager->get(Filesystem::class);
+        $this->configFilePool = $this->objectManager->get(ConfigFilePool::class);
+        $this->appConfig = $this->objectManager->get(ReinitableConfigInterface::class);
+        $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
+
+        $this->envConfig = $reader->load(ConfigFilePool::APP_ENV);
+        $this->deleteConfigValue();
+        $this->appConfig->reinit();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->getDirectoryWrite(DirectoryList::CONFIG)->writeFile(
+            $this->configFilePool->getPath(ConfigFilePool::APP_ENV),
+            "<?php\n return array();\n"
+        );
+        $this->writer->saveConfig([ConfigFilePool::APP_ENV => $this->envConfig]);
+        $this->appConfig->reinit();
+    }
+
+    public function testEnableSucceedsWhenConfigNotLocked(): void
+    {
+        $command = $this->objectManager->create(TemplateHintsEnableCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('Template hints enabled', $tester->getDisplay());
+        $this->assertSame('1', $this->getConfigValue());
+    }
+
+    #[DataFixture(LockedTemplateHintsConfig::class, ['value' => '0'])]
+    public function testEnableFailsWhenConfigLocked(): void
+    {
+        $command = $this->objectManager->create(TemplateHintsEnableCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('locked', $tester->getDisplay());
+        $this->assertNull($this->getConfigValue());
+    }
+
+    public function testDisableSucceedsWhenConfigNotLocked(): void
+    {
+        $command = $this->objectManager->create(TemplateHintsDisableCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('Template hints disabled', $tester->getDisplay());
+        $this->assertSame('0', $this->getConfigValue());
+    }
+
+    #[DataFixture(LockedTemplateHintsConfig::class, ['value' => '1'])]
+    public function testDisableFailsWhenConfigLocked(): void
+    {
+        $command = $this->objectManager->create(TemplateHintsDisableCommand::class);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('locked', $tester->getDisplay());
+        $this->assertNull($this->getConfigValue());
+    }
+
+    /**
+     * Get the config value from core_config_data.
+     *
+     * @return string|null
+     */
+    private function getConfigValue(): ?string
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName('core_config_data');
+
+        $select = $connection->select()
+            ->from($tableName, ['value'])
+            ->where('path = ?', self::CONFIG_PATH)
+            ->where('scope = ?', 'default')
+            ->where('scope_id = ?', 0);
+
+        $result = $connection->fetchOne($select);
+
+        return $result !== false ? $result : null;
+    }
+
+    /**
+     * Delete the config value from core_config_data to ensure clean state.
+     *
+     * @return void
+     */
+    private function deleteConfigValue(): void
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName('core_config_data');
+
+        $connection->delete(
+            $tableName,
+            [
+                'path = ?' => self::CONFIG_PATH,
+                'scope = ?' => 'default',
+                'scope_id = ?' => 0,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Description

The `dev:template-hints:enable` and `dev:template-hints:disable` commands silently wrote to `core_config_data` even when the `dev/debug/template_hints_storefront` config path was locked in `app/etc/env.php` or `app/etc/config.php`. This displayed a false success message while the locked value took precedence at runtime, making the change ineffective.

### Fix

Inject `DeploymentConfig` and `ConfigPathResolver` into both commands to check for locked values before saving — the same approach used by `bin/magento config:set` in `DefaultProcessor::isLocked()`.

When the config is locked, the commands now return `RETURN_FAILURE` with a clear error message instead of a misleading success.

Fixes magento/magento2#40523

## Files Changed

- `app/code/Magento/Developer/Console/Command/TemplateHintsEnableCommand.php`
- `app/code/Magento/Developer/Console/Command/TemplateHintsDisableCommand.php`
- `app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsEnableCommandTest.php` (new)
- `app/code/Magento/Developer/Test/Unit/Console/Command/TemplateHintsDisableCommandTest.php` (new)

## Manual Testing Scenarios

1. Lock the config in `app/etc/env.php`:
   ```php
   'system' => ['default' => ['dev' => ['debug' => ['template_hints_storefront' => '0']]]]
   ```
2. Run `bin/magento dev:template-hints:enable`
3. **Expected**: Error message about locked value, exit code 1
4. **Before fix**: False "Template hints enabled." message, exit code 0
5. Remove the lock from `env.php`
6. Run `bin/magento dev:template-hints:enable`
7. **Expected**: Normal "Template hints enabled." message, exit code 0
