### PR TITLE
fix(pagecache): pass authenticated non-GraphQL requests in Varnish VCL (#40673)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -103,6 +103,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Pass authenticated non-GraphQL requests (reproduces built-in VCL safety rule
+    # bypassed by the unconditional return(hash) below)
+    if (req.url !~ "/graphql" && req.http.Authorization) {
+        return (pass);
+    }
+
     return (hash);
 }
 

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -104,6 +104,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Pass authenticated non-GraphQL requests (reproduces built-in VCL safety rule
+    # bypassed by the unconditional return(hash) below)
+    if (req.url !~ "/graphql" && req.http.Authorization) {
+        return (pass);
+    }
+
     return (hash);
 }
 

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -108,6 +108,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Pass authenticated non-GraphQL requests (reproduces built-in VCL safety rule
+    # bypassed by the unconditional return(hash) below)
+    if (req.url !~ "/graphql" && req.http.Authorization) {
+        return (pass);
+    }
+
     return (hash);
 }
 

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -108,6 +108,12 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Pass authenticated non-GraphQL requests (reproduces built-in VCL safety rule
+    # bypassed by the unconditional return(hash) below)
+    if (req.url !~ "/graphql" && req.http.Authorization) {
+        return (pass);
+    }
+
     return (hash);
 }
 


### PR DESCRIPTION
## Description

Explicitly pass non-GraphQL requests carrying an `Authorization` header, reproducing a built-in Varnish safety rule that Magento's unconditional `return (hash)` bypasses.

### Problem

Magento's VCL templates end `vcl_recv` with an unconditional `return (hash)`. This means [Varnish's built-in `vcl_recv`](https://varnish-cache.org/docs/7.6/users-guide/vcl-built-in-code.html) never runs, including its safety rule that passes requests with `Authorization` headers.

The existing bypass only covers authenticated GraphQL requests (checking for `Bearer` token + missing `X-Magento-Cache-Id`). Non-GraphQL requests with any `Authorization` header (e.g., REST API with Basic auth, third-party integrations) currently pass through to `return (hash)` and could be served from cache or pollute the cache with authenticated responses.

### Solution

Add an explicit pass rule for non-GraphQL requests with an `Authorization` header:

```vcl
if (req.url !~ "/graphql" && req.http.Authorization) {
    return (pass);
}
```

This preserves the existing GraphQL cache-ID logic while restoring the built-in safety behavior for all other authenticated traffic.

### Files Changed

- `app/code/Magento/PageCache/etc/varnish4.vcl`
- `app/code/Magento/PageCache/etc/varnish5.vcl`
- `app/code/Magento/PageCache/etc/varnish6.vcl`
- `app/code/Magento/PageCache/etc/varnish7.vcl`

Ref magento/magento2#40673
