### PR TITLE
Fix indexer state updated value not being parsable as a datetime (#38411)

### DIFF
--- a/app/code/Magento/Indexer/Model/Indexer/State.php
+++ b/app/code/Magento/Indexer/Model/Indexer/State.php
@@ -86,7 +86,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
      */
     public function getIndexerId()
     {
-        return parent::getIndexerId();
+        return $this->getData('indexer_id');
     }
 
     /**
@@ -97,7 +97,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
      */
     public function setIndexerId($value)
     {
-        return parent::setIndexerId($value);
+        return $this->setData('indexer_id', $value);
     }
 
     /**
@@ -108,8 +108,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
     public function getStatus()
     {
         if ($this->isUseApplicationLock()) {
-            if (
-                parent::getStatus() == StateInterface::STATUS_WORKING &&
+            if (parent::getStatus() == StateInterface::STATUS_WORKING &&
                 !$this->lockManager->isLocked($this->lockPrefix . $this->getIndexerId())
             ) {
                 return StateInterface::STATUS_INVALID;
@@ -126,7 +125,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
      */
     public function getUpdated()
     {
-        return parent::getUpdated();
+        return $this->getData('updated');
     }
 
     /**
@@ -137,7 +136,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
      */
     public function setUpdated($value)
     {
-        return parent::setUpdated($value);
+        return $this->setData('updated', $value);
     }
 
     /**

--- a/app/code/Magento/Indexer/Model/Indexer/State.php
+++ b/app/code/Magento/Indexer/Model/Indexer/State.php
@@ -180,7 +180,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements StateInter
      */
     public function beforeSave()
     {
-        $this->setUpdated(time());
+        $this->setUpdated((new \DateTimeImmutable())->format('Y-m-d H:i:s'));
         return parent::beforeSave();
     }
 

--- a/app/code/Magento/Indexer/Model/Mview/View/State.php
+++ b/app/code/Magento/Indexer/Model/Mview/View/State.php
@@ -150,8 +150,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements \Magento\F
     {
         $status = $this->getData('status');
         if ($this->isUseApplicationLock()) {
-            if (
-                $status == \Magento\Framework\Mview\View\StateInterface::STATUS_WORKING &&
+            if ($status == \Magento\Framework\Mview\View\StateInterface::STATUS_WORKING &&
                 !$this->lockManager->isLocked($this->lockPrefix . $this->getViewId())
             ) {
                 return \Magento\Framework\Mview\View\StateInterface::STATUS_IDLE;

--- a/app/code/Magento/Indexer/Model/Mview/View/State.php
+++ b/app/code/Magento/Indexer/Model/Mview/View/State.php
@@ -105,7 +105,7 @@ class State extends \Magento\Framework\Model\AbstractModel implements \Magento\F
      */
     public function beforeSave()
     {
-        $this->setUpdated(time());
+        $this->setUpdated((new \DateTimeImmutable())->format('Y-m-d H:i:s'));
         return parent::beforeSave();
     }
 

--- a/app/code/Magento/Indexer/Test/Unit/Model/Indexer/StateTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Indexer/StateTest.php
@@ -92,6 +92,16 @@ class StateTest extends TestCase
         $this->assertNotNull($this->model->getUpdated());
     }
 
+    public function testBeforeSaveStoresParsableDateTime()
+    {
+        $this->model->beforeSave();
+        $updated = $this->model->getUpdated();
+
+        $this->assertIsString($updated);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $updated);
+        $this->assertInstanceOf(\DateTime::class, new \DateTime($updated));
+    }
+
     public function testSetStatus()
     {
         $setData = 'data';

--- a/app/code/Magento/Indexer/Test/Unit/Model/Mview/View/StateTest.php
+++ b/app/code/Magento/Indexer/Test/Unit/Model/Mview/View/StateTest.php
@@ -89,6 +89,16 @@ class StateTest extends TestCase
         $this->assertNotNull($this->model->getUpdated());
     }
 
+    public function testBeforeSaveStoresParsableDateTime()
+    {
+        $this->model->beforeSave();
+        $updated = $this->model->getUpdated();
+
+        $this->assertIsString($updated);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $updated);
+        $this->assertInstanceOf(\DateTime::class, new \DateTime($updated));
+    }
+
     public function testSetterAndGetterWithoutApplicationLock()
     {
         $this->configReaderMock->expects($this->any())->method('get')->willReturn(false);


### PR DESCRIPTION
### Description (*)

`Magento\Indexer\Model\Indexer\State::beforeSave()` and
`Magento\Indexer\Model\Mview\View\State::beforeSave()` set the `updated`
field to a raw Unix timestamp via `time()`:

```php
public function beforeSave()
{
    $this->setUpdated(time());
    return parent::beforeSave();
}
```

The `updated` column is a `datetime`, and the DB adapter formats the integer
on INSERT, so the **persisted** value is correct. However, the in-memory model
retains the raw integer after saving (Magento does not reload the entity after
`save()`).

`Magento\Indexer\Model\Indexer::getLatestUpdated()` then feeds that value
straight into a `\DateTime` constructor:

```php
$indexerUpdatedDate = new \DateTime($this->getState()->getUpdated());
$viewUpdatedDate = new \DateTime($this->getView()->getUpdated());
```

When the state has been saved but not reloaded within the same request (e.g. by
third-party code, observers, or ESI blocks), `getUpdated()` returns the raw
integer, and `new \DateTime("1783697110")` throws:

```
Exception: Failed to parse time string (1783697110) at position 8 (1): Unexpected character
```

#### Fix

Store the value pre-formatted as `Y-m-d H:i:s` in both `beforeSave()` methods —
identical to what the DB adapter already persists — so the in-memory value is
consistent with the persisted one and remains parsable by `\DateTime`:

```php
$this->setUpdated((new \DateTimeImmutable())->format('Y-m-d H:i:s'));
```

The persisted DB value is unchanged; only the in-memory representation is
corrected.

### Related Pull Requests

_None_

### Fixed Issues (*)

Fixes magento/magento2#38411

### Manual testing scenarios (*)

1. Load an indexer whose state has just been saved (without reloading it from
   the database), e.g.:
   ```php
   $indexer = $objectManager->create(\Magento\Indexer\Model\Indexer::class);
   $indexer->load('customer_grid');
   $indexer->getState()->setStatus(\Magento\Framework\Indexer\StateInterface::STATUS_VALID)->save();
   $indexer->getLatestUpdated();
   ```
2. **Before the fix:** `getLatestUpdated()` throws
   `Failed to parse time string`.
3. **After the fix:** `getLatestUpdated()` returns a valid datetime string with
   no exception.

### Questions or comments

The persisted database values are unaffected — the DB adapter already stored the
adapter-formatted datetime. This change only aligns the in-memory value with the
persisted one.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests (regression tests added
      for both `State` models)
- [x] All automated tests passed successfully (unit, integration, static)
