### PR TITLE
⚡ perf: index review summaries by entity_id for O(1) lookup (#40717)

### DIFF
--- a/app/code/Magento/Review/Model/Review.php
+++ b/app/code/Magento/Review/Model/Review.php
@@ -334,11 +334,14 @@ class Review extends \Magento\Framework\Model\AbstractModel implements IdentityI
             ->addStoreFilter($this->_storeManager->getStore()->getId())
             ->load();
 
+        $summariesByEntityId = [];
+        foreach ($summaryData as $summary) {
+            $summariesByEntityId[$summary->getEntityPkValue()] = $summary;
+        }
+
         foreach ($collection->getItems() as $item) {
-            foreach ($summaryData as $summary) {
-                if ($summary->getEntityPkValue() == $item->getEntityId()) {
-                    $item->setRatingSummary($summary);
-                }
+            if (isset($summariesByEntityId[$item->getEntityId()])) {
+                $item->setRatingSummary($summariesByEntityId[$item->getEntityId()]);
             }
             if (!$item->getRatingSummary()) {
                 $item->setRatingSummary(new DataObject());

--- a/app/code/Magento/Review/Test/Unit/Model/ReviewTest.php
+++ b/app/code/Magento/Review/Test/Unit/Model/ReviewTest.php
@@ -26,9 +26,9 @@ use Magento\Review\Model\Review\SummaryFactory;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManager;
 use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -217,6 +217,126 @@ class ReviewTest extends TestCase
     public function testGetPendingStatus()
     {
         $this->assertSame(Review::STATUS_PENDING, $this->review->getPendingStatus());
+    }
+
+    /**
+     * @param array<int, array{entity_id:int}> $productData
+     * @param array<int, array{entity_pk_value:int, value?:string}> $summaryData
+     * @param array<int, string> $expectedSummaryValues
+     */
+    #[DataProvider('appendSummaryDataProvider')]
+    public function testAppendSummary(array $productData, array $summaryData, array $expectedSummaryValues): void
+    {
+        $storeId = 4;
+        $storeMock = $this->createConfiguredMock(Store::class, ['getId' => $storeId]);
+        $collectionMock = $this->createMock(Collection::class);
+
+        $products = array_map(
+            static fn (array $data): DataObject => new DataObject($data),
+            $productData
+        );
+        $summaries = array_map(
+            static fn (array $data): DataObject => new DataObject($data),
+            $summaryData
+        );
+
+        $entityIds = array_column($productData, 'entity_id');
+        $summaryCollection = new class ($summaries) implements \IteratorAggregate {
+            /** @var array<int, int> */
+            public array $entityIds = [];
+
+            /** @var int */
+            public int $storeId = 0;
+
+            /**
+             * @param array<int, DataObject> $summaries
+             */
+            public function __construct(private readonly array $summaries)
+            {
+            }
+
+            public function addEntityFilter(array $entityIds): self
+            {
+                $this->entityIds = $entityIds;
+                return $this;
+            }
+
+            public function addStoreFilter(int $storeId): self
+            {
+                $this->storeId = $storeId;
+                return $this;
+            }
+
+            public function load(): self
+            {
+                return $this;
+            }
+
+            public function getIterator(): \ArrayIterator
+            {
+                return new \ArrayIterator($this->summaries);
+            }
+        };
+
+        $this->reviewSummaryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($summaryCollection);
+
+        $collectionMock->expects($this->exactly(2))
+            ->method('getItems')
+            ->willReturn($products);
+
+        $this->storeManagerMock->expects($this->once())
+            ->method('getStore')
+            ->willReturn($storeMock);
+
+        $this->assertSame($this->review, $this->review->appendSummary($collectionMock));
+        $this->assertSame($entityIds, $summaryCollection->entityIds);
+        $this->assertSame($storeId, $summaryCollection->storeId);
+
+        foreach ($products as $index => $product) {
+            $ratingSummary = $product->getRatingSummary();
+            $this->assertInstanceOf(DataObject::class, $ratingSummary);
+            if ($expectedSummaryValues[$index] === '') {
+                $this->assertSame([], $ratingSummary->getData());
+                continue;
+            }
+
+            $this->assertSame($expectedSummaryValues[$index], $ratingSummary->getData('value'));
+        }
+    }
+
+    /**
+     * @return array<string, array{
+     *     0: array<int, array{entity_id:int}>,
+     *     1: array<int, array{entity_pk_value:int, value?:string}>,
+     *     2: array<int, string>
+     * }>
+     */
+    public static function appendSummaryDataProvider(): array
+    {
+        return [
+            'products with matching and missing summaries' => [
+                [
+                    ['entity_id' => 10],
+                    ['entity_id' => 20],
+                    ['entity_id' => 30],
+                ],
+                [
+                    ['entity_pk_value' => 10, 'value' => 'first'],
+                    ['entity_pk_value' => 30, 'value' => 'third'],
+                ],
+                ['first', '', 'third'],
+            ],
+            'empty summary collection' => [
+                [
+                    ['entity_id' => 10],
+                    ['entity_id' => 20],
+                ],
+                [],
+                ['', ''],
+            ],
+        ];
     }
 
     public function testGetReviewUrl()


### PR DESCRIPTION
## Summary
- Replace O(n²) nested foreach in `Review::appendSummary()` with pre-indexed associative array for O(n) total complexity.
- Summaries are indexed by `entity_pk_value` before the product loop, then looked up via `isset()` instead of scanning all summaries per product.
- Behavior is identical: matching products get the summary, non-matching products get an empty `DataObject`.

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| Complexity | O(n × m) nested foreach | O(n + m) with indexed lookup |
| 100 products × 100 summaries | 10,000 comparisons | 200 iterations |

## Test Plan
- [x] Unit test with DataProvider covering:
  - Products with matching summaries
  - Products with no matching summary (empty DataObject fallback)
  - Empty summary collection
- [ ] PHPCS clean (requires CI)
- [ ] PHPStan clean (requires CI)

Ref: Fixes magento/magento2#40717
