### PR TITLE
perf(backend): lazy-load ACL instead of refreshing on every admin request (#39843)

### DIFF
--- a/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
+++ b/app/code/Magento/Backend/App/Action/Plugin/Authentication.php
@@ -141,7 +141,6 @@ class Authentication
                 }
             }
         }
-        $this->_auth->getAuthStorage()->refreshAcl();
         return $proceed($request);
     }
 

--- a/app/code/Magento/Backend/Model/Auth/Session.php
+++ b/app/code/Magento/Backend/Model/Auth/Session.php
@@ -139,7 +139,10 @@ class Session extends \Magento\Framework\Session\SessionManager implements \Mage
             return $this;
         }
         if (!$this->getAcl() || $user->getReloadAclFlag()) {
-            $this->setAcl($this->_aclBuilder->getAcl());
+            $acl = $this->_aclBuilder->getAcl();
+            if ($acl !== null) {
+                $this->setAcl($acl);
+            }
         }
         if ($user->getReloadAclFlag()) {
             $user->unsetData('password');
@@ -158,19 +161,28 @@ class Session extends \Magento\Framework\Session\SessionManager implements \Mage
     public function isAllowed($resource, $privilege = null)
     {
         $user = $this->getUser();
-        $acl = $this->getAcl();
+        if (!$user) {
+            return false;
+        }
 
-        if ($user && $acl) {
+        if (!$this->getAcl() || $user->getReloadAclFlag()) {
+            $this->refreshAcl($user);
+        }
+
+        $acl = $this->getAcl();
+        if (!$acl) {
+            return false;
+        }
+
+        try {
+            return $acl->isAllowed($user->getAclRole(), $resource, $privilege);
+        } catch (\Exception $e) {
             try {
-                return $acl->isAllowed($user->getAclRole(), $resource, $privilege);
-            } catch (\Exception $e) {
-                try {
-                    if (!$acl->hasResource($resource)) {
-                        return $acl->isAllowed($user->getAclRole(), null, $privilege);
-                    }
-                } catch (\Exception $e) {
-                    return false;
+                if (!$acl->hasResource($resource)) {
+                    return $acl->isAllowed($user->getAclRole(), null, $privilege);
                 }
+            } catch (\Exception $e) {
+                return false;
             }
         }
         return false;

--- a/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/AuthenticationTest.php
+++ b/app/code/Magento/Backend/Test/Unit/App/Action/Plugin/AuthenticationTest.php
@@ -63,7 +63,7 @@ class AuthenticationTest extends TestCase
         $subject = $this->createMock(Index::class);
         $request = $this->createPartialMock(Http::class, ['getActionName']);
         $user = $this->createPartialMock(User::class, ['reload', '__wakeup']);
-        $storage = $this->createPartialMock(Session::class, ['prolong', 'refreshAcl']);
+        $storage = $this->createPartialMock(Session::class, ['prolong']);
 
         $expectedResult = 'expectedResult';
         $action = 'index';
@@ -88,8 +88,6 @@ class AuthenticationTest extends TestCase
 
         $storage
             ->method('prolong');
-        $storage
-            ->method('refreshAcl');
 
         $proceed = function ($request) use ($expectedResult) {
             return $expectedResult;

--- a/app/code/Magento/Backend/Test/Unit/Model/Auth/SessionTest.php
+++ b/app/code/Magento/Backend/Test/Unit/Model/Auth/SessionTest.php
@@ -264,7 +264,7 @@ class SessionTest extends TestCase
         }
         if ($isUserDefined) {
             $userMock = $this->createMock(User::class);
-            $this->storage->expects($this->once())->method('getUser')->willReturn($userMock);
+            $this->storage->expects($this->any())->method('getUser')->willReturn($userMock);
         }
         if ($isAclDefined && $isUserDefined) {
             // phpstan:ignore
@@ -283,10 +283,99 @@ class SessionTest extends TestCase
     {
         return [
             "Negative: User not defined" => [false, true, true, false],
-            "Negative: Acl not defined" => [true, false, true, false],
             "Negative: Permission denied" => [true, true, false, false],
-            "Positive: Permission granted" => [true, true, false, false],
+            "Positive: Permission granted" => [true, true, true, true],
         ];
+    }
+
+    /**
+     * Test that isAllowed() lazy-loads the ACL when it hasn't been set yet.
+     */
+    public function testIsAllowedLazyLoadsAclOnFirstCall(): void
+    {
+        $userAclRole = 'Administrators';
+        $aclMock = $this->createMock(Acl::class);
+        $aclMock->expects($this->once())->method('isAllowed')->with($userAclRole, 'resource', null)->willReturn(true);
+
+        $this->aclBuilder->expects($this->once())->method('getAcl')->willReturn($aclMock);
+
+        $userMock = $this->createPartialMockWithReflection(
+            User::class,
+            ['getAclRole', 'getReloadAclFlag']
+        );
+        $userMock->expects($this->any())->method('getAclRole')->willReturn($userAclRole);
+        $userMock->expects($this->any())->method('getReloadAclFlag')->willReturn(false);
+        $this->storage->expects($this->any())->method('getUser')->willReturn($userMock);
+
+        $this->assertTrue($this->session->isAllowed('resource'));
+    }
+
+    /**
+     * Test that isAllowed() does NOT rebuild ACL when it is already loaded.
+     */
+    public function testIsAllowedReusesLoadedAcl(): void
+    {
+        $userAclRole = 'Administrators';
+        $aclMock = $this->createMock(Acl::class);
+        $aclMock->expects($this->exactly(2))->method('isAllowed')->willReturn(true);
+
+        $this->session->setAcl($aclMock);
+        $this->aclBuilder->expects($this->never())->method('getAcl');
+
+        $userMock = $this->createPartialMockWithReflection(
+            User::class,
+            ['getAclRole', 'getReloadAclFlag']
+        );
+        $userMock->expects($this->any())->method('getAclRole')->willReturn($userAclRole);
+        $userMock->expects($this->any())->method('getReloadAclFlag')->willReturn(false);
+        $this->storage->expects($this->any())->method('getUser')->willReturn($userMock);
+
+        $this->assertTrue($this->session->isAllowed('resource'));
+        $this->assertTrue($this->session->isAllowed('other_resource'));
+    }
+
+    /**
+     * Test that isAllowed() rebuilds ACL when reloadAclFlag is set.
+     */
+    public function testIsAllowedRebuildsAclWhenReloadFlagSet(): void
+    {
+        $userAclRole = 'Administrators';
+        $oldAcl = $this->createMock(Acl::class);
+        $newAcl = $this->createMock(Acl::class);
+        $newAcl->expects($this->once())->method('isAllowed')->willReturn(true);
+
+        $this->session->setAcl($oldAcl);
+        $this->aclBuilder->expects($this->once())->method('getAcl')->willReturn($newAcl);
+
+        $userMock = $this->createPartialMockWithReflection(
+            User::class,
+            ['getAclRole', 'getReloadAclFlag', 'setReloadAclFlag', 'unsetData', 'save']
+        );
+        $userMock->expects($this->any())->method('getAclRole')->willReturn($userAclRole);
+        $userMock->expects($this->any())->method('getReloadAclFlag')->willReturn(true);
+        $userMock->expects($this->once())->method('setReloadAclFlag')->with('0')->willReturnSelf();
+        $userMock->expects($this->once())->method('save');
+        $this->storage->expects($this->any())->method('getUser')->willReturn($userMock);
+
+        $this->assertTrue($this->session->isAllowed('resource'));
+        $this->assertSame($newAcl, $this->session->getAcl());
+    }
+
+    /**
+     * Test that isAllowed() returns false when ACL builder returns null.
+     */
+    public function testIsAllowedReturnsFalseWhenAclBuilderReturnsNull(): void
+    {
+        $this->aclBuilder->expects($this->once())->method('getAcl')->willReturn(null);
+
+        $userMock = $this->createPartialMockWithReflection(
+            User::class,
+            ['getReloadAclFlag']
+        );
+        $userMock->expects($this->any())->method('getReloadAclFlag')->willReturn(false);
+        $this->storage->expects($this->any())->method('getUser')->willReturn($userMock);
+
+        $this->assertFalse($this->session->isAllowed('resource'));
     }
 
     /**


### PR DESCRIPTION
## Description

The `Authentication` plugin called `refreshAcl()` on **every admin request** (line 144 of `Authentication.php`). Since the ACL object is stored in-memory only (not in session storage), `$this->getAcl()` returns `null` on every new request, causing `$this->_aclBuilder->getAcl()` to rebuild the entire ACL tree from the database. On stores with many ACL rules (17,000+ in the reporter's case), this adds ~200ms to every admin page load.

### Root Cause

```php
// Authentication.php - called on EVERY admin request
$this->_auth->getAuthStorage()->refreshAcl();
return $proceed($request);
```

The `refreshAcl()` method checks `!$this->getAcl()` which is always true (in-memory property resets per request), so it always calls `$this->_aclBuilder->getAcl()`.

### Fix

1. **Remove** the eager `refreshAcl()` call from `Authentication::aroundDispatch()`
2. **Add lazy loading** in `Session::isAllowed()` — the ACL is loaded on-demand only when an authorization check is actually performed
3. The `reloadAclFlag` is still respected (checked before each lazy load)
4. Added null-safety to `refreshAcl()` for when `_aclBuilder->getAcl()` returns null

This changes ACL loading from "load on every request" to "load on first `isAllowed()` call per request" — same behavior, without the overhead on requests that don't check permissions (e.g., AJAX endpoints).

Fixes magento/magento2#39843

## Files Changed

- `app/code/Magento/Backend/App/Action/Plugin/Authentication.php` — removed eager `refreshAcl()` call
- `app/code/Magento/Backend/Model/Auth/Session.php` — lazy ACL loading in `isAllowed()`, null-safe `refreshAcl()`

## Performance Impact

- **Before**: ~200ms ACL overhead on every admin request (17K+ rules)
- **After**: ACL loaded only once per request, only when `isAllowed()` is called
