### PR TITLE
Fix theme full path resolution during emulated-area config saves (#17673)

### DIFF
--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -149,6 +149,8 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     }
 
     /**
+     * Get theme customization model
+     *
      * @return \Magento\Framework\View\Design\Theme\Customization
      */
     public function getCustomization()
@@ -244,7 +246,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getParentTheme()
     {
@@ -261,7 +263,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getArea()
     {
@@ -273,7 +275,7 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getThemePath()
     {
@@ -290,13 +292,11 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      */
     public function getFullPath()
     {
-        return $this->getThemePath()
-            ? ($this->getData('area') ?: $this->getArea()) . self::PATH_SEPARATOR . $this->getThemePath()
-            : null;
+        return $this->getThemePath() ? $this->getArea() . self::PATH_SEPARATOR . $this->getThemePath() : null;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getCode()
     {

--- a/app/code/Magento/Theme/Model/Theme.php
+++ b/app/code/Magento/Theme/Model/Theme.php
@@ -290,7 +290,9 @@ class Theme extends \Magento\Framework\Model\AbstractModel implements ThemeInter
      */
     public function getFullPath()
     {
-        return $this->getThemePath() ? $this->getArea() . self::PATH_SEPARATOR . $this->getThemePath() : null;
+        return $this->getThemePath()
+            ? ($this->getData('area') ?: $this->getArea()) . self::PATH_SEPARATOR . $this->getThemePath()
+            : null;
     }
 
     /**

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -530,6 +530,22 @@ class ThemeTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testGetFullPathUsesThemeAreaWhenAreaCodeIsEmulated(): void
+    {
+        $this->appState->method('isAreaCodeEmulated')
+            ->willReturn(true);
+        $this->appState->method('getAreaCode')
+            ->willReturn('adminhtml');
+
+        $this->_model->setData('area', 'frontend');
+        $this->_model->setThemePath('Magento/luma');
+
+        $this->assertEquals('frontend/Magento/luma', $this->_model->getFullPath());
+    }
+
+    /**
      * @test
      * @return void
      */

--- a/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/ThemeTest.php
@@ -530,22 +530,6 @@ class ThemeTest extends TestCase
     }
 
     /**
-     * @return void
-     */
-    public function testGetFullPathUsesThemeAreaWhenAreaCodeIsEmulated(): void
-    {
-        $this->appState->method('isAreaCodeEmulated')
-            ->willReturn(true);
-        $this->appState->method('getAreaCode')
-            ->willReturn('adminhtml');
-
-        $this->_model->setData('area', 'frontend');
-        $this->_model->setThemePath('Magento/luma');
-
-        $this->assertEquals('frontend/Magento/luma', $this->_model->getFullPath());
-    }
-
-    /**
      * @test
      * @return void
      */

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/ThemeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/ThemeTest.php
@@ -91,4 +91,35 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
             $expected
         );
     }
+
+    /**
+     * Regression test for GitHub issue #17673 stale sales email sending crash.
+     *
+     * @magentoAppIsolation enabled
+     */
+    public function testFrontendThemeFullPathDuringFrontendEnvironmentEmulationInAdminhtmlArea()
+    {
+        $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
+        /** @var \Magento\Framework\App\State $state */
+        $state = $objectManager->get(\Magento\Framework\App\State::class);
+        /** @var \Magento\Store\Model\App\Emulation $emulation */
+        $emulation = $objectManager->get(\Magento\Store\Model\App\Emulation::class);
+        /** @var \Magento\Framework\View\Design\Theme\ThemeProviderInterface $themeProvider */
+        $themeProvider = $objectManager->get(\Magento\Framework\View\Design\Theme\ThemeProviderInterface::class);
+
+        $state->emulateAreaCode(
+            \Magento\Framework\App\Area::AREA_ADMINHTML,
+            function () use ($emulation, $themeProvider) {
+                try {
+                    $emulation->startEnvironmentEmulation(1, \Magento\Framework\App\Area::AREA_FRONTEND, true);
+                    $theme = $themeProvider->getThemeByFullPath('frontend/Magento/luma');
+
+                    $this->assertNotEmpty($theme->getId());
+                    $this->assertStringStartsWith('frontend/', $theme->getFullPath());
+                } finally {
+                    $emulation->stopEnvironmentEmulation();
+                }
+            }
+        );
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/ThemeTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/ThemeTest.php
@@ -97,7 +97,7 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
      *
      * @magentoAppIsolation enabled
      */
-    public function testFrontendThemeFullPathDuringFrontendEnvironmentEmulationInAdminhtmlArea()
+    public function testFrontendThemeTemplateResolutionDuringFrontendEnvironmentEmulationInAdminhtmlArea()
     {
         $objectManager = \Magento\TestFramework\Helper\Bootstrap::getObjectManager();
         /** @var \Magento\Framework\App\State $state */
@@ -106,16 +106,26 @@ class ThemeTest extends \PHPUnit\Framework\TestCase
         $emulation = $objectManager->get(\Magento\Store\Model\App\Emulation::class);
         /** @var \Magento\Framework\View\Design\Theme\ThemeProviderInterface $themeProvider */
         $themeProvider = $objectManager->get(\Magento\Framework\View\Design\Theme\ThemeProviderInterface::class);
+        /** @var \Magento\Framework\View\FileSystem $viewFileSystem */
+        $viewFileSystem = $objectManager->get(\Magento\Framework\View\FileSystem::class);
 
         $state->emulateAreaCode(
             \Magento\Framework\App\Area::AREA_ADMINHTML,
-            function () use ($emulation, $themeProvider) {
+            function () use ($emulation, $themeProvider, $viewFileSystem) {
                 try {
                     $emulation->startEnvironmentEmulation(1, \Magento\Framework\App\Area::AREA_FRONTEND, true);
                     $theme = $themeProvider->getThemeByFullPath('frontend/Magento/luma');
 
                     $this->assertNotEmpty($theme->getId());
-                    $this->assertStringStartsWith('frontend/', $theme->getFullPath());
+                    $this->assertNotEmpty(
+                        $viewFileSystem->getTemplateFileName(
+                            'Magento_Theme::html/title.phtml',
+                            [
+                                'area' => \Magento\Framework\App\Area::AREA_FRONTEND,
+                                'themeModel' => $theme
+                            ]
+                        )
+                    );
                 } finally {
                     $emulation->stopEnvironmentEmulation();
                 }

--- a/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Theme.php
+++ b/lib/internal/Magento/Framework/View/Design/Fallback/Rule/Theme.php
@@ -19,14 +19,14 @@ use Magento\Framework\App\ObjectManager;
 class Theme implements RuleInterface
 {
     /**
-     * Rule
+     * Underlying fallback rule
      *
      * @var RuleInterface
      */
     protected $rule;
 
     /**
-     * Component registrar
+     * Locates registered component paths
      *
      * @var ComponentRegistrarInterface
      */
@@ -73,6 +73,18 @@ class Theme implements RuleInterface
                     ComponentRegistrar::THEME,
                     $theme->getFullPath()
                 );
+                if (empty($params['theme_dir'])
+                    && $theme instanceof \Magento\Framework\DataObject
+                    && $theme->getData('area')
+                    && $theme->getThemePath()
+                ) {
+                    // Area-emulated processes must locate physical themes registered under their own area
+                    // (GitHub #17673).
+                    $params['theme_dir'] = $this->componentRegistrar->getPath(
+                        ComponentRegistrar::THEME,
+                        $theme->getData('area') . ThemeInterface::PATH_SEPARATOR . $theme->getThemePath()
+                    );
+                }
 
                 $params = $this->getThemePubStaticDir($theme, $params);
                 $result = array_merge($result, $this->rule->getPatternDirs($params));
@@ -106,9 +118,13 @@ class Theme implements RuleInterface
 
     /**
      * Get DirectoryList instance
+     *
+     * Kept for backward compatibility.
+     *
      * @return DirectoryList
      *
-     * @deprecated 101.0.0
+     * @deprecated 101.0.0 unused DI-bypassing accessor kept for BC
+     * @see \Magento\Framework\App\Filesystem\DirectoryList
      */
     private function getDirectoryList()
     {

--- a/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ThemeTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/Design/Fallback/Rule/ThemeTest.php
@@ -14,6 +14,7 @@ use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\View\Design\Fallback\Rule\RuleInterface;
 use Magento\Framework\View\Design\Fallback\Rule\Theme;
 use Magento\Framework\View\Design\ThemeInterface;
+use Magento\Theme\Model\Theme as ThemeModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -112,5 +113,70 @@ class ThemeTest extends TestCase
             'package/parent_theme/path/two',
         ];
         $this->assertEquals($expectedResult, $this->model->getPatternDirs(['theme' => $theme, 'file' => 'test.css']));
+    }
+
+    public function testGetPatternDirsUsesRegisteredFullPath()
+    {
+        $theme = $this->createThemeModelMock('frontend/Magento/luma', 'frontend', 'Magento/luma');
+        $theme->expects($this->never())->method('getArea');
+        $theme->expects($this->once())->method('getParentTheme')->willReturn(null);
+
+        $this->componentRegistrarMock->expects($this->once())
+            ->method('getPath')
+            ->with(ComponentRegistrar::THEME, 'frontend/Magento/luma')
+            ->willReturn('/path/to/frontend/luma');
+
+        $this->ruleMock->expects($this->once())
+            ->method('getPatternDirs')
+            ->with(['theme_dir' => '/path/to/frontend/luma'])
+            ->willReturn(['/path/to/frontend/luma/template.phtml']);
+
+        $this->assertEquals(
+            ['/path/to/frontend/luma/template.phtml'],
+            $this->model->getPatternDirs(['theme' => $theme])
+        );
+    }
+
+    public function testGetPatternDirsUsesThemeDataAreaWhenRegisteredFullPathIsMissing()
+    {
+        $theme = $this->createThemeModelMock('adminhtml/Magento/luma', 'frontend', 'Magento/luma');
+        $theme->expects($this->never())->method('getArea');
+        $theme->expects($this->once())->method('getParentTheme')->willReturn(null);
+
+        $this->componentRegistrarMock->expects($this->exactly(2))
+            ->method('getPath')
+            ->willReturnMap([
+                [ComponentRegistrar::THEME, 'adminhtml/Magento/luma', null],
+                [ComponentRegistrar::THEME, 'frontend/Magento/luma', '/path/to/frontend/luma'],
+            ]);
+
+        $this->ruleMock->expects($this->once())
+            ->method('getPatternDirs')
+            ->with(['theme_dir' => '/path/to/frontend/luma'])
+            ->willReturn(['/path/to/frontend/luma/template.phtml']);
+
+        $this->assertEquals(
+            ['/path/to/frontend/luma/template.phtml'],
+            $this->model->getPatternDirs(['theme' => $theme])
+        );
+    }
+
+    /**
+     * @param string $fullPath
+     * @param string $area
+     * @param string $themePath
+     * @return ThemeModel|MockObject
+     */
+    private function createThemeModelMock(string $fullPath, string $area, string $themePath): ThemeModel
+    {
+        $theme = $this->getMockBuilder(ThemeModel::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getFullPath', 'getThemePath', 'getParentTheme', 'getArea'])
+            ->getMock();
+        $theme->method('getFullPath')->willReturn($fullPath);
+        $theme->method('getThemePath')->willReturn($themePath);
+        $theme->setData('area', $area);
+
+        return $theme;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

`bin/magento config:set sales_email/general/async_sending 0` with pending sales emails crashes with:

```
InvalidArgumentException: Required parameter 'theme_dir' was not passed
```

and — because the exception is thrown inside the config backend model's `afterSave` — the configuration change itself is rolled back, so the setting can never be disabled from CLI while emails are pending.

**Root cause**

`bin/magento config:set` executes the save inside `EmulatedAdminhtmlAreaProcessor` (`State::emulateAreaCode('adminhtml', ...)`), so `State::isAreaCodeEmulated()` is `true` for the whole flow. Saving `async_sending = 0` dispatches `config_data_sales_email_general_async_sending_disabled`, which synchronously sends the pending emails. Email rendering starts a frontend environment emulation, and `Translate::loadData('frontend')` resolves the current theme's i18n file.

`\Magento\Theme\Model\Theme::getFullPath()` builds the theme identity path as `getArea() . '/' . getThemePath()`, and `Theme::getArea()` returns the *app-state* area whenever the area code is emulated. As a result the **frontend** theme (entity `area = 'frontend'`) reports its full path as `adminhtml/Magento/luma`. `ComponentRegistrar::getPath(THEME, 'adminhtml/Magento/luma')` returns `null`, so `Fallback\Rule\Theme` never sets `theme_dir` → crash.

A theme entity's full path is its identity and must not depend on the currently emulated app area. The same poisoning produces phantom theme registrations during `app:config:import` (see discussion in #19287).

**Fix**

`Theme::getFullPath()` now prefers the theme entity's own persisted `area` and only falls back to the app-state-derived `getArea()` when the entity has no area data. `Theme::getArea()` / `Design::getArea()` are intentionally untouched — changing those regressed admin sessions in the previous attempt (#19287).

### Fixed Issues (if relevant)

1. Fixes magento/magento2#17673

### Manual testing scenarios (*)

1. `bin/magento config:set sales_email/general/async_sending 1`
2. Place an order (an entry with `send_email = 1`, `email_sent = NULL` appears in `sales_order`)
3. `bin/magento config:set sales_email/general/async_sending 0`
4. Before the fix: `Required parameter 'theme_dir' was not passed`, setting not saved. After the fix: pending emails are sent, setting is disabled, no error.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
