### PR TITLE
Skip dispatch events for Forward actions in FrontController (#36786)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
@@ -7,7 +7,10 @@ declare(strict_types=1);
 
 namespace Magento\Framework\App;
 
+use Magento\Cms\Test\Fixture\Page as PageFixture;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager as FixtureManager;
 use Magento\TestFramework\ObjectManager;
 use Magento\TestFramework\Request as TestHttpRequest;
 use Magento\TestFramework\Response;
@@ -61,6 +64,25 @@ class FrontControllerEventsTest extends TestCase
         $frontController->dispatch($this->request);
 
         $this->assertPreAndPostDispatchEventsAreDispatched();
+    }
+
+    /**
+     * Test if frontend controller dispatches events once for forwarded CMS pages
+     *
+     * @magentoAppArea frontend
+     *
+     * @return void
+     */
+    #[DataFixture(PageFixture::class, ['identifier' => 'front-controller-forward'], 'page')]
+    public function testFrontendControllerDispatchesEventsOnceForForwardedCmsPage(): void
+    {
+        /** @var FrontControllerInterface $frontController */
+        $frontController = ObjectManager::getInstance()->create(FrontControllerInterface::class);
+        $this->configureRequestForPage('front-controller-forward');
+        $frontController->dispatch($this->request);
+
+        $this->assertEventDispatchCount('controller_action_predispatch', 1);
+        $this->assertEventDispatchCount('controller_action_postdispatch', 1);
     }
 
     /**
@@ -161,6 +183,22 @@ class FrontControllerEventsTest extends TestCase
         $request->setActionName($actionName);
         $request->setDispatched();
         $request->setRequestUri("$route/$actionPath/$actionName");
+    }
+
+    /**
+     * Prepare request for CMS page URL
+     *
+     * @param string $identifier
+     *
+     * @return void
+     */
+    private function configureRequestForPage(string $identifier): void
+    {
+        $request = $this->request;
+        $page = FixtureManager::getStorage()->get('page');
+
+        $request->setPathInfo($identifier);
+        $request->setRequestUri($page->getIdentifier());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
@@ -10,58 +10,35 @@ namespace Magento\Framework\App;
 use Magento\Cms\Test\Fixture\Page as PageFixture;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\TestFramework\Fixture\DataFixture;
-use Magento\TestFramework\Fixture\DataFixtureStorageManager as FixtureManager;
-use Magento\TestFramework\ObjectManager;
-use Magento\TestFramework\Request as TestHttpRequest;
-use Magento\TestFramework\Response;
-use PHPUnit\Framework\TestCase;
+use Magento\TestFramework\TestCase\AbstractController;
 
 /**
  * @magentoAppIsolation enabled
  */
-class FrontControllerEventsTest extends TestCase
+class FrontControllerEventsTest extends AbstractController
 {
     /**
      * @var ManagerInterface
      */
-    private $eventManager;
-
-    /**
-     * @var ObjectManager
-     */
-    private $objectManager;
-
-    /**
-     * @var TestHttpRequest
-     */
-    private $request;
+    private $eventManagerSpy;
 
     /**
      * @inheritDoc
      */
     protected function setUp(): void
     {
-        $this->objectManager = ObjectManager::getInstance();
-        $this->setupEventManagerSpy();
-        $this->eventManager = $this->objectManager->get(ManagerInterface::class);
-        $this->request = $this->objectManager->get(TestHttpRequest::class);
+        parent::setUp();
+        $this->eventManagerSpy = $this->setupEventManagerSpy();
     }
 
     /**
-     * Test if frontend controller dispatches events
-     *
-     * @magentoAppArea frontend
+     * Test if frontend controller dispatches events for a regular action
      *
      * @return void
      */
     public function testFrontendControllerDispatchesEvents(): void
     {
-        $this->setupEventManagerSpy();
-
-        /** @var FrontControllerInterface $frontController */
-        $frontController = ObjectManager::getInstance()->create(FrontControllerInterface::class);
-        $this->configureRequestForAction('cms', 'index', 'index');
-        $frontController->dispatch($this->request);
+        $this->dispatch('/cms/index/index');
 
         $this->assertPreAndPostDispatchEventsAreDispatched();
     }
@@ -69,71 +46,55 @@ class FrontControllerEventsTest extends TestCase
     /**
      * Test if frontend controller dispatches events once for forwarded CMS pages
      *
-     * @magentoAppArea frontend
+     * A CMS page request is forwarded by \Magento\Cms\Controller\Router to "cms/page/view".
+     * Pre/post-dispatch events must be triggered only for the resulting action and not for the forward itself.
      *
      * @return void
      */
-    #[DataFixture(PageFixture::class, ['identifier' => 'front-controller-forward'], 'page')]
+    #[DataFixture(PageFixture::class, ['identifier' => 'front-controller-forward', 'store_id' => 0], 'page')]
     public function testFrontendControllerDispatchesEventsOnceForForwardedCmsPage(): void
     {
-        /** @var FrontControllerInterface $frontController */
-        $frontController = ObjectManager::getInstance()->create(FrontControllerInterface::class);
-        $this->configureRequestForPage('front-controller-forward');
-        $frontController->dispatch($this->request);
+        $this->dispatch('/front-controller-forward');
 
         $this->assertEventDispatchCount('controller_action_predispatch', 1);
         $this->assertEventDispatchCount('controller_action_postdispatch', 1);
     }
 
     /**
-     * Test if no dispatch flag prevents dispatching action
-     *
-     * @magentoAppArea frontend
+     * Test if no dispatch flag prevents execution and post-dispatch events
      *
      * @return void
      */
     public function testSettingTheNoDispatchActionFlagProhibitsExecuteAndPostdispatchEvents(): void
     {
-        $this->setupEventManagerSpy();
-
-        /** @var FrontControllerInterface $frontController */
-        $frontController = ObjectManager::getInstance()->create(FrontControllerInterface::class);
-        $this->configureRequestForAction('cms', 'index', 'index');
-
         /** @var ActionFlag $actionFlag */
-        $actionFlag = ObjectManager::getInstance()->get(ActionFlag::class);
+        $actionFlag = $this->_objectManager->get(ActionFlag::class);
         $actionFlag->set('', ActionInterface::FLAG_NO_DISPATCH, true);
 
-        $result1 = $frontController->dispatch($this->request);
-        $this->assertTrue($result1 instanceof Response, 'Action was dispatched!');
+        $this->dispatch('/cms/index/index');
+
         $this->assertPreDispatchEventsAreDispatched();
     }
 
     /**
-     * Prepare spy on event manager
+     * Register a spy that records every dispatched event while delegating to the real event manager
      *
-     * @return void
+     * @return ManagerInterface
      */
-    public function setupEventManagerSpy(): void
+    private function setupEventManagerSpy(): ManagerInterface
     {
-        $eventManager = $this->objectManager->get(ManagerInterface::class);
+        $eventManager = $this->_objectManager->get(ManagerInterface::class);
         $eventManagerSpy = new class($eventManager) implements ManagerInterface {
             /**
-             * @var ManagerInterface
+             * @var array[]
              */
-            private $delegate;
-
-            /**
-             * @var array[];
-             */
-            private $dispatchedEvents;
+            private $dispatchedEvents = [];
 
             /**
              * @param ManagerInterface $delegate
              */
-            public function __construct(ManagerInterface $delegate)
+            public function __construct(private ManagerInterface $delegate)
             {
-                $this->delegate = $delegate;
             }
 
             public function dispatch($eventName, array $data = [])
@@ -148,7 +109,9 @@ class FrontControllerEventsTest extends TestCase
             }
         };
 
-        $this->objectManager->addSharedInstance($eventManagerSpy, get_class($eventManager));
+        $this->_objectManager->addSharedInstance($eventManagerSpy, get_class($eventManager));
+
+        return $eventManagerSpy;
     }
 
     /**
@@ -162,43 +125,7 @@ class FrontControllerEventsTest extends TestCase
     private function assertEventDispatchCount(string $eventName, int $expectedCount): void
     {
         $message = sprintf('Event %s was expected to be dispatched %d time(s).', $eventName, $expectedCount);
-        $this->assertCount($expectedCount, $this->eventManager->spyOnDispatchedEvent($eventName), $message);
-    }
-
-    /**
-     * Prepare request for test action
-     *
-     * @param string $route
-     * @param string $actionPath
-     * @param string $actionName
-     *
-     * @return void
-     */
-    private function configureRequestForAction(string $route, string $actionPath, string $actionName): void
-    {
-        $request = $this->request;
-
-        $request->setRouteName($route);
-        $request->setControllerName($actionPath);
-        $request->setActionName($actionName);
-        $request->setDispatched();
-        $request->setRequestUri("$route/$actionPath/$actionName");
-    }
-
-    /**
-     * Prepare request for CMS page URL
-     *
-     * @param string $identifier
-     *
-     * @return void
-     */
-    private function configureRequestForPage(string $identifier): void
-    {
-        $request = $this->request;
-        $page = FixtureManager::getStorage()->get('page');
-
-        $request->setPathInfo($identifier);
-        $request->setRequestUri($page->getIdentifier());
+        $this->assertCount($expectedCount, $this->eventManagerSpy->spyOnDispatchedEvent($eventName), $message);
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/FrontControllerEventsTest.php
@@ -51,7 +51,7 @@ class FrontControllerEventsTest extends AbstractController
      *
      * @return void
      */
-    #[DataFixture(PageFixture::class, ['identifier' => 'front-controller-forward', 'store_id' => 0], 'page')]
+    #[DataFixture(PageFixture::class, ['identifier' => 'front-controller-forward'], 'page')]
     public function testFrontendControllerDispatchesEventsOnceForForwardedCmsPage(): void
     {
         $this->dispatch('/front-controller-forward');

--- a/lib/internal/Magento/Framework/App/FrontController.php
+++ b/lib/internal/Magento/Framework/App/FrontController.php
@@ -91,6 +91,7 @@ class FrontController implements FrontControllerInterface
      * @param ActionFlag|null $actionFlag
      * @param EventManagerInterface|null $eventManager
      * @param RequestInterface|null $request
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         RouterListInterface $routerList,

--- a/lib/internal/Magento/Framework/App/FrontController.php
+++ b/lib/internal/Magento/Framework/App/FrontController.php
@@ -209,20 +209,35 @@ class FrontController implements FrontControllerInterface
 
         // Validation did not produce a result to replace the action's.
         if (!$result) {
-            $isForwardAction = $actionInstance instanceof Forward;
-            if (!$isForwardAction) {
-                $this->dispatchPreDispatchEvents($actionInstance, $request);
-            }
-            $result = $this->getActionResponse($actionInstance, $request);
-            if (!$isForwardAction && !$this->isSetActionNoPostDispatchFlag()) {
-                $this->dispatchPostDispatchEvents($actionInstance, $request);
-            }
+            $result = $this->dispatchAction($actionInstance, $request);
         }
 
         //handling redirect to 404
         if ($result instanceof NotFoundException) {
             throw $result;
         }
+        return $result;
+    }
+
+    /**
+     * Dispatch the action, skipping pre/post-dispatch events for internal forwards.
+     *
+     * @param ActionInterface $actionInstance
+     * @param RequestInterface $request
+     * @return ResponseInterface|ResultInterface
+     * @throws NotFoundException
+     */
+    private function dispatchAction(ActionInterface $actionInstance, RequestInterface $request)
+    {
+        $isForwardAction = $actionInstance instanceof Forward;
+        if (!$isForwardAction) {
+            $this->dispatchPreDispatchEvents($actionInstance, $request);
+        }
+        $result = $this->getActionResponse($actionInstance, $request);
+        if (!$isForwardAction && !$this->isSetActionNoPostDispatchFlag()) {
+            $this->dispatchPostDispatchEvents($actionInstance, $request);
+        }
+
         return $result;
     }
 

--- a/lib/internal/Magento/Framework/App/FrontController.php
+++ b/lib/internal/Magento/Framework/App/FrontController.php
@@ -6,6 +6,7 @@
 namespace Magento\Framework\App;
 
 use Magento\Framework\App\Action\AbstractAction;
+use Magento\Framework\App\Action\Forward;
 use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\Request\ValidatorInterface as RequestValidator;
@@ -208,9 +209,12 @@ class FrontController implements FrontControllerInterface
 
         // Validation did not produce a result to replace the action's.
         if (!$result) {
-            $this->dispatchPreDispatchEvents($actionInstance, $request);
+            $isForwardAction = $actionInstance instanceof Forward;
+            if (!$isForwardAction) {
+                $this->dispatchPreDispatchEvents($actionInstance, $request);
+            }
             $result = $this->getActionResponse($actionInstance, $request);
-            if (!$this->isSetActionNoPostDispatchFlag()) {
+            if (!$isForwardAction && !$this->isSetActionNoPostDispatchFlag()) {
                 $this->dispatchPostDispatchEvents($actionInstance, $request);
             }
         }

--- a/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
@@ -359,7 +359,7 @@ class FrontControllerTest extends TestCase
         $this->eventManagerMock->expects($this->exactly(2))
             ->method('dispatch')
             ->willReturnCallback(
-                function ($eventName, array $data = []) use (&$dispatchedEvents) {
+                function ($eventName) use (&$dispatchedEvents) {
                     $dispatchedEvents[] = $eventName;
                 }
             );

--- a/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/FrontControllerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Test\Unit;
 
 use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Forward;
 use Magento\Framework\App\ActionFlag;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\AreaInterface;
@@ -89,6 +90,11 @@ class FrontControllerTest extends TestCase
     private $areaMock;
 
     /**
+     * @var MockObject|EventManager
+     */
+    private $eventManagerMock;
+
+    /**
      * @inheritDoc
      */
     protected function setUp(): void
@@ -110,7 +116,7 @@ class FrontControllerTest extends TestCase
         $this->areaListMock = $this->createMock(AreaList::class);
         $this->areaMock = $this->createMock(AreaInterface::class);
         $actionFlagMock = $this->createMock(ActionFlag::class);
-        $eventManagerMock = $this->createMock(EventManager::class);
+        $this->eventManagerMock = $this->createMock(EventManager::class);
         $requestMock = $this->createMock(RequestInterface::class);
         $this->model = new FrontController(
             $this->routerList,
@@ -121,7 +127,7 @@ class FrontControllerTest extends TestCase
             $this->appStateMock,
             $this->areaListMock,
             $actionFlagMock,
-            $eventManagerMock,
+            $this->eventManagerMock,
             $requestMock
         );
     }
@@ -284,6 +290,89 @@ class FrontControllerTest extends TestCase
             ->with(true);
 
         $this->assertEquals($response, $this->model->dispatch($this->request));
+    }
+
+    /**
+     * @return void
+     */
+    public function testForwardActionDoesNotDispatchEvents(): void
+    {
+        $this->routerList->expects($this->any())
+            ->method('valid')
+            ->willReturn(true);
+
+        $response = $this->createMock(Http::class);
+        $forwardInstance = $this->getMockBuilder(Forward::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $forwardInstance->expects($this->any())
+            ->method('dispatch')
+            ->with($this->request)
+            ->willReturn($response);
+        $controllerInstance = $this->getMockBuilder(Action::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $controllerInstance->expects($this->any())
+            ->method('dispatch')
+            ->with($this->request)
+            ->willReturn($response);
+        $this->router
+            ->method('match')
+            ->willReturnCallback(
+                function ($arg1) use ($forwardInstance, $controllerInstance) {
+                    static $callCount = 0;
+                    if ($callCount == 0 && $arg1 == $this->request) {
+                        $callCount++;
+                        return $forwardInstance;
+                    } elseif ($callCount == 1 && $arg1 == $this->request) {
+                        $callCount++;
+                        return $controllerInstance;
+                    }
+                }
+            );
+
+        $this->routerList->expects($this->any())
+            ->method('current')
+            ->willReturn($this->router);
+
+        $this->appStateMock->expects($this->any())->method('getAreaCode')->willReturn('frontend');
+        $this->areaMock
+            ->method('load')
+            ->willReturnCallback(
+                function ($arg1) {
+                    if ($arg1 == Area::PART_DESIGN) {
+                        return $this->areaMock;
+                    } elseif ($arg1 == Area::PART_TRANSLATE) {
+                        return $this->areaMock;
+                    }
+                }
+            );
+        $this->areaListMock->expects($this->any())->method('getArea')->willReturn($this->areaMock);
+        $this->request
+            ->method('isDispatched')
+            ->willReturnOnConsecutiveCalls(false, false, true);
+        $this->request
+            ->method('setDispatched')
+            ->with(true);
+
+        $dispatchedEvents = [];
+        $this->eventManagerMock->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(
+                function ($eventName, array $data = []) use (&$dispatchedEvents) {
+                    $dispatchedEvents[] = $eventName;
+                }
+            );
+
+        $this->assertEquals($response, $this->model->dispatch($this->request));
+        $this->assertCount(
+            1,
+            array_filter($dispatchedEvents, fn ($eventName) => $eventName === 'controller_action_predispatch')
+        );
+        $this->assertCount(
+            1,
+            array_filter($dispatchedEvents, fn ($eventName) => $eventName === 'controller_action_postdispatch')
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

On any page that involves a *forward* — a CMS page (`Magento\Cms\Controller\Router`), a URL-rewritten product/category (`Magento\UrlRewrite\Controller\Router`), a no-route, etc. — the first action matched by the routing loop is a `Magento\Framework\App\Action\Forward` instance. Its `execute()` merely calls `$request->setDispatched(false)`, so `FrontController::dispatch()` loops again and matches the *real* action.

Because `FrontController::processRequest()` dispatched the predispatch/postdispatch events for **every** matched action, this meant `controller_action_predispatch` and `controller_action_postdispatch` (the generic events) were dispatched **twice** per request on every forwarded page — once for the throwaway `Forward` action and once for the real action.

For stores with expensive observers on these events (the reporter calls out `Magento\Persistent\Observer\SynchronizePersistentInfoObserver`), this doubles the observer cost on the most common storefront pages.

## Fixed Issues

1. Fixes magento/magento2#36786

## Approach

A `Forward` action performs no real work — it only re-routes. So in `processRequest()` we skip **both** the pre- and post-dispatch event blocks when the matched action is a `Forward` instance, while still calling `getActionResponse()` so the forward is performed:

```php
if (!$result) {
    $isForwardAction = $actionInstance instanceof Forward;
    if (!$isForwardAction) {
        $this->dispatchPreDispatchEvents($actionInstance, $request);
    }
    $result = $this->getActionResponse($actionInstance, $request);
    if (!$isForwardAction && !$this->isSetActionNoPostDispatchFlag()) {
        $this->dispatchPostDispatchEvents($actionInstance, $request);
    }
}
```

Both pre- and post-dispatch are skipped together (rather than predispatch only, as suggested in the issue) to avoid the asymmetry of firing postdispatch without a matching predispatch for the same action instance. The events now fire exactly once — for the real action.

## Manual testing scenarios

1. Install the [Smile debug toolbar](https://github.com/Smile-SA/magento2-module-debug-toolbar) (or add temporary logging in `FrontController::dispatchPreDispatchEvents()`).
2. Open any forwarded page (a CMS page, a product, a category).
3. **Before:** `controller_action_predispatch` (and `controller_action_postdispatch`) fire twice.
4. **After:** they fire once. Route- and action-specific dynamic events (`controller_action_predispatch_<route>`, `_<fullaction>`) are unaffected.

## Test Plan

- [x] Unit test added — `FrontControllerTest::testForwardActionDoesNotDispatchEvents`: a router returning a `Forward` then a real action results in `controller_action_predispatch`/`controller_action_postdispatch` firing exactly once.
- [x] Integration test added — `FrontControllerEventsTest::testFrontendControllerDispatchesEventsOnceForForwardedCmsPage`: a forwarded CMS page dispatches each generic event exactly once.
- [x] Unit suite green (Warden, PHP 8.4).
- [x] PHPCS (Magento2) clean on changed files.
- [x] PHPStan (level 1) clean on changed files.
