### PR TITLE
Fix Product Links always being processed in afterSave

### DIFF
--- a/app/code/Magento/Catalog/Model/Product.php
+++ b/app/code/Magento/Catalog/Model/Product.php
@@ -963,7 +963,10 @@ class Product extends \Magento\Catalog\Model\AbstractModel implements
      */
     public function afterSave()
     {
-        $this->getLinkInstance()->saveProductRelations($this);
+        if ($this->getData('ignore_links_flag') !== true) {
+            $this->getLinkInstance()->saveProductRelations($this);
+        }
+
         $this->getTypeInstance()->save($this);
 
         if ($this->getStockData()) {

--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -449,7 +449,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     private function processLinks(ProductInterface $product, $newLinks)
     {
         if ($newLinks === null) {
-            // If product links were not specified, don't do anything
+            // If product links were not specified, set the product links as null to prevent post-processing of links
+            $product->setProductLinks($newLinks);
             return $this;
         }
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -1257,8 +1257,9 @@ class ProductRepositoryTest extends TestCase
                 ->method('setProductLinks')
                 ->with($outputLinks);
         } else {
-            $this->initializedProduct->expects($this->never())
-                ->method('setProductLinks');
+            $this->initializedProduct->expects($this->once())
+                ->method('setProductLinks')
+                ->with(null);
         }
         $this->initializedProduct->expects($this->atLeastOnce())
             ->method('getSku')->willReturn($this->productData['sku']);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductTest.php
@@ -285,6 +285,11 @@ class ProductTest extends TestCase
     private $storeManager;
 
     /**
+     * @var ProductLink|MockObject
+     */
+    private $productLinkInstanceMock;
+
+    /**
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @inheritDoc
      */
@@ -413,6 +418,8 @@ class ProductTest extends TestCase
                 return $attributes;
             });
 
+        $this->productLinkInstanceMock = $this->createMock(ProductLink::class);
+
         $this->model = new Product(
             $contextMock,
             $this->registry,
@@ -421,7 +428,7 @@ class ProductTest extends TestCase
             $this->storeManager,
             $this->metadataServiceMock,
             $this->createMock(ProductUrl::class),
-            $this->createMock(ProductLink::class),
+            $this->productLinkInstanceMock,
             $this->createMock(ItemOptionFactory::class),
             $this->stockItemFactoryMock,
             $optionFactory,
@@ -1235,6 +1242,36 @@ class ProductTest extends TestCase
         $this->model->afterSave();
         $this->assertTrue($this->model->getHasOptions());
         $this->assertTrue($this->model->getRequiredOptions());
+    }
+
+    /**
+     * Product relations should be persisted on afterSave when the ignore_links_flag is not set.
+     *
+     * @return void
+     */
+    public function testAfterSaveProcessesLinksByDefault(): void
+    {
+        $this->productLinkInstanceMock->expects($this->once())
+            ->method('saveProductRelations')
+            ->with($this->model);
+        $this->configureSaveTest();
+        $this->model->beforeSave();
+        $this->model->afterSave();
+    }
+
+    /**
+     * Product relations should be skipped on afterSave when the ignore_links_flag is strictly true.
+     *
+     * @return void
+     */
+    public function testAfterSaveSkipsLinksWhenIgnoreLinksFlagIsTrue(): void
+    {
+        $this->model->setData('ignore_links_flag', true);
+        $this->productLinkInstanceMock->expects($this->never())
+            ->method('saveProductRelations');
+        $this->configureSaveTest();
+        $this->model->beforeSave();
+        $this->model->afterSave();
     }
 
     /**


### PR DESCRIPTION
### Description (*)
`Magento\Catalog\Model\Product::afterSave()` unconditionally called `getLinkInstance()->saveProductRelations($this)` on every save, re-processing product links even when the caller explicitly indicated that links should be left untouched. `Magento\Catalog\Model\ProductRepository` already exposes an `ignore_links_flag` to opt out of link pre-processing, but `afterSave()` never checked that flag — so the unchanged product_links were still re-processed and written to the database on every save.

This becomes visible under concurrent saves against the same product (e.g. updating multiple storeviews in parallel). The post-processing races with itself and fails with:

> HTTP 400 — "The linked products data is invalid. Verify the data and try again."

even when the PUT body contains no `product_links` at all. 

This PR makes `afterSave()` respect `ignore_links_flag`, and updates `ProductRepository::processLinks()` to set the `ignore_links_flag` when the links are `null`.

### Manual testing scenarios (*)
Preconditions: a Magento instance with ≥2 storeviews and at least 1 product that has related / upsell / crosssell links configured (e.g. 24-MB01 from sample data).

1. Run the script below against the instance.                                                                                                                                                          
2. Before this fix: at least one response returns HTTP 400 with "The linked products data is invalid. Verify the data and try again.", even though no product_links are in any PUT body.
3. After this fix: product_links are only processed when present in the PUT body.                                                                                                                                                

```js
  const BASE_URL = 'https://magento.test';
  const TOKEN    = '<admin-or-integration-token>';
  const SKU      = '24-MB01';
  const STORE_CODES = ['all', 'store_1', 'store_2', 'store_3', 'store_4', 'store_5', 'store_6', 'store_7', `store_8`];

  const randomName = () =>
    `perf-test-${Math.random().toString(36).slice(2, 10)}`;

  const putForStore = (store) =>
    fetch(`${BASE_URL}/rest/${store}/V1/products/${encodeURIComponent(SKU)}`, {
      method: 'PUT',
      headers: {
        Authorization: `Bearer ${TOKEN}`,
        'Content-Type': 'application/json',
      },
      body: JSON.stringify({ product: { name: randomName() } }),
    }).then(async (res) => ({
      store,
      status: res.status,
      body: await res.text(),
    }));

  const results = await Promise.all(STORE_CODES.map(putForStore));

  for (const { store, status, body } of results) {
    console.log(`[${store}] ${status} ${body.slice(0, 200)}`);
  }

  const failed = results.filter((r) => r.status >= 400);
  process.exit(failed.length ? 1 : 0);

```

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
