### PR TITLE
fix: remove dead HHVM detection from DateTimeFormatter

### DIFF
--- a/lib/internal/Magento/Framework/Stdlib/DateTime/DateTimeFormatter.php
+++ b/lib/internal/Magento/Framework/Stdlib/DateTime/DateTimeFormatter.php
@@ -34,7 +34,7 @@ class DateTimeFormatter implements DateTimeFormatterInterface
         $useIntlFormatObject = null,
         ?ResolverInterface $localeResolver = null
     ) {
-        $this->useIntlFormatObject = $useIntlFormatObject ?? !\defined('HHVM_VERSION');
+        $this->useIntlFormatObject = $useIntlFormatObject ?? true;
         $this->localeResolver = $localeResolver
             ?? ObjectManager::getInstance()->get(ResolverInterface::class);
     }

--- a/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeFormatterTest.php
+++ b/lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeFormatterTest.php
@@ -28,9 +28,6 @@ class DateTimeFormatterTest extends TestCase
 
     protected function setUp(): void
     {
-        if (defined('HHVM_VERSION')) {
-            $this->markTestSkipped('Skip this test for hhvm due to problem with \IntlDateFormatter::formatObject');
-        }
         $this->objectManager = new ObjectManager($this);
         $this->localeResolverMock = $this->createMock(ResolverInterface::class);
         $this->localeResolverMock->expects($this->any())


### PR DESCRIPTION
## Description

Remove the dead HHVM detection from `Magento\Framework\Stdlib\DateTime\DateTimeFormatter`.

### Problem

The constructor decides whether to use the native `IntlDateFormatter::formatObject()` based on HHVM detection:

```php
$this->useIntlFormatObject = $useIntlFormatObject ?? !\defined('HHVM_VERSION');
```

HHVM dropped PHP compatibility in 2018 (HHVM 3.30 was the last release able to run PHP code), and Magento has required PHP-proper for years — `HHVM_VERSION` can never be defined in a supported runtime, so the expression always evaluates to `true`.

The corresponding unit test also carries an HHVM-only `markTestSkipped()` branch that can never trigger.

### Solution

Default the flag to `true` directly and drop the stale HHVM skip from the unit test. The `$useIntlFormatObject` constructor parameter and the `doFormatObject()` fallback are intentionally kept — they are public API surface; this PR only removes the dead runtime detection.

### Files Changed

- `lib/internal/Magento/Framework/Stdlib/DateTime/DateTimeFormatter.php`
- `lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeFormatterTest.php`

### Related Pull Requests

Same cleanup pattern as magento/magento2#40686, magento/magento2#40687, magento/magento2#40688.

### Manual testing scenarios (*)

1. Run `lib/internal/Magento/Framework/Stdlib/Test/Unit/DateTime/DateTimeFormatterTest.php` — all tests pass.
2. Any storefront page rendering formatted dates (e.g. order dates) — output unchanged.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#40955: fix: remove dead HHVM detection from DateTimeFormatter