### PR TITLE
Stop reloading category data on import rows without a category column

### DIFF
--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -1871,12 +1871,20 @@ class Product extends AbstractEntity
     /**
      * In _saveProducts loop, save product's categories
      *
+     * Skipped entirely when the row has no category data, so unchanged category associations
+     * are not reloaded and redundantly re-saved for every product in the import (see
+     * getProductCategories() for the lazy fallback used by consumers of the existing data,
+     * such as URL rewrite generation).
+     *
      * @param int $rowNum
      * @param array $rowData
      * @return void
      */
     private function saveProductCategoriesPhase(int $rowNum, array $rowData) : void
     {
+        if (empty($rowData[self::COL_CATEGORY])) {
+            return;
+        }
         $rowSku = $rowData[self::COL_SKU];
         if (!array_key_exists($rowSku, $this->categoriesCache)) {
             $this->categoriesCache[$rowSku] = [];
@@ -2265,6 +2273,10 @@ class Product extends AbstractEntity
     /**
      * Resolve valid category ids from provided row data.
      *
+     * Returns an empty array when the row does not carry category data at all, instead of loading
+     * the product's existing categories - callers that need those (e.g. getProductCategories())
+     * load them lazily only when actually needed, instead of on every row of every import.
+     *
      * @param array $rowData
      * @return array
      */
@@ -2286,11 +2298,6 @@ class Product extends AbstractEntity
                     . ' ' . $error['exception']->getMessage()
                 );
             }
-        } else {
-            $product = $this->retrieveProductBySku($rowData['sku']);
-            if ($product) {
-                $categoryIds = $product->getCategoryIds();
-            }
         }
         return $categoryIds;
     }
@@ -2309,11 +2316,18 @@ class Product extends AbstractEntity
     /**
      * Retrieve product categories.
      *
+     * Falls back to the product's existing categories when the current import row did not carry
+     * category data for this SKU, since that data is then never loaded into categoriesCache.
+     *
      * @param string $productSku
      * @return array
      */
     public function getProductCategories($productSku)
     {
+        if (!array_key_exists($productSku, $this->categoriesCache)) {
+            $product = $this->retrieveProductBySku($productSku);
+            return $product ? $product->getCategoryIds() : [];
+        }
         return array_keys($this->categoriesCache[$productSku]);
     }
 

--- a/app/code/Magento/CatalogImportExport/Model/Import/Product.php
+++ b/app/code/Magento/CatalogImportExport/Model/Import/Product.php
@@ -2325,10 +2325,33 @@ class Product extends AbstractEntity
     public function getProductCategories($productSku)
     {
         if (!array_key_exists($productSku, $this->categoriesCache)) {
-            $product = $this->retrieveProductBySku($productSku);
-            return $product ? $product->getCategoryIds() : [];
+            return $this->getExistingProductCategoryIds((string)$productSku);
         }
         return array_keys($this->categoriesCache[$productSku]);
+    }
+
+    /**
+     * Read a product's existing category ids directly from the category-product link table.
+     *
+     * Deliberately does not go through the product repository: this runs mid-import (e.g. from
+     * URL rewrite generation), and loading the product there would prime the repository's
+     * per-request instance cache with a half-imported product.
+     *
+     * @param string $productSku
+     * @return array
+     */
+    private function getExistingProductCategoryIds(string $productSku): array
+    {
+        $newSku = $this->skuProcessor->getNewSku($productSku);
+        $entityId = $newSku['entity_id'] ?? $this->skuStorage->get($productSku)['entity_id'] ?? null;
+        if (!$entityId) {
+            return [];
+        }
+        $select = $this->_connection->select()
+            ->from($this->_resourceFactory->create()->getProductCategoryTable(), ['category_id'])
+            ->where('product_id = ?', (int)$entityId);
+
+        return array_map('intval', $this->_connection->fetchCol($select));
     }
 
     /**

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -958,7 +958,9 @@ class ProductTest extends AbstractImportTestCase
     public function testGetProductCategoriesFallsBackToExistingProductWhenNotInCache(): void
     {
         $productSku = 'productSku';
-        $productMock = $this->createMock(ProductInterface::class);
+        // getCategoryIds() is declared on the concrete Product model, not on ProductInterface,
+        // so it must be mocked against \Magento\Catalog\Model\Product to be configurable.
+        $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
         $productMock->expects($this->once())->method('getCategoryIds')->willReturn(['4', '7']);
 
         $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -16,6 +16,7 @@ use Magento\CatalogInventory\Model\ResourceModel\Stock\ItemFactory;
 use Magento\CatalogImportExport\Model\Import\Product\OptionFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Url;
 use Magento\CatalogImportExport\Model\Import\Product;
 use Magento\CatalogImportExport\Model\Import\Product\CategoryProcessor;
@@ -50,6 +51,7 @@ use Magento\Framework\EntityManager\EntityMetadata;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Filesystem\Driver\File as DriverFile;
@@ -945,6 +947,92 @@ class ProductTest extends AbstractImportTestCase
         $actualResult = $this->importProduct->getProductCategories($productSku);
 
         $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    /**
+     * getProductCategories() falls back to the product's existing categories when the SKU was
+     * never populated into categoriesCache (i.e. its import row had no category data at all).
+     *
+     * @return void
+     */
+    public function testGetProductCategoriesFallsBackToExistingProductWhenNotInCache(): void
+    {
+        $productSku = 'productSku';
+        $productMock = $this->createMock(ProductInterface::class);
+        $productMock->expects($this->once())->method('getCategoryIds')->willReturn(['4', '7']);
+
+        $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
+        $productRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($productSku)
+            ->willReturn($productMock);
+        $this->setPropertyValue($this->importProduct, 'productRepository', $productRepositoryMock);
+        $this->setPropertyValue($this->importProduct, 'categoriesCache', []);
+
+        $actualResult = $this->importProduct->getProductCategories($productSku);
+
+        $this->assertEquals(['4', '7'], $actualResult);
+    }
+
+    /**
+     * getProductCategories() returns an empty array when the product can't be found either.
+     *
+     * @return void
+     */
+    public function testGetProductCategoriesReturnsEmptyWhenProductMissingAndNotInCache(): void
+    {
+        $productSku = 'productSku';
+
+        $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
+        $productRepositoryMock->expects($this->once())
+            ->method('get')
+            ->with($productSku)
+            ->willThrowException(new NoSuchEntityException());
+        $this->setPropertyValue($this->importProduct, 'productRepository', $productRepositoryMock);
+        $this->setPropertyValue($this->importProduct, 'categoriesCache', []);
+
+        $this->assertEquals([], $this->importProduct->getProductCategories($productSku));
+    }
+
+    /**
+     * saveProductCategoriesPhase() must not touch categoriesCache, and therefore must not trigger
+     * the category-resave queries in _saveProductCategories(), for a row without category data.
+     *
+     * @return void
+     */
+    public function testSaveProductCategoriesPhaseSkipsRowsWithoutCategoryColumn(): void
+    {
+        $this->categoryProcessor->expects($this->never())->method('upsertCategories');
+        $this->setPropertyValue($this->importProduct, 'categoriesCache', []);
+
+        $this->invokeMethod(
+            $this->importProduct,
+            'saveProductCategoriesPhase',
+            [1, [Product::COL_SKU => 'productSku', Product::COL_CATEGORY => '']]
+        );
+
+        $this->assertEquals([], $this->getPropertyValue($this->importProduct, 'categoriesCache'));
+    }
+
+    /**
+     * processRowCategories() no longer loads the product's existing categories - that is now
+     * getProductCategories()'s job, done lazily only when actually needed.
+     *
+     * @return void
+     */
+    public function testProcessRowCategoriesReturnsEmptyWithoutLoadingProductWhenColumnMissing(): void
+    {
+        $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
+        $productRepositoryMock->expects($this->never())->method('get');
+        $this->setPropertyValue($this->importProduct, 'productRepository', $productRepositoryMock);
+
+        $result = $this->invokeMethod(
+            $this->importProduct,
+            'processRowCategories',
+            [[Product::COL_SKU => 'productSku', 'rowNum' => 1]]
+        );
+
+        $this->assertEquals([], $result);
     }
 
     /**

--- a/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
+++ b/app/code/Magento/CatalogImportExport/Test/Unit/Model/Import/ProductTest.php
@@ -51,7 +51,6 @@ use Magento\Framework\EntityManager\EntityMetadata;
 use Magento\Framework\EntityManager\MetadataPool;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Filesystem\Driver\File as DriverFile;
@@ -950,7 +949,8 @@ class ProductTest extends AbstractImportTestCase
     }
 
     /**
-     * getProductCategories() falls back to the product's existing categories when the SKU was
+     * getProductCategories() falls back to the product's existing category links (read directly
+     * from the category-product link table, not through the product repository) when the SKU was
      * never populated into categoriesCache (i.e. its import row had no category data at all).
      *
      * @return void
@@ -958,39 +958,30 @@ class ProductTest extends AbstractImportTestCase
     public function testGetProductCategoriesFallsBackToExistingProductWhenNotInCache(): void
     {
         $productSku = 'productSku';
-        // getCategoryIds() is declared on the concrete Product model, not on ProductInterface,
-        // so it must be mocked against \Magento\Catalog\Model\Product to be configurable.
-        $productMock = $this->createMock(\Magento\Catalog\Model\Product::class);
-        $productMock->expects($this->once())->method('getCategoryIds')->willReturn(['4', '7']);
-
-        $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
-        $productRepositoryMock->expects($this->once())
-            ->method('get')
-            ->with($productSku)
-            ->willReturn($productMock);
-        $this->setPropertyValue($this->importProduct, 'productRepository', $productRepositoryMock);
+        $this->skuProcessor->method('getNewSku')->with($productSku)->willReturn(['entity_id' => 11]);
+        $resource = $this->createMock(ResourceModel::class);
+        $resource->method('getProductCategoryTable')->willReturn('catalog_category_product');
+        $this->_resourceFactory->method('create')->willReturn($resource);
+        $this->select->method('where')->willReturnSelf();
+        $this->_connection->expects($this->once())->method('fetchCol')->willReturn(['4', '7']);
         $this->setPropertyValue($this->importProduct, 'categoriesCache', []);
 
         $actualResult = $this->importProduct->getProductCategories($productSku);
 
-        $this->assertEquals(['4', '7'], $actualResult);
+        $this->assertEquals([4, 7], $actualResult);
     }
 
     /**
-     * getProductCategories() returns an empty array when the product can't be found either.
+     * getProductCategories() returns an empty array when the product can't be resolved either.
      *
      * @return void
      */
     public function testGetProductCategoriesReturnsEmptyWhenProductMissingAndNotInCache(): void
     {
         $productSku = 'productSku';
-
-        $productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
-        $productRepositoryMock->expects($this->once())
-            ->method('get')
-            ->with($productSku)
-            ->willThrowException(new NoSuchEntityException());
-        $this->setPropertyValue($this->importProduct, 'productRepository', $productRepositoryMock);
+        $this->skuProcessor->method('getNewSku')->with($productSku)->willReturn(null);
+        $this->skuStorageMock->method('get')->with($productSku)->willReturn(null);
+        $this->_connection->expects($this->never())->method('fetchCol');
         $this->setPropertyValue($this->importProduct, 'categoriesCache', []);
 
         $this->assertEquals([], $this->importProduct->getProductCategories($productSku));


### PR DESCRIPTION
### Description (*)
Product import runs unnecessary category-related DB work for every row, even when the row's `categories` column is empty and no category data changed at all:

1. `Magento\CatalogImportExport\Model\Import\Product::processRowCategories()` loads the product's *existing* categories from the DB (`retrieveProductBySku()->getCategoryIds()`) whenever the row has no `categories` column - this was added so `AfterImportDataObserver` (URL rewrite generation) can see the product's categories after import.
2. `saveProductCategoriesPhase()` feeds that unchanged data into `categoriesCache` regardless of where it came from.
3. `_saveProductCategories($this->categoriesCache)` then processes those already-existing category associations exactly like new ones: for each category, a `SELECT MIN(position) ... WHERE category_id = ?` query (expensive on large `catalog_category_product` tables, no supporting index) plus an `INSERT ... ON DUPLICATE KEY UPDATE`.

For imports that don't touch categories at all, this means every product still triggers these queries for its pre-existing category associations. Under load with a large `catalog_category_product` table this has been reported to reach deadlocks in production, and is a flat, unnecessary cost on every append-mode import otherwise.

Fix: separate "categories provided by this row" from "categories the product already has in the DB":
- `processRowCategories()` now only returns categories actually present in the row's `categories` column, and no longer loads the product just to read its existing categories.
- `saveProductCategoriesPhase()` skips a row entirely (no `categoriesCache` entry at all) when it has no category data, instead of caching the unchanged data.
- `getProductCategories()` (read by `AfterImportDataObserver` for URL rewrite generation, among others) now lazily loads the product's existing categories, but only for SKUs that were never touched by `saveProductCategoriesPhase()`, and only when a caller actually asks for them - so the existing URL rewrite behavior is preserved without doing the work up front for every row.

Rows that do provide `categories` are unaffected - same processing, same DB writes as before.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Fixes magento/magento2#39422

### Manual testing scenarios (*)
1. Import a CSV with two columns (`sku`, plus any other non-category column) for a few existing products that already belong to categories, using append mode (API or admin import).
2. Enable query logging (`bin/magento dev:query-log:enable`) before the import.
3. Before the fix: the log shows a `SELECT MIN(position) ...` and an `INSERT ... ON DUPLICATE KEY UPDATE` against `catalog_category_product` for each imported product's existing categories. After the fix: neither query runs for these rows.
4. Confirm the products' category assignments are unchanged after the import, and that generated/expected URLs for those products still resolve correctly (URL rewrite generation still has access to the existing categories via the lazy fallback).
5. Repeat with a row that does set the `categories` column and confirm category assignment/URL generation behavior is unchanged from before this fix.

### Questions or comments
Added unit tests covering the new `processRowCategories()` / `saveProductCategoriesPhase()` / `getProductCategories()` behavior in the existing `ProductTest.php` suite (verified against the Magento2 coding standard; the isolated logic was also verified in a standalone harness since this test class's full suite requires generated Proxy/Factory classes not present in a bare checkout).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)