### PR TITLE
Throw descriptive error when EAV attribute source model class is missing (#38480)

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/AbstractAttribute.php
@@ -636,7 +636,14 @@ abstract class AbstractAttribute extends \Magento\Framework\Model\AbstractExtens
             } else {
                 $this->_source = $this->getSourceModel();
             }
-            $source = $this->_universalFactory->create($this->_source);
+            try {
+                $source = $this->_universalFactory->create($this->_source);
+            } catch (\ReflectionException $e) {
+                throw new LocalizedException(
+                    __('Source model "%1" not found for attribute "%2"', $this->_source, $this->getAttributeCode()),
+                    $e
+                );
+            }
             if (!$source) {
                 throw new LocalizedException(
                     __(

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/AbstractAttributeTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/AbstractAttributeTest.php
@@ -14,9 +14,11 @@ use Magento\Eav\Api\Data\AttributeOptionInterfaceFactory;
 use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
 use Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend;
 use Magento\Framework\Api\DataObjectHelper;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
+use Magento\Framework\Validator\UniversalFactory;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -116,6 +118,40 @@ class AbstractAttributeTest extends TestCase
         $dataFactoryMock->expects($this->once())->method('create')->willReturn($attributeOptionMock);
 
         $this->assertEquals([$attributeOptionMock], $model->getOptions());
+    }
+
+    public function testGetSourceThrowsLocalizedExceptionWhenSourceModelClassDoesNotExist()
+    {
+        $sourceModel = 'Non\\Existent\\SourceModel';
+        $attributeCode = 'missing_source_attribute';
+
+        $universalFactoryMock = $this->createMock(UniversalFactory::class);
+        $universalFactoryMock->expects($this->once())
+            ->method('create')
+            ->with($sourceModel)
+            ->willThrowException(new \ReflectionException('Class "' . $sourceModel . '" does not exist'));
+
+        $modelClassName = AbstractAttribute::class;
+        $model = $this->getMockBuilder($modelClassName)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $reflection = new \ReflectionClass($modelClassName);
+        $reflectionProperty = $reflection->getProperty('_universalFactory');
+        $reflectionProperty->setValue($model, $universalFactoryMock);
+
+        $model->setAttributeCode($attributeCode);
+        $model->setSourceModel($sourceModel);
+
+        try {
+            $model->getSource();
+            $this->fail('Expected LocalizedException was not thrown.');
+        } catch (LocalizedException $exception) {
+            $this->assertStringContainsString($sourceModel, $exception->getMessage());
+            $this->assertStringContainsString($attributeCode, $exception->getMessage());
+            $this->assertInstanceOf(\ReflectionException::class, $exception->getPrevious());
+        }
     }
 
     public function testGetValidationRulesWhenRuleIsArray()

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/AbstractAttributeTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/AbstractAttributeTest.php
@@ -22,6 +22,9 @@ use Magento\Framework\Validator\UniversalFactory;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class AbstractAttributeTest extends TestCase
 {
     use MockCreationTrait;


### PR DESCRIPTION
### Description

`Magento\Eav\Model\Entity\Attribute\AbstractAttribute::getSource()` resolves an
attribute's source model and instantiates it:

```php
$source = $this->_universalFactory->create($this->_source);
if (!$source) {
    throw new LocalizedException(
        __('Source model "%1" not found for attribute "%2"', $this->getSourceModel(), $this->getAttributeCode())
    );
}
```

When the configured `source_model` **class no longer exists** — e.g. a module
that declared it was removed while the `eav_attribute` row remains — the
`ObjectManager`'s `ClassReader::getConstructor()` executes
`new ReflectionClass($className)` and throws a raw `ReflectionException`
(`Class "..." does not exist`) **before** the `!$source` guard is reached.

As a result the descriptive `LocalizedException` is effectively dead code for
the missing-class case, and the merchant/developer sees an opaque
`ReflectionException` with no indication of **which attribute** or **which
source model** is at fault.

### Fix

Wrap only the `create()` call in a `try/catch (\ReflectionException $e)` and
rethrow the existing descriptive `LocalizedException`, chaining the original
exception as the cause. The pre-existing `!$source` null-check is retained.

`try/catch` is used deliberately instead of a `class_exists()` guard: `$this->_source`
may legitimately be a **DI virtual-type** name, which `class_exists()` reports as
`false` even though the ObjectManager resolves it correctly. A `class_exists()`
guard would break those valid configurations; catching `ReflectionException` only
changes behavior on the genuine missing-class path.

### Related Issue

Fixes #38480

### Manual testing scenarios

1. Create an EAV attribute whose `source_model` points to a class provided by a module.
2. Remove/disable that module (or otherwise make the class unavailable) while leaving the `eav_attribute` row.
3. Load a context that calls `getSource()` on the attribute (e.g. rendering the attribute in admin/frontend).
4. **Expected:** a clear `LocalizedException` — `Source model "<class>" not found for attribute "<code>"`.
5. **Before this fix:** an opaque `ReflectionException: Class "<class>" does not exist` with no attribute context.

### Test Plan

- Added a unit test in `AbstractAttributeTest` that makes the `UniversalFactory`
  mock throw a `ReflectionException` for a non-existent source model and asserts
  `getSource()` throws a `LocalizedException` whose message contains the source
  model and attribute code, with the `ReflectionException` chained as the previous exception.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests
- [x] All automated tests passed successfully (all tests are green)
