### PR TITLE
Fix hanging indexers when use_application_lock is combined with file lock provider (#40887)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Lock/Backend/FileLockTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Lock/Backend/FileLockTest.php
@@ -43,10 +43,13 @@ class FileLockTest extends \PHPUnit\Framework\TestCase
 
         $this->assertTrue($this->model->lock($name));
         $this->assertTrue($this->model->isLocked($name));
-        $this->assertFalse($this->model->lock($name, 2));
+        $this->assertTrue($this->model->lock($name, 2));
 
         $this->assertTrue($this->model->unlock($name));
         $this->assertFalse($this->model->isLocked($name));
+
+        $this->assertTrue($this->model->lock($name));
+        $this->assertTrue($this->model->unlock($name));
     }
 
     public function testUnlockWithoutExistingLock()

--- a/lib/internal/Magento/Framework/Lock/Backend/FileLock.php
+++ b/lib/internal/Magento/Framework/Lock/Backend/FileLock.php
@@ -85,6 +85,10 @@ class FileLock implements LockManagerInterface
     {
         try {
             $lockFile = $this->getLockPath($name);
+            if (isset($this->locks[$lockFile])) {
+                return true;
+            }
+
             $fileResource = $this->fileDriver->fileOpen($lockFile, 'w+');
             $skipDeadline = $timeout < 0;
             $deadline = microtime(true) + $timeout;

--- a/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/FileLockTest.php
+++ b/lib/internal/Magento/Framework/Lock/Test/Unit/Backend/FileLockTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Lock\Test\Unit\Backend;
+
+use Magento\Framework\Filesystem\Driver\File as FileDriver;
+use Magento\Framework\Lock\Backend\FileLock;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class FileLockTest extends TestCase
+{
+    /**
+     * @var FileDriver|MockObject
+     */
+    private $fileDriverMock;
+
+    /**
+     * @var FileLock
+     */
+    private $fileLock;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->fileDriverMock = $this->createMock(FileDriver::class);
+        $this->fileDriverMock->method('isExists')
+            ->with('/locks/')
+            ->willReturn(true);
+
+        $this->fileLock = new FileLock($this->fileDriverMock, '/locks');
+    }
+
+    /**
+     * Verify that locking an already-held lock in the same process succeeds.
+     *
+     * @return void
+     */
+    public function testLockIsReentrantForSameProcess(): void
+    {
+        $fileResource = fopen('php://memory', 'w+');
+
+        $this->fileDriverMock->expects($this->once())
+            ->method('fileOpen')
+            ->with('/locks/test_lock', 'w+')
+            ->willReturn($fileResource);
+        $this->fileDriverMock->expects($this->exactly(2))
+            ->method('fileLock')
+            ->willReturnMap([
+                [$fileResource, LOCK_EX | LOCK_NB, true],
+                [$fileResource, LOCK_UN | LOCK_NB, true],
+            ]);
+
+        $this->assertTrue($this->fileLock->lock('test_lock'));
+        $this->assertTrue($this->fileLock->lock('test_lock'));
+        $this->assertTrue($this->fileLock->unlock('test_lock'));
+    }
+}


### PR DESCRIPTION
### Description (*)

With `indexer/use_application_lock = true` and the `file` lock provider configured in `app/etc/env.php`, `bin/magento indexer:reindex` hangs forever.

**Root cause:** `\Magento\Indexer\Model\Indexer\State::setStatus()` acquires the application lock every time the status is set to `working`. Since AC-15270 (2.4.9), `\Magento\Indexer\Model\Indexer::reindexAll()` sets the `working` status **twice** in the same process — once before `executeFull()` and once after (to re-acquire a database lock potentially lost through connection close during multi-process reindex).

The database lock backend (`GET_LOCK`) is reentrant within a session, so the second acquisition succeeds there. `\Magento\Framework\Lock\Backend\FileLock::lock()` is **not** reentrant: it opens a *new* file handle on the same lock file, and `flock()` on a second handle can never succeed while the process already holds the lock on the first handle. With the default infinite timeout (`-1`), the retry loop spins forever.

**Fix:** `FileLock::lock()` now returns `true` immediately when the current process already holds the lock (tracked in `$this->locks`), matching the reentrant behavior of the database backend. `unlock()` already removes the entry, so release semantics are unchanged.

Note: one existing integration assertion (`FileLockTest::testLockAndUnlock`) asserted `lock($name, 2)` returns `false` when the same process re-locks the same name — that assertion documented the non-reentrant behavior and was updated to the new semantics.

### Related Pull Requests

<!-- none -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40887

### Manual testing scenarios (*)

1. Install a fresh Magento with `2.4-develop`
2. Add to `app/etc/env.php`:
   ```php
   'indexer' => ['use_application_lock' => true],
   'lock' => ['provider' => 'file', 'config' => ['path' => 'var/locks']],
   ```
3. Run `bin/magento indexer:reindex`
4. Before the fix: the command hangs forever on the first indexer. After the fix: all indexers complete.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
