### PR TITLE
Guard AwsS3 fileClose against already-closed stream (#40909)

### DIFF
--- a/app/code/Magento/AwsS3/Driver/AwsS3.php
+++ b/app/code/Magento/AwsS3/Driver/AwsS3.php
@@ -882,8 +882,10 @@ class AwsS3 implements RemoteDriverInterface
                 // Remove path from streams after
                 unset($this->streams[$path]);
 
+                // The adapter's writeStream() may already close the underlying stream resource
+                // (Guzzle Psr7\Stream::close()), so guard against fclose() on a closed resource.
                 // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
-                return fclose($stream);
+                return is_resource($stream) ? fclose($stream) : true;
             }
         }
 

--- a/app/code/Magento/AwsS3/Test/Unit/Driver/AwsS3Test.php
+++ b/app/code/Magento/AwsS3/Test/Unit/Driver/AwsS3Test.php
@@ -612,6 +612,22 @@ class AwsS3Test extends TestCase
         $this->driver->fileClose($resource);
     }
 
+    public function testFileCloseSucceedsWhenAdapterAlreadyClosedTheStream(): void
+    {
+        $resource = $this->driver->fileOpen('test/path', 'w');
+        $this->driver->fileWrite($resource, 'abc');
+        $this->adapterMock->method('fileExists')->willReturn(false);
+        // Emulate aws-sdk-php/Guzzle behavior: writeStream() closes the underlying stream resource.
+        $this->adapterMock->expects($this->once())
+            ->method('writeStream')
+            ->willReturnCallback(
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction.DiscouragedWithAlternative
+                static fn ($path, $stream) => fclose($stream)
+            );
+
+        self::assertTrue($this->driver->fileClose($resource));
+    }
+
     public function testFileCloseShouldReturnFalseIfTheArgumentIsNotAResource(): void
     {
         $this->assertEquals(false, $this->driver->fileClose(''));


### PR DESCRIPTION
### Description (*)

`Magento\AwsS3\Driver\AwsS3::fileClose()` writes the buffered stream to S3 and then closes the local handle:

```php
$this->adapter->writeStream($path, $resource, new Config(self::CONFIG));
unset($this->streams[$path]);
return fclose($stream);
```

Starting with `aws/aws-sdk-php >= 3.383.1` (resolved by the 2.4.7-p10 dependency bump), `writeStream()` closes the underlying stream resource itself via Guzzle's `Psr7\Stream::close()`. The subsequent `fclose($stream)` therefore runs on an already-closed resource. Under PHP 8 this is a hard `TypeError` (`fclose(): supplied resource is not a valid stream resource`) — it was only a non-fatal warning under PHP 7.

Any write-then-close path through the driver breaks. The most reliable trigger is a **scheduled import** copying its source file to `var/tmp`, where the cron job fails and the record is stored as `error`.

This PR guards the final close so an already-closed stream is treated as a successful close — a version-agnostic fix that does not depend on which `aws-sdk-php` patch release is installed:

```php
return is_resource($stream) ? fclose($stream) : true;
```

### Fixed Issues (*)

Fixes magento/magento2#40909

### Manual testing scenarios (*)

1. Configure AWS S3 as remote storage (`app/etc/env.php` → `remote_storage.driver = aws-s3`) with `aws/aws-sdk-php >= 3.383.1`.
2. Place an import source CSV under `var/import_export/scheduled_imports/`.
3. Create a Scheduled Import (**System → Data Transfer → Scheduled Import/Export**), server type "Local Server", pointing at that file.
4. Run `bin/magento cron:run`.

**Before:** the job fails with `TypeError: fclose(): supplied resource is not a valid stream resource` at `AwsS3::fileClose()`; `cron_schedule` records `error`.
**After:** the source file is copied to the temporary location and the import completes successfully.

### Questions or comments

The bug is covered by a unit test that emulates the adapter closing the stream inside `writeStream()`; reverting the guard makes it fail with the exact `TypeError` from the report.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (unit test added)
- [x] All automated tests passed successfully (all builds are green)
