### PR TITLE
Fix performance regression: stop rendering the customer account block as private content on every page (#40846)

### DIFF
--- a/app/code/Magento/Customer/Block/Account/Customer.php
+++ b/app/code/Magento/Customer/Block/Account/Customer.php
@@ -40,7 +40,6 @@ class Customer extends \Magento\Framework\View\Element\Template
     ) {
         parent::__construct($context, $data);
         $this->httpContext = $httpContext;
-        $this->_isScopePrivate = true;
     }
 
     /**

--- a/app/code/Magento/Customer/Test/Unit/Block/Account/CustomerTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Account/CustomerTest.php
@@ -55,4 +55,14 @@ class CustomerTest extends TestCase
 
         $this->assertSame($result, $this->block->customerLoggedIn($isLoggedIn));
     }
+
+    /**
+     * The block must not be private so it stays part of the full page cache instead of being
+     * rendered through a per-page /page_cache/block/render AJAX request. Login state is served
+     * through the X-Magento-Vary cache variant and the customer-data section.
+     */
+    public function testBlockIsNotScopePrivate()
+    {
+        $this->assertFalse($this->block->isScopePrivate());
+    }
 }


### PR DESCRIPTION
### Description (*)

Removes `$this->_isScopePrivate = true;` from `Magento\Customer\Block\Account\Customer`.

That flag, added in [`1d9e36cb624`](https://github.com/magento/magento2/commit/1d9e36cb624db5c4af4bb89cf7897a0a18c6685b) (AC-13322 "Customer Sign In"), forced the `customer` account block to be rendered as private content. As a result an AJAX request to `/page_cache/block/render?blocks=["customer","customer"]...` fires on **every** frontend page, for **every** visitor (guest or logged in), bypassing the full page cache and booting PHP each time. On high-traffic stores this is a significant, unnecessary load.

#### Root cause / why this is safe now

AC-13322 hole-punched this block to mask #39334 (the header showed a stale "Sign In" / guest state after login, because built-in FPC served the guest-variant HTML). Hole-punching was the wrong layer to fix that:

- It only masked the symptom for this one block (#40120 shows the same staleness persisted for `register-link` / `authorization-link`, which are also `httpContext`-gated).
- Varnish was never affected, because the VCL hashes on the `X-Magento-Vary` cookie for both lookup and store.

The actual root cause, a built-in-FPC save/load cache-key mismatch, was fixed later in **AC-14999** ([`090bbfe43c4`](https://github.com/magento/magento2/commit/090bbfe43c4), "FPC not work when login"): `PageCache/Model/App/Request/Http/IdentifierForSave::getValue()` now keys the save entry off the `X-Magento-Vary` cookie (`Http::COOKIE_VARY_STRING`) so it matches the load key produced by `Framework\App\PageCache\Identifier`. That commit is already on `2.4-develop`.

With the vary mechanism working again, this block no longer needs to be private: the login-agnostic markup is FPC-cacheable, the greeting/name comes from the `customer` customer-data section (client-side), and the logged-in/guest variant is served via `X-Magento-Vary`. So the hole-punch is now pure redundant overhead and is removed.

No need to restore the `FlushAllCache` observer on `customer_login` that AC-13322 also touched: flushing the entire page cache on every login is itself a regression, and it was never part of a released baseline.

### Related Pull Requests

N/A

### Fixed Issues (*)

1. Fixes magento/magento2#40846

### Manual testing scenarios (*)

1. Enable Full Page Cache (built-in or Varnish); use production-like mode.
2. As a guest, open the homepage and refresh a few times so the page is cached.
3. Open DevTools > Network, filter to Fetch/XHR for `/page_cache/block/render`.
   - **Before:** every page view fires a `/page_cache/block/render?blocks=["customer","customer"]...` request returning `{"customer":""}`.
   - **After:** no such request on any page (guest or logged in).
4. Regression check for #39334: while a guest homepage is cached, log in, then navigate back to the homepage. The header correctly shows the customer welcome/account dropdown, no stale "Sign In" / "Create an Account".
5. Store-switching (AC-15223 scenario) still shows the correct per-store cached content.

### Questions or comments

The unit test `Customer/Test/Unit/Block/Account/CustomerTest.php` gains `testBlockIsNotScopePrivate()` to guard against the flag being reintroduced.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all tests are executed on CI)
- [x] All changes are backward compatible unless a major version bump is planned. [Backward Compatibility Policy](https://developer.adobe.com/commerce/php/development/backward-compatibility/)
