### PR TITLE
fix(sales): skip stock validation when editing order with fully consumed stock (#39898)

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -590,21 +590,32 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
 
         /* Initialize catalog rule data with new session values */
         $this->initRuleData();
-        foreach ($order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true) as $orderItem) {
-            /* @var $orderItem \Magento\Sales\Model\Order\Item */
-            if (!$orderItem->getParentItem()) {
-                $qty = $orderItem->getQtyOrdered();
-                if (!$order->getReordered()) {
-                    $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
-                }
 
-                if ($qty > 0) {
-                    $item = $this->initFromOrderItem($orderItem, $qty);
-                    if (is_string($item)) {
-                        throw new \Magento\Framework\Exception\LocalizedException(__($item));
+        // Skip stock validation when re-adding items from the original order,
+        // as the stock was already allocated when the order was placed.
+        $quote = $this->getQuote();
+        $oldSuperMode = $quote->getIsSuperMode();
+        $quote->setIsSuperMode(true);
+
+        try {
+            foreach ($order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true) as $orderItem) {
+                /* @var $orderItem \Magento\Sales\Model\Order\Item */
+                if (!$orderItem->getParentItem()) {
+                    $qty = $orderItem->getQtyOrdered();
+                    if (!$order->getReordered()) {
+                        $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
+                    }
+
+                    if ($qty > 0) {
+                        $item = $this->initFromOrderItem($orderItem, $qty);
+                        if (is_string($item)) {
+                            throw new \Magento\Framework\Exception\LocalizedException(__($item));
+                        }
                     }
                 }
             }
+        } finally {
+            $quote->setIsSuperMode($oldSuperMode);
         }
 
         $shippingAddress = $order->getShippingAddress();

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
@@ -509,6 +509,119 @@ class CreateTest extends TestCase
     }
 
     /**
+     * Verify that initFromOrder enables super mode to skip stock validation
+     * and restores it after items are loaded.
+     */
+    public function testInitFromOrderEnablesSuperModeForItemLoading(): void
+    {
+        $this->sessionQuote->method('getData')
+            ->with('reordered')
+            ->willReturn(false);
+
+        $address = $this->createPartialMock(
+            Address::class,
+            ['setSameAsBilling', 'setCustomerAddressId', 'getSameAsBilling']
+        );
+        $address->method('getSameAsBilling')->willReturn(true);
+        $address->method('setCustomerAddressId')->willReturnSelf();
+
+        $superModeValues = [];
+        $quote = $this->createPartialMockWithReflection(Quote::class, [
+            'getBillingAddress', 'getShippingAddress', 'isVirtual', 'collectTotals',
+            'setIsSuperMode', 'getIsSuperMode', 'addProduct',
+        ]);
+        $quote->method('getBillingAddress')->willReturn($address);
+        $quote->method('getShippingAddress')->willReturn($address);
+        $quote->method('getIsSuperMode')->willReturn(false);
+        $quote->method('setIsSuperMode')->willReturnCallback(
+            function ($value) use (&$superModeValues, $quote) {
+                $superModeValues[] = $value;
+                return $quote;
+            }
+        );
+
+        $this->sessionQuote->method('getQuote')->willReturn($quote);
+
+        $orderItem = $this->createPartialMock(
+            OrderItem::class,
+            ['getParentItem', 'getQtyOrdered', 'getQtyShipped', 'getQtyInvoiced']
+        );
+        $orderItem->method('getQtyOrdered')->willReturn(100);
+        $orderItem->method('getParentItem')->willReturn(false);
+        $orderItem->method('getQtyShipped')->willReturn(0);
+        $orderItem->method('getQtyInvoiced')->willReturn(0);
+
+        $itemCollectionMock = $this->getMockBuilder(ItemCollection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getIterator'])
+            ->getMock();
+        $itemCollectionMock->method('getIterator')->willReturn(new \ArrayIterator([$orderItem]));
+
+        $this->orderMock->method('getItemsCollection')->willReturn($itemCollectionMock);
+        $this->orderMock->method('getShippingAddress')->willReturn($address);
+        $this->orderMock->method('getBillingAddress')->willReturn($address);
+        $this->orderMock->method('getCouponCode')->willReturn(null);
+
+        $this->adminOrderCreate->initFromOrder($this->orderMock);
+
+        $this->assertSame(true, $superModeValues[0] ?? null, 'Super mode must be enabled before item loading');
+        $this->assertSame(false, end($superModeValues), 'Super mode must be restored after item loading');
+    }
+
+    /**
+     * Verify that initFromOrder restores super mode when item loading fails.
+     */
+    public function testInitFromOrderRestoresSuperModeWhenItemLoadingFails(): void
+    {
+        $this->sessionQuote->method('getData')
+            ->with('reordered')
+            ->willReturn(false);
+
+        $superModeValues = [];
+        $quote = $this->createPartialMockWithReflection(Quote::class, ['setIsSuperMode', 'getIsSuperMode']);
+        $quote->method('getIsSuperMode')->willReturn(false);
+        $quote->method('setIsSuperMode')->willReturnCallback(
+            function ($value) use (&$superModeValues, $quote) {
+                $superModeValues[] = $value;
+                return $quote;
+            }
+        );
+        $this->sessionQuote->method('getQuote')->willReturn($quote);
+
+        $orderItem = $this->createPartialMock(
+            OrderItem::class,
+            ['getId', 'getParentItem', 'getQtyOrdered', 'getQtyShipped', 'getQtyInvoiced']
+        );
+        $orderItem->method('getId')->willReturn(1);
+        $orderItem->method('getQtyOrdered')->willReturn(1);
+        $orderItem->method('getParentItem')->willReturn(false);
+        $orderItem->method('getQtyShipped')->willReturn(0);
+        $orderItem->method('getQtyInvoiced')->willReturn(0);
+
+        $itemCollectionMock = $this->getMockBuilder(ItemCollection::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getIterator'])
+            ->getMock();
+        $itemCollectionMock->method('getIterator')->willReturn(new \ArrayIterator([$orderItem]));
+
+        $this->orderMock->method('getItemsCollection')->willReturn($itemCollectionMock);
+        $this->objectManager->expects($this->once())
+            ->method('create')
+            ->with(Product::class)
+            ->willThrowException(new \RuntimeException('Product load failed'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Product load failed');
+
+        try {
+            $this->adminOrderCreate->initFromOrder($this->orderMock);
+        } finally {
+            $this->assertSame(true, $superModeValues[0] ?? null, 'Super mode must be enabled before item loading');
+            $this->assertSame(false, end($superModeValues), 'Super mode must be restored after item loading fails');
+        }
+    }
+
+    /**
      *  Test case for setShippingAsBilling
      *
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateOrderEditStockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/AdminOrder/CreateOrderEditStockTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\AdminOrder;
+
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\Catalog\Test\Fixture\ProductStock as ProductStockFixture;
+use Magento\Checkout\Test\Fixture\PlaceOrder as PlaceOrderFixture;
+use Magento\Checkout\Test\Fixture\SetBillingAddress as SetBillingAddressFixture;
+use Magento\Checkout\Test\Fixture\SetDeliveryMethod as SetDeliveryMethodFixture;
+use Magento\Checkout\Test\Fixture\SetPaymentMethod as SetPaymentMethodFixture;
+use Magento\Checkout\Test\Fixture\SetShippingAddress as SetShippingAddressFixture;
+use Magento\Customer\Test\Fixture\Customer as CustomerFixture;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Registry;
+use Magento\Quote\Test\Fixture\AddProductToCart as AddProductToCartFixture;
+use Magento\Quote\Test\Fixture\CustomerCart as CustomerCartFixture;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\AppIsolation;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for admin order edit with fully consumed product stock.
+ *
+ * @see https://github.com/magento/magento2/issues/39898
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+#[AppArea('adminhtml')]
+#[AppIsolation(true)]
+#[DbIsolation(false)]
+class CreateOrderEditStockTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private ObjectManager $objectManager;
+
+    /**
+     * @var ManagerInterface
+     */
+    private ManagerInterface $messageManager;
+
+    /**
+     * @var EmailSender|MockObject
+     */
+    private EmailSender|MockObject $emailSenderMock;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->messageManager = $this->objectManager->get(ManagerInterface::class);
+        $this->emailSenderMock = $this->getMockBuilder(EmailSender::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * Verify that editing an order which consumed all available stock
+     * does not fail with "Product is out of stock" error.
+     */
+    #[
+        DataFixture(ProductFixture::class, ['sku' => 'test-stock-product', 'price' => 10], 'product'),
+        DataFixture(ProductStockFixture::class, ['prod_id' => '$product.id$', 'prod_qty' => 5, 'is_in_stock' => 1]),
+        DataFixture(CustomerFixture::class, ['email' => 'customer@example.com'], 'customer'),
+        DataFixture(CustomerCartFixture::class, ['customer_id' => '$customer.id$'], 'cart'),
+        DataFixture(
+            AddProductToCartFixture::class,
+            ['cart_id' => '$cart.id$', 'product_id' => '$product.id$', 'qty' => 5]
+        ),
+        DataFixture(SetBillingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetShippingAddressFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetDeliveryMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(SetPaymentMethodFixture::class, ['cart_id' => '$cart.id$']),
+        DataFixture(PlaceOrderFixture::class, ['cart_id' => '$cart.id$'], 'order'),
+    ]
+    public function testInitFromOrderSucceedsWhenProductStockIsFullyConsumed(): void
+    {
+        $fixtures = $this->objectManager->get(DataFixtureStorageManager::class)->getStorage();
+        $order = $fixtures->get('order');
+
+        /** @var Create $model */
+        $model = $this->objectManager->create(
+            Create::class,
+            ['messageManager' => $this->messageManager, 'emailSender' => $this->emailSenderMock]
+        );
+
+        // Clear any pre-existing messages
+        $this->messageManager->getMessages(true);
+        $this->objectManager->get(Registry::class)->unregister('rule_data');
+
+        $model->initFromOrder($order);
+
+        self::assertGreaterThan(
+            0,
+            $model->getQuote()->getItemsCollection()->count(),
+            'Order edit quote must contain items even when product stock is fully consumed'
+        );
+        self::assertSame(
+            0,
+            $this->messageManager->getMessages()->getCount(),
+            'No error messages should be generated when editing an order with consumed stock'
+        );
+    }
+}


### PR DESCRIPTION
## Description

When an order consumed all available stock for a product (e.g., ordered 100 units of a 100-unit product), attempting to edit that order in the admin showed "Product is out of stock" error. The edit failed even though the stock was legitimately allocated by the original order.

### Root Cause

`AdminOrder\Create::initFromOrder()` re-adds order items to a new quote via `addProduct()`, which triggers `QuantityValidator` stock checks. Since the original order already consumed the stock, `$stockItem->getIsInStock()` returns false, and the validator rejects the item.

The original order is canceled in `afterSubmit()` (releasing the stock) only **after** the new order is successfully placed — but the validation happens **before** that.

### Fix

Enable `IsSuperMode` on the quote during the `initFromOrder()` item loading loop. The `QuantityValidator` explicitly skips validation when super mode is active (line 135-137):

```php
if ($quoteItem->getQuote()->getIsSuperMode()) {
    return;
}
```

This is safe because:
- The stock was already allocated when the original order was placed
- The original order is canceled after the new one is submitted (releasing stock)
- Super mode is restored to its previous value after the loop

Fixes magento/magento2#39898

## Files Changed

- `app/code/Magento/Sales/Model/AdminOrder/Create.php` — enable super mode during `initFromOrder()` item loading

## Manual Testing Scenarios

1. Create a product with stock qty = 100
2. Place an order for 100 units (stock now fully consumed)
3. Go to Admin > Sales > Orders, open the order, click **Edit**
4. **Expected**: Order edit page loads successfully with all items
5. **Before fix**: Error "Product is out of stock" displayed
