### PR TITLE
fix(url-rewrite): prevent ArgumentCountError on empty spread in array_merge (#39579)

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -220,7 +220,7 @@ class DbStorage extends AbstractStorage
         foreach ($uniqueEntities as $storeId => $entityTypes) {
             foreach ($entityTypes as $entityType => $entities) {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $requestPaths = array_merge(...$entities);
+                $requestPaths = array_merge([], ...$entities);
                 $requestPathFilter = '';
                 if (!empty($requestPaths)) {
                     $requestPathFilter = ' AND ' . $this->connection->quoteIdentifier(UrlRewrite::REQUEST_PATH)
@@ -273,7 +273,7 @@ class DbStorage extends AbstractStorage
             $newRequestPaths = [];
             foreach ($entityTypes as $entityType => $entities) {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $requestPaths = array_merge(...$entities);
+                $requestPaths = array_merge([], ...$entities);
                 if (empty($requestPaths)) {
                     continue;
                 }

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
@@ -584,6 +584,43 @@ class DbStorageTest extends TestCase
     }
 
     /**
+     * Verify that replace() handles an empty urls array gracefully
+     * without throwing ArgumentCountError from array_merge(...$entities).
+     *
+     * @return void
+     */
+    public function testReplaceWithEmptyUrlsArray(): void
+    {
+        $result = $this->storage->replace([]);
+
+        $this->assertEquals([], $result);
+    }
+
+    /**
+     * Verify that replace() succeeds when URL rewrite has an empty string request path,
+     * which creates an entity entry that could trigger the array_merge spread issue.
+     *
+     * @return void
+     */
+    public function testReplaceWithEmptyRequestPathDoesNotThrowError(): void
+    {
+        $url = $this->createMock(UrlRewrite::class);
+        $url->method('toArray')->willReturn(['row1']);
+        $url->method('getEntityType')->willReturn('product');
+        $url->method('getEntityId')->willReturn('1');
+        $url->method('getStoreId')->willReturn('1');
+        $url->method('getRequestPath')->willReturn('');
+        $this->connectionMock->method('quoteIdentifier')->willReturnArgument(0);
+        $this->select->method($this->anything())->willReturnSelf();
+        $this->resource->method('getTableName')->with(DbStorage::TABLE_NAME)->willReturn('table_name');
+        $this->connectionMock->method('fetchOne')->willReturn(false);
+
+        $result = $this->storage->replace([$url]);
+
+        $this->assertEquals([$url], $result);
+    }
+
+    /**
      * @return void
      */
     public function testDeleteByData(): void


### PR DESCRIPTION
## Description

`DbStorage::deleteOldUrls()` and `DbStorage::checkDuplicates()` use `array_merge(...$entities)` to flatten the entity request paths. In PHP 8, when `$entities` is empty, the spread operator passes zero arguments to `array_merge()`, causing:

```
ArgumentCountError: array_merge() does not accept unknown named parameters
```

This occurs when calling `StorageInterface::replace()` with URL rewrites that don't exist in the database yet.

### Fix

Prepend an empty array as the first argument: `array_merge([], ...$entities)`. This ensures `array_merge` always receives at least one argument, returning an empty array when `$entities` is empty.

Both occurrences (lines 223 and 276) are fixed.

Fixes magento/magento2#39579

## Files Changed

- `app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php` — 2 lines changed

## Manual Testing Scenarios

1. Call `StorageInterface::replace()` with a URL rewrite for a non-existing entity
2. **Expected**: Method completes without error
3. **Before fix**: `ArgumentCountError` thrown from `array_merge()`
