### PR TITLE
fix: remove PHP 5.4 T_TRAIT polyfill from setup FileScanner

### DIFF
--- a/setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php
+++ b/setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php
@@ -76,13 +76,6 @@ class FileScanner
             throw new RuntimeException('No tokens were provided');
         }
 
-        /**
-         * Define PHP 5.4 'trait' token constant.
-         */
-        if (!defined('T_TRAIT')) {
-            define('T_TRAIT', 42001);
-        }
-
         $namespaceContentTokenTypes = [
             T_NS_SEPARATOR => T_NS_SEPARATOR,
             T_STRING => T_STRING,


### PR DESCRIPTION
## Description

Remove the PHP 5.4 `T_TRAIT` polyfill from `Magento\Setup\Module\Di\Code\Reader\FileScanner::scan()`.

### Problem

The method defines a tokenizer constant that has been native since PHP 5.4:

```php
/**
 * Define PHP 5.4 'trait' token constant.
 */
if (!defined('T_TRAIT')) {
    define('T_TRAIT', 42001);
}
```

Since Magento requires PHP 8.3+, `T_TRAIT` is always defined by the engine and this polyfill is unreachable dead code.

### Solution

Remove the comment and the `defined()/define()` block. Behavior is unchanged; existing scanner coverage still applies.

### Files Changed

- `setup/src/Magento/Setup/Module/Di/Code/Reader/FileScanner.php`

### Related Pull Requests

Same cleanup pattern as magento/magento2#40686, magento/magento2#40687, magento/magento2#40688.

### Manual testing scenarios (*)

1. Run `setup:di:compile` — code scanning (including trait detection) works as before.
2. Run the `Magento\Setup\Test\Unit\Module\Di\Code\Reader` unit tests — all pass.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40951: fix: remove PHP 5.4 T_TRAIT polyfill from setup FileScanner