### PR TITLE
fix: remove redundant idn_to_utf8 availability check in CreatePost

### DIFF
--- a/app/code/Magento/Customer/Controller/Account/CreatePost.php
+++ b/app/code/Magento/Customer/Controller/Account/CreatePost.php
@@ -548,7 +548,7 @@ class CreatePost extends AbstractAccount implements CsrfAwareActionInterface, Ht
         [$localPart, $domain] = explode('@', $email, 2);
 
         // Only decode if domain contains punycode (contains 'xn--')
-        if (function_exists('idn_to_utf8') && strpos($domain, 'xn--') !== false) {
+        if (strpos($domain, 'xn--') !== false) {
             $decodedDomain = idn_to_utf8($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46);
             if ($decodedDomain !== false && $decodedDomain !== $domain) {
                 $this->getRequest()->setParam('email', $localPart . '@' . $decodedDomain);


### PR DESCRIPTION
## Description

Remove the redundant `idn_to_utf8()` availability check from `Magento\Customer\Controller\Account\CreatePost`.

### Problem

The punycode email-domain decoding is guarded by a `function_exists()` check:

```php
if (function_exists('idn_to_utf8') && strpos($domain, 'xn--') !== false) {
```

`ext-intl` is a hard requirement in Magento's root `composer.json`, so `idn_to_utf8()` is always available and the check is dead. It also hides a subtle failure mode: on a hypothetical installation without intl, punycode domains would silently skip decoding instead of failing loudly.

### Solution

Keep the punycode detection, drop the availability check:

```php
if (strpos($domain, 'xn--') !== false) {
```

Behavior is byte-for-byte identical on every supported installation.

### Files Changed

- `app/code/Magento/Customer/Controller/Account/CreatePost.php`

### Related Pull Requests

Same cleanup pattern as magento/magento2#40686, magento/magento2#40687, magento/magento2#40688.

### Manual testing scenarios (*)

1. Register a customer account with an internationalized email domain (e.g. `user@xn--bcher-kva.example`) — the domain is decoded to UTF-8 as before.
2. Register with a plain ASCII email — no change in behavior.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40953: fix: remove redundant idn_to_utf8 availability check in CreatePost