### PR TITLE
fix: add X-Content-Type-Options nosniff header to Apache htaccess

### DIFF
--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -287,4 +287,7 @@ ErrorDocument 403 /errors/404.php
 
     ## Prevent clickjacking
     Header set X-Frame-Options SAMEORIGIN
+
+    ## Prevent MIME type sniffing
+    Header set X-Content-Type-Options "nosniff"
 </IfModule>


### PR DESCRIPTION
## Description

Add the `X-Content-Type-Options: nosniff` security header in `pub/.htaccess` alongside the existing `X-Frame-Options` header.

### Problem

The `.htaccess` configuration sets `X-Frame-Options: SAMEORIGIN` to prevent clickjacking but does not set `X-Content-Type-Options: nosniff`. Without this header, browsers may MIME-sniff responses and interpret files as a different content type than declared, which can lead to:

- Uploaded files in `/media/` being interpreted as executable HTML/JavaScript
- CSS files containing JavaScript being executed as script
- Content-type confusion attacks

### Solution

Add `Header set X-Content-Type-Options "nosniff"` in the `mod_headers` block of `pub/.htaccess`. This is set at the top-level `.htaccess` so it applies to all responses served through Apache.

### References

- [MDN: X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
- [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)

### Files Changed

- `pub/.htaccess`
