### PR TITLE
Fix TypeError in custom_attributesV2 GraphQL output for null and non-string attribute values (#38884)

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/ProductCustomAttributes.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/ProductCustomAttributes.php
@@ -144,7 +144,7 @@ class ProductCustomAttributes implements ResolverInterface
             }
             $customAttributes[] = [
                 'attribute_code' => $attributeCode,
-                'value' => $attributeValue
+                'value' => (string)$attributeValue
             ];
         }
 

--- a/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Product/ProductCustomAttributesTest.php
+++ b/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Product/ProductCustomAttributesTest.php
@@ -727,4 +727,60 @@ class ProductCustomAttributesTest extends TestCase
         $this->assertCount(1, $result['items']);
         $this->assertSame('42', $result['items'][0]['value']);
     }
+
+    /**
+     * Test resolve casts non-string scalar attribute values to string
+     *
+     * @return void
+     */
+    public function testResolveCastsNonStringScalarValueToString(): void
+    {
+        $productId = 1;
+        $attributeCode = 'int_attribute';
+
+        $attributeMock = $this->createMock(AttributeInterface::class);
+        $attributeMock->method('getAttributeCode')->willReturn($attributeCode);
+
+        $this->productMock->method('getId')->willReturn($productId);
+
+        $this->getFilteredAttributesMock
+            ->method('execute')
+            ->willReturn([
+                'items' => [$attributeMock],
+                'errors' => []
+            ]);
+
+        $this->filterCustomAttributeMock
+            ->method('execute')
+            ->willReturn([$attributeCode => 0]);
+
+        $this->productDataProviderMock
+            ->method('getProductDataById')
+            ->willReturn([
+                $attributeCode => 123 // Integer value
+            ]);
+
+        $this->getAttributeValueMock
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturnCallback(function ($entityType, $code, $value) {
+                $this->assertSame('123', $value);
+                return [
+                    'code' => $code,
+                    'value' => $value
+                ];
+            });
+
+        $result = $this->resolver->resolve(
+            $this->fieldMock,
+            $this->contextMock,
+            $this->resolveInfoMock,
+            ['model' => $this->productMock],
+            []
+        );
+
+        $this->assertArrayHasKey('items', $result);
+        $this->assertCount(1, $result['items']);
+        $this->assertSame('123', $result['items'][0]['value']);
+    }
 }

--- a/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Product/ProductCustomAttributesTest.php
+++ b/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Product/ProductCustomAttributesTest.php
@@ -764,6 +764,7 @@ class ProductCustomAttributesTest extends TestCase
             ->expects($this->once())
             ->method('execute')
             ->willReturnCallback(function ($entityType, $code, $value) {
+                $this->assertSame(ProductAttributeInterface::ENTITY_TYPE_CODE, $entityType);
                 $this->assertSame('123', $value);
                 return [
                     'code' => $code,

--- a/app/code/Magento/CustomerGraphQl/Model/Customer/Address/ExtractCustomerAddressData.php
+++ b/app/code/Magento/CustomerGraphQl/Model/Customer/Address/ExtractCustomerAddressData.php
@@ -159,10 +159,16 @@ class ExtractCustomerAddressData
 
         $customAttributes['custom_attributesV2'] = array_map(
             function (array $customAttribute) {
+                $value = $customAttribute['value'] ?? '';
+                if (is_array($value)) {
+                    $value = (count($value) !== count($value, COUNT_RECURSIVE))
+                        ? $this->jsonSerializer->serialize($value)
+                        : implode(',', $value);
+                }
                 return $this->getAttributeValue->execute(
                     AddressMetadataInterface::ENTITY_TYPE_ADDRESS,
                     $customAttribute['attribute_code'],
-                    $customAttribute['value']
+                    (string)$value
                 );
             },
             $attributes

--- a/app/code/Magento/CustomerGraphQl/Test/Unit/Model/Customer/Address/ExtractCustomerAddressDataTest.php
+++ b/app/code/Magento/CustomerGraphQl/Test/Unit/Model/Customer/Address/ExtractCustomerAddressDataTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CustomerGraphQl\Test\Unit\Model\Customer\Address;
+
+use Magento\Customer\Api\Data\AddressInterface;
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\CustomerFactory;
+use Magento\Customer\Model\ResourceModel\Customer as CustomerResourceModel;
+use Magento\CustomerGraphQl\Model\Customer\Address\ExtractCustomerAddressData;
+use Magento\EavGraphQl\Model\Output\Value\GetAttributeValueInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\Webapi\ServiceOutputProcessor;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for ExtractCustomerAddressData
+ *
+ * @see ExtractCustomerAddressData
+ */
+class ExtractCustomerAddressDataTest extends TestCase
+{
+    /**
+     * @var ExtractCustomerAddressData
+     */
+    private ExtractCustomerAddressData $extractCustomerAddressData;
+
+    /**
+     * @var ServiceOutputProcessor|MockObject
+     */
+    private ServiceOutputProcessor|MockObject $serviceOutputProcessorMock;
+
+    /**
+     * @var SerializerInterface|MockObject
+     */
+    private SerializerInterface|MockObject $jsonSerializerMock;
+
+    /**
+     * @var CustomerResourceModel|MockObject
+     */
+    private CustomerResourceModel|MockObject $customerResourceModelMock;
+
+    /**
+     * @var CustomerFactory|MockObject
+     */
+    private CustomerFactory|MockObject $customerFactoryMock;
+
+    /**
+     * @var GetAttributeValueInterface|MockObject
+     */
+    private GetAttributeValueInterface|MockObject $getAttributeValueMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->serviceOutputProcessorMock = $this->createMock(ServiceOutputProcessor::class);
+        $this->jsonSerializerMock = $this->createMock(SerializerInterface::class);
+        $this->customerResourceModelMock = $this->createMock(CustomerResourceModel::class);
+        $this->customerFactoryMock = $this->createMock(CustomerFactory::class);
+        $this->getAttributeValueMock = $this->createMock(GetAttributeValueInterface::class);
+
+        $customerMock = $this->createMock(Customer::class);
+        $customerMock->method('getDefaultBillingAddress')->willReturn(false);
+        $customerMock->method('getDefaultShippingAddress')->willReturn(false);
+        $this->customerFactoryMock->method('create')->willReturn($customerMock);
+
+        $this->extractCustomerAddressData = new ExtractCustomerAddressData(
+            $this->serviceOutputProcessorMock,
+            $this->jsonSerializerMock,
+            $this->customerResourceModelMock,
+            $this->customerFactoryMock,
+            $this->getAttributeValueMock
+        );
+    }
+
+    /**
+     * Test that null, integer and array custom attribute values do not cause a TypeError
+     * and are normalized to strings before being passed to the value provider
+     *
+     * @return void
+     */
+    public function testExecuteNormalizesNonStringCustomAttributeValues(): void
+    {
+        $addressMock = $this->createMock(AddressInterface::class);
+        $addressMock->method('getCustomerId')->willReturn(1);
+        $addressMock->method('getId')->willReturn(1);
+
+        $this->serviceOutputProcessorMock
+            ->method('process')
+            ->willReturn([
+                'id' => 1,
+                'country_id' => 'US',
+                'custom_attributes' => [
+                    ['attribute_code' => 'null_attribute', 'value' => null],
+                    ['attribute_code' => 'int_attribute', 'value' => 123],
+                    ['attribute_code' => 'multiselect_attribute', 'value' => ['a', 'b']],
+                ],
+            ]);
+
+        $expectedValues = [
+            'null_attribute' => '',
+            'int_attribute' => '123',
+            'multiselect_attribute' => 'a,b',
+        ];
+
+        $this->getAttributeValueMock
+            ->expects($this->exactly(3))
+            ->method('execute')
+            ->willReturnCallback(function ($entity, $code, $value) use ($expectedValues) {
+                $this->assertSame($expectedValues[$code], $value);
+                return [
+                    'code' => $code,
+                    'value' => $value,
+                    'sort_order' => 0,
+                ];
+            });
+
+        $result = $this->extractCustomerAddressData->execute($addressMock);
+
+        $this->assertArrayHasKey('custom_attributesV2', $result);
+        $this->assertCount(3, $result['custom_attributesV2']);
+    }
+}

--- a/app/code/Magento/CustomerGraphQl/Test/Unit/Model/Customer/Address/ExtractCustomerAddressDataTest.php
+++ b/app/code/Magento/CustomerGraphQl/Test/Unit/Model/Customer/Address/ExtractCustomerAddressDataTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\CustomerGraphQl\Test\Unit\Model\Customer\Address;
 
+use Magento\Customer\Api\AddressMetadataInterface;
 use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Model\Customer;
 use Magento\Customer\Model\CustomerFactory;
@@ -114,6 +115,7 @@ class ExtractCustomerAddressDataTest extends TestCase
             ->expects($this->exactly(3))
             ->method('execute')
             ->willReturnCallback(function ($entity, $code, $value) use ($expectedValues) {
+                $this->assertSame(AddressMetadataInterface::ENTITY_TYPE_ADDRESS, $entity);
                 $this->assertSame($expectedValues[$code], $value);
                 return [
                     'code' => $code,

--- a/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractQuoteAddressData.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Cart/ExtractQuoteAddressData.php
@@ -68,10 +68,14 @@ class ExtractQuoteAddressData
                 'customer_notes' => $address->getCustomerNotes(),
                 'custom_attributes' => array_map(
                     function (AttributeInterface $attribute) {
+                        $value = $attribute->getValue() ?? '';
+                        if (is_array($value)) {
+                            $value = implode(',', $value);
+                        }
                         return $this->getAttributeValue->execute(
                             'customer_address',
                             $attribute->getAttributeCode(),
-                            $attribute->getValue()
+                            (string)$value
                         );
                     },
                     $address->getCustomAttributes() ?? []

--- a/app/code/Magento/QuoteGraphQl/Test/Unit/Model/Cart/ExtractQuoteAddressDataTest.php
+++ b/app/code/Magento/QuoteGraphQl/Test/Unit/Model/Cart/ExtractQuoteAddressDataTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\QuoteGraphQl\Test\Unit\Model\Cart;
+
+use Magento\Framework\Api\AttributeInterface;
+use Magento\Framework\Api\ExtensibleDataObjectConverter;
+use Magento\Framework\GraphQl\Query\Uid;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\QuoteGraphQl\Model\Cart\ExtractQuoteAddressData;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Magento\EavGraphQl\Model\Output\Value\GetAttributeValueInterface;
+
+/**
+ * Test for ExtractQuoteAddressData
+ *
+ * @see ExtractQuoteAddressData
+ */
+class ExtractQuoteAddressDataTest extends TestCase
+{
+    /**
+     * @var ExtractQuoteAddressData
+     */
+    private ExtractQuoteAddressData $extractQuoteAddressData;
+
+    /**
+     * @var ExtensibleDataObjectConverter|MockObject
+     */
+    private ExtensibleDataObjectConverter|MockObject $dataObjectConverterMock;
+
+    /**
+     * @var Uid|MockObject
+     */
+    private Uid|MockObject $uidEncoderMock;
+
+    /**
+     * @var GetAttributeValueInterface|MockObject
+     */
+    private GetAttributeValueInterface|MockObject $getAttributeValueMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->dataObjectConverterMock = $this->createMock(ExtensibleDataObjectConverter::class);
+        $this->uidEncoderMock = $this->createMock(Uid::class);
+        $this->getAttributeValueMock = $this->createMock(GetAttributeValueInterface::class);
+
+        $this->extractQuoteAddressData = new ExtractQuoteAddressData(
+            $this->dataObjectConverterMock,
+            $this->uidEncoderMock,
+            $this->getAttributeValueMock
+        );
+    }
+
+    /**
+     * Test that null, integer and array custom attribute values do not cause a TypeError
+     * and are normalized to strings before being passed to the value provider
+     *
+     * @return void
+     */
+    public function testExecuteNormalizesNonStringCustomAttributeValues(): void
+    {
+        $nullAttributeMock = $this->createMock(AttributeInterface::class);
+        $nullAttributeMock->method('getAttributeCode')->willReturn('null_attribute');
+        $nullAttributeMock->method('getValue')->willReturn(null);
+
+        $intAttributeMock = $this->createMock(AttributeInterface::class);
+        $intAttributeMock->method('getAttributeCode')->willReturn('int_attribute');
+        $intAttributeMock->method('getValue')->willReturn(123);
+
+        $arrayAttributeMock = $this->createMock(AttributeInterface::class);
+        $arrayAttributeMock->method('getAttributeCode')->willReturn('multiselect_attribute');
+        $arrayAttributeMock->method('getValue')->willReturn(['a', 'b']);
+
+        $addressMock = $this->createMock(QuoteAddress::class);
+        $addressMock
+            ->method('getCustomAttributes')
+            ->willReturn([$nullAttributeMock, $intAttributeMock, $arrayAttributeMock]);
+
+        $this->dataObjectConverterMock->method('toFlatArray')->willReturn([]);
+        $this->uidEncoderMock->method('encode')->willReturn('encoded_uid');
+
+        $expectedValues = [
+            'null_attribute' => '',
+            'int_attribute' => '123',
+            'multiselect_attribute' => 'a,b',
+        ];
+
+        $this->getAttributeValueMock
+            ->expects($this->exactly(3))
+            ->method('execute')
+            ->willReturnCallback(function ($entity, $code, $value) use ($expectedValues) {
+                $this->assertSame($expectedValues[$code], $value);
+                return [
+                    'code' => $code,
+                    'value' => $value,
+                    'sort_order' => 0,
+                ];
+            });
+
+        $result = $this->extractQuoteAddressData->execute($addressMock);
+
+        $this->assertArrayHasKey('custom_attributes', $result);
+        $this->assertCount(3, $result['custom_attributes']);
+    }
+}

--- a/app/code/Magento/QuoteGraphQl/Test/Unit/Model/Cart/ExtractQuoteAddressDataTest.php
+++ b/app/code/Magento/QuoteGraphQl/Test/Unit/Model/Cart/ExtractQuoteAddressDataTest.php
@@ -97,6 +97,7 @@ class ExtractQuoteAddressDataTest extends TestCase
             ->expects($this->exactly(3))
             ->method('execute')
             ->willReturnCallback(function ($entity, $code, $value) use ($expectedValues) {
+                $this->assertSame('customer_address', $entity);
                 $this->assertSame($expectedValues[$code], $value);
                 return [
                     'code' => $code,


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`Magento\EavGraphQl\Model\Output\Value\GetAttributeValueInterface::execute()` declares a strictly typed `string $value` parameter (`declare(strict_types=1)`), but its call sites pass raw attribute values that can be `null`, `int`, `float`, or `array`:

1. `Magento\CustomerGraphQl\Model\Customer\Address\ExtractCustomerAddressData::formatCustomAttributes()` — passes `$customAttribute['value']` unprocessed. `null` for cleared attributes, arrays for multiselect attributes, ints for integer-typed attributes.
2. `Magento\QuoteGraphQl\Model\Cart\ExtractQuoteAddressData::execute()` — passes `$attribute->getValue()` unprocessed (reproduced by the issue reporter via `setShippingAddressesOnCart` with an int-typed address attribute).
3. `Magento\CatalogGraphQl\Model\Resolver\Product\ProductCustomAttributes::resolve()` — partially hardened by LYNX-533 (`?? ""` and array handling), but non-string scalars still pass uncast.

The result is a `TypeError` that surfaces as `"Internal server error"` in the GraphQL response whenever `custom_attributesV2` (products, customer addresses) or cart address `custom_attributes` include such a value.

This PR normalizes the value at each call site — `null` becomes `''`, flat arrays are imploded, nested arrays serialized (matching the pre-existing conventions in each class), and the result is cast to string — following the same call-site approach used by LYNX-533. The interface signature is intentionally left untouched: changing it would be a breaking change for third-party `GetAttributeValueInterface` providers.

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38884

### Manual testing scenarios (*)

1. Install vanilla Magento with OpenSearch, create a dropdown product attribute `test_ddl` (values not required, used in search/listing), add it to the default attribute set.
2. Create a simple product, set `test_ddl` to an option, save; then edit the product and clear the `test_ddl` value, save, reindex.
3. Run a GraphQL `products` query requesting `custom_attributesV2 { items { code ... on AttributeValue { value } } }`.
4. Before the fix: `"Internal server error"` and a `TypeError` in `exception.log`. After the fix: the product list is returned, the cleared attribute value is an empty string.
5. Additionally: create an int-typed customer address attribute, set it via `setShippingAddressesOnCart`, and query the cart shipping address `custom_attributes` — no error after the fix.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
