### PR TITLE
fix(pagecache): preserve stale cache object when bgfetch returns 5xx (#40673)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -146,6 +146,11 @@ sub vcl_backend_response {
 
     set beresp.grace = 3d;
 
+    # Preserve stale object when a background fetch returns a server error
+    if (beresp.status >= 500 && bereq.is_bgfetch) {
+        return (abandon);
+    }
+
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;
     }

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -150,6 +150,11 @@ sub vcl_backend_response {
 
     set beresp.grace = 3d;
 
+    # Preserve stale object when a background fetch returns a server error
+    if (beresp.status >= 500 && bereq.is_bgfetch) {
+        return (abandon);
+    }
+
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;
     }

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -150,6 +150,11 @@ sub vcl_backend_response {
 
     set beresp.grace = 3d;
 
+    # Preserve stale object when a background fetch returns a server error
+    if (beresp.status >= 500 && bereq.is_bgfetch) {
+        return (abandon);
+    }
+
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;
     }


### PR DESCRIPTION
## Description

Add `return (abandon)` when a background fetch receives a 5xx response, preventing a failing backend refresh from replacing a usable stale cache object.

### Problem

Magento's VCL templates use grace periods to serve stale content while revalidating in the background. However, if the backend returns a 5xx error during this background fetch, Varnish replaces the cached object with the error response. This defeats the purpose of grace-based serving during backend incidents.

### Solution

Add an early check in `vcl_backend_response`:
```vcl
if (beresp.status >= 500 && bereq.is_bgfetch) {
    return (abandon);
}
```

This follows [Varnish's documented grace behavior](https://varnish-cache.org/docs/7.6/users-guide/vcl-grace.html) and ensures stale objects survive backend failures during revalidation.

Applied to varnish5, varnish6, and varnish7 templates (`bereq.is_bgfetch` requires Varnish 5.1+).

### Files Changed

- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`

Ref magento/magento2#40673
