### PR TITLE
Allow digits in mview table and entity column names (#30582)

### DIFF
--- a/lib/internal/Magento/Framework/Mview/Test/Unit/_files/valid_mview.xml
+++ b/lib/internal/Magento/Framework/Mview/Test/Unit/_files/valid_mview.xml
@@ -18,4 +18,9 @@
             <table name="some_product_relation_other" entity_column="product_id" />
         </subscriptions>
     </view>
+    <view id="view_three" class="Ogogo\Class\Three" group="index">
+        <subscriptions>
+            <table name="vend_b2b_company_tier_prices" entity_column="price_rule_id1" />
+        </subscriptions>
+    </view>
 </config>

--- a/lib/internal/Magento/Framework/Mview/etc/mview.xsd
+++ b/lib/internal/Magento/Framework/Mview/etc/mview.xsd
@@ -101,22 +101,22 @@
     <xs:simpleType name="entityColumnType">
         <xs:annotation>
             <xs:documentation>
-                Entity column can contain only [a-z_].
+                Entity column can contain only [a-z0-9_].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-z_]+" />
+            <xs:pattern value="[a-z0-9_]+" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="tableNameType">
         <xs:annotation>
             <xs:documentation>
-                Table name can contain only [a-z_].
+                Table name can contain only [a-z0-9_].
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-z_]+" />
+            <xs:pattern value="[a-z0-9_]+" />
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
## Description

`lib/internal/Magento/Framework/Mview/etc/mview.xsd` declared `tableNameType` and `entityColumnType` with the pattern `[a-z_]+`. This rejects any table or column name containing a digit — for example `vend_b2b_company_tier_prices` or a column like `price_rule_id1`.

Digits are perfectly valid in MySQL identifiers and are common in third-party module table/column names. As reported in #30582, a legitimate `mview.xml` is therefore rejected at validation time:

```
Element 'table', attribute 'name': [facet 'pattern'] The value 'vend_b2b_company_tier_prices'
is not accepted by the pattern '[a-z_]+'.
```

The indexer XSDs (`indexer.xsd`, `indexer_merged.xsd`) already allow digits in both table names (`[a-zA-Z0-9_]+`) and class names, and the mview class-name pattern was likewise loosened in a previous change. The table/column name patterns in `mview.xsd` were the remaining gap.

## Fixed Issues

1. Fixes magento/magento2#30582

## Approach

Change both `tableNameType` and `entityColumnType` patterns from `[a-z_]+` to `[a-z0-9_]+`, allowing digits while staying consistent with Magento's lowercase identifier convention and with the indexer XSDs. Documentation annotations updated accordingly.

The existing `XsdTest::testSchemaCorrectlyIdentifiesValidXml` already validates `_files/valid_mview.xml` against the schema; that fixture is extended with a `<table>` whose name contains digits (`vend_b2b_company_tier_prices`) and an `entity_column` with a trailing digit (`price_rule_id1`), so the positive test now exercises the fix and would fail against the old pattern.

## Manual testing scenarios

1. In a module, declare an `mview.xml` with a `<table name="vend_b2b_company_tier_prices" entity_column="entity_id" />`.
2. **Before:** `bin/magento` config validation reports the table name as invalid; the indexer cannot be configured.
3. **After:** the configuration validates and loads.

## Test Plan

- [x] Unit — `Magento\Framework\Mview\Test\Unit\XsdTest`, `ConfigTest`, `Config\ReaderTest` all green (13 tests).
- [x] `valid_mview.xml` extended to cover digit-containing table/column names.
- [x] XSD remains a well-formed schema (loads in the validator).
