### PR TITLE
[Bug] GraphQL SearchCriteriaValidator not loaded — removed by module-graph-ql di.xml array override

### DIFF
--- a/app/code/Magento/GraphQl/etc/di.xml
+++ b/app/code/Magento/GraphQl/etc/di.xml
@@ -110,9 +110,8 @@
     <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
         <arguments>
             <argument name="validators" xsi:type="array">
-                <item name="backpressureValidator" xsi:type="object">
-                    Magento\GraphQl\Model\Backpressure\BackpressureFieldValidator
-                </item>
+                <item name="searchCriteriaValidator" xsi:type="object">Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator</item>
+                <item name="backpressureValidator" xsi:type="object">Magento\GraphQl\Model\Backpressure\BackpressureFieldValidator</item>
             </argument>
         </arguments>
     </type>

--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1990,13 +1990,6 @@
         </arguments>
     </type>
     <preference for="Magento\Framework\GraphQl\Query\Resolver\Argument\ValidatorInterface" type="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator"/>
-    <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
-        <arguments>
-            <argument name="validators" xsi:type="array">
-                <item name="searchCriteriaValidator" xsi:type="object">Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator</item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator">
         <arguments>
             <argument name="maxPageSize" xsi:type="number">300</argument>

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Query/SearchCriteriaValidatorTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Query/SearchCriteriaValidatorTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Query;
+
+use Magento\TestFramework\Fixture\Config;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+use Magento\TestFramework\TestCase\GraphQl\ResponseContainsErrorsException;
+
+/**
+ * Verify that SearchCriteriaValidator enforces the pageSize limit in GraphQL queries.
+ *
+ * Regression: Magento_GraphQl module-level di.xml was overriding the global di.xml array argument
+ * for CompositeValidator, silently dropping SearchCriteriaValidator from the composite.
+ */
+class SearchCriteriaValidatorTest extends GraphQlAbstract
+{
+    /**
+     * Verify that a pageSize argument exceeding the configured maximum returns an error.
+     *
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     */
+    #[
+        Config('graphql/validation/input_limit_enabled', 1),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
+    public function testProductsQueryExceedingPageSizeReturnsError(): void
+    {
+        $query = <<<QUERY
+        {
+            products(pageSize: 6, filter: {sku: {eq: "simple_product"}}) {
+                total_count
+            }
+        }
+        QUERY;
+
+        $this->expectException(ResponseContainsErrorsException::class);
+        $this->expectExceptionMessage('Maximum pageSize is 5');
+        $this->graphQlQuery($query);
+    }
+
+    /**
+     * Verify that a pageSize argument within the configured maximum succeeds.
+     *
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     */
+    #[
+        Config('graphql/validation/input_limit_enabled', 1),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
+    public function testProductsQueryWithinPageSizeLimitSucceeds(): void
+    {
+        $query = <<<QUERY
+        {
+            products(pageSize: 5, filter: {sku: {eq: "simple_product"}}) {
+                total_count
+            }
+        }
+        QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('products', $response);
+    }
+
+    /**
+     * Verify that pageSize is not enforced when input limiting is disabled.
+     *
+     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
+     */
+    #[
+        Config('graphql/validation/input_limit_enabled', 0),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
+    public function testProductsQueryPageSizeNotEnforcedWhenLimitingDisabled(): void
+    {
+        $query = <<<QUERY
+        {
+            products(pageSize: 100, filter: {sku: {eq: "simple_product"}}) {
+                total_count
+            }
+        }
+        QUERY;
+
+        $response = $this->graphQlQuery($query);
+        $this->assertArrayHasKey('products', $response);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Query/SearchCriteriaValidatorTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Query/SearchCriteriaValidatorTest.php
@@ -21,18 +21,16 @@ class SearchCriteriaValidatorTest extends GraphQlAbstract
 {
     /**
      * Verify that a pageSize argument exceeding the configured maximum returns an error.
-     *
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      */
     #[
         Config('graphql/validation/input_limit_enabled', 1),
         Config('graphql/validation/maximum_page_size', 5)
     ]
-    public function testProductsQueryExceedingPageSizeReturnsError(): void
+    public function testProductsQueryExceedingPageSizeReturnsError()
     {
         $query = <<<QUERY
         {
-            products(pageSize: 6, filter: {sku: {eq: "simple_product"}}) {
+            products(pageSize: 6, filter: {sku: {eq: "test"}}) {
                 total_count
             }
         }
@@ -45,18 +43,16 @@ class SearchCriteriaValidatorTest extends GraphQlAbstract
 
     /**
      * Verify that a pageSize argument within the configured maximum succeeds.
-     *
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      */
     #[
         Config('graphql/validation/input_limit_enabled', 1),
         Config('graphql/validation/maximum_page_size', 5)
     ]
-    public function testProductsQueryWithinPageSizeLimitSucceeds(): void
+    public function testProductsQueryWithinPageSizeLimitSucceeds()
     {
         $query = <<<QUERY
         {
-            products(pageSize: 5, filter: {sku: {eq: "simple_product"}}) {
+            products(pageSize: 5, filter: {sku: {eq: "test"}}) {
                 total_count
             }
         }
@@ -68,18 +64,16 @@ class SearchCriteriaValidatorTest extends GraphQlAbstract
 
     /**
      * Verify that pageSize is not enforced when input limiting is disabled.
-     *
-     * @magentoApiDataFixture Magento/GraphQl/Catalog/_files/simple_product.php
      */
     #[
         Config('graphql/validation/input_limit_enabled', 0),
         Config('graphql/validation/maximum_page_size', 5)
     ]
-    public function testProductsQueryPageSizeNotEnforcedWhenLimitingDisabled(): void
+    public function testProductsQueryPageSizeNotEnforcedWhenLimitingDisabled()
     {
         $query = <<<QUERY
         {
-            products(pageSize: 100, filter: {sku: {eq: "simple_product"}}) {
+            products(pageSize: 100, filter: {sku: {eq: "test"}}) {
                 total_count
             }
         }

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Query/CompositeValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Query/CompositeValidatorTest.php
@@ -5,12 +5,17 @@
  */
 declare(strict_types=1);
 
-namespace Magento\GraphQl\Query\Resolver\Argument\Validator;
+namespace Magento\GraphQl\Query;
 
+use Magento\Framework\App\Area;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\Config;
+use Magento\TestFramework\Fixture\DbIsolation;
 use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,6 +27,11 @@ use PHPUnit\Framework\TestCase;
  * Regression: module-level di.xml array arguments replace global di.xml entries,
  * so SearchCriteriaValidator was silently dropped from CompositeValidator.
  */
+#[
+    CoversClass(CompositeValidator::class),
+    AppArea(Area::AREA_GRAPHQL),
+    DbIsolation(false),
+]
 class CompositeValidatorTest extends TestCase
 {
     /**
@@ -39,10 +49,11 @@ class CompositeValidatorTest extends TestCase
 
     /**
      * Verify SearchCriteriaValidator in composite enforces pageSize when limiting is enabled.
-     *
-     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 1
-     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
      */
+    #[
+        Config('graphql/validation/input_limit_enabled', 1),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
     public function testSearchCriteriaValidatorEnforcesPageSizeLimit(): void
     {
         $field = $this->createMock(Field::class);
@@ -56,9 +67,11 @@ class CompositeValidatorTest extends TestCase
      * Verify composite does not throw when pageSize is within the configured limit.
      *
      * @doesNotPerformAssertions
-     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 1
-     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
      */
+    #[
+        Config('graphql/validation/input_limit_enabled', 1),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
     public function testCompositeAllowsPageSizeWithinLimit(): void
     {
         $field = $this->createMock(Field::class);
@@ -70,9 +83,11 @@ class CompositeValidatorTest extends TestCase
      * Verify composite does not throw when input limiting is disabled.
      *
      * @doesNotPerformAssertions
-     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 0
-     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
      */
+    #[
+        Config('graphql/validation/input_limit_enabled', 0),
+        Config('graphql/validation/maximum_page_size', 5)
+    ]
     public function testSearchCriteriaValidatorSkipsEnforcementWhenDisabled(): void
     {
         $field = $this->createMock(Field::class);

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Query/CompositeValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Query/CompositeValidatorTest.php
@@ -11,6 +11,7 @@ use Magento\Framework\App\Area;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator;
+use Magento\Store\Model\ScopeInterface;
 use Magento\TestFramework\Fixture\AppArea;
 use Magento\TestFramework\Fixture\Config;
 use Magento\TestFramework\Fixture\DbIsolation;
@@ -51,8 +52,8 @@ class CompositeValidatorTest extends TestCase
      * Verify SearchCriteriaValidator in composite enforces pageSize when limiting is enabled.
      */
     #[
-        Config('graphql/validation/input_limit_enabled', 1),
-        Config('graphql/validation/maximum_page_size', 5)
+        Config('graphql/validation/input_limit_enabled', 1, ScopeInterface::SCOPE_STORE, 'default'),
+        Config('graphql/validation/maximum_page_size', 5, ScopeInterface::SCOPE_STORE, 'default')
     ]
     public function testSearchCriteriaValidatorEnforcesPageSizeLimit(): void
     {
@@ -69,8 +70,8 @@ class CompositeValidatorTest extends TestCase
      * @doesNotPerformAssertions
      */
     #[
-        Config('graphql/validation/input_limit_enabled', 1),
-        Config('graphql/validation/maximum_page_size', 5)
+        Config('graphql/validation/input_limit_enabled', 1, ScopeInterface::SCOPE_STORE, 'default'),
+        Config('graphql/validation/maximum_page_size', 5, ScopeInterface::SCOPE_STORE, 'default')
     ]
     public function testCompositeAllowsPageSizeWithinLimit(): void
     {
@@ -85,8 +86,8 @@ class CompositeValidatorTest extends TestCase
      * @doesNotPerformAssertions
      */
     #[
-        Config('graphql/validation/input_limit_enabled', 0),
-        Config('graphql/validation/maximum_page_size', 5)
+        Config('graphql/validation/input_limit_enabled', 0, ScopeInterface::SCOPE_STORE, 'default'),
+        Config('graphql/validation/maximum_page_size', 5, ScopeInterface::SCOPE_STORE, 'default')
     ]
     public function testSearchCriteriaValidatorSkipsEnforcementWhenDisabled(): void
     {

--- a/dev/tests/integration/testsuite/Magento/GraphQl/Query/Resolver/Argument/Validator/CompositeValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/GraphQl/Query/Resolver/Argument/Validator/CompositeValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Query\Resolver\Argument\Validator;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verify that CompositeValidator correctly delegates to all registered validators.
+ *
+ * Integration test for composites per DoD: ensures SearchCriteriaValidator and
+ * BackpressureFieldValidator are loaded and functional within the composite.
+ *
+ * Regression: module-level di.xml array arguments replace global di.xml entries,
+ * so SearchCriteriaValidator was silently dropped from CompositeValidator.
+ */
+class CompositeValidatorTest extends TestCase
+{
+    /**
+     * @var CompositeValidator
+     */
+    private CompositeValidator $compositeValidator;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->compositeValidator = Bootstrap::getObjectManager()->get(CompositeValidator::class);
+    }
+
+    /**
+     * Verify SearchCriteriaValidator in composite enforces pageSize when limiting is enabled.
+     *
+     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 1
+     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
+     */
+    public function testSearchCriteriaValidatorEnforcesPageSizeLimit(): void
+    {
+        $field = $this->createMock(Field::class);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Maximum pageSize is 5');
+        $this->compositeValidator->validate($field, ['pageSize' => 6]);
+    }
+
+    /**
+     * Verify composite does not throw when pageSize is within the configured limit.
+     *
+     * @doesNotPerformAssertions
+     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 1
+     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
+     */
+    public function testCompositeAllowsPageSizeWithinLimit(): void
+    {
+        $field = $this->createMock(Field::class);
+
+        $this->compositeValidator->validate($field, ['pageSize' => 5]);
+    }
+
+    /**
+     * Verify composite does not throw when input limiting is disabled.
+     *
+     * @doesNotPerformAssertions
+     * @magentoConfigFixture default_store graphql/validation/input_limit_enabled 0
+     * @magentoConfigFixture default_store graphql/validation/maximum_page_size 5
+     */
+    public function testSearchCriteriaValidatorSkipsEnforcementWhenDisabled(): void
+    {
+        $field = $this->createMock(Field::class);
+
+        $this->compositeValidator->validate($field, ['pageSize' => 100]);
+    }
+}


### PR DESCRIPTION
## Preconditions

- Magento 2.4.7-p9 (`magento/module-graph-ql` 100.4.7-p9)
- Any GraphQL query with `pageSize` or `currentPage` arguments

---

## Steps to reproduce

1. Execute any GraphQL query with `pageSize` exceeding the configured limit, e.g.:

```graphql
{
    products(search: "test", pageSize: 999) {
        items {
            sku
        }
    }
}
```

---

## Expected result

GraphQL returns a validation error:

```json
{
    "data": {
        "products": null
    },
    "errors": [
        {
            "message": "Maximum pageSize is 10",
            "path": [
                "products"
            ],
            "locations": [
                {
                    "line": 2,
                    "column": 5
                }
            ],
            "extensions": {
                "category": "graphql-input"
            }
        }
    ]
}
```

(`Maximum pageSize is X` — where X is the configured `maxPageSize` value, default 300)

---

## Actual result

Query executes without validation. `pageSize: 999` is accepted silently. No error is returned.

---

## Root cause

`SearchCriteriaValidator` (which enforces `maxPageSize: 300`) is registered
in `magento2-base/app/etc/di.xml` (primary config):

```xml
<!-- magento2-base/app/etc/di.xml -->
<type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
    <arguments>
        <argument name="validators" xsi:type="array">
            <item name="searchCriteriaValidator" xsi:type="object">
                Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator
            </item>
        </argument>
    </arguments>
</type>
```

`module-graph-ql/etc/di.xml` (module config) also defines `validators` for the
same type, but only with `backpressureValidator`:

```xml
<!-- module-graph-ql/etc/di.xml -->
<type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
    <arguments>
        <argument name="validators" xsi:type="array">
            <item name="backpressureValidator" xsi:type="object">
                Magento\GraphQl\Model\Backpressure\BackpressureFieldValidator
            </item>
        </argument>
    </arguments>
</type>
```

Module-level DI configuration has higher priority than primary config.
When module config defines the same `xsi:type="array"` argument, it **replaces**
the primary config's array — it does **not** merge items. As a result,
`searchCriteriaValidator` is silently dropped.

**Verification at runtime:**

```php
$validator = $objectManager->get(
    \Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator::class
);
$ref = new ReflectionClass($validator);
$prop = $ref->getProperty('validators');
$prop->setAccessible(true);
var_dump(array_keys($prop->getValue($validator)));
// Output: ['backpressureValidator']
// Expected: ['searchCriteriaValidator', 'backpressureValidator']
```

## Proposed fix

Move `searchCriteriaValidator` registration **from** `magento2-base/app/etc/di.xml`
**to** `module-graph-ql/etc/di.xml`. Both validators should live at module level
so that future validators added by third-party modules can safely merge via
`xsi:type="array"`.

### `module-graph-ql/etc/di.xml` — after fix

```xml
<type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
    <arguments>
        <argument name="validators" xsi:type="array">
            <item name="searchCriteriaValidator" xsi:type="object">
                Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator
            </item>
            <item name="backpressureValidator" xsi:type="object">
                Magento\GraphQl\Model\Backpressure\BackpressureFieldValidator
            </item>
        </argument>
    </arguments>
</type>
```

### `magento2-base/app/etc/di.xml` — remove this block

```xml
<!-- REMOVE: -->
<type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
    <arguments>
        <argument name="validators" xsi:type="array">
            <item name="searchCriteriaValidator" xsi:type="object">
                Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator
            </item>
        </argument>
    </arguments>
</type>
```



### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any predefined sections require an update
- [ ] All automated tests passed successfully (all builds are green)

---

## Temporary workaround (composer patch)

Until the upstream fix is merged — apply a patch via `cweagans/composer-patches`.

### 1. `composer.json`

```json
"extra": {
    "composer-exit-on-patch-failure": true,
    "patches": {
        "magento/module-graph-ql": {
            "Fix search criteria composite validator": "patches/magento/module-graph-ql/fix-search-validator.diff"
        }
    }
}
```

### 2. `patches/magento/module-graph-ql/fix-search-validator.diff`

```diff
Index: etc/di.xml
===================================================================
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -107,6 +107,7 @@
     <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\CompositeValidator">
         <arguments>
             <argument name="validators" xsi:type="array">
+                <item name="searchCriteriaValidator" xsi:type="object">Magento\Framework\GraphQl\Query\Resolver\Argument\Validator\SearchCriteriaValidator</item>
                 <item name="backpressureValidator" xsi:type="object">
                     Magento\GraphQl\Model\Backpressure\BackpressureFieldValidator
                 </item>
```

### 3. Apply

```bash
composer require cweagans/composer-patches --no-update
composer update magento/module-graph-ql
# or simply:
composer install 
```

---

## Affected repositories

- `magento/magento2` — `app/etc/di.xml` (magento2-base)
- `magento/module-graph-ql` — `etc/di.xml`

## Affected versions

All versions of `magento/module-graph-ql` that introduced `backpressureValidator`
(i.e. all versions that define `CompositeValidator` type in their `etc/di.xml`).


### Resolved issues:
1. [x] resolves magento/magento2#40762: [Bug] GraphQL SearchCriteriaValidator not loaded — removed by module-graph-ql di.xml array override