### PR TITLE
Accept Phrase in Backend button $data PHPDoc (#36063)

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Button/ButtonList.php
+++ b/app/code/Magento/Backend/Block/Widget/Button/ButtonList.php
@@ -6,6 +6,8 @@
 
 namespace Magento\Backend\Block\Widget\Button;
 
+use Magento\Framework\Phrase;
+
 /**
  * Button list widget
  *
@@ -81,7 +83,7 @@ class ButtonList
      *
      * @param string $buttonId
      * @param string|null $key
-     * @param string $data
+     * @param Phrase|string $data
      * @return void
      */
     public function update($buttonId, $key, $data)

--- a/app/code/Magento/Backend/Block/Widget/Container.php
+++ b/app/code/Magento/Backend/Block/Widget/Container.php
@@ -9,6 +9,7 @@ namespace Magento\Backend\Block\Widget;
 use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Widget\Button\ButtonList;
 use Magento\Backend\Block\Widget\Button\Item as ButtonItem;
+use Magento\Framework\Phrase;
 
 /**
  * Backend container block
@@ -105,7 +106,7 @@ class Container extends Template implements ContainerInterface
      *
      * @param string $buttonId
      * @param string|null $key
-     * @param string $data
+     * @param Phrase|string $data
      * @return $this
      */
     public function updateButton($buttonId, $key, $data)


### PR DESCRIPTION
## Summary

`Magento\Backend\Block\Widget\Button\ButtonList::update()` and `Magento\Backend\Block\Widget\Container::updateButton()` document their `$data` parameter as `string`, but button properties — most commonly the label — are routinely supplied as a `Phrase` (e.g. `__('Save')`). PHPStan (level 5 and above, with `declare(strict_types=1)`) therefore reports a false positive:

```
Parameter #3 $data of method Magento\Backend\Block\Widget\Button\ButtonList::update()
expects string, Magento\Framework\Phrase given.
```

This widens the PHPDoc on both methods to `Phrase|string` to reflect actual usage.

## Why this approach

`Phrase` is `Stringable` and is the standard way translated UI strings are passed around in Magento, so `$data` legitimately receives either type. Widening the documented type of an **input** parameter is safe — it only accepts more — and resolves the false positive without any behavioural change. The change is PHPDoc-only.

The primary example from the issue (`MessageManagerInterface::addErrorMessage()`) was already addressed separately by typing those parameters as `string|\Stringable`; this PR covers the remaining reproducible cases in the Backend button widgets.

## Reproduction (before)

```php
<?php
declare(strict_types=1);

namespace Foo\Bar\Block;

use Magento\Backend\Block\Widget\Container;
use Magento\Backend\Block\Widget\Button\ButtonList;

class Probe extends Container
{
    public function probe(ButtonList $buttonList): void
    {
        $this->updateButton('save', 'label', __('Save'));
        $buttonList->update('save', 'label', __('Save'));
    }
}
```

```
vendor/bin/phpstan analyse --level 6 \
  -c dev/tests/static/testsuite/Magento/Test/Php/_files/phpstan/phpstan.neon Probe.php
```

Before: 2 errors (Phrase given, string expected). After: no errors.

## Test Plan

- [x] PHPStan no longer reports the false positive for the reproduction above
- [x] PHPStan on the changed files introduces no new errors
- [x] PHPCS (`Magento2` standard) clean on the changed files
- [x] Backend button-widget unit tests pass

Fixes #36063
