### PR TITLE
Fix bogus store-not-found error on store switch when ___from_store is absent

### DIFF
--- a/app/code/Magento/Store/Controller/Store/SwitchAction.php
+++ b/app/code/Magento/Store/Controller/Store/SwitchAction.php
@@ -108,6 +108,9 @@ class SwitchAction extends Action implements HttpGetActionInterface, HttpPostAct
             '___from_store',
             $this->storeCookieManager->getStoreCodeFromCookie()
         );
+        if (!$fromStoreCode) {
+            $fromStoreCode = $this->storeManager->getStore()->getCode();
+        }
 
         $requestedUrlToRedirect = $this->_redirect->getRedirectUrl();
         $redirectUrl = $requestedUrlToRedirect;

--- a/dev/tests/integration/testsuite/Magento/Store/Controller/Store/SwitchActionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Store/Controller/Store/SwitchActionTest.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Http\Context;
 use Magento\Framework\App\Response\RedirectInterface;
 use Magento\Framework\Encryption\UrlCoder;
 use Magento\Framework\Interception\InterceptorInterface;
+use Magento\Framework\Message\MessageInterface;
 use Magento\Store\Api\StoreResolverInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
@@ -258,5 +259,32 @@ class SwitchActionTest extends AbstractController
         $this->dispatch('stores/store/switch');
         $categorySecond = $this->categoryRepository->get($id, $targetStore->getId());
         $this->assertRedirect($this->stringContains($categorySecond->getUrlKey()));
+    }
+
+    /**
+     * Switching with a valid target store but no ___from_store and no store cookie must not
+     * raise a bogus "store wasn't found" error.
+     *
+     * Reproduces the admin CMS "View Page" preview of a page assigned to the default store
+     * view: the generated switch URL omits ___from_store, and a visitor without a store cookie
+     * previously triggered StoreRepository::get(null). The current store is now used as the
+     * origin store instead.
+     *
+     * @magentoDbIsolation enabled
+     * @return void
+     */
+    public function testSwitchWithoutFromStoreDoesNotError(): void
+    {
+        $targetStore = $this->storeManager->getStore('default');
+        $this->getRequest()->setParams(
+            [
+                StoreManagerInterface::PARAM_NAME => $targetStore->getCode(),
+                ActionInterface::PARAM_NAME_URL_ENCODED => $this->urlEncoder->encode('/'),
+            ]
+        );
+
+        $this->dispatch('stores/store/switch');
+
+        $this->assertSessionMessages($this->isEmpty(), MessageInterface::TYPE_ERROR);
     }
 }


### PR DESCRIPTION
### Description (*)

`Magento\Store\Controller\Store\SwitchAction::execute()` resolves the origin store from the `___from_store` request param, falling back to the store cookie:

```php
$fromStoreCode = $this->_request->getParam(
    '___from_store',
    $this->storeCookieManager->getStoreCodeFromCookie()
);
...
$fromStore = $this->storeRepository->get($fromStoreCode);
```

When **neither** `___from_store` **nor** a store cookie is present, `$fromStoreCode` is `null`, so `StoreRepository::get(null)` throws `NoSuchEntityException`. The controller catches it and shows the misleading error:

> The store that was requested wasn't found. Verify the store and try again.

…even though the **target** store (`___store`) is perfectly valid. The message appears as a flash message and disappears on the next request, which makes it look intermittent and leaves no log entry.

A concrete real-world trigger is the admin **CMS → Pages → Select → View ("View Page")** preview of a page assigned to the **default** store view. Core's `Magento\Cms\ViewModel\Page\Grid\UrlBuilder::prepareRequestQuery()` deliberately omits `___from_store` when the target equals the default store view, so a staff member previewing such a page (with no store cookie yet) always hits this error.

This PR falls back to the **current store** as the origin store when none is provided. A store-to-itself switch then simply sets the cookie and redirects with no error, and a genuine cross-store switch with a missing `___from_store` gets the correct origin. Genuinely invalid target stores still raise the error as before.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

N/A — reproducible on `2.4-develop` (see manual testing below).

### Manual testing scenarios (*)

1. Ensure the browser has **no** `store` cookie (fresh/incognito session).
2. Visit `https://<base-url>/stores/store/switch/?___store=default` (a valid store code, no `___from_store`).
   - **Before:** you are redirected back, and the page shows the error *"The store that was requested wasn't found. Verify the store and try again."*
   - **After:** you are redirected back with **no** error message.
3. Alternatively, in Admin go to **Content → Pages**, and for a page assigned to the default store view click **Select → View**.
   - **Before:** the storefront page shows the error banner.
   - **After:** no error banner.
4. Regression — a real cross-store switch (`?___from_store=default&___store=<other>`) and a genuinely invalid target (`?___store=does_not_exist`) behave exactly as before (valid switch works; invalid target still errors).

Integration coverage added in `SwitchActionTest::testSwitchWithoutFromStoreDoesNotError()`.

### Questions or comments

The current store is used as the origin store because `___from_store` semantically means "the store the visitor is switching *from*", i.e. the current request context. `$this->storeManager` is already used a few lines below in the same method.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (added integration test)
- [x] All automated tests passed successfully (all affected tests pass)


### Resolved issues:
1. [x] resolves magento/magento2#40989: Fix bogus store-not-found error on store switch when ___from_store is absent