### PR TITLE
Apply locale date format to admin grid range filters (#38140)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
@@ -60,8 +60,10 @@ define([
          * @returns {Range} Chainable.
          */
         initialize: function (config) {
-            if (config.dateFormat) {
-                this.constructor.defaults.templates.date.pickerDefaultDateFormat = config.dateFormat;
+            var dateFormat = config.dateFormat || (config.options && config.options.dateFormat);
+
+            if (dateFormat) {
+                this.constructor.defaults.templates.date.pickerDefaultDateFormat = dateFormat;
             }
             this._super()
                 .initChildren();

--- a/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
+++ b/app/code/Magento/Ui/view/base/web/js/grid/filters/range.js
@@ -60,7 +60,7 @@ define([
          * @returns {Range} Chainable.
          */
         initialize: function (config) {
-            var dateFormat = config.dateFormat || (config.options && config.options.dateFormat);
+            var dateFormat = config.dateFormat || config.options && config.options.dateFormat;
 
             if (dateFormat) {
                 this.constructor.defaults.templates.date.pickerDefaultDateFormat = dateFormat;

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/filters/range.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/grid/filters/range.test.js
@@ -70,5 +70,24 @@ define([
             group.elems.push(elem, elem);
             expect(group.getPreview()).toEqual([true, true]);
         });
+        it('Applies the locale date format provided under options.', function () {
+            // The locale-aware date format is supplied by the server under
+            // config.options.dateFormat; it must be used as the date picker default
+            // so non-US locales (e.g. dd/MM/y) are parsed correctly.
+            group = new Group({
+                elems: [],
+                index: 'index',
+                name: 'name',
+                indexField: 'id',
+                dataScope: 'scope',
+                provider: 'provider',
+                options: {
+                    dateFormat: 'dd/MM/y'
+                }
+            });
+
+            expect(group).toBeDefined();
+            expect(Group.defaults.templates.date.pickerDefaultDateFormat).toEqual('dd/MM/y');
+        });
     });
 });


### PR DESCRIPTION
## Summary

Admin grid date-range filters that are **not** tied to a column (e.g. the Media Gallery "Uploaded Date" filter) ignore the configured locale date format and always fall back to the US format `MM/dd/y`. With a non-US locale such as English (United Kingdom), entering `01/11` – `01/12` (1 Nov – 1 Dec) is parsed as 11 Jan – 12 Jan, so the wrong range is filtered and the picker redisplays the dates transposed.

Root cause is in `Magento_Ui/js/grid/filters/range`:

```js
initialize: function (config) {
    if (config.dateFormat) {
        this.constructor.defaults.templates.date.pickerDefaultDateFormat = config.dateFormat;
    }
    ...
```

The locale-aware format is provided by the server under `config.options.dateFormat` (value e.g. `dd/MM/y`), but the component reads `config.dateFormat`, which is `undefined`. As a result `pickerDefaultDateFormat` is never overridden and the child date pickers keep the default US format (`date.js` falls back to `pickerDefaultDateFormat` whenever `options.dateFormat` is absent).

## What the fix does

Reads the format from `config.options.dateFormat` as well, keeping the existing `config.dateFormat` as the higher-priority source for backward compatibility:

```js
var dateFormat = config.dateFormat || (config.options && config.options.dateFormat);

if (dateFormat) {
    this.constructor.defaults.templates.date.pickerDefaultDateFormat = dateFormat;
}
```

## Test Plan

- [x] Added a Jasmine spec to `range.test.js` asserting that a locale format supplied under `options.dateFormat` (`dd/MM/y`) becomes the date picker default.
- [x] JS syntax validated (`node --check`) for both files; the fix is backward compatible (top-level `config.dateFormat` still wins, no format set when neither is present).

> Note: the project's JS unit runner (karma/jasmine) is not provisioned in my local environment, so the new spec was validated for syntax and logic locally and will be executed by the upstream "JS Unit Tests" CI job.

Fixes #38140
