### PR TITLE
Match attribute option duplicates by label only, not by value (#33073)

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/OptionManagement.php
@@ -14,6 +14,7 @@ use Magento\Eav\Api\Data\AttributeOptionInterface;
 use Magento\Eav\Model\AttributeRepository;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute;
 use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option as AttributeOptionResource;
+use Magento\Eav\Model\Entity\Attribute\Source\SourceInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -75,7 +76,7 @@ class OptionManagement implements AttributeOptionManagementInterface, AttributeO
             throw new InputException(__('The attribute option label is empty. Enter the value and try again.'));
         }
 
-        if ($attribute->getSource()->getOptionId($label) !== null) {
+        if ($this->getOptionIdByLabel($attribute->getSource(), $label) !== null) {
             throw new InputException(
                 __(
                     'Admin store attribute option label "%1" already exists.',
@@ -116,8 +117,8 @@ class OptionManagement implements AttributeOptionManagementInterface, AttributeO
                 )
             );
         }
-        $optionIdByLabel = $attribute->getSource()->getOptionId($label);
-        if (!empty($optionIdByLabel) && (int)$optionIdByLabel !== (int)$optionId) {
+        $optionIdByLabel = $this->getOptionIdByLabel($attribute->getSource(), $label);
+        if ($optionIdByLabel !== null && (int)$optionIdByLabel !== (int)$optionId) {
             throw new InputException(
                 __(
                     'Admin store attribute option label \'%1\' already exists.',
@@ -253,6 +254,30 @@ class OptionManagement implements AttributeOptionManagementInterface, AttributeO
                 )
             );
         }
+    }
+
+    /**
+     * Find an option id by its label only.
+     *
+     * Unlike the source's getOptionId(), which also matches against the option value, this
+     * comparison is restricted to the label so that a numeric label is not mistaken for an
+     * existing option whose value (id) happens to equal that number.
+     *
+     * @param SourceInterface $source
+     * @param string $label
+     * @return string|null
+     */
+    private function getOptionIdByLabel(SourceInterface $source, string $label): ?string
+    {
+        foreach ($source->getAllOptions() as $option) {
+            if (isset($option['label'])
+                && mb_strtolower(trim((string)$option['label'])) === mb_strtolower($label)
+            ) {
+                return (string)$option['value'];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/OptionManagementTest.php
@@ -102,6 +102,7 @@ class OptionManagementTest extends TestCase
         $labelMock = $this->getAttributeOptionLabel();
         /** @var SourceInterface|MockObject $sourceMock */
         $sourceMock = $this->createMock(EavAttributeSource::class);
+        $sourceMock->method('getAllOptions')->willReturn([]);
         $sourceMock->method('getOptionId')
             ->willReturnMap(
                 [
@@ -226,6 +227,7 @@ class OptionManagementTest extends TestCase
         $attributeMock->method('usesSource')->willReturn(true);
         $attributeMock->expects($this->once())->method('setDefault')->with(['id_new_option']);
         $attributeMock->expects($this->once())->method('setOption')->with($option);
+        $sourceMock->method('getAllOptions')->willReturn([]);
         $attributeMock->method('getSource')->willReturn($sourceMock);
         $attributeMock->method('getAttributeCode')->willReturn($attributeCode);
         $this->attributeRepositoryMock->expects($this->once())
@@ -241,6 +243,111 @@ class OptionManagementTest extends TestCase
 
         $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock)
             ->willThrowException(new \Exception());
+        $this->model->add($entityType, $attributeCode, $optionMock);
+    }
+
+    /**
+     * A numeric label must not be rejected just because an unrelated option's value (id)
+     * equals that number. Only a matching label may be treated as a duplicate.
+     */
+    public function testAddWithNumericLabelCollidingWithExistingOptionValue(): void
+    {
+        $entityType = 42;
+        $storeId = 4;
+        $attributeCode = 'atrCde';
+        $label = '123';
+        $storeLabel = 'labelLabel';
+        $sortOder = 'optionSortOrder';
+        $newOptionId = 10;
+        $option = [
+            'value' => [
+                'id_new_option' => [
+                    0 => $label,
+                    $storeId => $storeLabel,
+                ],
+            ],
+            'order' => [
+                'id_new_option' => $sortOder,
+            ],
+            'is_default' => [
+                'id_new_option' => true,
+            ]
+        ];
+
+        $optionMock = $this->getAttributeOption();
+        $labelMock = $this->getAttributeOptionLabel();
+        /** @var SourceInterface|MockObject $sourceMock */
+        $sourceMock = $this->createMock(EavAttributeSource::class);
+        // An existing option whose value equals the numeric label being added.
+        $sourceMock->method('getAllOptions')
+            ->willReturn([['label' => 'Existing option', 'value' => $label]]);
+        $sourceMock->method('getOptionId')
+            ->willReturnMap(
+                [
+                    [$label, null],
+                    [$storeLabel, $newOptionId],
+                    [$newOptionId, $newOptionId],
+                ]
+            );
+
+        /** @var EavAbstractAttribute|MockObject $attributeMock */
+        $attributeMock = $this->createPartialMockWithReflection(
+            EavAbstractAttribute::class,
+            ['setDefault', 'setOption', 'usesSource', 'getSource']
+        );
+        $attributeMock->method('usesSource')->willReturn(true);
+        $attributeMock->expects($this->once())->method('setDefault')->with(['id_new_option']);
+        $attributeMock->expects($this->once())->method('setOption')->with($option);
+        $attributeMock->method('getSource')->willReturn($sourceMock);
+        $this->attributeRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($entityType, $attributeCode)
+            ->willReturn($attributeMock);
+        $optionMock->method('getLabel')->willReturn($label);
+        $optionMock->method('getSortOrder')->willReturn($sortOder);
+        $optionMock->method('getIsDefault')->willReturn(true);
+        $optionMock->method('getStoreLabels')->willReturn([$labelMock]);
+        $labelMock->method('getStoreId')->willReturn($storeId);
+        $labelMock->method('getLabel')->willReturn($storeLabel);
+        $this->resourceModelMock->expects($this->once())->method('save')->with($attributeMock);
+
+        $this->assertEquals(
+            $newOptionId,
+            $this->model->add($entityType, $attributeCode, $optionMock)
+        );
+    }
+
+    /**
+     * A duplicate label (case-insensitive) must still be rejected.
+     */
+    public function testAddThrowsWhenLabelAlreadyExists(): void
+    {
+        $this->expectException(InputException::class);
+        $this->expectExceptionMessage('Admin store attribute option label "optionlabel" already exists.');
+
+        $entityType = 42;
+        $attributeCode = 'atrCde';
+        $label = 'optionlabel';
+
+        $optionMock = $this->getAttributeOption();
+        /** @var SourceInterface|MockObject $sourceMock */
+        $sourceMock = $this->createMock(EavAttributeSource::class);
+        $sourceMock->method('getAllOptions')
+            ->willReturn([['label' => 'OptionLabel', 'value' => 5]]);
+
+        /** @var EavAbstractAttribute|MockObject $attributeMock */
+        $attributeMock = $this->createPartialMockWithReflection(
+            EavAbstractAttribute::class,
+            ['usesSource', 'getSource']
+        );
+        $attributeMock->method('usesSource')->willReturn(true);
+        $attributeMock->method('getSource')->willReturn($sourceMock);
+        $this->attributeRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($entityType, $attributeCode)
+            ->willReturn($attributeMock);
+        $optionMock->method('getLabel')->willReturn($label);
+
         $this->model->add($entityType, $attributeCode, $optionMock);
     }
 
@@ -294,9 +401,8 @@ class OptionManagementTest extends TestCase
             ->willReturn($label);
 
         $sourceMock->expects($this->once())
-            ->method('getOptionId')
-            ->with($label)
-            ->willReturn($optionId);
+            ->method('getAllOptions')
+            ->willReturn([['label' => $label, 'value' => $optionId]]);
 
         /** @var EavAbstractAttribute|MockObject $attributeMock */
         $attributeMock = $this->createPartialMockWithReflection(


### PR DESCRIPTION
## Summary

`AttributeOptionManagement::add()` (and `update()`) guards against duplicate option **labels** by calling `$attribute->getSource()->getOptionId($label)`. But `AbstractSource::getOptionId($value)` matches against **both** the label and the option value (id):

```php
if ($this->mbStrcasecmp($option['label'], $value) == 0 || $option['value'] == $value) {
    return $option['value'];
}
```

So when the label being added is a numeric string (e.g. `123`) and an unrelated option already has that number as its **value/option_id**, `getOptionId('123')` returns that id and `add()` wrongly throws:

> Admin store attribute option label "123" already exists.

This blocks adding legitimate numeric option labels, both in the admin attribute screen and during product import (reported in #33073).

## What the fix does

Adds a private `getOptionIdByLabel()` helper that scans `getAllOptions()` and matches on the **label only** (case-insensitive, preserving the previous `mbStrcasecmp` behaviour), and uses it for the duplicate-label guard in `add()` and `update()`.

`AbstractSource::getOptionId()` is intentionally left unchanged — it is shared API relied on elsewhere (including `retrieveOptionId()` in this same class, where matching by value is correct). The fix is scoped to the duplicate-label check that was misusing it.

## Test Plan

- [x] Unit tests added/updated — `OptionManagementTest`:
  - new `testAddWithNumericLabelCollidingWithExistingOptionValue` — adding label `123` succeeds even when an existing option's value is `123`.
  - new `testAddThrowsWhenLabelAlreadyExists` — a real (case-insensitive) label duplicate is still rejected.
  - existing `testAdd` / `testUpdate` updated to reflect the label-only lookup.
- [x] PHPCS clean (Magento2)
- [x] PHPStan clean (level 1)

Fixes #33073
