### PR TITLE
[Feature] Add configurable changelog size threshold to trigger full reindex in Mview for better performance

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -731,6 +731,24 @@
         <arguments>
             <argument name="state" xsi:type="object" shared="false">Magento\Indexer\Model\Mview\View\State</argument>
             <argument name="changelog" xsi:type="object" shared="false">Magento\Framework\Mview\View\Changelog</argument>
+            <!--
+                changelogMaxSize: keyed by mview view_id.
+                When the number of distinct pending entity IDs in the changelog exceeds this value,
+                a full reindex (executeFull) is triggered instead of an incremental update.
+                The indexer action class must have an executeFull() method.
+
+                This is an array argument - any module can contribute entries from their own di.xml
+                and they will be merged, exactly like changelogBatchSize. Example in a module di.xml:
+
+                <type name="Magento\Framework\Mview\View">
+                    <arguments>
+                        <argument name="changelogMaxSize" xsi:type="array">
+                            <item name="inventory" xsi:type="number">20000</item>
+                        </argument>
+                    </arguments>
+                </type>
+            -->
+            <argument name="changelogMaxSize" xsi:type="array"/>
         </arguments>
     </type>
     <type name="Magento\Framework\Mview\Config">

--- a/lib/internal/Magento/Framework/Mview/View.php
+++ b/lib/internal/Magento/Framework/Mview/View.php
@@ -66,6 +66,14 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
     private $changelogBatchSize;
 
     /**
+     * Maximum changelog size (distinct entity count) per view_id before forcing a full reindex.
+     * Keyed by view_id. If not set for a view, full reindex is never forced.
+     *
+     * @var array
+     */
+    private $changelogMaxSize;
+
+    /**
      * @var ChangelogBatchWalkerFactory
      */
     private $changelogBatchWalkerFactory;
@@ -79,6 +87,7 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
      * @param array $data
      * @param array $changelogBatchSize
      * @param ChangelogBatchWalkerFactory $changelogBatchWalkerFactory
+     * @param array $changelogMaxSize
      */
     public function __construct(
         ConfigInterface $config,
@@ -88,7 +97,8 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
         SubscriptionFactory $subscriptionFactory,
         array $data = [],
         array $changelogBatchSize = [],
-        ?ChangelogBatchWalkerFactory $changelogBatchWalkerFactory = null
+        ?ChangelogBatchWalkerFactory $changelogBatchWalkerFactory = null,
+        array $changelogMaxSize = []
     ) {
         $this->config = $config;
         $this->actionFactory = $actionFactory;
@@ -96,6 +106,7 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
         $this->changelog = $changelog;
         $this->subscriptionFactory = $subscriptionFactory;
         $this->changelogBatchSize = $changelogBatchSize;
+        $this->changelogMaxSize = $changelogMaxSize;
         parent::__construct($data);
         $this->changelogBatchWalkerFactory = $changelogBatchWalkerFactory ?:
             ObjectManager::getInstance()->get(ChangelogBatchWalkerFactory::class);
@@ -302,7 +313,9 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
     }
 
     /**
-     * Execute action from last version to current version, by batches
+     * Execute action from last version to current version, by batches.
+     * If changelogMaxSize is configured for the current view and the pending changelog count
+     * exceeds the threshold, a full reindex is triggered instead of incremental.
      *
      * @param ActionInterface $action
      * @param int $lastVersionId
@@ -312,8 +325,23 @@ class View extends DataObject implements ViewInterface, ViewSubscriptionInterfac
      */
     private function executeAction(ActionInterface $action, int $lastVersionId, int $currentVersionId)
     {
-        $batchSize = isset($this->changelogBatchSize[$this->getChangelog()->getViewId()])
-            ? (int) $this->changelogBatchSize[$this->getChangelog()->getViewId()]
+        $viewId = $this->getChangelog()->getViewId();
+
+        // Check if a max changelog size is configured for this view
+        if (isset($this->changelogMaxSize[$viewId])
+            && method_exists($action, 'executeFull')
+            && $lastVersionId !== $currentVersionId
+        ) {
+            $maxSize = (int)$this->changelogMaxSize[$viewId];
+            $pendingCount = $this->getChangelog()->getPendingCount($lastVersionId, $currentVersionId);
+            if ($pendingCount > $maxSize) {
+                $action->executeFull();
+                return;
+            }
+        }
+
+        $batchSize = isset($this->changelogBatchSize[$viewId])
+            ? (int) $this->changelogBatchSize[$viewId]
             : self::DEFAULT_BATCH_SIZE;
 
         $batches = $this->getWalker()->walk($this->getChangelog(), $lastVersionId, $currentVersionId, $batchSize);

--- a/lib/internal/Magento/Framework/Mview/View/Changelog.php
+++ b/lib/internal/Magento/Framework/Mview/View/Changelog.php
@@ -300,6 +300,32 @@ class Changelog implements ChangelogInterface
     }
 
     /**
+     * Get count of distinct pending entity ids in changelog between two version ids
+     *
+     * @param int $fromVersionId
+     * @param int $toVersionId
+     * @return int
+     * @throws ChangelogTableNotExistsException
+     */
+    public function getPendingCount(int $fromVersionId, int $toVersionId): int
+    {
+        $changelogTableName = $this->resource->getTableName($this->getName());
+        if (!$this->connection->isTableExists($changelogTableName)) {
+            throw new ChangelogTableNotExistsException(new Phrase("Table %1 does not exist", [$changelogTableName]));
+        }
+
+        $select = $this->connection->select()
+            ->from(
+                $changelogTableName,
+                [new \Zend_Db_Expr('COUNT(DISTINCT ' . $this->getColumnName() . ')')]
+            )
+            ->where('version_id > ?', (int)$fromVersionId)
+            ->where('version_id <= ?', (int)$toVersionId);
+
+        return (int)$this->connection->fetchOne($select);
+    }
+
+    /**
      * Get maximum version_id from changelog
      *
      * @return int

--- a/lib/internal/Magento/Framework/Mview/View/ChangelogInterface.php
+++ b/lib/internal/Magento/Framework/Mview/View/ChangelogInterface.php
@@ -80,4 +80,13 @@ interface ChangelogInterface
      * @return string
      */
     public function getViewId();
+
+    /**
+     * Get count of distinct pending entity ids in changelog between two version ids
+     *
+     * @param int $fromVersionId
+     * @param int $toVersionId
+     * @return int
+     */
+    public function getPendingCount(int $fromVersionId, int $toVersionId): int;
 }


### PR DESCRIPTION
### Overview

When the Mview changelog grows very large (e.g. after a bulk import or a data migration), processing thousands of incremental entity IDs one batch at a time is slower than simply running a full reindex. This PR adds a configurable `changelogMaxSize` threshold per indexer view that, when exceeded, automatically calls `executeFull()` on the action instead of processing incremental batches.

### Problem

There is no way to configure a maximum changelog size beyond which a full reindex is more efficient than incremental processing. Projects dealing with large data volumes have resorted to hardcoded patches to force full reindexing for specific changelog tables.

### Solution

- Add `getPendingCount(int $fromVersionId, int $toVersionId): int` to `ChangelogInterface` and implement it in `Changelog` using an efficient `COUNT(DISTINCT entity_id)` SQL query (no PHP memory overhead).
- Add a `changelogMaxSize` array constructor parameter to `Magento\Framework\Mview\View` (keyed by `view_id`, same pattern as `changelogBatchSize`).
- In `View::executeAction()`, if a threshold is configured for the current view and `method_exists($action, 'executeFull')`, check the pending count and call `executeFull()` when the threshold is exceeded. Falls back to normal incremental processing if the action has no `executeFull()` method.
- Declare the empty `changelogMaxSize` argument in `app/etc/di.xml` with documentation.

### How to configure

In any module's `di.xml` (arrays are merged by the DI framework, same as `changelogBatchSize`):

```xml
<type name="Magento\Framework\Mview\View">
    <arguments>
        <argument name="changelogMaxSize" xsi:type="array">
            <item name="inventory" xsi:type="number">20000</item>
        </argument>
    </arguments>
</type>
```

### Notes

This can be easily reproducible on cloud environments with large stock imports. Inventory indexer it never ends using partial reindex having large changelog and incrementing with every import. With those changes, inventory can reindex faster and avoid process stuck or eternal reindex. (20000 rows actually configured on a real environment on cloud with patch and working properly)

### Resolved issues:
1. [x] resolves magento/magento2#40911: [Feature] Add configurable changelog size threshold to trigger full reindex in Mview for better performance