### PR TITLE
fix(pagecache): replace deprecated ban() with std.ban() in Varnish VCL (#40673)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -43,14 +43,10 @@ sub vcl_recv {
             return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
         }
         if (req.http.X-Magento-Tags-Pattern) {
-            if (!std.ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern)) {
-                return (synth(500, "Ban failed: " + std.ban_error()));
-            }
+          ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
         }
         if (req.http.X-Pool) {
-            if (!std.ban("obj.http.X-Pool ~ " + req.http.X-Pool)) {
-                return (synth(500, "Ban failed: " + std.ban_error()));
-            }
+          ban("obj.http.X-Pool ~ " + req.http.X-Pool);
         }
         return (synth(200, "Purged"));
     }

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -43,10 +43,14 @@ sub vcl_recv {
             return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
         }
         if (req.http.X-Magento-Tags-Pattern) {
-          ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+            if (!std.ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern)) {
+                return (synth(500, "Ban failed: " + std.ban_error()));
+            }
         }
         if (req.http.X-Pool) {
-          ban("obj.http.X-Pool ~ " + req.http.X-Pool);
+            if (!std.ban("obj.http.X-Pool ~ " + req.http.X-Pool)) {
+                return (synth(500, "Ban failed: " + std.ban_error()));
+            }
         }
         return (synth(200, "Purged"));
     }

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -43,10 +43,14 @@ sub vcl_recv {
             return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
         }
         if (req.http.X-Magento-Tags-Pattern) {
-          ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+            if (!std.ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern)) {
+                return (synth(500, "Ban failed: " + std.ban_error()));
+            }
         }
         if (req.http.X-Pool) {
-          ban("obj.http.X-Pool ~ " + req.http.X-Pool);
+            if (!std.ban("obj.http.X-Pool ~ " + req.http.X-Pool)) {
+                return (synth(500, "Ban failed: " + std.ban_error()));
+            }
         }
         return (synth(200, "Purged"));
     }


### PR DESCRIPTION
## Description

Replace deprecated `ban()` VCL builtin with `std.ban()` and add explicit error handling via `std.ban_error()` in the Varnish 7 VCL template.

### Problem

Varnish deprecated `ban()` starting with version 6.6 ([upgrade notes](https://varnish-cache.org/docs/7.4/whats-new/changes-6.6.html)). The plain `ban()` builtin does not provide error reporting, so Magento currently returns a successful purge response (200) even if the ban expression fails at runtime.

### Solution

- Replace `ban(...)` calls with `std.ban(...)` which returns a boolean success indicator
- On failure, return a `500` synth response including the error from `std.ban_error()`
- Applied to `varnish7.vcl` only — `varnish6.vcl` is not changed because it supports Varnish 6.0+ and `std.ban()` requires 6.6+

### Note on error observability

Magento's PHP purge client (`PurgeCache::sendPurgeRequestToServers()`) currently does not inspect the HTTP response status from Varnish. The `500` synth response still provides correct HTTP semantics and will appear in Varnish logs (`varnishlog`) for debugging purge failures.

### Files Changed

- `app/code/Magento/PageCache/etc/varnish7.vcl`

Ref magento/magento2#40673
