### PR TITLE
Zero grace period on uncacheable Varnish pass objects (#40641)

### DIFF
--- a/app/code/Magento/PageCache/etc/varnish4.vcl
+++ b/app/code/Magento/PageCache/etc/varnish4.vcl
@@ -161,9 +161,11 @@ sub vcl_backend_response {
     if (beresp.status != 200 && beresp.status != 404) {
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
         return (deliver);
     } elsif (beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
         set beresp.ttl = 86400s;
         return (deliver);
     }
@@ -181,6 +183,7 @@ sub vcl_backend_response {
          && beresp.http.set-cookie ~ "X-Magento-Vary=") {
            set beresp.ttl = 0s;
            set beresp.uncacheable = true;
+           set beresp.grace = 0s;
         }
         unset beresp.http.set-cookie;
     }
@@ -194,12 +197,14 @@ sub vcl_backend_response {
         # Mark as Hit-For-Pass for the next 2 minutes
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
     if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish5.vcl
+++ b/app/code/Magento/PageCache/etc/varnish5.vcl
@@ -161,6 +161,7 @@ sub vcl_backend_response {
     # cache only successfully responses and 404s that are not marked as private
     if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
         set beresp.ttl = 86400s;
         return (deliver);
     }
@@ -178,6 +179,7 @@ sub vcl_backend_response {
          && beresp.http.set-cookie ~ "X-Magento-Vary=") {
            set beresp.ttl = 0s;
            set beresp.uncacheable = true;
+           set beresp.grace = 0s;
         }
         unset beresp.http.set-cookie;
     }
@@ -191,12 +193,14 @@ sub vcl_backend_response {
         # Mark as Hit-For-Pass for the next 2 minutes
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
     if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish6.vcl
+++ b/app/code/Magento/PageCache/etc/varnish6.vcl
@@ -165,6 +165,7 @@ sub vcl_backend_response {
     # cache only successfully responses and 404s that are not marked as private
     if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
         set beresp.ttl = 86400s;
         return (deliver);
     }
@@ -182,6 +183,7 @@ sub vcl_backend_response {
          && beresp.http.set-cookie ~ "X-Magento-Vary=") {
            set beresp.ttl = 0s;
            set beresp.uncacheable = true;
+           set beresp.grace = 0s;
         }
         unset beresp.http.set-cookie;
     }
@@ -195,12 +197,14 @@ sub vcl_backend_response {
         # Mark as Hit-For-Pass for the next 2 minutes
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
     if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     return (deliver);

--- a/app/code/Magento/PageCache/etc/varnish7.vcl
+++ b/app/code/Magento/PageCache/etc/varnish7.vcl
@@ -165,6 +165,7 @@ sub vcl_backend_response {
     # cache only successfully responses and 404s that are not marked as private
     if ((beresp.status != 200 && beresp.status != 404) || beresp.http.Cache-Control ~ "private") {
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
         set beresp.ttl = 86400s;
         return (deliver);
     }
@@ -182,6 +183,7 @@ sub vcl_backend_response {
          && beresp.http.set-cookie ~ "X-Magento-Vary=") {
            set beresp.ttl = 0s;
            set beresp.uncacheable = true;
+           set beresp.grace = 0s;
         }
         unset beresp.http.set-cookie;
     }
@@ -195,12 +197,14 @@ sub vcl_backend_response {
         # Mark as Hit-For-Pass for the next 2 minutes
         set beresp.ttl = 120s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
     if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
         set beresp.ttl = 0s;
         set beresp.uncacheable = true;
+        set beresp.grace = 0s;
     }
 
     return (deliver);


### PR DESCRIPTION
### Description

`vcl_backend_response` sets `beresp.grace = 3d` unconditionally at the top of
the subroutine. Grace period exists to let Varnish serve a stale-but-cached
object while revalidating in the background — it only has meaning for
**cacheable** objects.

Every branch that later sets `beresp.uncacheable = true` (private responses,
non-200/404 responses, X-Magento-Vary cookie mismatch, hit-for-pass, GraphQL
cache-id mismatch) still inherits that 3-day grace. Uncacheable objects are
stored as "pass"/"hit-for-pass" objects in Varnish's Transient storage, and
their retention time is `ttl + grace + keep` — not just `ttl`. With grace
stuck at 3 days, every no-cache response pins a Transient allocation for
~3 days regardless of its intended `ttl`.

On sites with an effectively unbounded no-cache URL space (cache-busting
query params, per-session or per-request URLs, GraphQL cache-id mismatches),
Transient storage grows continuously as new pass objects accumulate faster
than they expire, until Varnish is OOM-killed by the Linux kernel — causing
a production outage.

### Fix

Set `beresp.grace = 0s` alongside every `beresp.uncacheable = true`
assignment in `vcl_backend_response`, across all four VCL templates
(`varnish4.vcl`, `varnish5.vcl`, `varnish6.vcl`, `varnish7.vcl`). Uncacheable
objects now expire strictly on their own `ttl` (120s for hit-for-pass, 86400s
for private/error responses), with no grace-period extension.

Cacheable objects are untouched — `beresp.grace = 3d` still applies to them
as before.

### Manual testing scenarios

1. Enable Varnish FPC.
2. Send an endless stream of requests carrying `Cache-Control: no-store` (or
   hitting URLs that resolve to hit-for-pass, e.g. random query strings).
3. Watch `varnishstat -1 | grep -i transient` before and after the patch.
   - Before: `SMA.Transient.g_bytes` grows without bound as objects are
     retained for ttl + 3-day grace.
   - After: Transient memory stabilizes once objects begin expiring on their
     configured `ttl` (as low as 120s for hit-for-pass objects).

### Fixed Issues

Fixes magento/magento2#40641

### Contribution checklist

- [x] I agree to contribute to the project under Magento Open Source project's [license](https://github.com/magento/magento2/blob/2.4-develop/LICENSE.txt)
- [x] I have made corresponding changes to the documentation if needed (not applicable — VCL sample templates only)
- [x] I have added tests to cover my changes (not applicable — VCL templates have no automated test harness upstream)
- [x] All new and existing tests passed
