### PR TITLE
Clear stale persistent-emulation tax data when reverting to guest (#38509)

### DIFF
--- a/app/code/Magento/Persistent/Observer/CheckExpirePersistentQuoteObserver.php
+++ b/app/code/Magento/Persistent/Observer/CheckExpirePersistentQuoteObserver.php
@@ -131,7 +131,7 @@ class CheckExpirePersistentQuoteObserver implements ObserverInterface
             $this->_eventManager->dispatch('persistent_session_expired');
             $this->quoteManager->expire();
             $this->_checkoutSession->clearQuote();
-            $this->_customerSession->setCustomerId(null)->setCustomerGroupId(null);
+            $this->resetCustomerSession();
             return;
         }
 
@@ -145,8 +145,26 @@ class CheckExpirePersistentQuoteObserver implements ObserverInterface
         ) {
             $this->_eventManager->dispatch('persistent_session_expired');
             $this->quoteManager->expire();
-            $this->_customerSession->setCustomerId(null)->setCustomerGroupId(null);
+            $this->resetCustomerSession();
         }
+    }
+
+    /**
+     * Reset emulated customer data on the customer session back to the guest state.
+     *
+     * Also clears the tax destination data left by persistent emulation
+     * (EmulateCustomerObserver) so guest price rendering is not calculated against
+     * the expired customer's tax address.
+     *
+     * @return void
+     */
+    private function resetCustomerSession(): void
+    {
+        $this->_customerSession->setCustomerId(null)
+            ->setCustomerGroupId(null)
+            ->setDefaultTaxBillingAddress(null)
+            ->setDefaultTaxShippingAddress(null)
+            ->setCustomerTaxClassId(null);
     }
 
     /**

--- a/app/code/Magento/Persistent/Observer/CheckExpirePersistentQuoteObserver.php
+++ b/app/code/Magento/Persistent/Observer/CheckExpirePersistentQuoteObserver.php
@@ -19,15 +19,11 @@ use Magento\Quote\Model\Quote;
 class CheckExpirePersistentQuoteObserver implements ObserverInterface
 {
     /**
-     * Customer session
-     *
      * @var \Magento\Customer\Model\Session
      */
     protected $_customerSession;
 
     /**
-     * Checkout session
-     *
      * @var \Magento\Checkout\Model\Session
      */
     protected $_checkoutSession;
@@ -40,8 +36,6 @@ class CheckExpirePersistentQuoteObserver implements ObserverInterface
     protected $_eventManager = null;
 
     /**
-     * Persistent session
-     *
      * @var \Magento\Persistent\Helper\Session
      */
     protected $_persistentSession = null;
@@ -52,22 +46,16 @@ class CheckExpirePersistentQuoteObserver implements ObserverInterface
     protected $quoteManager;
 
     /**
-     * Persistent data
-     *
      * @var \Magento\Persistent\Helper\Data
      */
     protected $_persistentData = null;
 
     /**
-     * Request
-     *
      * @var \Magento\Framework\App\RequestInterface
      */
     private $request;
 
     /**
-     * Checkout Page path
-     *
      * @var string
      */
     private $checkoutPagePath = 'checkout';

--- a/app/code/Magento/Persistent/Observer/RemoveGuestPersistenceOnEmptyCartObserver.php
+++ b/app/code/Magento/Persistent/Observer/RemoveGuestPersistenceOnEmptyCartObserver.php
@@ -16,8 +16,6 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class RemoveGuestPersistenceOnEmptyCartObserver implements ObserverInterface
 {
     /**
-     * Customer session
-     *
      * @var \Magento\Customer\Model\Session
      */
     private $customerSession;
@@ -30,8 +28,6 @@ class RemoveGuestPersistenceOnEmptyCartObserver implements ObserverInterface
     private $persistenceSessionHelper;
 
     /**
-     * Quote manager
-     *
      * @var \Magento\Persistent\Model\QuoteManager
      */
     private $quoteManager;
@@ -44,8 +40,6 @@ class RemoveGuestPersistenceOnEmptyCartObserver implements ObserverInterface
     private $persistenceDataHelper;
 
     /**
-     * Cart Repository
-     *
      * @var \Magento\Quote\Api\CartRepositoryInterface $cartRepository
      */
     private $cartRepository;

--- a/app/code/Magento/Persistent/Observer/RemoveGuestPersistenceOnEmptyCartObserver.php
+++ b/app/code/Magento/Persistent/Observer/RemoveGuestPersistenceOnEmptyCartObserver.php
@@ -99,7 +99,10 @@ class RemoveGuestPersistenceOnEmptyCartObserver implements ObserverInterface
 
         if (!$cart || $cart->getItemsCount() == 0) {
             $this->customerSession->setCustomerId(null)
-                ->setCustomerGroupId(null);
+                ->setCustomerGroupId(null)
+                ->setDefaultTaxBillingAddress(null)
+                ->setDefaultTaxShippingAddress(null)
+                ->setCustomerTaxClassId(null);
             $this->quoteManager->setGuest();
         }
     }

--- a/app/code/Magento/Persistent/Test/Unit/Observer/CheckExpirePersistentQuoteObserverTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Observer/CheckExpirePersistentQuoteObserverTest.php
@@ -94,13 +94,17 @@ class CheckExpirePersistentQuoteObserverTest extends TestCase
     protected function setUp(): void
     {
         $this->sessionMock = $this->createMock(Session::class);
-        $this->customerSessionMock = $this->getMockBuilder(CustomerSession::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['isLoggedIn', 'setCustomerId', 'setCustomerGroupId'])
-            ->addMethods(
-                ['setDefaultTaxBillingAddress', 'setDefaultTaxShippingAddress', 'setCustomerTaxClassId']
-            )
-            ->getMock();
+        $this->customerSessionMock = $this->createPartialMockWithReflection(
+            CustomerSession::class,
+            [
+                'isLoggedIn',
+                'setCustomerId',
+                'setCustomerGroupId',
+                'setDefaultTaxBillingAddress',
+                'setDefaultTaxShippingAddress',
+                'setCustomerTaxClassId'
+            ]
+        );
         $this->persistentHelperMock = $this->createMock(Data::class);
         $this->observerMock = $this->createPartialMockWithReflection(
             Observer::class,

--- a/app/code/Magento/Persistent/Test/Unit/Observer/CheckExpirePersistentQuoteObserverTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Observer/CheckExpirePersistentQuoteObserverTest.php
@@ -94,7 +94,13 @@ class CheckExpirePersistentQuoteObserverTest extends TestCase
     protected function setUp(): void
     {
         $this->sessionMock = $this->createMock(Session::class);
-        $this->customerSessionMock = $this->createMock(CustomerSession::class);
+        $this->customerSessionMock = $this->getMockBuilder(CustomerSession::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isLoggedIn', 'setCustomerId', 'setCustomerGroupId'])
+            ->addMethods(
+                ['setDefaultTaxBillingAddress', 'setDefaultTaxShippingAddress', 'setCustomerTaxClassId']
+            )
+            ->getMock();
         $this->persistentHelperMock = $this->createMock(Data::class);
         $this->observerMock = $this->createPartialMockWithReflection(
             Observer::class,
@@ -207,6 +213,26 @@ class CheckExpirePersistentQuoteObserverTest extends TestCase
         $this->customerSessionMock
             ->expects($this->{$setCustomerIdCounter}())
             ->method('setCustomerId')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock
+            ->expects($this->{$setCustomerIdCounter}())
+            ->method('setCustomerGroupId')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock
+            ->expects($this->{$setCustomerIdCounter}())
+            ->method('setDefaultTaxBillingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock
+            ->expects($this->{$setCustomerIdCounter}())
+            ->method('setDefaultTaxShippingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock
+            ->expects($this->{$setCustomerIdCounter}())
+            ->method('setCustomerTaxClassId')
             ->with(null)
             ->willReturnSelf();
         $this->requestMock->expects($this->atLeastOnce())->method('getRequestUri')->willReturn($refererUri);

--- a/app/code/Magento/Persistent/Test/Unit/Observer/RemoveGuestPersistenceOnEmptyCartObserverTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Observer/RemoveGuestPersistenceOnEmptyCartObserverTest.php
@@ -71,7 +71,13 @@ class RemoveGuestPersistenceOnEmptyCartObserverTest extends TestCase
         $this->persistentHelperMock = $this->createMock(SessionHelper::class);
         $this->sessionModelMock = $this->createMock(PersistentSession::class);
         $this->persistentDataMock = $this->createMock(PersistentHelper::class);
-        $this->customerSessionMock = $this->createMock(CustomerSession::class);
+        $this->customerSessionMock = $this->getMockBuilder(CustomerSession::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isLoggedIn', 'setCustomerId', 'setCustomerGroupId'])
+            ->addMethods(
+                ['setDefaultTaxBillingAddress', 'setDefaultTaxShippingAddress', 'setCustomerTaxClassId']
+            )
+            ->getMock();
         $this->quoteManagerMock = $this->createMock(QuoteManager::class);
         $this->observerMock = $this->createMock(Observer::class);
         $this->cartRepositoryMock = $this->createMock(
@@ -140,7 +146,20 @@ class RemoveGuestPersistenceOnEmptyCartObserverTest extends TestCase
             ->willReturnSelf();
         $this->customerSessionMock->expects($this->once())
             ->method('setCustomerGroupId')
-            ->with(null);
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setDefaultTaxBillingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setDefaultTaxShippingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setCustomerTaxClassId')
+            ->with(null)
+            ->willReturnSelf();
         $this->quoteManagerMock->expects($this->once())->method('setGuest');
 
         $this->model->execute($this->observerMock);
@@ -170,7 +189,20 @@ class RemoveGuestPersistenceOnEmptyCartObserverTest extends TestCase
             ->willReturnSelf();
         $this->customerSessionMock->expects($this->once())
             ->method('setCustomerGroupId')
-            ->with(null);
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setDefaultTaxBillingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setDefaultTaxShippingAddress')
+            ->with(null)
+            ->willReturnSelf();
+        $this->customerSessionMock->expects($this->once())
+            ->method('setCustomerTaxClassId')
+            ->with(null)
+            ->willReturnSelf();
         $this->quoteManagerMock->expects($this->once())->method('setGuest');
 
         $this->model->execute($this->observerMock);

--- a/app/code/Magento/Persistent/Test/Unit/Observer/RemoveGuestPersistenceOnEmptyCartObserverTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Observer/RemoveGuestPersistenceOnEmptyCartObserverTest.php
@@ -71,13 +71,17 @@ class RemoveGuestPersistenceOnEmptyCartObserverTest extends TestCase
         $this->persistentHelperMock = $this->createMock(SessionHelper::class);
         $this->sessionModelMock = $this->createMock(PersistentSession::class);
         $this->persistentDataMock = $this->createMock(PersistentHelper::class);
-        $this->customerSessionMock = $this->getMockBuilder(CustomerSession::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['isLoggedIn', 'setCustomerId', 'setCustomerGroupId'])
-            ->addMethods(
-                ['setDefaultTaxBillingAddress', 'setDefaultTaxShippingAddress', 'setCustomerTaxClassId']
-            )
-            ->getMock();
+        $this->customerSessionMock = $this->createPartialMockWithReflection(
+            CustomerSession::class,
+            [
+                'isLoggedIn',
+                'setCustomerId',
+                'setCustomerGroupId',
+                'setDefaultTaxBillingAddress',
+                'setDefaultTaxShippingAddress',
+                'setCustomerTaxClassId'
+            ]
+        );
         $this->quoteManagerMock = $this->createMock(QuoteManager::class);
         $this->observerMock = $this->createMock(Observer::class);
         $this->cartRepositoryMock = $this->createMock(


### PR DESCRIPTION
### Description (*)

When **Persistent Shopping Cart** is enabled and catalog prices are configured to
display **including tax**, a guest can be shown the **tax-excluded** price on the
category-list and product-view pages after a previously-emulated customer session
is torn down — and that wrong price is written into the full-page / price-box
cache under the guest cache key.

**Root cause**

During persistent emulation, `Magento\Persistent\Observer\EmulateCustomerObserver`
populates the customer session with the emulated customer's tax destination:

- `setDefaultTaxShippingAddress([...])`
- `setDefaultTaxBillingAddress([...])`
- the customer group id / tax class

When the persistent session is torn down — the cart becomes empty
(`RemoveGuestPersistenceOnEmptyCartObserver`) or the persistent quote expires /
becomes outdated (`CheckExpirePersistentQuoteObserver`) — those observers reset
the customer session back to guest:

```php
$this->customerSession->setCustomerId(null)->setCustomerGroupId(null);
```

They reset the id and group, but **never clear** the
`DefaultTaxBillingAddress` / `DefaultTaxShippingAddress` / `CustomerTaxClassId`
left in the session by emulation. On the next request the visitor is a guest
again (group `0` → guest cache vary), yet
`Magento\Catalog\Helper\Data::getTaxPrice()` still reads
`customerSession->getDefaultTaxShippingAddress()` /
`getDefaultTaxBillingAddress()` for the catalog display case and computes the
price against the **stale** customer tax destination — producing a tax-excluded
price that is then cached in the guest bucket.

**Fix**

Clear the emulated tax destination data (`DefaultTaxBillingAddress`,
`DefaultTaxShippingAddress`, `CustomerTaxClassId`) on the customer session
wherever these two observers reset the session to guest.

### Fixed Issues (*)

Fixes magento/magento2#38509

### Manual testing scenarios (*)

1. Create a taxable product in a category. Configure a tax rate/rule for a
   default country (e.g. Denmark) and set catalog prices to display **including
   tax** everywhere.
2. Allow a second country with **no** tax rate (e.g. United States) and create a
   customer whose default address is in that no-tax country.
3. Enable **Persistent Shopping Cart** and set a short cookie lifetime (~3 min).
4. As a guest, view the category/product page — prices show **including tax**.
5. Log in as the no-tax customer, add the product to the cart, then let the
   session / persistent quote expire (or empty the cart).
6. As a guest again, refresh the category and product pages.

**Before:** prices display **excluding tax**, and the FPC / price-box cache is
poisoned with the tax-excluded value.
**After:** guest prices correctly display **including tax**.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests (extended
      `RemoveGuestPersistenceOnEmptyCartObserverTest` and
      `CheckExpirePersistentQuoteObserverTest`; verified failing without the fix)
- [x] All automated tests passed successfully (unit + existing Persistent
      integration observer tests)
