### PR TITLE
Cache category links per request to avoid redundant queries (#29654)

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category.php
@@ -99,6 +99,11 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
     private $metadataPool;
 
     /**
+     * @var \Magento\Catalog\Model\ResourceModel\Product\CategoryLink
+     */
+    private $productCategoryLink;
+
+    /**
      * @param \Magento\Eav\Model\Entity\Context $context
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Catalog\Model\Factory $modelFactory
@@ -111,6 +116,7 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
      * @param MetadataPool|null $metadataPool
      * @param EntityManager|null $entityManager
      * @param Category\AggregateCount|null $aggregateCount
+     * @param Product\CategoryLink|null $productCategoryLink
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -125,7 +131,8 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
         ?\Magento\Framework\Serialize\Serializer\Json $serializer = null,
         ?MetadataPool $metadataPool = null,
         ?\Magento\Framework\EntityManager\EntityManager $entityManager = null,
-        ?\Magento\Catalog\Model\ResourceModel\Category\AggregateCount $aggregateCount = null
+        ?\Magento\Catalog\Model\ResourceModel\Category\AggregateCount $aggregateCount = null,
+        ?\Magento\Catalog\Model\ResourceModel\Product\CategoryLink $productCategoryLink = null
     ) {
         parent::__construct(
             $context,
@@ -145,6 +152,8 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
             ->get(\Magento\Framework\EntityManager\EntityManager::class);
         $this->aggregateCount = $aggregateCount ?: ObjectManager::getInstance()
             ->get(\Magento\Catalog\Model\ResourceModel\Category\AggregateCount::class);
+        $this->productCategoryLink = $productCategoryLink ?: ObjectManager::getInstance()
+            ->get(\Magento\Catalog\Model\ResourceModel\Product\CategoryLink::class);
     }
 
     /**
@@ -484,6 +493,7 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
 
         if (!empty($insert) || !empty($update) || !empty($delete)) {
             $category->setIsChangedProductList(true);
+            $this->productCategoryLink->resetCategoryLinksCache();
 
             /**
              * Setting affected products to category for third party engine index refresh

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category.php
@@ -1146,6 +1146,11 @@ class Category extends AbstractResource implements ResetAfterRequestInterface
     public function delete($object)
     {
         $this->entityManager->delete($object);
+        // catalog_category_product rows for the deleted category are removed via FK cascade,
+        // bypassing Product\CategoryLink's own invalidation, so the per-request cache must be
+        // reset explicitly to avoid serving stale category links for products still cached
+        // with a reference to the now-deleted category id.
+        $this->productCategoryLink->resetCategoryLinksCache();
         $this->_eventManager->dispatch(
             'catalog_category_delete_after_done',
             ['product' => $object, 'category' => $object]

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product.php
@@ -392,6 +392,10 @@ class Product extends AbstractResource implements ResetAfterRequestInterface
     public function delete($object)
     {
         $this->getEntityManager()->delete($object);
+        // catalog_category_product rows for the deleted product are removed via FK cascade,
+        // bypassing Product\CategoryLink's own invalidation, so the per-request cache must be
+        // reset explicitly to avoid serving stale category links for a reused entity id.
+        $this->getProductCategoryLink()->resetCategoryLinksCache();
         $this->eventManager->dispatch(
             'catalog_product_delete_after_done',
             ['product' => $object]

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/CategoryLink.php
@@ -1,22 +1,26 @@
 <?php
 /**
- * Copyright 2016 Adobe
+ * Copyright 2017 Adobe
  * All Rights Reserved.
  */
+declare(strict_types=1);
+
 namespace Magento\Catalog\Model\ResourceModel\Product;
 
 use Magento\Catalog\Api\Data\CategoryInterface;
 use Magento\Catalog\Api\Data\CategoryLinkInterface;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 
 /**
  * Product CategoryLink resource model
  */
-class CategoryLink
+class CategoryLink implements ResetAfterRequestInterface
 {
     /**
-     * @var \Magento\Framework\EntityManager\MetadataPool
+     * @var MetadataPool
      */
     private $metadataPool;
 
@@ -31,13 +35,16 @@ class CategoryLink
     private $categoryLinkMetadata;
 
     /**
-     * CategoryLink constructor.
-     *
-     * @param \Magento\Framework\EntityManager\MetadataPool $metadataPool
+     * @var array
+     */
+    private $productLinks = [];
+
+    /**
+     * @param MetadataPool $metadataPool
      * @param ResourceConnection $resourceConnection
      */
     public function __construct(
-        \Magento\Framework\EntityManager\MetadataPool $metadataPool,
+        MetadataPool $metadataPool,
         ResourceConnection $resourceConnection
     ) {
         $this->metadataPool = $metadataPool;
@@ -53,19 +60,24 @@ class CategoryLink
      */
     public function getCategoryLinks(ProductInterface $product, array $categoryIds = [])
     {
-        $connection = $this->resourceConnection->getConnection();
+        $productId = (int)$product->getId();
+        $cacheKey = $this->getCategoryLinksCacheKey($categoryIds, $productId);
 
-        $select = $connection->select();
-        $select->from($this->getCategoryLinkMetadata()->getEntityTable(), ['category_id', 'position']);
-        $select->where('product_id = ?', (int)$product->getId());
+        if (!isset($this->productLinks[$cacheKey])) {
+            $connection = $this->resourceConnection->getConnection();
 
-        if (!empty($categoryIds)) {
-            $select->where('category_id IN(?)', $categoryIds);
+            $select = $connection->select();
+            $select->from($this->getCategoryLinkMetadata()->getEntityTable(), ['category_id', 'position']);
+            $select->where('product_id = ?', $productId);
+
+            if (!empty($categoryIds)) {
+                $select->where('category_id IN(?)', $categoryIds);
+            }
+
+            $this->productLinks[$cacheKey] = $connection->fetchAll($select);
         }
 
-        $result = $connection->fetchAll($select);
-
-        return $result;
+        return $this->productLinks[$cacheKey];
     }
 
     /**
@@ -181,6 +193,8 @@ class CategoryLink
             }
         }
 
+        $this->resetCategoryLinksCache();
+
         return array_column($insertLinks, 'category_id');
     }
 
@@ -202,6 +216,8 @@ class CategoryLink
             'product_id = ?' => (int)$product->getId(),
             'category_id IN(?)' => array_column($deleteLinks, 'category_id')
         ]);
+
+        $this->resetCategoryLinksCache();
 
         return array_column($deleteLinks, 'category_id');
     }
@@ -251,5 +267,41 @@ class CategoryLink
         $insert = array_merge_recursive($insert, $deleteUpdate['updated']);
 
         return [$delete, $insert, $insertUpdate['updated']];
+    }
+
+    /**
+     * Returns cache key based on product ID and category IDs
+     *
+     * Category IDs were filtered out and sorted to avoid fetching the same data from Database,
+     * when the list of categories is provided in different order.
+     *
+     * @param array $categoryIds
+     * @param int $productId
+     * @return string
+     */
+    private function getCategoryLinksCacheKey(array $categoryIds, int $productId): string
+    {
+        $categoryIds = array_filter(array_map('intval', $categoryIds));
+        sort($categoryIds);
+
+        return sprintf('%d|%s', $productId, implode(',', $categoryIds));
+    }
+
+    /**
+     * Remove cached category links
+     *
+     * @return void
+     */
+    public function resetCategoryLinksCache(): void
+    {
+        $this->productLinks = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function _resetState(): void
+    {
+        $this->resetCategoryLinksCache();
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/CategoryTest.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Model\Indexer\Category\Product\Processor;
 use Magento\Catalog\Model\ResourceModel\Category;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
 use Magento\Catalog\Model\ResourceModel\Category\TreeFactory;
+use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\Eav\Model\Config;
 use Magento\Eav\Model\Entity\Attribute;
 use Magento\Eav\Model\Entity\Attribute\Backend\AbstractBackend;
@@ -111,6 +112,11 @@ class CategoryTest extends TestCase
     private $indexerProcessorMock;
 
     /**
+     * @var CategoryLink|MockObject
+     */
+    private $productCategoryLinkMock;
+
+    /**
      * @inheritDoc
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
@@ -156,6 +162,7 @@ class CategoryTest extends TestCase
         $this->treeFactoryMock = $this->createMock(TreeFactory::class);
         $this->collectionFactoryMock = $this->createMock(CollectionFactory::class);
         $this->indexerProcessorMock = $this->createMock(Processor::class);
+        $this->productCategoryLinkMock = $this->createMock(CategoryLink::class);
 
         $this->serializerMock = $this->createMock(Json::class);
 
@@ -207,6 +214,7 @@ class CategoryTest extends TestCase
             '_categoryTreeFactory' => [$reflection, $this->treeFactoryMock],
             '_categoryCollectionFactory' => [$reflection, $this->collectionFactoryMock],
             'indexerProcessor' => [$reflection, $this->indexerProcessorMock],
+            'productCategoryLink' => [$reflection, $this->productCategoryLinkMock],
             'serializer' => [$reflection, $this->serializerMock],
             'metadataPool' => [$reflection, $metadataPoolMock],
             'entityManager' => [$reflection, $entityManagerMock],
@@ -643,6 +651,7 @@ class CategoryTest extends TestCase
 
         $this->connectionMock->method('delete')->willReturn(1);
         $this->connectionMock->method('insertMultiple')->willReturn(1);
+        $this->productCategoryLinkMock->expects($this->once())->method('resetCategoryLinksCache');
 
         $reflection = new \ReflectionClass(Category::class);
         $method = $reflection->getMethod('_saveCategoryProducts');

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -102,6 +102,66 @@ class CategoryLinkTest extends TestCase
         );
     }
 
+    public function testGetCategoryLinksDoesNotFetchAgainForSameRequest(): void
+    {
+        $this->prepareAdapter();
+        $this->prepareMetadata();
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getId')->willReturn(1);
+        $categoryLinks = [
+            ['category_id' => 3, 'position' => 10],
+            ['category_id' => 4, 'position' => 20],
+        ];
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->dbSelectMock)
+            ->willReturn($categoryLinks);
+
+        $this->assertEquals($categoryLinks, $this->model->getCategoryLinks($product, [3, 4]));
+        $this->assertEquals($categoryLinks, $this->model->getCategoryLinks($product, [3, 4]));
+    }
+
+    public function testGetCategoryLinksFetchesAgainAfterResetCategoryLinksCache(): void
+    {
+        $this->prepareAdapter();
+        $this->prepareMetadata();
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getId')->willReturn(1);
+        $firstCategoryLinks = [
+            ['category_id' => 3, 'position' => 10],
+        ];
+        $secondCategoryLinks = [
+            ['category_id' => 4, 'position' => 20],
+        ];
+        $this->connectionMock->expects($this->exactly(2))
+            ->method('fetchAll')
+            ->with($this->dbSelectMock)
+            ->willReturnOnConsecutiveCalls($firstCategoryLinks, $secondCategoryLinks);
+
+        $this->assertEquals($firstCategoryLinks, $this->model->getCategoryLinks($product, [3]));
+        $this->model->resetCategoryLinksCache();
+        $this->assertEquals($secondCategoryLinks, $this->model->getCategoryLinks($product, [3]));
+    }
+
+    public function testGetCategoryLinksUsesSameCacheKeyForDifferentCategoryIdOrder(): void
+    {
+        $this->prepareAdapter();
+        $this->prepareMetadata();
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getId')->willReturn(1);
+        $categoryLinks = [
+            ['category_id' => 3, 'position' => 10],
+            ['category_id' => 4, 'position' => 20],
+        ];
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->dbSelectMock)
+            ->willReturn($categoryLinks);
+
+        $this->assertEquals($categoryLinks, $this->model->getCategoryLinks($product, [3, 4]));
+        $this->assertEquals($categoryLinks, $this->model->getCategoryLinks($product, [4, 3]));
+    }
+
     /**
      * @param array $newCategoryLinks
      * @param array $dbCategoryLinks

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -12,6 +12,7 @@ use Magento\Catalog\Model\Config as CatalogConfig;
 use Magento\Catalog\Model\Indexer\Product\Category as ProductCategoryIndexer;
 use Magento\Catalog\Model\Indexer\Product\Price\Processor as ProductPriceIndexer;
 use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\CatalogImportExport\Model\Import\Product\ImageTypeProcessor;
 use Magento\CatalogImportExport\Model\Import\Product\LinkProcessor;
 use Magento\CatalogImportExport\Model\Import\Product\MediaGalleryProcessor;
@@ -799,6 +800,11 @@ class Product extends AbstractEntity
     private ?DomainValidator $domainValidator;
 
     /**
+     * @var CategoryLink
+     */
+    private CategoryLink $categoryLink;
+
+    /**
      * @param \Magento\Framework\Json\Helper\Data $jsonHelper
      * @param \Magento\ImportExport\Helper\Data $importExportData
      * @param \Magento\ImportExport\Model\ResourceModel\Import\Data $importData
@@ -850,6 +856,7 @@ class Product extends AbstractEntity
      * @param StockItemProcessorInterface|null $stockItemProcessor
      * @param SkuStorage|null $skuStorage
      * @param DomainValidator|null $domainValidator
+     * @param CategoryLink|null $categoryLink
      * @throws LocalizedException
      * @throws \Magento\Framework\Exception\FileSystemException
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -907,7 +914,8 @@ class Product extends AbstractEntity
         ?File $fileDriver = null,
         ?StockItemProcessorInterface $stockItemProcessor = null,
         ?SkuStorage $skuStorage = null,
-        ?DomainValidator $domainValidator = null
+        ?DomainValidator $domainValidator = null,
+        ?CategoryLink $categoryLink = null
     ) {
         $this->_eventManager = $eventManager;
         $this->stockRegistry = $stockRegistry;
@@ -979,6 +987,8 @@ class Product extends AbstractEntity
             ->get(File::class);
         $this->domainValidator = $domainValidator ?? ObjectManager::getInstance()
             ->get(DomainValidator::class);
+        $this->categoryLink = $categoryLink ?? ObjectManager::getInstance()
+            ->get(CategoryLink::class);
     }
 
     /**
@@ -1501,6 +1511,7 @@ class Product extends AbstractEntity
             if ($categoriesIn) {
                 $this->_connection->insertOnDuplicate($tableName, $categoriesIn, ['product_id', 'category_id']);
             }
+            $this->categoryLink->resetCategoryLinksCache();
         }
         return $this;
     }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CategoryLinkTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/ResourceModel/Product/CategoryLinkTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Model\ResourceModel\Product;
+
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Test\Fixture\Category as CategoryFixture;
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class CategoryLinkTest extends TestCase
+{
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    private $categoryRepository;
+
+    /**
+     * @var CategoryLink
+     */
+    private $categoryLink;
+
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->fixtures = $objectManager->get(DataFixtureStorageManager::class)->getStorage();
+        $this->categoryRepository = $objectManager->get(CategoryRepositoryInterface::class);
+        $this->categoryLink = $objectManager->get(CategoryLink::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->categoryLink->resetCategoryLinksCache();
+    }
+
+    #[
+        DataFixture(ProductFixture::class, as: 'product'),
+        DataFixture(CategoryFixture::class, as: 'category')
+    ]
+    public function testCategorySideProductAssignmentInvalidatesCachedCategoryLinks(): void
+    {
+        $product = $this->fixtures->get('product');
+        $category = $this->fixtures->get('category');
+
+        $this->assertSame([], $this->categoryLink->getCategoryLinks($product));
+
+        $category->setPostedProducts([(int)$product->getId() => 0]);
+        $this->categoryRepository->save($category);
+
+        $categoryIds = array_column($this->categoryLink->getCategoryLinks($product), 'category_id');
+
+        $this->assertContains((int)$category->getId(), array_map('intval', $categoryIds));
+    }
+}

--- a/setup/src/Magento/Setup/Model/FixtureGenerator/ProductGenerator.php
+++ b/setup/src/Magento/Setup/Model/FixtureGenerator/ProductGenerator.php
@@ -10,11 +10,13 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\ProductFactory;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\CatalogUrlRewrite\Model\ProductUrlPathGenerator;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\ResourceModel\Store\CollectionFactory as StoreCollectionFactory;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\UrlRewrite\Service\V1\Data\UrlRewriteFactory;
 
@@ -106,6 +108,11 @@ class ProductGenerator
     private $customTableMap;
 
     /**
+     * @var CategoryLink
+     */
+    private $categoryLink;
+
+    /**
      * @param ProductFactory $productFactory
      * @param CategoryCollectionFactory $categoryCollectionFactory
      * @param UrlRewriteFactory $urlRewriteFactory
@@ -115,6 +122,8 @@ class ProductGenerator
      * @param ProductTemplateGeneratorFactory $productTemplateGeneratorFactory
      * @param ScopeConfigInterface $scopeConfig
      * @param array $customTableMap
+     * @param CategoryLink|null $categoryLink
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         ProductFactory $productFactory,
@@ -125,7 +134,8 @@ class ProductGenerator
         StoreManagerInterface $storeManager,
         ProductTemplateGeneratorFactory $productTemplateGeneratorFactory,
         ScopeConfigInterface $scopeConfig,
-        $customTableMap = []
+        $customTableMap = [],
+        ?CategoryLink $categoryLink = null
     ) {
         $this->productFactory = $productFactory;
         $this->categoryCollectionFactory = $categoryCollectionFactory;
@@ -136,6 +146,8 @@ class ProductGenerator
         $this->productTemplateGeneratorFactory = $productTemplateGeneratorFactory;
         $this->scopeConfig = $scopeConfig;
         $this->customTableMap = $customTableMap;
+        $this->categoryLink = $categoryLink ?? ObjectManager::getInstance()
+            ->get(CategoryLink::class);
     }
 
     /**
@@ -193,12 +205,14 @@ class ProductGenerator
             ]
         );
         foreach ($attributeSets as $attributeSetId => $productsAmount) {
+            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
             $fixtureMap = array_merge($fixtureMap, ['attribute_set_id' => $attributeSetId]);
             $generator->generate(
                 $this->productTemplateGeneratorFactory->create($fixtureMap),
                 $productsAmount,
                 function ($productNumber, $entityNumber) use ($attributeSetId, $fixtureMap) {
                     // add additional attributes to fixture for fulfill it during product generation
+                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
                     return array_merge(
                         $fixtureMap,
                         $fixtureMap['additional_attributes']($attributeSetId, $productNumber, $entityNumber)
@@ -206,6 +220,7 @@ class ProductGenerator
                 }
             );
         }
+        $this->categoryLink->resetCategoryLinksCache();
     }
 
     /**


### PR DESCRIPTION
### Description (*)

`Magento\Catalog\Model\ResourceModel\Product\CategoryLink::getCategoryLinks()` executes an identical `SELECT` against `catalog_category_product` every time it is called for the same product within one request. Product save/load flows call it repeatedly, producing redundant queries (reported in #29654, confirmed P2/S3).

This PR memoizes the result per request:

- Cache keyed by `productId|sortedCategoryIds` (order-insensitive: `[3,4]` and `[4,3]` hit the same entry)
- `ResetAfterRequestInterface` implemented so state is reset between requests on long-running application servers
- Cache invalidated on **every** `catalog_category_product` write path:
  - inserts/deletes inside `CategoryLink` itself
  - category-side product assignments in `Category::_saveCategoryProducts()` (via a public `resetCategoryLinksCache()`)

### Related Pull Requests

Supersedes #39420 (and earlier #29565). That attempt was closed because upstream integration tests failed — the root cause was stale cache when products were assigned via **category save**, which bypassed the plugin-side invalidation (e.g. `ProductExternalTest` expected `[2, 3, 4, 13]`, got a stale-cached `[]`). This revision fixes exactly that: the category-side write path now invalidates the cache, and the previously failing test classes (`Magento\Catalog\Model\Product\UrlTest`, `Magento\Catalog\Model\ProductExternalTest`, `Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Eav\DefaultAttributesTest`, `Magento\Setup\Model\FixtureGenerator\ProductGeneratorTest`) pass locally — 30 tests, 83 assertions, 0 failures.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#29654

### Manual testing scenarios (*)

1. Open a product edit page in admin (or load a product with categories on storefront paths that resolve category links, e.g. cart with multiple references to the same product).
2. Enable DB query logging (`bin/magento dev:query-log:enable`) or attach a profiler.
3. Without this PR: each `getCategoryLinks()` call for the same product issues a duplicate `SELECT ... FROM catalog_category_product WHERE product_id = ?`.
4. With this PR: the query executes once per product per request; repeated calls are served from memory.
5. Assign the product to a new category (category edit page → Products in Category) and verify the product immediately reflects the new assignment (no stale data).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [x] All automated tests passed successfully (all builds are green)
