### PR TITLE
Fix media uploader ignoring DI-configured allowed file extensions (#39025)

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/web/js/media-uploader.js
+++ b/app/code/Magento/Backend/view/adminhtml/web/js/media-uploader.js
@@ -41,7 +41,11 @@ define([
                 targetElement = this.element.find('.fileinput-button.form-buttons')[0],
                 uploadUrl = $(uploaderElement).attr('data-url'),
                 fileId = null,
-                allowedExt = ['jpeg', 'jpg', 'png', 'gif'],
+                allowedExt = this.options.allowedExtensions?.length ?
+                    this.options.allowedExtensions.map(function (ext) {
+                        return ext.toLowerCase();
+                    }) :
+                    ['jpeg', 'jpg', 'png', 'gif'],
                 allowedResize = false,
                 options = {
                     proudlyDisplayPoweredByUppy: false,

--- a/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Wysiwyg/Images/Content/Uploader.php
@@ -5,6 +5,9 @@
  */
 namespace Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content;
 
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Serialize\Serializer\Json;
+
 /**
  * Uploader block for Wysiwyg Images
  *
@@ -19,18 +22,26 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
     protected $_imagesStorage;
 
     /**
+     * @var Json
+     */
+    private $serializer;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Magento\Framework\File\Size $fileSize
      * @param \Magento\Cms\Model\Wysiwyg\Images\Storage $imagesStorage
      * @param array $data
+     * @param Json|null $serializer
      */
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,
         \Magento\Framework\File\Size $fileSize,
         \Magento\Cms\Model\Wysiwyg\Images\Storage $imagesStorage,
-        array $data = []
+        array $data = [],
+        ?Json $serializer = null
     ) {
         $this->_imagesStorage = $imagesStorage;
+        $this->serializer = $serializer ?: ObjectManager::getInstance()->get(Json::class);
         parent::__construct($context, $fileSize, $data);
     }
 
@@ -57,6 +68,26 @@ class Uploader extends \Magento\Backend\Block\Media\Uploader
         )->setFilters(
             ['images' => ['label' => __('Images (%1)', implode(', ', $labels)), 'files' => $files]]
         );
+    }
+
+    /**
+     * Get list of file extensions allowed to upload for the current media type
+     *
+     * @return string[]
+     */
+    public function getAllowedExtensions(): array
+    {
+        return $this->_imagesStorage->getAllowedExtensions($this->_getMediaType());
+    }
+
+    /**
+     * Get JSON-encoded list of file extensions allowed to upload for the current media type
+     *
+     * @return string
+     */
+    public function getAllowedExtensionsJson(): string
+    {
+        return $this->serializer->serialize($this->getAllowedExtensions());
     }
 
     /**

--- a/app/code/Magento/Cms/Test/Unit/Block/Adminhtml/Wysiwyg/Images/Content/UploaderTest.php
+++ b/app/code/Magento/Cms/Test/Unit/Block/Adminhtml/Wysiwyg/Images/Content/UploaderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Cms\Test\Unit\Block\Adminhtml\Wysiwyg\Images\Content;
+
+use Magento\Backend\Block\Template\Context;
+use Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader;
+use Magento\Cms\Model\Wysiwyg\Images\Storage;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Data\Form\FormKey;
+use Magento\Framework\File\Size;
+use Magento\Framework\Math\Random;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\UrlInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test allowed extensions exposure of the Wysiwyg Images uploader block.
+ */
+class UploaderTest extends TestCase
+{
+    /**
+     * @var Uploader
+     */
+    private $block;
+
+    /**
+     * @var Storage|MockObject
+     */
+    private $imagesStorageMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+        $objectManager->prepareObjectManager();
+
+        $randomMock = $this->createMock(Random::class);
+        $randomMock->method('getUniqueHash')->willReturn('id');
+        $formKeyMock = $this->createMock(FormKey::class);
+        $formKeyMock->method('getFormKey')->willReturn('form_key');
+        $requestMock = $this->createMock(RequestInterface::class);
+        $requestMock->method('getParam')->with('type')->willReturn('image');
+        $urlBuilderMock = $this->createMock(UrlInterface::class);
+
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getMathRandom')->willReturn($randomMock);
+        $contextMock->method('getFormKey')->willReturn($formKeyMock);
+        $contextMock->method('getRequest')->willReturn($requestMock);
+        $contextMock->method('getUrlBuilder')->willReturn($urlBuilderMock);
+
+        $this->imagesStorageMock = $this->createMock(Storage::class);
+        $this->imagesStorageMock->method('getAllowedExtensions')
+            ->with('image')
+            ->willReturn(['gif', 'jpg', 'jpeg', 'png', 'pdf']);
+
+        $this->block = new Uploader(
+            $contextMock,
+            $this->createMock(Size::class),
+            $this->imagesStorageMock,
+            [],
+            new Json()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAllowedExtensionsReturnsStorageConfiguredExtensions(): void
+    {
+        $this->assertSame(['gif', 'jpg', 'jpeg', 'png', 'pdf'], $this->block->getAllowedExtensions());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetAllowedExtensionsJsonReturnsSerializedExtensions(): void
+    {
+        $this->assertSame('["gif","jpg","jpeg","png","pdf"]', $this->block->getAllowedExtensionsJson());
+    }
+}

--- a/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
+++ b/app/code/Magento/Cms/view/adminhtml/templates/browser/content/uploader.phtml
@@ -17,7 +17,8 @@ $blockHtmlId = $block->getHtmlId();
             "maxFileSize": <?= /* @noEscape */ $block->getFileSizeService()->getMaxFileSize() ?>,
             "maxWidth": <?= /* @noEscape */ $block->getImageUploadMaxWidth() ?>,
             "maxHeight": <?= /* @noEscape */ $block->getImageUploadMaxHeight() ?>,
-            "isResizeEnabled": <?= /* @noEscape */ $block->getImageUploadConfigData()->getIsResizeEnabled() ?>
+            "isResizeEnabled": <?= /* @noEscape */ $block->getImageUploadConfigData()->getIsResizeEnabled() ?>,
+            "allowedExtensions": <?= /* @noEscape */ $block->getAllowedExtensionsJson() ?>
         }
     }'
 >

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Backend/view/adminhtml/web/js/media-uploader.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Backend/view/adminhtml/web/js/media-uploader.test.js
@@ -54,5 +54,48 @@ define([
             expect(uppyInstance.use).toHaveBeenCalledWith(window.Uppy.DropTarget, jasmine.any(Object));
             expect(uppyInstance.use).toHaveBeenCalledWith(window.Uppy.XHRUpload, jasmine.any(Object));
         });
+
+        it('File with extension outside the default list should be rejected', function () {
+            const onBeforeFileAdded = window.Uppy.Uppy.calls.mostRecent().args[0].onBeforeFileAdded;
+
+            expect(onBeforeFileAdded({
+                id: '1',
+                name: 'document.pdf',
+                size: 1024,
+                extension: 'pdf'
+            })).toBe(false);
+        });
+
+        it('File matching the allowedExtensions option should be accepted', function () {
+            let onBeforeFileAdded, result;
+
+            $('<div>').mediaUploader({
+                allowedExtensions: ['PDF']
+            });
+
+            onBeforeFileAdded = window.Uppy.Uppy.calls.mostRecent().args[0].onBeforeFileAdded;
+            result = onBeforeFileAdded({
+                id: '1',
+                name: 'document.pdf',
+                size: 1024,
+                extension: 'pdf'
+            });
+
+            expect(result).not.toBe(false);
+            expect(result.tempFileId).toEqual(jasmine.any(String));
+        });
+
+        it('File outside the allowedExtensions option should be rejected', function () {
+            $('<div>').mediaUploader({
+                allowedExtensions: ['pdf']
+            });
+
+            expect(window.Uppy.Uppy.calls.mostRecent().args[0].onBeforeFileAdded({
+                id: '1',
+                name: 'image.jpg',
+                size: 1024,
+                extension: 'jpg'
+            })).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
### Description (*)

Since 2.4.7 (AC-10720, migration from the outdated jQuery fileUpload library to Uppy), `Magento_Backend/js/media-uploader.js` hardcodes the list of allowed file extensions:

```js
allowedExt = ['jpeg', 'jpg', 'png', 'gif'],
```

This silently ignores the DI-configurable allowed extensions (`Magento\Cms\Model\Wysiwyg\Images\Storage::getAllowedExtensions()`), so any project that extended the allowed types via `di.xml` (e.g. to allow PDF uploads in the CMS media gallery) is broken after upgrading to 2.4.7 — the server-side upload controller still accepts the configured types, but the client-side Uppy check rejects them with "Disallowed file type."

Before the Uppy migration the client-side check was effectively absent (`acceptFileTypes` was defined but never used), which is why DI overrides used to work.

**Fix:**
- `Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader` exposes the storage-configured extensions (`getAllowedExtensions()` / `getAllowedExtensionsJson()`).
- `browser/content/uploader.phtml` passes them to the widget as the `allowedExtensions` option.
- `media-uploader.js` uses `this.options.allowedExtensions` (case-insensitive) when provided, and falls back to the previous hardcoded list otherwise — so other consumers of the widget (e.g. the product gallery uploader, which never supported DI-configured types) keep their exact current behavior.

Out of scope (discussed in the issue): a single admin-configurable source of allowed media types and a dedicated non-image file uploader (#9850) are feature requests, not part of this regression fix.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39025

### Manual testing scenarios (*)

1. Add a `di.xml` override extending the allowed extensions for the CMS media gallery, e.g. allow `pdf` for `Magento\Cms\Model\Wysiwyg\Images\Storage`:
   ```xml
   <type name="Magento\Cms\Model\Wysiwyg\Images\Storage">
       <arguments>
           <argument name="extensions" xsi:type="array">
               <item name="allowed" xsi:type="array">
                   <item name="pdf" xsi:type="string">application/pdf</item>
               </item>
           </argument>
       </arguments>
   </type>
   ```
2. Go to **Content → Pages → Edit → Content → Insert Image...** (or any WYSIWYG media gallery).
3. Upload a PDF file.
4. Before the fix: upload is rejected client-side with "Disallowed file type." After the fix: the file uploads successfully.
5. Verify a disallowed type (e.g. `.txt`) is still rejected, and that the product gallery uploader still accepts only jpeg/jpg/png/gif.

### Semantic Version Checker

The SVC build reports this PR as **MINOR**, and that is expected rather than something to fix: `Magento\Cms\Block\Adminhtml\Wysiwyg\Images\Content\Uploader` is `@api`, and the change adds two public methods (`getAllowedExtensions()`, `getAllowedExtensionsJson()`) and one optional constructor parameter (`?Json $serializer = null`, with an `ObjectManager` fallback). Nothing existing changes — no signature, constant, interface or protected member is modified or removed — so existing subclasses and callers are unaffected. All remaining findings are PATCH-level.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)

