### PR TITLE
Set beresp.keep in VCL for conditional backend revalidation (#40673)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -144,6 +144,7 @@ sub process_graphql_headers {
 sub vcl_backend_response {
 
     set beresp.grace = 3d;
+    set beresp.keep = 1d;
 
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -145,6 +145,7 @@ sub process_graphql_headers {
 sub vcl_backend_response {
 
     set beresp.grace = 3d;
+    set beresp.keep = 1d;
 
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -248,7 +248,7 @@ sub vcl_hit {
             return (deliver);
         } else {
             # Hit after TTL and grace expiration
-            return (restart);
+            return (miss);
         }
     } else {
         # server is not healthy, retrieve from cache

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -149,6 +149,7 @@ sub process_graphql_headers {
 sub vcl_backend_response {
 
     set beresp.grace = 3d;
+    set beresp.keep = 1d;
 
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -248,7 +248,7 @@ sub vcl_hit {
             return (deliver);
         } else {
             # Hit after TTL and grace expiration
-            return (restart);
+            return (miss);
         }
     } else {
         # server is not healthy, retrieve from cache

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -149,6 +149,7 @@ sub process_graphql_headers {
 sub vcl_backend_response {
 
     set beresp.grace = 3d;
+    set beresp.keep = 1d;
 
     if (beresp.http.content-type ~ "text") {
         set beresp.do_esi = true;


### PR DESCRIPTION
## Description

Set `beresp.keep` in `vcl_backend_response` and fix the `vcl_hit` lookup path in Varnish 6/7 templates to enable conditional backend revalidation via `304 Not Modified` responses.

### Problem

Magento sets `beresp.grace = 3d` but never sets `beresp.keep`. The Varnish runtime parameter `default_keep` defaults to `0` ([reference](https://varnish-cache.org/docs/6.6/reference/varnishd.html)), which means expired objects are not preserved for conditional revalidation. Without `keep`, Varnish cannot issue `If-Modified-Since` or `If-None-Match` headers to the backend.

Additionally, `varnish6.vcl` and `varnish7.vcl` use `return (restart)` in `vcl_hit` when an object is past grace. On restart, `vcl_recv` sets `req.hash_always_miss = true`, which forces an unconditional miss and bypasses any kept object — preventing conditional revalidation even if `keep` were set.

### Solution

1. Add `set beresp.keep = 1d;` alongside the existing `beresp.grace` in all 4 VCL templates
2. Change `return (restart)` to `return (miss)` in `vcl_hit` for varnish6 and varnish7 templates so the kept object remains accessible for conditional backend requests

`return (miss)` transitions to `vcl_miss` → backend fetch while preserving the kept object, allowing Varnish to send conditional headers. The varnish4 (`return (fetch)`) and varnish5 (`return (miss)`) templates already use the correct flow.

### Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl` — add `beresp.keep`
- `app/code/Magento/PageCache/etc/varnish5.vcl` — add `beresp.keep`
- `app/code/Magento/PageCache/etc/varnish6.vcl` — add `beresp.keep` + fix `vcl_hit` flow
- `app/code/Magento/PageCache/etc/varnish7.vcl` — add `beresp.keep` + fix `vcl_hit` flow

Ref magento/magento2#40673
