### PR TITLE
fix: mitigate httpoxy vulnerability (CVE-2016-5385) in nginx config

### DIFF
--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -53,6 +53,7 @@ location ~* ^/setup($|/) {
         # allow 127.0.0.1;
 
         fastcgi_pass   fastcgi_backend;
+        fastcgi_param  HTTP_PROXY "";
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
         fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
@@ -80,6 +81,7 @@ location ~* ^/update($|/) {
     location ~ ^/update/index.php {
         fastcgi_split_path_info ^(/update/index.php)(/.+)$;
         fastcgi_pass   fastcgi_backend;
+        fastcgi_param  HTTP_PROXY "";
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         fastcgi_param  PATH_INFO        $fastcgi_path_info;
@@ -211,6 +213,7 @@ location /errors/ {
 location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
     try_files $uri =404;
     fastcgi_pass   fastcgi_backend;
+    fastcgi_param  HTTP_PROXY "";
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 


### PR DESCRIPTION
## Description

Mitigate the [httpoxy vulnerability](https://httpoxy.org/) (CVE-2016-5385) in the sample Nginx configuration by clearing the `Proxy` request header before it reaches PHP-FPM.

### Problem

When Nginx passes a request to PHP-FPM via FastCGI, any `Proxy:` HTTP request header is automatically mapped to the `HTTP_PROXY` environment variable by the CGI specification. A malicious client can send a crafted `Proxy:` header to redirect outbound HTTP requests made by PHP (via Guzzle, cURL, or `file_get_contents`) through an attacker-controlled proxy.

This affects any PHP code that respects the `HTTP_PROXY` environment variable, including:
- Guzzle HTTP client (used extensively by Magento for payment gateways, shipping providers, etc.)
- PHP's native stream wrapper with `file_get_contents`
- Any library that reads `HTTP_PROXY` for proxy configuration

The Varnish VCL templates already mitigate this (see magento/magento2#40654), but the Nginx sample config does not.

### Solution

Add `fastcgi_param HTTP_PROXY "";` to all three FastCGI pass blocks in `nginx.conf.sample`:
- Setup application (`/setup`)
- Update application (`/update`)
- Main application (PHP entry point)

This ensures the `HTTP_PROXY` environment variable is always empty regardless of client-supplied headers.

### References

- https://httpoxy.org/
- [CVE-2016-5385](https://nvd.nist.gov/vuln/detail/CVE-2016-5385)
- [Nginx official mitigation](https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx/)

### Files Changed

- `nginx.conf.sample`
