### PR TITLE
fix: add X-Content-Type-Options nosniff header to nginx config

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -70,6 +70,7 @@ location ~* ^/setup($|/) {
 
     location ~ ^/setup/pub/ {
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
     }
 }
 
@@ -93,6 +94,7 @@ location ~* ^/update($|/) {
 
     location ~ ^/update/pub/ {
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
     }
 }
 
@@ -106,6 +108,7 @@ location /pub/ {
     }
     alias $MAGE_ROOT/pub/;
     add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
 }
 
 location /static/ {
@@ -120,6 +123,7 @@ location /static/ {
     location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2|html|json|webmanifest)$ {
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
 
         if (!-f $request_filename) {
             rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
@@ -128,6 +132,7 @@ location /static/ {
     location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
         add_header Cache-Control "no-store";
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
         expires    off;
 
         if (!-f $request_filename) {
@@ -138,6 +143,7 @@ location /static/ {
         rewrite ^/static/(version\d*/)?(.*)$ /static.php?resource=$2 last;
     }
     add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
 }
 
 location /media/ {
@@ -173,16 +179,19 @@ location /media/ {
     location ~* \.(ico|jpg|jpeg|png|gif|svg|svgz|webp|avif|avifs|js|css|eot|ttf|otf|woff|woff2)$ {
         add_header Cache-Control "public";
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
         expires +1y;
         try_files $uri $uri/ /get.php$is_args$args;
     }
     location ~* \.(zip|gz|gzip|bz2|csv|xml)$ {
         add_header Cache-Control "no-store";
         add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
         expires    off;
         # try_files $uri $uri/ /get.php$is_args$args;
     }
     add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-Content-Type-Options "nosniff";
 }
 
 location /media/customer/ {


### PR DESCRIPTION
## Description

Add the `X-Content-Type-Options: nosniff` security header alongside the existing `X-Frame-Options` header in all applicable location blocks in `nginx.conf.sample`.

### Problem

The sample Nginx configuration sets `X-Frame-Options: SAMEORIGIN` in multiple location blocks to prevent clickjacking, but does not set `X-Content-Type-Options: nosniff`. Without this header, browsers may perform MIME type sniffing on responses, potentially interpreting files as a different content type than declared.

This can lead to security issues such as:
- A CSS file containing JavaScript being executed as script
- An uploaded image being interpreted as HTML
- Content-type confusion attacks on user-uploaded files served from `/media/`

### Solution

Add `add_header X-Content-Type-Options "nosniff";` in every location block that already sets `X-Frame-Options`, including:
- `/setup/pub/` and `/update/pub/` (admin setup/update assets)
- `/pub/` (public assets)
- `/static/` (versioned static assets, compressed files, fallback)
- `/media/` (media assets, compressed files, fallback)

This follows the same pattern used for `X-Frame-Options` — applied per-location rather than globally, matching Nginx's `add_header` inheritance behavior (child blocks don't inherit parent `add_header` directives).

### References

- [MDN: X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)

### Files Changed

- `nginx.conf.sample`
