### PR TITLE
Fix PluginList::getPlugin() failing after config scope change (#40962)

### DIFF
--- a/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
+++ b/lib/internal/Magento/Framework/Interception/PluginList/PluginList.php
@@ -170,6 +170,10 @@ class PluginList extends Scoped implements InterceptionPluginList
     public function getPlugin($type, $code)
     {
         if (!isset($this->_pluginInstances[$type][$code])) {
+            $this->_loadScopedData();
+            if (!isset($this->_inherited[$type]) && !array_key_exists($type, $this->_inherited)) {
+                $this->_inheritPlugins($type);
+            }
             $this->_pluginInstances[$type][$code] = $this->_objectManager->get(
                 $this->_inherited[$type][$code]['instance']
             );

--- a/lib/internal/Magento/Framework/Interception/Test/Unit/PluginList/PluginListTest.php
+++ b/lib/internal/Magento/Framework/Interception/Test/Unit/PluginList/PluginListTest.php
@@ -240,6 +240,61 @@ class PluginListTest extends TestCase
     }
 
     /**
+     * Plugin instances recorded by an interceptor must still resolve after the plugged
+     * method switches the configuration scope and another interception reloads scoped data.
+     */
+    public function testGetPluginResolvesPluginAfterScopeChange()
+    {
+        $currentScope = 'backend';
+        $this->configScopeMock->method('getCurrentScope')
+            ->willReturnCallback(
+                function () use (&$currentScope) {
+                    return $currentScope;
+                }
+            );
+
+        $backendInherited = [
+            Item::class => [
+                'simple_plugin' => [
+                    'sortOrder' => 10,
+                    'instance' => Simple::class
+                ]
+            ]
+        ];
+        $backendProcessed = [
+            'Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item_getName___self' => [
+                4 => ['simple_plugin']
+            ]
+        ];
+        $this->configLoaderMock->method('load')->willReturnMap(
+            [
+                ['global|backend|interception', [[], $backendInherited, $backendProcessed]],
+                ['global|backend|frontend|interception', [[], [], []]]
+            ]
+        );
+
+        $inheritPlugins = function ($type) use ($backendInherited) {
+            if ($type === 'Magento\Framework\Interception\Test\Unit\Custom\Module\Model\Item') {
+                $this->_inherited[$type] = $backendInherited[$type]; /** @phpstan-ignore-line */
+            } else {
+                $this->_inherited[$type] = null; /** @phpstan-ignore-line */
+            }
+        };
+        $inheritPlugins = $inheritPlugins->bindTo($this->object, PluginList::class);
+        $this->object->method('_inheritPlugins')->willReturnCallback($inheritPlugins);
+
+        // interceptor records the plugin list in the initial scope
+        $this->assertSame([4 => ['simple_plugin']], $this->object->getNext(Item::class, 'getName'));
+
+        // the plugged method switches scope; a subsequent interception reloads scoped data
+        $currentScope = 'frontend';
+        $this->object->getNext(ItemContainer::class, 'getName');
+
+        // the interceptor resolves the previously recorded plugin
+        $this->assertEquals(Simple::class, $this->object->getPlugin(Item::class, 'simple_plugin'));
+    }
+
+    /**
      * @param array $expectedResult
      * @param string $type
      * @param string $method


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`PluginList::getNext()` lazily (re)builds interception data for the active configuration scope (`_loadScopedData()` + `_inheritPlugins()`), but `PluginList::getPlugin()` blindly trusts the already-loaded `_inherited` state.

When a plugged method switches the configuration scope to one that has not been loaded yet (e.g. `Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor::process()` calls `ScopeInterface::setCurrentScope(Area::AREA_ADMINHTML)` during `app:config:import` / `setup:install`), the next interception inside that method calls `_loadScopedData()`, and `PluginListGenerator::loadScopedVirtualTypes()` resets `_inherited` to `[]` for the new scope. The interceptor that was mid-flight then resolves its previously recorded after/around plugin via `getPlugin()`, which reads `$this->_inherited[$type][$code]['instance']` on a key that no longer exists — yielding `ObjectManager::get(null)` and:

```
Warning: Undefined array key "Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor"
  in lib/internal/Magento/Framework/Interception/PluginList/PluginList.php on line 174
ReflectionException: Class "" does not exist
```

Any module declaring an after/around plugin on a method that switches scope is affected in developer/default mode (no compiled interception metadata). Production mode is unaffected because compiled interception metadata bypasses the runtime rebuild.

Note: the original report used a plugin on `Magento\Deploy\Console\Command\App\ConfigImport\Processor`. That target no longer reproduces on 2.4-develop because `ConfigImportCommand` already runs the processor inside `EmulatedAdminhtmlAreaProcessor` (since 2.4.2), so the scope is `adminhtml` before the interceptor records its plugin list. The corrected reproduction below targets `EmulatedAdminhtmlAreaProcessor::process` itself.

The fix mirrors `getNext()`'s guard at the top of `getPlugin()`: reload scoped data and inherit plugins for the type before resolving the instance. Cost is one `isset()` on the hot path after warm-up (the guard only runs on plugin-instance cache miss, and `_loadScopedData()` short-circuits on an already-loaded scope).

A unit regression test reproduces the exact sequence: `getNext()` records the plugin list in one scope, the scope switches and another interception reloads scoped data, then `getPlugin()` resolves the previously recorded plugin. The test errors on `2.4-develop` without the fix and passes with it.

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40962 (re-report of magento/magento2#35617, closed stale without a fix)

### Manual testing scenarios (*)

1. Switch to developer mode: `bin/magento deploy:mode:set developer` (no `setup:di:compile`)
2. In any module's **global** `etc/di.xml`, declare an `after` plugin on `Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor::process`:
   ```xml
   <type name="Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor">
       <plugin name="repro_plugin" type="Vendor\Module\Plugin\EmulatedAdminhtmlAreaProcessorPlugin"/>
   </type>
   ```
   ```php
   public function afterProcess($subject, $result)
   {
       return $result;
   }
   ```
3. Add a `system` section to `app/etc/config.php` with a value differing from the DB, e.g. `'system' => ['default' => ['general' => ['store_information' => ['name' => 'Repro']]]]`
4. Run `bin/magento cache:flush && bin/magento app:config:import -n`
5. Before the fix: `System config was processed` is printed, then the command fails with `Warning: Undefined array key "Magento\Config\Console\Command\EmulatedAdminhtmlAreaProcessor" in .../PluginList.php on line 174` and exits non-zero. After the fix: import completes and the after plugin executes.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)

