### PR TITLE
Return quote base grand total from QuoteAdapter::getGrandTotalAmount() (#33872)

### DIFF
--- a/app/code/Magento/Payment/Gateway/Data/Quote/QuoteAdapter.php
+++ b/app/code/Magento/Payment/Gateway/Data/Quote/QuoteAdapter.php
@@ -11,7 +11,7 @@ use Magento\Quote\Api\Data\CartInterface;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
 
 /**
- * Class QuoteAdapter
+ * Adapts quote data to the payment gateway order data contract.
  */
 class QuoteAdapter implements OrderAdapterInterface
 {

--- a/app/code/Magento/Payment/Gateway/Data/Quote/QuoteAdapter.php
+++ b/app/code/Magento/Payment/Gateway/Data/Quote/QuoteAdapter.php
@@ -122,11 +122,11 @@ class QuoteAdapter implements OrderAdapterInterface
     /**
      * Returns order grand total amount
      *
-     * @return null
+     * @return float
      */
     public function getGrandTotalAmount()
     {
-        return null;
+        return $this->quote->getBaseGrandTotal();
     }
 
     /**

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
@@ -14,7 +14,6 @@ use Magento\Payment\Gateway\Data\Quote\QuoteAdapter;
 use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\Data\CurrencyInterface;
-use Magento\Quote\Model\Quote;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -35,16 +34,16 @@ class QuoteAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->quoteMock = $this->getMockBuilder(Quote::class)
+        $this->quoteMock = $this->getMockBuilder(QuoteAdapterTestQuote::class)
             ->disableOriginalConstructor()
             ->onlyMethods([
+                'getBaseGrandTotal',
                 'getBillingAddress',
                 'getCurrency',
                 'getCustomer',
                 'getReservedOrderId',
                 'getShippingAddress',
             ])
-            ->addMethods(['getBaseGrandTotal'])
             ->getMock();
 
         $this->addressAdapterFactoryMock =

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTest.php
@@ -35,7 +35,17 @@ class QuoteAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->quoteMock = $this->createMock(Quote::class);
+        $this->quoteMock = $this->getMockBuilder(Quote::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getBillingAddress',
+                'getCurrency',
+                'getCustomer',
+                'getReservedOrderId',
+                'getShippingAddress',
+            ])
+            ->addMethods(['getBaseGrandTotal'])
+            ->getMock();
 
         $this->addressAdapterFactoryMock =
             $this->getMockBuilder(AddressAdapterFactory::class)
@@ -63,6 +73,14 @@ class QuoteAdapterTest extends TestCase
         $expected = '1';
         $this->quoteMock->expects($this->once())->method('getReservedOrderId')->willReturn($expected);
         $this->assertEquals($expected, $this->model->getOrderIncrementId());
+    }
+
+    public function testGetGrandTotalAmount()
+    {
+        $expected = 100.50;
+        $this->quoteMock->expects($this->once())->method('getBaseGrandTotal')->willReturn($expected);
+
+        $this->assertEquals($expected, $this->model->getGrandTotalAmount());
     }
 
     public function testGetCustomerId()

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTestQuote.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTestQuote.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2015 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
@@ -9,8 +9,16 @@ namespace Magento\Payment\Test\Unit\Gateway\Data\Quote;
 
 use Magento\Quote\Model\Quote;
 
+/**
+ * Quote double declaring the magic getter mocked by QuoteAdapterTest.
+ */
 class QuoteAdapterTestQuote extends Quote
 {
+    /**
+     * Return the base grand total; overridden in test mocks.
+     *
+     * @return float|null
+     */
     public function getBaseGrandTotal()
     {
         return null;

--- a/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTestQuote.php
+++ b/app/code/Magento/Payment/Test/Unit/Gateway/Data/Quote/QuoteAdapterTestQuote.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright 2015 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Payment\Test\Unit\Gateway\Data\Quote;
+
+use Magento\Quote\Model\Quote;
+
+class QuoteAdapterTestQuote extends Quote
+{
+    public function getBaseGrandTotal()
+    {
+        return null;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Payment/Gateway/Data/Quote/QuoteAdapterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Gateway/Data/Quote/QuoteAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2025 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);

--- a/dev/tests/integration/testsuite/Magento/Payment/Gateway/Data/Quote/QuoteAdapterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Payment/Gateway/Data/Quote/QuoteAdapterTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Payment\Gateway\Data\Quote;
+
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Test\Fixture\AddProductToCart as AddProductToCartFixture;
+use Magento\Quote\Test\Fixture\GuestCart as GuestCartFixture;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+class QuoteAdapterTest extends TestCase
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->fixtures = $this->objectManager->get(DataFixtureStorageManager::class)->getStorage();
+    }
+
+    #[
+        DataFixture(ProductFixture::class, ['price' => 10], 'product'),
+        DataFixture(GuestCartFixture::class, as: 'cart'),
+        DataFixture(
+            AddProductToCartFixture::class,
+            ['cart_id' => '$cart.id$', 'product_id' => '$product.id$', 'qty' => 2]
+        ),
+    ]
+    public function testGetGrandTotalAmountReturnsQuoteBaseGrandTotal(): void
+    {
+        $cartId = (int)$this->fixtures->get('cart')->getId();
+        $quote = $this->objectManager->get(CartRepositoryInterface::class)->get($cartId);
+        $quote->collectTotals();
+
+        $adapter = $this->objectManager->create(QuoteAdapter::class, ['quote' => $quote]);
+
+        $grandTotalAmount = $adapter->getGrandTotalAmount();
+
+        $this->assertNotNull($grandTotalAmount);
+        $this->assertGreaterThan(0, $grandTotalAmount);
+        $this->assertEquals($quote->getBaseGrandTotal(), $grandTotalAmount);
+    }
+
+    /**
+     * In a multi-currency store the amount and the currency code exposed to payment gateways must be a
+     * consistent base-currency pair, mirroring OrderAdapter. The base grand total (not the display grand
+     * total) must be returned so the amount never gets paired with a mismatching currency code.
+     */
+    #[
+        DataFixture(ProductFixture::class, ['price' => 10], 'product'),
+        DataFixture(GuestCartFixture::class, as: 'cart'),
+        DataFixture(
+            AddProductToCartFixture::class,
+            ['cart_id' => '$cart.id$', 'product_id' => '$product.id$', 'qty' => 2]
+        ),
+    ]
+    public function testGetGrandTotalAmountReturnsBaseAmountInMultiCurrencyStore(): void
+    {
+        $rate = 1.5;
+        $cartId = (int)$this->fixtures->get('cart')->getId();
+        $quote = $this->objectManager->get(CartRepositoryInterface::class)->get($cartId);
+
+        // Collect the real base totals (base currency), then overlay a distinct display currency.
+        $quote->collectTotals();
+        $baseGrandTotal = (float)$quote->getBaseGrandTotal();
+        $quote->setQuoteCurrencyCode('EUR');
+        $quote->setBaseToQuoteRate($rate);
+        $quote->setGrandTotal($baseGrandTotal * $rate);
+
+        // Sanity check: the quote is now genuinely multi-currency.
+        $this->assertNotEquals(
+            $quote->getBaseCurrencyCode(),
+            $quote->getQuoteCurrencyCode(),
+            'Test setup must produce a quote whose display currency differs from the base currency.'
+        );
+        $this->assertNotEquals(
+            $baseGrandTotal,
+            (float)$quote->getGrandTotal(),
+            'Test setup must produce differing base and display grand totals.'
+        );
+
+        $adapter = $this->objectManager->create(QuoteAdapter::class, ['quote' => $quote]);
+
+        // Amount is the base grand total, not the display grand total.
+        $this->assertEquals($baseGrandTotal, $adapter->getGrandTotalAmount());
+        $this->assertNotEquals((float)$quote->getGrandTotal(), (float)$adapter->getGrandTotalAmount());
+
+        // Currency code is the base currency, so amount and currency stay a consistent pair.
+        $this->assertEquals($quote->getBaseCurrencyCode(), $adapter->getCurrencyCode());
+    }
+}


### PR DESCRIPTION
## Description

`Magento\Payment\Gateway\Data\Quote\QuoteAdapter::getGrandTotalAmount()` is an unimplemented stub that always returns `null`:

```php
public function getGrandTotalAmount()
{
    return null;
}
```

Its sibling `Magento\Payment\Gateway\Data\Order\OrderAdapter::getGrandTotalAmount()` correctly returns `$this->order->getBaseGrandTotal()`. Both classes implement the same `OrderAdapterInterface`, so payment gateways that read the grand total from a quote-backed payment data object (e.g. during pre-order authorization) receive `null` instead of the actual amount.

This change implements the method to mirror `OrderAdapter`, returning the quote's base grand total.

## Fixed Issues

Fixes #33872

## Manual testing scenarios

1. Obtain a `QuoteAdapter` for a quote with a non-zero base grand total (e.g. via `Magento\Payment\Gateway\Data\Quote\QuoteAdapterFactory`).
2. Call `getGrandTotalAmount()`.
3. **Before:** `null` is returned regardless of the quote total.
4. **After:** the quote's base grand total is returned, consistent with `OrderAdapter::getGrandTotalAmount()`.

## Questions or comments

Minimal change mirroring the existing `OrderAdapter` implementation. No return type hint was added to the signature to preserve the `OrderAdapterInterface` contract and backward compatibility.

## Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests (`Test/Unit/.../Quote/QuoteAdapterTest`)
- [x] All new or changed code is covered with integration tests (`integration/.../Payment/Gateway/Data/Quote/QuoteAdapterTest`)
- [x] All automated tests passed successfully (unit, integration, PHPCS Magento2, PHPStan level 1)
