### PR TITLE
fix(ui): allow negative values in validate-number-range (#40818)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
+++ b/app/code/Magento/Ui/view/base/web/js/lib/validation/rules.js
@@ -723,7 +723,7 @@ define([
                     return true;
                 }
 
-                isNumeric = /^(?:\d+\.?\d*|\.\d+)$/.test(value);
+                isNumeric = /^-?(?:\d+\.?\d*|\.\d+)$/.test(value);
 
                 if (!isNumeric) {
                     return false;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/lib/validation/rules.test.js
@@ -149,11 +149,19 @@ define([
             });
 
             it('should return true for value within negative range', function () {
-                expect(rules['validate-number-range'].handler('-5', '-10--1')).toBe(false);
+                expect(rules['validate-number-range'].handler('-5', '-10--1')).toBe(true);
             });
 
             it('should return false for value outside negative range', function () {
                 expect(rules['validate-number-range'].handler('0', '-10--1')).toBe(false);
+            });
+
+            it('should return true for negative value within mixed range', function () {
+                expect(rules['validate-number-range'].handler('-5', '-99-10000')).toBe(true);
+            });
+
+            it('should return false for value below mixed-sign range minimum', function () {
+                expect(rules['validate-number-range'].handler('-100', '-99-10000')).toBe(false);
             });
 
             it('should return false for invalid range param', function () {


### PR DESCRIPTION
## Description
ACP2E-3867 added a numeric pre-check `/^(?:\d+\.?\d*|\.\d+)$/` to
`validate-number-range`. The regex rejects any leading minus sign, so UI
components declaring a range like `validate-number-range -99-10000` reject
legitimate negative inputs even though the range explicitly allows them.

The dataAttrRange regex on the very next line already accepts `-?` on
both bounds, so the upstream short-circuit was the only blocker. Allow
an optional leading `-` in the numeric pre-check.

Updated the jasmine spec to reflect the correct expected behaviour for
negative ranges (the existing test was asserting the buggy result) and
added coverage for the mixed-sign range case from the issue.

Fixes #40818

## Fixed Issues
- Fixes #40818: UI components validate-number-range validation rule no longer allowing negative values

## Manual testing scenarios
Declare a UI component field with:
```xml
<item name="validate-number-range" xsi:type="string">-99-10000</item>
```
Before: any negative input fails with `The value is not within the specified range.`
After: negatives within the range pass; values outside the range still fail.

## Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (rules.test.js coverage extended)
- [x] Changes to the codebase comply with [technical guidelines](https://developer.adobe.com/commerce/php/coding-standards/technical-guidelines/)