### PR TITLE
Fix stale EAV attribute code in setup cache after rename (#38636)

### DIFF
--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -960,6 +960,14 @@ class EavSetup
             throw new LocalizedException(__('Attribute with ID: "%1" does not exist', $id));
         }
 
+        $resolvedEntityTypeId = $this->getEntityTypeId($entityTypeId);
+        $mainTable = $this->setup->getTable('eav_attribute');
+        $setupCache = $this->setup->getSetupCache();
+        $cachedRow = $setupCache->has($mainTable, $resolvedEntityTypeId, $attributeId)
+            ? $setupCache->get($mainTable, $resolvedEntityTypeId, $attributeId)
+            : [];
+        $cachedCode = $cachedRow['attribute_code'] ?? null;
+
         $this->setup->updateTableRow(
             'eav_attribute',
             'attribute_id',
@@ -967,8 +975,17 @@ class EavSetup
             $field,
             $value,
             'entity_type_id',
-            $this->getEntityTypeId($entityTypeId)
+            $resolvedEntityTypeId
         );
+
+        // updateTableRow() only refreshes the attribute_id-keyed cache entry; purge
+        // the attribute_code-keyed entries so an attribute_code change is not masked
+        // by stale cache data on a subsequent getAttribute()/addAttribute() call.
+        $setupCache->remove($mainTable, $resolvedEntityTypeId, $attributeId);
+        $setupCache->remove($mainTable, $resolvedEntityTypeId, $id);
+        if ($cachedCode !== null) {
+            $setupCache->remove($mainTable, $resolvedEntityTypeId, $cachedCode);
+        }
 
         return $this;
     }

--- a/app/code/Magento/Eav/Setup/EavSetup.php
+++ b/app/code/Magento/Eav/Setup/EavSetup.php
@@ -935,26 +935,11 @@ class EavSetup
             );
         }
 
-        $attributeFields = $this->_getAttributeTableFields();
-        if (is_array($field)) {
-            $bind = [];
-            foreach ($field as $k => $v) {
-                if (isset($attributeFields[$k])) {
-                    $bind[$k] = $this->setup->getConnection()->prepareColumnValue(
-                        $attributeFields[$k],
-                        $v
-                    );
-                }
-            }
-            if (!$bind) {
-                return $this;
-            }
-            $field = $bind;
-        } else {
-            if (!isset($attributeFields[$field])) {
-                return $this;
-            }
+        $field = $this->prepareAttributeDataField($field);
+        if ($field === null) {
+            return $this;
         }
+
         $attributeId = $this->getAttributeId($entityTypeId, $id);
         if (false === $attributeId) {
             throw new LocalizedException(__('Attribute with ID: "%1" does not exist', $id));
@@ -988,6 +973,32 @@ class EavSetup
         }
 
         return $this;
+    }
+
+    /**
+     * Prepare attribute data field for update
+     *
+     * @param string|array $field
+     * @return string|array|null
+     */
+    private function prepareAttributeDataField($field)
+    {
+        $attributeFields = $this->_getAttributeTableFields();
+        if (!is_array($field)) {
+            return isset($attributeFields[$field]) ? $field : null;
+        }
+
+        $bind = [];
+        foreach ($field as $k => $v) {
+            if (isset($attributeFields[$k])) {
+                $bind[$k] = $this->setup->getConnection()->prepareColumnValue(
+                    $attributeFields[$k],
+                    $v
+                );
+            }
+        }
+
+        return $bind ?: null;
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -50,6 +50,30 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Verify that renamed attribute code cache does not prevent re-adding the original code.
+     */
+    public function testAddAttributeAfterAttributeCodeRename()
+    {
+        $entity = \Magento\Catalog\Model\Product::ENTITY;
+        $attributeCode = 'eav_setup_rename_test';
+        $renamedAttributeCode = 'eav_setup_rename_test_old';
+
+        $this->eavSetup->addAttribute($entity, $attributeCode, $this->getRenameAttributeData());
+        $originalId = (int)$this->eavSetup->getAttributeId($entity, $attributeCode);
+
+        $this->eavSetup->updateAttribute($entity, $attributeCode, ['attribute_code' => $renamedAttributeCode]);
+        $this->eavSetup->addAttribute($entity, $attributeCode, $this->getRenameAttributeData());
+
+        $renamedId = (int)$this->eavSetup->getAttributeId($entity, $renamedAttributeCode);
+        $newId = (int)$this->eavSetup->getAttributeId($entity, $attributeCode);
+
+        $this->assertNotFalse($this->eavSetup->getAttributeId($entity, $renamedAttributeCode));
+        $this->assertNotFalse($this->eavSetup->getAttributeId($entity, $attributeCode));
+        $this->assertNotSame($renamedId, $newId);
+        $this->assertSame($originalId, $renamedId);
+    }
+
+    /**
      * Data provider for testAddAttributeThrowException().
      *
      * @return array
@@ -134,6 +158,35 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
             'backend' => '',
             'frontend' => '',
             'label' => 'Eav Setup Test',
+            'input' => 'text',
+            'class' => '',
+            'source' => '',
+            'global' => \Magento\Catalog\Model\ResourceModel\Eav\Attribute::SCOPE_STORE,
+            'visible' => 0,
+            'required' => 0,
+            'user_defined' => 1,
+            'default' => 'none',
+            'searchable' => 0,
+            'filterable' => 0,
+            'comparable' => 0,
+            'visible_on_front' => 0,
+            'unique' => 0,
+            'apply_to' => 'category',
+        ];
+
+        return $attributeData;
+    }
+
+    /**
+     * Get attribute data for rename regression test.
+     */
+    private function getRenameAttributeData()
+    {
+        $attributeData = [
+            'type' => 'varchar',
+            'backend' => '',
+            'frontend' => '',
+            'label' => 'Eav Setup Rename Test',
             'input' => 'text',
             'class' => '',
             'source' => '',

--- a/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Setup/EavSetupTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class EavSetupTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Eav setup.
+     * Setup model used for EAV attribute operations.
      *
      * @var \Magento\Eav\Setup\EavSetup
      */
@@ -35,7 +35,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @param string $attributeCode
      *
-     * 
+     *
      */
     #[DataProvider('addAttributeDataProvider')]
     public function testAddAttribute($attributeCode)
@@ -91,7 +91,7 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @param string|null $attributeCode
      *
-     * 
+     *
      */
     #[DataProvider('addAttributeThrowExceptionDataProvider')]
     public function testAddAttributeThrowException($attributeCode)
@@ -124,13 +124,15 @@ class EavSetupTest extends \PHPUnit\Framework\TestCase
      *
      * @param string|null $attributeCode
      *
-     * 
+     *
      */
     #[DataProvider('addInvalidAttributeThrowExceptionDataProvider')]
     public function testAddInvalidAttributeThrowException($attributeCode)
     {
         $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
-        $this->expectExceptionMessage('Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field,');
+        $this->expectExceptionMessage(
+            'Please use only letters (a-z or A-Z), numbers (0-9) or underscore (_) in this field,'
+        );
 
         $attributeData = $this->getAttributeData();
         $this->eavSetup->addAttribute(\Magento\Catalog\Model\Product::ENTITY, $attributeCode, $attributeData);


### PR DESCRIPTION
### Description (*)

`Magento\Eav\Setup\EavSetup::getAttribute()` populates the setup cache for each
attribute under **two** keys — its `attribute_id` and its `attribute_code`:

```php
$setupCache->setRow($mainTable, $entityTypeId, $row['attribute_id'], $row);
$setupCache->setRow($mainTable, $entityTypeId, $row['attribute_code'], $row);
```

`Magento\Setup\Module\DataSetup::updateTableRow()` — used by
`EavSetup::_updateAttribute()` — refreshes only the `attribute_id`-keyed cache
entry after an `UPDATE`. The `attribute_code`-keyed entry is left untouched.

As a result, when an attribute is renamed and then re-added with the original
code in the same request:

```php
$setup->updateAttribute($entityType, 'attribute', ['attribute_code' => 'attribute_old']);
$setup->addAttribute($entityType, 'attribute', [ /* new data */ ]);
```

`addAttribute('attribute')` calls `getAttribute($entityType, 'attribute', 'attribute_id')`,
which hits the **stale** code-keyed cache entry still pointing at the original
attribute id. `addAttribute` therefore treats it as an existing attribute and
runs `updateAttribute()` on it (renaming `attribute_old` back to `attribute`)
instead of inserting a new attribute — so nothing changes.

#### Fix

Invalidate the stale setup-cache entries in `_updateAttribute()` after the row
is updated. The pre-update `attribute_code` is captured before `updateTableRow()`
(which overwrites the id-keyed cache row), then the id-keyed and code-keyed
entries are removed. `getAttribute()` transparently re-reads from the database on
the next lookup.

### Related Pull Requests

_None_

### Fixed Issues (*)

Fixes magento/magento2#38636

### Manual testing scenarios (*)

Using a single setup/data-patch instance:

1. `addAttribute($entityType, 'attribute', [...])`.
2. `updateAttribute($entityType, 'attribute', ['attribute_code' => 'attribute_old'])`.
3. `addAttribute($entityType, 'attribute', [...])`.
4. **Before the fix:** step 3 renames the existing attribute back to `attribute`
   — `attribute_old` no longer exists and no new attribute is created.
5. **After the fix:** step 3 inserts a new `attribute`, and `attribute_old`
   retains its renamed code — both attributes exist as distinct records.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with tests (integration regression test
      added in `EavSetupTest`)
- [x] All automated tests passed successfully (unit, integration, static)
