### PR TITLE
Fix PHP 8.5 deprecation: Using null as the key parameter for array_key_exists()

### DIFF
--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -20,27 +20,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Used for "name" attribute of captcha's input field
      */
-    const INPUT_NAME_FIELD_VALUE = 'captcha';
+    public const INPUT_NAME_FIELD_VALUE = 'captcha';
 
     /**
      * Always show captcha
      */
-    const MODE_ALWAYS = 'always';
+    public const MODE_ALWAYS = 'always';
 
     /**
      * Show captcha only after certain number of unsuccessful attempts
      */
-    const MODE_AFTER_FAIL = 'after_fail';
+    public const MODE_AFTER_FAIL = 'after_fail';
 
     /**
      * Captcha fonts path
      */
-    const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
+    public const XML_PATH_CAPTCHA_FONTS = 'captcha/fonts';
 
     /**
      * Default captcha type
      */
-    const DEFAULT_CAPTCHA_TYPE = 'Zend';
+    public const DEFAULT_CAPTCHA_TYPE = 'Zend';
 
     /**
      * List uses Models of Captcha

--- a/app/code/Magento/Captcha/Helper/Data.php
+++ b/app/code/Magento/Captcha/Helper/Data.php
@@ -84,11 +84,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Captcha
      *
-     * @param string $formId
+     * @param string|null $formId
      * @return \Magento\Captcha\Model\CaptchaInterface
      */
     public function getCaptcha($formId)
     {
+        $formId = $formId ?? '';
         if (!array_key_exists($formId, $this->_captcha)) {
             $captchaType = ucfirst($this->getConfig('type'));
             if (!$captchaType) {

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -89,7 +89,11 @@ class AjaxLogin
         }
         $username = $loginParams['username'] ?? null;
         $captchaString = $loginParams[$captchaInputName] ?? null;
-        $loginFormId = $loginParams[$captchaFormIdField] ?? '';
+        $loginFormId = $loginParams[$captchaFormIdField] ?? null;
+
+        if ($loginFormId === null) {
+            return $proceed();
+        }
 
         if (!in_array($loginFormId, $this->formIds) && $this->helper->getCaptcha($loginFormId)->isRequired($username)) {
             return $this->returnJsonError(__('Provided form does not exist'));

--- a/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
+++ b/app/code/Magento/Captcha/Model/Customer/Plugin/AjaxLogin.php
@@ -89,7 +89,7 @@ class AjaxLogin
         }
         $username = $loginParams['username'] ?? null;
         $captchaString = $loginParams[$captchaInputName] ?? null;
-        $loginFormId = $loginParams[$captchaFormIdField] ?? null;
+        $loginFormId = $loginParams[$captchaFormIdField] ?? '';
 
         if (!in_array($loginFormId, $this->formIds) && $this->helper->getCaptcha($loginFormId)->isRequired($username)) {
             return $this->returnJsonError(__('Provided form does not exist'));

--- a/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
@@ -87,7 +87,8 @@ class DataTest extends TestCase
         )->method(
             'create'
         )->with(
-            'Zend'
+            'Zend',
+            'user_create'
         )->willReturn(
             new DefaultModel(
                 $this->createMock(SessionManager::class),
@@ -114,7 +115,7 @@ class DataTest extends TestCase
 
         $this->factoryMock->expects($this->once())
             ->method('create')
-            ->with('Zend')
+            ->with('Zend', $this->identicalTo(''))
             ->willReturn(
                 new DefaultModel(
                     $this->createMock(SessionManager::class),

--- a/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Helper/DataTest.php
@@ -103,6 +103,33 @@ class DataTest extends TestCase
     }
 
     /**
+     * @covers \Magento\Captcha\Helper\Data::getCaptcha
+     */
+    public function testGetCaptchaWithNullFormId()
+    {
+        $this->configMock->expects($this->once())
+            ->method('getValue')
+            ->with('customer/captcha/type')
+            ->willReturn('zend');
+
+        $this->factoryMock->expects($this->once())
+            ->method('create')
+            ->with('Zend')
+            ->willReturn(
+                new DefaultModel(
+                    $this->createMock(SessionManager::class),
+                    $this->createMock(Data::class),
+                    $this->createPartialMock(LogFactory::class, ['create']),
+                    '',                       // null formId coalesced to ''
+                    $this->createMock(Random::class),
+                    $this->createMock(UserContextInterface::class)
+                )
+            );
+
+        $this->assertInstanceOf(DefaultModel::class, $this->helper->getCaptcha(null));
+    }
+
+    /**
      * @covers \Magento\Captcha\Helper\Data::getConfig
      */
     public function testGetConfigNode()

--- a/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Model/Customer/Plugin/AjaxLoginTest.php
@@ -95,7 +95,7 @@ class AjaxLoginTest extends TestCase
             ->willReturn($this->requestMock);
 
         $this->captchaHelperMock
-            ->expects($this->exactly(1))
+            ->expects($this->any())
             ->method('getCaptcha')
             ->willReturn($this->captchaMock);
 
@@ -193,7 +193,11 @@ class AjaxLoginTest extends TestCase
         $this->serializerMock->expects($this->once())->method('unserialize')
             ->willReturn($requestContent);
 
-        $this->captchaMock->expects($this->once())->method('isRequired')->with($username)
+        $expectEarlyReturn = !array_key_exists('captcha_form_id', $requestContent)
+            || $requestContent['captcha_form_id'] === null;
+        $this->captchaMock
+            ->expects($expectEarlyReturn ? $this->never() : $this->once())
+            ->method('isRequired')->with($username)
             ->willReturn(false);
         $expectLogAttempt = $requestContent['captcha_form_id'] ?? false;
         $this->captchaMock


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On PHP 8.5, an AJAX customer login (e.g. the "Checkout using your account" sign-in popup) fails with **"Could not authenticate. Please try again later"** and the following deprecation is logged as `report.CRITICAL`:
```
[2026-06-11T19:13:56.998006+00:00] report.CRITICAL: Exception: Deprecated Functionality: Using null as the key parameter for array_key_exists() is deprecated, use an empty s
tring instead in /var/www/vendor/magento/module-captcha/Helper/Data.php on line 92 in /var/www/vendor/magento/framework/App/ErrorHandler.php:61
Stack trace:
#0 [internal function]: Magento\Framework\App\ErrorHandler->handler(8192, 'Using null as t...', '/var/www/vendor...', 92)
#1 /var/www/vendor/magento/module-captcha/Helper/Data.php(92): array_key_exists(NULL, Array)
#2 /var/www/vendor/magento/module-captcha/Model/Customer/Plugin/AjaxLogin.php(94): Magento\Captcha\Helper\Data->getCaptcha(NULL)
#3 /var/www/vendor/magento/framework/Interception/Interceptor.php(135): Magento\Captcha\Model\Customer\Plugin\AjaxLogin->aroundExecute(Object(Magento\Customer\Controller\Aja
x\Login\Interceptor), Object(Closure))
#4 /var/www/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Customer\Controller\Ajax\Login\Interceptor->{closure:Magento\Framework\Interception\Intercept
or::___callPlugins():104}()
#5 /var/www/generated/code/Magento/Customer/Controller/Ajax/Login/Interceptor.php(23): Magento\Customer\Controller\Ajax\Login\Interceptor->___callPlugins('execute', Array, N
ULL)
#6 /var/www/vendor/magento/framework/App/Action/Action.php(111): Magento\Customer\Controller\Ajax\Login\Interceptor->execute()
#7 /var/www/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\App\Action\Action->dispatch(Object(Magento\Framework\App\Request\Http))
#8 /var/www/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Customer\Controller\Ajax\Login\Interceptor->___callParent('dispatch', Array)
#9 /var/www/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Customer\Controller\Ajax\Login\Interceptor->{closure:Magento\Framework\Interception\Intercept
or::___callPlugins():104}(Object(Magento\Framework\App\Request\Http))
#10 /var/www/generated/code/Magento/Customer/Controller/Ajax/Login/Interceptor.php(32): Magento\Customer\Controller\Ajax\Login\Interceptor->___callPlugins('dispatch', Array,
 Array)
#11 /var/www/vendor/magento/framework/App/FrontController.php(245): Magento\Customer\Controller\Ajax\Login\Interceptor->dispatch(Object(Magento\Framework\App\Request\Http))
#12 /var/www/vendor/magento/framework/App/FrontController.php(212): Magento\Framework\App\FrontController->getActionResponse(Object(Magento\Customer\Controller\Ajax\Login\In
terceptor), Object(Magento\Framework\App\Request\Http))
#13 /var/www/vendor/magento/framework/App/FrontController.php(146): Magento\Framework\App\FrontController->processRequest(Object(Magento\Framework\App\Request\Http), Object(
Magento\Customer\Controller\Ajax\Login\Interceptor))
#14 /var/www/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\App\FrontController->dispatch(Object(Magento\Framework\App\Request\Http))
#15 /var/www/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\App\FrontController\Interceptor->___callParent('dispatch', Array)
#16 /var/www/vendor/magento/module-store/App/FrontController/Plugin/RequestPreprocessor.php(99): Magento\Framework\App\FrontController\Interceptor->{closure:Magento\Framewor
k\Interception\Interceptor::___callPlugins():104}(Object(Magento\Framework\App\Request\Http))
#17 /var/www/vendor/magento/framework/Interception/Interceptor.php(135): Magento\Store\App\FrontController\Plugin\RequestPreprocessor->aroundDispatch(Object(Magento\Framewor
k\App\FrontController\Interceptor), Object(Closure), Object(Magento\Framework\App\Request\Http))
#18 /var/www/vendor/magento/module-page-cache/Model/App/FrontController/BuiltinPlugin.php(72): Magento\Framework\App\FrontController\Interceptor->{closure:Magento\Framework\
Interception\Interceptor::___callPlugins():104}(Object(Magento\Framework\App\Request\Http))
#19 /var/www/vendor/magento/framework/Interception/Interceptor.php(135): Magento\PageCache\Model\App\FrontController\BuiltinPlugin->aroundDispatch(Object(Magento\Framework\A
pp\FrontController\Interceptor), Object(Closure), Object(Magento\Framework\App\Request\Http))
#20 /var/www/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\App\FrontController\Interceptor->{closure:Magento\Framework\Interception\Intercept
or::___callPlugins():104}(Object(Magento\Framework\App\Request\Http))
#21 /var/www/generated/code/Magento/Framework/App/FrontController/Interceptor.php(23): Magento\Framework\App\FrontController\Interceptor->___callPlugins('dispatch', Array, N
ULL)
#22 /var/www/vendor/magento/framework/App/Http.php(116): Magento\Framework\App\FrontController\Interceptor->dispatch(Object(Magento\Framework\App\Request\Http))
#23 /var/www/vendor/magento/framework/Interception/Interceptor.php(58): Magento\Framework\App\Http->launch()
#24 /var/www/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Framework\App\Http\Interceptor->___callParent('launch', Array)
#25 /var/www/vendor/magento/module-application-performance-monitor/Plugin/ApplicationPerformanceMonitor.php(38): Magento\Framework\App\Http\Interceptor->{closure:Magento\Fra
mework\Interception\Interceptor::___callPlugins():104}()
#26 /var/www/vendor/magento/framework/Interception/Interceptor.php(135): Magento\ApplicationPerformanceMonitor\Plugin\ApplicationPerformanceMonitor->aroundLaunch(Object(Mage
nto\Framework\App\Http\Interceptor), Object(Closure))
#27 /var/www/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Framework\App\Http\Interceptor->{closure:Magento\Framework\Interception\Interceptor::___call
Plugins():104}()
#28 /var/www/generated/code/Magento/Framework/App/Http/Interceptor.php(23): Magento\Framework\App\Http\Interceptor->___callPlugins('launch', Array, NULL)
#29 /var/www/vendor/magento/framework/App/Bootstrap.php(264): Magento\Framework\App\Http\Interceptor->launch()
#30 /var/www/pub/index.php(30): Magento\Framework\App\Bootstrap->run(Object(Magento\Framework\App\Http\Interceptor))
#31 {main} {"report_id":"2ae3a657eaf9a9217bb256096f1da0896e4ce0d7afe08a8200685c8aa1283a3d","exception":"[object] (Exception(code: 0): Deprecated Functionality: Using null as
 the key parameter for array_key_exists() is deprecated, use an empty string instead in /var/www/vendor/magento/module-captcha/Helper/Data.php on line 92 at /var/www/vendor/
magento/framework/App/ErrorHandler.php:61)"} []

```
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/500b817f-0a61-4f84-9d36-cf0f32b012c2" />

**Root cause:** when the AJAX login request payload does not contain `captcha_form_id`, `Magento\Captcha\Model\Customer\Plugin\AjaxLogin::aroundExecute()` resolves the form id to `null` and passes it to `Magento\Captcha\Helper\Data::getCaptcha()`, which calls `array_key_exists($formId, $this->_captcha)`. Passing `null` as the key to `array_key_exists()` is deprecated in PHP 8.5, and Magento's `ErrorHandler` converts the deprecation into an exception, breaking the login flow.

  **Fix:**
  - `Magento\Captcha\Helper\Data::getCaptcha()` - normalize `null` form id to `''` before the `array_key_exists()` call. This is a no-op behavior-wise: PHP has always coerced a `null` array key to `''` on write, so the internal `$this->_captcha` cache keys stay exactly the same. The public method signature is unchanged (no BC break), and the fix covers every caller of this public helper method, not just this plugin.
  - `Magento\Captcha\Model\Customer\Plugin\AjaxLogin::aroundExecute()` - default a missing `captcha_form_id` to `''` instead of `null` so the plugin no longer feeds `null` downstream. `in_array()` semantics are unaffected (`null == ''` under the loose comparison used there).


### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1. Run Magento on PHP 8.5
  2. Go to **Stores > Configuration > Sales > Checkout > Checkout Options** and set **Allow Guest Checkout** to **No**, then flush the cache
  3. Make sure CAPTCHA for the `user_login` form is not forced (default config)
  4. As a not-logged-in customer, add a product to the cart and proceed to checkout — the "Checkout as a new customer / Checkout using your account" popup appears
  5. In the "Checkout using your account" block, enter the credentials of an existing customer and click **Sign In**
  6. **Before the fix:** the request fails with "Could not authenticate. Please try again later", and `var/report`/`var/log` contains `report.CRITICAL: Exception: Deprecated
  Functionality: Using null as the key parameter for array_key_exists() ... in module-captcha/Helper/Data.php on line 92`
  7. **After the fix:** the customer signs in successfully and no deprecation is logged


### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40875: Fix PHP 8.5 deprecation: Using null as the key parameter for array_key_exists()