### PR TITLE
Fix PHP 8.5: KEY_MYSQL_SSL_VERIFY hardcoded as 1014 resolves to the wrong PDO attribute

### DIFF
--- a/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
+++ b/dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon
@@ -47,6 +47,10 @@ parameters:
         - '#Constant TESTS_MODULES_PATH not found.#'
         - '#Constant TESTS_INSTALLATION_DB_CONFIG_FILE not found.#'
         - '#Constant T_[A-Z_]+ not found.#'
+        # PHPStan 1.x ships no stubs for the PHP 8.4+ Pdo\Mysql class constants and reports them as
+        # undefined regardless of the runtime PHP version. ConfigOptionsListConstants resolves them
+        # behind a PHP_VERSION_ID >= 80400 guard.
+        - '#Access to undefined constant Pdo\\Mysql::ATTR_[A-Z_]+\.#'
         # Ignore Predis\Client - optional dependency for Redis fallback
         - '#Class Predis\\Client not found.#'
         - '#Instantiated class Predis\\Client not found.#'

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -139,13 +139,7 @@ class ConfigOptionsListConstants
     public const KEY_MYSQL_SSL_KEY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY;
     public const KEY_MYSQL_SSL_CERT = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT;
     public const KEY_MYSQL_SSL_CA = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA;
-
-    /**
-     * Constant \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT cannot be used as it was introduced in PHP 7.1.4
-     * and Magento 2 is currently supporting PHP 7.1.3.
-     */
-    public const KEY_MYSQL_SSL_VERIFY = 1014;
-    /**#@-*/
+    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
 
     /**
      * Db config key

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -131,7 +131,6 @@ class ConfigOptionsListConstants
 
     /**#@+
      * Array keys for database driver options configurations
-     * 
      * PHP 8.4+ deprecated PDO::MYSQL_ATTR_SSL_* constants in favor of Pdo\Mysql::ATTR_SSL_*
      * PHP 8.5+ removed the deprecated constants entirely
      * We use the new constants if available (PHP 8.4+), otherwise fall back to legacy constants

--- a/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
+++ b/lib/internal/Magento/Framework/Config/ConfigOptionsListConstants.php
@@ -139,7 +139,10 @@ class ConfigOptionsListConstants
     public const KEY_MYSQL_SSL_KEY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_KEY : \PDO::MYSQL_ATTR_SSL_KEY;
     public const KEY_MYSQL_SSL_CERT = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CERT : \PDO::MYSQL_ATTR_SSL_CERT;
     public const KEY_MYSQL_SSL_CA = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_CA : \PDO::MYSQL_ATTR_SSL_CA;
-    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400 ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+    public const KEY_MYSQL_SSL_VERIFY = \PHP_VERSION_ID >= 80400
+        ? \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT
+        : \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+    /**#@-*/
 
     /**
      * Db config key

--- a/lib/internal/Magento/Framework/Config/Test/Unit/ConfigOptionsListConstantsTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/ConfigOptionsListConstantsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Config\Test\Unit;
+
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use PHPUnit\Framework\TestCase;
+
+class ConfigOptionsListConstantsTest extends TestCase
+{
+    /**
+     * The MySQL SSL driver option keys must resolve to the attributes of the running PHP version.
+     *
+     * PHP 8.5 moved Pdo\Mysql::ATTR_DIRECT_QUERY out of the driver specific attribute range, shifting
+     * every following attribute down by one. A hardcoded integer therefore addresses a different
+     * attribute depending on the PHP version it runs on.
+     */
+    public function testMysqlSslKeysMatchPdoAttributes(): void
+    {
+        if (\PHP_VERSION_ID >= 80400) {
+            $this->assertSame(\Pdo\Mysql::ATTR_SSL_KEY, ConfigOptionsListConstants::KEY_MYSQL_SSL_KEY);
+            $this->assertSame(\Pdo\Mysql::ATTR_SSL_CERT, ConfigOptionsListConstants::KEY_MYSQL_SSL_CERT);
+            $this->assertSame(\Pdo\Mysql::ATTR_SSL_CA, ConfigOptionsListConstants::KEY_MYSQL_SSL_CA);
+            $this->assertSame(
+                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT,
+                ConfigOptionsListConstants::KEY_MYSQL_SSL_VERIFY
+            );
+
+            return;
+        }
+
+        $this->assertSame(\PDO::MYSQL_ATTR_SSL_KEY, ConfigOptionsListConstants::KEY_MYSQL_SSL_KEY);
+        $this->assertSame(\PDO::MYSQL_ATTR_SSL_CERT, ConfigOptionsListConstants::KEY_MYSQL_SSL_CERT);
+        $this->assertSame(\PDO::MYSQL_ATTR_SSL_CA, ConfigOptionsListConstants::KEY_MYSQL_SSL_CA);
+        $this->assertSame(
+            \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT,
+            ConfigOptionsListConstants::KEY_MYSQL_SSL_VERIFY
+        );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`Pdo\Mysql::ATTR_DIRECT_QUERY` no longer occupies a driver-specific attribute value in PHP 8.5 — it is now an alias of `PDO::ATTR_EMULATE_PREPARES` (`20`). Every attribute after it in the driver-specific range shifts down by one, so `ATTR_SSL_VERIFY_SERVER_CERT` is `1013` on PHP 8.5 where it was `1014` on PHP 8.4. `ATTR_SERVER_PUBLIC_KEY` still exists (`1011`).

`KEY_MYSQL_SSL_VERIFY` was hardcoded as `1014` (a legacy workaround from when Magento supported PHP 7.1.3). On PHP 8.5 that value is `ATTR_LOCAL_INFILE_DIRECTORY`, which expects a path — passing `false` crashes every installation on boot with an open_basedir `PDOException`.

Applies the same `PHP_VERSION_ID >= 80400` pattern already used for `KEY_MYSQL_SSL_KEY`, `KEY_MYSQL_SSL_CERT` and `KEY_MYSQL_SSL_CA`.

Also included:

- A unit test covering all four `KEY_MYSQL_SSL_*` constants against the running PHP version's attributes, so a hardcoded integer cannot creep back in.
- A PHPStan suppression for `Access to undefined constant Pdo\Mysql::ATTR_*`. PHPStan 1.x ships no stubs for the PHP 8.4+ `Pdo\Mysql` class constants and reports them as undefined regardless of the runtime PHP version. Three of the four reported lines (`KEY_MYSQL_SSL_KEY`, `KEY_MYSQL_SSL_CERT`, `KEY_MYSQL_SSL_CA`) predate this pull request and surface only because `LiveCodeTest::testPhpStan` analyses whole changed files.
- Removal of a pre-existing trailing whitespace on line 134, reported by `testCodeStyle` for the same reason.

### Related Pull Requests
<!-- related pull request placeholder -->
mage-os/mageos-magento2#313

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Fresh install Magento 2.4.9 on PHP 8.5 with open_basedir — crashes without fix
2. Apply fix, reinstall — boots successfully
3. Check env.php: `driver_options` contains `1013 => false` (the PHP 8.5 value of `ATTR_SSL_VERIFY_SERVER_CERT`) instead of `1014 => false`

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
The PHPStan entry touches a shared static-test config, which is wider scope than the fix itself. Happy to narrow it to a `path:`-scoped entry per file instead, or drop it if you'd rather handle the stub gap separately — but any pull request touching `ConfigOptionsListConstants.php` will hit those four errors until something changes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40855: Fix PHP 8.5: KEY_MYSQL_SSL_VERIFY hardcoded as 1014 collides with ren…