### PR TITLE
fix(pagecache): bypass Varnish cache for login-as-customer requests (#39147)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -62,8 +62,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart and checkout
-    if (req.url ~ "/checkout") {
+    # Bypass shopping cart, checkout, login-as-customer
+    if (req.url ~ "/checkout" || req.url ~ "/loginascustomer") {
         return (pass);
     }
 

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -63,8 +63,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass shopping cart and checkout
-    if (req.url ~ "/checkout") {
+    # Bypass shopping cart, checkout, login-as-customer
+    if (req.url ~ "/checkout" || req.url ~ "/loginascustomer") {
         return (pass);
     }
 

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -67,8 +67,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass customer, shopping cart, checkout
-    if (req.url ~ "/customer" || req.url ~ "/checkout") {
+    # Bypass customer, shopping cart, checkout, login-as-customer
+    if (req.url ~ "/customer" || req.url ~ "/checkout" || req.url ~ "/loginascustomer") {
         return (pass);
     }
 

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -67,8 +67,8 @@ sub vcl_recv {
         return (pass);
     }
 
-    # Bypass customer, shopping cart, checkout
-    if (req.url ~ "/customer" || req.url ~ "/checkout") {
+    # Bypass customer, shopping cart, checkout, login-as-customer
+    if (req.url ~ "/customer" || req.url ~ "/checkout" || req.url ~ "/loginascustomer") {
         return (pass);
     }
 


### PR DESCRIPTION
## Description

The Login as Customer feature fails intermittently when Varnish is enabled. The root cause is that the login endpoint (`GET /loginascustomer/login/index/?secret=...`) resets the PHP session ID via a `Set-Cookie` header, but Varnish strips `Set-Cookie` from cacheable GET responses:

```vcl
if (beresp.ttl > 0s && (bereq.method == "GET" || bereq.method == "HEAD")) {
    unset beresp.http.set-cookie;
}
```

The browser never receives the new session ID, so subsequent requests use the old session and the login silently fails.

### Why `/loginascustomer` is not caught by existing bypasses

The VCL already bypasses `/customer` and `/checkout`, but `/loginascustomer` does **not** contain `/customer` as a path segment — it's a single frontName `loginascustomer` without a preceding slash before `customer`.

### Fix

Add `/loginascustomer` to the bypass list in `vcl_recv` across all VCL templates (v4-v7). This ensures the login request passes through to the backend with `Set-Cookie` headers intact.

Fixes magento/magento2#39147

## Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl`
- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`

## Manual Testing Scenarios

1. Enable Varnish as full page cache
2. Log into the admin panel
3. Navigate to Customers > All Customers
4. Click "Login as Customer" on any customer
5. **Expected**: Customer session is established, frontend shows logged-in state
6. **Before fix**: Login fails randomly — session cookie stripped by Varnish
