### PR TITLE
fix(webapi): support snake_case keys in constructor data for message queue deserialization (#39217)

### DIFF
--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -243,7 +243,10 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface, ResetAf
         $res = [];
         $parameters = $constructor->getParameters();
         foreach ($parameters as $parameter) {
-            if (isset($data[$parameter->getName()])) {
+            $paramName = $parameter->getName();
+            $snakeCaseName = strtolower(preg_replace("/(?<=\\w)(?=[A-Z])/", "_$1", $paramName));
+            if (isset($data[$paramName]) || isset($data[$snakeCaseName])) {
+                $paramValue = $data[$paramName] ?? $data[$snakeCaseName];
                 $parameterType = $this->typeProcessor->getParamType($parameter);
 
                 // Allow only simple types or Api Data Objects
@@ -254,7 +257,7 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface, ResetAf
                 }
 
                 try {
-                    $res[$parameter->getName()] = $this->convertValue($data[$parameter->getName()], $parameterType);
+                    $res[$paramName] = $this->convertValue($paramValue, $parameterType);
                 } catch (\ReflectionException $e) {
                     // Parameter was not correclty declared or the class is uknown.
                     // By not returing the contructor value, we will automatically fall back to the "setters" way.

--- a/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
+++ b/lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php
@@ -308,6 +308,11 @@ class ServiceInputProcessor implements ServicePayloadConverterInterface, ResetAf
             if (isset($constructorArgs[$propertyName])) {
                 continue;
             }
+            // Also skip if the property was matched via snake_case → camelCase in constructor
+            $camelFromSnake = lcfirst(SimpleDataObjectConverter::snakeCaseToUpperCamelCase($propertyName));
+            if (isset($constructorArgs[$camelFromSnake])) {
+                continue;
+            }
 
             // Converts snake_case to uppercase CamelCase to help form getter/setter method names
             // This use case is for REST only. SOAP request data is already camel cased

--- a/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
+++ b/lib/internal/Magento/Framework/Webapi/Test/Unit/ServiceInputProcessorTest.php
@@ -289,6 +289,26 @@ class ServiceInputProcessorTest extends TestCase
         $this->assertEquals('Test', $arg->getName());
     }
 
+    /**
+     * Verify that constructor parameters are matched when data keys use snake_case
+     * (e.g. from ServiceOutputProcessor serialization) instead of camelCase.
+     */
+    public function testSimpleConstructorPropertiesWithSnakeCaseKeys()
+    {
+        $data = ['simpleConstructor' => ['entity_id' => 42, 'name' => 'SnakeCase']];
+        $result = $this->serviceInputProcessor->process(
+            TestService::class,
+            'simpleConstructor',
+            $data
+        );
+        $this->assertNotNull($result);
+        $arg = $result[0];
+
+        $this->assertInstanceOf(SimpleConstructor::class, $arg);
+        $this->assertEquals(42, $arg->getEntityId());
+        $this->assertEquals('SnakeCase', $arg->getName());
+    }
+
     public function testSimpleArrayProperties()
     {
         $data = ['ids' => [1, 2, 3, 4]];


### PR DESCRIPTION
## Description

When using a class as a message queue request type with camelCase constructor parameters (e.g., `$storeId`, `$sessionIds`, `$websiteStoreId`), the message queue consumer fails to instantiate the object because the serialized data uses snake_case keys (`store_id`, `session_ids`, `website_store_id`).

### Root Cause

`ServiceInputProcessor::getConstructorData()` matches constructor parameter names **only in camelCase** against the data array (line 246):

```php
if (isset($data[$parameter->getName()])) {  // camelCase only
```

However, `ServiceOutputProcessor::convertValue()` converts property names to **snake_case** when serializing objects. This mismatch means the constructor data is never found.

The `process()` method in the same class already handles this correctly (line 196-200) by trying both camelCase and snake_case.

### Fix

Apply the same snake_case fallback pattern from `process()` to `getConstructorData()`:

```php
$snakeCaseName = strtolower(preg_replace("/(?<=\\w)(?=[A-Z])/", "_$1", $paramName));
if (isset($data[$paramName]) || isset($data[$snakeCaseName])) {
    $paramValue = $data[$paramName] ?? $data[$snakeCaseName];
```

Fixes magento/magento2#39217

## Files Changed

- `lib/internal/Magento/Framework/Webapi/ServiceInputProcessor.php` — add snake_case fallback in `getConstructorData()`

## Manual Testing Scenarios

1. Create a class with camelCase constructor params (e.g., `$websiteStoreId`)
2. Use it as a message queue request type in `communication.xml`
3. Publish a message with this type
4. **Expected**: Consumer processes the message, object instantiated correctly
5. **Before fix**: Error — constructor params not matched, empty object created
