### PR TITLE
⚡ perf: cache resolved theme in Theme Resolver (#40721)

### DIFF
--- a/app/code/Magento/Theme/Model/Theme/Resolver.php
+++ b/app/code/Magento/Theme/Model/Theme/Resolver.php
@@ -58,8 +58,9 @@ class Resolver implements \Magento\Framework\View\Design\Theme\ResolverInterface
     public function get()
     {
         $area = $this->appState->getAreaCode();
-        if ($this->isThemeResolved[$area] ?? false) {
-            return $this->resolvedThemes[$area];
+        $cacheKey = (string)$area;
+        if ($this->isThemeResolved[$cacheKey] ?? false) {
+            return $this->resolvedThemes[$cacheKey];
         }
 
         $designTheme = $this->design->getDesignTheme();
@@ -79,8 +80,8 @@ class Resolver implements \Magento\Framework\View\Design\Theme\ResolverInterface
             }
         }
 
-        $this->resolvedThemes[$area] = $result;
-        $this->isThemeResolved[$area] = true;
+        $this->resolvedThemes[$cacheKey] = $result;
+        $this->isThemeResolved[$cacheKey] = true;
 
         return $result;
     }

--- a/app/code/Magento/Theme/Model/Theme/Resolver.php
+++ b/app/code/Magento/Theme/Model/Theme/Resolver.php
@@ -11,6 +11,16 @@ namespace Magento\Theme\Model\Theme;
 class Resolver implements \Magento\Framework\View\Design\Theme\ResolverInterface
 {
     /**
+     * @var array
+     */
+    private $resolvedThemes = [];
+
+    /**
+     * @var bool[]
+     */
+    private $isThemeResolved = [];
+
+    /**
      * @var \Magento\Framework\View\DesignInterface
      */
     protected $design;
@@ -48,19 +58,30 @@ class Resolver implements \Magento\Framework\View\Design\Theme\ResolverInterface
     public function get()
     {
         $area = $this->appState->getAreaCode();
-        if ($this->design->getDesignTheme()->getArea() == $area || $this->design->getArea() == $area) {
-            return $this->design->getDesignTheme();
+        if ($this->isThemeResolved[$area] ?? false) {
+            return $this->resolvedThemes[$area];
         }
 
-        /** @var \Magento\Theme\Model\ResourceModel\Theme\Collection $themeCollection */
-        $themeCollection = $this->themeFactory->create();
-        $themeIdentifier = $this->design->getConfigurationDesignTheme($area);
-        if (is_numeric($themeIdentifier)) {
-            $result = $themeCollection->getItemById($themeIdentifier);
+        $designTheme = $this->design->getDesignTheme();
+        if (($designTheme && $designTheme->getArea() == $area) || $this->design->getArea() == $area) {
+            $result = $designTheme;
         } else {
-            $themeFullPath = $area . \Magento\Framework\View\Design\ThemeInterface::PATH_SEPARATOR . $themeIdentifier;
-            $result = $themeCollection->getThemeByFullPath($themeFullPath);
+            /** @var \Magento\Theme\Model\ResourceModel\Theme\Collection $themeCollection */
+            $themeCollection = $this->themeFactory->create();
+            $themeIdentifier = $this->design->getConfigurationDesignTheme($area);
+            if (is_numeric($themeIdentifier)) {
+                $result = $themeCollection->getItemById($themeIdentifier);
+            } else {
+                $themeFullPath = $area
+                    . \Magento\Framework\View\Design\ThemeInterface::PATH_SEPARATOR
+                    . $themeIdentifier;
+                $result = $themeCollection->getThemeByFullPath($themeFullPath);
+            }
         }
+
+        $this->resolvedThemes[$area] = $result;
+        $this->isThemeResolved[$area] = true;
+
         return $result;
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ResolverTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ResolverTest.php
@@ -68,7 +68,7 @@ class ResolverTest extends TestCase
     public function testGetByAreaWithThemeDefaultArea()
     {
         $this->designMock->expects(
-            $this->exactly(2)
+            $this->once()
         )->method(
             'getDesignTheme'
         )->willReturn(
@@ -101,7 +101,7 @@ class ResolverTest extends TestCase
     public function testGetByAreaWithDesignDefaultArea()
     {
         $this->designMock->expects(
-            $this->exactly(2)
+            $this->once()
         )->method(
             'getDesignTheme'
         )->willReturn(
@@ -257,5 +257,125 @@ class ResolverTest extends TestCase
         );
 
         $this->assertEquals($this->themeMock, $this->model->get());
+    }
+
+    public function testGetCachesResolvedThemeByArea()
+    {
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getDesignTheme'
+        )->willReturn(
+            $this->themeMock
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getArea'
+        )->willReturn(
+            'design_area'
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getConfigurationDesignTheme'
+        )->with(
+            'other_area'
+        )->willReturn(
+            'other_theme'
+        );
+
+        $this->themeMock->expects(
+            $this->once()
+        )->method(
+            'getArea'
+        )->willReturn(
+            'theme_area'
+        );
+
+        $this->themeCollectionFactoryMock->expects(
+            $this->once()
+        )->method(
+            'create'
+        )->willReturn(
+            $this->themeCollectionMock
+        );
+
+        $this->themeCollectionMock->expects(
+            $this->once()
+        )->method(
+            'getThemeByFullPath'
+        )->with(
+            'other_area' . ThemeInterface::PATH_SEPARATOR . 'other_theme'
+        )->willReturn(
+            $this->themeMock
+        );
+
+        $this->appStateMock->expects(
+            $this->exactly(2)
+        )->method(
+            'getAreaCode'
+        )->willReturn(
+            'other_area'
+        );
+
+        $this->assertSame($this->themeMock, $this->model->get());
+        $this->assertSame($this->themeMock, $this->model->get());
+    }
+
+    public function testGetCachesNullResolvedThemeByArea()
+    {
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getDesignTheme'
+        )->willReturn(
+            null
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getArea'
+        )->willReturn(
+            'design_area'
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getConfigurationDesignTheme'
+        )->with(
+            'other_area'
+        )->willReturn(
+            12
+        );
+
+        $this->themeCollectionFactoryMock->expects(
+            $this->once()
+        )->method(
+            'create'
+        )->willReturn(
+            $this->themeCollectionMock
+        );
+
+        $this->themeCollectionMock->expects(
+            $this->once()
+        )->method(
+            'getItemById'
+        )->with(
+            12
+        )->willReturn(
+            null
+        );
+
+        $this->appStateMock->expects(
+            $this->exactly(2)
+        )->method(
+            'getAreaCode'
+        )->willReturn(
+            'other_area'
+        );
+
+        $this->assertNull($this->model->get());
+        $this->assertNull($this->model->get());
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Model/Theme/ResolverTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Theme/ResolverTest.php
@@ -378,4 +378,68 @@ class ResolverTest extends TestCase
         $this->assertNull($this->model->get());
         $this->assertNull($this->model->get());
     }
+
+    public function testGetWithNullAreaCodeDoesNotTriggerDeprecation()
+    {
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getDesignTheme'
+        )->willReturn(
+            $this->themeMock
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getArea'
+        )->willReturn(
+            'design_area'
+        );
+        $this->designMock->expects(
+            $this->once()
+        )->method(
+            'getConfigurationDesignTheme'
+        )->with(
+            null
+        )->willReturn(
+            'some_theme'
+        );
+
+        $this->themeMock->expects(
+            $this->once()
+        )->method(
+            'getArea'
+        )->willReturn(
+            'theme_area'
+        );
+
+        $this->themeCollectionFactoryMock->expects(
+            $this->once()
+        )->method(
+            'create'
+        )->willReturn(
+            $this->themeCollectionMock
+        );
+
+        $this->themeCollectionMock->expects(
+            $this->once()
+        )->method(
+            'getThemeByFullPath'
+        )->with(
+            ThemeInterface::PATH_SEPARATOR . 'some_theme'
+        )->willReturn(
+            $this->themeMock
+        );
+
+        $this->appStateMock->expects(
+            $this->exactly(2)
+        )->method(
+            'getAreaCode'
+        )->willReturn(
+            null
+        );
+
+        $this->assertSame($this->themeMock, $this->model->get());
+        $this->assertSame($this->themeMock, $this->model->get());
+    }
 }


### PR DESCRIPTION
## Summary
- Cache resolved theme per area in `Theme\Resolver::get()` to avoid redundant theme collection loading within the same request.
- Uses sentinel boolean pattern (`$isThemeResolved[$area]`) to correctly cache null results without re-querying.
- Each area (frontend, adminhtml) is cached independently.

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| Theme collection queries | 1× per `get()` call on cache miss | 1× per area per request |
| Null handling | N/A | Correctly cached via sentinel flag |

## Test Plan
- [x] Unit test verifies repeated `get()` calls return cached theme without re-resolving
- [x] Unit test verifies null theme result is cached (sentinel pattern, not re-fetched)
- [ ] PHPCS clean (requires CI)
- [ ] PHPStan clean (requires CI)

Ref: Fixes magento/magento2#40721
