### PR TITLE
Respond 405 Method Not Allowed with Allow header on HTTP method mismatch (#24018)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/Index/ResetPasswordTest.php
+++ b/dev/tests/integration/testsuite/Magento/Customer/Controller/Adminhtml/Index/ResetPasswordTest.php
@@ -15,7 +15,7 @@ use Magento\Framework\App\Request\Http as HttpRequest;
 class ResetPasswordTest extends \Magento\TestFramework\TestCase\AbstractBackendController
 {
     /**
-     * Base controller URL
+     * URL prefix shared by the controller actions under test.
      *
      * @var string
      */
@@ -57,7 +57,8 @@ class ResetPasswordTest extends \Magento\TestFramework\TestCase\AbstractBackendC
         );
         $this->getRequest()->setPostValue(['customer_id' => '1'])->setMethod(HttpRequest::METHOD_POST);
         $this->dispatch('backend/customer/index/resetPassword');
-        $this->assertEquals('noroute', $this->getRequest()->getControllerName());
+        $this->assertEquals(405, $this->getResponse()->getHttpResponseCode());
+        $this->assertEquals('GET, HEAD', $this->getResponse()->getHeader('Allow')->getFieldValue());
     }
 
     /**

--- a/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
+++ b/dev/tests/integration/testsuite/Magento/Newsletter/Controller/Adminhtml/NewsletterTemplateTest.php
@@ -156,6 +156,7 @@ class NewsletterTemplateTest extends \Magento\TestFramework\TestCase\AbstractBac
         $this->getRequest()->setMethod(\Laminas\Http\Request::METHOD_GET)->setParam('id', $this->model->getId());
         $this->dispatch('backend/newsletter/template/save');
 
-        $this->assertEquals(404, $this->getResponse()->getStatusCode());
+        $this->assertEquals(405, $this->getResponse()->getStatusCode());
+        $this->assertEquals('POST', $this->getResponse()->getHeader('Allow')->getFieldValue());
     }
 }

--- a/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
+++ b/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
@@ -18,6 +18,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Make sure that a request's method can be processed by an action.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class HttpMethodValidator implements ValidatorInterface
 {

--- a/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
+++ b/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Request;
 
 use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Interception\InterceptorInterface;
 use Magento\Framework\Phrase;
@@ -31,15 +33,23 @@ class HttpMethodValidator implements ValidatorInterface
     private $log;
 
     /**
+     * @var RawFactory
+     */
+    private $rawFactory;
+
+    /**
      * @param HttpMethodMap $map
      * @param LoggerInterface $logger
+     * @param RawFactory|null $rawFactory
      */
     public function __construct(
         HttpMethodMap $map,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ?RawFactory $rawFactory = null
     ) {
         $this->map = $map;
         $this->log = $logger;
+        $this->rawFactory = $rawFactory ?: ObjectManager::getInstance()->get(RawFactory::class);
     }
 
     /**
@@ -65,6 +75,21 @@ class HttpMethodValidator implements ValidatorInterface
         $this->log->debug(
             "URI '$uri'' cannot be accessed with $method method ($actionClass)"
         );
+
+        $allowedMethods = [];
+        foreach ($this->map->getMap() as $httpMethod => $interface) {
+            if ($action instanceof $interface) {
+                $allowedMethods[] = $httpMethod;
+            }
+        }
+
+        if ($allowedMethods) {
+            throw new InvalidRequestException(
+                $this->rawFactory->create()
+                    ->setHttpResponseCode(405)
+                    ->setHeader('Allow', implode(', ', $allowedMethods), true)
+            );
+        }
 
         throw new InvalidRequestException(
             new NotFoundException(new Phrase('Page not found.'))

--- a/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
+++ b/lib/internal/Magento/Framework/App/Request/HttpMethodValidator.php
@@ -14,7 +14,6 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Exception\NotFoundException;
 use Magento\Framework\Interception\InterceptorInterface;
-use Magento\Framework\Phrase;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -92,7 +91,7 @@ class HttpMethodValidator implements ValidatorInterface
         }
 
         throw new InvalidRequestException(
-            new NotFoundException(new Phrase('Page not found.'))
+            new NotFoundException(__('Page not found.'))
         );
     }
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
@@ -11,13 +11,11 @@ namespace Magento\Framework\App\Test\Unit\Request;
 use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\App\Action\HttpPutActionInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\Request\HttpMethodMap;
 use Magento\Framework\App\Request\HttpMethodValidator;
 use Magento\Framework\App\Request\InvalidRequestException;
-use Magento\Framework\App\Response\HttpInterface;
-use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Controller\Result\RawFactory;
 use Magento\Framework\Exception\NotFoundException;
 use PHPUnit\Framework\TestCase;
@@ -50,7 +48,16 @@ class HttpMethodValidatorTest extends TestCase
     public function testRestrictedActionReturnsMethodNotAllowedWithAllowHeader(): void
     {
         $action = $this->createRestrictedAction();
-        $raw = new Raw();
+        $raw = $this->createMock(ResultInterface::class);
+        $raw->expects($this->once())
+            ->method('setHttpResponseCode')
+            ->with(405)
+            ->willReturnSelf();
+        $raw->expects($this->once())
+            ->method('setHeader')
+            ->with('Allow', 'GET, POST', true)
+            ->willReturnSelf();
+
         $this->rawFactory->expects($this->once())
             ->method('create')
             ->willReturn($raw);
@@ -69,21 +76,6 @@ class HttpMethodValidatorTest extends TestCase
             $this->fail('Invalid request exception was not thrown.');
         } catch (InvalidRequestException $exception) {
             $this->assertSame($raw, $exception->getReplaceResult());
-
-            $response = $this->createMock(HttpInterface::class);
-            $response->expects($this->once())
-                ->method('setHttpResponseCode')
-                ->with(405);
-            $response->expects($this->once())
-                ->method('setHeader')
-                ->with('Allow', 'GET, POST', true)
-                ->willReturnSelf();
-            $response->expects($this->once())
-                ->method('setBody')
-                ->with(null)
-                ->willReturnSelf();
-
-            $exception->getReplaceResult()->renderResult($response);
         }
     }
 
@@ -119,7 +111,7 @@ class HttpMethodValidatorTest extends TestCase
                 [
                     'GET' => HttpGetActionInterface::class,
                     'POST' => HttpPostActionInterface::class,
-                    'PUT' => HttpPutActionInterface::class,
+                    'PUT' => 'Magento\Framework\App\Action\HttpPutActionInterface',
                 ]
             ),
             $this->logger,

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
@@ -21,6 +21,9 @@ use Magento\Framework\Exception\NotFoundException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class HttpMethodValidatorTest extends TestCase
 {
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Request/HttpMethodValidatorTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Framework\App\Test\Unit\Request;
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Action\HttpPutActionInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Request\HttpMethodMap;
+use Magento\Framework\App\Request\HttpMethodValidator;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\Response\HttpInterface;
+use Magento\Framework\Controller\Result\Raw;
+use Magento\Framework\Controller\Result\RawFactory;
+use Magento\Framework\Exception\NotFoundException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class HttpMethodValidatorTest extends TestCase
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var RawFactory
+     */
+    private $rawFactory;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->rawFactory = $this->createMock(RawFactory::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRestrictedActionReturnsMethodNotAllowedWithAllowHeader(): void
+    {
+        $action = $this->createRestrictedAction();
+        $raw = new Raw();
+        $this->rawFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($raw);
+        $this->logger->expects($this->once())
+            ->method('debug')
+            ->with(
+                "URI '/restricted'' cannot be accessed with PUT method ("
+                . get_class($action) . ')'
+            );
+
+        $request = $this->createRequest('PUT', '/restricted');
+        $validator = $this->createValidator();
+
+        try {
+            $validator->validate($request, $action);
+            $this->fail('Invalid request exception was not thrown.');
+        } catch (InvalidRequestException $exception) {
+            $this->assertSame($raw, $exception->getReplaceResult());
+
+            $response = $this->createMock(HttpInterface::class);
+            $response->expects($this->once())
+                ->method('setHttpResponseCode')
+                ->with(405);
+            $response->expects($this->once())
+                ->method('setHeader')
+                ->with('Allow', 'GET, POST', true)
+                ->willReturnSelf();
+            $response->expects($this->once())
+                ->method('setBody')
+                ->with(null)
+                ->willReturnSelf();
+
+            $exception->getReplaceResult()->renderResult($response);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testUnmappedMethodOnActionWithoutLimitationsReturnsNotFoundException(): void
+    {
+        $this->rawFactory->expects($this->never())
+            ->method('create');
+        $this->logger->expects($this->once())
+            ->method('debug');
+
+        $request = $this->createRequest('UNKNOWN', '/unmapped');
+        $action = $this->createMock(ActionInterface::class);
+        $validator = $this->createValidator();
+
+        try {
+            $validator->validate($request, $action);
+            $this->fail('Invalid request exception was not thrown.');
+        } catch (InvalidRequestException $exception) {
+            $this->assertInstanceOf(NotFoundException::class, $exception->getReplaceResult());
+        }
+    }
+
+    /**
+     * @return HttpMethodValidator
+     */
+    private function createValidator(): HttpMethodValidator
+    {
+        return new HttpMethodValidator(
+            new HttpMethodMap(
+                [
+                    'GET' => HttpGetActionInterface::class,
+                    'POST' => HttpPostActionInterface::class,
+                    'PUT' => HttpPutActionInterface::class,
+                ]
+            ),
+            $this->logger,
+            $this->rawFactory
+        );
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @return Http
+     */
+    private function createRequest(string $method, string $uri): Http
+    {
+        $request = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getMethod', 'getRequestUri'])
+            ->getMock();
+        $request->method('getMethod')
+            ->willReturn($method);
+        $request->method('getRequestUri')
+            ->willReturn($uri);
+
+        return $request;
+    }
+
+    /**
+     * Create an action restricted to GET and POST requests.
+     *
+     * @return ActionInterface
+     */
+    private function createRestrictedAction(): ActionInterface
+    {
+        return new class implements HttpGetActionInterface, HttpPostActionInterface {
+            /**
+             * @inheritDoc
+             */
+            public function execute()
+            {
+                throw new \RuntimeException('The action is not expected to be executed.');
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Description (*)

When a request's HTTP method doesn't match an action's HTTP-method marker interface (e.g. a GET request to an action implementing only `HttpPostActionInterface`), `HttpMethodValidator` responds with **404 Page Not Found**. Per RFC 7231 §6.5.5 the correct response is **405 Method Not Allowed**, and the origin server MUST include an `Allow` header listing the methods the resource supports.

This picks up where #25047 left off and addresses both review demands that stalled it:

1. **`Allow` header (RFC 7231 requirement)** — the validator now computes the supported methods from the HTTP-method marker interfaces the action implements (via `HttpMethodMap`, so e.g. an action implementing `HttpGetActionInterface` advertises `GET, HEAD`) and returns a `Raw` result with status 405 and the `Allow` header as the `InvalidRequestException` replace result.
2. **Page-cache safety** — `FrontController::processRequest()` calls `$this->response->setNoCacheHeaders()` *before* request validation runs, so the 405 is delivered with `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache`. Verified live through the full nginx + Varnish stack: the response is not cacheable (Varnish default VCL never caches `no-store` responses).

Behavior is preserved for the edge case of an unmapped/unknown HTTP method hitting an action without method limitations: it still results in the 404 mechanism, because a 405 without a computable `Allow` header would itself violate the RFC.

Verified live (GET on the POST-only `customer/account/loginPost`):

```
HTTP/2 405
allow: POST
cache-control: no-store, no-cache, must-revalidate, max-age=0
```

### Fixed Issues (if relevant)

1. Fixes magento/magento2#24018

### Manual testing scenarios (*)

1. Perform a GET request to a POST-only route, e.g. `curl -i https://<host>/customer/account/loginPost/`
2. Before the fix: `404 Not Found`. After the fix: `405 Method Not Allowed` with `Allow: POST` and no-cache headers.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
