### PR TITLE
Fix S3 export failure caused by directory creation for bare filenames in openFile (#40296)

### DIFF
--- a/app/code/Magento/AwsS3/Driver/AwsS3.php
+++ b/app/code/Magento/AwsS3/Driver/AwsS3.php
@@ -167,7 +167,8 @@ class AwsS3 implements RemoteDriverInterface
      */
     public function createDirectory($path, $permissions = 0777): bool
     {
-        if ($path === '/') {
+        $path = $this->normalizeRelativePath($path);
+        if ($path === '/' || $path === '.' || $path === '') {
             return true;
         }
 

--- a/app/code/Magento/AwsS3/Test/Unit/Driver/AwsS3Test.php
+++ b/app/code/Magento/AwsS3/Test/Unit/Driver/AwsS3Test.php
@@ -512,6 +512,14 @@ class AwsS3Test extends TestCase
         self::assertFalse($this->driver->createDirectory(self::URL . 'test/test2/'));
     }
 
+    public function testCreateDirectoryWithCurrentDirectoryReturnsTrueWithoutAdapterCall(): void
+    {
+        $this->adapterMock->expects(self::never())
+            ->method('createDirectory');
+
+        self::assertTrue($this->driver->createDirectory('.'));
+    }
+
     /**
      * Verify that createDirectory resolves '.' path components when parent exists.
      */

--- a/lib/internal/Magento/Framework/Filesystem/Directory/Write.php
+++ b/lib/internal/Magento/Framework/Filesystem/Directory/Write.php
@@ -341,7 +341,9 @@ class Write extends Read implements WriteInterface
             throw new FileSystemException(new Phrase('Invalid file path: path cannot be null or empty'));
         }
         $folder = dirname($path);
-        $this->create($folder);
+        // dirname() returns '.' for bare filenames; create the directory root itself in that case
+        // instead of appending a '/.' segment, which remote storage drivers cannot handle
+        $this->create($folder === '.' || $folder === '' ? null : $folder);
         $this->assertWritable($this->isExist($path) ? $path : $folder);
         $absolutePath = $this->driver->getAbsolutePath($this->path, $path);
 

--- a/lib/internal/Magento/Framework/Filesystem/Test/Unit/Directory/WriteTest.php
+++ b/lib/internal/Magento/Framework/Filesystem/Test/Unit/Directory/WriteTest.php
@@ -135,6 +135,51 @@ class WriteTest extends TestCase
         $this->write->openFile($targetPath);
     }
 
+    public function testOpenFileWithBareFileNameCreatesDirectoryRoot()
+    {
+        $path = 'barefile.csv';
+        $absolutePath = $this->getAbsolutePath($path);
+        $absoluteCurrentDirectory = $this->getAbsolutePath('.');
+        $write = $this->getMockBuilder(Write::class)
+            ->setConstructorArgs([
+                $this->fileFactory,
+                $this->driver,
+                $this->path,
+                0555
+            ])
+            ->onlyMethods(['create'])
+            ->getMock();
+
+        $write->expects($this->once())
+            ->method('create')
+            ->with(null)
+            ->willReturn(true);
+        $this->driver->expects($this->any())
+            ->method('getAbsolutePath')
+            ->willReturnMap([
+                [$this->path, $path, null, $absolutePath],
+                [$this->path, '.', null, $absoluteCurrentDirectory],
+            ]);
+        $this->driver->expects($this->once())
+            ->method('getRealPathSafety')
+            ->with($absolutePath)
+            ->willReturn($absolutePath);
+        $this->driver->expects($this->once())
+            ->method('isExists')
+            ->with($absolutePath)
+            ->willReturn(false);
+        $this->driver->expects($this->once())
+            ->method('isWritable')
+            ->with($absoluteCurrentDirectory)
+            ->willReturn(true);
+        $this->fileFactory->expects($this->once())
+            ->method('create')
+            ->with($absolutePath, $this->driver, 'w')
+            ->willReturn($this->createMock(\Magento\Framework\Filesystem\File\WriteInterface::class));
+
+        $write->openFile($path);
+    }
+
     /**
      * Assert is file expectation
      *
@@ -233,9 +278,9 @@ class WriteTest extends TestCase
             WriteInterface::class,
             [
                 // ReadInterface methods
-                'getAbsolutePath', 'getRelativePath', 'read', 'readFile', 'isExist', 
+                'getAbsolutePath', 'getRelativePath', 'read', 'readFile', 'isExist',
                 'isDirectory', 'isFile', 'isReadable', 'search', 'stat',
-                // WriteInterface methods  
+                // WriteInterface methods
                 'create', 'delete', 'renameFile', 'copyFile', 'createSymlink',
                 'changePermissions', 'changePermissionsRecursively', 'touch',
                 'isWritable', 'openFile', 'writeFile', 'getDriver',


### PR DESCRIPTION
### Description (*)

With `remote_storage` configured for AWS S3, running an entity export (`bin/magento queue:consumers:start exportProcessor`) fails:

```
Unable to write file at location: import_export/./.
Error executing "PutObject" on "https://<bucket>.amazonaws.com/import_export/./" ... 403 Forbidden
```

**Root cause:** `\Magento\ImportExport\Model\Export\Adapter\Csv::_init()` opens its temporary file with a bare relative filename (`importexport_<hash>`). `\Magento\Framework\Filesystem\Directory\Write::openFile()` derives the parent folder via `dirname($path)`, which returns `'.'` for bare filenames, and unconditionally calls `$this->create('.')`. That resolves to an absolute path ending in `/.` — on the local filesystem driver this is harmless, but on the AwsS3 driver it results in `PutObject` with the malformed key `import_export/./`, which S3 rejects.

**Fix:**
- `Write::openFile()` now passes `null` to `create()` when `dirname()` yields `'.'`/`''`, so the directory root itself is (lazily) created with a clean path — preserving the existing behavior where opening a file in a not-yet-existing directory root creates that root.
- `\Magento\AwsS3\Driver\AwsS3::createDirectory()` additionally treats `'.'` and an empty normalized path like the root path (no adapter call), as a second layer of defense for direct driver calls.

### Related Pull Requests

<!-- none -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40296

### Manual testing scenarios (*)

1. Configure `remote_storage` with the `aws-s3` driver in `app/etc/env.php`
2. In admin, go to System → Data Transfer → Export, select Products / CSV and submit
3. Run `bin/magento queue:consumers:start exportProcessor --max-messages=1`
4. Before the fix: `Unable to write file at location: import_export/./` (PutObject 403). After the fix: the export file is written to the bucket under `import_export/`.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
