### PR TITLE
fix(catalog): guard empty website_id in tier price validation (#40799)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
+++ b/app/code/Magento/Catalog/Model/Product/Attribute/Backend/GroupPrice/AbstractGroupPrice.php
@@ -236,7 +236,13 @@ abstract class AbstractGroupPrice extends Price implements ResetAfterRequestInte
             if (!empty($priceRow['delete'])) {
                 continue;
             }
-            if ($priceRow['website_id'] == 0) {
+            // Price rows with empty website_id can arrive from the admin form
+            // after a website has been unassigned from the product; skip them
+            // to avoid "Undefined array key" warnings on the currency lookup.
+            if (!isset($priceRow['website_id']) || $priceRow['website_id'] === '' || $priceRow['website_id'] == 0) {
+                continue;
+            }
+            if (!isset($rates[$priceRow['website_id']])) {
                 continue;
             }
 


### PR DESCRIPTION
## Description
When a website is unassigned from a product in admin, the tier_price form
may post rows with an empty `website_id`. `AbstractGroupPrice::validate`
then evaluates `$rates[$priceRow['website_id']]['code']` which raises
`Warning: Undefined array key ""` and short-circuits the save —
`Product is not saved`, the validate endpoint returns `error: true`.

Skip rows whose `website_id` is missing or empty (already skipped when
`=== 0` / global scope), and skip rows whose `website_id` has no entry in
the rates map.

Fixes #40799

## Fixed Issues
- Fixes #40799: Warning: Undefined array key "" in AbstractGroupPrice.php on line 248 when saving product

## Manual testing scenarios
1. Set up multi-website store with advanced pricing on a product (tier prices per website/customer group).
2. Save product with tier prices across two websites.
3. Unassign one website from the product, save.
4. Reload product edit page and save again — saves successfully (before: validate endpoint returns the `Undefined array key ""` warning and product is not saved).

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (43 existing tests pass)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)