### PR TITLE
Fix add products to cart parent SKU configurable

### DIFF
--- a/app/code/Magento/Quote/Model/Cart/AddProductsToCart.php
+++ b/app/code/Magento/Quote/Model/Cart/AddProductsToCart.php
@@ -92,20 +92,24 @@ class AddProductsToCart
     public function addItemsToCart(Quote $cart, array $cartItems): array
     {
         $failedCartItems = [];
-        // add new cart items for preload
-        $skus = \array_map(
-            function ($item) {
-                return $item->getSku();
-            },
-            $cartItems
-        );
-        $this->productReader->loadProducts($skus, $cart->getStoreId());
+
+        // Collect all SKUs to pre-load: child SKUs + parent SKUs when present (GH-40598)
+        $skus = [];
+        foreach ($cartItems as $cartItem) {
+            $skus[] = $cartItem->getSku();
+            if ($cartItem->getParentSku() !== null) {
+                $skus[] = $cartItem->getParentSku();
+            }
+        }
+        $this->productReader->loadProducts(array_unique($skus), $cart->getStoreId());
+
         foreach ($cartItems as $cartItemPosition => $cartItem) {
-            $product = $this->productReader->getProductBySku($cartItem->getSku());
+            // Use the child product for stock quantity display, regardless of which product is added
+            $childProduct = $this->productReader->getProductBySku($cartItem->getSku());
             $stockItemQuantity = 0.0;
-            if ($product) {
+            if ($childProduct) {
                 $stockItem = $this->stockRegistry->getStockItem(
-                    $product->getId(),
+                    $childProduct->getId(),
                     $cart->getStore()->getWebsiteId()
                 );
                 $stockItemQuantity = $stockItem->getQty() - $stockItem->getMinQty();
@@ -146,13 +150,19 @@ class AddProductsToCart
             );
         }
 
-        $productBySku = $this->productReader->getProductBySku($sku);
+        /*
+         * GH-40598: When parent_sku is provided the buy request must be processed by the Configurable
+         * type instance (on the parent product), not by the Simple type instance (on the child).
+         * We therefore load/clone the parent product when available, falling back to the child SKU.
+         */
+        $resolvedSku = $cartItem->getParentSku() ?? $sku;
+        $productBySku = $this->productReader->getProductBySku($resolvedSku);
         $product = isset($productBySku) ? clone $productBySku : null;
 
         if (!$product || !$product->isSaleable() || !$product->isAvailable()) {
             return [
                 $this->error->create(
-                    __('Could not find a product with SKU "%sku"', ['sku' => $sku])->render(),
+                    __('Could not find a product with SKU "%sku"', ['sku' => $resolvedSku])->render(),
                     $cartItemPosition,
                     $stockItemQuantity
                 )

--- a/app/code/Magento/Quote/Model/Cart/AddProductsToCart.php
+++ b/app/code/Magento/Quote/Model/Cart/AddProductsToCart.php
@@ -150,11 +150,6 @@ class AddProductsToCart
             );
         }
 
-        /*
-         * GH-40598: When parent_sku is provided the buy request must be processed by the Configurable
-         * type instance (on the parent product), not by the Simple type instance (on the child).
-         * We therefore load/clone the parent product when available, falling back to the child SKU.
-         */
         $resolvedSku = $cartItem->getParentSku() ?? $sku;
         $productBySku = $this->productReader->getProductBySku($resolvedSku);
         $product = isset($productBySku) ? clone $productBySku : null;

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -102,6 +102,12 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
         return $superAttributesData;
     }
 
+    /**
+     * Checks whether this provider is applicable for the current option
+     *
+     * @param array $optionData
+     * @return bool
+     */
     private function isProviderApplicable(array $optionData): bool
     {
         return ($optionData[0] ?? null) === self::OPTION_TYPE;

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -110,7 +110,11 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
      */
     private function isProviderApplicable(array $optionData): bool
     {
-        return ($optionData[0] ?? null) === self::OPTION_TYPE;
+        if ($optionData[0] !== self::OPTION_TYPE) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -16,22 +16,10 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Cart\BuyRequest\BuyRequestDataProviderInterface;
 use Magento\Quote\Model\Cart\Data\CartItem;
 
-/**
- * DataProvider for building super attribute options in buy requests
- *
- * Supports two resolution strategies for configurable products:
- *   1. Via selected_options (base64-encoded UIDs) — used by addProductsToCart with selected_options.
- *   2. Via parent_sku fallback — used by addProductsToCart with parent_sku + child sku (GH-40598).
- */
 class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
 {
     private const OPTION_TYPE = 'configurable';
 
-    /**
-     * @param ProductRepositoryInterface $productRepository
-     * @param OptionCollection $optionCollection
-     * @param MetadataPool $metadataPool
-     */
     public function __construct(
         private readonly ProductRepositoryInterface $productRepository,
         private readonly OptionCollection $optionCollection,
@@ -41,14 +29,11 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
 
     /**
      * @inheritdoc
-     *
-     * @throws LocalizedException
      */
     public function execute(CartItem $cartItem): array
     {
         $configurableProductData = $this->resolveFromSelectedOptions($cartItem);
 
-        // Fallback: if no configurable UIDs found in selected_options, try resolving via parent_sku
         if (empty($configurableProductData) && $cartItem->getParentSku() !== null) {
             $configurableProductData = $this->resolveFromParentSku(
                 $cartItem->getParentSku(),
@@ -59,13 +44,6 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
         return ['super_attribute' => $configurableProductData];
     }
 
-    /**
-     * Resolves super_attribute data from base64-encoded selected_options UIDs.
-     *
-     * @param CartItem $cartItem
-     * @return array
-     * @throws LocalizedException
-     */
     private function resolveFromSelectedOptions(CartItem $cartItem): array
     {
         $configurableProductData = [];
@@ -88,15 +66,7 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
     }
 
     /**
-     * Resolves super_attribute data from parent_sku + child sku.
-     *
-     * Mirrors the logic from ConfigurableProductGraphQl\SuperAttributeDataProvider,
-     * enabling addProductsToCart to honour the documented parent_sku field.
-     *
-     * @param string $parentSku
-     * @param string $childSku
-     * @return array
-     * @throws LocalizedException
+     * Resolves super_attribute from parent_sku + child sku (GH-40598 fallback).
      */
     private function resolveFromParentSku(string $parentSku, string $childSku): array
     {
@@ -134,29 +104,15 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
         return $superAttributesData;
     }
 
-    /**
-     * Checks whether this provider is applicable for the current option
-     *
-     * @param array $optionData
-     * @return bool
-     */
     private function isProviderApplicable(array $optionData): bool
     {
         return ($optionData[0] ?? null) === self::OPTION_TYPE;
     }
 
-    /**
-     * Validates the provided options structure
-     *
-     * @param array $optionData
-     * @throws LocalizedException
-     */
     private function validateInput(array $optionData): void
     {
         if (count($optionData) !== 3) {
-            throw new LocalizedException(
-                __('Wrong format of the entered option data')
-            );
+            throw new LocalizedException(__('Wrong format of the entered option data'));
         }
     }
 }

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -16,6 +16,9 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Cart\BuyRequest\BuyRequestDataProviderInterface;
 use Magento\Quote\Model\Cart\Data\CartItem;
 
+/**
+ * DataProvider for building super attribute options in buy requests
+ */
 class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
 {
     private const OPTION_TYPE = 'configurable';

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -112,10 +112,18 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
         return ($optionData[0] ?? null) === self::OPTION_TYPE;
     }
 
+    /**
+     * Validates the provided options structure
+     *
+     * @param array $optionData
+     * @throws LocalizedException
+     */
     private function validateInput(array $optionData): void
     {
         if (count($optionData) !== 3) {
-            throw new LocalizedException(__('Wrong format of the entered option data'));
+            throw new LocalizedException(
+                __('Wrong format of the entered option data')
+            );
         }
     }
 }

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -32,6 +32,8 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
 
     /**
      * @inheritdoc
+     *
+     * @throws LocalizedException
      */
     public function execute(CartItem $cartItem): array
     {

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -7,16 +7,37 @@ declare(strict_types=1);
 
 namespace Magento\QuoteConfigurableOptions\Model\Cart\BuyRequest;
 
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProductGraphQl\Model\Options\Collection as OptionCollection;
+use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Cart\BuyRequest\BuyRequestDataProviderInterface;
 use Magento\Quote\Model\Cart\Data\CartItem;
 
 /**
  * DataProvider for building super attribute options in buy requests
+ *
+ * Supports two resolution strategies for configurable products:
+ *   1. Via selected_options (base64-encoded UIDs) — used by addProductsToCart with selected_options.
+ *   2. Via parent_sku fallback — used by addProductsToCart with parent_sku + child sku (GH-40598).
  */
 class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
 {
     private const OPTION_TYPE = 'configurable';
+
+    /**
+     * @param ProductRepositoryInterface $productRepository
+     * @param OptionCollection $optionCollection
+     * @param MetadataPool $metadataPool
+     */
+    public function __construct(
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly OptionCollection $optionCollection,
+        private readonly MetadataPool $metadataPool,
+    ) {
+    }
 
     /**
      * @inheritdoc
@@ -25,8 +46,30 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
      */
     public function execute(CartItem $cartItem): array
     {
+        $configurableProductData = $this->resolveFromSelectedOptions($cartItem);
+
+        // Fallback: if no configurable UIDs found in selected_options, try resolving via parent_sku
+        if (empty($configurableProductData) && $cartItem->getParentSku() !== null) {
+            $configurableProductData = $this->resolveFromParentSku(
+                $cartItem->getParentSku(),
+                $cartItem->getSku()
+            );
+        }
+
+        return ['super_attribute' => $configurableProductData];
+    }
+
+    /**
+     * Resolves super_attribute data from base64-encoded selected_options UIDs.
+     *
+     * @param CartItem $cartItem
+     * @return array
+     * @throws LocalizedException
+     */
+    private function resolveFromSelectedOptions(CartItem $cartItem): array
+    {
         $configurableProductData = [];
-        foreach ($cartItem->getSelectedOptions() as $optionData) {
+        foreach ($cartItem->getSelectedOptions() ?? [] as $optionData) {
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $optionData = \explode('/', base64_decode($optionData->getId()));
 
@@ -41,7 +84,54 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
             }
         }
 
-        return ['super_attribute' => $configurableProductData];
+        return $configurableProductData;
+    }
+
+    /**
+     * Resolves super_attribute data from parent_sku + child sku.
+     *
+     * Mirrors the logic from ConfigurableProductGraphQl\SuperAttributeDataProvider,
+     * enabling addProductsToCart to honour the documented parent_sku field.
+     *
+     * @param string $parentSku
+     * @param string $childSku
+     * @return array
+     * @throws LocalizedException
+     */
+    private function resolveFromParentSku(string $parentSku, string $childSku): array
+    {
+        try {
+            $parentProduct = $this->productRepository->get($parentSku);
+            $childProduct  = $this->productRepository->get($childSku);
+        } catch (NoSuchEntityException) {
+            throw new LocalizedException(__('Could not find a product with SKU "%1" or "%2".', $parentSku, $childSku));
+        }
+
+        $configurableLinks = $parentProduct->getExtensionAttributes()?->getConfigurableProductLinks() ?? [];
+        if (!in_array($childProduct->getId(), $configurableLinks, strict: true)) {
+            throw new LocalizedException(
+                __('The product "%1" is not a variant of "%2".', $childSku, $parentSku)
+            );
+        }
+
+        $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
+        $parentLinkId = (int) $parentProduct->getData($linkField);
+
+        $this->optionCollection->addProductId($parentLinkId);
+        $options = $this->optionCollection->getAttributesByProductId($parentLinkId);
+
+        $superAttributesData = [];
+        foreach ($options as $option) {
+            $code = $option['attribute_code'];
+            foreach ($option['values'] as $optionValue) {
+                if ($optionValue['value_index'] === $childProduct->getData($code)) {
+                    $superAttributesData[$option['attribute_id']] = $optionValue['value_index'];
+                    break;
+                }
+            }
+        }
+
+        return $superAttributesData;
     }
 
     /**
@@ -52,11 +142,7 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
      */
     private function isProviderApplicable(array $optionData): bool
     {
-        if ($optionData[0] !== self::OPTION_TYPE) {
-            return false;
-        }
-
-        return true;
+        return ($optionData[0] ?? null) === self::OPTION_TYPE;
     }
 
     /**

--- a/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Model/Cart/BuyRequest/SuperAttributeDataProvider.php
@@ -37,20 +37,6 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
      */
     public function execute(CartItem $cartItem): array
     {
-        $configurableProductData = $this->resolveFromSelectedOptions($cartItem);
-
-        if (empty($configurableProductData) && $cartItem->getParentSku() !== null) {
-            $configurableProductData = $this->resolveFromParentSku(
-                $cartItem->getParentSku(),
-                $cartItem->getSku()
-            );
-        }
-
-        return ['super_attribute' => $configurableProductData];
-    }
-
-    private function resolveFromSelectedOptions(CartItem $cartItem): array
-    {
         $configurableProductData = [];
         foreach ($cartItem->getSelectedOptions() ?? [] as $optionData) {
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
@@ -67,7 +53,14 @@ class SuperAttributeDataProvider implements BuyRequestDataProviderInterface
             }
         }
 
-        return $configurableProductData;
+        if (empty($configurableProductData) && $cartItem->getParentSku() !== null) {
+            $configurableProductData = $this->resolveFromParentSku(
+                $cartItem->getParentSku(),
+                $cartItem->getSku()
+            );
+        }
+
+        return ['super_attribute' => $configurableProductData];
     }
 
     /**

--- a/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
@@ -49,65 +49,36 @@ class SuperAttributeDataProviderTest extends TestCase
         );
     }
 
-    // -------------------------------------------------------------------------
-    // selected_options path (existing behaviour)
-    // -------------------------------------------------------------------------
-
-    /**
-     * When selected_options contain a valid configurable UID, super_attribute is built from them.
-     */
     public function testExecuteResolvesFromSelectedOptions(): void
     {
-        // configurable/93/57  -> attributeId=93, valueIndex=57
         $uid = base64_encode('configurable/93/57');
-
         $selectedOption = $this->createMock(SelectedOption::class);
         $selectedOption->method('getId')->willReturn($uid);
 
-        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
-
-        $result = $this->provider->execute($cartItem);
+        $result = $this->provider->execute(new CartItem('simple-child', 1.0, null, [$selectedOption]));
 
         $this->assertSame(['super_attribute' => ['93' => '57']], $result);
     }
 
-    /**
-     * Non-configurable selected_options (e.g. custom-options) are ignored.
-     */
     public function testExecuteIgnoresNonConfigurableSelectedOptions(): void
     {
         $uid = base64_encode('custom-option/10/20');
-
         $selectedOption = $this->createMock(SelectedOption::class);
         $selectedOption->method('getId')->willReturn($uid);
 
-        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
-
-        $result = $this->provider->execute($cartItem);
+        $result = $this->provider->execute(new CartItem('simple-child', 1.0, null, [$selectedOption]));
 
         $this->assertSame(['super_attribute' => []], $result);
     }
 
-    /**
-     * When no selected_options are provided but parent_sku is set, the provider
-     * falls back to resolving super_attribute via parent_sku + child sku (GH-40598).
-     */
     public function testExecuteFallsBackToParentSkuWhenNoSelectedOptions(): void
     {
-        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'ParentItem');
-
         [$parentMock, $childMock] = $this->buildProductMocks(
             parentId: 10,
             childId: 42,
             configurableLinks: [42],
             linkFieldValue: 10,
-            options: [
-                [
-                    'attribute_code' => 'color',
-                    'attribute_id'   => 93,
-                    'values'         => [['value_index' => 5]],
-                ],
-            ],
+            options: [['attribute_code' => 'color', 'attribute_id' => 93, 'values' => [['value_index' => 5]]]],
             childAttributeValue: 5
         );
 
@@ -116,62 +87,40 @@ class SuperAttributeDataProviderTest extends TestCase
             ['ParentItem-Variant', false, null, false, $childMock],
         ]);
 
-        $result = $this->provider->execute($cartItem);
+        $result = $this->provider->execute(new CartItem('ParentItem-Variant', 1.0, 'ParentItem'));
 
         $this->assertSame(['super_attribute' => [93 => 5]], $result);
     }
 
-    /**
-     * selected_options take priority over parent_sku: if configurable UIDs are present
-     * the parent_sku fallback must NOT be triggered.
-     */
     public function testSelectedOptionsTakePriorityOverParentSku(): void
     {
         $uid = base64_encode('configurable/93/57');
-
         $selectedOption = $this->createMock(SelectedOption::class);
         $selectedOption->method('getId')->willReturn($uid);
 
-        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'ParentItem', [$selectedOption]);
-
-        // Repository should never be called when selected_options already contain the data
         $this->productRepository->expects($this->never())->method('get');
 
-        $result = $this->provider->execute($cartItem);
+        $result = $this->provider->execute(new CartItem('ParentItem-Variant', 1.0, 'ParentItem', [$selectedOption]));
 
         $this->assertSame(['super_attribute' => ['93' => '57']], $result);
     }
 
-    /**
-     * GH-40598: When neither selected_options nor parent_sku are provided, the provider
-     * returns an empty super_attribute array (simple product behaviour unchanged).
-     */
     public function testExecuteReturnsEmptyWhenNoSelectedOptionsAndNoParentSku(): void
     {
-        $cartItem = new CartItem('simple-standalone', 1.0);
-
         $this->productRepository->expects($this->never())->method('get');
 
-        $result = $this->provider->execute($cartItem);
+        $result = $this->provider->execute(new CartItem('simple-standalone', 1.0));
 
         $this->assertSame(['super_attribute' => []], $result);
     }
 
-    /**
-     * GH-40598: A LocalizedException is thrown when the child SKU is not a variant
-     * of the supplied parent_sku.
-     */
     public function testExecuteThrowsWhenChildIsNotVariantOfParent(): void
     {
-        $cartItem = new CartItem('other-simple', 1.0, 'ParentItem');
-
-        // getConfigurableProductLinks() is a generated extension attribute method —
-        // we must use createPartialMockWithReflection to be able to stub it.
         $extensionAttributes = $this->createPartialMockWithReflection(
             ProductExtensionInterface::class,
             ['getConfigurableProductLinks']
         );
-        $extensionAttributes->method('getConfigurableProductLinks')->willReturn([99]); // child id 42 not in list
+        $extensionAttributes->method('getConfigurableProductLinks')->willReturn([99]);
 
         $parentMock = $this->createMock(Product::class);
         $parentMock->method('getId')->willReturn(10);
@@ -179,7 +128,7 @@ class SuperAttributeDataProviderTest extends TestCase
         $parentMock->method('getData')->willReturn(10);
 
         $childMock = $this->createMock(Product::class);
-        $childMock->method('getId')->willReturn(42); // 42 != 99
+        $childMock->method('getId')->willReturn(42);
 
         $this->productRepository->method('get')->willReturnMap([
             ['ParentItem',   false, null, false, $parentMock],
@@ -189,59 +138,29 @@ class SuperAttributeDataProviderTest extends TestCase
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('not a variant');
 
-        $this->provider->execute($cartItem);
+        $this->provider->execute(new CartItem('other-simple', 1.0, 'ParentItem'));
     }
 
-    /**
-     * GH-40598: A LocalizedException is thrown when the parent or child product does not exist.
-     */
     public function testExecuteThrowsWhenProductNotFound(): void
     {
-        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'NonExistentParent');
-
-        $this->productRepository->method('get')
-            ->willThrowException(new NoSuchEntityException());
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
 
         $this->expectException(LocalizedException::class);
 
-        $this->provider->execute($cartItem);
+        $this->provider->execute(new CartItem('ParentItem-Variant', 1.0, 'NonExistentParent'));
     }
 
-    /**
-     * GH-40598: A LocalizedException is thrown when a selected_option UID has wrong format.
-     */
     public function testExecuteThrowsOnMalformedSelectedOptionUid(): void
     {
-        $uid = base64_encode('configurable/only-two-parts');  // should be 3 parts
-
+        $uid = base64_encode('configurable/only-two-parts');
         $selectedOption = $this->createMock(SelectedOption::class);
         $selectedOption->method('getId')->willReturn($uid);
 
-        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
-
         $this->expectException(LocalizedException::class);
 
-        $this->provider->execute($cartItem);
+        $this->provider->execute(new CartItem('simple-child', 1.0, null, [$selectedOption]));
     }
 
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    /**
-     * Build parent & child product mocks for the parent_sku fallback path.
-     *
-     * getConfigurableProductLinks() is a generated extension attribute method —
-     * we must use createPartialMockWithReflection to be able to stub it.
-     *
-     * @param int   $parentId
-     * @param int   $childId
-     * @param int[] $configurableLinks
-     * @param int   $linkFieldValue
-     * @param array $options
-     * @param mixed $childAttributeValue
-     * @return array{0: MockObject, 1: MockObject}
-     */
     private function buildProductMocks(
         int $parentId,
         int $childId,
@@ -267,13 +186,9 @@ class SuperAttributeDataProviderTest extends TestCase
 
         $productMetadata = $this->createMock(EntityMetadataInterface::class);
         $productMetadata->method('getLinkField')->willReturn('entity_id');
-        $this->metadataPool->method('getMetadata')
-            ->with(ProductInterface::class)
-            ->willReturn($productMetadata);
+        $this->metadataPool->method('getMetadata')->with(ProductInterface::class)->willReturn($productMetadata);
 
-        $this->optionCollection->method('getAttributesByProductId')
-            ->with($linkFieldValue)
-            ->willReturn($options);
+        $this->optionCollection->method('getAttributesByProductId')->with($linkFieldValue)->willReturn($options);
 
         return [$parentMock, $childMock];
     }

--- a/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2020 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);

--- a/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
+++ b/app/code/Magento/QuoteConfigurableOptions/Test/Unit/Model/Cart/BuyRequest/SuperAttributeDataProviderTest.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Copyright 2020 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\QuoteConfigurableOptions\Test\Unit\Model\Cart\BuyRequest;
+
+use Magento\Catalog\Api\Data\ProductExtensionInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProductGraphQl\Model\Options\Collection as OptionCollection;
+use Magento\Framework\EntityManager\EntityMetadataInterface;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
+use Magento\Quote\Model\Cart\Data\CartItem;
+use Magento\Quote\Model\Cart\Data\SelectedOption;
+use Magento\QuoteConfigurableOptions\Model\Cart\BuyRequest\SuperAttributeDataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Magento\QuoteConfigurableOptions\Model\Cart\BuyRequest\SuperAttributeDataProvider
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class SuperAttributeDataProviderTest extends TestCase
+{
+    use MockCreationTrait;
+
+    private SuperAttributeDataProvider $provider;
+    private ProductRepositoryInterface&MockObject $productRepository;
+    private OptionCollection&MockObject $optionCollection;
+    private MetadataPool&MockObject $metadataPool;
+
+    protected function setUp(): void
+    {
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
+        $this->optionCollection  = $this->createMock(OptionCollection::class);
+        $this->metadataPool      = $this->createMock(MetadataPool::class);
+
+        $this->provider = new SuperAttributeDataProvider(
+            $this->productRepository,
+            $this->optionCollection,
+            $this->metadataPool,
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // selected_options path (existing behaviour)
+    // -------------------------------------------------------------------------
+
+    /**
+     * When selected_options contain a valid configurable UID, super_attribute is built from them.
+     */
+    public function testExecuteResolvesFromSelectedOptions(): void
+    {
+        // configurable/93/57  -> attributeId=93, valueIndex=57
+        $uid = base64_encode('configurable/93/57');
+
+        $selectedOption = $this->createMock(SelectedOption::class);
+        $selectedOption->method('getId')->willReturn($uid);
+
+        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
+
+        $result = $this->provider->execute($cartItem);
+
+        $this->assertSame(['super_attribute' => ['93' => '57']], $result);
+    }
+
+    /**
+     * Non-configurable selected_options (e.g. custom-options) are ignored.
+     */
+    public function testExecuteIgnoresNonConfigurableSelectedOptions(): void
+    {
+        $uid = base64_encode('custom-option/10/20');
+
+        $selectedOption = $this->createMock(SelectedOption::class);
+        $selectedOption->method('getId')->willReturn($uid);
+
+        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
+
+        $result = $this->provider->execute($cartItem);
+
+        $this->assertSame(['super_attribute' => []], $result);
+    }
+
+    /**
+     * When no selected_options are provided but parent_sku is set, the provider
+     * falls back to resolving super_attribute via parent_sku + child sku (GH-40598).
+     */
+    public function testExecuteFallsBackToParentSkuWhenNoSelectedOptions(): void
+    {
+        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'ParentItem');
+
+        [$parentMock, $childMock] = $this->buildProductMocks(
+            parentId: 10,
+            childId: 42,
+            configurableLinks: [42],
+            linkFieldValue: 10,
+            options: [
+                [
+                    'attribute_code' => 'color',
+                    'attribute_id'   => 93,
+                    'values'         => [['value_index' => 5]],
+                ],
+            ],
+            childAttributeValue: 5
+        );
+
+        $this->productRepository->method('get')->willReturnMap([
+            ['ParentItem',         false, null, false, $parentMock],
+            ['ParentItem-Variant', false, null, false, $childMock],
+        ]);
+
+        $result = $this->provider->execute($cartItem);
+
+        $this->assertSame(['super_attribute' => [93 => 5]], $result);
+    }
+
+    /**
+     * selected_options take priority over parent_sku: if configurable UIDs are present
+     * the parent_sku fallback must NOT be triggered.
+     */
+    public function testSelectedOptionsTakePriorityOverParentSku(): void
+    {
+        $uid = base64_encode('configurable/93/57');
+
+        $selectedOption = $this->createMock(SelectedOption::class);
+        $selectedOption->method('getId')->willReturn($uid);
+
+        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'ParentItem', [$selectedOption]);
+
+        // Repository should never be called when selected_options already contain the data
+        $this->productRepository->expects($this->never())->method('get');
+
+        $result = $this->provider->execute($cartItem);
+
+        $this->assertSame(['super_attribute' => ['93' => '57']], $result);
+    }
+
+    /**
+     * GH-40598: When neither selected_options nor parent_sku are provided, the provider
+     * returns an empty super_attribute array (simple product behaviour unchanged).
+     */
+    public function testExecuteReturnsEmptyWhenNoSelectedOptionsAndNoParentSku(): void
+    {
+        $cartItem = new CartItem('simple-standalone', 1.0);
+
+        $this->productRepository->expects($this->never())->method('get');
+
+        $result = $this->provider->execute($cartItem);
+
+        $this->assertSame(['super_attribute' => []], $result);
+    }
+
+    /**
+     * GH-40598: A LocalizedException is thrown when the child SKU is not a variant
+     * of the supplied parent_sku.
+     */
+    public function testExecuteThrowsWhenChildIsNotVariantOfParent(): void
+    {
+        $cartItem = new CartItem('other-simple', 1.0, 'ParentItem');
+
+        // getConfigurableProductLinks() is a generated extension attribute method —
+        // we must use createPartialMockWithReflection to be able to stub it.
+        $extensionAttributes = $this->createPartialMockWithReflection(
+            ProductExtensionInterface::class,
+            ['getConfigurableProductLinks']
+        );
+        $extensionAttributes->method('getConfigurableProductLinks')->willReturn([99]); // child id 42 not in list
+
+        $parentMock = $this->createMock(Product::class);
+        $parentMock->method('getId')->willReturn(10);
+        $parentMock->method('getExtensionAttributes')->willReturn($extensionAttributes);
+        $parentMock->method('getData')->willReturn(10);
+
+        $childMock = $this->createMock(Product::class);
+        $childMock->method('getId')->willReturn(42); // 42 != 99
+
+        $this->productRepository->method('get')->willReturnMap([
+            ['ParentItem',   false, null, false, $parentMock],
+            ['other-simple', false, null, false, $childMock],
+        ]);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('not a variant');
+
+        $this->provider->execute($cartItem);
+    }
+
+    /**
+     * GH-40598: A LocalizedException is thrown when the parent or child product does not exist.
+     */
+    public function testExecuteThrowsWhenProductNotFound(): void
+    {
+        $cartItem = new CartItem('ParentItem-Variant', 1.0, 'NonExistentParent');
+
+        $this->productRepository->method('get')
+            ->willThrowException(new NoSuchEntityException());
+
+        $this->expectException(LocalizedException::class);
+
+        $this->provider->execute($cartItem);
+    }
+
+    /**
+     * GH-40598: A LocalizedException is thrown when a selected_option UID has wrong format.
+     */
+    public function testExecuteThrowsOnMalformedSelectedOptionUid(): void
+    {
+        $uid = base64_encode('configurable/only-two-parts');  // should be 3 parts
+
+        $selectedOption = $this->createMock(SelectedOption::class);
+        $selectedOption->method('getId')->willReturn($uid);
+
+        $cartItem = new CartItem('simple-child', 1.0, null, [$selectedOption]);
+
+        $this->expectException(LocalizedException::class);
+
+        $this->provider->execute($cartItem);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build parent & child product mocks for the parent_sku fallback path.
+     *
+     * getConfigurableProductLinks() is a generated extension attribute method —
+     * we must use createPartialMockWithReflection to be able to stub it.
+     *
+     * @param int   $parentId
+     * @param int   $childId
+     * @param int[] $configurableLinks
+     * @param int   $linkFieldValue
+     * @param array $options
+     * @param mixed $childAttributeValue
+     * @return array{0: MockObject, 1: MockObject}
+     */
+    private function buildProductMocks(
+        int $parentId,
+        int $childId,
+        array $configurableLinks,
+        int $linkFieldValue,
+        array $options,
+        mixed $childAttributeValue,
+    ): array {
+        $extensionAttributes = $this->createPartialMockWithReflection(
+            ProductExtensionInterface::class,
+            ['getConfigurableProductLinks']
+        );
+        $extensionAttributes->method('getConfigurableProductLinks')->willReturn($configurableLinks);
+
+        $parentMock = $this->createMock(Product::class);
+        $parentMock->method('getId')->willReturn($parentId);
+        $parentMock->method('getExtensionAttributes')->willReturn($extensionAttributes);
+        $parentMock->method('getData')->willReturn($linkFieldValue);
+
+        $childMock = $this->createMock(Product::class);
+        $childMock->method('getId')->willReturn($childId);
+        $childMock->method('getData')->willReturn($childAttributeValue);
+
+        $productMetadata = $this->createMock(EntityMetadataInterface::class);
+        $productMetadata->method('getLinkField')->willReturn('entity_id');
+        $this->metadataPool->method('getMetadata')
+            ->with(ProductInterface::class)
+            ->willReturn($productMetadata);
+
+        $this->optionCollection->method('getAttributesByProductId')
+            ->with($linkFieldValue)
+            ->willReturn($options);
+
+        return [$parentMock, $childMock];
+    }
+}

--- a/app/code/Magento/QuoteConfigurableOptions/composer.json
+++ b/app/code/Magento/QuoteConfigurableOptions/composer.json
@@ -4,6 +4,8 @@
     "require": {
         "php": "~8.3.0||~8.4.0||~8.5.0",
         "magento/framework": "*",
+        "magento/module-catalog": "*",
+        "magento/module-configurable-product-graph-ql": "*",
         "magento/module-quote": "*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/QuoteConfigurableOptions/etc/module.xml
+++ b/app/code/Magento/QuoteConfigurableOptions/etc/module.xml
@@ -6,5 +6,10 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_QuoteConfigurableOptions"/>
+    <module name="Magento_QuoteConfigurableOptions">
+        <sequence>
+            <module name="Magento_ConfigurableProductGraphQl"/>
+            <module name="Magento_Catalog"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
### Description (*)

`addProductsToCart` mutation ignores `parent_sku` for configurable products, causing the item to be added without the correct variant options (wrong product type instance processes the buy request).

Two root causes are fixed:

**1. `QuoteConfigurableOptions\SuperAttributeDataProvider`**
When `selected_options` contains no configurable UIDs, the provider now falls back to resolving `super_attribute` data from `parent_sku` + child `sku` using `ConfigurableProductGraphQl\Model\Options\Collection` — mirroring the existing logic in `ConfigurableProductGraphQl\SuperAttributeDataProvider`.

**2. `Quote\Model\Cart\AddProductsToCart::addItemToCart`**
When `parent_sku` is present, the service now loads the parent configurable product and passes it to `Quote::addProduct()` instead of the child simple product. This ensures the Configurable type instance processes the `buyRequest` with the resolved `super_attribute` data.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40598

### Manual testing scenarios (*)

**Prerequisites:** A configurable product (e.g. SKU `MH01`) with at least one child variant (e.g. SKU `MH01-XS-Black`).

**Scenario 1 — `parent_sku` without `selected_options` (main fix)**
1. Create an empty cart: `createEmptyCart`.
2. Run `addProductsToCart` with:
```graphql
cartItems: [{
  quantity: 1
  sku: "MH01-XS-Black"
  parent_sku: "MH01"
}]
```
3. Check the cart — the item must appear as a **ConfigurableCartItem** with the correct variant options selected.
4. Before the fix: the item was either rejected or added without variant info.
**Scenario 2 — `selected_options` (regression check)**
1. Create an empty cart.
2. Run `addProductsToCart` with a base64-encoded configurable UID in `selected_options` (no `parent_sku`).
3. Check the cart — behaviour must be unchanged.
**Scenario 3 — invalid `parent_sku`**
1. Run `addProductsToCart` with a `parent_sku` that does not own the given child `sku`.
2. Expect a user-friendly error: `"The product ... is not a variant of ..."`.
### Questions or comments
- The fallback reads extension attributes (`getConfigurableProductLinks`) which are loaded only when the product is fetched via `ProductRepository`. If the product is already in the object cache this is a no-op.
- Unit tests (8 cases) cover: selected_options path, parent_sku fallback, priority rules, invalid variant, product not found, malformed UID.
### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)