### PR TITLE
Add workaround for parameter type 'parent' in constructors for PHP < 8.5

### DIFF
--- a/lib/internal/Magento/Framework/Code/Test/Unit/Reader/ClassReaderTest.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Reader/ClassReaderTest.php
@@ -79,6 +79,22 @@ class ClassReaderTest extends TestCase
         $this->model->getConstructor($className);
     }
 
+    public function testGetConstructorWithClassWithParameterTypeParent(): void
+    {
+        $this->assertEquals(
+            [
+                [
+                    'parentObject',
+                    \ClassWithoutConstruct::class,
+                    true,
+                    null,
+                    false,
+                ]
+            ],
+            $this->model->getConstructor(\ClassWithParameterTypeParent::class)
+        );
+    }
+
     /**
      * Data provider
      *

--- a/lib/internal/Magento/Framework/Code/Test/Unit/Reader/_files/ClassesForArgumentsReader.php
+++ b/lib/internal/Magento/Framework/Code/Test/Unit/Reader/_files/ClassesForArgumentsReader.php
@@ -304,3 +304,10 @@ class ClassWithMixedArgumentsForParentCall extends FirstClassForParentCall
         $this->_runeTimeException = $runeTimeException;
     }
 }
+
+class ClassWithParameterTypeParent extends ClassWithoutConstruct
+{
+    public function __construct(parent $parentObject)
+    {
+    }
+}

--- a/lib/internal/Magento/Framework/GetParameterClassTrait.php
+++ b/lib/internal/Magento/Framework/GetParameterClassTrait.php
@@ -31,6 +31,11 @@ trait GetParameterClassTrait
             return null;
         }
 
+        // Workaround for PHP versions < 8.5, which do not resolve the 'parent' type automatically.
+        if (\PHP_VERSION_ID < 80500 && 'parent' === (string)$parameterType) {
+            return $reflectionParameter->getDeclaringClass()->getParentClass();
+        }
+
         // get $parameterType package name
         $parameterPackage = strstr(trim((string)$parameterType), "\\", true);
 


### PR DESCRIPTION
### Description (*)

With PHP < 8.5 the `Magento\Framework\Code\Reader\ClassReader::getConstructor()` is not able to handle classes that have a parameter of type `parent` in their constructor.

Here's a small example:

```php
class ClassWithParameterTypeParent extends ClassWithoutConstruct
{
    public function __construct(parent $parentObject)
    {}
}
```

It will lead to an error like this:

> 1) Magento\Framework\Code\Test\Unit\Reader\ClassReaderTest::testGetConstructorWithClassWithParameterTypeParent
> ReflectionException: Impossible to process constructor argument Parameter #0 [ <required> parent $classObject ] of ClassWithParameterTypeParent class
> 
> /srv/htdocs/magento2/lib/internal/Magento/Framework/Code/Reader/ClassReader.php:57
> /srv/htdocs/magento2/lib/internal/Magento/Framework/Code/Test/Unit/Reader/ClassReaderTest.php:84
> 
> Caused by
> ReflectionException: Class "parent" does not exist
> 
> /srv/htdocs/magento2/lib/internal/Magento/Framework/GetParameterClassTrait.php:41
> /srv/htdocs/magento2/lib/internal/Magento/Framework/Code/Reader/ClassReader.php:42
> /srv/htdocs/magento2/lib/internal/Magento/Framework/Code/Test/Unit/Reader/ClassReaderTest.php:84

The reason is that `Magento\Framework\GetParameterClassTrait::getParameterClass()` utilizes PHP's `ReflectionNamedType` to get the type of a parameter. But in the older PHP version it returns `parent` instead of the real parent's class name. And this leads to an exception, because there is no class named `parent`.

This PR addresses the issue by adding a specific check for PHP versions < 8.5 and fetches the parent class name via reflection.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40783

### Manual testing scenarios (*)

Please look at the referenced issue.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
