### PR TITLE
Exclude disabled categories from the GraphQL route query

### DIFF
--- a/app/code/Magento/CatalogUrlRewriteGraphQl/Model/DataProvider/UrlRewrite/CatalogTreeDataProvider.php
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/Model/DataProvider/UrlRewrite/CatalogTreeDataProvider.php
@@ -10,6 +10,7 @@ namespace Magento\CatalogUrlRewriteGraphQl\Model\DataProvider\UrlRewrite;
 use Magento\Catalog\Model\CategoryRepository;
 use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\CategoryTree as CategoryTreeDataProvider;
 use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ExtractDataFromCategoryTree;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\UrlRewriteGraphQl\Model\DataProvider\EntityDataProviderInterface;
@@ -55,6 +56,7 @@ class CatalogTreeDataProvider implements EntityDataProviderInterface
      * @param int|null $storeId
      * @return array
      * @throws GraphQlNoSuchEntityException
+     * @throws NoSuchEntityException
      */
     public function getData(
         string $entity_type,
@@ -63,6 +65,10 @@ class CatalogTreeDataProvider implements EntityDataProviderInterface
         ?int $storeId = null
     ): array {
         $categoryId = (int)$id;
+        $category = $this->categoryRepository->get($categoryId, $storeId);
+        if (!$category->getIsActive()) {
+            throw new GraphQlNoSuchEntityException(__('Category doesn\'t exist'));
+        }
         $categoriesTree = $this->categoryTree->getTreeCollection($info, $categoryId, $storeId);
         if ($categoriesTree->count() == 0) {
             throw new GraphQlNoSuchEntityException(__('Category doesn\'t exist'));

--- a/app/code/Magento/CatalogUrlRewriteGraphQl/Test/Unit/Model/DataProvider/UrlRewrite/CatalogTreeDataProviderTest.php
+++ b/app/code/Magento/CatalogUrlRewriteGraphQl/Test/Unit/Model/DataProvider/UrlRewrite/CatalogTreeDataProviderTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogUrlRewriteGraphQl\Test\Unit\Model\DataProvider\UrlRewrite;
+
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\CategoryRepository;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\CategoryTree as CategoryTreeDataProvider;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ExtractDataFromCategoryTree;
+use Magento\CatalogUrlRewriteGraphQl\Model\DataProvider\UrlRewrite\CatalogTreeDataProvider;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CatalogTreeDataProviderTest extends TestCase
+{
+    /**
+     * @var CategoryTreeDataProvider|MockObject
+     */
+    private $categoryTreeMock;
+
+    /**
+     * @var ExtractDataFromCategoryTree|MockObject
+     */
+    private $extractDataFromCategoryTreeMock;
+
+    /**
+     * @var CategoryRepository|MockObject
+     */
+    private $categoryRepositoryMock;
+
+    /**
+     * @var ResolveInfo|MockObject
+     */
+    private $resolveInfoMock;
+
+    /**
+     * @var CatalogTreeDataProvider
+     */
+    private $model;
+
+    protected function setUp(): void
+    {
+        $this->categoryTreeMock = $this->createMock(CategoryTreeDataProvider::class);
+        $this->extractDataFromCategoryTreeMock = $this->createMock(ExtractDataFromCategoryTree::class);
+        $this->categoryRepositoryMock = $this->createMock(CategoryRepository::class);
+        $this->resolveInfoMock = $this->createStub(ResolveInfo::class);
+
+        $this->model = new CatalogTreeDataProvider(
+            $this->categoryTreeMock,
+            $this->extractDataFromCategoryTreeMock,
+            $this->categoryRepositoryMock
+        );
+    }
+
+    /**
+     * A disabled category must not be resolvable through the GraphQL route query.
+     */
+    public function testGetDataThrowsForDisabledCategory(): void
+    {
+        $categoryMock = $this->createStub(Category::class);
+        $categoryMock->method('getIsActive')->willReturn(false);
+        $this->categoryRepositoryMock->expects($this->once())->method('get')->with(5, 1)->willReturn($categoryMock);
+
+        $this->categoryTreeMock->expects($this->never())->method('getTreeCollection');
+        $this->extractDataFromCategoryTreeMock->expects($this->never())->method('buildTree');
+
+        $this->expectException(GraphQlNoSuchEntityException::class);
+
+        $this->model->getData('category', 5, $this->resolveInfoMock, 1);
+    }
+
+    /**
+     * A missing category propagates the repository's not-found exception.
+     */
+    public function testGetDataThrowsWhenCategoryDoesNotExist(): void
+    {
+        $this->categoryRepositoryMock->expects($this->once())->method('get')
+            ->willThrowException(NoSuchEntityException::singleField('id', 5));
+
+        $this->categoryTreeMock->expects($this->never())->method('getTreeCollection');
+        $this->extractDataFromCategoryTreeMock->expects($this->never())->method('buildTree');
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->model->getData('category', 5, $this->resolveInfoMock, 1);
+    }
+
+    /**
+     * An enabled category is still resolved as before.
+     */
+    public function testGetDataReturnsTreeForEnabledCategory(): void
+    {
+        $categoryMock = $this->createStub(Category::class);
+        $categoryMock->method('getIsActive')->willReturn(true);
+        $this->categoryRepositoryMock->expects($this->once())->method('get')->with(5, 1)->willReturn($categoryMock);
+
+        $collectionMock = $this->createStub(Collection::class);
+        $collectionMock->method('count')->willReturn(1);
+        $collectionMock->method('getItems')->willReturn([]);
+        $this->categoryTreeMock->expects($this->once())->method('getTreeCollection')
+            ->with($this->resolveInfoMock, 5, 1)
+            ->willReturn($collectionMock);
+
+        $this->extractDataFromCategoryTreeMock->expects($this->once())->method('buildTree')
+            ->with($collectionMock, [5])
+            ->willReturn([5 => ['name' => 'Test Category']]);
+
+        $result = $this->model->getData('category', 5, $this->resolveInfoMock, 1);
+
+        $this->assertSame('category', $result['type_id']);
+        $this->assertSame('Test Category', $result['name']);
+    }
+}


### PR DESCRIPTION
### Description (*)
The GraphQL `route` query returns a valid result (type `CATEGORY`, a relative URL) for a category that has been disabled, instead of returning `null`. This is a security/data exposure issue: a category the merchant explicitly disabled is still reachable and resolvable through the storefront GraphQL API.

Root cause: `Magento\CatalogUrlRewriteGraphQl\Model\DataProvider\UrlRewrite\CatalogTreeDataProvider::getData()` loads the category tree and only checks whether the category exists at all, never whether it is active. The analogous `ProductDataProvider::getData()` already rejects disabled products the same way (`Status::STATUS_ENABLED` check, since 2.4.9), but no equivalent check was ever added on the category side.

Fix: use the `CategoryRepository` that was already injected into `CatalogTreeDataProvider` (but previously unused) to load the category and check `getIsActive()` before resolving the tree, throwing `GraphQlNoSuchEntityException` if the category is disabled - matching the product behavior and the `route` query's documented contract.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Fixes magento/magento2#40987

### Manual testing scenarios (*)
1. Create a new category, keep it enabled, note its URL key.
2. Disable the category.
3. Run the GraphQL query:
```graphql
query route {
  route(url: "your-url-key") {
    type
    relative_url
  }
}
```
4. Before the fix: the category is returned (`type: CATEGORY`, a relative URL). After the fix: `route` returns `null`.
5. Repeat with the category re-enabled and confirm it resolves normally as before.

### Questions or comments
Unit test added: `Magento\CatalogUrlRewriteGraphQl\Test\Unit\Model\DataProvider\UrlRewrite\CatalogTreeDataProviderTest` (verified against the Magento2 coding standard and passing locally under PHPUnit 12).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)