### PR TITLE
Cache attribute options loaded by Table source getSpecificOptions() (#36174)

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -40,6 +40,13 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource im
     private $storeManager;
 
     /**
+     * Cache of specific options indexed by store, attribute and requested option ids
+     *
+     * @var array
+     */
+    private array $specificOptionsCache = [];
+
+    /**
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\CollectionFactory $attrOptionCollectionFactory
      * @param \Magento\Eav\Model\ResourceModel\Entity\Attribute\OptionFactory $attrOptionFactory
      * @param StoreManagerInterface|null $storeManager
@@ -105,13 +112,19 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource im
      */
     public function getSpecificOptions($ids, $withEmpty = true)
     {
-        $options = $this->_attrOptionCollectionFactory->create()
-            ->setPositionOrder('asc')
-            ->setAttributeFilter($this->getAttribute()->getId())
-            ->addFieldToFilter('main_table.option_id', ['in' => $ids])
-            ->setStoreFilter($this->getAttribute()->getStoreId())
-            ->load()
-            ->toOptionArray();
+        $storeId = $this->getAttribute()->getStoreId();
+        $attributeId = $this->getAttribute()->getId();
+        $idsKey = implode(',', is_array($ids) ? $ids : [$ids]);
+        if (!isset($this->specificOptionsCache[$storeId][$attributeId][$idsKey])) {
+            $this->specificOptionsCache[$storeId][$attributeId][$idsKey] = $this->_attrOptionCollectionFactory->create()
+                ->setPositionOrder('asc')
+                ->setAttributeFilter($attributeId)
+                ->addFieldToFilter('main_table.option_id', ['in' => $ids])
+                ->setStoreFilter($storeId)
+                ->load()
+                ->toOptionArray();
+        }
+        $options = $this->specificOptionsCache[$storeId][$attributeId][$idsKey];
         if ($withEmpty) {
             $options = $this->addEmptyOption($options);
         }
@@ -291,5 +304,6 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource im
     {
         $this->_optionsDefault = [];
         $this->_options = null;
+        $this->specificOptionsCache = [];
     }
 }

--- a/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
+++ b/app/code/Magento/Eav/Test/Unit/Model/Entity/Attribute/Source/TableTest.php
@@ -224,6 +224,52 @@ class TableTest extends TestCase
         ];
     }
 
+    public function testGetSpecificOptionsUsesCachedOptionsForSameIds()
+    {
+        $attributeId = 1;
+        $storeId = 5;
+        $optionIds = [1, 2];
+        $options = [
+            ['label' => 'The first label', 'value' => '1'],
+            ['label' => 'The second label', 'value' => '2']
+        ];
+
+        $this->abstractAttributeMock->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($attributeId);
+        $this->abstractAttributeMock->expects($this->exactly(2))
+            ->method('getStoreId')
+            ->willReturn($storeId);
+
+        $this->collectionFactory->expects($this->once())
+            ->method('create')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setPositionOrder')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setAttributeFilter')
+            ->with($attributeId)
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with('main_table.option_id', ['in' => $optionIds])
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setStoreFilter')
+            ->with($storeId)
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('load')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('toOptionArray')
+            ->willReturn($options);
+
+        $this->assertEquals($options, $this->model->getSpecificOptions($optionIds, false));
+        $this->assertEquals($options, $this->model->getSpecificOptions($optionIds, false));
+    }
+
     /**
      * @param array $optionsIds
      * @param array|string $value
@@ -269,6 +315,49 @@ class TableTest extends TestCase
             ->willReturn($options);
 
         $this->assertEquals($expectedResult, $this->model->getOptionText($value));
+    }
+
+    public function testGetOptionTextUsesCachedSpecificOptionsForSameValue()
+    {
+        $attributeId = 1;
+        $storeId = 5;
+        $optionId = '1';
+        $options = [['label' => 'test label', 'value' => '1']];
+
+        $this->abstractAttributeMock->expects($this->exactly(2))
+            ->method('getId')
+            ->willReturn($attributeId);
+        $this->abstractAttributeMock->expects($this->exactly(2))
+            ->method('getStoreId')
+            ->willReturn($storeId);
+
+        $this->collectionFactory->expects($this->once())
+            ->method('create')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setPositionOrder')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setAttributeFilter')
+            ->with($attributeId)
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('addFieldToFilter')
+            ->with('main_table.option_id', ['in' => $optionId])
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('setStoreFilter')
+            ->with($storeId)
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('load')
+            ->willReturnSelf();
+        $this->collectionFactory->expects($this->once())
+            ->method('toOptionArray')
+            ->willReturn($options);
+
+        $this->assertEquals('test label', $this->model->getOptionText($optionId));
+        $this->assertEquals('test label', $this->model->getOptionText($optionId));
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`Magento\Eav\Model\Entity\Attribute\Source\Table::getSpecificOptions()` builds and loads a fresh attribute-option collection — i.e. runs a DB query — on **every** call. Since `getOptionText()` delegates to it, every `$product->getAttributeText('some_select_attribute')` call hits the database, even when the same attribute/value is resolved repeatedly. On a product listing rendering a few select/swatch attributes for dozens of products this produces hundreds of identical queries per page.

The sibling `getAllOptions()` in the same class already memoizes results per store/attribute in `$this->_options`; `getSpecificOptions()` never received the same treatment.

**The fix** memoizes the loaded option array in a new private `$specificOptionsCache`, keyed by store id, attribute id and the normalized requested option ids. Key properties of the approach:

- The whole per-ids-set result is cached, so the collection's position-order guarantee is preserved exactly.
- The `$withEmpty` handling stays outside the cache (`addEmptyOption()` operates on a copy).
- The cache is cleared in `_resetState()`, keeping the class's `ResetAfterRequestInterface` contract intact.

This supersedes the abandoned #39476, which cached individual options and merged cached with freshly-loaded entries (breaking option ordering) and did not reset its cache in `_resetState()`.

#### Performance measurements

200 consecutive `getOptionText()` calls for the same select-attribute value, median of 5 runs (local Warden env, MySQL, clean state per run):

| | Median (ms) | DB queries |
|---|---|---|
| Before | 52.70 | 200 |
| After | 0.56 | 1 |

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#36174

### Manual testing scenarios (*)

1. Create (or use) a dropdown/multiselect product attribute sourced by `Magento\Eav\Model\Entity\Attribute\Source\Table` with a few options, assign a value to a product.
2. In any block/template/script resolve the label repeatedly, e.g. call `$product->getAttributeText('your_attribute')` several times (a category listing rendering attribute labels for many products does this naturally).
3. With a DB query log (or profiler) enabled, observe that `eav_attribute_option` option-load queries are executed only once per unique (store, attribute, requested ids) combination instead of once per call.
4. Verify labels are still resolved correctly per store view (store-specific option labels keep working), and that multiselect values (`'1,2'`) still return the expected label arrays.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
