### PR TITLE
Fix mage/translate resolving inherited prototype members as translations (#38536)

### DIFF
--- a/dev/tests/js/jasmine/tests/lib/mage/translate.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/translate.test.js
@@ -46,6 +46,14 @@ define([
             $.mage.translate.add('Hello World!', 'Bonjour tout le monde!');
             expect('Bonjour tout le monde!').toEqual($.mage.translate.translate('Hello World!'));
         });
+        it('does not treat inherited prototype members as translations', function () {
+            // When the dictionary is empty it is an array, so keys such as
+            // 'filter' or 'map' would otherwise resolve to Array.prototype
+            // members (functions) instead of returning the untranslated text.
+            $.each(['filter', 'map', 'forEach', 'constructor', 'hasOwnProperty'], function (i, key) {
+                expect(key).toEqual($.mage.translate.translate(key));
+            });
+        });
     });
 
 });

--- a/lib/web/mage/translate.js
+++ b/lib/web/mage/translate.js
@@ -39,7 +39,7 @@ define([
                      * @return {String}
                      */
                     translate: function (text) {
-                        return typeof _data[text] !== 'undefined' ? _data[text] : text;
+                        return Object.prototype.hasOwnProperty.call(_data, text) ? _data[text] : text;
                     }
                 };
             }())


### PR DESCRIPTION
## Summary

`$.mage.__()` / `$.mage.translate.translate()` decides whether a string has a translation with:

```js
return typeof _data[text] !== 'undefined' ? _data[text] : text;
```

`_data` is the parsed `js-translation.json`. When a store has no JS translations, that file is `[]`, so `_data` is an **array**. Reading `_data[text]` walks the prototype chain, so any text matching an `Array.prototype` (or `Object.prototype`) member resolves to that member instead of `undefined`. For example `$.mage.__('filter')` returns the native `Array.prototype.filter` function rather than the string `"filter"`.

This breaks the admin grid "Save View As…" feature reported in #38536: naming a view `filter` (or `map`, `forEach`, …) feeds a function into the i18n binding's `setText`, throwing `TypeError: number 0 is not a function` and leaving the Default View dropdown blank after refresh.

## What the fix does

Replaces the loose `typeof … !== 'undefined'` lookup with an own-property check:

```js
return Object.prototype.hasOwnProperty.call(_data, text) ? _data[text] : text;
```

Only real entries in the dictionary are treated as translations; inherited prototype members never are. `Object.prototype.hasOwnProperty.call(...)` is used (rather than `_data.hasOwnProperty(...)`) to stay compliant with the `no-prototype-builtins` ESLint rule and to remain correct even when `_data` is an array.

## Test Plan

- Extended `dev/tests/js/jasmine/tests/lib/mage/translate.test.js` with a regression case asserting that `filter`, `map`, `forEach`, `constructor`, and `hasOwnProperty` return the untranslated text instead of inherited members.
- Existing translate specs (string / array / object / two-arg `add`) continue to pass — real translations are unaffected.
- Verified behaviour against empty-array, polluted-array, and object dictionaries.

Fixes #38536
