### PR TITLE
fix(framework): stop prepending dot to cookie domain in JS cookie config (#40515)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/View/Element/Js/CookieDomainTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/View/Element/Js/CookieDomainTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\View\Element\Js;
+
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\AppIsolation;
+use Magento\TestFramework\Fixture\Config as ConfigFixture;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for cookie domain handling in JS cookie configuration block.
+ *
+ * Verifies that configured cookie domains are passed through to the frontend
+ * without modification (no leading dot prepended).
+ *
+ * @see https://github.com/magento/magento2/issues/40515
+ */
+#[AppArea('frontend')]
+class CookieDomainTest extends TestCase
+{
+    /**
+     * Verify that a configured cookie domain is returned without a leading dot.
+     *
+     * Per RFC 6265, browsers handle domain matching for cookies without a leading dot
+     * the same as with one. Prepending a dot causes cross-subdomain cookie collision
+     * in multistore setups with sibling domains.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        ConfigFixture('web/cookie/cookie_domain', 'example.com', 'store'),
+    ]
+    public function testGetDomainDoesNotPrependDot(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Cookie $block */
+        $block = $objectManager->create(Cookie::class);
+
+        $this->assertSame(
+            'example.com',
+            $block->getDomain(),
+            'Cookie domain must not have a leading dot prepended'
+        );
+    }
+
+    /**
+     * Verify that a subdomain cookie domain is returned without a leading dot.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        ConfigFixture('web/cookie/cookie_domain', 'sub.example.com', 'store'),
+    ]
+    public function testGetDomainPreservesSubdomain(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Cookie $block */
+        $block = $objectManager->create(Cookie::class);
+
+        $this->assertSame(
+            'sub.example.com',
+            $block->getDomain(),
+            'Subdomain cookie domain must be returned as-is'
+        );
+    }
+
+    /**
+     * Verify that an IP address cookie domain is returned unchanged.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        ConfigFixture('web/cookie/cookie_domain', '127.0.0.1', 'store'),
+    ]
+    public function testGetDomainPreservesIpAddress(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Cookie $block */
+        $block = $objectManager->create(Cookie::class);
+
+        $this->assertSame(
+            '127.0.0.1',
+            $block->getDomain(),
+            'IP address cookie domain must be returned unchanged'
+        );
+    }
+
+    /**
+     * Verify that a domain already having a leading dot is returned as-is.
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        ConfigFixture('web/cookie/cookie_domain', '.example.com', 'store'),
+    ]
+    public function testGetDomainPreservesExistingLeadingDot(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var Cookie $block */
+        $block = $objectManager->create(Cookie::class);
+
+        $this->assertSame(
+            '.example.com',
+            $block->getDomain(),
+            'Domain with existing leading dot must be returned as-is'
+        );
+    }
+}

--- a/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
+++ b/lib/internal/Magento/Framework/View/Element/Js/Cookie.php
@@ -18,8 +18,6 @@ use Magento\Framework\View\Element\Template\Context;
 class Cookie extends Template
 {
     /**
-     * Session config
-     *
      * @var ConfigInterface
      */
     protected $sessionConfig;
@@ -55,16 +53,7 @@ class Cookie extends Template
      */
     public function getDomain()
     {
-        $domain = $this->sessionConfig->getCookieDomain();
-
-        if ($this->ipValidator->isValid($domain)) {
-            return $domain;
-        }
-
-        if (!empty($domain[0]) && $domain[0] !== '.') {
-            $domain = '.' . $domain;
-        }
-        return $domain;
+        return $this->sessionConfig->getCookieDomain();
     }
 
     /**

--- a/lib/internal/Magento/Framework/View/Test/Unit/Element/Js/CookieTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Element/Js/CookieTest.php
@@ -82,17 +82,13 @@ class CookieTest extends TestCase
 
     /**     */
     #[DataProvider('domainDataProvider')]
-    public function testGetDomain($domain, $isIp, $expectedResult)
+    public function testGetDomain($domain, $expectedResult)
     {
         $this->sessionConfigMock->expects($this->once())
             ->method('getCookieDomain')
             ->willReturn($domain);
-        $this->ipValidatorMock->expects($this->once())
-            ->method('isValid')
-            ->with($domain)
-            ->willReturn($isIp);
 
-        $result = $this->model->getDomain($domain);
+        $result = $this->model->getDomain();
         $this->assertEquals($expectedResult, $result);
     }
 
@@ -102,9 +98,10 @@ class CookieTest extends TestCase
     public static function domainDataProvider()
     {
         return [
-            ['127.0.0.1', true, '127.0.0.1'],
-            ['example.com', false, '.example.com'],
-            ['.example.com', false, '.example.com'],
+            ['127.0.0.1', '127.0.0.1'],
+            ['example.com', 'example.com'],
+            ['.example.com', '.example.com'],
+            ['sub.example.com', 'sub.example.com'],
         ];
     }
 


### PR DESCRIPTION
## Description

`Magento\Framework\View\Element\Js\Cookie::getDomain()` unconditionally prepended a dot to configured cookie domains (e.g., `example.com` became `.example.com`). Per [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3), a leading dot causes the cookie to match all subdomains, which breaks multistore setups where stores run on sibling domains.

**Example of the broken behavior:**
- Store 1 configured with cookie domain `example.com` → cookie set as `.example.com`
- Store 2 configured with cookie domain `sub.example.com` → cookie set as `.sub.example.com`
- `.example.com` matches `sub.example.com`, causing session collision — logging into store 2 destroys store 1's session

### Fix

Remove the dot-prepending logic entirely. Per RFC 6265 Section 5.2.3, modern browsers already treat domains without a leading dot as domain cookies. The leading dot is a legacy behavior from RFC 2109 that is redundant and only causes unexpected cross-subdomain cookie sharing.

The session config's `getCookieDomain()` returns the correctly configured domain — no transformation is needed.

Fixes magento/magento2#40515

## Files Changed

- `lib/internal/Magento/Framework/View/Element/Js/Cookie.php` — simplified `getDomain()`
- `lib/internal/Magento/Framework/View/Test/Unit/Element/Js/CookieTest.php` — updated test expectations

## Manual Testing Scenarios

1. Set up two store views: `example.local` and `sub.example.local`
2. Configure cookie domain per store: `example.local` for store 1, `sub.example.local` for store 2
3. Login on store 1, then login on store 2
4. **Expected**: Both sessions remain active independently
5. **Before fix**: Logging into store 2 invalidates store 1's session
