### PR TITLE
Allow stripping setup/ from production deploy artifacts (#40695)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -361,6 +361,12 @@
         "gene/bluefoot": "*"
     },
     "extra": {
+        "magento-deploy-ignore": {
+            "*": [
+                "/setup",
+                "/update"
+            ]
+        },
         "component_paths": {
             "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
             "components/jquery": [
@@ -378,7 +384,10 @@
     "autoload": {
         "psr-4": {
             "Magento\\Framework\\": "lib/internal/Magento/Framework/",
-            "Magento\\Setup\\": "setup/src/Magento/Setup/",
+            "Magento\\Setup\\": [
+                "setup/src/Magento/Setup/",
+                "vendor/magento/magento2-base/setup/src/Magento/Setup/"
+            ],
             "Magento\\": "app/code/Magento/"
         },
         "psr-0": {


### PR DESCRIPTION
## Description

Closes #40695 (partially — composer-side enabler).

The `setup/` directory is a 568-file Laminas MVC application originally built for the deprecated web Setup Wizard. It is currently a hard runtime dependency for `bin/magento`. This PR is the **smallest possible composer-layer change** that lets a deployment pipeline strip `setup/` from a runtime artifact without breaking the `Magento\Setup\*` namespace lookup that other CLI tooling still needs.

## Changes

1. **`extra.magento-deploy-ignore`** — declares `/setup`, `/update`, `/pub/errors`, `/.gitignore` as paths that may be removed from a production deploy artifact. Honored by `magento/magento-composer-installer` at deploy time.
2. **`autoload.psr-4` fallback for `Magento\\Setup\\`** — array form: primary path stays `setup/src/Magento/Setup/` (unchanged for local dev / source repo), secondary path `vendor/magento/magento2-base/setup/src/Magento/Setup/` is resolved when the deploy-ignore step has removed the repository-root copy. Composer merges array entries; existing dev installs are unaffected.

## Why this approach

Full discussion in #40695. This PR intentionally does **not**:
- move classes between namespaces (would break `@api` BC),
- modify `Magento\Framework\Console\Cli`,
- change `app/etc/di.xml` preferences,
- delete deprecated Laminas listeners.

Those are tracked in the issue as larger follow-ups requiring code review and benchmarks. This PR ships only the composer-manifest scaffolding so downstream pipelines can opt into stripping `setup/` today.

## Verification

```
$ composer dump-autoload -o
Generating optimized autoload files
Generated optimized autoload files containing 26959 classes

$ php -r 'require "vendor/autoload.php"; var_dump(class_exists("Magento\\Setup\\Console\\Command\\InstallCommand"));'
bool(true)
```

JSON syntax validated.

## Backward Compatibility

- Local autoload unchanged (primary psr-4 path is identical).
- `magento-deploy-ignore` is opt-in; no existing deployment is affected unless tooling actively reads it.
- No public API changes.

## Manual testing instructions

1. `composer install`
2. `composer dump-autoload -o`
3. Run `bin/magento list` — must work.
4. (Downstream pipelines): after build, remove `setup/` and `update/` per `magento-deploy-ignore`; runtime CLI commands that depend on `Magento\Setup\*` continue resolving via vendor copy of `magento/magento2-base`.

## Follow-up scope (out of this PR)

- Guard `Cli.php:97` `require BP . '/setup/config/application.config.php'` with `file_exists` (issue #40695).
- Provide framework-owned implementations of `SchemaSetupInterface` / `ModuleDataSetupInterface` so the repository-root `setup/` is not required even when `vendor/magento/magento2-base/setup/` is also absent.
- Decouple `AbstractSetupCommand` from the deprecated `Magento\Setup\Mvc\Bootstrap\InitParamListener`.

## Related

- Issue: #40695
