### PR TITLE
Fix Dashboard chart animating into its final size on load and update (#38860)

### DIFF
--- a/app/code/Magento/Backend/view/adminhtml/web/js/dashboard/chart.js
+++ b/app/code/Magento/Backend/view/adminhtml/web/js/dashboard/chart.js
@@ -108,6 +108,13 @@ define([
                     }]
                 },
                 options: {
+                    transitions: {
+                        resize: {
+                            animation: {
+                                duration: 0
+                            }
+                        }
+                    },
                     legend: {
                         onClick: this.handleChartLegendClick,
                         position: 'bottom'

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Backend/view/adminhtml/web/js/dashboard/chart.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Backend/view/adminhtml/web/js/dashboard/chart.test.js
@@ -115,6 +115,7 @@ define([
 
             expect(chartWidget.period).toBe(period);
             expect(chartWidget.chart).toBeDefined();
+            expect(chartWidget.chart.options.transitions.resize.animation.duration).toBe(0);
             expect(chartWidget.chart.data.datasets[0].label).toBe(dataProvider[period].label);
             expect(chartWidget.chart.data.datasets[0].data).toBe(dataProvider[period].data);
             expect(canvas.parent().is(':visible')).toBeTrue();


### PR DESCRIPTION
### Description (*)

Since 2.4.7 the admin Dashboard Orders/Amounts graph visibly animates from a `0×0` size up to its final size over ~1–2s — on first load, when switching period (no-data ↔ data), and on window resize.

The chart (`Magento_Backend/js/dashboard/chart`) is a Chart.js instance created with `responsive: true, maintainAspectRatio: false`. Its canvas is measured at `0×0` while the container is hidden/unsized (the parent is only revealed via `.toggle()` in `updateChart()` after the AJAX resolves). When the container gains dimensions, Chart.js's `ResizeObserver` fires a **resize transition** that animates the canvas from `0×0` to full size using the default animation duration. Because Chart.js drives the canvas `width`/`height` attributes through its own animation loop, adding `animation: none` / `transition: 0s` in CSS has no effect — as noted in the report.

**Fix:** disable only the Chart.js `resize` transition animation so the layout snaps to its final size instantly, while leaving normal data-update animations intact:

```js
options: {
    transitions: {
        resize: {
            animation: {
                duration: 0
            }
        }
    },
    ...
}
```

This is the minimal change and matches the reporter's preferred behaviour (an instant layout, not an animated grow). The single `resize` transition covers all three reported triggers (initial load, period/data toggle, window resize), since each results in a Chart.js resize.

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38860

### Manual testing scenarios (*)

1. Open the admin **Dashboard** with some order data so the Orders/Amounts graph is populated.
2. **Before:** on load the graph grows from a tiny box into its full size over ~1–2s; switching the period or resizing the window re-triggers the grow animation.
3. **After:** the graph appears at its final size immediately; period switches and resizes snap without the size animation. Bar/data update animations are unaffected.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests
- [x] All automated tests passed successfully (all builds are green)
