### PR TITLE
Wrap async HTTP client connection errors in HttpException (fixes shipping-rate collection on carrier timeout) (#40888)

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/AsyncClient/GuzzleWrapDeferred.php
+++ b/lib/internal/Magento/Framework/HTTP/AsyncClient/GuzzleWrapDeferred.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Magento\Framework\HTTP\AsyncClient;
 
 use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\CancellationException;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -87,6 +88,10 @@ class GuzzleWrapDeferred implements HttpResponseDeferredInterface
             } else {
                 $this->exception = new HttpException($requestException->getMessage(), 0, $requestException);
             }
+        } catch (GuzzleException $guzzleException) {
+            // ConnectException (cURL timeout), TooManyRedirectsException, etc. are still
+            // failures to send the request - honor the documented @throws HttpException contract.
+            $this->exception = new HttpException($guzzleException->getMessage(), 0, $guzzleException);
         } catch (\Throwable $exception) {
             $this->exception = $exception;
         }

--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/AsyncClient/GuzzleWrapDeferredTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/AsyncClient/GuzzleWrapDeferredTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\HTTP\Test\Unit\AsyncClient;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Magento\Framework\HTTP\AsyncClient\GuzzleWrapDeferred;
+use Magento\Framework\HTTP\AsyncClient\HttpException;
+use PHPUnit\Framework\TestCase;
+
+class GuzzleWrapDeferredTest extends TestCase
+{
+    public function testGetWrapsConnectExceptionInHttpException(): void
+    {
+        $connectException = new ConnectException(
+            'Connection timed out',
+            new Request('GET', 'http://localhost')
+        );
+        $promise = $this->createMock(PromiseInterface::class);
+        $promise->method('wait')->willThrowException($connectException);
+
+        $deferred = new GuzzleWrapDeferred($promise);
+
+        try {
+            $deferred->get();
+            $this->fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            $this->assertSame($connectException, $exception->getPrevious());
+        }
+    }
+
+    public function testGetConvertsBadResponseExceptionToResponse(): void
+    {
+        $promise = $this->createMock(PromiseInterface::class);
+        $promise->method('wait')->willThrowException(
+            new ServerException(
+                'Server error',
+                new Request('GET', 'http://localhost'),
+                new Response(503, ['Retry-After' => '60'], 'Service unavailable')
+            )
+        );
+
+        $deferred = new GuzzleWrapDeferred($promise);
+
+        $response = $deferred->get();
+
+        $this->assertSame(503, $response->getStatusCode());
+        $this->assertSame(['retry-after' => '60'], $response->getHeaders());
+        $this->assertSame('Service unavailable', $response->getBody());
+    }
+}


### PR DESCRIPTION
### Description

`Magento\Framework\HTTP\AsyncClient\GuzzleWrapDeferred::get()` documents
`@throws HttpException` for any failure to send a request. However, `unwrap()`
only converts `GuzzleHttp\Exception\RequestException` into `HttpException`:

```php
} catch (RequestException $requestException) {
    ...
    $this->exception = new HttpException($requestException->getMessage(), 0, $requestException);
} catch (\Throwable $exception) {
    $this->exception = $exception;   // ConnectException lands here, stored RAW
}
```

`GuzzleHttp\Exception\ConnectException` (a cURL timeout, error 28) extends
`TransferException`, **not** `RequestException`, so it falls into the
`\Throwable` branch and is re-thrown unwrapped by `get()`.

Shipping carriers only guard against the documented contract:

- `Magento\Dhl\Model\Carrier::_getQuotesRest()` / `::_getQuotes()` — `catch (HttpException $e)`
- `Magento\Ups\Model\Carrier` REST rate paths — `catch (HttpException $e)`
- `Magento\Ups\Model\UpsAuth::getAccessToken()` — `catch (HttpException $e)`

So when one carrier times out, the raw `ConnectException` escapes the
rate-collection callback, propagates through
`Magento\Shipping\Model\Shipping::collectCarrierRates()` (no catch around
result appending) and aborts the **entire** rate request — every shipping
method disappears at the checkout shipping step.

### Fix

Add a `catch (GuzzleException)` clause between the existing `RequestException`
and `\Throwable` clauses, wrapping connection-level Guzzle failures into
`HttpException`. `cancel()` is intentionally left untouched: it relies on
`GuzzleHttp\Promise\CancellationException`, which does not implement
`GuzzleHttp\Exception\GuzzleException`, so it still reaches the `\Throwable`
branch that `cancel()` depends on.

### Related Issue

Fixes #40888

### Manual testing scenarios

1. Enable DHL or UPS online rates plus another method (e.g. Flat Rate).
2. Point the carrier gateway at an endpoint that times out (blackhole/firewall drop, or a very low timeout against a slow host).
3. Go to checkout and request shipping rates for a deliverable address.
4. **Expected:** the timed-out carrier returns no rate; all other shipping methods remain available.
5. **Before this fix:** an uncaught `GuzzleHttp\Exception\ConnectException` (`cURL error 28`) breaks the whole shipping step — no methods offered.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests
- [x] All automated tests passed successfully (all tests are green)
