### PR TITLE
Add VED currency and remove obsolete VEF for Venezuela (GH-40698)

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -274,8 +274,8 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'UYU', /*Uruguay Peso Uruguayo*/
         'UZS', /*Uzbekistan Sum*/
         'VUV', /*Vanuatu Vatu*/
-        'VEB', /*Venezuelan Bolivar*/
-        'VEF', /*Venezuelan bolívar fuerte*/
+        'VEB', /*Venezuelan Bolívar (obsolete, pre-2008)*/
+        'VED', /*Venezuelan Bolívar Digital (current ISO 4217, since Oct 2021)*/
         'VND', /*Vietnamese Dong*/
         'CHE', /*WIR Euro*/
         'CHW', /*WIR Franc*/

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
@@ -36,13 +36,14 @@ class ConfigTest extends TestCase
         'JMD', 'JPY', 'JOD', 'KZT', 'KES', 'KWD', 'KGS', 'LAK', 'LVL', 'LBP',
         'LSL', 'LRD', 'LYD', 'LTL', 'MOP', 'MKD', 'MGA', 'MWK', 'MYR', 'MVR',
         'LSM', 'MRO', 'MUR', 'MXN', 'MDL', 'MNT', 'MAD', 'MZN', 'MMK', 'NAD',
-        'NPR', 'ANG', 'YTL', 'NZD', 'NIC', 'NGN', 'KPW', 'NOK', 'OMR', 'PKR',
-        'PAB', 'PGK', 'PYG', 'PEN', 'PHP', 'PLN', 'QAR', 'RHD', 'RON', 'RUB',
-        'RWF', 'SHP', 'STD', 'SAR', 'RSD', 'SCR', 'SLL', 'SGD', 'SKK', 'SBD',
-        'SOS', 'ZAR', 'KRW', 'LKR', 'SDG', 'SRD', 'SZL', 'SEK', 'CHF', 'SYP',
-        'TWD', 'TJS', 'TZS', 'THB', 'TOP', 'TTD', 'TND', 'TMM', 'USD', 'UGX',
-        'UAH', 'AED', 'UYU', 'UZS', 'VUV', 'VEB', 'VEF', 'VND', 'CHE', 'CHW',
-        'XOF', 'WST', 'YER', 'ZMK', 'ZWD', 'TRY', 'AZM', 'ROL', 'TRL', 'XPF',
+        'NPR', 'ANG', 'XCG', 'YTL', 'NZD', 'NIC', 'NIO', 'NGN', 'KPW', 'NOK',
+        'OMR', 'PKR', 'PAB', 'PGK', 'PYG', 'PEN', 'PHP', 'PLN', 'QAR', 'RHD',
+        'RON', 'RUB', 'RWF', 'SHP', 'STD', 'SAR', 'RSD', 'SCR', 'SLL', 'SGD',
+        'SKK', 'SBD', 'SOS', 'ZAR', 'KRW', 'LKR', 'SDG', 'SRD', 'SZL', 'SEK',
+        'CHF', 'SYP', 'TWD', 'TJS', 'TZS', 'THB', 'TOP', 'TTD', 'TND', 'TMM',
+        'USD', 'UGX', 'UAH', 'AED', 'UYU', 'UZS', 'VUV', 'VEB', 'VED', 'VND',
+        'CHE', 'CHW', 'XOF', 'WST', 'YER', 'ZMK', 'ZWD', 'TRY', 'AZM', 'ROL',
+        'TRL', 'XPF',
     ];
 
     private static $samplePresentLocales = [

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/ConfigTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
 {
+    /**
+     * @var array
+     */
     private static $allAllowedLocales = [
         'af_ZA', 'ar_DZ', 'ar_EG', 'ar_KW', 'ar_MA', 'ar_SA', 'az_Latn_AZ', 'be_BY', 'bg_BG', 'bn_BD',
         'bs_Latn_BA', 'ca_ES', 'cs_CZ', 'cy_GB', 'da_DK', 'de_AT', 'de_CH', 'de_DE', 'el_GR', 'en_AU',
@@ -25,6 +28,9 @@ class ConfigTest extends TestCase
         'lo_LA', 'es_VE', 'en_IE',
     ];
 
+    /**
+     * @var array
+     */
     private static $allAllowedCurrencies = [
         'AFN', 'ALL', 'AZN', 'DZD', 'AOA', 'ARS', 'AMD', 'AWG', 'AUD', 'BSD',
         'BHD', 'BDT', 'BBD', 'BYN', 'BZD', 'BMD', 'BTN', 'BOB', 'BAM', 'BWP',
@@ -46,29 +52,47 @@ class ConfigTest extends TestCase
         'TRL', 'XPF',
     ];
 
+    /**
+     * @var array
+     */
     private static $samplePresentLocales = [
         'en_US', 'lv_LV', 'pt_BR', 'it_IT', 'ar_EG', 'bg_BG', 'en_IE', 'es_ES',
         'en_AU', 'pt_PT', 'ru_RU', 'en_CA', 'vi_VN', 'ja_JP', 'en_GB', 'zh_CN',
         'zh_TW', 'fr_FR', 'ar_KW', 'pl_PL', 'ko_KR', 'sk_SK', 'el_GR', 'hi_IN',
     ];
 
+    /**
+     * @var array
+     */
     private static $sampleAbsentLocales = [
         'aa_BB', 'foo_BAR', 'cc_DD',
     ];
 
+    /**
+     * @var array
+     */
     private static $sampleAdditionalLocales = [
         'en_AA', 'es_ZZ',
     ];
 
+    /**
+     * @var array
+     */
     private static $samplePresentCurrencies = [
         'AUD', 'BBD', 'GBP', 'CAD', 'CZK', 'GQE', 'CNY', 'DJF', 'HKD', 'JPY', 'MYR',
         'MXN', 'NZD', 'PHP', 'SGD', 'CHF', 'TWD', 'USD', 'AED', 'ZWD', 'ROL', 'CHE',
     ];
 
+    /**
+     * @var array
+     */
     private static $sampleAbsentCurrencies = [
         'ABC', 'DEF', 'GHI', 'ZZZ',
     ];
 
+    /**
+     * @var array
+     */
     private static $sampleAdditionalCurrencies = [
         'QED', 'PNP', 'EJN', 'MTO', 'EBY',
     ];


### PR DESCRIPTION
### Description (*)

Venezuela has undergone multiple currency redenominations. Magento currently
includes `VEF` (Bolívar Fuerte), which has not been legal tender since
August 20, 2018, while the current official currency `VED` (Bolívar Digital,
ISO 4217, in effect since October 1, 2021) is entirely absent.

This causes silent failures: exchange rate lookups return `0` when the
requested currency code does not exist in Magento's allowed list, breaking
shipping carrier and payment gateway integrations for Venezuelan merchants.

**Changes:**
- Replace `VEF` (Bolívar Fuerte, obsolete since Aug 2018) with `VED`
  (Bolívar Digital, current ISO 4217 code since Oct 2021) in
  `lib/internal/Magento/Framework/Locale/Config.php`
- Update `VEB` comment to clarify it is a pre-2008 historical currency
- Sync `ConfigTest.php` fixture with `Config.php` (also adds `XCG` and
  `NIO` that were present in `Config.php` but missing from the test array)

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40698

### Manual testing scenarios (*)

1. Go to **Stores → Configuration → General → Currency Setup**
2. Verify that **Venezuelan Bolívar Digital (VED)** appears in the
   "Allowed Currencies" multiselect
3. Verify that **VEF** no longer appears in the list
4. Select `VED` as the store base currency and save — no error should occur
5. Go to **Stores → Currency → Currency Rates**, import rates for `VED`
   and verify the rate is fetched correctly (not `0`)

### Questions or comments

`VEB` (pre-2008 Bolívar) has been kept for historical/backward compatibility
as it was already present and the issue did not request its removal.
Happy to remove it in a follow-up or in this PR if preferred.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)