### PR TITLE
fix: remove dead libxml_set_external_entity_loader guard in Config Dom

### DIFF
--- a/lib/internal/Magento/Framework/Config/Dom.php
+++ b/lib/internal/Magento/Framework/Config/Dom.php
@@ -364,10 +364,6 @@ class Dom
         $schema,
         $errorFormat = self::ERROR_FORMAT_DEFAULT
     ) {
-        if (!function_exists('libxml_set_external_entity_loader')) {
-            return [];
-        }
-
         if (!self::$urnResolver) {
             self::$urnResolver = new UrnResolver();
         }


### PR DESCRIPTION
## Description

Remove the dead `libxml_set_external_entity_loader()` availability guard from `Magento\Framework\Config\Dom::validateDomDocument()`.

### Problem

The method starts with a guard that is always false:

```php
if (!function_exists('libxml_set_external_entity_loader')) {
    return [];
}
```

`libxml_set_external_entity_loader()` is provided by ext-libxml, which is bundled with PHP and cannot be disabled; the function has existed since PHP 5.4. Since Magento requires PHP 8.3+, this branch is unreachable.

Worse, if the branch were ever taken it would return an empty error list — silently skipping XSD schema validation entirely and reporting the document as valid.

### Solution

Remove the dead guard. Behavior on every supported PHP version is unchanged.

### Files Changed

- `lib/internal/Magento/Framework/Config/Dom.php`

### Related Pull Requests

Same cleanup pattern as magento/magento2#40686, magento/magento2#40687, magento/magento2#40688.

### Manual testing scenarios (*)

1. Run `lib/internal/Magento/Framework/Config/Test/Unit/DomTest.php` — all validation tests pass.
2. Run the `Magento/Framework/Config` integration suite — schema validation behaves as before.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40950: fix: remove dead libxml_set_external_entity_loader guard in Config Dom