### PR TITLE
Skip removed images when scheduling product image resize (#39146)

### DIFF
--- a/app/code/Magento/Catalog/Observer/ImageResizeAfterProductSave.php
+++ b/app/code/Magento/Catalog/Observer/ImageResizeAfterProductSave.php
@@ -80,7 +80,7 @@ class ImageResizeAfterProductSave implements ObserverInterface
             return;
         }
 
-        /** @var $product \Magento\Catalog\Model\Product */
+        /** @var \Magento\Catalog\Model\Product $product */
         $product = $observer->getEvent()->getProduct();
 
         if ($this->state->isAreaCodeEmulated()) {
@@ -94,7 +94,14 @@ class ImageResizeAfterProductSave implements ObserverInterface
         } else {
             $new = $product->getData('media_gallery');
             $original = $product->getOrigData('media_gallery');
-            $mediaGallery = !empty($new['images']) ? array_column($new['images'], 'file') : [];
+            $mediaGallery = !empty($new['images'])
+                ? array_column(
+                    array_filter($new['images'], function ($image) {
+                        return empty($image['removed']);
+                    }),
+                    'file'
+                )
+                : [];
             $mediaOriginalGallery = !empty($original['images']) ? array_column($original['images'], 'file') : [];
 
             foreach (array_diff($mediaGallery, $mediaOriginalGallery) as $image) {

--- a/app/code/Magento/Catalog/Test/Unit/Observer/ImageResizeAfterProductSaveTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Observer/ImageResizeAfterProductSaveTest.php
@@ -71,32 +71,26 @@ class ImageResizeAfterProductSaveTest extends TestCase
     protected function setUp(): void
     {
         $this->imagePath = 'path/to/image.jpg';
-        $images = [new DataObject(['file' => $this->imagePath])];
         $this->observerMock = $this->createMock(Observer::class);
         $this->eventMock = $this->createPartialMockWithReflection(
             Event::class,
             ['getProduct']
         );
-        $this->productMock = $this->createPartialMock(Product::class, ['getId', 'getMediaGalleryImages']);
+        $this->productMock = $this->createPartialMock(
+            Product::class,
+            ['getId', 'getMediaGalleryImages', 'getData', 'getOrigData']
+        );
         $this->stateMock = $this->createPartialMock(State::class, ['isAreaCodeEmulated']);
         $this->catalogMediaConfigMock = $this->createPartialMock(CatalogMediaConfig::class, ['getMediaUrlFormat']);
         $this->imageResizeSchedulerMock = $this->createPartialMock(ImageResizeScheduler::class, ['schedule']);
         $this->imageResizeMock = $this->createPartialMock(ImageResize::class, ['resizeFromImageName']);
 
         $this->observerMock
-            ->expects($this->once())
             ->method('getEvent')
             ->willReturn($this->eventMock);
         $this->eventMock
-            ->expects($this->once())
             ->method('getProduct')
             ->willReturn($this->productMock);
-        $this->productMock
-            ->method('getId')->willReturn(null);
-        $this->productMock
-            ->expects($this->once())
-            ->method('getMediaGalleryImages')
-            ->willReturn($images);
     }
 
     /**
@@ -104,6 +98,7 @@ class ImageResizeAfterProductSaveTest extends TestCase
      */
     public function testExecuteImageResizeScheduler(): void
     {
+        $this->setUpNewProduct();
         $observer = new ImageResizeAfterProductSave(
             $this->imageResizeMock,
             $this->stateMock,
@@ -126,6 +121,7 @@ class ImageResizeAfterProductSaveTest extends TestCase
      */
     public function testExecuteImageResize(): void
     {
+        $this->setUpNewProduct();
         $observer = new ImageResizeAfterProductSave(
             $this->imageResizeMock,
             $this->stateMock,
@@ -141,5 +137,73 @@ class ImageResizeAfterProductSaveTest extends TestCase
             ->expects($this->never())
             ->method('schedule');
         $observer->execute($this->observerMock);
+    }
+
+    /**
+     * Images flagged as removed before saving an existing product must not be scheduled for resize.
+     *
+     * @see https://github.com/magento/magento2/issues/39146
+     */
+    public function testExecuteSkipsImagesFlaggedAsRemoved(): void
+    {
+        $existingImage = 'path/to/existing-image.jpg';
+        $removedImage = 'path/to/removed-image.tmp';
+        $newImage = 'path/to/new-image.jpg';
+
+        $this->productMock
+            ->method('getId')
+            ->willReturn(1);
+        $this->productMock
+            ->expects($this->never())
+            ->method('getMediaGalleryImages');
+        $this->productMock
+            ->method('getData')
+            ->with('media_gallery')
+            ->willReturn([
+                'images' => [
+                    ['file' => $existingImage],
+                    ['file' => $removedImage, 'removed' => '1'],
+                    ['file' => $newImage],
+                ],
+            ]);
+        $this->productMock
+            ->method('getOrigData')
+            ->with('media_gallery')
+            ->willReturn([
+                'images' => [
+                    ['file' => $existingImage],
+                ],
+            ]);
+
+        $observer = new ImageResizeAfterProductSave(
+            $this->imageResizeMock,
+            $this->stateMock,
+            $this->catalogMediaConfigMock,
+            $this->imageResizeSchedulerMock,
+            true
+        );
+        $this->imageResizeMock
+            ->expects($this->never())
+            ->method('resizeFromImageName');
+        $this->imageResizeSchedulerMock
+            ->expects($this->once())
+            ->method('schedule')
+            ->with($newImage);
+        $observer->execute($this->observerMock);
+    }
+
+    /**
+     * Configure the product mock for the new-product code path.
+     */
+    private function setUpNewProduct(): void
+    {
+        $images = [new DataObject(['file' => $this->imagePath])];
+        $this->productMock
+            ->method('getId')
+            ->willReturn(null);
+        $this->productMock
+            ->expects($this->once())
+            ->method('getMediaGalleryImages')
+            ->willReturn($images);
     }
 }


### PR DESCRIPTION
### Description (*)

When an image is uploaded to a product and then **removed before the product is saved**, the gallery entry remains in `media_gallery['images']` flagged `removed => '1'` with a temporary `.tmp` file path. `Magento\Catalog\Observer\ImageResizeAfterProductSave` built the list of images to resize with `array_column($new['images'], 'file')` without excluding those removed entries, so the `.tmp` path was scheduled for resize. The `media.storage.catalog.image.resize` consumer then failed because that `.tmp` file never existed at the catalog product path, surfacing a system-message error in the admin.

This change excludes images flagged as removed before diffing the new and original galleries, so only genuinely added images are scheduled for resize. The fix is scoped to the existing-product code path of the observer; the new-product path is unchanged.

### Related Pull Requests

Supersedes the abandoned #39872 (closed) with an observer-only change and unit coverage, avoiding the MFTF churn that blocked the previous attempt.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39146

### Manual testing scenarios (*)

1. Set the indexer mode to **Update by Schedule**.
2. Go to **Catalog → Products** and edit an existing product.
3. Upload an image, then remove that uploaded image **without saving** the product.
4. Save the product.
5. Run the `media.storage.catalog.image.resize` consumer.

**Before:** the consumer fails trying to resize the non-existent `.tmp` image and an error system message is shown.
**After:** the removed image is not scheduled; the consumer completes without error.

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests
 - [x] All automated tests passed successfully (all builds are green)
