### PR TITLE
Hide configurable options used only by disabled variations (#38899)

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
@@ -55,18 +55,48 @@ class ConfigurableAttributeData
      */
     protected function getAttributeOptionsData($attribute, $config)
     {
+        $attributeId = $attribute->getAttributeId();
+        $usedValues = $this->getUsedAttributeValues($attributeId, $config);
         $attributeOptionsData = [];
         foreach ($attribute->getOptions() as $attributeOption) {
             $optionId = $attributeOption['value_index'];
+            $products = $config[$attributeId][$optionId] ?? [];
+            // Skip options that are not used by any enabled configurable variation (e.g. only disabled
+            // simple products carry them). Values used by enabled but out-of-stock products are kept so
+            // that out-of-stock swatches/options are still rendered as unavailable.
+            if (empty($products) && !isset($usedValues[(string)$optionId])) {
+                continue;
+            }
             $attributeOptionsData[] = [
                 'id' => $optionId,
                 'label' => $attributeOption['label'],
-                'products' => isset($config[$attribute->getAttributeId()][$optionId])
-                    ? $config[$attribute->getAttributeId()][$optionId]
-                    : [],
+                'products' => $products,
             ];
         }
         return $attributeOptionsData;
+    }
+
+    /**
+     * Collect attribute values that belong to enabled configurable variations.
+     *
+     * The index is built only from allowed (enabled) products, so a value missing here means no enabled
+     * variation uses it - as opposed to a value used by an enabled product that is merely out of stock.
+     *
+     * @param int|string $attributeId
+     * @param array $config
+     * @return array
+     */
+    private function getUsedAttributeValues($attributeId, array $config)
+    {
+        $usedValues = [];
+        if (isset($config['index']) && is_array($config['index'])) {
+            foreach ($config['index'] as $productValues) {
+                if (isset($productValues[$attributeId])) {
+                    $usedValues[(string)$productValues[$attributeId]] = true;
+                }
+            }
+        }
+        return $usedValues;
     }
 
     /**

--- a/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
+++ b/app/code/Magento/ConfigurableProduct/Model/ConfigurableAttributeData.php
@@ -10,7 +10,8 @@ use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute;
 
 /**
- * Class ConfigurableAttributeData
+ * Provides configurable product attribute data for frontend configuration.
+ *
  * @api
  * @since 100.0.2
  */
@@ -49,6 +50,8 @@ class ConfigurableAttributeData
     }
 
     /**
+     * Get options data for a configurable attribute.
+     *
      * @param Attribute $attribute
      * @param array $config
      * @return array
@@ -100,6 +103,8 @@ class ConfigurableAttributeData
     }
 
     /**
+     * Get configured attribute value from preconfigured product data.
+     *
      * @param int $attributeId
      * @param Product $product
      * @return mixed|null

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ConfigurableAttributeDataTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Model/ConfigurableAttributeDataTest.php
@@ -127,4 +127,85 @@ class ConfigurableAttributeDataTest extends TestCase
 
         $this->assertEquals($expected, $this->configurableAttributeData->getAttributesData($this->product, $options));
     }
+
+    /**
+     * Options that are not used by any enabled variation must be excluded, while values used by enabled
+     * but out-of-stock variations must be kept so they are still rendered as unavailable.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
+     */
+    public function testDisabledVariationOptionsAreExcluded()
+    {
+        $storeId = '1';
+        $attributeId = 5;
+        $attributeOptions = [
+            ['value_index' => 'in_stock', 'label' => 'In Stock'],
+            ['value_index' => 'out_of_stock', 'label' => 'Out Of Stock'],
+            ['value_index' => 'disabled', 'label' => 'Disabled'],
+        ];
+        $position = 2;
+
+        // Only "in_stock" has salable products; "out_of_stock" appears in the index (enabled product,
+        // no salable products); "disabled" appears nowhere (only a disabled simple product uses it).
+        $options = [
+            $attributeId => ['in_stock' => ['1']],
+            'index' => [
+                '1' => [$attributeId => 'in_stock'],
+                '2' => [$attributeId => 'out_of_stock'],
+            ],
+        ];
+
+        $expected = [
+            'attributes' => [
+                $attributeId => [
+                    'id' => $attributeId,
+                    'code' => 'test_attribute',
+                    'label' => 'Test',
+                    'position' => $position,
+                    'options' => [
+                        0 => [
+                            'id' => 'in_stock',
+                            'label' => 'In Stock',
+                            'products' => ['1'],
+                        ],
+                        1 => [
+                            'id' => 'out_of_stock',
+                            'label' => 'Out Of Stock',
+                            'products' => [],
+                        ],
+                    ],
+                ],
+            ],
+            'defaultValues' => [
+                $attributeId => null,
+            ],
+        ];
+
+        $productAttributeMock = $this->createPartialMockWithReflection(
+            EavAttribute::class,
+            ['getId', 'setId', 'getAttributeCode', 'setAttributeCode', 'getStoreLabel', 'setStoreLabel']
+        );
+        $productAttributeMock->method('getId')->willReturn($attributeId);
+        $productAttributeMock->method('getAttributeCode')->willReturn($expected['attributes'][$attributeId]['code']);
+        $productAttributeMock->method('getStoreLabel')->willReturn($expected['attributes'][$attributeId]['label']);
+
+        $attributeMock = $this->createPartialMock(ConfigurableAttribute::class, []);
+        $attributeMock->setProductAttribute($productAttributeMock);
+        $attributeMock->setPosition($position);
+        $attributeMock->setAttributeId($attributeId);
+        $attributeMock->setOptions($attributeOptions);
+
+        $this->product->method('getStoreId')->willReturn($storeId);
+
+        $configurableProduct = $this->createMock(Configurable::class);
+        $configurableProduct->expects($this->once())
+            ->method('getConfigurableAttributes')
+            ->with($this->product)
+            ->willReturn([$attributeMock]);
+
+        $this->product->setTypeInstance($configurableProduct);
+        $this->product->setHasPreconfiguredValues(false);
+
+        $this->assertEquals($expected, $this->configurableAttributeData->getAttributesData($this->product, $options));
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Block/Product/View/Type/ConfigurableTest.php
+++ b/dev/tests/integration/testsuite/Magento/ConfigurableProduct/Block/Product/View/Type/ConfigurableTest.php
@@ -10,6 +10,7 @@ namespace Magento\ConfigurableProduct\Block\Product\View\Type;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Helper\Product as HelperProduct;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute as ConfigurableAttribute;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable\Attribute\Collection;
@@ -167,6 +168,35 @@ class ConfigurableTest extends TestCase
         $this->assertArrayHasKey('basePrice', $config['prices']);
         $this->assertArrayHasKey('images', $config);
         $this->assertCount(0, $config['images']);
+    }
+
+    /**
+     * Verify that an attribute option used only by a disabled variation is not present in the config.
+     *
+     * @return void
+     */
+    public function testGetJsonConfigExcludesDisabledVariationOption(): void
+    {
+        $disabledChild = $this->productRepository->get('simple_10');
+        $disabledOptionValue = (int)$disabledChild->getData('test_configurable');
+        $disabledChild->setStatus(Status::STATUS_DISABLED);
+        $this->productRepository->save($disabledChild);
+        $this->productRepository->cleanCache();
+
+        $configurable = $this->productRepository->get('configurable', false, null, true);
+        $block = $this->objectManager->get(LayoutInterface::class)->createBlock(Configurable::class);
+        $block->setProduct($configurable);
+
+        $config = $this->serializer->unserialize($block->getJsonConfig());
+        $attribute = reset($config['attributes']);
+        $optionIds = array_map('intval', array_column($attribute['options'], 'id'));
+
+        $this->assertNotContains(
+            $disabledOptionValue,
+            $optionIds,
+            'Option of a disabled configurable variation must not be present in the config.'
+        );
+        $this->assertCount(1, $attribute['options']);
     }
 
     /**


### PR DESCRIPTION
### Description

When a configurable product has an attribute value that is only carried by a **disabled** simple product (e.g. a single-dimension "color" configurable where one color's variation is disabled in the backend), that option was still rendered on the storefront — as a crossed-out (unavailable) swatch — instead of being hidden entirely.

Root cause is in `Magento\ConfigurableProduct\Model\ConfigurableAttributeData::getAttributeOptionsData()`. It iterates over **every** option of the configurable attribute (`$attribute->getOptions()`) and emits an entry for each one, defaulting `products` to an empty array when no allowed (enabled) product uses that value:

```php
'products' => isset($config[$attribute->getAttributeId()][$optionId])
    ? $config[$attribute->getAttributeId()][$optionId]
    : [],
```

`$config` is built (in `ConfigurableProduct\Helper\Data::getOptions()`) only from `getAllowProducts()`, which already filters out disabled products. So an option whose only variation is disabled ends up with `products => []` but is still present in `jsonConfig.attributes[].options`. The Swatches renderer then renders it (marked `data-option-empty="true"`), which appears as a crossed-out swatch.

The plain (non-swatch) configurable dropdown already omits these options client-side (`configurable.js` only renders an option when `allowedProducts.length > 0 || allowedOptions includes id`), so the swatch and dropdown behaved inconsistently.

### Fix

Skip option values that are used by **no enabled variation** when building the attributes config, so the option is absent from `jsonConfig` entirely (matching the dropdown behavior).

The distinction between a *disabled* variation and an *enabled but out-of-stock* variation matters: both can produce an empty `products` array (the latter when "Display Out of Stock Products" is off). Out-of-stock but enabled products are present in the product `index`, so the fix keeps any option value found in the index — out-of-stock options continue to render as unavailable exactly as before. Only values used by no enabled variation (i.e. disabled-only) are removed.

### Manual testing scenarios

1. Create a configurable product driven by a swatch attribute (e.g. `color`) with several variations.
2. In the backend, disable one of the child products (Product Status → Disabled).
3. Reindex and flush cache.
4. Open the configurable product on the storefront.
   - **Before:** the disabled variation's swatch is shown as a crossed-out / unavailable option.
   - **After:** the disabled variation's swatch is not rendered at all.
5. Verify an *enabled but out-of-stock* variation (with "Display Out of Stock Products" disabled) still renders as an unavailable/crossed-out swatch — this behavior is unchanged.

### Fixed Issues

Fixes magento/magento2#38899

### Contribution checklist

- [x] I agree to contribute to the project under Magento Open Source project's [license](https://github.com/magento/magento2/blob/2.4-develop/LICENSE.txt)
- [x] I have added tests to cover my changes (unit test in `ConfigurableAttributeDataTest`, integration test in `ConfigurableTest`)
- [x] All new and existing tests passed
- [x] I confirm that the change does not require documentation updates
