### PR TITLE
perf: opcache-friendly compiled config for catalog_attributes.xml

### DIFF
--- a/app/code/Magento/Catalog/Model/Attribute/Config/Data.php
+++ b/app/code/Magento/Catalog/Model/Attribute/Config/Data.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Catalog\Model\Attribute\Config;
 
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 
 /**
@@ -19,14 +20,16 @@ class Data extends \Magento\Framework\Config\Data
      * @param \Magento\Framework\Config\CacheInterface $cache
      * @param string|null $cacheId
      * @param SerializerInterface|null $serializer
+     * @param ConfigWriterInterface|null $configWriter
      * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
      */
     public function __construct(
         \Magento\Catalog\Model\Attribute\Config\Reader $reader,
         \Magento\Framework\Config\CacheInterface $cache,
         $cacheId = 'catalog_attributes',
-        ?SerializerInterface $serializer = null
+        ?SerializerInterface $serializer = null,
+        ?ConfigWriterInterface $configWriter = null
     ) {
-        parent::__construct($reader, $cache, $cacheId, $serializer);
+        parent::__construct($reader, $cache, $cacheId, $serializer, null, $configWriter);
     }
 }

--- a/app/code/Magento/Catalog/etc/di.xml
+++ b/app/code/Magento/Catalog/etc/di.xml
@@ -472,6 +472,7 @@
     <type name="Magento\Catalog\Model\Attribute\Config\Data">
         <arguments>
             <argument name="reader" xsi:type="object">Magento\Catalog\Model\Attribute\Config\Reader\Proxy</argument>
+            <argument name="configWriter" xsi:type="object">Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem</argument>
         </arguments>
     </type>
     <type name="Magento\Catalog\Model\ProductOptions\Config">

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -897,6 +897,7 @@
         <arguments>
             <argument name="cache" xsi:type="object">Magento\Framework\App\Interception\Cache\CompiledConfig</argument>
             <argument name="reader" xsi:type="object">Magento\Framework\Event\Config\Reader\Proxy</argument>
+            <argument name="configWriter" xsi:type="object">Magento\Framework\App\ObjectManager\ConfigWriter\Filesystem</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\View\Asset\Collection" shared="false" />

--- a/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriter/Filesystem.php
+++ b/lib/internal/Magento/Framework/App/ObjectManager/ConfigWriter/Filesystem.php
@@ -41,10 +41,10 @@ class Filesystem implements ConfigWriterInterface
     {
         $this->initialize();
         $configuration = sprintf('<?php return %s;', var_export($config, true));
-        file_put_contents(
-            $this->directoryList->getPath(DirectoryList::GENERATED_METADATA) . '/' . $key  . '.php',
-            $configuration
-        );
+        $targetPath = $this->directoryList->getPath(DirectoryList::GENERATED_METADATA) . '/' . $key  . '.php';
+        $tempPath = $targetPath . '.' . getmypid() . '.tmp';
+        file_put_contents($tempPath, $configuration);
+        rename($tempPath, $targetPath);
     }
 
     /**

--- a/lib/internal/Magento/Framework/Config/Data.php
+++ b/lib/internal/Magento/Framework/Config/Data.php
@@ -5,8 +5,10 @@
  */
 namespace Magento\Framework\Config;
 
-use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ObjectManager\ConfigLoader\Compiled;
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
+use Magento\Framework\Serialize\SerializerInterface;
 
 /**
  * Represents loaded and cached configuration data, should be used to gain access to different types
@@ -71,6 +73,11 @@ class Data implements \Magento\Framework\Config\DataInterface
     private $serializer;
 
     /**
+     * @var ConfigWriterInterface|null
+     */
+    private $configWriter;
+
+    /**
      * Constructor
      *
      * @param ReaderInterface $reader
@@ -78,6 +85,7 @@ class Data implements \Magento\Framework\Config\DataInterface
      * @param string $cacheId
      * @param SerializerInterface|null $serializer
      * @param array|null $cacheTags
+     * @param ConfigWriterInterface|null $configWriter
      */
     public function __construct(
         ReaderInterface $reader,
@@ -85,11 +93,13 @@ class Data implements \Magento\Framework\Config\DataInterface
         $cacheId,
         ?SerializerInterface $serializer = null,
         ?array $cacheTags = null,
+        ?ConfigWriterInterface $configWriter = null,
     ) {
         $this->reader = $reader;
         $this->cache = $cache;
         $this->cacheId = $cacheId;
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(SerializerInterface::class);
+        $this->configWriter = $configWriter;
         if ($cacheTags) {
             $this->cacheTags = $cacheTags;
         }
@@ -103,6 +113,11 @@ class Data implements \Magento\Framework\Config\DataInterface
      */
     protected function initData()
     {
+        if ($this->configWriter && $this->isCompiledConfigAvailable($this->cacheId)) {
+            $this->merge($this->loadCompiledConfig($this->cacheId));
+            return;
+        }
+
         $data = $this->cache->load($this->cacheId);
         if (false === $data) {
             $data = $this->reader->read();
@@ -111,7 +126,33 @@ class Data implements \Magento\Framework\Config\DataInterface
             $data = $this->serializer->unserialize($data);
         }
 
+        if ($this->configWriter) {
+            $this->configWriter->write($this->cacheId, $data);
+        }
+
         $this->merge($data);
+    }
+
+    /**
+     * Check if a compiled PHP config file is available
+     *
+     * @param string $key
+     * @return bool
+     */
+    protected function isCompiledConfigAvailable(string $key): bool
+    {
+        return file_exists(Compiled::getFilePath($key));
+    }
+
+    /**
+     * Load configuration from a compiled PHP file
+     *
+     * @param string $key
+     * @return array
+     */
+    protected function loadCompiledConfig(string $key): array
+    {
+        return include Compiled::getFilePath($key);
     }
 
     /**
@@ -157,10 +198,28 @@ class Data implements \Magento\Framework\Config\DataInterface
     public function reset()
     {
         $this->cache->remove($this->cacheId);
+        $this->removeCompiledConfig($this->cacheId);
         $this->_data = [];
         $configData = $this->reader->read();
         if ($configData) {
             $this->merge($configData);
+        }
+    }
+
+    /**
+     * Remove compiled PHP config file if it exists
+     *
+     * @param string $key
+     * @return void
+     */
+    protected function removeCompiledConfig(string $key): void
+    {
+        if (!$this->configWriter) {
+            return;
+        }
+        $compiledPath = Compiled::getFilePath($key);
+        if (file_exists($compiledPath)) {
+            @unlink($compiledPath);
         }
     }
 

--- a/lib/internal/Magento/Framework/Config/Data/Scoped.php
+++ b/lib/internal/Magento/Framework/Config/Data/Scoped.php
@@ -5,8 +5,9 @@
  */
 namespace Magento\Framework\Config\Data;
 
-use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
+use Magento\Framework\Serialize\SerializerInterface;
 
 /**
  * Provides scoped configuration
@@ -40,6 +41,11 @@ class Scoped extends \Magento\Framework\Config\Data
     private $serializer;
 
     /**
+     * @var ConfigWriterInterface|null
+     */
+    private $configWriter;
+
+    /**
      * Constructor
      *
      * @param \Magento\Framework\Config\ReaderInterface $reader
@@ -47,19 +53,22 @@ class Scoped extends \Magento\Framework\Config\Data
      * @param \Magento\Framework\Config\CacheInterface $cache
      * @param string $cacheId
      * @param SerializerInterface|null $serializer
+     * @param ConfigWriterInterface|null $configWriter
      */
     public function __construct(
         \Magento\Framework\Config\ReaderInterface $reader,
         \Magento\Framework\Config\ScopeInterface $configScope,
         \Magento\Framework\Config\CacheInterface $cache,
         $cacheId,
-        ?SerializerInterface $serializer = null
+        ?SerializerInterface $serializer = null,
+        ?ConfigWriterInterface $configWriter = null
     ) {
         $this->_reader = $reader;
         $this->_configScope = $configScope;
         $this->_cache = $cache;
         $this->_cacheId = $cacheId;
         $this->serializer = $serializer ?: ObjectManager::getInstance()->get(SerializerInterface::class);
+        $this->configWriter = $configWriter;
     }
 
     /**
@@ -89,17 +98,10 @@ class Scoped extends \Magento\Framework\Config\Data
             }
             foreach ($this->_scopePriorityScheme as $scopeCode) {
                 if (false == isset($this->_loadedScopes[$scopeCode])) {
-                    if ($scopeCode !== 'primary' && ($data = $this->_cache->load($scopeCode . '::' . $this->_cacheId))
-                    ) {
-                        $data = $this->serializer->unserialize($data);
+                    if ($scopeCode !== 'primary') {
+                        $data = $this->loadScopeData($scopeCode);
                     } else {
                         $data = $this->_reader->read($scopeCode);
-                        if ($scopeCode !== 'primary') {
-                            $this->_cache->save(
-                                $this->serializer->serialize($data),
-                                $scopeCode . '::' . $this->_cacheId
-                            );
-                        }
                     }
                     $this->merge($data);
                     $this->_loadedScopes[$scopeCode] = true;
@@ -109,5 +111,35 @@ class Scoped extends \Magento\Framework\Config\Data
                 }
             }
         }
+    }
+
+    /**
+     * Load data for a specific scope, using compiled file, cache backend, or reader
+     *
+     * @param string $scopeCode
+     * @return array
+     */
+    private function loadScopeData(string $scopeCode): array
+    {
+        $cacheKey = $scopeCode . '::' . $this->_cacheId;
+
+        if ($this->configWriter && $this->isCompiledConfigAvailable($cacheKey)) {
+            return $this->loadCompiledConfig($cacheKey);
+        }
+
+        $data = $this->_cache->load($cacheKey);
+
+        if ($data !== false) {
+            $data = $this->serializer->unserialize($data);
+        } else {
+            $data = $this->_reader->read($scopeCode);
+            $this->_cache->save($this->serializer->serialize($data), $cacheKey);
+        }
+
+        if ($this->configWriter) {
+            $this->configWriter->write($cacheKey, $data);
+        }
+
+        return $data;
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Data/ScopedTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Data/ScopedTest.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * Copyright 2015 Adobe
+ * Copyright 2025 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
 
 namespace Magento\Framework\Config\Test\Unit\Data;
 
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
 use Magento\Framework\Config\CacheInterface;
 use Magento\Framework\Config\Data\Scoped;
 use Magento\Framework\Config\ReaderInterface;
@@ -49,6 +50,11 @@ class ScopedTest extends TestCase
      */
     private $serializerMock;
 
+    /**
+     * @var ConfigWriterInterface|MockObject
+     */
+    private $configWriterMock;
+
     protected function setUp(): void
     {
         $this->objectManager = new ObjectManager($this);
@@ -56,6 +62,7 @@ class ScopedTest extends TestCase
         $this->_configScopeMock = $this->createMock(ScopeInterface::class);
         $this->_cacheMock = $this->createMock(CacheInterface::class);
         $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->configWriterMock = $this->createMock(ConfigWriterInterface::class);
 
         $this->_model = $this->objectManager->getObject(
             Scoped::class,
@@ -64,7 +71,8 @@ class ScopedTest extends TestCase
                 'configScope' => $this->_configScopeMock,
                 'cache' => $this->_cacheMock,
                 'cacheId' => 'tag',
-                'serializer' => $this->serializerMock
+                'serializer' => $this->serializerMock,
+                'configWriter' => null
             ]
         );
     }
@@ -198,5 +206,213 @@ class ScopedTest extends TestCase
 
         /** test preventing of double config data loading from reader */
         $this->assertEquals('testValue', $this->_model->get('some'));
+    }
+
+    /**
+     * When a compiled file exists for a scope, data should be loaded from it.
+     * Cache backend and XML reader must NOT be called.
+     */
+    public function testGetScopeSwitchingWithCompiledData(): void
+    {
+        $compiledData = ['compiled' => 'scopeValue'];
+
+        $this->_configScopeMock->expects($this->any())
+            ->method('getCurrentScope')
+            ->willReturn('adminhtml');
+
+        $this->_cacheMock->expects($this->never())
+            ->method('load');
+        $this->_readerMock->expects($this->never())
+            ->method('read');
+        $this->serializerMock->expects($this->never())
+            ->method('unserialize');
+
+        $model = $this->createCompiledScopedConfig(
+            compiledScopes: ['adminhtml::tag' => $compiledData],
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals('scopeValue', $model->get('compiled'));
+
+        /** Verify repeated access does not trigger additional loads */
+        $this->assertEquals('scopeValue', $model->get('compiled'));
+    }
+
+    /**
+     * On scope cache miss with configWriter present, the compiled file should be written after reading.
+     */
+    public function testCompiledFileWrittenOnScopeCacheMiss(): void
+    {
+        $testValue = ['some' => 'testValue'];
+        $serializedData = 'serialized data';
+
+        $this->_configScopeMock->expects($this->any())
+            ->method('getCurrentScope')
+            ->willReturn('adminhtml');
+
+        $this->_cacheMock->expects($this->once())
+            ->method('load')
+            ->with('adminhtml::tag')
+            ->willReturn(false);
+
+        $this->_readerMock->expects($this->once())
+            ->method('read')
+            ->with('adminhtml')
+            ->willReturn($testValue);
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with($testValue)
+            ->willReturn($serializedData);
+
+        $this->_cacheMock->expects($this->once())
+            ->method('save')
+            ->with($serializedData, 'adminhtml::tag');
+
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with('adminhtml::tag', $testValue);
+
+        $model = $this->createCompiledScopedConfig(
+            compiledScopes: [],
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals('testValue', $model->get('some'));
+    }
+
+    /**
+     * The 'primary' scope should never attempt compilation (it bypasses cache already).
+     */
+    public function testPrimaryScopeNotCompiled(): void
+    {
+        $primaryData = ['primary' => 'data'];
+
+        $this->_configScopeMock->expects($this->any())
+            ->method('getCurrentScope')
+            ->willReturn('primary');
+
+        $this->_cacheMock->expects($this->never())
+            ->method('load');
+
+        $this->_readerMock->expects($this->once())
+            ->method('read')
+            ->with('primary')
+            ->willReturn($primaryData);
+
+        $this->configWriterMock->expects($this->never())
+            ->method('write');
+
+        $model = $this->createCompiledScopedConfig(
+            compiledScopes: [],
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals('data', $model->get('primary'));
+    }
+
+    /**
+     * When configWriter is null, behavior is identical to original (backward compat).
+     */
+    public function testNoCompilationWithoutConfigWriter(): void
+    {
+        $testValue = ['some' => 'testValue'];
+        $serializedData = 'serialized data';
+
+        $this->_configScopeMock->expects($this->any())
+            ->method('getCurrentScope')
+            ->willReturn('frontend');
+
+        $this->_cacheMock->expects($this->once())
+            ->method('load')
+            ->with('frontend::tag')
+            ->willReturn(false);
+
+        $this->_readerMock->expects($this->once())
+            ->method('read')
+            ->with('frontend')
+            ->willReturn($testValue);
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with($testValue)
+            ->willReturn($serializedData);
+
+        $this->_cacheMock->expects($this->once())
+            ->method('save')
+            ->with($serializedData, 'frontend::tag');
+
+        /** Use the default model (no configWriter) */
+        $model = $this->objectManager->getObject(
+            Scoped::class,
+            [
+                'reader' => $this->_readerMock,
+                'configScope' => $this->_configScopeMock,
+                'cache' => $this->_cacheMock,
+                'cacheId' => 'tag',
+                'serializer' => $this->serializerMock,
+                'configWriter' => null
+            ]
+        );
+
+        $this->assertEquals('testValue', $model->get('some'));
+    }
+
+    /**
+     * Create a Scoped instance with compiled-file behavior controlled by test parameters.
+     *
+     * Uses an anonymous subclass to override filesystem checks for compiled configs,
+     * since file_exists() and include() cannot be mocked in unit tests.
+     *
+     * @param array<string, array> $compiledScopes Map of scope cache key => compiled data
+     * @param ConfigWriterInterface|null $configWriter
+     * @return Scoped
+     */
+    private function createCompiledScopedConfig(
+        array $compiledScopes = [],
+        ?ConfigWriterInterface $configWriter = null
+    ): Scoped {
+        $reader = $this->_readerMock;
+        $configScope = $this->_configScopeMock;
+        $cache = $this->_cacheMock;
+        $serializer = $this->serializerMock;
+
+        return new class(
+            $reader,
+            $configScope,
+            $cache,
+            'tag',
+            $serializer,
+            $compiledScopes,
+            $configWriter
+        ) extends Scoped {
+            /**
+             * @var array<string, array>
+             */
+            private array $compiledScopes;
+
+            public function __construct(
+                ReaderInterface $reader,
+                ScopeInterface $configScope,
+                CacheInterface $cache,
+                string $cacheId,
+                SerializerInterface $serializer,
+                array $compiledScopes,
+                ?ConfigWriterInterface $configWriter
+            ) {
+                $this->compiledScopes = $compiledScopes;
+                parent::__construct($reader, $configScope, $cache, $cacheId, $serializer, $configWriter);
+            }
+
+            protected function isCompiledConfigAvailable(string $key): bool
+            {
+                return isset($this->compiledScopes[$key]);
+            }
+
+            protected function loadCompiledConfig(string $key): array
+            {
+                return $this->compiledScopes[$key] ?? [];
+            }
+        };
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Data/ScopedTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Data/ScopedTest.php
@@ -372,47 +372,14 @@ class ScopedTest extends TestCase
         array $compiledScopes = [],
         ?ConfigWriterInterface $configWriter = null
     ): Scoped {
-        $reader = $this->_readerMock;
-        $configScope = $this->_configScopeMock;
-        $cache = $this->_cacheMock;
-        $serializer = $this->serializerMock;
-
-        return new class(
-            $reader,
-            $configScope,
-            $cache,
+        return new TestableCompiledScoped(
+            $this->_readerMock,
+            $this->_configScopeMock,
+            $this->_cacheMock,
             'tag',
-            $serializer,
+            $this->serializerMock,
             $compiledScopes,
             $configWriter
-        ) extends Scoped {
-            /**
-             * @var array<string, array>
-             */
-            private array $compiledScopes;
-
-            public function __construct(
-                ReaderInterface $reader,
-                ScopeInterface $configScope,
-                CacheInterface $cache,
-                string $cacheId,
-                SerializerInterface $serializer,
-                array $compiledScopes,
-                ?ConfigWriterInterface $configWriter
-            ) {
-                $this->compiledScopes = $compiledScopes;
-                parent::__construct($reader, $configScope, $cache, $cacheId, $serializer, $configWriter);
-            }
-
-            protected function isCompiledConfigAvailable(string $key): bool
-            {
-                return isset($this->compiledScopes[$key]);
-            }
-
-            protected function loadCompiledConfig(string $key): array
-            {
-                return $this->compiledScopes[$key] ?? [];
-            }
-        };
+        );
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/Data/TestableCompiledScoped.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/Data/TestableCompiledScoped.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Config\Test\Unit\Data;
+
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
+use Magento\Framework\Config\CacheInterface;
+use Magento\Framework\Config\Data\Scoped;
+use Magento\Framework\Config\ReaderInterface;
+use Magento\Framework\Config\ScopeInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * Test double that overrides filesystem-dependent methods for compiled scoped config
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class TestableCompiledScoped extends Scoped
+{
+    /**
+     * @var array<string, array>
+     */
+    private array $compiledScopes;
+
+    /**
+     * @param ReaderInterface $reader
+     * @param ScopeInterface $configScope
+     * @param CacheInterface $cache
+     * @param string $cacheId
+     * @param SerializerInterface $serializer
+     * @param array $compiledScopes
+     * @param ConfigWriterInterface|null $configWriter
+     */
+    public function __construct(
+        ReaderInterface $reader,
+        ScopeInterface $configScope,
+        CacheInterface $cache,
+        string $cacheId,
+        SerializerInterface $serializer,
+        array $compiledScopes,
+        ?ConfigWriterInterface $configWriter
+    ) {
+        $this->compiledScopes = $compiledScopes;
+        parent::__construct($reader, $configScope, $cache, $cacheId, $serializer, $configWriter);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isCompiledConfigAvailable(string $key): bool
+    {
+        return isset($this->compiledScopes[$key]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function loadCompiledConfig(string $key): array
+    {
+        return $this->compiledScopes[$key] ?? [];
+    }
+}

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * Copyright 2015 Adobe
+ * Copyright 2025 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
 
 namespace Magento\Framework\Config\Test\Unit;
 
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
 use Magento\Framework\Config\CacheInterface;
 use Magento\Framework\Config\Data;
 use Magento\Framework\Config\ReaderInterface;
@@ -31,11 +32,17 @@ class DataTest extends TestCase
      */
     private $serializerMock;
 
+    /**
+     * @var ConfigWriterInterface|MockObject
+     */
+    private $configWriterMock;
+
     protected function setUp(): void
     {
         $this->readerMock = $this->createMock(ReaderInterface::class);
         $this->cacheMock = $this->createMock(CacheInterface::class);
         $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->configWriterMock = $this->createMock(ConfigWriterInterface::class);
     }
 
     public function testGetConfigNotCached()
@@ -108,5 +115,224 @@ class DataTest extends TestCase
             $this->serializerMock
         );
         $config->reset();
+    }
+
+    /**
+     * When a compiled PHP file exists, data should be loaded from it.
+     * Cache backend and XML reader must NOT be called.
+     */
+    public function testGetConfigFromCompiledFile(): void
+    {
+        $compiledData = ['compiled' => 'value'];
+        $cacheId = 'test';
+
+        $this->cacheMock->expects($this->never())
+            ->method('load');
+        $this->readerMock->expects($this->never())
+            ->method('read');
+        $this->serializerMock->expects($this->never())
+            ->method('unserialize');
+
+        $config = $this->createCompiledDataConfig(
+            $cacheId,
+            compiledFileExists: true,
+            compiledData: $compiledData,
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals($compiledData, $config->get());
+        $this->assertEquals('value', $config->get('compiled'));
+    }
+
+    /**
+     * When configWriter is set and compiled file does not exist and cache misses,
+     * data comes from the XML reader and the compiled file is written via configWriter.
+     */
+    public function testCompiledFileWrittenOnCacheMiss(): void
+    {
+        $data = ['reader' => 'data'];
+        $cacheId = 'test';
+
+        $this->cacheMock->expects($this->once())
+            ->method('load')
+            ->willReturn(false);
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->willReturn($data);
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with($data);
+
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with($cacheId, $data);
+
+        $config = $this->createCompiledDataConfig(
+            $cacheId,
+            compiledFileExists: false,
+            compiledData: null,
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals($data, $config->get());
+    }
+
+    /**
+     * When configWriter is set and compiled file does not exist but cache hits,
+     * data comes from cache AND the compiled file is still written for next request.
+     */
+    public function testCompiledFileWrittenOnCacheHit(): void
+    {
+        $data = ['cached' => 'data'];
+        $serializedData = '{"cached":"data"}';
+        $cacheId = 'test';
+
+        $this->cacheMock->expects($this->once())
+            ->method('load')
+            ->willReturn($serializedData);
+        $this->readerMock->expects($this->never())
+            ->method('read');
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($serializedData)
+            ->willReturn($data);
+
+        $this->configWriterMock->expects($this->once())
+            ->method('write')
+            ->with($cacheId, $data);
+
+        $config = $this->createCompiledDataConfig(
+            $cacheId,
+            compiledFileExists: false,
+            compiledData: null,
+            configWriter: $this->configWriterMock
+        );
+
+        $this->assertEquals($data, $config->get());
+    }
+
+    /**
+     * When configWriter is null, behavior is identical to original (backward compat).
+     * No compilation attempts, cache and reader work as before.
+     */
+    public function testNoCompilationWithoutConfigWriter(): void
+    {
+        $data = ['a' => 'b'];
+        $cacheId = 'test';
+
+        $this->cacheMock->expects($this->once())
+            ->method('load')
+            ->willReturn(false);
+        $this->readerMock->expects($this->once())
+            ->method('read')
+            ->willReturn($data);
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with($data);
+
+        $config = new Data(
+            $this->readerMock,
+            $this->cacheMock,
+            $cacheId,
+            $this->serializerMock
+        );
+
+        $this->assertEquals($data, $config->get());
+    }
+
+    /**
+     * When reset() is called, the compiled file should be removed.
+     */
+    public function testResetRemovesCompiledConfig(): void
+    {
+        $data = ['a' => 'b'];
+        $serializedData = '{"a":"b"}';
+        $cacheId = 'test';
+
+        $this->cacheMock->expects($this->once())
+            ->method('load')
+            ->willReturn($serializedData);
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($serializedData)
+            ->willReturn($data);
+
+        $config = $this->createCompiledDataConfig(
+            $cacheId,
+            compiledFileExists: false,
+            compiledData: null,
+            configWriter: $this->configWriterMock
+        );
+
+        $config->reset();
+        $this->assertContains($cacheId, $config->getRemovedCompiledKeys());
+    }
+
+    /**
+     * Create a Data instance with compiled-file behavior controlled by test parameters.
+     *
+     * Uses an anonymous subclass to override the compiled-file filesystem checks,
+     * since file_exists() and include() cannot be mocked in unit tests.
+     */
+    private function createCompiledDataConfig(
+        string $cacheId,
+        bool $compiledFileExists,
+        ?array $compiledData,
+        ?ConfigWriterInterface $configWriter = null
+    ): Data {
+        $reader = $this->readerMock;
+        $cache = $this->cacheMock;
+        $serializer = $this->serializerMock;
+
+        return new class(
+            $reader,
+            $cache,
+            $cacheId,
+            $serializer,
+            $compiledFileExists,
+            $compiledData,
+            $configWriter
+        ) extends Data {
+            private bool $compiledFileExists;
+            private ?array $compiledData;
+
+            /** @var string[] */
+            private array $removedKeys = [];
+
+            public function __construct(
+                ReaderInterface $reader,
+                CacheInterface $cache,
+                string $cacheId,
+                SerializerInterface $serializer,
+                bool $compiledFileExists,
+                ?array $compiledData,
+                ?ConfigWriterInterface $configWriter
+            ) {
+                $this->compiledFileExists = $compiledFileExists;
+                $this->compiledData = $compiledData;
+                parent::__construct($reader, $cache, $cacheId, $serializer, null, $configWriter);
+            }
+
+            protected function isCompiledConfigAvailable(string $key): bool
+            {
+                return $this->compiledFileExists;
+            }
+
+            protected function loadCompiledConfig(string $key): array
+            {
+                return $this->compiledData ?? [];
+            }
+
+            protected function removeCompiledConfig(string $key): void
+            {
+                $this->removedKeys[] = $key;
+            }
+
+            /** @return string[] */
+            public function getRemovedCompiledKeys(): array
+            {
+                return $this->removedKeys;
+            }
+        };
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -271,7 +271,7 @@ class DataTest extends TestCase
     /**
      * Create a Data instance with compiled-file behavior controlled by test parameters.
      *
-     * Uses an anonymous subclass to override the compiled-file filesystem checks,
+     * Uses a test subclass to override the compiled-file filesystem checks,
      * since file_exists() and include() cannot be mocked in unit tests.
      */
     private function createCompiledDataConfig(
@@ -280,59 +280,14 @@ class DataTest extends TestCase
         ?array $compiledData,
         ?ConfigWriterInterface $configWriter = null
     ): Data {
-        $reader = $this->readerMock;
-        $cache = $this->cacheMock;
-        $serializer = $this->serializerMock;
-
-        return new class(
-            $reader,
-            $cache,
+        return new TestableCompiledData(
+            $this->readerMock,
+            $this->cacheMock,
             $cacheId,
-            $serializer,
+            $this->serializerMock,
             $compiledFileExists,
             $compiledData,
             $configWriter
-        ) extends Data {
-            private bool $compiledFileExists;
-            private ?array $compiledData;
-
-            /** @var string[] */
-            private array $removedKeys = [];
-
-            public function __construct(
-                ReaderInterface $reader,
-                CacheInterface $cache,
-                string $cacheId,
-                SerializerInterface $serializer,
-                bool $compiledFileExists,
-                ?array $compiledData,
-                ?ConfigWriterInterface $configWriter
-            ) {
-                $this->compiledFileExists = $compiledFileExists;
-                $this->compiledData = $compiledData;
-                parent::__construct($reader, $cache, $cacheId, $serializer, null, $configWriter);
-            }
-
-            protected function isCompiledConfigAvailable(string $key): bool
-            {
-                return $this->compiledFileExists;
-            }
-
-            protected function loadCompiledConfig(string $key): array
-            {
-                return $this->compiledData ?? [];
-            }
-
-            protected function removeCompiledConfig(string $key): void
-            {
-                $this->removedKeys[] = $key;
-            }
-
-            /** @return string[] */
-            public function getRemovedCompiledKeys(): array
-            {
-                return $this->removedKeys;
-            }
-        };
+        );
     }
 }

--- a/lib/internal/Magento/Framework/Config/Test/Unit/TestableCompiledData.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/TestableCompiledData.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Config\Test\Unit;
+
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
+use Magento\Framework\Config\CacheInterface;
+use Magento\Framework\Config\Data;
+use Magento\Framework\Config\ReaderInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+
+/**
+ * Test double that overrides filesystem-dependent methods for compiled config
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class TestableCompiledData extends Data
+{
+    /**
+     * @var bool
+     */
+    private bool $compiledFileExists;
+
+    /**
+     * @var array|null
+     */
+    private ?array $compiledData;
+
+    /**
+     * @var string[]
+     */
+    private array $removedKeys = [];
+
+    /**
+     * @param ReaderInterface $reader
+     * @param CacheInterface $cache
+     * @param string $cacheId
+     * @param SerializerInterface $serializer
+     * @param bool $compiledFileExists
+     * @param array|null $compiledData
+     * @param ConfigWriterInterface|null $configWriter
+     */
+    public function __construct(
+        ReaderInterface $reader,
+        CacheInterface $cache,
+        string $cacheId,
+        SerializerInterface $serializer,
+        bool $compiledFileExists,
+        ?array $compiledData,
+        ?ConfigWriterInterface $configWriter
+    ) {
+        $this->compiledFileExists = $compiledFileExists;
+        $this->compiledData = $compiledData;
+        parent::__construct($reader, $cache, $cacheId, $serializer, null, $configWriter);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isCompiledConfigAvailable(string $key): bool
+    {
+        return $this->compiledFileExists;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function loadCompiledConfig(string $key): array
+    {
+        return $this->compiledData ?? [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function removeCompiledConfig(string $key): void
+    {
+        $this->removedKeys[] = $key;
+    }
+
+    /**
+     * Get list of removed compiled config keys
+     *
+     * @return string[]
+     */
+    public function getRemovedCompiledKeys(): array
+    {
+        return $this->removedKeys;
+    }
+}

--- a/lib/internal/Magento/Framework/Event/Config/Data.php
+++ b/lib/internal/Magento/Framework/Event/Config/Data.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\Event\Config;
 
+use Magento\Framework\App\ObjectManager\ConfigWriterInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 
 /**
@@ -27,14 +28,16 @@ class Data extends \Magento\Framework\Config\Data\Scoped
      * @param \Magento\Framework\Config\CacheInterface $cache
      * @param string|null $cacheId
      * @param SerializerInterface|null $serializer
+     * @param ConfigWriterInterface|null $configWriter
      */
     public function __construct(
         \Magento\Framework\Event\Config\Reader $reader,
         \Magento\Framework\Config\ScopeInterface $configScope,
         \Magento\Framework\Config\CacheInterface $cache,
         $cacheId = 'event_config_cache',
-        ?SerializerInterface $serializer = null
+        ?SerializerInterface $serializer = null,
+        ?ConfigWriterInterface $configWriter = null
     ) {
-        parent::__construct($reader, $configScope, $cache, $cacheId, $serializer);
+        parent::__construct($reader, $configScope, $cache, $cacheId, $serializer, $configWriter);
     }
 }

--- a/lib/internal/Magento/Framework/Event/Config/Data.php
+++ b/lib/internal/Magento/Framework/Event/Config/Data.php
@@ -29,6 +29,7 @@ class Data extends \Magento\Framework\Config\Data\Scoped
      * @param string|null $cacheId
      * @param SerializerInterface|null $serializer
      * @param ConfigWriterInterface|null $configWriter
+     * phpcs:disable Generic.CodeAnalysis.UselessOverridingMethod.Found
      */
     public function __construct(
         \Magento\Framework\Event\Config\Reader $reader,


### PR DESCRIPTION
## Summary

- Extends compiled config pattern to `Magento\Catalog\Model\Attribute\Config\Data`
- Catalog attribute configuration is static XML loaded on product/category pages
- Adds `ConfigWriterInterface` constructor parameter and DI wiring
- No new tests needed — behavior covered by base class unit tests

## Performance Impact

Exact numbers with Blackfire and PHP SPX profiling will be provided in a follow-up comment.

## Dependencies

Depends on #40689 (base class changes for compiled config support).
