### PR TITLE
fix: remove Apache 2.2 compatibility blocks from htaccess files

### DIFF
--- a/.github/.htaccess
+++ b/.github/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    Order deny,allow
-    Deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
+Require all denied

--- a/.htaccess.sample
+++ b/.htaccess.sample
@@ -185,166 +185,58 @@
     RedirectMatch 403 /\.git
 
     <Files composer.json>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files composer.lock>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .gitignore>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .htaccess>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .htaccess.sample>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .php_cs.dist>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files CHANGELOG.md>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files COPYING.txt>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files Gruntfile.js>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files LICENSE.txt>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files LICENSE_AFL.txt>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files nginx.conf.sample>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files package.json>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files php.ini.sample>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files README.md>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files magento_umask>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files auth.json>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .user.ini>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
 
 # For 404s and 403s that aren't handled by the application, show plain 404 response

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/.htaccess
+++ b/dev/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/acceptance/.htaccess.sample
+++ b/dev/tests/acceptance/.htaccess.sample
@@ -1,11 +1,5 @@
 ##############################################
 ## Allow access to command.php
     <FilesMatch "command.php">
-        <IfVersion < 2.4>
-            order allow,deny
-            allow from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all granted
-        </IfVersion>
+        Require all granted
     </FilesMatch>

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromClone/cache/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testFromCreateProject/cache/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/cache/.htaccess
+++ b/dev/tests/integration/testsuite/Magento/Framework/Composer/_files/testSkeleton/cache/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/generated/.htaccess
+++ b/generated/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/phpserver/.htaccess
+++ b/phpserver/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -205,42 +205,18 @@
 ## Deny access to release notes to prevent disclosure of the installed Magento version
 
     <Files RELEASE_NOTES.txt>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
     <Files .htaccess>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
 ## Deny access  to cron.php
     <Files cron.php>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
 ## Deny access  to .user.ini
     <Files .user.ini>
-        <IfVersion < 2.4>
-            order allow,deny
-            deny from all
-        </IfVersion>
-        <IfVersion >= 2.4>
-            Require all denied
-        </IfVersion>
+        Require all denied
     </Files>
 
 # For 404s and 403s that aren't handled by the application, show plain 404 response

--- a/pub/media/custom_options/.htaccess
+++ b/pub/media/custom_options/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    order deny,allow
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
+Require all denied

--- a/pub/media/customer/.htaccess
+++ b/pub/media/customer/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/pub/media/customer_address/.htaccess
+++ b/pub/media/customer_address/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
+Require all denied

--- a/pub/media/downloadable/.htaccess
+++ b/pub/media/downloadable/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/pub/media/import/.htaccess
+++ b/pub/media/import/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/pub/media/theme_customization/.htaccess
+++ b/pub/media/theme_customization/.htaccess
@@ -1,10 +1,4 @@
 Options -Indexes
 <Files ~ "\.xml$">
-    <IfVersion < 2.4>
-        order allow,deny
-        deny from all
-    </IfVersion>
-    <IfVersion >= 2.4>
-        Require all denied
-    </IfVersion>
+    Require all denied
 </Files>

--- a/setup/.htaccess
+++ b/setup/.htaccess
@@ -1,13 +1,7 @@
 # If you want to enable the web based setup functionality, add your ip address
-# to the allow list below or comment out the IfVersion Deny deny blocks below.
+# to the allow list below or comment out the Deny blocks below.
 <Files "index.php">
-    <IfVersion < 2.4>
-        order allow,deny
-        deny from all
-    </IfVersion>
-    <IfVersion >= 2.4>
-        Require all denied
-    </IfVersion>
+    Require all denied
 </Files>
 
 Options -Indexes

--- a/setup/config/.htaccess
+++ b/setup/config/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/setup/performance-toolkit/.htaccess
+++ b/setup/performance-toolkit/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/setup/src/.htaccess
+++ b/setup/src/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/setup/view/.htaccess
+++ b/setup/view/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,8 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
-
+Require all denied

--- a/vendor/.htaccess
+++ b/vendor/.htaccess
@@ -1,7 +1,1 @@
-<IfVersion < 2.4>
-    order allow,deny
-    deny from all
-</IfVersion>
-<IfVersion >= 2.4>
-    Require all denied
-</IfVersion>
+Require all denied


### PR DESCRIPTION
## Description

Remove `<IfVersion>` dual-syntax blocks that maintain Apache 2.2 compatibility from all `.htaccess` files, keeping only the Apache 2.4+ `Require` directives.

### Problem

Every `.htaccess` file that restricts access uses a dual-syntax pattern:

```apache
<IfVersion < 2.4>
    order allow,deny
    deny from all
</IfVersion>
<IfVersion >= 2.4>
    Require all denied
</IfVersion>
```

Apache 2.2 reached end-of-life in **July 2017** — nearly 9 years ago. All major Linux distributions have shipped Apache 2.4+ for years. The `<IfVersion>` wrappers add visual noise and maintenance burden across 29 files without protecting any supported deployment.

### Solution

Replace all dual-syntax `<IfVersion>` blocks with the plain Apache 2.4+ equivalent:

```apache
Require all denied
```

### Files Changed

- `.htaccess.sample` (18 `<Files>` blocks simplified)
- `pub/.htaccess` (4 `<Files>` blocks simplified)
- `setup/.htaccess` (1 `<Files>` block simplified, comment updated)
- `dev/tests/acceptance/.htaccess.sample` (1 `<FilesMatch>` block simplified)
- `pub/media/theme_customization/.htaccess` (1 `<Files>` block simplified)
- 17 simple deny-all files: `generated/`, `var/`, `pub/media/customer/`, `pub/media/downloadable/`, `pub/media/import/`, `pub/media/custom_options/`, `pub/media/customer_address/`, `vendor/`, `phpserver/`, `lib/`, `dev/`, `bin/`, `app/`, `.github/`, `setup/config/`, `setup/src/`, `setup/view/`, `setup/performance-toolkit/`
- 6 test fixture `.htaccess` files under `dev/tests/integration/`
