### PR TITLE
fix: remove IE/Flash references and fix font MIME types in htaccess

### DIFF
--- a/pub/.htaccess
+++ b/pub/.htaccess
@@ -1,4 +1,8 @@
 ############################################
+## Copyright 2026 Adobe
+## All Rights Reserved.
+
+############################################
 ## Optional override of deployment mode. We recommend you use the
 ## command bin/magento deploy:mode:set to switch modes instead
 
@@ -253,37 +257,7 @@ ErrorDocument 403 /errors/404.php
 
     #FileETag none
 
-# ######################################################################
-# # INTERNET EXPLORER                                                  #
-# ######################################################################
-
-# ----------------------------------------------------------------------
-# | Document modes                                                     |
-# ----------------------------------------------------------------------
-
-# Force Internet Explorer 8/9/10 to render pages in the highest mode
-# available in the various cases when it may not.
-#
-# https://hsivonen.fi/doctype/#ie8
-#
-# (!) Starting with Internet Explorer 11, document modes are deprecated.
-# If your business still relies on older web apps and services that were
-# designed for older versions of Internet Explorer, you might want to
-# consider enabling `Enterprise Mode` throughout your company.
-#
-# https://msdn.microsoft.com/en-us/library/ie/bg182625.aspx#docmode
-# http://blogs.msdn.com/b/ie/archive/2014/04/02/stay-up-to-date-with-enterprise-mode-for-internet-explorer-11.aspx
-
 <IfModule mod_headers.c>
-    ############################################
-    Header set X-UA-Compatible "IE=edge"
-
-    # `mod_headers` cannot match based on the content-type, however,
-    # the `X-UA-Compatible` response header should be send only for
-    # HTML documents and not for the other resources.
-    <FilesMatch "\.(appcache|atom|bbaw|bmp|crx|css|cur|eot|f4[abpv]|flv|geojson|gif|htc|ico|jpe?g|js|json(ld)?|m4[av]|manifest|map|mp4|oex|og[agv]|opus|otf|pdf|png|rdf|rss|safariextz|svgz?|swf|topojson|tt[cf]|txt|vcard|vcf|vtt|webapp|web[mp]|webmanifest|woff2?|xloc|xml|xpi)$">
-        Header unset X-UA-Compatible
-    </FilesMatch>
 
     ## Prevent clickjacking
     Header set X-Frame-Options SAMEORIGIN

--- a/pub/media/.htaccess
+++ b/pub/media/.htaccess
@@ -1,3 +1,7 @@
+############################################
+## Copyright 2026 Adobe
+## All Rights Reserved.
+
 Options -Indexes
 
 <IfModule mod_php7.c>
@@ -61,10 +65,10 @@ AddType image/svg+xml svg svgz
 
 # Fonts
 AddType application/vnd.ms-fontobject eot
-AddType application/x-font-ttf ttf
-AddType application/x-font-otf otf
-AddType application/x-font-woff woff
-AddType application/font-woff2 woff2
+AddType font/ttf ttf
+AddType font/otf otf
+AddType font/woff woff
+AddType font/woff2 woff2
 
 # Archives and exports
 AddType application/zip gzip
@@ -129,9 +133,9 @@ AddType application/xml xml
         ExpiresDefault "access plus 1 year"
     </FilesMatch>
     ExpiresByType application/vnd.ms-fontobject "access plus 1 year"
-    ExpiresByType application/x-font-ttf "access plus 1 year"
-    ExpiresByType application/x-font-otf "access plus 1 year"
-    ExpiresByType application/x-font-woff "access plus 1 year"
-    ExpiresByType application/font-woff2 "access plus 1 year"
+    ExpiresByType font/ttf "access plus 1 year"
+    ExpiresByType font/otf "access plus 1 year"
+    ExpiresByType font/woff "access plus 1 year"
+    ExpiresByType font/woff2 "access plus 1 year"
 
 </IfModule>

--- a/pub/static/.htaccess
+++ b/pub/static/.htaccess
@@ -1,3 +1,7 @@
+############################################
+## Copyright 2026 Adobe
+## All Rights Reserved.
+
 <IfModule mod_php7.c>
     php_flag engine 0
 </IfModule>
@@ -22,11 +26,6 @@ Options -MultiViews
     RewriteCond %{REQUEST_FILENAME} !-l
 
     RewriteRule .* ../static.php?resource=$0 [L]
-    # Detects if moxieplayer request with uri params and redirects to uri without params
-    <Files moxieplayer.swf>
-     	RewriteCond %{QUERY_STRING} !^$
-     	RewriteRule ^(.*)$ %{REQUEST_URI}? [R=301,L]
-     </Files>
 </IfModule>
 
 ############################################
@@ -57,10 +56,10 @@ AddType image/svg+xml svg svgz
 
 # Fonts
 AddType application/vnd.ms-fontobject eot
-AddType application/x-font-ttf ttf
-AddType application/x-font-otf otf
-AddType application/x-font-woff woff
-AddType application/font-woff2 woff2
+AddType font/ttf ttf
+AddType font/otf otf
+AddType font/woff woff
+AddType font/woff2 woff2
 
 # Manifest
 AddType application/manifest+json webmanifest
@@ -136,10 +135,10 @@ AddType application/xml xml
         ExpiresDefault "access plus 1 year"
     </FilesMatch>
     ExpiresByType application/vnd.ms-fontobject "access plus 1 year"
-    ExpiresByType application/x-font-ttf "access plus 1 year"
-    ExpiresByType application/x-font-otf "access plus 1 year"
-    ExpiresByType application/x-font-woff "access plus 1 year"
-    ExpiresByType application/font-woff2 "access plus 1 year"
+    ExpiresByType font/ttf "access plus 1 year"
+    ExpiresByType font/otf "access plus 1 year"
+    ExpiresByType font/woff "access plus 1 year"
+    ExpiresByType font/woff2 "access plus 1 year"
     ExpiresByType font/opentype "access plus 1 year"
     ExpiresByType font/truetype "access plus 1 year"
 


### PR DESCRIPTION
## Description

Remove references to dead technologies (Internet Explorer, Adobe Flash) and update deprecated font MIME types to IANA-registered standards in `.htaccess` files.

### Changes

#### 1. Remove IE `X-UA-Compatible` header and document modes section

`pub/.htaccess` sets `X-UA-Compatible: IE=edge` and includes a large `FilesMatch` block to unset it on non-HTML resources. Internet Explorer is completely end-of-life:
- IE 11 reached EOL in June 2022
- Edge has used Chromium since January 2020
- No modern browser recognizes `X-UA-Compatible`

This removes the header, the FilesMatch exclusion block, and the explanatory comment section (~20 lines).

#### 2. Remove Flash moxieplayer reference

`pub/static/.htaccess` contains a rewrite rule for `moxieplayer.swf` (a Flash-based media player). Adobe Flash reached end-of-life in December 2020 and is blocked by all modern browsers.

#### 3. Fix deprecated font MIME types

Both `pub/media/.htaccess` and `pub/static/.htaccess` use non-standard `application/x-font-*` MIME types for fonts. These are replaced with the IANA-registered types:

| Old (deprecated) | New (IANA standard) |
|---|---|
| `application/x-font-ttf` | `font/ttf` |
| `application/x-font-otf` | `font/otf` |
| `application/x-font-woff` | `font/woff` |
| `application/font-woff2` | `font/woff2` |

Updated in both `AddType` directives and `ExpiresByType` directives.

### Files Changed

- `pub/.htaccess` (IE section removal)
- `pub/static/.htaccess` (Flash removal + font MIME types)
- `pub/media/.htaccess` (font MIME types)
