### PR TITLE
Fix company field being cleared at checkout when Show Company differs by store scope (#39424)

### DIFF
--- a/app/code/Magento/Quote/Model/ShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/ShippingAddressManagement.php
@@ -10,6 +10,7 @@ use Magento\Customer\Model\Config\Backend\Show\Customer;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\ScopeInterface;
 use Psr\Log\LoggerInterface as Logger;
 
 /**
@@ -103,7 +104,11 @@ class ShippingAddressManagement implements \Magento\Quote\Model\ShippingAddressM
         $sameAsBilling = $address->getSameAsBilling() ? 1 : 0;
         $customerAddressId = $address->getCustomerAddressId();
         if ($saveInAddressBook &&
-            !$this->scopeConfig->getValue(Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY)) {
+            !$this->scopeConfig->getValue(
+                Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY,
+                ScopeInterface::SCOPE_STORE,
+                $quote->getStoreId()
+            )) {
             $address->setCompany(null);
         }
 

--- a/dev/tests/integration/testsuite/Magento/Quote/Model/ShippingAddressManagementTest.php
+++ b/dev/tests/integration/testsuite/Magento/Quote/Model/ShippingAddressManagementTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model;
+
+use Magento\Customer\Model\Config\Backend\Show\Customer;
+use Magento\Quote\Api\Data\AddressInterfaceFactory;
+use Magento\Quote\Test\Fixture\GuestCart as GuestCartFixture;
+use Magento\TestFramework\Fixture\Config as ConfigFixture;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for shipping address management
+ *
+ * @magentoDbIsolation enabled
+ */
+class ShippingAddressManagementTest extends TestCase
+{
+    /**
+     * @var DataFixtureStorage
+     */
+    private DataFixtureStorage $fixtures;
+
+    /**
+     * @var ShippingAddressManagementInterface
+     */
+    private ShippingAddressManagementInterface $shippingAddressManagement;
+
+    /**
+     * @var AddressInterfaceFactory
+     */
+    private AddressInterfaceFactory $addressFactory;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->fixtures = $objectManager->get(DataFixtureStorageManager::class)->getStorage();
+        $this->shippingAddressManagement = $objectManager->get(ShippingAddressManagementInterface::class);
+        $this->addressFactory = $objectManager->get(AddressInterfaceFactory::class);
+    }
+
+    /**
+     * @return void
+     */
+    #[
+        ConfigFixture(Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY, '0'),
+        ConfigFixture(Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY, 'opt', 'store', 'default'),
+        DataFixture(GuestCartFixture::class, as: 'cart'),
+    ]
+    public function testAssignPreservesCompanyWhenCompanyIsEnabledForQuoteStore(): void
+    {
+        $cartId = (int)$this->fixtures->get('cart')->getId();
+        $company = 'Magento Company';
+        $address = $this->addressFactory->create();
+        $address->setFirstname('John');
+        $address->setLastname('Doe');
+        $address->setStreet(['Green str, 67']);
+        $address->setCity('Montgomery');
+        $address->setCountryId('US');
+        $address->setRegionId(1);
+        $address->setPostcode('36104');
+        $address->setTelephone('3340000000');
+        $address->setCompany($company);
+        $address->setSaveInAddressBook(1);
+
+        $this->shippingAddressManagement->assign($cartId, $address);
+
+        $this->assertSame(
+            $company,
+            $this->shippingAddressManagement->get($cartId)->getCompany()
+        );
+    }
+}


### PR DESCRIPTION
### Description

`Magento\Quote\Model\ShippingAddressManagement::assign()` reads the
`customer/address/company_show` configuration **without a scope**, so it always
evaluates the *default* config scope:

```php
!$this->scopeConfig->getValue(Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY)
```

`Show Company` is a per-website setting. When it is `No` at the default scope but
`Optional`/`Required` at a website scope, the check wrongly treats the company
field as hidden and calls `$address->setCompany(null)`, wiping the company that
the customer entered at checkout for a new address (`saveInAddressBook = 1`).

The value is now read at the quote's store scope:

```php
!$this->scopeConfig->getValue(
    Customer::XML_PATH_CUSTOMER_ADDRESS_SHOW_COMPANY,
    ScopeInterface::SCOPE_STORE,
    $quote->getStoreId()
)
```

### Related Issue

Fixes #39424

### Manual testing scenarios

1. `Stores → Configuration → Customers → Customer Configuration → Name and Address Options`.
2. Default Config scope: set `Show Company` to **No**, save.
3. Switch to a Website scope: set `Show Company` to **Optional** (or **Required**), save.
4. On the storefront (that website), add a product to the cart and go to checkout.
5. Add a new shipping address, fill in the **Company** field, select `Save in address book`.
6. Proceed to payment and place the order.
7. **Expected:** the company value is persisted on the quote address, the order
   shipping address, and the saved customer address.
8. **Before this fix:** the company value is empty in all three places.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (integration regression test added)
- [x] All automated tests passed successfully (all tests are green)
