### PR TITLE
Convert lowercase month token in mageUtils.convertToMomentFormat (#28740)

### DIFF
--- a/dev/tests/js/jasmine/tests/lib/mage/misc.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/misc.test.js
@@ -692,12 +692,12 @@ define([
 
         it('Check ajaxSubmit method', function () {
             var options = {
-                data: {}
-            },
-            config = {
-                ajaxSaveType: 'default'
-            },
-            d = new $.Deferred();
+                    data: {}
+                },
+                config = {
+                    ajaxSaveType: 'default'
+                },
+                d = new $.Deferred();
 
             spyOn($, 'ajax').and.callFake(function () {
                 d.reject();

--- a/dev/tests/js/jasmine/tests/lib/mage/misc.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/misc.test.js
@@ -54,6 +54,13 @@ define([
             expect(utils.convertToMomentFormat(format)).toBe(momentFormat);
         });
 
+        it('Check convertToMomentFormat function with lowercase month tokens', function () {
+            expect(utils.convertToMomentFormat('dd.m.yyyy')).toBe('DD.M.YYYY');
+            expect(utils.convertToMomentFormat('dd.mm.yyyy')).toBe('DD.MM.YYYY');
+            expect(utils.convertToMomentFormat('m/d/yy')).toBe('M/DD/YYYY');
+            expect(utils.convertToMomentFormat('MM/dd/yyyy')).toBe('MM/DD/YYYY');
+        });
+
         it('Check "filterFormData" method', function () {
             var suffix = 'prepared-for-send',
                 separator = '-',

--- a/lib/web/mage/utils/misc.js
+++ b/lib/web/mage/utils/misc.js
@@ -288,6 +288,8 @@ define([
 
             newFormat = format.replace(/yyyy|yy|y/, 'YYYY'); // replace the year
             newFormat = newFormat.replace(/dd|d/g, 'DD'); // replace the date
+            newFormat = newFormat.replace(/mm/g, 'MM'); // replace the month
+            newFormat = newFormat.replace(/m/g, 'M'); // replace the month
 
             return newFormat;
         },


### PR DESCRIPTION
### Description

`mageUtils.convertToMomentFormat()` (`lib/web/mage/utils/misc.js`) converts
jQuery UI / PHP-style date-format tokens into moment.js tokens, but it only
handled the **year** and **day** tokens:

```js
newFormat = format.replace(/yyyy|yy|y/, 'YYYY'); // replace the year
newFormat = newFormat.replace(/dd|d/g, 'DD');     // replace the date
return newFormat;
```

The **lowercase month** token was never converted. In jQuery UI / PHP date
formats a lowercase `m`/`mm` means the month, but in moment.js lowercase
`m`/`mm` means **minutes** — the month token in moment is uppercase `M`/`MM`.

So a format such as `dd.m.yyyy` was converted to `DD.m.YYYY`, which moment.js
interprets with a minutes placeholder. The datepicker knockout binding
(`Magento_Ui/js/lib/knockout/bindings/datepicker` `update()`) recomputes the
date from this invalid format and silently changes the value the field holds.

This lowercase-month handling existed historically and was dropped in
`972adf4`.

### Fix

Convert the lowercase month token after the day token, leaving already
uppercase month tokens (used by the CLDR locale formats that
`convertToMomentFormat` also receives, e.g. `y-MM-dd`) untouched:

```js
newFormat = newFormat.replace(/mm/g, 'MM'); // replace the month
newFormat = newFormat.replace(/m/g, 'M');   // replace the month
```

### Related Issue

Fixes #28740

### Manual testing scenarios

1. Add a datepicker whose `dateFormat` uses a lowercase month, e.g. `dd.m.yyyy`.
2. Trigger a knockout update on the bound observable (e.g. programmatic value change).
3. **Expected:** the field keeps the correct date.
4. **Before this fix:** the date jumps, because `DD.m.YYYY` is not a valid moment month format.

### Test Plan

- Added a Jasmine spec in `dev/tests/js/jasmine/tests/lib/mage/misc.test.js`
  asserting lowercase month conversion (`dd.m.yyyy` → `DD.M.YYYY`,
  `dd.mm.yyyy` → `DD.MM.YYYY`, `m/d/yy` → `M/DD/YYYY`) and that uppercase month
  is preserved (`MM/dd/yyyy` → `MM/DD/YYYY`).
- Verified the change against the actual module: the new cases fail before the
  fix and pass after it; existing year/day and CLDR uppercase-month conversions
  are unaffected.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests
- [x] All automated tests passed successfully (all tests are green)
