### PR TITLE
Respect app/etc/config.php in integration test sandbox (#15196)

### DIFF
--- a/dev/tests/integration/framework/Magento/TestFramework/Application.php
+++ b/dev/tests/integration/framework/Magento/TestFramework/Application.php
@@ -309,7 +309,7 @@ class Application
      */
     private function getLocalConfig()
     {
-        return $this->_configDir . '/config.php';
+        return $this->_configDir . '/env.php';
     }
 
     /**
@@ -333,14 +333,23 @@ class Application
     }
 
     /**
-     * Weather the application is installed or not.
+     * Whether the application is installed or not.
+     *
+     * The check is based on the installation date in the deployment configuration (env.php) rather than
+     * the mere existence of a configuration file: config.php is copied from the application into
+     * the sandbox before installation and must not be mistaken for an installed application.
      *
      * @return bool
      */
     public function isInstalled()
     {
+        $localConfigFile = $this->getLocalConfig();
         // phpcs:ignore Magento2.Functions.DiscouragedFunction
-        return is_file($this->getLocalConfig());
+        if (!is_file($localConfigFile)) {
+            return false;
+        }
+        $localConfig = include $localConfigFile;
+        return isset($localConfig['install']['date']);
     }
 
     /**
@@ -664,7 +673,7 @@ class Application
     private function copyAppConfigFiles()
     {
         $globalConfigFiles = Glob::glob(
-            $this->_globalConfigDir . '/{di.xml,*/di.xml,db_schema.xml,vendor_path.php}',
+            $this->_globalConfigDir . '/{di.xml,*/di.xml,db_schema.xml,vendor_path.php,config.php}',
             Glob::GLOB_BRACE
         );
         foreach ($globalConfigFiles as $file) {

--- a/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
+++ b/dev/tests/integration/framework/tests/unit/testsuite/Magento/Test/ApplicationTest.php
@@ -317,6 +317,96 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that the application is not considered installed when the deployment configuration is absent.
+     *
+     * @return void
+     */
+    public function testIsInstalledReturnsFalseWhenEnvFileIsAbsent()
+    {
+        $installDir = $this->createSandboxDir();
+        $subject = $this->createApplicationWithInstallDir($installDir);
+
+        $this->assertFalse($subject->isInstalled());
+    }
+
+    /**
+     * Test that a copied config.php alone does not mark the application as installed.
+     *
+     * @return void
+     */
+    public function testIsInstalledReturnsFalseWhenOnlyConfigFileIsPresent()
+    {
+        $installDir = $this->createSandboxDir();
+        file_put_contents($installDir . '/etc/config.php', "<?php\nreturn ['modules' => []];\n");
+        $subject = $this->createApplicationWithInstallDir($installDir);
+
+        $this->assertFalse($subject->isInstalled());
+    }
+
+    /**
+     * Test that the application is not considered installed when env.php has no installation date.
+     *
+     * @return void
+     */
+    public function testIsInstalledReturnsFalseWhenInstallDateIsAbsent()
+    {
+        $installDir = $this->createSandboxDir();
+        file_put_contents($installDir . '/etc/env.php', "<?php\nreturn ['install' => []];\n");
+        $subject = $this->createApplicationWithInstallDir($installDir);
+
+        $this->assertFalse($subject->isInstalled());
+    }
+
+    /**
+     * Test that the application is considered installed when env.php contains the installation date.
+     *
+     * @return void
+     */
+    public function testIsInstalledReturnsTrueWhenInstallDateIsPresent()
+    {
+        $installDir = $this->createSandboxDir();
+        file_put_contents(
+            $installDir . '/etc/env.php',
+            "<?php\nreturn ['install' => ['date' => 'Mon, 01 Jan 2024 00:00:00 +0000']];\n"
+        );
+        $subject = $this->createApplicationWithInstallDir($installDir);
+
+        $this->assertTrue($subject->isInstalled());
+    }
+
+    /**
+     * Create a unique sandbox installation directory with an etc/ subdirectory.
+     *
+     * @return string
+     */
+    private function createSandboxDir(): string
+    {
+        $installDir = sys_get_temp_dir() . '/' . uniqid('m2-integration-sandbox-', true);
+        mkdir($installDir . '/etc', 0777, true);
+
+        return $installDir;
+    }
+
+    /**
+     * Create an Application instance bound to the given sandbox installation directory.
+     *
+     * @param string $installDir
+     * @return Application
+     */
+    private function createApplicationWithInstallDir(string $installDir): Application
+    {
+        return new Application(
+            $this->shell,
+            $installDir,
+            'config.php',
+            'global-config.php',
+            '',
+            $this->appMode,
+            $this->autoloadWrapper
+        );
+    }
+
+    /**
      * Test \Magento\TestFramework\Application will correctly load specified areas.
      * @param string $areaCode
      * @return void


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`app/etc/config.php` is an integral part of the application: it holds the module enable/disable states and any configuration the merchant locked via `bin/magento config:set --lock-config`. The integration test framework, however, never copies it into the test sandbox — `\Magento\TestFramework\Application::copyAppConfigFiles()` only picks up `di.xml`, `db_schema.xml` and `vendor_path.php`. As a result the integration test suite always runs with **all** modules enabled and **without** the locked configuration, i.e. against an application that differs from the one actually deployed. This was reported in #15196 and, despite the issue being closed, the module/locked-config part was never resolved (multiple confirmations in the comments up to 2.4.x).

This PR makes the sandbox respect the application configuration:

1. `copyAppConfigFiles()` now also copies `app/etc/config.php` into the sandbox `etc/` directory, so `setup:install` preserves module states and locked configuration values apply during tests.
2. `isInstalled()` no longer treats the mere existence of `<sandbox>/etc/config.php` as "application installed" — that heuristic would break as soon as `config.php` is copied before installation. It now checks the installation date in the sandbox deployment configuration (`env.php`), which is only written by an actual installation.

The change is backwards compatible:
* On a pristine `magento/magento2` checkout there is no `app/etc/config.php`, so the glob simply does not match and nothing changes (core CI unaffected).
* Existing sandboxes remain detected as installed, because a completed installation always writes `install/date` to `env.php`.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#15196: Magento 2 integration tests enable all modules and ignore `app/etc/config.php`

### Manual testing scenarios (*)

1. Install Magento and disable any module, e.g. `bin/magento module:disable Magento_Vertex` (or lock a configuration value with `bin/magento config:set --lock-config web/secure/use_in_frontend 1`)
2. Run the integration test suite: `cd dev/tests/integration && ../../../vendor/bin/phpunit -c phpunit.xml.dist <any test>`
3. Before this change: the sandbox is installed with all modules enabled and without the locked configuration values
4. After this change: the sandbox preserves the module states from `app/etc/config.php` and the locked configuration values are effective in the tested scenarios

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
