### PR TITLE
fix: remove redundant gc_collect_cycles availability guards

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -1325,9 +1325,7 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                 break;
             }
             $this->resetSourceAttributeOptionCache();
-            if (function_exists('gc_collect_cycles')) {
-                gc_collect_cycles();
-            }
+            gc_collect_cycles();
 
             if ($this->lastProcessedLinkFieldValue <= $lastProcessedLinkFieldValue) {
                 $this->_logger->critical(

--- a/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Batch/Product.php
+++ b/app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Batch/Product.php
@@ -490,8 +490,6 @@ class Product extends AbstractDb
         $this->select = null;
         $this->attributesCache = [];
 
-        if (function_exists('gc_collect_cycles')) {
-            gc_collect_cycles();
-        }
+        gc_collect_cycles();
     }
 }


### PR DESCRIPTION
## Description

Remove redundant `function_exists('gc_collect_cycles')` guards.

### Problem

Two batch-processing code paths guard `gc_collect_cycles()` behind availability checks:

```php
if (function_exists('gc_collect_cycles')) {
    gc_collect_cycles();
}
```

`gc_collect_cycles()` is a PHP core (Zend engine) function available unconditionally in every PHP build since 5.3 — it cannot be absent and cannot be disabled per-build. The guards are dead code.

### Solution

Call `gc_collect_cycles()` directly in both places. Behavior is unchanged.

### Files Changed

- `app/code/Magento/Sitemap/Model/ResourceModel/Catalog/Batch/Product.php`
- `app/code/Magento/CatalogImportExport/Model/Export/Product.php`

### Related Pull Requests

Same cleanup pattern as magento/magento2#40686, magento/magento2#40687, magento/magento2#40688.

### Manual testing scenarios (*)

1. Generate a sitemap for a store with products — batch memory cleanup runs as before.
2. Export products via admin (Catalog → Export) — pagination and memory management behave as before.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40954: fix: remove redundant gc_collect_cycles availability guards