### PR TITLE
Fix parallel static content deploy not returning error exit code on failure

### DIFF
--- a/app/code/Magento/Deploy/Process/Queue.php
+++ b/app/code/Magento/Deploy/Process/Queue.php
@@ -92,6 +92,15 @@ class Queue
     private $start = 0;
 
     /**
+     * Tracks whether any forked child process exited with a non-zero status.
+     * PHP exceptions do not cross fork boundaries, so child failures are only
+     * detectable via pcntl_wexitstatus in the parent process.
+     *
+     * @var bool
+     */
+    private bool $hasErrors = false;
+
+    /**
      * @var int
      */
     private $lastJobStarted = 0;
@@ -195,6 +204,12 @@ class Queue
 
         if (!empty($packages)) {
             throw new TimeoutException('Not all packages are deployed.');
+        }
+
+        if ($this->hasErrors) {
+            throw new \RuntimeException(
+                'Static content deploy failed: one or more packages could not be deployed. Check the log for details.'
+            );
         }
 
         return $returnStatus;
@@ -360,7 +375,15 @@ class Queue
 
             // process child process
             $this->inProgress = [];
-            $this->deployPackageService->deploy($package, $this->options, true);
+            try {
+                $this->deployPackageService->deploy($package, $this->options, true);
+            } catch (\Throwable $e) {
+                // Log and exit cleanly so the parent receives a well-defined non-zero
+                // exit status via pcntl_wexitstatus instead of PHP's fatal-error code.
+                $this->logger->error($e->getMessage());
+                // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
+                exit(1);
+            }
             // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
             exit(0);
         } else {
@@ -403,8 +426,10 @@ class Queue
                     );
 
                     unset($this->inProgress[$package->getPath()]);
-                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
-                    return pcntl_wexitstatus($status) === 0;
+                    if ($exitStatus !== 0) {
+                        $this->hasErrors = true;
+                    }
+                    return $exitStatus === 0;
                 } elseif ($result === -1) {
                     // phpcs:ignore Magento2.Functions.DiscouragedFunction
                     $errno = pcntl_errno();

--- a/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php
@@ -716,4 +716,59 @@ class QueueTest extends TestCase
             'failure exit' => [1, false],
         ];
     }
+
+    /**
+     * Test that isDeployed sets hasErrors when a child process exits with a non-zero status.
+     *
+     * @return void
+     * @covers ::isDeployed
+     */
+    public function testIsDeployedSetsHasErrorsOnChildFailure(): void
+    {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('pcntl_fork not available');
+        }
+
+        $pid = pcntl_fork();
+        if ($pid === -1) {
+            $this->fail('Failed to fork');
+        } elseif ($pid === 0) {
+            // phpcs:ignore Magento2.Security.LanguageConstruct.ExitUsage
+            exit(1);
+        }
+
+        usleep(2000000); // wait for child to become a zombie
+
+        $queue = $this->createQueue(4);
+        $package = $this->createMock(Package::class);
+        $package->expects($this->any())->method('getPath')->willReturn('test/path');
+        $package->expects($this->any())->method('getState')->willReturn(null);
+        $package->expects($this->once())->method('setState')->with(Package::STATE_COMPLETED);
+
+        $this->setPrivateProperty($queue, 'processIds', ['test/path' => $pid]);
+        $this->setPrivateProperty($queue, 'inProgress', ['test/path' => $package]);
+
+        $this->logger->expects($this->once())->method('info');
+
+        $this->invokeMethod($queue, 'isDeployed', [$package]);
+
+        $this->assertTrue($this->getPrivateProperty($queue, 'hasErrors'));
+
+        $this->setPrivateProperty($queue, 'inProgress', []);
+    }
+
+    /**
+     * Test that process() throws RuntimeException when child process failures were detected.
+     *
+     * @return void
+     * @covers ::process
+     */
+    public function testProcessThrowsRuntimeExceptionWhenHasErrors(): void
+    {
+        $queue = $this->createQueue();
+        $this->setPrivateProperty($queue, 'hasErrors', true);
+
+        $this->expectException(\RuntimeException::class);
+        $queue->process();
+    }
 }


### PR DESCRIPTION
### Description

Fixes #22883

When running `setup:static-content:deploy` with `--jobs > 1` (parallel mode), the CLI command returns exit code `0` even when a worker process fails. Build pipelines and CI systems that check the exit code to detect failures are silently misled into thinking the deploy succeeded.

### Root Cause

In `Queue::process()`, `$returnStatus` is initialised to `0` and never updated. The parent process correctly detects child failures inside `isDeployed()` via `pcntl_waitpid` and `pcntl_wexitstatus`, but the non-zero exit status was only logged — it was not propagated back to the caller.

Additionally, when a child's `deploy()` call throws an exception, the child exits with PHP's default unhandled-exception code (255) rather than a clean `1`, producing noisy output in the log.

### Fix

**`app/code/Magento/Deploy/Process/Queue.php`**
- Added `$hasErrors` flag (default `false`). Set to `true` in `isDeployed()` when `pcntl_wexitstatus` returns non-zero.
- In `process()`, after all workers finish, throw `RuntimeException` if `$hasErrors` is set. This propagates through the strategy and `DeployStaticContent::deploy()` to the CLI command, which exits with code `1`.
- Wrapped the child's `deploy()` call in `try/catch (\Throwable)` so exceptions produce a clean `exit(1)` with a logged error message.

**`app/code/Magento/Deploy/Test/Unit/Process/QueueTest.php`**
- Added `testIsDeployedSetsHasErrorsOnChildFailure` — forks a child that exits `1` and asserts `hasErrors` is `true`.
- Added `testProcessThrowsRuntimeExceptionWhenHasErrors` — asserts `process()` throws `RuntimeException` when `hasErrors` is set.

### Steps to reproduce

```bash
# Add a throw inside DeployPackage::deploy() or LockerProcess::unlockProcess()
php bin/magento setup:static-content:deploy -f --jobs 2 --theme Magento/blank
echo $?   # returns 0 — expected: 1
```

### Expected result

CLI exits with a non-zero status code when any worker process fails during parallel static content deployment.

### Actual result

CLI exits with `0` regardless of worker failures; error messages appear in output but the exit code does not reflect the failure.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit tests
 - [x] All automated tests passed successfully (all builds are green)
