### PR TITLE
fix(developer): escape paths with spaces in dev:tests:run command (#38707)

### DIFF
--- a/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
+++ b/app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php
@@ -102,7 +102,11 @@ class DevTestsRunCommand extends Command
             $dirName = realpath(BP . '/dev/tests/' . $dir);
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
             chdir($dirName);
-            $command = PHP_BINARY . ' ' . BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit ' . $options;
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $phpBinary = escapeshellarg(PHP_BINARY);
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            $phpunitPath = escapeshellarg(BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit');
+            $command = $phpBinary . ' ' . $phpunitPath . ' ' . $options;
             if ($commandArguments = $input->getOption(self::INPUT_OPT_COMMAND_ARGUMENTS)) {
                 $command .= ' ' . $commandArguments;
             }


### PR DESCRIPTION
## Description

The `bin/magento dev:tests:run` command fails when the PHP binary path contains spaces (e.g., `/Users/user/Library/Application Support/php/bin/php81`).

### Root Cause

Line 105 builds the shell command by concatenating `PHP_BINARY` and the phpunit path without quoting:

```php
$command = PHP_BINARY . ' ' . BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit ' . $options;
```

When `PHP_BINARY` contains spaces, `passthru()` interprets them as argument separators, causing "No such file or directory".

### Fix

Use `escapeshellarg()` for both the PHP binary and phpunit paths:

```php
$phpBinary = escapeshellarg(PHP_BINARY);
$phpunitPath = escapeshellarg(BP . '/' . $vendorDir . '/phpunit/phpunit/phpunit');
$command = $phpBinary . ' ' . $phpunitPath . ' ' . $options;
```

Fixes magento/magento2#38707

## Files Changed

- `app/code/Magento/Developer/Console/Command/DevTestsRunCommand.php`

## Manual Testing Scenarios

1. Set up PHP binary in a path with spaces (e.g., symlink to `/tmp/my path/php`)
2. Run `php bin/magento dev:tests:run unit`
3. **Expected**: Tests execute normally
4. **Before fix**: "No such file or directory" error
