### PR TITLE
Show zero-rate taxes in the applied taxes breakdown (#35022)

### DIFF
--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -348,7 +348,7 @@ abstract class AbstractCalculator
         $appliedTaxes = [];
         $totalAppliedAmount = 0;
         foreach ($appliedRates as $appliedRate) {
-            $appliedAmount = $totalTaxRate ? $rowTax / $totalTaxRate * $appliedRate['percent'] : 0;
+            $appliedAmount = $totalTaxRate > 0.0 ? $rowTax / $totalTaxRate * $appliedRate['percent'] : 0;
             //Use delta rounding to split tax amounts for each tax rates between items
             $appliedAmount = $this->deltaRound(
                 $appliedAmount,

--- a/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
+++ b/app/code/Magento/Tax/Model/Calculation/AbstractCalculator.php
@@ -348,11 +348,7 @@ abstract class AbstractCalculator
         $appliedTaxes = [];
         $totalAppliedAmount = 0;
         foreach ($appliedRates as $appliedRate) {
-            if ($appliedRate['percent'] == 0) {
-                continue;
-            }
-
-            $appliedAmount = $rowTax / $totalTaxRate * $appliedRate['percent'];
+            $appliedAmount = $totalTaxRate ? $rowTax / $totalTaxRate * $appliedRate['percent'] : 0;
             //Use delta rounding to split tax amounts for each tax rates between items
             $appliedAmount = $this->deltaRound(
                 $appliedAmount,

--- a/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Calculation/UnitBaseCalculatorTest.php
@@ -130,7 +130,7 @@ class UnitBaseCalculatorTest extends TestCase
             'config'                => $this->mockConfig,
             'storeId'               => self::STORE_ID,
             'addressRateRequest'    => $this->addressRateRequest,
-            'appliedRateDataObjectFactory'    => $this->appliedTaxRateDataObjectFactoryMock,
+            'appliedTaxRateDataObjectFactory'    => $this->appliedTaxRateDataObjectFactoryMock,
             'appliedTaxDataObjectFactory'    => $appliedTaxDataObjectFactoryMock,
         ];
         $this->model = $objectManager->getObject(UnitBaseCalculator::class, $arguments);
@@ -220,6 +220,57 @@ class UnitBaseCalculatorTest extends TestCase
         );
         $this->assertEqualsWithDelta(self::TYPE, $this->taxDetailsItem->getType(), self::EPSILON);
         $this->assertEqualsWithDelta(0.0, $this->taxDetailsItem->getRowTax(), self::EPSILON);
+    }
+
+    public function testCalculateWithTaxInPriceIncludesZeroAppliedTaxRate(): void
+    {
+        $mockItem = $this->getMockItem();
+        $mockItem->expects($this->once())
+            ->method('getIsTaxIncluded')
+            ->willReturn(true);
+
+        $this->mockConfig->expects($this->once())
+            ->method('crossBorderTradeEnabled')
+            ->willReturn(false);
+        $this->mockConfig->expects($this->once())
+            ->method('applyTaxAfterDiscount')
+            ->willReturn(true);
+
+        $this->mockCalculationTool->expects($this->once())
+            ->method('getRate')
+            ->with($this->addressRateRequest)
+            ->willReturn(0);
+        $this->mockCalculationTool->expects($this->once())
+            ->method('getStoreRate')
+            ->with($this->addressRateRequest, self::STORE_ID)
+            ->willReturn(0);
+        $this->mockCalculationTool->expects($this->once())
+            ->method('getAppliedRates')
+            ->withAnyParameters()
+            ->willReturn(
+                [
+                    [
+                        'id' => 'DE-0',
+                        'percent' => 0,
+                        'rates' => [
+                            [
+                                'code' => 'DE-0',
+                                'title' => 'Germany 0%',
+                                'percent' => 0,
+                            ],
+                        ],
+                    ],
+                ]
+            );
+
+        $this->assertSame($this->taxDetailsItem, $this->model->calculate($mockItem, self::QUANTITY));
+        $appliedTaxes = $this->taxDetailsItem->getAppliedTaxes();
+
+        $this->assertArrayHasKey('DE-0', $appliedTaxes);
+        $this->assertEqualsWithDelta(0.0, $appliedTaxes['DE-0']->getAmount(), self::EPSILON);
+        $this->assertEqualsWithDelta(0.0, $appliedTaxes['DE-0']->getPercent(), self::EPSILON);
+        $this->assertArrayHasKey('DE-0', $appliedTaxes['DE-0']->getRates());
+        $this->assertEqualsWithDelta(0.0, $appliedTaxes['DE-0']->getRates()['DE-0']->getPercent(), self::EPSILON);
     }
 
     /**


### PR DESCRIPTION
### Description (*)

With **Display Full Tax Summary** and **Show Zero Tax Subtotal** enabled, a configured **0% tax rate** is not shown in the cart/order tax breakdown — only a bare `Tax` label appears, while non-zero rates (e.g. 21%) render correctly.

Root cause is in `Magento\Tax\Model\Calculation\AbstractCalculator::getAppliedTaxes()`, which began each applied-rate iteration with:

```php
if ($appliedRate['percent'] == 0) {
    continue;
}
```

This unconditionally dropped every 0% rate, so no `AppliedTax` data object was ever created for a zero rate and the rate was absent from `applied_taxes`. Whether a zero rate is *displayed* is meant to be controlled downstream by `Magento\Tax\Model\Config::displayCartZeroTax()` / `displaySalesZeroTax()` (consumed by `TaxConfigProvider` and `Block\Sales\Order\Tax`), not silently discarded during calculation.

### What changed

- Removed the early `continue` so 0% applied rates produce an `AppliedTax` entry (amount `0`, percent `0`, with their rate data objects). Display remains gated by the existing zero-tax configuration.
- Guarded the applied-amount calculation against division by zero — `$rowTax / $totalTaxRate` would throw `DivisionByZeroError` when the only applied rate(s) are 0% (so `$totalTaxRate === 0`).

No display logic was changed. Existing tax calculation scenarios use non-zero rates and are unaffected.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#35022

### Manual testing scenarios (*)

1. Create two tax rates on the default tax rule: one for Germany at **0%**, one for the Netherlands at **21%**.
2. Configure **Tax → Cart Display Settings**: *Display Full Tax Summary* = Yes, *Display Zero Tax Subtotal* = Yes.
3. In the cart estimate block, select **Netherlands** — the 21% rate is shown.
4. Switch the country to **Germany**.

**Before:** only a bare `Tax` label is shown, with no rate.
**After:** the 0% rate is shown in the tax breakdown.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests
 - [x] All automated tests passed successfully (all builds are green)
