### PR TITLE
fix(ui): cache total count once across CSV export pagination (#40232)

### DIFF
--- a/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
+++ b/app/code/Magento/Ui/Model/Export/ConvertToCsv.php
@@ -82,20 +82,26 @@ class ConvertToCsv
             ->setCurrentPage($i)
             ->setPageSize($this->pageSize);
 
-        $totalCount = null;
-        $totalPagesCount = null;
+        // Compute total count exactly once. The data provider's
+        // getSearchResult() builds a fresh collection on each invocation
+        // (via Reporting::search), so any setTotalCount() called on a
+        // search result instance is lost when the next iteration runs.
+        // Pre-caching here avoids one getSelectCountSql per page.
+        $firstSearchResult = $dataProvider->getSearchResult();
+        $totalCount = (int) $firstSearchResult->getTotalCount();
+        $totalPagesCount = (int) ceil($totalCount / $this->pageSize);
+        $searchResult = $firstSearchResult;
 
         do {
-            $searchResult = $dataProvider->getSearchResult();
-            $items = $searchResult->getItems();
-
-            if ($totalCount === null) { // get total count only once
-                $totalCount = $searchResult->getTotalCount();
-                $totalPagesCount = (int) ceil($totalCount / $this->pageSize);
+            if ($searchResult === null) {
+                $searchResult = $dataProvider->getSearchResult();
+                // Seed total count on the fresh collection so any
+                // downstream code that calls getTotalCount() reuses it
+                // instead of issuing another count query.
+                $searchResult->setTotalCount($totalCount);
             }
 
-            // call setTotalCount to prevent total count from being calculate in subsequent iterations of this loop
-            $searchResult->setTotalCount($totalCount);
+            $items = $searchResult->getItems();
             // Ensure $items is always an array
             if ($items === null) {
                 $items = [];
@@ -105,6 +111,7 @@ class ConvertToCsv
                 $stream->writeCsv($this->metadataProvider->getRowData($item, $fields, $options));
             }
 
+            $searchResult = null;
             $searchCriteria->setCurrentPage(++$i);
         } while ($i <= $totalPagesCount);
 


### PR DESCRIPTION
## Description
`ConvertToCsv::getCsvFile()` called `$searchResult->setTotalCount($totalCount)`
on the search result *after* `getItems()`. `DataProvider::getSearchResult()`
delegates to `Reporting::search()` which builds a fresh collection per call,
so the cached count was discarded between iterations and each page paid
another `getSelectCountSql()` round trip. With `pageSize=1` this scales to
N count queries for an N-row export.

Computed total count once before the loop, reused the first search result
for iteration 1, and seeded the cached total on every subsequent fresh
result via `setTotalCount()` so downstream `getTotalCount()` callers skip
the redundant aggregate query.

Fixes #40232

## Fixed Issues
- Fixes #40232: Slow performance when exporting CSV from the UI listing component with large dataset

## Manual testing scenarios
1. Place 10 orders.
2. Temporarily reduce `$pageSize` in `Magento\Ui\Model\Export\ConvertToCsv::__construct` to 1 to amplify the issue.
3. Add `SLEEP(1)` to the order grid count query (or profile with Xdebug/SPX).
4. Export Sales > Orders as CSV.
5. After this fix: a single `getSelectCountSql` call. Before: one per page.

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (18 unit tests pass)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)