### PR TITLE
fix: adjustCreditMemoItemQuantities causes a fatal error on missing order/invoice

### DIFF
--- a/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
+++ b/app/code/Magento/Sales/Controller/Adminhtml/Order/Creditmemo/Save.php
@@ -91,8 +91,8 @@ class Save extends \Magento\Backend\App\Action implements HttpPostActionInterfac
             $this->creditmemoLoader->setCreditmemo($this->getRequest()->getParam('creditmemo'));
             $this->creditmemoLoader->setInvoiceId($this->getRequest()->getParam('invoice_id'));
             $creditmemo = $this->creditmemoLoader->load();
-            $this->adjustCreditMemoItemQuantities($creditmemo);
             if ($creditmemo) {
+                $this->adjustCreditMemoItemQuantities($creditmemo);
                 if (!$creditmemo->isValidGrandTotal()) {
                     throw new \Magento\Framework\Exception\LocalizedException(
                         __('The credit memo\'s total must be positive.')

--- a/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Controller/Adminhtml/Order/Creditmemo/SaveTest.php
@@ -183,6 +183,7 @@ class SaveTest extends TestCase
                 'context' => $context,
                 'creditmemoLoader' => $this->memoLoaderMock,
                 'creditmemoSender' => $this->creditmemoSender,
+                'resultForwardFactory' => $this->resultForwardFactoryMock,
                 'salesData' => $this->salesData
             ]
         );
@@ -406,6 +407,37 @@ class SaveTest extends TestCase
                ->method('send');
         }
          $this->assertEquals($this->resultRedirectMock, $this->_controller->execute());
+    }
+
+    /**
+     * Test execute when creditmemo loader returns false (e.g. invalid IDs)
+     * Should forward to noroute without throwing a TypeError
+     */
+    public function testExecuteWhenCreditmemoLoadReturnsFalse(): void
+    {
+        $data = ['comment_text' => ''];
+        $this->_requestMock->expects($this->once())
+            ->method('getPost')
+            ->with('creditmemo')
+            ->willReturn($data);
+        $this->_requestMock->expects($this->any())->method('getParam')->willReturn(null);
+
+        $this->memoLoaderMock->expects($this->once())
+            ->method('load')
+            ->willReturn(false);
+
+        $this->resultForwardFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->resultForwardMock);
+        $this->resultForwardMock->expects($this->once())
+            ->method('forward')
+            ->with('noroute');
+        $this->resultRedirectFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($this->resultRedirectMock);
+
+        $result = $this->_controller->execute();
+        $this->assertInstanceOf(Forward::class, $result);
     }
 
     /**


### PR DESCRIPTION
## Preconditions and environment

- Magento version: 2.4.8-p4
- Admin user attempting to create a credit memo for an order
- Occurs when an invalid/missing `order_id`, `creditmemo_id`, or `invoice_id` is passed to the credit memo save action 

## Steps to reproduce

1. Navigate to **Admin > Sales > Orders** and open any order.
2. Attempt to create a credit memo by navigating directly to the credit memo save URL with an invalid or missing `order_id` / `creditmemo_id` parameter (e.g. via a stale or manipulated POST request to `admin/sales/order_creditmemo/save`).
3. Submit the form.

## Expected result

The controller handles the failed credit memo load gracefully and redirects to the `noroute` page (or back with an appropriate error), without throwing a fatal error.

## Actual result

A `TypeError` is thrown and logged as a `CRITICAL` error, crashing the request:

```
[2026-04-25T08:09:22.547554+00:00] main.CRITICAL: TypeError:
Magento\Sales\Controller\Adminhtml\Order\Creditmemo\Save::adjustCreditMemoItemQuantities():
Argument #1 ($creditMemo) must be of type Magento\Sales\Model\Order\Creditmemo, false given,
called in vendor/magento/module-sales/Controller/Adminhtml/Order/Creditmemo/Save.php on line 88
and defined in vendor/magento/module-sales/Controller/Adminhtml/Order/Creditmemo/Save.php:152
```

## Additional information

**Root cause:** In `Save::execute()`, `adjustCreditMemoItemQuantities($creditmemo)` is called on line 94 *before* the `if ($creditmemo)` guard on line 95. When `CreditmemoLoader::load()` returns `false`, the typed method receives `false` instead of a `Creditmemo` instance, triggering the `TypeError`.

**Fix:** Move the `adjustCreditMemoItemQuantities($creditmemo)` call inside the `if ($creditmemo)` block so it is only invoked when a valid credit memo object has been loaded.

## Release note

Fixed a `TypeError` crash in the admin credit memo save controller (`Magento\Sales\Controller\Adminhtml\Order\Creditmemo\Save`) that occurred when the credit memo could not be loaded. The `adjustCreditMemoItemQuantities` call is now correctly guarded by the existing `if ($creditmemo)` check.

### Resolved issues:
1. [x] resolves magento/magento2#40790: fix: adjustCreditMemoItemQuantities causes a fatal error on missing order/invoice