### PR TITLE
Fix repeated setup:upgrade failure for db_schema constraints declared with xsi:type="index" (#21304)

### DIFF
--- a/lib/internal/Magento/Framework/Setup/Declaration/Schema/Declaration/SchemaBuilder.php
+++ b/lib/internal/Magento/Framework/Setup/Declaration/Schema/Declaration/SchemaBuilder.php
@@ -239,6 +239,7 @@ class SchemaBuilder
             $resource = $this->getStructuralElementResource($tableData);
             $tableData['resource'] = $resource;
             $tableData['comment'] = $tableData['comment'] ?? null;
+            $tableData = $this->normalizeIndexesDeclaredAsConstraints($tableData);
             /** @var Table $table */
             $table = $this->elementFactory->create('table', $tableData);
             $columns = $this->processColumns($tableData, $resource, $table);
@@ -315,7 +316,7 @@ class SchemaBuilder
             $indexData['name'] = $this->elementNameResolver->getFullIndexName(
                 $table,
                 $indexData['column'],
-                $indexData['indexType'] ?? null
+                $indexData['indexType'] ?? $indexData['type'] ?? null
             );
             $indexData = $this->processGenericData($indexData, $resource, $table);
             $indexData['columns'] = $this->convertColumnNamesToObjects($indexData['column'], $table);
@@ -324,6 +325,30 @@ class SchemaBuilder
         }
 
         return $indexes;
+    }
+
+    /**
+     * Move index declarations from constraints to indexes.
+     *
+     * @param array $tableData
+     * @return array
+     */
+    private function normalizeIndexesDeclaredAsConstraints(array $tableData): array
+    {
+        if (!isset($tableData['constraint'])) {
+            return $tableData;
+        }
+
+        foreach ($tableData['constraint'] as $referenceId => $constraintData) {
+            if (($constraintData['type'] ?? null) !== 'index') {
+                continue;
+            }
+
+            $tableData['index'][$referenceId] = $constraintData;
+            unset($tableData['constraint'][$referenceId]);
+        }
+
+        return $tableData;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Declaration/SchemaBuilderTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/Declaration/Schema/Declaration/SchemaBuilderTest.php
@@ -12,6 +12,7 @@ use Magento\Framework\DB\Adapter\SqlVersionProvider;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Stdlib\BooleanUtils;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Framework\Setup\Declaration\Schema\Declaration\TableElement\ElementNameResolver;
 use Magento\Framework\Setup\Declaration\Schema\Declaration\SchemaBuilder;
 use Magento\Framework\Setup\Declaration\Schema\Declaration\ValidationComposite;
 use Magento\Framework\Setup\Declaration\Schema\Dto\Columns\Integer;
@@ -308,6 +309,104 @@ class SchemaBuilderTest extends TestCase
         );
     }
 
+    /**
+     * @throws LocalizedException
+     */
+    public function testIndexConstraintIsAddedAsIndex(): void
+    {
+        $tableData = [
+            'test_table' => [
+                'name' => 'test_table',
+                'engine' => 'innodb',
+                'resource' => 'default',
+                'column' => [
+                    'indexed_column' => [
+                        'name' => 'indexed_column',
+                        'type' => 'int',
+                        'padding' => 10,
+                    ],
+                ],
+                'constraint' => [
+                    'TEST_TABLE_INDEXED_COLUMN' => [
+                        'name' => 'TEST_TABLE_INDEXED_COLUMN',
+                        'type' => 'index',
+                        'column' => [
+                            'indexed_column'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $indexName = 'TEST_TABLE_INDEXED_COLUMN';
+        $table = $this->createTable('test_table');
+        $column = $this->createIntegerColumn('indexed_column', $table);
+        $index = $this->createIndex($indexName, $table, [$column]);
+        $elementNameResolverMock = $this->getMockBuilder(ElementNameResolver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $elementNameResolverMock->expects(self::once())
+            ->method('getFullIndexName')
+            ->with($table, ['indexed_column'], 'index')
+            ->willReturn($indexName);
+        $model = $this->objectManagerHelper->getObject(
+            SchemaBuilder::class,
+            [
+                'elementFactory' => $this->elementFactoryMock,
+                'booleanUtils' => new BooleanUtils(),
+                'sharding' => $this->shardingMock,
+                'validationComposite' => $this->validationCompositeMock,
+                'resourceConnection' => $this->resourceConnectionMock,
+                'elementNameResolver' => $elementNameResolverMock
+            ]
+        );
+        $this->elementFactoryMock->expects(self::exactly(3))
+            ->method('create')
+            ->willReturnCallback(
+                function ($type, array $data) use ($table, $column, $index) {
+                    if ($type === 'table') {
+                        return $table;
+                    }
+                    if ($type === 'int') {
+                        return $column;
+                    }
+                    if ($type === 'index') {
+                        self::assertSame(['indexed_column'], $data['column']);
+                        self::assertSame([$column], $data['columns']);
+
+                        return $index;
+                    }
+                }
+            );
+        $this->shardingMock->expects(self::once())
+            ->method('canUseResource')
+            ->with('default')
+            ->willReturn(true);
+        $this->validationCompositeMock->expects(self::once())
+            ->method('validate')
+            ->willReturn([]);
+        $resourceConnectionMock = $this->getMockBuilder(ResourceConnection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resourceConnectionMock->method('getTableName')
+            ->willReturnCallback(
+                function ($tableName) {
+                    return $tableName;
+                }
+            );
+        /** @var Schema $schema */
+        $schema = $this->objectManagerHelper->getObject(
+            Schema::class,
+            ['resourceConnection' => $resourceConnectionMock]
+        );
+
+        $model->addTablesData($tableData);
+        $model->build($schema);
+        $resultTable = $schema->getTableByName('test_table');
+
+        self::assertSame([$indexName => $index], $resultTable->getIndexes());
+        self::assertSame([], $resultTable->getConstraints());
+    }
+
     /**     * @param array $tablesData
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      * @throws LocalizedException
@@ -366,7 +465,7 @@ class SchemaBuilderTest extends TestCase
         $resourceConnectionMock->expects(self::exactly(6))
             ->method('getTableName')
             ->willReturnCallback(
-                function($arg1) {
+                function ($arg1) {
                     if ($arg1 == 'first_table') {
                         return 'first_table';
                     } elseif ($arg1 == 'second_table') {


### PR DESCRIPTION
### Description (*)

Declaring an index as `<constraint xsi:type="index" referenceId="...">` in `db_schema.xml` is XSD-legal and used in the wild, but breaks every `setup:upgrade` after the first one:

```
SQLSTATE[42000]: Syntax error or access violation: 1061 Duplicate key name '...'
```

(or, when the corresponding `index` whitelist entry also exists, the index is silently **dropped and re-created on every upgrade run** — minutes of table rebuild per deploy on large tables).

**Root cause**

`SchemaBuilder::processConstraints()` instantiates a `<constraint xsi:type="index">` as an *index* DTO but stores it in the table's **constraints** collection. The schema generated from the live database reads the physical key back into the **indexes** collection. `TableDiff::calculateDiff()` compares per element-type bucket, so the declared element and the DB element never match: the diff registers a creation of the "missing" index on every run.

Verified live: with such a declaration, `setup:db:status` reports a permanent phantom `add_complex_element` + `drop_element` pair for the same index on an otherwise up-to-date installation.

**Fix**

Normalize during declaration parsing: entries declared as `<constraint xsi:type="index">` are routed to the index pipeline and land in the table's indexes collection, where they match the DB-generated schema. Name resolution still goes through `ElementNameResolver::getFullIndexName()` with type `index`, producing byte-identical index names — existing installations see a clean, empty diff (verified live: `UpToDateDeclarativeSchema: true` after the fix, index name unchanged). The XSD is intentionally untouched for backward compatibility.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#21304

### Manual testing scenarios (*)

1. Add to any module's `db_schema.xml`:
   ```xml
   <constraint xsi:type="index" referenceId="ADMINNOTIFICATION_INBOX_DATE_ADDED">
       <column name="date_added"/>
   </constraint>
   ```
   and the corresponding `db_schema_whitelist.json` constraint entry.
2. Run `bin/magento setup:upgrade` — the index is created.
3. Run `bin/magento setup:upgrade` again.
4. Before the fix: `1061 Duplicate key name 'ADMINNOTIFICATION_INBOX_DATE_ADDED'`. After the fix: upgrade completes, `bin/magento setup:db:status` reports all modules up to date, index name unchanged.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
