### PR TITLE
perf: enable PHPUnit 12 execution ordering and GC control in test configs

### DIFF
--- a/dev/tests/integration/phpunit.xml.dist
+++ b/dev/tests/integration/phpunit.xml.dist
@@ -11,7 +11,10 @@
          columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
-         stderr="true">
+         stderr="true"
+         executionOrder="depends"
+         controlGarbageCollector="true"
+         numberOfTestsBeforeGarbageCollection="50">
     <source>
         <include>
             <directory suffix=".php">../../../app/code/Magento</directory>

--- a/dev/tests/unit/phpunit.xml.dist
+++ b/dev/tests/unit/phpunit.xml.dist
@@ -10,7 +10,10 @@
          colors="true"
          columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="./framework/bootstrap.php">
+         bootstrap="./framework/bootstrap.php"
+         executionOrder="depends,duration"
+         controlGarbageCollector="true"
+         numberOfTestsBeforeGarbageCollection="200">
     <source>
         <include>
             <directory suffix=".php">../../../app/code/*</directory>


### PR DESCRIPTION
## Summary

Enables three PHPUnit 12 configuration attributes across integration and unit test configs to improve test execution time and memory stability:

- **`executionOrder="depends"`** (integration) — ensures `@depends` / `#[Depends]` chains execute in the correct order. Uses `depends` only (not `depends,duration`) to preserve the explicit "Memory Usage Tests run first" guarantee documented in the suite definition.
- **`executionOrder="depends,duration"`** (unit) — respects dependency chains *and* schedules faster tests first. Safe here because there are no ordering constraints between unit test suites.
- **`controlGarbageCollector="true"`** (both) — lets PHPUnit trigger `gc_collect_cycles()` periodically during long runs, preventing gradual memory bloat that causes slowdowns and OOM kills in CI. Thresholds: 50 tests for integration (heavier fixture graphs), 200 for unit (lightweight).

## Problem

1. **Test ordering**: The current configs use PHPUnit's default discovery order. 22 integration test files use `@depends`/`#[Depends]` (e.g. `ConfigurableTest.php`), but without `executionOrder="depends"`, PHPUnit does not guarantee dependency chains execute correctly — leading to intermittent failures.

2. **Memory growth**: Long integration test runs accumulate cyclic references from fixture graphs, DI containers, and service objects. Without periodic GC, PHP's refcount-based memory management cannot reclaim these, causing memory usage to grow monotonically until the process is killed or becomes swap-bound.

## Changes

| File | Attribute | Value | Why |
|------|-----------|-------|-----|
| `dev/tests/integration/phpunit.xml.dist` | `executionOrder` | `depends` | Respect `@depends` without reordering suites (preserves Memory Usage Tests priority) |
| `dev/tests/integration/phpunit.xml.dist` | `controlGarbageCollector` | `true` | Periodic GC during long integration runs |
| `dev/tests/integration/phpunit.xml.dist` | `numberOfTestsBeforeGarbageCollection` | `50` | Integration tests are heavy; GC every 50 tests |
| `dev/tests/unit/phpunit.xml.dist` | `executionOrder` | `depends,duration` | Respect dependencies + run fast tests first |
| `dev/tests/unit/phpunit.xml.dist` | `controlGarbageCollector` | `true` | Periodic GC during full suite runs |
| `dev/tests/unit/phpunit.xml.dist` | `numberOfTestsBeforeGarbageCollection` | `200` | Unit tests are lighter; less frequent GC needed |

## Test plan

- [x] `php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist --list-suites` — config accepted by PHPUnit 12.5.14
- [x] `php vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist --no-coverage app/code/Magento/Catalog/Test/Unit/` — 2632 tests pass
- [x] All attributes validate against PHPUnit 12.5 XSD schema
- [ ] CI integration tests pass with new config

## References

- [PHPUnit 12.5 configuration docs](https://docs.phpunit.de/en/12.5/configuration.html)
- [PHPUnit 12.5 CLI options](https://docs.phpunit.de/en/12.5/cli-options.html)
