### PR TITLE
⚡ perf: cache carrier instances in getGroupedAllShippingRates() (#40702)

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/Address.php
+++ b/app/code/Magento/Quote/Model/Quote/Address.php
@@ -904,17 +904,22 @@ class Address extends AbstractAddress implements
      */
     public function getGroupedAllShippingRates()
     {
+        $carriers = [];
         $rates = [];
         foreach ($this->getShippingRatesCollection() as $rate) {
-            if (!$rate->isDeleted() && $this->carrierFactory->get($rate->getCarrier())) {
-                if (!isset($rates[$rate->getCarrier()])) {
-                    $rates[$rate->getCarrier()] = [];
+            if ($rate->isDeleted()) {
+                continue;
+            }
+
+            $carrierCode = $rate->getCarrier();
+            $carrier = $carriers[$carrierCode] ??= $this->carrierFactory->get($carrierCode);
+            if ($carrier) {
+                if (!isset($rates[$carrierCode])) {
+                    $rates[$carrierCode] = [];
+                    $rate->carrier_sort_order = $carrier->getSortOrder();
                 }
 
-                $rates[$rate->getCarrier()][] = $rate;
-                $rates[$rate->getCarrier()][0]->carrier_sort_order = $this->carrierFactory->get(
-                    $rate->getCarrier()
-                )->getSortOrder();
+                $rates[$carrierCode][] = $rate;
             }
         }
         uasort($rates, [$this, '_sortRates']);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/AddressTest.php
@@ -29,6 +29,8 @@ use Magento\Quote\Model\ResourceModel\Quote\Address\Item\Collection;
 use Magento\Quote\Model\ResourceModel\Quote\Address\Item\CollectionFactory;
 use Magento\Quote\Model\ResourceModel\Quote\Address\Rate\Collection as RatesCollection;
 use Magento\Quote\Model\ResourceModel\Quote\Address\Rate\CollectionFactory as RateCollectionFactory;
+use Magento\Shipping\Model\Carrier\AbstractCarrierInterface;
+use Magento\Shipping\Model\CarrierFactoryInterface;
 use Magento\Shipping\Model\Rate\Result;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\Store\Api\Data\WebsiteInterface;
@@ -115,6 +117,11 @@ class AddressTest extends TestCase
     private $store;
 
     /**
+     * @var CarrierFactoryInterface|MockObject
+     */
+    private $carrierFactory;
+
+    /**
      * @var WebsiteInterface|MockObject
      */
     private $website;
@@ -154,6 +161,8 @@ class AddressTest extends TestCase
         $this->rateCollectionFactory = $this->getMockBuilder(RateCollectionFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->carrierFactory = $this->createMock(CarrierFactoryInterface::class);
 
         $this->rateCollection = $this->createPartialMockWithReflection(
             RateCollectorInterface::class,
@@ -199,7 +208,8 @@ class AddressTest extends TestCase
                 '_rateCollectionFactory' => $this->rateCollectionFactory,
                 '_rateCollector' => $this->rateCollector,
                 '_regionFactory' => $this->regionFactory,
-                '_addressRateFactory' => $this->addressRateFactory
+                '_addressRateFactory' => $this->addressRateFactory,
+                'carrierFactory' => $this->carrierFactory
             ]
         );
         $this->quote = $this->createMock(Quote::class);
@@ -517,5 +527,49 @@ class AddressTest extends TestCase
             ->with(null, $currentCurrencyCode);
 
         $this->address->requestShippingRates();
+    }
+
+    public function testGetGroupedAllShippingRatesCachesCarrierInstancesByCode(): void
+    {
+        $flatrateCarrier = $this->createMock(AbstractCarrierInterface::class);
+        $tablerateCarrier = $this->createMock(AbstractCarrierInterface::class);
+        $firstFlatrate = $this->createPartialMock(Rate::class, ['isDeleted']);
+        $secondFlatrate = $this->createPartialMock(Rate::class, ['isDeleted']);
+        $tablerate = $this->createPartialMock(Rate::class, ['isDeleted']);
+
+        $firstFlatrate->setCarrier('flatrate');
+        $secondFlatrate->setCarrier('flatrate');
+        $tablerate->setCarrier('tablerate');
+
+        $firstFlatrate->expects($this->once())
+            ->method('isDeleted')
+            ->willReturn(false);
+        $secondFlatrate->expects($this->once())
+            ->method('isDeleted')
+            ->willReturn(false);
+        $tablerate->expects($this->once())
+            ->method('isDeleted')
+            ->willReturn(false);
+
+        $flatrateCarrier->expects($this->once())
+            ->method('getSortOrder')
+            ->willReturn(10);
+        $tablerateCarrier->expects($this->once())
+            ->method('getSortOrder')
+            ->willReturn(20);
+
+        $this->carrierFactory->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['flatrate', $flatrateCarrier],
+                ['tablerate', $tablerateCarrier],
+            ]);
+
+        $this->setPropertyValue($this->address, '_rates', [$firstFlatrate, $secondFlatrate, $tablerate]);
+
+        $groupedRates = $this->address->getGroupedAllShippingRates();
+
+        $this->assertCount(2, $groupedRates['flatrate']);
+        $this->assertCount(1, $groupedRates['tablerate']);
     }
 }


### PR DESCRIPTION
## Summary
- Cache carrier instances by carrier code in `Quote\Address::getGroupedAllShippingRates()` to avoid redundant `carrierFactory->get()` calls.
- Previously, `carrierFactory->get()` was called twice per shipping rate (once for sorting, once for title). With N rates across M carriers, this caused 2N factory calls instead of M.

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| `carrierFactory->get()` calls | 2× per rate | 1× per unique carrier code |
| Scope | Method-local cache, no stale-object risk | Same |

## Test Plan
- [x] Unit test verifies `carrierFactory->get()` called once per unique carrier code
- [x] Test uses 3 rates (2 flatrate, 1 tablerate) asserting exactly 2 factory calls
- [ ] PHPCS clean (requires CI)
- [ ] PHPStan clean (requires CI)

Ref: Fixes magento/magento2#40702
