### PR TITLE
Avoid PHP 8.5 deprecation, by avoiding accessing array key 'null' when resolving scope codes

### DIFF
--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -40,11 +40,8 @@ class ScopeCodeResolver
      */
     public function resolve($scopeType, $scopeCode)
     {
-        // use empty string in case $scopeCode is null, needed to avoid deprecated warnings on PHP >=8.5
-        $scopeCodeKey = $scopeCode ?? '';
-
-        if (isset($this->resolvedScopeCodes[$scopeType][$scopeCodeKey])) {
-            return $this->resolvedScopeCodes[$scopeType][$scopeCodeKey];
+        if ($scopeCode !== null && isset($this->resolvedScopeCodes[$scopeType][$scopeCode])) {
+            return $this->resolvedScopeCodes[$scopeType][$scopeCode];
         }
 
         if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
@@ -58,7 +55,11 @@ class ScopeCodeResolver
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
-        $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
+        if ($scopeCode === null) {
+            return $resolverScopeCode;
+        }
+
+        $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
 
         return $resolverScopeCode;
     }

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -58,10 +58,6 @@ class ScopeCodeResolver
             $resolverScopeCode = $resolverScopeCode->getCode();
         }
 
-        if ($scopeCode === null) {
-            $scopeCode = $resolverScopeCode;
-        }
-
         $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
 
         return $resolverScopeCode;

--- a/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
+++ b/lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php
@@ -40,8 +40,11 @@ class ScopeCodeResolver
      */
     public function resolve($scopeType, $scopeCode)
     {
-        if (isset($scopeCode, $this->resolvedScopeCodes[$scopeType][$scopeCode])) {
-            return $this->resolvedScopeCodes[$scopeType][$scopeCode];
+        // use empty string in case $scopeCode is null, needed to avoid deprecated warnings on PHP >=8.5
+        $scopeCodeKey = $scopeCode ?? '';
+
+        if (isset($this->resolvedScopeCodes[$scopeType][$scopeCodeKey])) {
+            return $this->resolvedScopeCodes[$scopeType][$scopeCodeKey];
         }
 
         if ($scopeType !== ScopeConfigInterface::SCOPE_TYPE_DEFAULT) {
@@ -59,7 +62,7 @@ class ScopeCodeResolver
             $scopeCode = $resolverScopeCode;
         }
 
-        $this->resolvedScopeCodes[$scopeType][$scopeCode] = $resolverScopeCode;
+        $this->resolvedScopeCodes[$scopeType][$scopeCodeKey] = $resolverScopeCode;
 
         return $resolverScopeCode;
     }

--- a/lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
@@ -69,4 +69,19 @@ class ScopeCodeResolverTest extends TestCase
             ->willReturn($scopeCode);
         $this->assertEquals($scopeCode, $this->scopeCodeResolver->resolve($scopeType, $scopeId));
     }
+
+    public function testResolveWithScopeCodeNullAndScopeTypeDefault()
+    {
+        $scopeType = 'default';
+        $scopeCode = null;
+
+        $this->scopeResolverPool->expects($this->never())
+            ->method('get');
+        $this->scopeResolver->expects($this->never())
+            ->method('getScope');
+        $this->scope->expects($this->never())
+            ->method('getCode');
+
+        $this->scopeCodeResolver->resolve($scopeType, $scopeCode);
+    }
 }


### PR DESCRIPTION
### Description (*)
See #40886

In PHP, when using `null` as an array key, it got silently converted to an empty string, but [this is now deprecated in PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset), see this demonstration here: https://3v4l.org/9jqqo#v

This PR fixes this particular problem in the `ScopeCodeResolver` class.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Fixes #40886

### Manual testing scenarios (*)
1. In backoffice, go to Content > Design > Configuration
2. In the first row (the one scoped Global), click the Edit link
3. Expect to see no error
4. Also, run the updated phpunit test without the changes to the `ScopeCodeResolver` class, and you'll see it fail with the following error, it will no longer fail with the adjusted code:
```
$ ../../../vendor/bin/phpunit -c phpunit.xml.dist ../../../lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php
PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.7
Configuration: dev/tests/unit/phpunit.xml.dist

.E                                                                                                                                                                                                                                                 2 / 2 (100%)

Time: 00:00.009, Memory: 8.00 MB

There was 1 error:

1) Magento\Framework\App\Test\Unit\Config\ScopeCodeResolverTest::testResolveWithScopeCodeNullAndScopeTypeDefault
PHPUnit\Framework\Exception: Deprecated: Using null as an array offset is deprecated, use an empty string instead in lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php:65.

dev/tests/unit/framework/bootstrap.php:62
lib/internal/Magento/Framework/App/Config/ScopeCodeResolver.php:65
lib/internal/Magento/Framework/App/Test/Unit/Config/ScopeCodeResolverTest.php:85

ERRORS!
Tests: 2, Assertions: 6, Errors: 1.
```

### Questions or comments
This is a bug that a lot of users of Magento 2.4.9 who use PHP 8.5 will run into this, so it would probably not be a bad idea to include this in Magento 2.4.9-p1 or 2.4.9-p2

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
