### PR TITLE
fix: add missing PUT, DELETE, PATCH, HEAD, OPTIONS methods to Curl client

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Client/Curl.php
+++ b/lib/internal/Magento/Framework/HTTP/Client/Curl.php
@@ -246,6 +246,64 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     }
 
     /**
+     * Make PUT request
+     *
+     * @param string $uri
+     * @param array|string $params
+     * @return void
+     */
+    public function put($uri, $params = [])
+    {
+        $this->makeRequest("PUT", $uri, $params);
+    }
+
+    /**
+     * Make DELETE request
+     *
+     * @param string $uri
+     * @param array|string $params
+     * @return void
+     */
+    public function delete($uri, $params = [])
+    {
+        $this->makeRequest("DELETE", $uri, $params);
+    }
+
+    /**
+     * Make PATCH request
+     *
+     * @param string $uri
+     * @param array|string $params
+     * @return void
+     */
+    public function patch($uri, $params = [])
+    {
+        $this->makeRequest("PATCH", $uri, $params);
+    }
+
+    /**
+     * Make HEAD request
+     *
+     * @param string $uri
+     * @return void
+     */
+    public function head($uri)
+    {
+        $this->makeRequest("HEAD", $uri);
+    }
+
+    /**
+     * Make OPTIONS request
+     *
+     * @param string $uri
+     * @return void
+     */
+    public function options($uri)
+    {
+        $this->makeRequest("OPTIONS", $uri);
+    }
+
+    /**
      * Get response headers
      *
      * @return array

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
@@ -72,6 +72,47 @@ class CurlTest extends TestCase
     }
 
     /**
+     * @dataProvider httpMethodsDataProvider
+     */
+    public function testHttpMethod(string $method, array $args, string $expectedHttpMethod): void
+    {
+        $curl = new class () extends Curl {
+            public string $lastMethod = '';
+            public string $lastUri = '';
+            public $lastParams = [];
+
+            protected function makeRequest($method, $uri, $params = [])
+            {
+                $this->lastMethod = $method;
+                $this->lastUri = $uri;
+                $this->lastParams = $params;
+            }
+        };
+
+        $curl->$method(...$args);
+
+        $this->assertEquals($expectedHttpMethod, $curl->lastMethod);
+        $this->assertEquals($args[0], $curl->lastUri);
+        if (isset($args[1])) {
+            $this->assertEquals($args[1], $curl->lastParams);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function httpMethodsDataProvider(): array
+    {
+        return [
+            'put' => ['put', ['http://example.com', ['key' => 'value']], 'PUT'],
+            'delete' => ['delete', ['http://example.com', ['key' => 'value']], 'DELETE'],
+            'patch' => ['patch', ['http://example.com', ['key' => 'value']], 'PATCH'],
+            'head' => ['head', ['http://example.com'], 'HEAD'],
+            'options' => ['options', ['http://example.com'], 'OPTIONS'],
+        ];
+    }
+
+    /**
      * @return array
      */
     public function headersDataProvider()


### PR DESCRIPTION
## Summary

Adds missing standard HTTP methods to `Magento\Framework\HTTP\Client\Curl`:
- `put($uri, $params)` 
- `delete($uri, $params)`
- `patch($uri, $params)`
- `head($uri)`
- `options($uri)`

Related: #39330, #39469 (both closed without merge)

## Problem

The Curl HTTP client only supports `GET` and `POST`, forcing developers to drop down to raw cURL or use third-party HTTP clients for standard REST operations like PUT, DELETE, and PATCH.

## Changes

- Added five new public methods to `Curl.php` following the existing `get()`/`post()` pattern
- All methods delegate to the existing `makeRequest()` which already handles arbitrary HTTP methods via `CURLOPT_CUSTOMREQUEST`
- Added unit tests for each new method
- No interface changes (backward compatible)

## Test plan

- [ ] Unit tests pass: `vendor/bin/phpunit lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php`
- [ ] Static analysis: `vendor/bin/phpcs --standard=Magento2` passes on changed files
- [ ] Integration: verify Curl client works for PUT/DELETE/PATCH requests against a test endpoint
