### PR TITLE
fix: remove end-of-life PHP version references from htaccess files

### DIFF
--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -6,61 +6,14 @@
 #   SetEnv MAGE_MODE default
 
 ############################################
-## Uncomment these lines for CGI mode.
-## Make sure to specify the correct cgi php binary file name
-## it might be /cgi-bin/php-cgi
-
-#    Action php5-cgi /cgi-bin/php5-cgi
-#    AddHandler php5-cgi .php
-
-############################################
-## GoDaddy specific options
-
-#   Options -MultiViews
-
-## You might also need to add this line to php.ini
-##     cgi.fix_pathinfo = 1
-## If it still doesn't work, rename php.ini to php5.ini
-
-############################################
 ## Enable usage of methods arguments in backtrace
 
     #SetEnv MAGE_DEBUG_SHOW_ARGS 1
 
 ############################################
-## This line is specific for 1and1 hosting
-
-    #AddType x-mapp-php5 .php
-    #AddHandler x-mapp-php5 .php
-
-############################################
 ## Default index file
 
     DirectoryIndex index.php
-
-<IfModule mod_php7.c>
-############################################
-## Adjust memory limit
-
-    php_value memory_limit 756M
-    php_value max_execution_time 18000
-
-############################################
-## Disable automatic session start
-## before autoload was initialized
-
-    php_flag session.auto_start off
-
-############################################
-## Enable resulting html compression
-
-    #php_flag zlib.output_compression on
-
-###########################################
-# Disable user agent verification to not break multiple image upload
-
-    php_flag suhosin.session.cryptua off
-</IfModule>
 
 <IfModule mod_php.c>
 ############################################

--- a/pub/media/.htaccess
+++ b/pub/media/.htaccess
@@ -1,9 +1,5 @@
 Options -Indexes
 
-<IfModule mod_php7.c>
-    php_flag engine 0
-</IfModule>
-
 <IfModule mod_php.c>
     php_flag engine 0
 </IfModule>

--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -1,7 +1,3 @@
-<IfModule mod_php7.c>
-    php_flag engine 0
-</IfModule>
-
 <IfModule mod_php.c>
     php_flag engine 0
 </IfModule>


### PR DESCRIPTION
## Description

Remove references to end-of-life PHP versions (PHP 5.x and PHP 7.x) from `.htaccess` files.

### Problem

Several `.htaccess` files contain:

1. **`<IfModule mod_php7.c>` blocks** — Duplicate configuration blocks for PHP 7.x alongside the `mod_php.c` blocks for PHP 8+. PHP 7.4 (the last 7.x release) reached EOL in November 2022, and Magento 2.4.7+ requires PHP 8.2+.

2. **Suhosin extension reference** — `php_flag suhosin.session.cryptua off` inside the `mod_php7.c` block. The Suhosin extension is abandoned and never supported PHP 7+, making this directive dead code even on PHP 7.

3. **PHP 5 CGI references** — Commented-out `php5-cgi` handler, `x-mapp-php5` type definitions, and `php5.ini` references from hosting-specific workarounds that are over a decade old.

### Solution

- Remove all `<IfModule mod_php7.c>` blocks (3 files)
- Remove commented-out PHP 5 CGI handler section
- Remove 1and1 hosting PHP 5 workaround
- Remove GoDaddy CGI section referencing `php5.ini`
- Keep all `<IfModule mod_php.c>` blocks (PHP 8+ compatible)

### Files Changed

- `pub/.htaccess` (remove mod_php7 block, suhosin, PHP 5 CGI/hosting sections)
- `pub/media/.htaccess` (remove mod_php7 block)
- `pub/static/.htaccess` (remove mod_php7 block)
