### PR TITLE
Fix mediaGallery array key typo in export Product model

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Export/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Export/Product.php
@@ -1791,7 +1791,7 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
 
         $data['rowWebsites'] = $rowWebsites;
         $data['rowCategories'] = $rowCategories;
-        $data['mediaGalery'] = $this->getMediaGallery($productLinkIds);
+        $data['mediaGallery'] = $this->getMediaGallery($productLinkIds);
         $data['linksRows'] = $this->prepareLinks($productLinkIds);
 
         $data['customOptionsData'] = $this->getCustomOptionsData($productLinkIds);
@@ -1905,11 +1905,11 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                     implode(Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $websiteCodes);
                 $multiRawData['rowWebsites'][$productId] = [];
             }
-            if (!empty($multiRawData['mediaGalery'][$productLinkId])) {
+            if (!empty($multiRawData['mediaGallery'][$productLinkId])) {
                 $additionalImages = [];
                 $additionalImageLabels = [];
                 $additionalImageIsDisabled = [];
-                foreach ($multiRawData['mediaGalery'][$productLinkId] as $mediaItem) {
+                foreach ($multiRawData['mediaGallery'][$productLinkId] as $mediaItem) {
                     if ((int)$mediaItem['_media_store_id'] === Store::DEFAULT_STORE_ID) {
                         $additionalImages[] = $mediaItem['_media_image'];
                         $additionalImageLabels[] = $mediaItem['_media_label'];
@@ -1925,7 +1925,7 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
                     implode(Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $additionalImageLabels);
                 $dataRow['hide_from_product_page'] =
                     implode(Import::DEFAULT_GLOBAL_MULTI_VALUE_SEPARATOR, $additionalImageIsDisabled);
-                $multiRawData['mediaGalery'][$productLinkId] = [];
+                $multiRawData['mediaGallery'][$productLinkId] = [];
             }
             foreach ($this->_linkTypeProvider->getLinkTypes() as $linkTypeName => $linkId) {
                 if (!empty($multiRawData['linksRows'][$productLinkId][$linkId])) {
@@ -1952,8 +1952,8 @@ class Product extends \Magento\ImportExport\Model\Export\Entity\AbstractEntity
             $dataRow = $this->rowCustomizer->addData($dataRow, $productId);
         } else {
             $additionalImageIsDisabled = [];
-            if (!empty($multiRawData['mediaGalery'][$productLinkId])) {
-                foreach ($multiRawData['mediaGalery'][$productLinkId] as $mediaItem) {
+            if (!empty($multiRawData['mediaGallery'][$productLinkId])) {
+                foreach ($multiRawData['mediaGallery'][$productLinkId] as $mediaItem) {
                     if ((int)$mediaItem['_media_store_id'] === $storeId) {
                         if ($mediaItem['_media_is_disabled'] == true) {
                             $additionalImageIsDisabled[] = $mediaItem['_media_image'];


### PR DESCRIPTION
### Description (*)

The array key `mediaGalery` is misspelled (missing an `l`) in `Magento\CatalogImportExport\Model\Export\Product`. It should be `mediaGallery`.

The key is written once (`$data['mediaGalery'] = $this->getMediaGallery(...)`) and read in five other places within the same class. This change corrects the spelling in all 6 occurrences.

The key is a private, in-memory array key used only inside this class to carry media gallery data between `collectRawData()` and `_getExportData()`/`appendMultirowData()`. It is not a database column, not part of any public API, and — as verified with a repository-wide search — it is not referenced anywhere else in the codebase. Renaming it is therefore behavior-preserving and safe.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40368

### Manual testing scenarios (*)

1. In the Admin panel, go to **System > Data Transfer > Export**.
2. Set **Entity Type** to `Products` and run the export.
3. Open the generated CSV and confirm the additional image columns (`additional_images`, `additional_image_labels`, `hide_from_product_page`) are populated correctly for products that have gallery images.
4. Behavior is identical before and after this change; the fix only corrects the internal array key spelling.

### Questions or comments

This is a pure typo correction with no functional change. The internal array key was previously `mediaGalery` and is now `mediaGallery`, matching the correctly-spelled `getMediaGallery()` method it is populated from.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (not applicable — spelling-only change to an internal array key, no behavioral change to test)
 - [ ] All automated tests passed successfully (all builds are green) — CI pending
