### PR TITLE
Fixed media folder symlinks

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/Validator/ProductOptionValidator.php
+++ b/app/code/Magento/Catalog/Helper/Product/Validator/ProductOptionValidator.php
@@ -95,7 +95,7 @@ class ProductOptionValidator extends AbstractHelper
     private function validateFilePath(string $quotePath, string $orderPath): void
     {
         $mediaDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA);
-        $allowedDirectory = rtrim($mediaDirectory->getAbsolutePath(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $allowedDirectory = realpath(rtrim($mediaDirectory->getAbsolutePath(), DIRECTORY_SEPARATOR)) . DIRECTORY_SEPARATOR;
         $driver = $mediaDirectory->getDriver();
 
         $quoteFullPath = $this->buildFullPath($quotePath, $allowedDirectory);


### PR DESCRIPTION
### Description (*)
The new validation gives errors when a situation uses atomic deployments where the media folder is set as a shared folder.

Given some debugging, we can see that the `$quoteResolved` path resolves the symlink:
`/home/www/example.com/shared/pub/media/custom_options/quote`

While the `$mediaDirectory->getAbsolutePath()` does not resolve symlinks:
`/home/www/example.com/releases/000/pub/media/`

By wrapping it in realPath we force it to resolve those symlinks and we end up comparing
`/home/www/example.com/shared/pub/media/custom_options/quote` to `/home/www/example.com/shared/pub/media/` which is what we want to see in situations with a symlink

### Manual testing scenarios (*)
1. Make a symlink from pub/media to somewhere else (e.g. even an external disk)
2. Attempt to add a product option file to your cart
3. See how the `Invalid file path.` error gets throw.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40839: Fixed media folder symlinks