### PR TITLE
Fix undefined array key in FinalPriceBox::hasSpecialPrice for products missing from special_price_map

### DIFF
--- a/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
+++ b/app/code/Magento/Catalog/Pricing/Render/FinalPriceBox.php
@@ -154,17 +154,20 @@ class FinalPriceBox extends BasePriceBox
     public function hasSpecialPrice()
     {
         if ($this->isProductList()) {
-            if (!$this->getData('special_price_map')) {
+            $specialPriceMap = $this->getData('special_price_map');
+            if (!$specialPriceMap || !is_array($specialPriceMap)) {
                 return false;
             }
-
-            return (bool)$this->getData('special_price_map')[$this->saleableItem->getId()];
-        } else {
-            $displayRegularPrice = $this->getPriceType(Price\RegularPrice::PRICE_CODE)->getAmount()->getValue();
-            $displayFinalPrice = $this->getPriceType(Price\FinalPrice::PRICE_CODE)->getAmount()->getValue();
-
-            return $displayFinalPrice < $displayRegularPrice;
+            $productId = $this->saleableItem->getId();
+            if (array_key_exists($productId, $specialPriceMap)) {
+                return (bool)$specialPriceMap[$productId];
+            }
         }
+
+        $displayRegularPrice = $this->getPriceType(Price\RegularPrice::PRICE_CODE)->getAmount()->getValue();
+        $displayFinalPrice = $this->getPriceType(Price\FinalPrice::PRICE_CODE)->getAmount()->getValue();
+
+        return $displayFinalPrice < $displayRegularPrice;
     }
 
     /**

--- a/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
@@ -399,6 +399,59 @@ class FinalPriceBoxTest extends TestCase
     /**
      * @return void
      */
+    public function testHasSpecialPriceReturnsFalseWhenSpecialPriceMapIsNotSet(): void
+    {
+        $this->object->setData('is_product_list', true);
+        $this->product->expects($this->never())->method('getId');
+        $this->priceInfo->expects($this->never())->method('getPrice');
+
+        $this->assertFalse($this->object->hasSpecialPrice());
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasSpecialPriceFallsBackWhenProductIsMissingFromSpecialPriceMap(): void
+    {
+        $this->product->method('getId')->willReturn(42);
+        $this->object->setData('is_product_list', true);
+        $this->object->setData('special_price_map', [7 => false]);
+
+        $regularPriceType = $this->createMock(RegularPrice::class);
+        $finalPriceType = $this->createMock(FinalPrice::class);
+        $regularPriceAmount = $this->createMock(AmountInterface::class);
+        $finalPriceAmount = $this->createMock(AmountInterface::class);
+
+        $regularPriceAmount->expects($this->once())
+            ->method('getValue')
+            ->willReturn(20.0);
+        $finalPriceAmount->expects($this->once())
+            ->method('getValue')
+            ->willReturn(10.0);
+
+        $regularPriceType->expects($this->once())
+            ->method('getAmount')
+            ->willReturn($regularPriceAmount);
+        $finalPriceType->expects($this->once())
+            ->method('getAmount')
+            ->willReturn($finalPriceAmount);
+
+        $this->priceInfo
+            ->method('getPrice')
+            ->willReturnCallback(function ($arg) use ($regularPriceType, $finalPriceType) {
+                if ($arg == RegularPrice::PRICE_CODE) {
+                    return $regularPriceType;
+                } elseif ($arg == FinalPrice::PRICE_CODE) {
+                    return $finalPriceType;
+                }
+            });
+
+        $this->assertTrue($this->object->hasSpecialPrice());
+    }
+
+    /**
+     * @return void
+     */
     public function testShowMinimalPrice(): void
     {
         $minimalPrice = 5.0;

--- a/app/code/Magento/ConfigurableProduct/Pricing/Render/FinalPriceBox.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Render/FinalPriceBox.php
@@ -67,21 +67,24 @@ class FinalPriceBox extends \Magento\Catalog\Pricing\Render\FinalPriceBox
     public function hasSpecialPrice()
     {
         if ($this->isProductList()) {
-            if (!$this->getData('special_price_map')) {
+            $specialPriceMap = $this->getData('special_price_map');
+            if (!$specialPriceMap || !is_array($specialPriceMap)) {
                 return false;
             }
-
-            return (bool)$this->getData('special_price_map')[$this->saleableItem->getId()];
-        } else {
-            $product = $this->getSaleableItem();
-            foreach ($this->configurableOptionsProvider->getProducts($product) as $subProduct) {
-                $regularPrice = $subProduct->getPriceInfo()->getPrice(RegularPrice::PRICE_CODE)->getValue();
-                $finalPrice = $subProduct->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue();
-                if ($finalPrice < $regularPrice) {
-                    return true;
-                }
+            $productId = $this->saleableItem->getId();
+            if (array_key_exists($productId, $specialPriceMap)) {
+                return (bool)$specialPriceMap[$productId];
             }
-            return false;
         }
+
+        $product = $this->getSaleableItem();
+        foreach ($this->configurableOptionsProvider->getProducts($product) as $subProduct) {
+            $regularPrice = $subProduct->getPriceInfo()->getPrice(RegularPrice::PRICE_CODE)->getValue();
+            $finalPrice = $subProduct->getPriceInfo()->getPrice(FinalPrice::PRICE_CODE)->getValue();
+            if ($finalPrice < $regularPrice) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Render/FinalPriceBoxTest.php
@@ -152,6 +152,59 @@ class FinalPriceBoxTest extends TestCase
     }
 
     /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testHasSpecialPriceReturnsFalseWhenSpecialPriceMapIsNotSet(): void
+    {
+        $this->model->setData('is_product_list', true);
+        $this->saleableItem->expects($this->never())->method('getId');
+        $this->configurableOptionsProvider->expects($this->never())->method('getProducts');
+
+        $this->assertFalse($this->model->hasSpecialPrice());
+    }
+
+    /**
+     * @return void
+     * @throws \Exception
+     */
+    public function testHasSpecialPriceFallsBackWhenProductIsMissingFromSpecialPriceMap(): void
+    {
+        $priceMockOne = $this->createMock(PriceInterface::class);
+        $priceMockOne->expects($this->once())
+            ->method('getValue')
+            ->willReturn(20.);
+        $priceMockTwo = $this->createMock(PriceInterface::class);
+        $priceMockTwo->expects($this->once())
+            ->method('getValue')
+            ->willReturn(10.);
+        $priceInfoMock = $this->createMock(PriceInfoInterface::class);
+        $priceInfoMock->expects($this->exactly(2))
+            ->method('getPrice')
+            ->willReturnMap(
+                [
+                    [RegularPrice::PRICE_CODE, $priceMockOne],
+                    [FinalPrice::PRICE_CODE, $priceMockTwo],
+                ]
+            );
+
+        $productMock = $this->createMock(Product::class);
+        $productMock->expects($this->exactly(2))
+            ->method('getPriceInfo')
+            ->willReturn($priceInfoMock);
+        $this->configurableOptionsProvider->expects($this->once())
+            ->method('getProducts')
+            ->with($this->saleableItem)
+            ->willReturn([$productMock]);
+
+        $this->model->setData('is_product_list', true);
+        $this->model->setData('special_price_map', [7 => false]);
+        $this->saleableItem->expects($this->once())->method('getId')->willReturn(42);
+
+        $this->assertTrue($this->model->hasSpecialPrice());
+    }
+
+    /**
      * @return array
      */
     public static function hasSpecialPriceDataProvider(): array


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`Magento\Catalog\Block\Product\ListProduct::getProductPrice()` sets `is_product_list` and a `special_price_map` on the shared `product.price.render.default` layout block. The map is built exclusively from the category layer collection (`SpecialPriceBulkResolver::generateSpecialPriceMap()`).

The same shared block is reused by every other price render in the same request — core itself does this in `Magento\CatalogWidget\Block\Product\ProductsList::getProductPriceHtml()` and `Magento\Catalog\Block\Product\AbstractProduct::getProductPrice()`. When such a render happens after the category list (e.g. a `products_list` widget or a PageBuilder Products element inside the category description), `is_product_list` is still `true` and the map is still scoped to the category collection. For any product that is not part of that collection, `FinalPriceBox::hasSpecialPrice()` performs an unguarded array access:

```
Warning: Undefined array key 8539 in vendor/magento/module-catalog/Pricing/Render/FinalPriceBox.php on line 161
```

The warning escalates to an exception via `Magento\Framework\App\ErrorHandler`, which kills the widget render — the category description content silently disappears and a `main.CRITICAL` entry is logged on every cold-cache render.

This PR makes `hasSpecialPrice()` fall back to the actual price comparison (the pre-`special_price_map` behaviour) when the saleable item is not covered by the map, instead of failing. The same unguarded access exists in `Magento\ConfigurableProduct\Pricing\Render\FinalPriceBox::hasSpecialPrice()` (line 74) and is fixed the same way, falling back to the existing child-product comparison loop.

Compared to the closed #40550: this also covers the ConfigurableProduct price box, and it falls back to the real price computation rather than returning `false`, so widget products that do have a special price keep their special price styling.

The `special_price_map` is a performance optimization (one bulk query for the list instead of per-product price lookups); products covered by the map keep the fast path, products outside it get the previous per-product behaviour.

### Related Pull Requests

https://github.com/magento/magento2/pull/40550 (closed, superseded by this PR)

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40606
2. Fixes magento/magento2#40547

### Manual testing scenarios (*)

1. Create a category with display mode "Static block and products" (or add PageBuilder content to a regular category)
2. Assign at least one product to the category
3. Add a `products_list` widget (or a PageBuilder Products element) to the category description/static block that contains at least one product **not** assigned to the category — ideally one with a special price
4. Reindex and flush cache
5. Open the category page on the storefront
6. Before: `main.CRITICAL Exception: Warning: Undefined array key <id> in .../FinalPriceBox.php on line 161` in `var/log/exception.log`, widget content missing/broken
7. After: no exception, widget renders all products, products with special price show special price styling

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40866: Fix undefined array key in FinalPriceBox::hasSpecialPrice for products missing from special_price_map