### PR TITLE
Fix TypeError in customerOrders invoice items under strict types (#36829)

### DIFF
--- a/app/code/Magento/SalesGraphQl/Model/Resolver/Invoice/InvoiceItems.php
+++ b/app/code/Magento/SalesGraphQl/Model/Resolver/Invoice/InvoiceItems.php
@@ -113,7 +113,7 @@ class InvoiceItems implements ResolverInterface
     {
         $orderItem = $this->orderItemProvider->getOrderItemById((int)$invoiceItem->getOrderItemId());
         return [
-            'id' => base64_encode($invoiceItem->getEntityId()),
+            'id' => base64_encode((string)$invoiceItem->getEntityId()),
             'product_name' => $invoiceItem->getName(),
             'product_sku' => $invoiceItem->getSku(),
             'product_sale_price' => [

--- a/app/code/Magento/SalesGraphQl/Test/Unit/Model/Resolver/Invoice/InvoiceItemsTest.php
+++ b/app/code/Magento/SalesGraphQl/Test/Unit/Model/Resolver/Invoice/InvoiceItemsTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\SalesGraphQl\Test\Unit\Model\Resolver\Invoice;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Sales\Api\Data\InvoiceInterface;
+use Magento\Sales\Api\Data\InvoiceItemInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\SalesGraphQl\Model\OrderItem\DataProvider as OrderItemProvider;
+use Magento\SalesGraphQl\Model\Resolver\Invoice\InvoiceItems;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceItemsTest extends TestCase
+{
+    /**
+     * @var ValueFactory|MockObject
+     */
+    private $valueFactory;
+
+    /**
+     * @var OrderItemProvider|MockObject
+     */
+    private $orderItemProvider;
+
+    /**
+     * @var InvoiceItems
+     */
+    private $invoiceItemsResolver;
+
+    protected function setUp(): void
+    {
+        $this->valueFactory = $this->createMock(ValueFactory::class);
+        $this->orderItemProvider = $this->createMock(OrderItemProvider::class);
+        $this->invoiceItemsResolver = new InvoiceItems(
+            $this->valueFactory,
+            $this->orderItemProvider
+        );
+    }
+
+    public function testResolveCastsIntegerInvoiceItemIdBeforeEncoding(): void
+    {
+        $orderItemId = 7;
+        $invoiceItemEntityId = 42;
+        $callback = null;
+
+        $field = $this->createMock(Field::class);
+        $context = null;
+        $info = $this->createMock(ResolveInfo::class);
+        $order = $this->createMock(OrderInterface::class);
+        $invoice = $this->createMock(InvoiceInterface::class);
+        $invoiceItem = $this->createMock(InvoiceItemInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $invoice->expects($this->once())
+            ->method('getItems')
+            ->willReturn([$invoiceItem]);
+
+        $invoiceItem->method('getOrderItemId')
+            ->willReturn($orderItemId);
+        $invoiceItem->expects($this->once())
+            ->method('getEntityId')
+            ->willReturn($invoiceItemEntityId);
+        $invoiceItem->method('getName')
+            ->willReturn('Test Product');
+        $invoiceItem->method('getSku')
+            ->willReturn('test-product');
+        $invoiceItem->method('getPrice')
+            ->willReturn(10.00);
+        $invoiceItem->method('getQty')
+            ->willReturn(1.00);
+        $invoiceItem->method('getDiscountAmount')
+            ->willReturn(0.00);
+
+        $order->method('getOrderCurrencyCode')
+            ->willReturn('USD');
+        $order->method('getDiscountDescription')
+            ->willReturn(null);
+        $order->method('getDiscountAmount')
+            ->willReturn(0.00);
+
+        $orderItem->expects($this->once())
+            ->method('getParentItem')
+            ->willReturn(null);
+
+        $orderItemData = [
+            'model' => $orderItem,
+            'product_type' => 'simple'
+        ];
+        $this->orderItemProvider->expects($this->once())
+            ->method('addOrderItemId')
+            ->with($orderItemId);
+        $this->orderItemProvider->expects($this->exactly(2))
+            ->method('getOrderItemById')
+            ->with($orderItemId)
+            ->willReturn($orderItemData);
+
+        $this->valueFactory->expects($this->once())
+            ->method('create')
+            ->willReturnCallback(function (\Closure $resolver) use (&$callback): string {
+                $callback = $resolver;
+                return 'deferred-result';
+            });
+
+        $result = $this->invoiceItemsResolver->resolve(
+            $field,
+            $context,
+            $info,
+            [
+                'model' => $invoice,
+                'order' => $order
+            ]
+        );
+
+        $this->assertSame('deferred-result', $result);
+        $this->assertInstanceOf(\Closure::class, $callback);
+        $resolvedItems = $callback();
+
+        $this->assertSame(base64_encode('42'), $resolvedItems[$orderItemId]['id']);
+    }
+}


### PR DESCRIPTION
### Description (*)

`app/code/Magento/SalesGraphQl/Model/Resolver/Invoice/InvoiceItems.php` declares `strict_types=1` and calls `base64_encode($invoiceItem->getEntityId())`. `InvoiceItemInterface::getEntityId()` has no return type and can return an integer. Under strict types this throws:

```
TypeError: base64_encode(): Argument #1 ($string) must be of type string, int given
```

This surfaces through the deprecated-but-still-supported `customerOrders` query when requesting `invoices { items { id } }`.

The fix casts the entity ID to string before encoding — the same pattern already used in the same module in `Magento\SalesGraphQl\Model\Formatter\Order` (`base64_encode((string)$orderModel->getEntityId())`).

A unit test covers the resolver's deferred callback with an integer entity ID; it fails with the exact TypeError above when the cast is removed.

### Related Pull Requests

Supersedes #33805 by @bgorski (MRM Commerce). The other part of his original fix (missing `model` in the `Orders` resolver) has already been merged separately via AC-6084; this remaining one-line cast never landed. I contacted Bartek and he is fine with closing his PR in favor of this one. Credit for the original diagnosis goes to him.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#36829

### Manual testing scenarios (*)

1. Register a customer and place an order for that customer.
2. Generate an invoice for the order.
3. Generate a customer token:
```graphql
mutation {
  generateCustomerToken(email: "customer@example.com", password: "password") {
    token
  }
}
```
4. Using the token, run:
```graphql
query {
  customerOrders {
    items {
      order_number
      invoices {
        id
        items {
          id
        }
      }
    }
  }
}
```
5. Without this PR the query can fail with the `TypeError` above when the invoice item entity ID is an integer; with this PR it returns the base64-encoded ID.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [x] All automated tests passed successfully (all builds are green)
