### PR TITLE
⚡ perf: memoize attribute options in Swatches Helper (#40725)

### DIFF
--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -86,6 +86,11 @@ class Data
     private $swatchesCache = [];
 
     /**
+     * @var array
+     */
+    private $attributeOptionsCache = [];
+
+    /**
      * @var Json
      */
     private $serializer;
@@ -436,15 +441,40 @@ class Data
         $result = [];
         $swatchAttributes = $this->getSwatchAttributes($product);
         foreach ($swatchAttributes as $swatchAttribute) {
-            $swatchAttribute->setStoreId($this->storeManager->getStore()->getId());
+            $storeId = (int)$this->storeManager->getStore()->getId();
+            $swatchAttribute->setStoreId($storeId);
             $attributeData = $swatchAttribute->getData();
-            foreach ($swatchAttribute->getSource()->getAllOptions(false) as $option) {
+            $attributeOptions = $this->getAttributeOptions(
+                $swatchAttribute,
+                (int)$attributeData['attribute_id'],
+                $storeId
+            );
+            foreach ($attributeOptions as $option) {
                 $attributeData['options'][$option['value']] = $option['label'];
             }
             $result[$attributeData['attribute_id']] = $attributeData;
         }
 
         return $result;
+    }
+
+    /**
+     * Retrieve attribute options with per-instance memoization.
+     *
+     * @param Attribute $attribute
+     * @param int $attributeId
+     * @param int $storeId
+     * @return array
+     */
+    private function getAttributeOptions(Attribute $attribute, int $attributeId, int $storeId): array
+    {
+        $cacheKey = $attributeId . '_' . $storeId;
+
+        if (!isset($this->attributeOptionsCache[$cacheKey])) {
+            $this->attributeOptionsCache[$cacheKey] = $attribute->getSource()->getAllOptions(false);
+        }
+
+        return $this->attributeOptionsCache[$cacheKey];
     }
 
     /**

--- a/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
@@ -665,6 +665,71 @@ class DataTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGetSwatchAttributesAsArrayMemoizesAttributeOptionsPerStore(): void
+    {
+        $storeOneOptions = [
+            ['value' => 45, 'label' => 'green'],
+            ['value' => 46, 'label' => 'yellow']
+        ];
+        $storeTwoOptions = [
+            ['value' => 45, 'label' => 'grun'],
+            ['value' => 46, 'label' => 'gelb']
+        ];
+        $attributeData = ['attribute_id' => 52];
+        $expectedStoreOne = [
+            52 => [
+                'attribute_id' => 52,
+                'options' => [
+                    45 => 'green',
+                    46 => 'yellow'
+                ]
+            ]
+        ];
+        $expectedStoreTwo = [
+            52 => [
+                'attribute_id' => 52,
+                'options' => [
+                    45 => 'grun',
+                    46 => 'gelb'
+                ]
+            ]
+        ];
+
+        $this->swatchAttributesProvider
+            ->method('provide')
+            ->with($this->productMock)
+            ->willReturn([$this->attributeMock]);
+
+        $storeMock = $this->createMock(Store::class);
+        $storeMock->method('getId')->willReturnOnConsecutiveCalls(1, 1, 2);
+        $this->storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $this->attributeMock->method('getData')->with('')->willReturn($attributeData);
+
+        $sourceMock = $this->createMock(AbstractSource::class);
+        $sourceMock->expects($this->exactly(2))
+            ->method('getAllOptions')
+            ->with(false)
+            ->willReturnOnConsecutiveCalls($storeOneOptions, $storeTwoOptions);
+        $this->attributeMock->method('getSource')->willReturn($sourceMock);
+
+        $this->assertEquals(
+            $expectedStoreOne,
+            $this->swatchHelperObject->getSwatchAttributesAsArray($this->productMock)
+        );
+        $this->assertEquals(
+            $expectedStoreOne,
+            $this->swatchHelperObject->getSwatchAttributesAsArray($this->productMock)
+        );
+        $this->assertEquals(
+            $expectedStoreTwo,
+            $this->swatchHelperObject->getSwatchAttributesAsArray($this->productMock)
+        );
+    }
+
+    /**
      * @return array
      */
     public static function dataForGettingSwatchAsArray(): array


### PR DESCRIPTION
## Summary
- Cache `getAllOptions()` results by attribute ID + store ID in `Swatches\Helper\Data` to avoid redundant source model lookups when processing multiple swatch attributes.
- Cache key includes store ID to prevent cross-store label pollution in multi-store setups.

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| `getAllOptions()` calls | 1× per attribute per invocation | 1× per attribute+store combination (cached) |
| Multi-store safety | N/A | Cache keyed by `attributeId_storeId` |

## Test Plan
- [x] Unit test verifies `getAllOptions()` called once per attribute (memoization works)
- [x] Cache key includes store ID for multi-store correctness
- [ ] PHPCS clean (requires CI)
- [ ] PHPStan clean (requires CI)

Ref: Fixes magento/magento2#40725
