### PR TITLE
Scan .phtml templates when building js-translation.json (#33245)

### DIFF
--- a/app/code/Magento/Translation/Model/Js/DataProvider.php
+++ b/app/code/Magento/Translation/Model/Js/DataProvider.php
@@ -96,7 +96,9 @@ class DataProvider implements DataProviderInterface
             $this->filesUtility->getJsFiles('base', $themePath),
             $this->filesUtility->getJsFiles($areaCode, $themePath),
             $this->filesUtility->getStaticHtmlFiles('base', $themePath),
-            $this->filesUtility->getStaticHtmlFiles($areaCode, $themePath)
+            $this->filesUtility->getStaticHtmlFiles($areaCode, $themePath),
+            $this->filesUtility->getPhtmlFilesByArea('base', $themePath),
+            $this->filesUtility->getPhtmlFilesByArea($areaCode, $themePath)
         );
 
         $dictionary = [];

--- a/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
+++ b/app/code/Magento/Translation/Test/Unit/Model/Js/DataProviderTest.php
@@ -112,6 +112,10 @@ class DataProviderTest extends TestCase
             ['base', $themePath, '*', '*', [$filePaths[2]]],
             [$areaCode, $themePath, '*', '*', [$filePaths[3]]]
         ];
+        $phtmlFilesMap = [
+            ['base', $themePath, '*', '*', []],
+            [$areaCode, $themePath, '*', '*', []]
+        ];
 
         $this->appStateMock->expects($this->once())
             ->method('getAreaCode')
@@ -122,6 +126,9 @@ class DataProviderTest extends TestCase
         $this->filesUtilityMock->expects($this->any())
             ->method('getStaticHtmlFiles')
             ->willReturnMap($staticFilesMap);
+        $this->filesUtilityMock->expects($this->any())
+            ->method('getPhtmlFilesByArea')
+            ->willReturnMap($phtmlFilesMap);
 
         $willReturn = [];
 
@@ -175,6 +182,9 @@ class DataProviderTest extends TestCase
         $this->filesUtilityMock->expects($this->any())
             ->method('getStaticHtmlFiles')
             ->willReturn(['test']);
+        $this->filesUtilityMock->expects($this->any())
+            ->method('getPhtmlFilesByArea')
+            ->willReturn(['test']);
         $this->configMock->expects($this->any())
             ->method('getPatterns')
             ->willReturn($patterns);
@@ -183,6 +193,58 @@ class DataProviderTest extends TestCase
             ->willThrowException(new \Exception('Test exception'));
 
         $this->model->getData($themePath);
+    }
+
+    /**
+     * Verify data translate from phtml files.
+     *
+     * @return void
+     */
+    public function testGetDataExtractsPhrasesFromPhtmlFiles(): void
+    {
+        $themePath = 'blank';
+        $areaCode = 'frontend';
+        $phtmlFilePath = ['path/to/template.phtml'];
+
+        $this->appStateMock->expects($this->once())
+            ->method('getAreaCode')
+            ->willReturn($areaCode);
+        $this->filesUtilityMock->expects($this->any())
+            ->method('getJsFiles')
+            ->willReturnMap([
+                ['base', $themePath, '*', '*', []],
+                [$areaCode, $themePath, '*', '*', []]
+            ]);
+        $this->filesUtilityMock->expects($this->any())
+            ->method('getStaticHtmlFiles')
+            ->willReturnMap([
+                ['base', $themePath, '*', '*', []],
+                [$areaCode, $themePath, '*', '*', []]
+            ]);
+        $this->filesUtilityMock->expects($this->any())
+            ->method('getPhtmlFilesByArea')
+            ->willReturnMap([
+                ['base', $themePath, '*', '*', [$phtmlFilePath]],
+                [$areaCode, $themePath, '*', '*', []]
+            ]);
+
+        $this->fileReadMock->expects($this->once())
+            ->method('readAll')
+            ->willReturn('content <!-- ko i18n: "Hello" --><!-- /ko -->');
+        $this->configMock->expects($this->any())
+            ->method('getPatterns')
+            ->willReturn([
+                '~(?:i18n\:|_\.i18n\()\s*(["\'])(.*?)(?<!\\\\)\1~'
+            ]);
+        $this->translateMock->expects($this->once())
+            ->method('render')
+            ->with(['Hello'], [])
+            ->willReturn('Hello translated');
+
+        $this->assertEquals(
+            ['Hello' => 'Hello translated'],
+            $this->model->getData($themePath)
+        );
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -888,6 +888,43 @@ class Files
     }
 
     /**
+     * Returns list of PHTML files in Magento
+     *
+     * @param string $area
+     * @param string $themePath
+     * @param string $namespace
+     * @param string $module
+     * @return array
+     */
+    public function getPhtmlFilesByArea($area = '*', $themePath = '*/*', $namespace = '*', $module = '*')
+    {
+        $key = $area . $themePath . $namespace . $module . __METHOD__;
+        if (isset(self::$_cache[$key])) {
+            return self::$_cache[$key];
+        }
+        $moduleTemplatePaths = [];
+        foreach ($this->componentRegistrar->getPaths(ComponentRegistrar::MODULE) as $moduleName => $moduleDir) {
+            $keyInfo = explode('_', $moduleName);
+            if ($keyInfo[0] == $namespace || $namespace == '*') {
+                if ($keyInfo[1] == $module || $module == '*') {
+                    $moduleTemplatePaths[] = $moduleDir . "/view/{$area}/templates";
+                }
+            }
+        }
+        $themePaths = $this->getThemePaths($area, $namespace . '_' . $module, '/templates');
+        $files = self::getFiles(
+            array_merge(
+                $themePaths,
+                $moduleTemplatePaths
+            ),
+            '*.phtml'
+        );
+        $result = self::composeDataSets($files);
+        self::$_cache[$key] = $result;
+        return $result;
+    }
+
+    /**
      * Get list of static view files that are subject of Magento static view files pre-processing system
      *
      * @param string $filePattern

--- a/lib/internal/Magento/Framework/App/Utility/Files.php
+++ b/lib/internal/Magento/Framework/App/Utility/Files.php
@@ -1057,6 +1057,7 @@ class Files
      * Parse meta-info of a static file in module
      *
      * @deprecated 102.0.4 Replaced with method accumulateStaticFiles()
+     * @see Files::accumulateStaticFiles()
      *
      * @param string $file
      * @return array


### PR DESCRIPTION
## Description

`js-translation.json` (the frontend translation dictionary) is built by scanning theme/module files for translatable strings using the patterns defined in `Magento\Translation\Model\Js\Config`. However `Magento\Translation\Model\Js\DataProvider::getData()` only enumerates:

- `*.js` files (`getJsFiles`)
- static knockout `*.html` templates (`getStaticHtmlFiles`)

`*.phtml` templates are never scanned. As a result, JS-side translatable strings embedded in `.phtml` files are never extracted, so they render untranslated on the frontend even when a matching CSV translation exists. Examples that are missed:

- knockout bindings: `<!-- ko i18n: 'foo bar' --><!-- /ko -->`, `data-bind="i18n: 'foo bar'"`
- inline JS helpers: `$t('foo bar')`, `$.mage.__('foo bar')`

The extraction patterns themselves already cover these tokens — only the file enumeration was incomplete.

## Fixed Issues

Fixes magento/magento2#33245

## Manual testing scenarios

1. Set store locale to French (France).
2. Add a CSV translation for `foo bar 123` → `barre de foo 123`.
3. In a module `.phtml` template add `<!-- ko i18n: 'foo bar 123' --><!-- /ko -->`.
4. Deploy static content / flush cache, load the frontend.

**Before:** the string renders as `foo bar 123` (not in `js-translation.json`).
**After:** the string is collected into `js-translation.json` and renders translated.

## What changed

- `Magento\Framework\App\Utility\Files::getPhtmlFilesByArea()` — new method mirroring `getStaticHtmlFiles()`, returning `*.phtml` template files filtered by area/theme. Additive; the existing `getPhtmlFiles()` is untouched.
- `Magento\Translation\Model\Js\DataProvider::getData()` — also merges base + area `.phtml` files into the scan list.

The extraction patterns are JS-specific (`i18n:`, `$t(`, `$.mage.__(`, …) and do not match server-side `__()` calls, so PHP phrases are not pulled in (they remain handled by the CSV dictionary).

## Test plan

- [x] Unit tests: added regression test in `DataProviderTest` proving a `ko i18n` phrase in a `.phtml` file is extracted into the dictionary; existing tests updated for the new file-utility call.
- [x] PHPCS (Magento2 standard): clean.
- [x] PHPStan (level 1, Magento config): clean.
