### PR TITLE
Fix toolbar count and pagination including grouped products without website-assigned children (#40873)

### DIFF
--- a/app/code/Magento/GroupedProduct/Plugin/CatalogSearch/Model/Indexer/Fulltext/Action/GetSearchableProductsSelect.php
+++ b/app/code/Magento/GroupedProduct/Plugin/CatalogSearch/Model/Indexer/Fulltext/Action/GetSearchableProductsSelect.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\GroupedProduct\Plugin\CatalogSearch\Model\Indexer\Fulltext\Action;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\CatalogSearch\Model\Indexer\Fulltext\Action\GetSearchableProductsSelect as SearchableProductsSelect;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Select;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\GroupedProduct\Model\Product\Type\Grouped;
+use Magento\GroupedProduct\Model\ResourceModel\Product\Link;
+use Magento\Store\Model\StoreManagerInterface;
+
+class GetSearchableProductsSelect
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resource;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var MetadataPool
+     */
+    private $metadataPool;
+
+    /**
+     * @param ResourceConnection $resource
+     * @param StoreManagerInterface $storeManager
+     * @param MetadataPool $metadataPool
+     */
+    public function __construct(
+        ResourceConnection $resource,
+        StoreManagerInterface $storeManager,
+        MetadataPool $metadataPool
+    ) {
+        $this->resource = $resource;
+        $this->storeManager = $storeManager;
+        $this->metadataPool = $metadataPool;
+    }
+
+    /**
+     * Exclude grouped products without website-assigned children from the store fulltext index.
+     *
+     * @param SearchableProductsSelect $subject
+     * @param Select $select
+     * @param int $storeId
+     * @return Select
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     * @throws \Exception
+     */
+    public function afterExecute(
+        SearchableProductsSelect $subject,
+        Select $select,
+        int $storeId
+    ): Select {
+        $connection = $this->resource->getConnection();
+        $websiteId = (int) $this->storeManager->getStore($storeId)->getWebsiteId();
+        $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
+        $childExistsSelect = $connection->select()
+            ->from(['grouped_link' => $this->resource->getTableName('catalog_product_link')], new \Zend_Db_Expr('1'))
+            ->join(
+                ['grouped_child_website' => $this->resource->getTableName('catalog_product_website')],
+                'grouped_child_website.product_id = grouped_link.linked_product_id',
+                []
+            )
+            ->where('grouped_link.product_id = e.' . $linkField)
+            ->where('grouped_link.link_type_id = ?', Link::LINK_TYPE_GROUPED)
+            ->where('grouped_child_website.website_id = ?', $websiteId)
+            ->limit(1);
+
+        $select->where(
+            sprintf(
+                'e.type_id != %s OR EXISTS (%s)',
+                $connection->quote(Grouped::TYPE_CODE),
+                $childExistsSelect
+            )
+        );
+
+        return $select;
+    }
+}

--- a/app/code/Magento/GroupedProduct/composer.json
+++ b/app/code/Magento/GroupedProduct/composer.json
@@ -22,6 +22,7 @@
         "magento/module-wishlist": "*"
     },
     "suggest": {
+        "magento/module-catalog-search": "*",
         "magento/module-grouped-product-sample-data": "*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/GroupedProduct/etc/di.xml
+++ b/app/code/Magento/GroupedProduct/etc/di.xml
@@ -39,6 +39,9 @@
     <type name="Magento\Catalog\Model\Product\Type">
         <plugin name="grouped_output" type="Magento\GroupedProduct\Model\Product\Type\Plugin" />
     </type>
+    <type name="Magento\CatalogSearch\Model\Indexer\Fulltext\Action\GetSearchableProductsSelect">
+        <plugin name="grouped_product_has_website_child" type="Magento\GroupedProduct\Plugin\CatalogSearch\Model\Indexer\Fulltext\Action\GetSearchableProductsSelect"/>
+    </type>
     <type name="Magento\Catalog\Model\Product\CartConfiguration">
         <plugin name="isProductConfigured" type="Magento\GroupedProduct\Model\Product\Cart\Configuration\Plugin\Grouped" />
     </type>

--- a/dev/tests/integration/testsuite/Magento/GroupedProduct/Model/Indexer/Fulltext/GroupedProductWebsiteChildrenTest.php
+++ b/dev/tests/integration/testsuite/Magento/GroupedProduct/Model/Indexer/Fulltext/GroupedProductWebsiteChildrenTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\GroupedProduct\Model\Indexer\Fulltext;
+
+use Magento\Catalog\Test\Fixture\Category as CategoryFixture;
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\CatalogSearch\Model\Indexer\Fulltext;
+use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection;
+use Magento\Framework\Indexer\IndexerRegistry;
+use Magento\GroupedProduct\Test\Fixture\Product as GroupedProductFixture;
+use Magento\Store\Model\Store;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\AppIsolation;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class GroupedProductWebsiteChildrenTest extends TestCase
+{
+    #[
+        AppArea('frontend'),
+        AppIsolation(true),
+        DbIsolation(false),
+        DataFixture(CategoryFixture::class, ['name' => 'Grouped Fulltext Category'], 'category'),
+        DataFixture(
+            ProductFixture::class,
+            ['sku' => 'grouped-fulltext-orphan-child', 'website_ids' => [], 'category_ids' => ['$category.id$']],
+            'orphan_child'
+        ),
+        DataFixture(
+            ProductFixture::class,
+            ['sku' => 'grouped-fulltext-valid-child', 'category_ids' => ['$category.id$']],
+            'valid_child'
+        ),
+        DataFixture(
+            ProductFixture::class,
+            ['sku' => 'grouped-fulltext-simple-1', 'category_ids' => ['$category.id$']],
+            'simple_1'
+        ),
+        DataFixture(
+            ProductFixture::class,
+            ['sku' => 'grouped-fulltext-simple-2', 'category_ids' => ['$category.id$']],
+            'simple_2'
+        ),
+        DataFixture(
+            GroupedProductFixture::class,
+            [
+                'sku' => 'grouped-fulltext-invalid-1',
+                'category_ids' => ['$category.id$'],
+                'product_links' => ['$orphan_child$']
+            ],
+            'invalid_grouped_1'
+        ),
+        DataFixture(
+            GroupedProductFixture::class,
+            [
+                'sku' => 'grouped-fulltext-invalid-2',
+                'category_ids' => ['$category.id$'],
+                'product_links' => ['$orphan_child$']
+            ],
+            'invalid_grouped_2'
+        ),
+        DataFixture(
+            GroupedProductFixture::class,
+            [
+                'sku' => 'grouped-fulltext-valid',
+                'category_ids' => ['$category.id$'],
+                'product_links' => ['$valid_child$']
+            ],
+            'valid_grouped'
+        )
+    ]
+    public function testGroupedProductsWithoutWebsiteAssignedChildrenAreExcludedFromFulltextSize(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $objectManager->get(IndexerRegistry::class)->get(Fulltext::INDEXER_ID)->reindexAll();
+
+        $collection = $objectManager->create(
+            Collection::class,
+            ['searchRequestName' => 'catalog_view_container']
+        );
+        $collection->setStoreId(Store::DISTRO_STORE_ID);
+        $collection->addFieldToFilter(
+            'category_ids',
+            DataFixtureStorageManager::getStorage()->get('category')->getId()
+        );
+
+        $this->assertSame(4, $collection->getSize());
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/GroupedProduct/Model/Indexer/Fulltext/GroupedProductWebsiteChildrenTest.php
+++ b/dev/tests/integration/testsuite/Magento/GroupedProduct/Model/Indexer/Fulltext/GroupedProductWebsiteChildrenTest.php
@@ -13,7 +13,6 @@ use Magento\CatalogSearch\Model\Indexer\Fulltext;
 use Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection;
 use Magento\Framework\Indexer\IndexerRegistry;
 use Magento\GroupedProduct\Test\Fixture\Product as GroupedProductFixture;
-use Magento\Store\Model\Store;
 use Magento\TestFramework\Fixture\AppArea;
 use Magento\TestFramework\Fixture\AppIsolation;
 use Magento\TestFramework\Fixture\DataFixture;
@@ -86,7 +85,7 @@ class GroupedProductWebsiteChildrenTest extends TestCase
             Collection::class,
             ['searchRequestName' => 'catalog_view_container']
         );
-        $collection->setStoreId(Store::DISTRO_STORE_ID);
+        $collection->setStoreId(1);
         $collection->addFieldToFilter(
             'category_ids',
             DataFixtureStorageManager::getStorage()->get('category')->getId()


### PR DESCRIPTION
### Description (*)

When a grouped product's associated simple products are all **not** assigned to the current website, the grouped product is correctly excluded from the category product listing — but it is still included in the toolbar total and pagination, producing counts like "Items 1-4 of 6" when only 2 products render, and empty pages.

**Root cause:** The toolbar/pagination total comes from the search engine hit count (`CatalogSearch` fulltext collection `getSize()`), while the rendered items come from the SQL load, which INNER JOINs `catalog_product_index_price` (`Collection::_productLimitationPrice()`). A grouped product with no children assigned to the website has **no price index row** for that website (grouped price rows are derived from children), so SQL drops it — but the fulltext indexer still indexed the grouped product for that store, so the engine count includes it. Engine count ≠ SQL row count.

**Fix:** A `GroupedProduct`-scoped plugin on `\Magento\CatalogSearch\Model\Indexer\Fulltext\Action\GetSearchableProductsSelect` filters grouped products out of the searchable-products select unless at least one associated child is assigned to the store's website — mirroring the existing price index behavior. Configurable products already have equivalent store-scoped child handling; grouped products had no such exclusion.

The new integration test asserts collection size 4 (2 simples + 1 valid grouped + its child): without the fix it fails with `6` (the two childless-on-website grouped products are counted), with the fix it passes.

### Related Pull Requests

<!-- none -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40873

### Manual testing scenarios (*)

1. Create simple product A and remove it from all websites; create 4 grouped products containing only A
2. Create simples B and C assigned to the website; assign all 6 products to a category
3. Set "Products per Page on Grid Allowed Values" to include 4; position B on page 1, C on page 2
4. Reindex + flush cache, open the category with 4 products per page
5. Before the fix: toolbar shows 6 items / 2 pages with gaps. After the fix: toolbar shows 2 items and pagination matches rendered products.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
