### PR TITLE
fix(sales): admin reorder drops OOS items when backorders disabled (#39958)

### DIFF
--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -590,21 +590,38 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
 
         /* Initialize catalog rule data with new session values */
         $this->initRuleData();
-        foreach ($order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true) as $orderItem) {
-            /* @var $orderItem \Magento\Sales\Model\Order\Item */
-            if (!$orderItem->getParentItem()) {
-                $qty = $orderItem->getQtyOrdered();
-                if (!$order->getReordered()) {
-                    $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
-                }
 
-                if ($qty > 0) {
-                    $item = $this->initFromOrderItem($orderItem, $qty);
-                    if (is_string($item)) {
-                        throw new \Magento\Framework\Exception\LocalizedException(__($item));
+        // Bypass salability checks for products that are out of stock on
+        // the original order. Otherwise non-MSI stores with backorders
+        // disabled would silently drop items in Create::initFromOrderItem
+        // (Quote::addProduct -> Product::isSalable -> StockRegistry says
+        // is_in_stock=false), leaving Admin "Reorder" with an empty quote
+        // and a confusing "This product is out of stock" message.
+        $catalogProduct = $this->_objectManager->get(\Magento\Catalog\Helper\Product::class);
+        $previousSkipSaleableCheck = $catalogProduct->getSkipSaleableCheck();
+        $catalogProduct->setSkipSaleableCheck(true);
+
+        try {
+            foreach (
+                $order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true) as $orderItem
+            ) {
+                /* @var $orderItem \Magento\Sales\Model\Order\Item */
+                if (!$orderItem->getParentItem()) {
+                    $qty = $orderItem->getQtyOrdered();
+                    if (!$order->getReordered()) {
+                        $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
+                    }
+
+                    if ($qty > 0) {
+                        $item = $this->initFromOrderItem($orderItem, $qty);
+                        if (is_string($item)) {
+                            throw new \Magento\Framework\Exception\LocalizedException(__($item));
+                        }
                     }
                 }
             }
+        } finally {
+            $catalogProduct->setSkipSaleableCheck($previousSkipSaleableCheck);
         }
 
         $shippingAddress = $order->getShippingAddress();

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -294,6 +294,11 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
     private $paymentMethodSpecifications;
 
     /**
+     * @var \Magento\Catalog\Helper\Product
+     */
+    private \Magento\Catalog\Helper\Product $catalogProductHelper;
+
+    /**
      * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
      * @param \Magento\Framework\Registry $coreRegistry
@@ -330,6 +335,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      * @param HttpRequest|null $request
      * @param SpecificationFactory|null $paymentMethodSpecificationFactory
      * @param array $paymentMethodSpecifications
+     * @param \Magento\Catalog\Helper\Product|null $catalogProductHelper
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -368,7 +374,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         ?OrderRepositoryInterface $orderRepositoryInterface = null,
         ?HttpRequest $request = null,
         ?SpecificationFactory $paymentMethodSpecificationFactory = null,
-        array $paymentMethodSpecifications = []
+        array $paymentMethodSpecifications = [],
+        ?\Magento\Catalog\Helper\Product $catalogProductHelper = null
     ) {
         $this->_objectManager = $objectManager;
         $this->_eventManager = $eventManager;
@@ -412,6 +419,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $this->paymentMethodSpecificationFactory = $paymentMethodSpecificationFactory ?: ObjectManager::getInstance()
             ->get(SpecificationFactory::class);
         $this->paymentMethodSpecifications = $paymentMethodSpecifications;
+        $this->catalogProductHelper = $catalogProductHelper ?: ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Helper\Product::class);
     }
 
     /**
@@ -597,9 +606,8 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         // (Quote::addProduct -> Product::isSalable -> StockRegistry says
         // is_in_stock=false), leaving Admin "Reorder" with an empty quote
         // and a confusing "This product is out of stock" message.
-        $catalogProduct = $this->_objectManager->get(\Magento\Catalog\Helper\Product::class);
-        $previousSkipSaleableCheck = $catalogProduct->getSkipSaleableCheck();
-        $catalogProduct->setSkipSaleableCheck(true);
+        $previousSkipSaleableCheck = $this->catalogProductHelper->getSkipSaleableCheck();
+        $this->catalogProductHelper->setSkipSaleableCheck(true);
 
         try {
             foreach (
@@ -621,7 +629,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
                 }
             }
         } finally {
-            $catalogProduct->setSkipSaleableCheck($previousSkipSaleableCheck);
+            $this->catalogProductHelper->setSkipSaleableCheck($previousSkipSaleableCheck);
         }
 
         $shippingAddress = $order->getShippingAddress();

--- a/app/code/Magento/Sales/Model/AdminOrder/Create.php
+++ b/app/code/Magento/Sales/Model/AdminOrder/Create.php
@@ -337,6 +337,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
      * @param array $paymentMethodSpecifications
      * @param \Magento\Catalog\Helper\Product|null $catalogProductHelper
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     public function __construct(
         \Magento\Framework\ObjectManagerInterface $objectManager,
@@ -600,37 +601,7 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         /* Initialize catalog rule data with new session values */
         $this->initRuleData();
 
-        // Bypass salability checks for products that are out of stock on
-        // the original order. Otherwise non-MSI stores with backorders
-        // disabled would silently drop items in Create::initFromOrderItem
-        // (Quote::addProduct -> Product::isSalable -> StockRegistry says
-        // is_in_stock=false), leaving Admin "Reorder" with an empty quote
-        // and a confusing "This product is out of stock" message.
-        $previousSkipSaleableCheck = $this->catalogProductHelper->getSkipSaleableCheck();
-        $this->catalogProductHelper->setSkipSaleableCheck(true);
-
-        try {
-            foreach (
-                $order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true) as $orderItem
-            ) {
-                /* @var $orderItem \Magento\Sales\Model\Order\Item */
-                if (!$orderItem->getParentItem()) {
-                    $qty = $orderItem->getQtyOrdered();
-                    if (!$order->getReordered()) {
-                        $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
-                    }
-
-                    if ($qty > 0) {
-                        $item = $this->initFromOrderItem($orderItem, $qty);
-                        if (is_string($item)) {
-                            throw new \Magento\Framework\Exception\LocalizedException(__($item));
-                        }
-                    }
-                }
-            }
-        } finally {
-            $this->catalogProductHelper->setSkipSaleableCheck($previousSkipSaleableCheck);
-        }
+        $this->initFromOrderItems($order);
 
         $shippingAddress = $order->getShippingAddress();
         if ($shippingAddress) {
@@ -690,6 +661,49 @@ class Create extends \Magento\Framework\DataObject implements \Magento\Checkout\
         $this->quoteRepository->save($quote);
 
         return $this;
+    }
+
+    /**
+     * Add the original order items to the quote, bypassing salability checks.
+     *
+     * Out-of-stock products on the original order would otherwise be silently
+     * dropped in initFromOrderItem (Quote::addProduct -> Product::isSalable ->
+     * StockRegistry reports is_in_stock=false) on non-MSI stores with
+     * backorders disabled, leaving Admin "Reorder" with an empty quote and a
+     * confusing "This product is out of stock" message.
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    private function initFromOrderItems(\Magento\Sales\Model\Order $order): void
+    {
+        $previousSkipSaleableCheck = $this->catalogProductHelper->getSkipSaleableCheck();
+        $this->catalogProductHelper->setSkipSaleableCheck(true);
+
+        try {
+            $orderItems = $order->getItemsCollection($this->_salesConfig->getAvailableProductTypes(), true);
+            foreach ($orderItems as $orderItem) {
+                /* @var $orderItem \Magento\Sales\Model\Order\Item */
+                if ($orderItem->getParentItem()) {
+                    continue;
+                }
+
+                $qty = $orderItem->getQtyOrdered();
+                if (!$order->getReordered()) {
+                    $qty -= max($orderItem->getQtyShipped(), $orderItem->getQtyInvoiced());
+                }
+
+                if ($qty > 0) {
+                    $item = $this->initFromOrderItem($orderItem, $qty);
+                    if (is_string($item)) {
+                        throw new \Magento\Framework\Exception\LocalizedException(__($item));
+                    }
+                }
+            }
+        } finally {
+            $this->catalogProductHelper->setSkipSaleableCheck($previousSkipSaleableCheck);
+        }
     }
 
     /**

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
@@ -505,6 +505,18 @@ class CreateTest extends TestCase
         $quote->expects($this->once())
             ->method('setCustomerGroupId');
 
+        $catalogProduct = $this->getMockBuilder(\Magento\Catalog\Helper\Product::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSkipSaleableCheck', 'setSkipSaleableCheck'])
+            ->getMock();
+        $this->objectManager->method('get')
+            ->willReturnCallback(function ($type) use ($catalogProduct) {
+                if ($type === \Magento\Catalog\Helper\Product::class) {
+                    return $catalogProduct;
+                }
+                return null;
+            });
+
         $this->adminOrderCreate->initFromOrder($this->orderMock);
     }
 

--- a/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/AdminOrder/CreateTest.php
@@ -113,6 +113,11 @@ class CreateTest extends TestCase
     private ObjectManagerInterface $objectManager;
 
     /**
+     * @var \Magento\Catalog\Helper\Product|MockObject
+     */
+    private \Magento\Catalog\Helper\Product $catalogProductHelper;
+
+    /**
      * @var ManagerInterface|ManagerInterface&MockObject|MockObject
      */
     private ManagerInterface $messageManager;
@@ -177,6 +182,10 @@ class CreateTest extends TestCase
 
         $this->objectManager = $this->createMock(ObjectManagerInterface::class);
         $this->messageManager = $this->createMock(ManagerInterface::class);
+        $this->catalogProductHelper = $this->getMockBuilder(\Magento\Catalog\Helper\Product::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getSkipSaleableCheck', 'setSkipSaleableCheck'])
+            ->getMock();
         $objectManagerHelper = new ObjectManagerHelper($this);
         $this->adminOrderCreate = $objectManagerHelper->getObject(
             Create::class,
@@ -192,6 +201,7 @@ class CreateTest extends TestCase
                 'dataObjectHelper' => $this->dataObjectHelper,
                 'quoteRepository' => $this->quoteRepository,
                 'quoteFactory' => $this->quoteFactory,
+                'catalogProductHelper' => $this->catalogProductHelper,
             ]
         );
     }
@@ -505,18 +515,6 @@ class CreateTest extends TestCase
         $quote->expects($this->once())
             ->method('setCustomerGroupId');
 
-        $catalogProduct = $this->getMockBuilder(\Magento\Catalog\Helper\Product::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getSkipSaleableCheck', 'setSkipSaleableCheck'])
-            ->getMock();
-        $this->objectManager->method('get')
-            ->willReturnCallback(function ($type) use ($catalogProduct) {
-                if ($type === \Magento\Catalog\Helper\Product::class) {
-                    return $catalogProduct;
-                }
-                return null;
-            });
-
         $this->adminOrderCreate->initFromOrder($this->orderMock);
     }
 
@@ -721,6 +719,7 @@ class CreateTest extends TestCase
                 'quoteRepository' => $this->quoteRepository,
                 'quoteFactory' => $this->quoteFactory,
                 'customerRepository' => $customerRepository,
+                'catalogProductHelper' => $this->catalogProductHelper,
             ]
         );
     }


### PR DESCRIPTION
## Description
On non-MSI stores with backorders disabled, Admin "Reorder" produced an
empty quote and the message `This product is out of stock` with all
order details missing. `Create::initFromOrderItem` calls
`Quote::addProduct`, which invokes `Product::isSalable`; `StockRegistry`
then reports `is_in_stock=false` for any product whose live stock has
depleted since the original order, and the item is silently skipped.
`IsSuperMode` does not help here: it only short-circuits
`QuantityValidatorObserver`, which fires later in the pipeline.

Enable `Catalog\Helper\Product::skipSaleableCheck` for the duration of
`initFromOrder` so the admin can rebuild the original order regardless
of current stock state. The flag is restored in a `finally` block so the
helper's state does not leak to other code paths in the same request.

Fixes #39958

## Fixed Issues
- Fixes #39958: Admin Reorder Error When Product Is Out of Stock in Magento 2.4.7

## Manual testing scenarios
1. Non-MSI store with backorders disabled.
2. Place an order for a product with stock quantity = 1.
3. Disable the product or set qty to 0 so live stock cannot fulfil the original order.
4. Go to admin and click Reorder on the original order.
5. After this fix: admin reorder rebuilds the quote with the original items. Before: empty quote + "This product is out of stock" message.

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (13 existing tests pass)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)