### PR TITLE
⚡ perf: optimize hasLinks() and hasSamples() in Downloadable product type (#40727)

### DIFF
--- a/app/code/Magento/Downloadable/Model/Product/Type.php
+++ b/app/code/Magento/Downloadable/Model/Product/Type.php
@@ -170,7 +170,14 @@ class Type extends \Magento\Catalog\Model\Product\Type\Virtual
     {
         $hasLinks = $product->getData('links_exist');
         if (null === $hasLinks) {
-            $hasLinks = (count($this->getLinks($product)) > 0);
+            $links = $product->getDownloadableLinks();
+            if ($links !== null) {
+                $hasLinks = !empty($links);
+            } else {
+                $hasLinks = $this->_linksFactory->create()
+                    ->addProductToFilter($product->getEntityId())
+                    ->getSize() > 0;
+            }
         }
         return $hasLinks;
     }
@@ -238,7 +245,14 @@ class Type extends \Magento\Catalog\Model\Product\Type\Virtual
      */
     public function hasSamples($product)
     {
-        return count($this->getSamples($product)) > 0;
+        $samples = $product->getDownloadableSamples();
+        if ($samples !== null) {
+            return $samples->getSize() > 0;
+        }
+
+        return $this->_samplesFactory->create()
+            ->addProductToFilter($product->getEntityId())
+            ->getSize() > 0;
     }
 
     /**

--- a/app/code/Magento/Downloadable/Model/Product/Type.php
+++ b/app/code/Magento/Downloadable/Model/Product/Type.php
@@ -169,17 +169,16 @@ class Type extends \Magento\Catalog\Model\Product\Type\Virtual
     public function hasLinks($product)
     {
         $hasLinks = $product->getData('links_exist');
-        if (null === $hasLinks) {
-            $links = $product->getDownloadableLinks();
-            if ($links !== null) {
-                $hasLinks = !empty($links);
-            } else {
-                $hasLinks = $this->_linksFactory->create()
-                    ->addProductToFilter($product->getEntityId())
-                    ->getSize() > 0;
-            }
+        if (null !== $hasLinks) {
+            return (bool)$hasLinks;
         }
-        return $hasLinks;
+        $links = $product->getDownloadableLinks();
+        if ($links !== null) {
+            return !empty($links);
+        }
+        return $this->_linksFactory->create()
+            ->addProductToFilter($product->getEntityId())
+            ->getSize() > 0;
     }
 
     /**

--- a/app/code/Magento/Downloadable/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Model/Product/TypeTest.php
@@ -16,6 +16,8 @@ use Magento\Downloadable\Model\Product\TypeHandler\TypeHandlerInterface;
 use Magento\Downloadable\Model\ResourceModel\Link;
 use Magento\Downloadable\Model\ResourceModel\Link\Collection;
 use Magento\Downloadable\Model\ResourceModel\Link\CollectionFactory;
+use Magento\Downloadable\Model\ResourceModel\Sample\Collection as SampleCollection;
+use Magento\Downloadable\Model\ResourceModel\Sample\CollectionFactory as SampleCollectionFactory;
 use Magento\Downloadable\Model\ResourceModel\SampleFactory;
 use Magento\Eav\Model\Config;
 use Magento\Framework\Event\ManagerInterface;
@@ -71,6 +73,11 @@ class TypeTest extends TestCase
     private $linksFactory;
 
     /**
+     * @var SampleCollectionFactory|MockObject
+     */
+    private $samplesFactory;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     protected function setUp(): void
@@ -88,7 +95,7 @@ class TypeTest extends TestCase
             CollectionFactory::class,
             ['create']
         );
-        $samplesFactory = $this->createMock(\Magento\Downloadable\Model\ResourceModel\Sample\CollectionFactory::class);
+        $this->samplesFactory = $this->createMock(SampleCollectionFactory::class);
         $sampleFactory = $this->createMock(\Magento\Downloadable\Model\SampleFactory::class);
         $linkFactory = $this->createMock(LinkFactory::class);
 
@@ -127,6 +134,7 @@ class TypeTest extends TestCase
                 'setTypeHasOptions',
                 'setLinksExist',
                 'getDownloadableLinks',
+                'getDownloadableSamples',
                 'getResource',
                 'canAffectOptions',
                 '__wakeup',
@@ -162,7 +170,7 @@ class TypeTest extends TestCase
                 'sampleResFactory' => $sampleResFactory,
                 'linkResource' => $linkResource,
                 'linksFactory' => $this->linksFactory,
-                'samplesFactory' => $samplesFactory,
+                'samplesFactory' => $this->samplesFactory,
                 'sampleFactory' => $sampleFactory,
                 'linkFactory' => $linkFactory,
                 'eavConfig' => $eavConfigMock,
@@ -185,11 +193,101 @@ class TypeTest extends TestCase
 
     public function testHasLinks()
     {
-        $this->product->method('getLinksPurchasedSeparately')->willReturn(true);
-        $this->product->expects($this->exactly(2))
+        $this->product->expects($this->once())
             ->method('getDownloadableLinks')
             ->willReturn(['link1', 'link2']);
         $this->assertTrue($this->target->hasLinks($this->product));
+    }
+
+    public function testHasLinksReturnsFalseWhenCachedLinksAreEmpty(): void
+    {
+        $this->product->expects($this->once())
+            ->method('getDownloadableLinks')
+            ->willReturn([]);
+
+        $this->assertFalse($this->target->hasLinks($this->product));
+    }
+
+    public function testHasLinksUsesDbFallbackWhenCachedLinksAreUnavailable(): void
+    {
+        $linksCollection = $this->createPartialMock(
+            Collection::class,
+            ['addProductToFilter', 'getSize']
+        );
+
+        $this->product->expects($this->once())
+            ->method('getDownloadableLinks')
+            ->willReturn(null);
+        $this->product->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn(123);
+        $this->linksFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($linksCollection);
+        $linksCollection->expects($this->once())
+            ->method('addProductToFilter')
+            ->with(123)
+            ->willReturnSelf();
+        $linksCollection->expects($this->once())
+            ->method('getSize')
+            ->willReturn(1);
+
+        $this->assertTrue($this->target->hasLinks($this->product));
+    }
+
+    public function testHasSamplesReturnsTrueWhenSampleCollectionHasItems(): void
+    {
+        $sampleCollection = $this->createMock(SampleCollection::class);
+
+        $this->product->expects($this->once())
+            ->method('getDownloadableSamples')
+            ->willReturn($sampleCollection);
+        $sampleCollection->expects($this->once())
+            ->method('getSize')
+            ->willReturn(1);
+
+        $this->assertTrue($this->target->hasSamples($this->product));
+    }
+
+    public function testHasSamplesReturnsFalseWhenSampleCollectionIsEmpty(): void
+    {
+        $sampleCollection = $this->createMock(SampleCollection::class);
+
+        $this->product->expects($this->once())
+            ->method('getDownloadableSamples')
+            ->willReturn($sampleCollection);
+        $sampleCollection->expects($this->once())
+            ->method('getSize')
+            ->willReturn(0);
+
+        $this->assertFalse($this->target->hasSamples($this->product));
+    }
+
+    public function testHasSamplesUsesDbFallbackWhenCachedSamplesAreUnavailable(): void
+    {
+        $sampleCollection = $this->createPartialMock(
+            SampleCollection::class,
+            ['addProductToFilter', 'getSize']
+        );
+
+        $this->product->expects($this->once())
+            ->method('getDownloadableSamples')
+            ->willReturn(null);
+        $this->product->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn(123);
+        $this->samplesFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($sampleCollection);
+        $sampleCollection->expects($this->once())
+            ->method('addProductToFilter')
+            ->with(123)
+            ->willReturnSelf();
+        $sampleCollection->expects($this->once())
+            ->method('getSize')
+            ->willReturn(1);
+
+        $this->assertTrue($this->target->hasSamples($this->product));
     }
 
     public function testCheckProductBuyState()

--- a/app/code/Magento/Downloadable/Test/Unit/Model/Product/TypeTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Model/Product/TypeTest.php
@@ -135,6 +135,7 @@ class TypeTest extends TestCase
                 'setLinksExist',
                 'getDownloadableLinks',
                 'getDownloadableSamples',
+                'getData',
                 'getResource',
                 'canAffectOptions',
                 '__wakeup',
@@ -191,8 +192,36 @@ class TypeTest extends TestCase
         $this->assertEquals($result, $this->target);
     }
 
+    public function testHasLinksReturnsTrueWhenLinksExistFlagIsSet(): void
+    {
+        $this->product->expects($this->once())
+            ->method('getData')
+            ->with('links_exist')
+            ->willReturn(1);
+        $this->product->expects($this->never())
+            ->method('getDownloadableLinks');
+
+        $this->assertTrue($this->target->hasLinks($this->product));
+    }
+
+    public function testHasLinksReturnsFalseWhenLinksExistFlagIsZero(): void
+    {
+        $this->product->expects($this->once())
+            ->method('getData')
+            ->with('links_exist')
+            ->willReturn(0);
+        $this->product->expects($this->never())
+            ->method('getDownloadableLinks');
+
+        $this->assertFalse($this->target->hasLinks($this->product));
+    }
+
     public function testHasLinks()
     {
+        $this->product->expects($this->once())
+            ->method('getData')
+            ->with('links_exist')
+            ->willReturn(null);
         $this->product->expects($this->once())
             ->method('getDownloadableLinks')
             ->willReturn(['link1', 'link2']);
@@ -201,6 +230,10 @@ class TypeTest extends TestCase
 
     public function testHasLinksReturnsFalseWhenCachedLinksAreEmpty(): void
     {
+        $this->product->expects($this->once())
+            ->method('getData')
+            ->with('links_exist')
+            ->willReturn(null);
         $this->product->expects($this->once())
             ->method('getDownloadableLinks')
             ->willReturn([]);
@@ -215,6 +248,10 @@ class TypeTest extends TestCase
             ['addProductToFilter', 'getSize']
         );
 
+        $this->product->expects($this->once())
+            ->method('getData')
+            ->with('links_exist')
+            ->willReturn(null);
         $this->product->expects($this->once())
             ->method('getDownloadableLinks')
             ->willReturn(null);


### PR DESCRIPTION
## Summary
- Optimize `hasLinks()` and `hasSamples()` in Downloadable product type to avoid loading full link/sample collections just to check existence.
- Both methods now check for already-cached data on the product object first (`getDownloadableLinks()` / `getDownloadableSamples()`), returning immediately without any DB query.
- Only when cached data is unavailable (cold cache), falls back to lightweight `getSize()` query instead of full `getLinks()`/`getSamples()` which load all objects with titles, prices, and joins.

## Why this approach (not just getSize)
Call site analysis shows `hasLinks()` / `hasSamples()` are often followed by template code that loads the full collection. The collection result is cached on the product data object. So:
- **Warm cache** (most common in templates): cached check returns instantly, zero DB queries
- **Cold cache** (standalone boolean checks in `hasOptions()`, `isSalable()`, `canConfigure()`): `getSize()` issues lightweight COUNT instead of full collection load
- **Net effect**: never worse than before, significantly better for standalone boolean checks

## Performance Impact
| Method | Before | After (warm cache) | After (cold cache) |
|--------|--------|--------------------|--------------------|
| `hasLinks()` | Full `getLinks()` load | Instant (cached check) | `SELECT COUNT(*)` |
| `hasSamples()` | Full `getSamples()` load | Instant (cached check) | `SELECT COUNT(*)` |

## Test Plan
- [x] Unit tests for cached data path (both true/false cases)
- [x] Unit tests for DB fallback path when cached data is null
- [x] Tests cover both hasLinks and hasSamples
- [ ] PHPCS clean (requires CI)
- [ ] PHPStan clean (requires CI)

Ref: Fixes magento/magento2#40727
