### PR TITLE
use constant-time comparison for custom option download secret_key

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Option/Type/File/ValidatorInfo.php
+++ b/app/code/Magento/Catalog/Model/Product/Option/Type/File/ValidatorInfo.php
@@ -8,6 +8,7 @@ namespace Magento\Catalog\Model\Product\Option\Type\File;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Encryption\Helper\Security;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\File\Size;
@@ -137,7 +138,10 @@ class ValidatorInfo extends Validator
         if ($this->validatePath($optionValue) && $validatorChain->isValid($this->fileFullPath, $optionValue['title'])) {
             return $this->rootDirectory->isReadable($this->fileRelativePath)
                 && isset($optionValue['secret_key'])
-                && $this->buildSecretKey($this->fileRelativePath) == $optionValue['secret_key'];
+                && Security::compareStrings(
+                    $this->buildSecretKey($this->fileRelativePath),
+                    (string)$optionValue['secret_key']
+                );
         } else {
             $errors = $this->getValidatorErrors($validatorChain->getErrors(), $optionValue, $option);
             if (count($errors) > 0) {

--- a/app/code/Magento/Sales/Controller/Download/DownloadCustomOption.php
+++ b/app/code/Magento/Sales/Controller/Download/DownloadCustomOption.php
@@ -12,6 +12,7 @@ use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\Action\Context;
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Framework\Controller\Result\ForwardFactory;
+use Magento\Framework\Encryption\Helper\Security;
 
 class DownloadCustomOption extends \Magento\Framework\App\Action\Action implements HttpGetActionInterface
 {
@@ -104,7 +105,8 @@ class DownloadCustomOption extends \Magento\Framework\App\Action\Action implemen
 
         try {
             $info = $this->serializer->unserialize($option->getValue());
-            if ($this->getRequest()->getParam('key') != $info['secret_key']) {
+            $secretKey = (string)$this->getRequest()->getParam('key');
+            if (!Security::compareStrings((string)($info['secret_key'] ?? ''), $secretKey)) {
                 return $resultForward->forward('noroute');
             }
             return $this->download->createResponse($info);

--- a/app/code/Magento/Wishlist/Controller/Index/DownloadCustomOption.php
+++ b/app/code/Magento/Wishlist/Controller/Index/DownloadCustomOption.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Encryption\Helper\Security;
 use Magento\Framework\Serialize\Serializer\Json;
 
 /**
@@ -96,7 +97,7 @@ class DownloadCustomOption extends \Magento\Wishlist\Controller\AbstractIndex im
             $info = $this->json->unserialize($option->getValue());
             $secretKey = $this->getRequest()->getParam('key');
 
-            if ($secretKey == $info['secret_key']) {
+            if (Security::compareStrings((string)($info['secret_key'] ?? ''), (string)$secretKey)) {
                 return $this->_fileResponseFactory->create(
                     $info['title'],
                     ['value' => $info['quote_path'], 'type' => 'filename'],


### PR DESCRIPTION
### Description (*)

The storefront file-download gates for custom options compare the attacker-supplied `key` query parameter against the stored per-file `secret_key` using a loose, non-constant-time `==`/`!=`. Since `secret_key` is `substr(hash('sha256', <file bytes>), 0, 20)`, a value that happens to be numeric-form type-juggles so a crafted `key` matches, and the byte-by-byte comparison also leaks the token through timing, which lets someone pull another shopper's uploaded file. This swaps the three comparisons (the Sales and Wishlist download controllers, plus the file-option validator) to `Magento\Framework\Encryption\Helper\Security::compareStrings`, matching how the rest of the codebase already compares secrets. Behavior for a correct key is unchanged.

### Related Pull Requests

N/A

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios (*)

1. Add a product that has a "File" custom option to the cart and upload a file.
2. Open the option download link `sales/download/downloadCustomOption/id/<optionId>/key/<secret_key>` with the correct key and confirm the file downloads; with a wrong key confirm it forwards to `noroute`. Repeat for the wishlist link `wishlist/index/downloadCustomOption`.
3. For a file whose 20-char `secret_key` is an all-numeric substring, request the link with a numerically-equal but textually different `key` (for example dropping a leading zero). Before the change the file downloaded; after it forwards to `noroute`.

### Questions or comments

The Sales controller unit test already covers the correct-key and wrong-key paths and still passes with `compareStrings`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#40956: use constant-time comparison for custom option download secret_key