### PR TITLE
Fix shipping amount overwritten by billing address in TotalsCollector

### DIFF
--- a/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
+++ b/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
@@ -152,6 +152,9 @@ class TotalsCollector
         $total->setGrandTotal(0);
         $total->setBaseGrandTotal(0);
 
+        $total->setShippingAmount(0);
+        $total->setBaseShippingAmount(0);
+
         /** @var \Magento\Quote\Model\Quote\Address $address */
         foreach ($quote->getAllAddresses() as $address) {
             $addressTotal = $this->collectAddressTotals($quote, $address);

--- a/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
+++ b/app/code/Magento/Quote/Model/Quote/TotalsCollector.php
@@ -8,6 +8,7 @@
 namespace Magento\Quote\Model\Quote;
 
 use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Total\Collector;
 use Magento\Quote\Model\Quote\Address\Total\CollectorFactory;
 use Magento\Quote\Model\Quote\Address\Total\CollectorInterface;
@@ -155,9 +156,11 @@ class TotalsCollector
         foreach ($quote->getAllAddresses() as $address) {
             $addressTotal = $this->collectAddressTotals($quote, $address);
 
-            $total->setShippingAmount($addressTotal->getShippingAmount());
-            $total->setBaseShippingAmount($addressTotal->getBaseShippingAmount());
-            $total->setShippingDescription($addressTotal->getShippingDescription());
+            if ($address->getAddressType() !== Address::ADDRESS_TYPE_BILLING) {
+                $total->setShippingAmount($addressTotal->getShippingAmount());
+                $total->setBaseShippingAmount($addressTotal->getBaseShippingAmount());
+                $total->setShippingDescription($addressTotal->getShippingDescription());
+            }
 
             $total->setSubtotal((float)$total->getSubtotal() + $addressTotal->getSubtotal());
             $total->setBaseSubtotal((float)$total->getBaseSubtotal() + $addressTotal->getBaseSubtotal());

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2024 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -99,10 +99,16 @@ class TotalsCollectorTest extends TestCase
         $shippingAmount = 10.0;
         $shippingDescription = 'Flat Rate - Fixed';
 
-        $shippingAddress = $this->createMock(Address::class);
+        $shippingAddress = $this->getMockBuilder(Address::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getAddressType'])
+            ->getMock();
         $shippingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_SHIPPING);
 
-        $billingAddress = $this->createMock(Address::class);
+        $billingAddress = $this->getMockBuilder(Address::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getAddressType'])
+            ->getMock();
         $billingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_BILLING);
 
         $shippingAddressTotal = $this->createMock(Total::class);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -166,4 +166,62 @@ class TotalsCollectorTest extends TestCase
             'Shipping description must not be overwritten by the billing address'
         );
     }
+
+    /**
+     * Verifies that shipping amount is 0 (not null) for virtual-only quotes
+     * that have only a billing address.
+     *
+     * @see https://github.com/magento/magento2/issues/26209
+     */
+    public function testCollectSetsZeroShippingAmountForVirtualOnlyQuote(): void
+    {
+        $billingAddress = new class extends Address {
+            public function __construct()
+            {
+            }
+
+            public function getAddressType(): string
+            {
+                return self::ADDRESS_TYPE_BILLING;
+            }
+        };
+
+        $billingAddressTotal = new Total([
+            'subtotal'                    => 50.0,
+            'base_subtotal'               => 50.0,
+            'subtotal_with_discount'      => 50.0,
+            'base_subtotal_with_discount' => 50.0,
+            'grand_total'                 => 50.0,
+            'base_grand_total'            => 50.0,
+        ]);
+
+        $quoteMock = $this->createMock(Quote::class);
+        $quoteMock->method('getAllAddresses')->willReturn([$billingAddress]);
+        $quoteMock->method('getData')->with('coupon_code')->willReturn(null);
+
+        $aggregateTotal = new Total();
+        $this->totalFactoryMock->method('create')->willReturn($aggregateTotal);
+
+        $this->model->method('collectAddressTotals')
+            ->willReturnMap([
+                [$quoteMock, $billingAddress, $billingAddressTotal],
+            ]);
+
+        $this->eventManagerMock->method('dispatch');
+        $this->quantityCollectorMock->method('collectItemsQtys');
+        $this->quoteValidatorMock->method('validateQuoteAmount');
+
+        $result = $this->model->collect($quoteMock);
+
+        $this->assertSame(
+            0,
+            $result->getShippingAmount(),
+            'Shipping amount must be 0 (not null) for virtual-only quotes'
+        );
+        $this->assertSame(
+            0,
+            $result->getBaseShippingAmount(),
+            'Base shipping amount must be 0 (not null) for virtual-only quotes'
+        );
+    }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Magento\Quote\Test\Unit\Model\Quote;
 
 use Magento\Framework\Event\ManagerInterface;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address;
 use Magento\Quote\Model\Quote\Address\Total;
@@ -56,16 +55,10 @@ class TotalsCollectorTest extends TestCase
     private QuantityCollector $quantityCollectorMock;
 
     /**
-     * @var ObjectManagerHelper
-     */
-    private ObjectManagerHelper $objectManagerHelper;
-
-    /**
      * @inheritDoc
      */
     protected function setUp(): void
     {
-        $this->objectManagerHelper = new ObjectManagerHelper($this);
         $this->totalFactoryMock = $this->createMock(TotalFactory::class);
         $this->eventManagerMock = $this->createMock(ManagerInterface::class);
         $this->quoteValidatorMock = $this->createMock(QuoteValidator::class);
@@ -121,38 +114,28 @@ class TotalsCollectorTest extends TestCase
             }
         };
 
-        $shippingAddressTotal = $this->createMock(Total::class);
-        $shippingAddressTotal->method('getShippingAmount')->willReturn($shippingAmount);
-        $shippingAddressTotal->method('getBaseShippingAmount')->willReturn($shippingAmount);
-        $shippingAddressTotal->method('getShippingDescription')->willReturn($shippingDescription);
-        $shippingAddressTotal->method('getSubtotal')->willReturn(100.0);
-        $shippingAddressTotal->method('getBaseSubtotal')->willReturn(100.0);
-        $shippingAddressTotal->method('getSubtotalWithDiscount')->willReturn(100.0);
-        $shippingAddressTotal->method('getBaseSubtotalWithDiscount')->willReturn(100.0);
-        $shippingAddressTotal->method('getGrandTotal')->willReturn(110.0);
-        $shippingAddressTotal->method('getBaseGrandTotal')->willReturn(110.0);
+        // Use real Total instances — Total extends DataObject and all its get/set
+        // methods are magic, which PHPUnit cannot configure via method stubs.
+        $shippingAddressTotal = new Total([
+            'shipping_amount'              => $shippingAmount,
+            'base_shipping_amount'         => $shippingAmount,
+            'shipping_description'         => $shippingDescription,
+            'subtotal'                     => 100.0,
+            'base_subtotal'                => 100.0,
+            'subtotal_with_discount'       => 100.0,
+            'base_subtotal_with_discount'  => 100.0,
+            'grand_total'                  => 110.0,
+            'base_grand_total'             => 110.0,
+        ]);
 
-        $billingAddressTotal = $this->createMock(Total::class);
-        $billingAddressTotal->method('getShippingAmount')->willReturn(0.0);
-        $billingAddressTotal->method('getBaseShippingAmount')->willReturn(0.0);
-        $billingAddressTotal->method('getShippingDescription')->willReturn('');
-        $billingAddressTotal->method('getSubtotal')->willReturn(0.0);
-        $billingAddressTotal->method('getBaseSubtotal')->willReturn(0.0);
-        $billingAddressTotal->method('getSubtotalWithDiscount')->willReturn(0.0);
-        $billingAddressTotal->method('getBaseSubtotalWithDiscount')->willReturn(0.0);
-        $billingAddressTotal->method('getGrandTotal')->willReturn(0.0);
-        $billingAddressTotal->method('getBaseGrandTotal')->willReturn(0.0);
+        $billingAddressTotal = new Total();
 
         $quoteMock = $this->createMock(Quote::class);
         // Billing address comes AFTER shipping address (triggering the bug)
         $quoteMock->method('getAllAddresses')->willReturn([$shippingAddress, $billingAddress]);
-        $quoteMock->method('getGrandTotal')->willReturn(110.0);
-        $quoteMock->method('getBaseGrandTotal')->willReturn(110.0);
         $quoteMock->method('getData')->with('coupon_code')->willReturn(null);
 
-        /** @var Total $aggregateTotal */
-        $aggregateTotal = $this->objectManagerHelper->getObject(Total::class);
-
+        $aggregateTotal = new Total();
         $this->totalFactoryMock->method('create')->willReturn($aggregateTotal);
 
         $this->model->method('collectAddressTotals')

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -25,6 +25,9 @@ use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class TotalsCollectorTest extends TestCase
 {
     /**
@@ -93,7 +96,7 @@ class TotalsCollectorTest extends TestCase
      */
     public function testCollectPreservesShippingAmountWhenBillingAddressComesAfter(): void
     {
-        $shippingAmount     = 10.0;
+        $shippingAmount = 10.0;
         $shippingDescription = 'Flat Rate - Fixed';
 
         $shippingAddress = $this->createMock(Address::class);
@@ -137,15 +140,10 @@ class TotalsCollectorTest extends TestCase
         $this->totalFactoryMock->method('create')->willReturn($aggregateTotal);
 
         $this->model->method('collectAddressTotals')
-            ->willReturnCallback(
-                static function (Quote $quote, Address $address) use (
-                    $shippingAddress,
-                    $shippingAddressTotal,
-                    $billingAddressTotal
-                ): Total {
-                    return $address === $shippingAddress ? $shippingAddressTotal : $billingAddressTotal;
-                }
-            );
+            ->willReturnMap([
+                [$quoteMock, $shippingAddress, $shippingAddressTotal],
+                [$quoteMock, $billingAddress, $billingAddressTotal],
+            ]);
 
         $this->eventManagerMock->method('dispatch');
         $this->quantityCollectorMock->method('collectItemsQtys');
@@ -156,17 +154,17 @@ class TotalsCollectorTest extends TestCase
         $this->assertEquals(
             $shippingAmount,
             $result->getShippingAmount(),
-            'Shipping amount must come from the shipping address and must not be overwritten by the billing address'
+            'Shipping amount must not be overwritten by the billing address'
         );
         $this->assertEquals(
             $shippingAmount,
             $result->getBaseShippingAmount(),
-            'Base shipping amount must come from the shipping address and must not be overwritten by the billing address'
+            'Base shipping amount must not be overwritten by the billing address'
         );
         $this->assertEquals(
             $shippingDescription,
             $result->getShippingDescription(),
-            'Shipping description must come from the shipping address and must not be overwritten by the billing address'
+            'Shipping description must not be overwritten by the billing address'
         );
     }
 }

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -99,17 +99,27 @@ class TotalsCollectorTest extends TestCase
         $shippingAmount = 10.0;
         $shippingDescription = 'Flat Rate - Fixed';
 
-        $shippingAddress = $this->getMockBuilder(Address::class)
-            ->disableOriginalConstructor()
-            ->addMethods(['getAddressType'])
-            ->getMock();
-        $shippingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_SHIPPING);
+        $shippingAddress = new class extends Address {
+            public function __construct()
+            {
+            }
 
-        $billingAddress = $this->getMockBuilder(Address::class)
-            ->disableOriginalConstructor()
-            ->addMethods(['getAddressType'])
-            ->getMock();
-        $billingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_BILLING);
+            public function getAddressType(): string
+            {
+                return self::ADDRESS_TYPE_SHIPPING;
+            }
+        };
+
+        $billingAddress = new class extends Address {
+            public function __construct()
+            {
+            }
+
+            public function getAddressType(): string
+            {
+                return self::ADDRESS_TYPE_BILLING;
+            }
+        };
 
         $shippingAddressTotal = $this->createMock(Total::class);
         $shippingAddressTotal->method('getShippingAmount')->willReturn($shippingAmount);

--- a/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
+++ b/app/code/Magento/Quote/Test/Unit/Model/Quote/TotalsCollectorTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright 2024 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Test\Unit\Model\Quote;
+
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Quote\Model\Quote\Address\Total\Collector;
+use Magento\Quote\Model\Quote\Address\Total\CollectorFactory;
+use Magento\Quote\Model\Quote\Address\TotalFactory;
+use Magento\Quote\Model\Quote\QuantityCollector;
+use Magento\Quote\Model\Quote\TotalsCollector;
+use Magento\Quote\Model\Quote\TotalsCollectorList;
+use Magento\Quote\Model\QuoteValidator;
+use Magento\Quote\Model\ShippingAssignmentFactory;
+use Magento\Quote\Model\ShippingFactory;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TotalsCollectorTest extends TestCase
+{
+    /**
+     * @var TotalsCollector|MockObject
+     */
+    private TotalsCollector $model;
+
+    /**
+     * @var TotalFactory|MockObject
+     */
+    private TotalFactory $totalFactoryMock;
+
+    /**
+     * @var ManagerInterface|MockObject
+     */
+    private ManagerInterface $eventManagerMock;
+
+    /**
+     * @var QuoteValidator|MockObject
+     */
+    private QuoteValidator $quoteValidatorMock;
+
+    /**
+     * @var QuantityCollector|MockObject
+     */
+    private QuantityCollector $quantityCollectorMock;
+
+    /**
+     * @var ObjectManagerHelper
+     */
+    private ObjectManagerHelper $objectManagerHelper;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManagerHelper = new ObjectManagerHelper($this);
+        $this->totalFactoryMock = $this->createMock(TotalFactory::class);
+        $this->eventManagerMock = $this->createMock(ManagerInterface::class);
+        $this->quoteValidatorMock = $this->createMock(QuoteValidator::class);
+        $this->quantityCollectorMock = $this->createMock(QuantityCollector::class);
+
+        $this->model = $this->getMockBuilder(TotalsCollector::class)
+            ->setConstructorArgs([
+                $this->createMock(Collector::class),
+                $this->createMock(CollectorFactory::class),
+                $this->eventManagerMock,
+                $this->createMock(StoreManagerInterface::class),
+                $this->totalFactoryMock,
+                $this->createMock(TotalsCollectorList::class),
+                $this->createMock(ShippingFactory::class),
+                $this->createMock(ShippingAssignmentFactory::class),
+                $this->quoteValidatorMock,
+                $this->quantityCollectorMock,
+            ])
+            ->onlyMethods(['collectAddressTotals'])
+            ->getMock();
+    }
+
+    /**
+     * Verifies that shipping totals from the shipping address are not overwritten
+     * when billing address is collected after the shipping address.
+     *
+     * @see https://github.com/magento/magento2/issues/26209
+     */
+    public function testCollectPreservesShippingAmountWhenBillingAddressComesAfter(): void
+    {
+        $shippingAmount     = 10.0;
+        $shippingDescription = 'Flat Rate - Fixed';
+
+        $shippingAddress = $this->createMock(Address::class);
+        $shippingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_SHIPPING);
+
+        $billingAddress = $this->createMock(Address::class);
+        $billingAddress->method('getAddressType')->willReturn(Address::ADDRESS_TYPE_BILLING);
+
+        $shippingAddressTotal = $this->createMock(Total::class);
+        $shippingAddressTotal->method('getShippingAmount')->willReturn($shippingAmount);
+        $shippingAddressTotal->method('getBaseShippingAmount')->willReturn($shippingAmount);
+        $shippingAddressTotal->method('getShippingDescription')->willReturn($shippingDescription);
+        $shippingAddressTotal->method('getSubtotal')->willReturn(100.0);
+        $shippingAddressTotal->method('getBaseSubtotal')->willReturn(100.0);
+        $shippingAddressTotal->method('getSubtotalWithDiscount')->willReturn(100.0);
+        $shippingAddressTotal->method('getBaseSubtotalWithDiscount')->willReturn(100.0);
+        $shippingAddressTotal->method('getGrandTotal')->willReturn(110.0);
+        $shippingAddressTotal->method('getBaseGrandTotal')->willReturn(110.0);
+
+        $billingAddressTotal = $this->createMock(Total::class);
+        $billingAddressTotal->method('getShippingAmount')->willReturn(0.0);
+        $billingAddressTotal->method('getBaseShippingAmount')->willReturn(0.0);
+        $billingAddressTotal->method('getShippingDescription')->willReturn('');
+        $billingAddressTotal->method('getSubtotal')->willReturn(0.0);
+        $billingAddressTotal->method('getBaseSubtotal')->willReturn(0.0);
+        $billingAddressTotal->method('getSubtotalWithDiscount')->willReturn(0.0);
+        $billingAddressTotal->method('getBaseSubtotalWithDiscount')->willReturn(0.0);
+        $billingAddressTotal->method('getGrandTotal')->willReturn(0.0);
+        $billingAddressTotal->method('getBaseGrandTotal')->willReturn(0.0);
+
+        $quoteMock = $this->createMock(Quote::class);
+        // Billing address comes AFTER shipping address (triggering the bug)
+        $quoteMock->method('getAllAddresses')->willReturn([$shippingAddress, $billingAddress]);
+        $quoteMock->method('getGrandTotal')->willReturn(110.0);
+        $quoteMock->method('getBaseGrandTotal')->willReturn(110.0);
+        $quoteMock->method('getData')->with('coupon_code')->willReturn(null);
+
+        /** @var Total $aggregateTotal */
+        $aggregateTotal = $this->objectManagerHelper->getObject(Total::class);
+
+        $this->totalFactoryMock->method('create')->willReturn($aggregateTotal);
+
+        $this->model->method('collectAddressTotals')
+            ->willReturnCallback(
+                static function (Quote $quote, Address $address) use (
+                    $shippingAddress,
+                    $shippingAddressTotal,
+                    $billingAddressTotal
+                ): Total {
+                    return $address === $shippingAddress ? $shippingAddressTotal : $billingAddressTotal;
+                }
+            );
+
+        $this->eventManagerMock->method('dispatch');
+        $this->quantityCollectorMock->method('collectItemsQtys');
+        $this->quoteValidatorMock->method('validateQuoteAmount');
+
+        $result = $this->model->collect($quoteMock);
+
+        $this->assertEquals(
+            $shippingAmount,
+            $result->getShippingAmount(),
+            'Shipping amount must come from the shipping address and must not be overwritten by the billing address'
+        );
+        $this->assertEquals(
+            $shippingAmount,
+            $result->getBaseShippingAmount(),
+            'Base shipping amount must come from the shipping address and must not be overwritten by the billing address'
+        );
+        $this->assertEquals(
+            $shippingDescription,
+            $result->getShippingDescription(),
+            'Shipping description must come from the shipping address and must not be overwritten by the billing address'
+        );
+    }
+}


### PR DESCRIPTION
## Problem

When `getBillingAddress()` is called on a quote **after** `getShippingAddress()`, PHP adds the billing address as the second element in the internal addresses collection. `TotalsCollector::collect()` iterates every address from `getAllAddresses()` and unconditionally overwrites the aggregate shipping fields with each address's data:

```php
$total->setShippingAmount($addressTotal->getShippingAmount());      // overwrites!
$total->setBaseShippingAmount($addressTotal->getBaseShippingAmount());
$total->setShippingDescription($addressTotal->getShippingDescription());
```

Because a billing address never carries a shipping method, its shipping amount is always `0`. When billing is processed last it zeros out the previously correct shipping amount, causing `$quote->getShippingAmount()` to return `0`.

Fixes #26209

## Solution

Guard the three shipping-specific assignments with an address-type check so they are only applied from non-billing (i.e., shipping) addresses:

```php
if ($address->getAddressType() !== Address::ADDRESS_TYPE_BILLING) {
    $total->setShippingAmount($addressTotal->getShippingAmount());
    $total->setBaseShippingAmount($addressTotal->getBaseShippingAmount());
    $total->setShippingDescription($addressTotal->getShippingDescription());
}
```

Subtotal, discount, and grand-total accumulation are unchanged; only the shipping-specific fields are gated.

## Steps to reproduce (from the issue)

```php
$quote = $quoteFactory->create();
$product = $productRepository->get('simple');
$quote->addProduct($product, 1);

$quote->getShippingAddress()->addData([...]);

$shippingAddress = $quote->getShippingAddress();
$shippingAddress->setCollectShippingRates(true);
$shippingAddress->collectShippingRates();
$shippingAddress->setShippingMethod('flatrate_flatrate');

$quote->getBillingAddress()->addData([...]); // called AFTER getShippingAddress()

$quote->collectTotals();
var_dump($quote->getShippingAmount()); // was int(0), now float(5) ✓
```

## Test coverage

Added `TotalsCollectorTest::testCollectPreservesShippingAmountWhenBillingAddressComesAfter()` which:
- Stubs `collectAddressTotals()` to return controlled totals per address
- Places billing address **after** shipping address in `getAllAddresses()`
- Asserts the aggregate shipping amount, base amount, and description come from the shipping address

## Checklist

- [x] Minimal code change (3 lines wrapped in an if-guard)
- [x] Unit test added covering the regression scenario
- [x] No change to subtotal / grand-total accumulation logic
- [x] Reproduces on `2.4-develop` (reconfirmed April 2026)