### PR TITLE
fix(message-queue): add primary key to queue_poison_pill table (#39239)

### DIFF
--- a/app/code/Magento/MessageQueue/Model/ResourceModel/PoisonPill.php
+++ b/app/code/Magento/MessageQueue/Model/ResourceModel/PoisonPill.php
@@ -19,14 +19,14 @@ class PoisonPill extends AbstractDb implements PoisonPillPutInterface, PoisonPil
     /**
      * Table name.
      */
-    const QUEUE_POISON_PILL_TABLE = 'queue_poison_pill';
+    public const QUEUE_POISON_PILL_TABLE = 'queue_poison_pill';
 
     /**
      * @inheritdoc
      */
     protected function _construct()
     {
-        $this->_init(self::QUEUE_POISON_PILL_TABLE, 'version');
+        $this->_init(self::QUEUE_POISON_PILL_TABLE, 'id');
     }
 
     /**

--- a/app/code/Magento/MessageQueue/etc/db_schema.xml
+++ b/app/code/Magento/MessageQueue/etc/db_schema.xml
@@ -22,6 +22,11 @@
         </constraint>
     </table>
     <table name="queue_poison_pill" resource="default" engine="innodb" comment="Sequence table for poison pill versions">
+        <column xsi:type="int" name="id" unsigned="true" nullable="false" identity="true"
+                comment="Entity ID"/>
         <column xsi:type="varchar" name="version" length="255" nullable="false" comment="Poison Pill version."/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="id"/>
+        </constraint>
     </table>
 </schema>

--- a/app/code/Magento/MessageQueue/etc/db_schema_whitelist.json
+++ b/app/code/Magento/MessageQueue/etc/db_schema_whitelist.json
@@ -12,7 +12,11 @@
     },
     "queue_poison_pill": {
         "column": {
+            "id": true,
             "version": true
+        },
+        "constraint": {
+            "PRIMARY": true
         }
     }
 }

--- a/dev/tests/static/testsuite/Magento/Test/Integrity/DBSchema/_files/primary_key_exemption_list.txt
+++ b/dev/tests/static/testsuite/Magento/Test/Integrity/DBSchema/_files/primary_key_exemption_list.txt
@@ -1,1 +1,0 @@
-queue_poison_pill


### PR DESCRIPTION
## Description

The `queue_poison_pill` table has no primary key, which causes Magento installation to fail on Galera/Percona XtraDB Cluster databases with `pxc_strict_mode = ENFORCING`:

```
SQLSTATE[HY000]: General error: 1105 Percona-XtraDB-Cluster prohibits use of DML command
on a table (queue_poison_pill) without an explicit primary key with pxc_strict_mode = ENFORCING
```

This is a long-standing issue (originally reported as #33822) that affects all Galera-based MySQL setups.

### Fix

Add an auto-increment `id` column as the primary key to `queue_poison_pill`. The table's behavior is unchanged — it still holds a single version row, managed via INSERT/UPDATE in `PoisonPill::put()`.

Fixes magento/magento2#39239

## Files Changed

- `app/code/Magento/MessageQueue/etc/db_schema.xml` — add `id` column + PRIMARY constraint
- `app/code/Magento/MessageQueue/etc/db_schema_whitelist.json` — register new column and constraint
- `app/code/Magento/MessageQueue/Model/ResourceModel/PoisonPill.php` — use `id` as identifier field

## Manual Testing Scenarios

1. Set up a Galera/PXC cluster with `pxc_strict_mode = ENFORCING`
2. Run `bin/magento setup:install`
3. **Expected**: Installation completes without DML errors on `queue_poison_pill`
4. **Before fix**: Error at `Module 'Magento_MessageQueue': Running schema recurring...`
