### PR TITLE
fix(wishlist-graphql): resolve configured_variant for parent_sku+sku input (#40588)

### DIFF
--- a/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/ChildSkuDataProvider.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/ChildSkuDataProvider.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Wishlist\Model\Wishlist\BuyRequest;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
+
+/**
+ * Build a configurable super_attribute buy request from the child SKU
+ * supplied as `sku` in the addProductsToWishlist mutation when the
+ * parent SKU is provided via `parent_sku`.
+ *
+ * Without this provider, wishlist items added through GraphQL using
+ * parent_sku + sku do not resolve `configured_variant` because no
+ * `simple_product` option is recorded against the wishlist item.
+ */
+class ChildSkuDataProvider implements BuyRequestDataProviderInterface
+{
+    /**
+     * @var ProductRepositoryInterface
+     */
+    private ProductRepositoryInterface $productRepository;
+
+    /**
+     * @var Configurable
+     */
+    private Configurable $configurableType;
+
+    /**
+     * @param ProductRepositoryInterface $productRepository
+     * @param Configurable $configurableType
+     */
+    public function __construct(
+        ProductRepositoryInterface $productRepository,
+        Configurable $configurableType
+    ) {
+        $this->productRepository = $productRepository;
+        $this->configurableType = $configurableType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function execute(WishlistItem $wishlistItemData, ?int $productId): array
+    {
+        $parentSku = $wishlistItemData->getParentSku();
+        $sku = $wishlistItemData->getSku();
+
+        if ($parentSku === null || $sku === null || $parentSku === $sku) {
+            return [];
+        }
+
+        // If the caller already provided encoded selected_options the
+        // dedicated SuperAttributeDataProvider takes care of building
+        // the super_attribute map. Avoid duplicating its work.
+        if (!empty($wishlistItemData->getSelectedOptions())) {
+            return [];
+        }
+
+        try {
+            $child = $this->productRepository->get($sku, false, null, true);
+            $parent = $this->productRepository->get($parentSku, false, null, true);
+        } catch (NoSuchEntityException $e) {
+            return [];
+        }
+
+        if ($parent->getTypeId() !== Configurable::TYPE_CODE) {
+            return [];
+        }
+
+        $superAttribute = [];
+        foreach ($this->configurableType->getConfigurableAttributesAsArray($parent) as $attribute) {
+            $attributeId = (int)$attribute['attribute_id'];
+            $attributeCode = $attribute['attribute_code'] ?? null;
+            if (!$attributeId || !$attributeCode) {
+                continue;
+            }
+            $value = $child->getData($attributeCode);
+            if ($value !== null && $value !== '') {
+                $superAttribute[$attributeId] = $value;
+            }
+        }
+
+        if (empty($superAttribute)) {
+            return [];
+        }
+
+        $result = ['super_attribute' => $superAttribute];
+        if ($productId) {
+            $result['product'] = $productId;
+        }
+
+        return $result;
+    }
+}

--- a/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/ChildSkuDataProvider.php
+++ b/app/code/Magento/Wishlist/Model/Wishlist/BuyRequest/ChildSkuDataProvider.php
@@ -7,8 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\Wishlist\Model\Wishlist\BuyRequest;
 
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
 
@@ -20,29 +21,32 @@ use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
  * Without this provider, wishlist items added through GraphQL using
  * parent_sku + sku do not resolve `configured_variant` because no
  * `simple_product` option is recorded against the wishlist item.
+ *
+ * The configurable axes are read from the parent product's
+ * `configurable_product_options` extension attribute so the provider does
+ * not introduce a hard dependency on the ConfigurableProduct module; when
+ * that module is absent the extension attribute is empty and the provider
+ * is a no-op.
  */
 class ChildSkuDataProvider implements BuyRequestDataProviderInterface
 {
+    /**
+     * Product type code of configurable products.
+     */
+    private const CONFIGURABLE_TYPE = 'configurable';
+
     /**
      * @var ProductRepositoryInterface
      */
     private ProductRepositoryInterface $productRepository;
 
     /**
-     * @var Configurable
-     */
-    private Configurable $configurableType;
-
-    /**
      * @param ProductRepositoryInterface $productRepository
-     * @param Configurable $configurableType
      */
     public function __construct(
-        ProductRepositoryInterface $productRepository,
-        Configurable $configurableType
+        ProductRepositoryInterface $productRepository
     ) {
         $this->productRepository = $productRepository;
-        $this->configurableType = $configurableType;
     }
 
     /**
@@ -64,30 +68,13 @@ class ChildSkuDataProvider implements BuyRequestDataProviderInterface
             return [];
         }
 
-        try {
-            $child = $this->productRepository->get($sku, false, null, true);
-            $parent = $this->productRepository->get($parentSku, false, null, true);
-        } catch (NoSuchEntityException $e) {
+        $products = $this->resolveConfigurablePair($parentSku, $sku);
+        if ($products === null) {
             return [];
         }
+        [$parent, $child] = $products;
 
-        if ($parent->getTypeId() !== Configurable::TYPE_CODE) {
-            return [];
-        }
-
-        $superAttribute = [];
-        foreach ($this->configurableType->getConfigurableAttributesAsArray($parent) as $attribute) {
-            $attributeId = (int)$attribute['attribute_id'];
-            $attributeCode = $attribute['attribute_code'] ?? null;
-            if (!$attributeId || !$attributeCode) {
-                continue;
-            }
-            $value = $child->getData($attributeCode);
-            if ($value !== null && $value !== '') {
-                $superAttribute[$attributeId] = $value;
-            }
-        }
-
+        $superAttribute = $this->buildSuperAttribute($parent, $child);
         if (empty($superAttribute)) {
             return [];
         }
@@ -98,5 +85,82 @@ class ChildSkuDataProvider implements BuyRequestDataProviderInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Load the parent/child pair and validate the parent is a configurable product.
+     *
+     * @param string $parentSku
+     * @param string $sku
+     * @return array{0: ProductInterface, 1: Product}|null
+     */
+    private function resolveConfigurablePair(string $parentSku, string $sku): ?array
+    {
+        try {
+            $child = $this->productRepository->get($sku, false, null, true);
+            $parent = $this->productRepository->get($parentSku, false, null, true);
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
+
+        if ($parent->getTypeId() !== self::CONFIGURABLE_TYPE || !$child instanceof Product) {
+            return null;
+        }
+
+        return [$parent, $child];
+    }
+
+    /**
+     * Map the child's values for the parent's configurable axes to a super_attribute array.
+     *
+     * @param ProductInterface $parent
+     * @param Product $child
+     * @return array
+     */
+    private function buildSuperAttribute(ProductInterface $parent, Product $child): array
+    {
+        $attributeIds = $this->getConfigurableAttributeIds($parent);
+        if (empty($attributeIds)) {
+            return [];
+        }
+
+        $superAttribute = [];
+        foreach ($child->getAttributes() as $attribute) {
+            $attributeId = (int)$attribute->getAttributeId();
+            if (!in_array($attributeId, $attributeIds, true)) {
+                continue;
+            }
+            $value = $child->getData($attribute->getAttributeCode());
+            if ($value !== null && $value !== '') {
+                $superAttribute[$attributeId] = $value;
+            }
+        }
+
+        return $superAttribute;
+    }
+
+    /**
+     * Collect the configurable axis attribute IDs from the parent's extension attributes.
+     *
+     * @param ProductInterface $parent
+     * @return int[]
+     */
+    private function getConfigurableAttributeIds(ProductInterface $parent): array
+    {
+        $extensionAttributes = $parent->getExtensionAttributes();
+        $options = $extensionAttributes ? $extensionAttributes->getConfigurableProductOptions() : null;
+        if (empty($options)) {
+            return [];
+        }
+
+        $attributeIds = [];
+        foreach ($options as $option) {
+            $attributeId = (int)$option->getAttributeId();
+            if ($attributeId) {
+                $attributeIds[] = $attributeId;
+            }
+        }
+
+        return $attributeIds;
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Magento\Wishlist\Test\Unit\Model\Wishlist\BuyRequest;
 
-use Magento\Catalog\Api\Data\ProductExtensionInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Api\Data\OptionInterface;
@@ -241,10 +240,7 @@ class ChildSkuDataProviderTest extends TestCase
             $options[] = $option;
         }
 
-        $extensionAttributes = $this->createMock(ProductExtensionInterface::class);
-        $extensionAttributes->method('getConfigurableProductOptions')->willReturn($options);
-
-        $parentProduct->method('getExtensionAttributes')->willReturn($extensionAttributes);
+        $parentProduct->method('getExtensionAttributes')->willReturn(new ProductExtensionAttributesStub($options));
 
         return $parentProduct;
     }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Wishlist\Test\Unit\Model\Wishlist\BuyRequest;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Wishlist\Model\Wishlist\BuyRequest\ChildSkuDataProvider;
+use Magento\Wishlist\Model\Wishlist\Data\SelectedOption;
+use Magento\Wishlist\Model\Wishlist\Data\WishlistItem;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ChildSkuDataProviderTest extends TestCase
+{
+    /**
+     * @var ProductRepositoryInterface|MockObject
+     */
+    private ProductRepositoryInterface $productRepository;
+
+    /**
+     * @var Configurable|MockObject
+     */
+    private Configurable $configurableType;
+
+    /**
+     * @var ChildSkuDataProvider
+     */
+    private ChildSkuDataProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
+        $this->configurableType = $this->createMock(Configurable::class);
+
+        $this->provider = new ChildSkuDataProvider(
+            $this->productRepository,
+            $this->configurableType
+        );
+    }
+
+    public function testExecuteReturnsEmptyArrayWhenNoParentSku(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', null);
+
+        $this->productRepository->expects($this->never())->method('get');
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testExecuteReturnsEmptyArrayWhenParentSkuEqualsSku(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'same-sku', 'same-sku');
+
+        $this->productRepository->expects($this->never())->method('get');
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testExecuteReturnsEmptyArrayWhenSelectedOptionsPresent(): void
+    {
+        $selectedOption = $this->createMock(SelectedOption::class);
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku', null, null, [$selectedOption]);
+
+        $this->productRepository->expects($this->never())->method('get');
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testExecuteReturnsEmptyArrayOnNoSuchEntityException(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
+
+        $this->productRepository->expects($this->once())
+            ->method('get')
+            ->willThrowException(new NoSuchEntityException());
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testExecuteReturnsEmptyArrayWhenParentIsNotConfigurable(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
+
+        /** @var Product|MockObject $childProduct */
+        $childProduct = $this->createMock(Product::class);
+        /** @var Product|MockObject $parentProduct */
+        $parentProduct = $this->createMock(Product::class);
+
+        $this->productRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['child-sku', false, null, true, $childProduct],
+                ['parent-sku', false, null, true, $parentProduct],
+            ]);
+
+        $parentProduct->expects($this->once())
+            ->method('getTypeId')
+            ->willReturn('simple');
+
+        $this->configurableType->expects($this->never())->method('getConfigurableAttributesAsArray');
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+
+    public function testExecuteReturnsSuperAttributeMapForValidChildSku(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
+        $productId = 42;
+
+        /** @var Product|MockObject $childProduct */
+        $childProduct = $this->createMock(Product::class);
+        /** @var Product|MockObject $parentProduct */
+        $parentProduct = $this->createMock(Product::class);
+
+        $this->productRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['child-sku', false, null, true, $childProduct],
+                ['parent-sku', false, null, true, $parentProduct],
+            ]);
+
+        $parentProduct->expects($this->once())
+            ->method('getTypeId')
+            ->willReturn(Configurable::TYPE_CODE);
+
+        $this->configurableType->expects($this->once())
+            ->method('getConfigurableAttributesAsArray')
+            ->with($parentProduct)
+            ->willReturn([
+                ['attribute_id' => '93', 'attribute_code' => 'color'],
+                ['attribute_id' => '157', 'attribute_code' => 'size'],
+            ]);
+
+        $childProduct->expects($this->exactly(2))
+            ->method('getData')
+            ->willReturnCallback(static function (string $key) {
+                return match ($key) {
+                    'color' => '56',
+                    'size'  => '168',
+                    default => null,
+                };
+            });
+
+        $result = $this->provider->execute($wishlistItem, $productId);
+
+        $this->assertSame(
+            [
+                'super_attribute' => [93 => '56', 157 => '168'],
+                'product' => $productId,
+            ],
+            $result
+        );
+    }
+
+    public function testExecuteReturnsSuperAttributeMapWithoutProductIdWhenProductIdIsNull(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
+
+        /** @var Product|MockObject $childProduct */
+        $childProduct = $this->createMock(Product::class);
+        /** @var Product|MockObject $parentProduct */
+        $parentProduct = $this->createMock(Product::class);
+
+        $this->productRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['child-sku', false, null, true, $childProduct],
+                ['parent-sku', false, null, true, $parentProduct],
+            ]);
+
+        $parentProduct->expects($this->once())
+            ->method('getTypeId')
+            ->willReturn(Configurable::TYPE_CODE);
+
+        $this->configurableType->expects($this->once())
+            ->method('getConfigurableAttributesAsArray')
+            ->with($parentProduct)
+            ->willReturn([
+                ['attribute_id' => '93', 'attribute_code' => 'color'],
+            ]);
+
+        $childProduct->expects($this->once())
+            ->method('getData')
+            ->with('color')
+            ->willReturn('56');
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertArrayHasKey('super_attribute', $result);
+        $this->assertArrayNotHasKey('product', $result);
+        $this->assertSame([93 => '56'], $result['super_attribute']);
+    }
+
+    public function testExecuteSkipsAttributesWithEmptyValueOnChild(): void
+    {
+        $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
+
+        /** @var Product|MockObject $childProduct */
+        $childProduct = $this->createMock(Product::class);
+        /** @var Product|MockObject $parentProduct */
+        $parentProduct = $this->createMock(Product::class);
+
+        $this->productRepository->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['child-sku', false, null, true, $childProduct],
+                ['parent-sku', false, null, true, $parentProduct],
+            ]);
+
+        $parentProduct->expects($this->once())
+            ->method('getTypeId')
+            ->willReturn(Configurable::TYPE_CODE);
+
+        $this->configurableType->expects($this->once())
+            ->method('getConfigurableAttributesAsArray')
+            ->with($parentProduct)
+            ->willReturn([
+                ['attribute_id' => '93', 'attribute_code' => 'color'],
+                ['attribute_id' => '157', 'attribute_code' => 'size'],
+            ]);
+
+        $childProduct->expects($this->exactly(2))
+            ->method('getData')
+            ->willReturnCallback(static function (string $key) {
+                return match ($key) {
+                    'color' => null,
+                    'size'  => '',
+                    default => null,
+                };
+            });
+
+        $result = $this->provider->execute($wishlistItem, null);
+
+        $this->assertSame([], $result);
+    }
+}

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
@@ -261,7 +261,7 @@ class ChildSkuDataProviderTest extends TestCase
         $attribute = $this->getMockBuilder(AbstractAttribute::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getAttributeId', 'getAttributeCode'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $attribute->method('getAttributeId')->willReturn($attributeId);
         $attribute->method('getAttributeCode')->willReturn($attributeCode);
 

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ChildSkuDataProviderTest.php
@@ -7,9 +7,11 @@ declare(strict_types=1);
 
 namespace Magento\Wishlist\Test\Unit\Model\Wishlist\BuyRequest;
 
+use Magento\Catalog\Api\Data\ProductExtensionInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
-use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\ConfigurableProduct\Api\Data\OptionInterface;
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Wishlist\Model\Wishlist\BuyRequest\ChildSkuDataProvider;
 use Magento\Wishlist\Model\Wishlist\Data\SelectedOption;
@@ -19,15 +21,12 @@ use PHPUnit\Framework\TestCase;
 
 class ChildSkuDataProviderTest extends TestCase
 {
+    private const CONFIGURABLE_TYPE = 'configurable';
+
     /**
      * @var ProductRepositoryInterface|MockObject
      */
     private ProductRepositoryInterface $productRepository;
-
-    /**
-     * @var Configurable|MockObject
-     */
-    private Configurable $configurableType;
 
     /**
      * @var ChildSkuDataProvider
@@ -37,11 +36,9 @@ class ChildSkuDataProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
-        $this->configurableType = $this->createMock(Configurable::class);
 
         $this->provider = new ChildSkuDataProvider(
-            $this->productRepository,
-            $this->configurableType
+            $this->productRepository
         );
     }
 
@@ -96,9 +93,7 @@ class ChildSkuDataProviderTest extends TestCase
     {
         $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
 
-        /** @var Product|MockObject $childProduct */
         $childProduct = $this->createMock(Product::class);
-        /** @var Product|MockObject $parentProduct */
         $parentProduct = $this->createMock(Product::class);
 
         $this->productRepository->expects($this->exactly(2))
@@ -112,7 +107,7 @@ class ChildSkuDataProviderTest extends TestCase
             ->method('getTypeId')
             ->willReturn('simple');
 
-        $this->configurableType->expects($this->never())->method('getConfigurableAttributesAsArray');
+        $parentProduct->expects($this->never())->method('getExtensionAttributes');
 
         $result = $this->provider->execute($wishlistItem, null);
 
@@ -124,10 +119,8 @@ class ChildSkuDataProviderTest extends TestCase
         $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
         $productId = 42;
 
-        /** @var Product|MockObject $childProduct */
         $childProduct = $this->createMock(Product::class);
-        /** @var Product|MockObject $parentProduct */
-        $parentProduct = $this->createMock(Product::class);
+        $parentProduct = $this->createConfigurableParent(['93', '157']);
 
         $this->productRepository->expects($this->exactly(2))
             ->method('get')
@@ -136,16 +129,11 @@ class ChildSkuDataProviderTest extends TestCase
                 ['parent-sku', false, null, true, $parentProduct],
             ]);
 
-        $parentProduct->expects($this->once())
-            ->method('getTypeId')
-            ->willReturn(Configurable::TYPE_CODE);
-
-        $this->configurableType->expects($this->once())
-            ->method('getConfigurableAttributesAsArray')
-            ->with($parentProduct)
+        $childProduct->expects($this->once())
+            ->method('getAttributes')
             ->willReturn([
-                ['attribute_id' => '93', 'attribute_code' => 'color'],
-                ['attribute_id' => '157', 'attribute_code' => 'size'],
+                $this->createAttribute('93', 'color'),
+                $this->createAttribute('157', 'size'),
             ]);
 
         $childProduct->expects($this->exactly(2))
@@ -173,10 +161,8 @@ class ChildSkuDataProviderTest extends TestCase
     {
         $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
 
-        /** @var Product|MockObject $childProduct */
         $childProduct = $this->createMock(Product::class);
-        /** @var Product|MockObject $parentProduct */
-        $parentProduct = $this->createMock(Product::class);
+        $parentProduct = $this->createConfigurableParent(['93']);
 
         $this->productRepository->expects($this->exactly(2))
             ->method('get')
@@ -185,16 +171,9 @@ class ChildSkuDataProviderTest extends TestCase
                 ['parent-sku', false, null, true, $parentProduct],
             ]);
 
-        $parentProduct->expects($this->once())
-            ->method('getTypeId')
-            ->willReturn(Configurable::TYPE_CODE);
-
-        $this->configurableType->expects($this->once())
-            ->method('getConfigurableAttributesAsArray')
-            ->with($parentProduct)
-            ->willReturn([
-                ['attribute_id' => '93', 'attribute_code' => 'color'],
-            ]);
+        $childProduct->expects($this->once())
+            ->method('getAttributes')
+            ->willReturn([$this->createAttribute('93', 'color')]);
 
         $childProduct->expects($this->once())
             ->method('getData')
@@ -212,10 +191,8 @@ class ChildSkuDataProviderTest extends TestCase
     {
         $wishlistItem = new WishlistItem(1.0, 'child-sku', 'parent-sku');
 
-        /** @var Product|MockObject $childProduct */
         $childProduct = $this->createMock(Product::class);
-        /** @var Product|MockObject $parentProduct */
-        $parentProduct = $this->createMock(Product::class);
+        $parentProduct = $this->createConfigurableParent(['93', '157']);
 
         $this->productRepository->expects($this->exactly(2))
             ->method('get')
@@ -224,16 +201,11 @@ class ChildSkuDataProviderTest extends TestCase
                 ['parent-sku', false, null, true, $parentProduct],
             ]);
 
-        $parentProduct->expects($this->once())
-            ->method('getTypeId')
-            ->willReturn(Configurable::TYPE_CODE);
-
-        $this->configurableType->expects($this->once())
-            ->method('getConfigurableAttributesAsArray')
-            ->with($parentProduct)
+        $childProduct->expects($this->once())
+            ->method('getAttributes')
             ->willReturn([
-                ['attribute_id' => '93', 'attribute_code' => 'color'],
-                ['attribute_id' => '157', 'attribute_code' => 'size'],
+                $this->createAttribute('93', 'color'),
+                $this->createAttribute('157', 'size'),
             ]);
 
         $childProduct->expects($this->exactly(2))
@@ -249,5 +221,50 @@ class ChildSkuDataProviderTest extends TestCase
         $result = $this->provider->execute($wishlistItem, null);
 
         $this->assertSame([], $result);
+    }
+
+    /**
+     * Build a configurable parent product mock exposing the given configurable axis attribute IDs.
+     *
+     * @param string[] $attributeIds
+     * @return Product|MockObject
+     */
+    private function createConfigurableParent(array $attributeIds): Product
+    {
+        $parentProduct = $this->createMock(Product::class);
+        $parentProduct->method('getTypeId')->willReturn(self::CONFIGURABLE_TYPE);
+
+        $options = [];
+        foreach ($attributeIds as $attributeId) {
+            $option = $this->createMock(OptionInterface::class);
+            $option->method('getAttributeId')->willReturn($attributeId);
+            $options[] = $option;
+        }
+
+        $extensionAttributes = $this->createMock(ProductExtensionInterface::class);
+        $extensionAttributes->method('getConfigurableProductOptions')->willReturn($options);
+
+        $parentProduct->method('getExtensionAttributes')->willReturn($extensionAttributes);
+
+        return $parentProduct;
+    }
+
+    /**
+     * Build an EAV attribute mock with the given ID and code.
+     *
+     * @param string $attributeId
+     * @param string $attributeCode
+     * @return AbstractAttribute|MockObject
+     */
+    private function createAttribute(string $attributeId, string $attributeCode): AbstractAttribute
+    {
+        $attribute = $this->getMockBuilder(AbstractAttribute::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getAttributeId', 'getAttributeCode'])
+            ->getMockForAbstractClass();
+        $attribute->method('getAttributeId')->willReturn($attributeId);
+        $attribute->method('getAttributeCode')->willReturn($attributeCode);
+
+        return $attribute;
     }
 }

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ProductExtensionAttributesStub.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ProductExtensionAttributesStub.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Wishlist\Test\Unit\Model\Wishlist\BuyRequest;
+
+final class ProductExtensionAttributesStub
+{
+    /**
+     * @param array $options
+     */
+    public function __construct(private readonly array $options)
+    {
+    }
+
+    public function getConfigurableProductOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ProductExtensionAttributesStub.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Model/Wishlist/BuyRequest/ProductExtensionAttributesStub.php
@@ -7,7 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\Wishlist\Test\Unit\Model\Wishlist\BuyRequest;
 
-final class ProductExtensionAttributesStub
+/**
+ * Deterministic stand-in for the generated ProductExtensionInterface used by ChildSkuDataProviderTest.
+ */
+class ProductExtensionAttributesStub
 {
     /**
      * @param array $options
@@ -16,6 +19,11 @@ final class ProductExtensionAttributesStub
     {
     }
 
+    /**
+     * Return the configured configurable product options.
+     *
+     * @return array
+     */
     public function getConfigurableProductOptions(): array
     {
         return $this->options;

--- a/app/code/Magento/Wishlist/etc/graphql/di.xml
+++ b/app/code/Magento/Wishlist/etc/graphql/di.xml
@@ -10,6 +10,7 @@
         <arguments>
             <argument name="providers" xsi:type="array">
                 <item name="super_attribute" xsi:type="object">Magento\Wishlist\Model\Wishlist\BuyRequest\SuperAttributeDataProvider</item>
+                <item name="child_sku" xsi:type="object">Magento\Wishlist\Model\Wishlist\BuyRequest\ChildSkuDataProvider</item>
                 <item name="customizable_option" xsi:type="object">Magento\Wishlist\Model\Wishlist\BuyRequest\CustomizableOptionDataProvider</item>
                 <item name="bundle" xsi:type="object">Magento\Wishlist\Model\Wishlist\BuyRequest\BundleDataProvider</item>
                 <item name="downloadable" xsi:type="object">Magento\Wishlist\Model\Wishlist\BuyRequest\DownloadableLinkDataProvider</item>


### PR DESCRIPTION
## Description
`addProductsToWishlist` accepts both `selected_options` (encoded option IDs) and
`parent_sku` + `sku` to identify a configurable child. Only the
`selected_options` input ran through `SuperAttributeDataProvider`, so when a
caller supplied `parent_sku` + child `sku` the buy request never carried
`super_attribute`, the wishlist item never recorded a `simple_product` option,
and `configured_variant` resolved to null.

Added `ChildSkuDataProvider`: when `parent_sku` is set, `sku` differs, and no
`selected_options` were sent, load both products, walk the parent's
configurable attributes, and emit `super_attribute` mapping each
attribute_id to the child's stored value. Wired into the existing
`BuyRequestBuilder` provider list in `etc/graphql/di.xml`.

Fixes #40588

## Fixed Issues
- Fixes #40588: addProductsToWishlist mutation is not returning configured variant (Selected variant) while adding child product

## Manual testing scenarios
```graphql
mutation {
  addProductsToWishlist(
    wishlistId: "1"
    wishlistItems: [{ parent_sku: "configurable-parent", sku: "configurable-red", quantity: 1 }]
  ) {
    wishlist {
      items_v2(currentPage: 1, pageSize: 5) {
        items {
          __typename
          ... on ConfigurableWishlistItem { configured_variant { sku } }
        }
      }
    }
    user_errors { code message }
  }
}
```
Before: `configured_variant` is `null`. After: `configured_variant.sku == "configurable-red"`.

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (183 Wishlist unit tests)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)