### PR TITLE
fix(reports): prevent infinite loop in report event table cleanup (#39928)

### DIFF
--- a/app/code/Magento/Reports/Model/ResourceModel/Event.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Event.php
@@ -177,9 +177,16 @@ class Event extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @return $this
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    /**
+     * Maximum number of batch iterations to prevent infinite loops
+     * when new events are inserted faster than they are cleaned up.
+     */
+    private const CLEAN_BATCH_LIMIT = 100;
+
     public function clean(\Magento\Reports\Model\Event $object)
     {
-        while (true) {
+        $iterations = 0;
+        while ($iterations < self::CLEAN_BATCH_LIMIT) {
             $select = $this->getConnection()->select()->from(
                 ['event_table' => $this->getMainTable()],
                 ['event_id']
@@ -197,6 +204,7 @@ class Event extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             }
 
             $this->getConnection()->delete($this->getMainTable(), ['event_id IN(?)' => $eventIds]);
+            $iterations++;
         }
         return $this;
     }

--- a/app/code/Magento/Reports/Model/ResourceModel/Event.php
+++ b/app/code/Magento/Reports/Model/ResourceModel/Event.php
@@ -13,6 +13,12 @@ namespace Magento\Reports\Model\ResourceModel;
 class Event extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
 {
     /**
+     * Maximum number of batch iterations to prevent infinite loops
+     * when new events are inserted faster than they are cleaned up.
+     */
+    private const CLEAN_BATCH_LIMIT = 100;
+
+    /**
      * Core store config
      *
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
@@ -177,12 +183,6 @@ class Event extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @return $this
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    /**
-     * Maximum number of batch iterations to prevent infinite loops
-     * when new events are inserted faster than they are cleaned up.
-     */
-    private const CLEAN_BATCH_LIMIT = 100;
-
     public function clean(\Magento\Reports\Model\Event $object)
     {
         $iterations = 0;

--- a/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/EventTest.php
+++ b/app/code/Magento/Reports/Test/Unit/Model/ResourceModel/EventTest.php
@@ -289,4 +289,48 @@ class EventTest extends TestCase
 
         $this->event->clean($eventMock);
     }
+
+    /**
+     * Verify that clean() terminates after the maximum batch iteration limit
+     * even when orphaned events keep being found (prevents infinite loop).
+     *
+     * @return void
+     */
+    public function testCleanTerminatesAfterBatchLimit(): void
+    {
+        $eventMock = $this->getMockBuilder(\Magento\Reports\Model\Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $selectMock = $this->createPartialMockWithReflection(
+            Select::class,
+            ['where', 'limit', 'from', 'joinLeft']
+        );
+
+        // Always return event IDs — simulating new events being inserted continuously
+        $deleteCount = 0;
+        $this->connectionMock
+            ->method('fetchCol')
+            ->willReturn([1, 2, 3]);
+
+        $this->connectionMock
+            ->method('delete')
+            ->willReturnCallback(function () use (&$deleteCount) {
+                $deleteCount++;
+                return 3;
+            });
+        $this->connectionMock
+            ->expects($this->any())
+            ->method('select')
+            ->willReturn($selectMock);
+
+        $selectMock->method('from')->willReturnSelf();
+        $selectMock->method('joinLeft')->willReturnSelf();
+        $selectMock->method('where')->willReturnSelf();
+        $selectMock->method('limit')->willReturnSelf();
+
+        $this->event->clean($eventMock);
+
+        $this->assertSame(100, $deleteCount, 'Clean must stop after 100 batch iterations to prevent infinite loop');
+    }
 }


### PR DESCRIPTION
## Description

The `clean()` method in `Magento\Reports\Model\ResourceModel\Event` uses an unbounded `while(true)` loop to delete orphaned report events in batches of 1,000. On high-traffic stores, new events are continuously inserted into `report_event` while the cron job is running, meaning the `fetchCol()` query always finds more rows to delete. This causes the cron job to run indefinitely, blocking subsequent cron tasks and accumulating database locks.

### Fix

Replace `while(true)` with a bounded loop limited to 100 iterations (100,000 rows per cron run). Any remaining orphaned events will be cleaned up in the next scheduled cron execution. This is consistent with how other Magento cleanup crons handle large datasets.

Fixes magento/magento2#39928

## Files Changed

- `app/code/Magento/Reports/Model/ResourceModel/Event.php` — add iteration limit to `clean()`
- `app/code/Magento/Reports/Test/Unit/Model/ResourceModel/EventTest.php` — new test verifying loop terminates after batch limit

## Manual Testing Scenarios

1. Populate `report_event` table with millions of orphaned rows (events referencing non-existent visitors)
2. Run `bin/magento cron:run --group=default`
3. **Expected**: Cleanup processes up to 100,000 rows and exits; remaining rows cleaned in next run
4. **Before fix**: Cleanup runs indefinitely, blocking other cron jobs
