### PR TITLE
Add a dedicated modifier pool for the category form (#30134)

### DIFF
--- a/app/code/Magento/Catalog/etc/adminhtml/di.xml
+++ b/app/code/Magento/Catalog/etc/adminhtml/di.xml
@@ -171,6 +171,12 @@
             <argument name="pool" xsi:type="object">Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool</argument>
         </arguments>
     </type>
+    <virtualType name="Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool"/>
+    <type name="Magento\Catalog\Model\Category\DataProvider">
+        <arguments>
+            <argument name="pool" xsi:type="object">Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool</argument>
+        </arguments>
+    </type>
     <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Listing\Modifier\Pool" type="Magento\Ui\DataProvider\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryDataProviderModifier.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/CategoryDataProviderModifier.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Model\Category;
+
+use Magento\Ui\DataProvider\Modifier\ModifierInterface;
+
+/**
+ * Test modifier for category data provider.
+ */
+class CategoryDataProviderModifier implements ModifierInterface
+{
+    public const META_KEY = 'category_form_test_modifier';
+
+    /**
+     * @inheritdoc
+     */
+    public function modifyData(array $data)
+    {
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function modifyMeta(array $meta)
+    {
+        $meta[self::META_KEY] = [
+            'arguments' => [
+                'data' => [
+                    'config' => [
+                        'componentType' => 'fieldset'
+                    ]
+                ]
+            ]
+        ];
+
+        return $meta;
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/DataProviderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Category/DataProviderTest.php
@@ -119,6 +119,32 @@ class DataProviderTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGetMetaAppliesModifierFromCategoryFormModifierPool(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $objectManager->configure([
+            'Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool' => [
+                'arguments' => [
+                    'modifiers' => [
+                        'category_form_test_modifier' => [
+                            'class' => CategoryDataProviderModifier::class,
+                            'sortOrder' => 10
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $objectManager->removeSharedInstance('Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool');
+
+        $dataProvider = $this->createDataProvider();
+        $meta = $dataProvider->getMeta();
+
+        $this->assertArrayHasKey(CategoryDataProviderModifier::META_KEY, $meta);
+    }
+
+    /**
      * Check that deprecated custom layout attribute is hidden.
      *
      * @return void


### PR DESCRIPTION
### Description (*)

The category edit form has no dedicated modifier pool. `Magento\Catalog\Model\Category\DataProvider` receives `null` as the `pool` argument and falls back to the generic `Magento\Ui\DataProvider\Modifier\Pool` created in the parent (`ModifierPoolDataProvider`) constructor.

As a result, every extension that wants to add a category-form modifier has to define its own pool virtualType **and** override the DataProvider's `pool` argument. When two extensions do this, the di.xml definitions conflict and the last one wins — the other extension's modifiers are silently dropped.

Products already solve this properly: `Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool` is defined in `app/code/Magento/Catalog/etc/adminhtml/di.xml` and injected into the product form DataProvider, so extensions simply add items to the shared pool.

This PR applies the same pattern to categories:

- Adds the `Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool` virtualType
- Injects it as the `pool` argument of `Magento\Catalog\Model\Category\DataProvider`
- Adds an integration test proving a modifier registered in the dedicated pool is applied by `getMeta()`

### Related Pull Requests

Supersedes #30119 by @bgorski (MRM Commerce), which was approved but stalled on unrelated flaky functional-test failures. I contacted Bartek and he is fine with closing his PR in favor of this one. All credit for the original diagnosis and fix approach goes to him.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#30134

### Manual testing scenarios (*)

1. Create a module with a class implementing `Magento\Ui\DataProvider\Modifier\ModifierInterface` that adds a recognizable key in `modifyMeta()`.
2. In the module's `etc/adminhtml/di.xml`, add the modifier to the `Magento\Catalog\Ui\DataProvider\Category\Form\Modifier\Pool` virtualType `modifiers` argument (same as you would for the product form pool).
3. Open **Catalog → Categories** in the admin panel and edit any category.
4. Without this PR, the modifier is never invoked. With this PR, the modifier is applied to the category form meta.
5. Repeat with two independent modules registering modifiers — both apply, no di.xml conflict.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [x] All automated tests passed successfully (all builds are green)
