### PR TITLE
fix: correctly scope USPS REST access token cache keys

### DIFF
--- a/app/code/Magento/Usps/Model/UspsAuth.php
+++ b/app/code/Magento/Usps/Model/UspsAuth.php
@@ -22,6 +22,7 @@ class UspsAuth extends AbstractCarrier
     public const OAUTH_REQUEST_END_POINT = 'oauth2/v3/token';
     private const CONTENT_TYPE_FORM_URLENCODED = 'application/x-www-form-urlencoded';
     private const ERROR_LOG_MESSAGE = '---Exception from auth api---';
+    private const OAUTH_SCOPE = 'prices shipments tracking labels payments international-labels';
 
     /**
      * @var AsyncClientInterface
@@ -65,7 +66,7 @@ class UspsAuth extends AbstractCarrier
      */
     public function getAccessToken(string $clientId, string $clientSecret, string $clientUrl): string|false|null
     {
-        $cacheKey = self::CACHE_KEY_PREFIX;
+        $cacheKey = $this->getCacheKey($clientId, $clientUrl);
         $accessToken = $this->cache->load($cacheKey);
         if (!$accessToken) {
             $headers = [
@@ -76,7 +77,7 @@ class UspsAuth extends AbstractCarrier
                 'grant_type' => 'client_credentials',
                 'client_id' => $clientId,
                 'client_secret' => $clientSecret,
-                'scope' => 'prices shipments tracking labels payments international-labels'
+                'scope' => self::OAUTH_SCOPE
             ]);
             try {
                 $asyncResponse = $this->httpClient->request(new Request(
@@ -104,6 +105,22 @@ class UspsAuth extends AbstractCarrier
             }
         }
         return $accessToken;
+    }
+
+    /**
+     * Build a cache key scoped to the OAuth endpoint and client identity.
+     *
+     * @param string $clientId
+     * @param string $clientUrl
+     * @return string
+     */
+    private function getCacheKey(string $clientId, string $clientUrl): string
+    {
+        return self::CACHE_KEY_PREFIX . hash('sha256', implode('|', [
+            $clientUrl,
+            $clientId,
+            self::OAUTH_SCOPE
+        ]));
     }
 
     /**

--- a/app/code/Magento/Usps/Test/Unit/Model/UspsAuthTest.php
+++ b/app/code/Magento/Usps/Test/Unit/Model/UspsAuthTest.php
@@ -22,6 +22,8 @@ use Magento\Framework\HTTP\AsyncClient\HttpResponseDeferredInterface;
 
 class UspsAuthTest extends TestCase
 {
+    private const OAUTH_SCOPE = 'prices shipments tracking labels payments international-labels';
+
     /**
      * @var Cache|MockObject
      */
@@ -70,14 +72,49 @@ class UspsAuthTest extends TestCase
         string $clientUrl
     ): void {
         $expectedCachedToken = 'cached-access-token';
+        $expectedCacheKey = $this->getExpectedCacheKey($clientId, $clientUrl);
         $this->cacheMock->expects($this->once())
             ->method('load')
-            ->with(UspsAuth::CACHE_KEY_PREFIX)
+            ->with($expectedCacheKey)
             ->willReturn($expectedCachedToken);
 
         $this->asyncHttpClientMock->expects($this->never())->method('request');
         $result = $this->uspsAuth->getAccessToken($clientId, $clientSecret, $clientUrl);
         $this->assertEquals($expectedCachedToken, $result);
+    }
+
+    /**
+     * @return void
+     * @throws LocalizedException
+     * @throws \Throwable
+     */
+    public function testGetAccessTokenUsesClientSpecificCacheKeys(): void
+    {
+        $firstClientId = 'first-client-id';
+        $secondClientId = 'second-client-id';
+        $clientUrl = 'https://apis.usps.com/oauth2/v3/token';
+        $firstCacheKey = $this->getExpectedCacheKey($firstClientId, $clientUrl);
+        $secondCacheKey = $this->getExpectedCacheKey($secondClientId, $clientUrl);
+
+        $this->assertNotSame($firstCacheKey, $secondCacheKey);
+
+        $this->cacheMock->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnMap([
+                [$firstCacheKey, 'first-client-token'],
+                [$secondCacheKey, 'second-client-token'],
+            ]);
+
+        $this->asyncHttpClientMock->expects($this->never())->method('request');
+
+        $this->assertSame(
+            'first-client-token',
+            $this->uspsAuth->getAccessToken($firstClientId, 'first-client-secret', $clientUrl)
+        );
+        $this->assertSame(
+            'second-client-token',
+            $this->uspsAuth->getAccessToken($secondClientId, 'second-client-secret', $clientUrl)
+        );
     }
 
     /**
@@ -93,7 +130,7 @@ class UspsAuthTest extends TestCase
     ): void {
         $this->cacheMock->expects($this->once())
             ->method('load')
-            ->with(UspsAuth::CACHE_KEY_PREFIX)
+            ->with($this->getExpectedCacheKey($clientId, $clientUrl))
             ->willReturn(false);
 
         $this->asyncHttpClientMock->expects($this->once())
@@ -118,7 +155,7 @@ class UspsAuthTest extends TestCase
     ): void {
         $this->cacheMock->expects($this->once())
             ->method('load')
-            ->with(UspsAuth::CACHE_KEY_PREFIX)
+            ->with($this->getExpectedCacheKey($clientId, $clientUrl))
             ->willReturn(false);
 
         $asyncResponseMock = $this->createMock(HttpResponseDeferredInterface::class);
@@ -154,7 +191,7 @@ class UspsAuthTest extends TestCase
         // Simulate cache miss
         $this->cacheMock->expects($this->once())
             ->method('load')
-            ->with(UspsAuth::CACHE_KEY_PREFIX)
+            ->with($this->getExpectedCacheKey($clientId, $clientUrl))
             ->willReturn(false);
 
         // Simulate request payload
@@ -162,7 +199,7 @@ class UspsAuthTest extends TestCase
             'grant_type' => 'client_credentials',
             'client_id' => $clientId,
             'client_secret' => $clientSecret,
-            'scope' => 'prices shipments tracking labels payments international-labels',
+            'scope' => self::OAUTH_SCOPE,
         ]);
 
         // Mock async response
@@ -191,7 +228,7 @@ class UspsAuthTest extends TestCase
         // Assert cache save
         $this->cacheMock->expects($this->once())
             ->method('save')
-            ->with('new-access-token', UspsAuth::CACHE_KEY_PREFIX, [], 3600);
+            ->with('new-access-token', $this->getExpectedCacheKey($clientId, $clientUrl), [], 3600);
 
         $result = $this->uspsAuth->getAccessToken($clientId, $clientSecret, $clientUrl);
         $this->assertEquals('new-access-token', $result);
@@ -223,5 +260,19 @@ class UspsAuthTest extends TestCase
     private function getErrorResponse(): string
     {
         return json_encode(['errors' => ['message' => 'Invalid credentials']]);
+    }
+
+    /**
+     * @param string $clientId
+     * @param string $clientUrl
+     * @return string
+     */
+    private function getExpectedCacheKey(string $clientId, string $clientUrl): string
+    {
+        return UspsAuth::CACHE_KEY_PREFIX . hash('sha256', implode('|', [
+            $clientUrl,
+            $clientId,
+            self::OAUTH_SCOPE
+        ]));
     }
 }


### PR DESCRIPTION
### Description (*)

This pull request fixes USPS REST OAuth token caching so that access tokens are not shared across different USPS REST client credentials.

Previously, `Magento\Usps\Model\UspsAuth::getAccessToken()` always used the fixed cache key `usps_api_token_`. In a multi-website or multi-store setup with different USPS REST credentials, one scope could reuse a bearer token that was fetched for another scope.

The cache key now includes the OAuth token endpoint, client ID and requested OAuth scope. The client secret is not included in the cache key.

Unit coverage has been updated to check the scoped cache key behaviour, including a case where two different client IDs on the same endpoint read different cached tokens.

### Manual testing scenarios (*)

1. Configure two website or store scopes with USPS REST enabled and different USPS REST client IDs.
2. Clear the Magento cache.
3. Request USPS rates or another USPS REST action from the first scope.
4. Request USPS rates or another USPS REST action from the second scope before the first token expires.
5. Confirm that each scope uses a token cached for its own USPS REST client ID and token endpoint.

### Questions or comments

With the original cache key being just `self::CACHE_KEY_PREFIX` makes me wonder if this is a half complete feature thats been released, or just not properly code reviewed?

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#40813: fix: correctly scope USPS REST access token cache keys