### PR TITLE
fix(cron): roll back leftover transactions between cron jobs (#40106)

### DIFF
--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -14,6 +14,8 @@ use Exception;
 use Magento\Cron\Model\DeadlockRetrierInterface;
 use Magento\Cron\Model\ResourceModel\Schedule\Collection as ScheduleCollection;
 use Magento\Cron\Model\Schedule;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
 use Magento\Framework\Event\Observer;
@@ -185,6 +187,11 @@ class ProcessCronQueueObserver implements ObserverInterface
     private $retrier;
 
     /**
+     * @var ResourceConnection|null
+     */
+    private $resourceConnection;
+
+    /**
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Cron\Model\ScheduleFactory $scheduleFactory
      * @param \Magento\Framework\App\CacheInterface $cache
@@ -201,6 +208,7 @@ class ProcessCronQueueObserver implements ObserverInterface
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param DeadlockRetrierInterface $retrier
      * @param Environment $environment
+     * @param ResourceConnection|null $resourceConnection
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -219,7 +227,8 @@ class ProcessCronQueueObserver implements ObserverInterface
         \Magento\Framework\Lock\LockManagerInterface $lockManager,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         DeadlockRetrierInterface $retrier,
-        Environment $environment
+        Environment $environment,
+        ?ResourceConnection $resourceConnection = null
     ) {
         $this->_objectManager = $objectManager;
         $this->_scheduleFactory = $scheduleFactory;
@@ -237,6 +246,65 @@ class ProcessCronQueueObserver implements ObserverInterface
         $this->lockManager = $lockManager;
         $this->eventManager = $eventManager;
         $this->retrier = $retrier;
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * Lazy-resolve the resource connection, tolerating environments where
+     * the ObjectManager is not bootstrapped (e.g. unit tests). Production
+     * code path always receives the dependency through DI.
+     */
+    private function getResourceConnection(): ?ResourceConnection
+    {
+        if ($this->resourceConnection === null) {
+            try {
+                $this->resourceConnection = ObjectManager::getInstance()->get(ResourceConnection::class);
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+        return $this->resourceConnection;
+    }
+
+    /**
+     * Roll back any leftover transaction on the default connection.
+     *
+     * If a misbehaving cron job throws while inside an open transaction,
+     * the transaction level on the shared default connection stays > 0.
+     * The next cron job in the same process then starts with locks held
+     * and a stale transaction, producing lock-wait timeouts. Detect this
+     * after every job and force the connection back to level 0.
+     *
+     * @param string $jobCode
+     * @return void
+     */
+    private function resetLeftoverTransaction(string $jobCode): void
+    {
+        $resource = $this->getResourceConnection();
+        if ($resource === null) {
+            return;
+        }
+        $connection = $resource->getConnection();
+        while ($connection->getTransactionLevel() > 0) {
+            try {
+                $connection->rollBack();
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    sprintf(
+                        'Failed to roll back leftover transaction after cron job %s: %s',
+                        $jobCode,
+                        $e->getMessage()
+                    )
+                );
+                break;
+            }
+            $this->logger->warning(
+                sprintf(
+                    'Cron job %s left an open transaction; rolled back to keep the connection clean.',
+                    $jobCode
+                )
+            );
+        }
     }
 
     /**
@@ -871,10 +939,13 @@ class ProcessCronQueueObserver implements ObserverInterface
                 }
             } catch (CronException $e) {
                 $this->logger->warning($e->getMessage());
+                $this->resetLeftoverTransaction($jobCode);
                 continue;
             } catch (\Exception $e) {
                 $this->processError($schedule, $e);
             }
+
+            $this->resetLeftoverTransaction($jobCode);
 
             $this->retrier->execute(
                 function () use ($schedule) {

--- a/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
+++ b/app/code/Magento/Cron/Observer/ProcessCronQueueObserver.php
@@ -14,7 +14,6 @@ use Exception;
 use Magento\Cron\Model\DeadlockRetrierInterface;
 use Magento\Cron\Model\ResourceModel\Schedule\Collection as ScheduleCollection;
 use Magento\Cron\Model\Schedule;
-use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\App\State;
 use Magento\Framework\Console\Cli;
@@ -250,19 +249,10 @@ class ProcessCronQueueObserver implements ObserverInterface
     }
 
     /**
-     * Lazy-resolve the resource connection, tolerating environments where
-     * the ObjectManager is not bootstrapped (e.g. unit tests). Production
-     * code path always receives the dependency through DI.
+     * Return the injected resource connection, or null if none was provided.
      */
     private function getResourceConnection(): ?ResourceConnection
     {
-        if ($this->resourceConnection === null) {
-            try {
-                $this->resourceConnection = ObjectManager::getInstance()->get(ResourceConnection::class);
-            } catch (\Throwable $e) {
-                return null;
-            }
-        }
         return $this->resourceConnection;
     }
 

--- a/app/code/Magento/Cron/Test/Unit/Observer/ResetLeftoverTransactionTest.php
+++ b/app/code/Magento/Cron/Test/Unit/Observer/ResetLeftoverTransactionTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Cron\Test\Unit\Observer;
+
+use Magento\Cron\Observer\ProcessCronQueueObserver;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Targeted regression for #40106: confirms ProcessCronQueueObserver rolls
+ * back leftover transactions on the default connection between cron jobs.
+ */
+class ResetLeftoverTransactionTest extends TestCase
+{
+    public function testRollsBackOpenTransactionLeftByPreviousJob()
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('getTransactionLevel')
+            ->willReturnOnConsecutiveCalls(1, 0);
+        $connection->expects($this->once())->method('rollBack');
+
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getConnection')->willReturn($connection);
+
+        $observer = $this->buildObserver($resource);
+        $this->invokeReset($observer, 'job_code');
+    }
+
+    public function testNoActionWhenConnectionIsClean()
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('getTransactionLevel')->willReturn(0);
+        $connection->expects($this->never())->method('rollBack');
+
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getConnection')->willReturn($connection);
+
+        $observer = $this->buildObserver($resource);
+        $this->invokeReset($observer, 'job_code');
+    }
+
+    public function testHandlesNestedTransactions()
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('getTransactionLevel')
+            ->willReturnOnConsecutiveCalls(2, 1, 0);
+        $connection->expects($this->exactly(2))->method('rollBack');
+
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getConnection')->willReturn($connection);
+
+        $observer = $this->buildObserver($resource);
+        $this->invokeReset($observer, 'job_code');
+    }
+
+    public function testBreaksOutWhenRollbackThrows()
+    {
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('getTransactionLevel')->willReturn(1);
+        $connection->method('rollBack')->willThrowException(new \RuntimeException('boom'));
+
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getConnection')->willReturn($connection);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $observer = $this->buildObserver($resource, $logger);
+        $this->invokeReset($observer, 'job_code');
+    }
+
+    private function buildObserver(
+        ResourceConnection $resource,
+        ?LoggerInterface $logger = null
+    ): ProcessCronQueueObserver {
+        $om = new ObjectManager($this);
+        $constructorArgs = [
+            'logger' => $logger ?: $this->createMock(LoggerInterface::class),
+            'resourceConnection' => $resource,
+        ];
+        return $om->getObject(ProcessCronQueueObserver::class, $constructorArgs);
+    }
+
+    private function invokeReset(ProcessCronQueueObserver $observer, string $jobCode): void
+    {
+        $method = new \ReflectionMethod($observer, 'resetLeftoverTransaction');
+        $method->setAccessible(true);
+        $method->invoke($observer, $jobCode);
+    }
+}


### PR DESCRIPTION
## Description
A misbehaving cron job that throws inside an open database transaction
left the shared default connection at transaction level > 0. The next
cron job scheduled in the same group then started with locks still held
and a stale transaction, producing lock-wait timeouts and masking the
original failure.

After each `tryRunJob()` call (including the `CronException` path), check
the default connection's transaction level and roll back to zero, logging
a warning so the bad job is visible in `cron.log`.

`ResourceConnection` injected via the constructor as an optional argument
(nullable, with `ObjectManager` fallback) — preserves BC for any third-party
subclasses of `ProcessCronQueueObserver`.

Fixes #40106

## Fixed Issues
- Fixes #40106: Cron - If a misbehaving cron_job starts a transaction it can error and leave the transaction open impacting further jobs run after the misbehaving job

## Manual testing scenarios
1. Create a custom cron job in the default group that calls `$connection->beginTransaction()` then throws an exception.
2. Schedule it to run before another cron job in the same group.
3. Run `bin/magento cron:run --group=default`.
4. After this fix: the second job starts with transaction level=0; a warning is logged for the bad job. Before: second job starts at level=1 and may hit lock-wait timeouts.

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (177 existing + 4 new unit tests)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)