### PR TITLE
Fix Escaper::escapeHtml dropping content after a stray "<" when allowed tags are passed (#37693)

### DIFF
--- a/lib/internal/Magento/Framework/Escaper.php
+++ b/lib/internal/Magento/Framework/Escaper.php
@@ -151,8 +151,8 @@ class Escaper
      */
     private function prepareUnescapedCharacters(string $data): ?string
     {
-        $patterns = ['/\&/u'];
-        $replacements = ['&amp;'];
+        $patterns = ['/\&/u', '/<(?![a-zA-Z\/!])/u'];
+        $replacements = ['&amp;', '&lt;'];
         return \preg_replace($patterns, $replacements, $data);
     }
 

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -265,6 +265,16 @@ class EscaperTest extends TestCase
                 'expected' => '&amp;<br>&quot;&#039;&amp;&lt;&gt;&quot;&#039;&#9;',
                 'allowedTags' => ['br'],
             ],
+            'text with stray less-than and allowed tag' => [
+                'data' => 'Speed < 10m/s',
+                'expected' => 'Speed &lt; 10m/s',
+                'allowedTags' => ['b'],
+            ],
+            'text with allowed tag and stray less-than' => [
+                'data' => '<b>Bold</b> Speed < 10m/s',
+                'expected' => '<b>Bold</b> Speed &lt; 10m/s',
+                'allowedTags' => ['b'],
+            ],
             'text with multiple allowed tags, includes self closing tag' => [
                 'data' => '<span>some text in tags<br /></span>',
                 'expected' => '<span>some text in tags<br></span>',
@@ -645,7 +655,7 @@ class EscaperTest extends TestCase
         $method = new \ReflectionMethod(Escaper::class, 'prepareUnescapedCharacters');
 
         $input = '& < & >';
-        $expected = '&amp; < &amp; >';
+        $expected = '&amp; &lt; &amp; >';
 
         $this->assertSame($expected, $method->invoke($this->escaper, $input));
     }

--- a/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/EscaperTest.php
@@ -266,20 +266,13 @@ class EscaperTest extends TestCase
                 'allowedTags' => ['br'],
             ],
             'text with stray less-than and allowed tag' => [
-                'data' => 'Speed < 10m/s',
-                'expected' => 'Speed &lt; 10m/s',
-                'allowedTags' => ['b'],
-            ],
+                'data' => 'Speed < 10m/s', 'expected' => 'Speed &lt; 10m/s', 'allowedTags' => ['b']],
             'text with allowed tag and stray less-than' => [
-                'data' => '<b>Bold</b> Speed < 10m/s',
-                'expected' => '<b>Bold</b> Speed &lt; 10m/s',
-                'allowedTags' => ['b'],
-            ],
+                'data' => '<b>Bold</b> Speed < 10m/s', 'expected' => '<b>Bold</b> Speed &lt; 10m/s',
+                'allowedTags' => ['b']],
             'text with multiple allowed tags, includes self closing tag' => [
-                'data' => '<span>some text in tags<br /></span>',
-                'expected' => '<span>some text in tags<br></span>',
-                'allowedTags' => ['span', 'br'],
-            ],
+                'data' => '<span>some text in tags<br /></span>', 'expected' => '<span>some text in tags<br></span>',
+                'allowedTags' => ['span', 'br']],
             'text with multiple allowed tags and allowed attribute in double quotes' => [
                 'data' => 'Only <span id="sku_max_allowed"><b>2</b></span> in stock',
                 'expected' => 'Only <span id="sku_max_allowed"><b>2</b></span> in stock',
@@ -321,34 +314,23 @@ class EscaperTest extends TestCase
             ],
             'text with html comment' => [
                 'data' => 'Only <span><b>2</b></span> in stock <!-- HTML COMMENT -->',
-                'expected' => 'Only <span><b>2</b></span> in stock ',
-                'allowedTags' => ['span', 'b'],
-            ],
+                'expected' => 'Only <span><b>2</b></span> in stock ', 'allowedTags' => ['span', 'b']],
             'text with multi-line html comment' => [
                 'data' => "Only <span><b>2</b></span> in stock <!-- --!\n\n><img src=#>-->",
-                'expected' => 'Only <span><b>2</b></span> in stock ',
-                'allowedTags' => ['span', 'b'],
-            ],
+                'expected' => 'Only <span><b>2</b></span> in stock ', 'allowedTags' => ['span', 'b']],
             'text with non ascii characters' => [
                 'data' => ['абвгд', 'مثال', '幸福'],
                 'expected' => ['абвгд', 'مثال', '幸福'],
                 'allowedTags' => [],
             ],
             'html and body tags' => [
-                'data' => '<html><body><span>String</span></body></html>',
-                'expected' => '<span>String</span>',
-                'allowedTags' => ['span'],
-            ],
+                'data' => '<html><body><span>String</span></body></html>', 'expected' => '<span>String</span>',
+                'allowedTags' => ['span']],
             'invalid tag' => [
-                'data' => '<some tag> some text',
-                'expected' => ' some text',
-                'allowedTags' => ['span'],
-            ],
+                'data' => '<some tag> some text', 'expected' => ' some text', 'allowedTags' => ['span']],
             'text with japanese lang' => [
                 'data' => '<span>だ だ だ some text in tags<br /></span>',
-                'expected' => '<span>だ だ だ some text in tags</span>',
-                'allowedTags' => ['span'],
-            ],
+                'expected' => '<span>だ だ だ some text in tags</span>', 'allowedTags' => ['span']],
         ];
     }
 


### PR DESCRIPTION
### Description (*)

When `Escaper::escapeHtml()` is called with a non-empty `$allowedTags` array, the input is routed through `DOMDocument::loadHTML()`. That branch installs a custom `set_error_handler` that converts **any** libxml parse warning into a thrown `\InvalidArgumentException`.

If the input contains a stray `<` that is not the start of a valid tag — e.g. `Speed < 10m/s` — libxml emits `htmlParseStartTag: invalid element name`, the handler throws, `loadHTML()` aborts mid-parse leaving a **truncated** DOM (only the text before the stray `<`), the exception is caught and logged as `CRITICAL`, and the truncated content is returned. So `escapeHtml('Speed < 10m/s', ['b'])` returns `Speed` and spams `exception.log`.

Without allowed tags the same input is handled safely by `htmlspecialchars()`, so the bug is specific to the allowed-tags path.

**Fix:** in `prepareUnescapedCharacters()` (which already escapes `&` → `&amp;` before `loadHTML()`), also escape `<` characters that are **not** the start of a valid tag — i.e. not immediately followed by an ASCII letter, `/`, or `!` — into `&lt;`. Real/allowed tags (`<b>`, `</b>`), and comments (`<!--`) are untouched; only stray `<` become entities, which `loadHTML()` parses cleanly as text. Replacement order (`&` first, then `<`) is preserved so the `&` inside a produced `&lt;` is not double-escaped.

### Security impact

This change only **adds** escaping (stray `<` → `&lt;`) and never relaxes it. Sequences that begin a real tag are unchanged and still flow through the existing allowed/prohibited-tag filtering, so no tag that was previously stripped can now pass, and no new XSS vector is introduced. Net effect on the security posture is neutral-to-positive.

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#37693

### Manual testing scenarios (*)

1. In any `.phtml` (or via a unit call) render:
   ```php
   echo $escaper->escapeHtml('Speed < 10m/s', ['b']);
   ```
2. **Before:** output is `Speed` and a `CRITICAL InvalidArgumentException: DOMDocument::loadHTML(): htmlParseStartTag ...` appears in `var/log/exception.log`.
3. **After:** output is `Speed &lt; 10m/s` (renders as `Speed < 10m/s`), no exception logged.
4. Confirm an allowed tag still works: `escapeHtml('<b>Bold</b> Speed < 10m/s', ['b'])` → `<b>Bold</b> Speed &lt; 10m/s`.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests
- [x] All automated tests passed successfully (all builds are green)
