### PR TITLE
Fix flat indexer ignoring store-scope NULL attribute overrides (#38548)

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilder.php
@@ -330,9 +330,10 @@ class TableBuilder
                         []
                     );
 
-                    $columnValue = $this->_connection->getIfNullSql(
-                        's' . $countTableName . '.value',
-                        $countTableName . '.value'
+                    $columnValue = $this->_connection->getCheckSql(
+                        's' . $countTableName . '.value_id IS NULL',
+                        $countTableName . '.value',
+                        's' . $countTableName . '.value'
                     );
                     $select->columns([$columnName => $columnValue]);
 

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilderTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Model\Indexer\Product\Flat;
+
+use Magento\Catalog\Api\Data\ProductAttributeInterface;
+use Magento\Catalog\Helper\Product\Flat\Indexer as FlatIndexerHelper;
+use Magento\Catalog\Model\Product\Action as ProductAction;
+use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
+use Magento\Catalog\Test\Fixture\Attribute as AttributeFixture;
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Test\Fixture\Store as StoreFixture;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\AppIsolation;
+use Magento\TestFramework\Fixture\Config;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+#[AppArea('frontend')]
+class TableBuilderTest extends TestCase
+{
+    /**
+     * Store-scope attribute value explicitly overridden with NULL must not fall back
+     * to the default-scope value in the flat table built by full reindex.
+     *
+     * @return void
+     */
+    #[
+        DbIsolation(false),
+        AppIsolation(true),
+        Config('catalog/frontend/flat_catalog_product', 1),
+        Config('catalog/frontend/flat_catalog_product', 1, ScopeInterface::SCOPE_STORE, 'default'),
+        DataFixture(StoreFixture::class, as: 'store2'),
+        DataFixture(
+            AttributeFixture::class,
+            [
+                ProductAttributeInterface::SCOPE => 'store',
+                ProductAttributeInterface::USED_IN_PRODUCT_LISTING => true,
+            ],
+            as: 'attribute'
+        ),
+        DataFixture(ProductFixture::class, as: 'product_with_override'),
+        DataFixture(ProductFixture::class, as: 'product_without_override'),
+    ]
+    public function testStoreScopeNullOverrideIsNotReplacedByDefaultValue(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $fixtures = DataFixtureStorageManager::getStorage();
+        $storeId = (int)$fixtures->get('store2')->getId();
+        $attribute = $fixtures->get('attribute');
+        $attributeCode = $attribute->getAttributeCode();
+        $productWithOverrideId = (int)$fixtures->get('product_with_override')->getId();
+        $productWithoutOverrideId = (int)$fixtures->get('product_without_override')->getId();
+
+        /** @var ProductAction $productAction */
+        $productAction = $objectManager->get(ProductAction::class);
+        $productAction->updateAttributes(
+            [$productWithOverrideId, $productWithoutOverrideId],
+            [$attributeCode => 'default scope value'],
+            Store::DEFAULT_STORE_ID
+        );
+        $productAction->updateAttributes([$productWithOverrideId], [$attributeCode => null], $storeId);
+
+        $this->assertStoreValueRowExists($productWithOverrideId, (int)$attribute->getAttributeId(), $storeId);
+
+        /** @var Processor $processor */
+        $processor = $objectManager->get(Processor::class);
+        $processor->reindexAll();
+
+        $flatValues = $this->fetchFlatValues($attributeCode, $storeId);
+        $this->assertArrayHasKey($productWithOverrideId, $flatValues);
+        $this->assertNull(
+            $flatValues[$productWithOverrideId],
+            'Flat table must contain the store-scope NULL override, not the default-scope value'
+        );
+        $this->assertArrayHasKey($productWithoutOverrideId, $flatValues);
+        $this->assertSame(
+            'default scope value',
+            $flatValues[$productWithoutOverrideId],
+            'Flat table must fall back to the default-scope value when there is no store-scope row'
+        );
+    }
+
+    /**
+     * Assert precondition: a store-scope row with NULL value exists for the attribute.
+     *
+     * @param int $productId
+     * @param int $attributeId
+     * @param int $storeId
+     * @return void
+     */
+    private function assertStoreValueRowExists(int $productId, int $attributeId, int $storeId): void
+    {
+        /** @var ProductResource $productResource */
+        $productResource = Bootstrap::getObjectManager()->get(ProductResource::class);
+        $connection = $productResource->getConnection();
+        $select = $connection->select()
+            ->from($productResource->getTable('catalog_product_entity_varchar'), ['value_id', 'value'])
+            ->where('attribute_id = ?', $attributeId)
+            ->where('store_id = ?', $storeId)
+            ->where($productResource->getLinkField() . ' = ?', $productId);
+        $row = $connection->fetchRow($select);
+
+        $this->assertNotFalse($row, 'Store-scope attribute value row must exist');
+        $this->assertNull($row['value'], 'Store-scope attribute value row must hold NULL value');
+    }
+
+    /**
+     * Fetch attribute column values from the store flat table indexed by entity id.
+     *
+     * @param string $attributeCode
+     * @param int $storeId
+     * @return array
+     */
+    private function fetchFlatValues(string $attributeCode, int $storeId): array
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var FlatIndexerHelper $flatHelper */
+        $flatHelper = $objectManager->get(FlatIndexerHelper::class);
+        /** @var ProductResource $productResource */
+        $productResource = $objectManager->get(ProductResource::class);
+        $connection = $productResource->getConnection();
+        $select = $connection->select()
+            ->from($productResource->getTable($flatHelper->getFlatTableName($storeId)), ['entity_id', $attributeCode]);
+
+        return $connection->fetchPairs($select);
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilderTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/Indexer/Product/Flat/TableBuilderTest.php
@@ -8,9 +8,6 @@ declare(strict_types=1);
 namespace Magento\Catalog\Model\Indexer\Product\Flat;
 
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
-use Magento\Catalog\Helper\Product\Flat\Indexer as FlatIndexerHelper;
-use Magento\Catalog\Model\Product\Action as ProductAction;
-use Magento\Catalog\Model\ResourceModel\Product as ProductResource;
 use Magento\Catalog\Test\Fixture\Attribute as AttributeFixture;
 use Magento\Catalog\Test\Fixture\Product as ProductFixture;
 use Magento\Store\Model\ScopeInterface;
@@ -61,8 +58,7 @@ class TableBuilderTest extends TestCase
         $productWithOverrideId = (int)$fixtures->get('product_with_override')->getId();
         $productWithoutOverrideId = (int)$fixtures->get('product_without_override')->getId();
 
-        /** @var ProductAction $productAction */
-        $productAction = $objectManager->get(ProductAction::class);
+        $productAction = $objectManager->get('Magento\Catalog\Model\Product\Action');
         $productAction->updateAttributes(
             [$productWithOverrideId, $productWithoutOverrideId],
             [$attributeCode => 'default scope value'],
@@ -72,8 +68,7 @@ class TableBuilderTest extends TestCase
 
         $this->assertStoreValueRowExists($productWithOverrideId, (int)$attribute->getAttributeId(), $storeId);
 
-        /** @var Processor $processor */
-        $processor = $objectManager->get(Processor::class);
+        $processor = $objectManager->get('Magento\Catalog\Model\Indexer\Product\Flat\Processor');
         $processor->reindexAll();
 
         $flatValues = $this->fetchFlatValues($attributeCode, $storeId);
@@ -100,8 +95,7 @@ class TableBuilderTest extends TestCase
      */
     private function assertStoreValueRowExists(int $productId, int $attributeId, int $storeId): void
     {
-        /** @var ProductResource $productResource */
-        $productResource = Bootstrap::getObjectManager()->get(ProductResource::class);
+        $productResource = Bootstrap::getObjectManager()->get('Magento\Catalog\Model\ResourceModel\Product');
         $connection = $productResource->getConnection();
         $select = $connection->select()
             ->from($productResource->getTable('catalog_product_entity_varchar'), ['value_id', 'value'])
@@ -124,10 +118,8 @@ class TableBuilderTest extends TestCase
     private function fetchFlatValues(string $attributeCode, int $storeId): array
     {
         $objectManager = Bootstrap::getObjectManager();
-        /** @var FlatIndexerHelper $flatHelper */
-        $flatHelper = $objectManager->get(FlatIndexerHelper::class);
-        /** @var ProductResource $productResource */
-        $productResource = $objectManager->get(ProductResource::class);
+        $flatHelper = $objectManager->get('Magento\Catalog\Helper\Product\Flat\Indexer');
+        $productResource = $objectManager->get('Magento\Catalog\Model\ResourceModel\Product');
         $connection = $productResource->getConnection();
         $select = $connection->select()
             ->from($productResource->getTable($flatHelper->getFlatTableName($storeId)), ['entity_id', $attributeCode]);


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

When a store-scope attribute value is explicitly overridden with an empty value (a store-scope row with `NULL` value in `catalog_product_entity_*`), the flat catalog full reindex writes the **default-scope value** into `catalog_product_flat_{store_id}` instead of the store override.

**Root cause:** `TableBuilder::_fillTemporaryTable()` builds the attribute column as `IFNULL(store.value, default.value)`. `IFNULL` cannot distinguish "no store-scope row exists" from "a store-scope row exists with an explicit `NULL` value", so the second case wrongly falls back to the default-scope value.

The "Update on save" path does not have this bug: `Magento\Catalog\Model\Indexer\Product\Flat\Action\Indexer::write()` fetches rows ordered by `store_id ASC` and overwrites based on row **existence**, honoring the `NULL` override. This is exactly the mode divergence reported in the issue ("Update on save" correct, "Update by schedule"/full reindex wrong).

Store-scope rows with `NULL` values are produced by core itself — e.g. the admin mass **Update Attributes** action (`Magento\Catalog\Model\ResourceModel\Product\Action::updateAttributes()` → `_saveAttributeValue()` inserts the prepared value as-is).

**Fix:** replace the `IFNULL` value expression with a row-existence check:

```php
$columnValue = $this->_connection->getCheckSql(
    's' . $countTableName . '.value_id IS NULL',
    $countTableName . '.value',
    's' . $countTableName . '.value'
);
```

The fallback to the default-scope value still happens whenever no store-scope row exists (covered by a control assertion in the new test).

### Related Pull Requests

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38548

### Manual testing scenarios (*)

1. Multi-store setup, Flat Catalog Product enabled (`Stores > Configuration > Catalog > Storefront > Use Flat Catalog Product = Yes`), `catalog_product_flat` indexer in "Update by schedule" mode.
2. Create a store-view scope product attribute with `backend_type = varchar`, "Used in Product Listing" = Yes.
3. Set an attribute value for a product in the "All Store Views" scope (e.g. `test`).
4. Switch to a store view scope, uncheck "Use Default Value" and save an empty value (`catalog_product_entity_varchar` now contains a store-scope row with `NULL` value).
5. Run full reindex (`bin/magento indexer:reindex catalog_product_flat`).
6. Check `catalog_product_flat_{store_id}`: the attribute column must be `NULL` (store override), not `test`. Without the fix it contains `test`.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
