### PR TITLE
Honor id_prefix on Symfony cache preload keys (#40877)

### DIFF
--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -606,6 +606,7 @@ class Factory
                     [
                         'adapter' => $result,
                         'preloadKeys' => $backendOptions['preload_keys'],
+                        'idPrefix' => $idPrefix,
                     ]
                 );
             }

--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/PreloadingSymfonyAdapter.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/PreloadingSymfonyAdapter.php
@@ -38,18 +38,50 @@ class PreloadingSymfonyAdapter implements FrontendInterface
      *
      * @param FrontendInterface $adapter Underlying cache adapter
      * @param array $preloadKeys List of cache key identifiers to preload
+     * @param string $idPrefix Cache ID prefix applied by the underlying adapter
      */
     public function __construct(
         FrontendInterface $adapter,
-        array $preloadKeys = []
+        array $preloadKeys = [],
+        string $idPrefix = ''
     ) {
         $this->adapter = $adapter;
-        $this->preloadKeys = $preloadKeys;
+        $this->preloadKeys = $this->normalizePreloadKeys($preloadKeys, $idPrefix);
 
         // Preload keys on initialization (one-time cost per worker)
-        if (!empty($preloadKeys)) {
-            $this->preloadKeys($preloadKeys);
+        if (!empty($this->preloadKeys)) {
+            $this->preloadKeys($this->preloadKeys);
         }
+    }
+
+    /**
+     * Strip the configured ID prefix from preload keys
+     *
+     * The documentation asks for preload keys to include the ID prefix (for example 061_SYSTEM_DEFAULT),
+     * which is what the legacy Zend/Redis backend expected. The Symfony adapter applies the ID prefix
+     * itself, so a prefixed key would be looked up as prefix + prefix + key and never match. Normalizing
+     * the keys back to their logical identifier keeps the documented, backward-compatible configuration
+     * working while still supporting keys that were provided without the prefix.
+     *
+     * @param array $keys
+     * @param string $idPrefix
+     * @return array
+     */
+    private function normalizePreloadKeys(array $keys, string $idPrefix): array
+    {
+        if ($idPrefix === '') {
+            return $keys;
+        }
+
+        $normalized = [];
+        foreach ($keys as $key) {
+            $key = (string)$key;
+            $normalized[] = str_starts_with($key, $idPrefix)
+                ? substr($key, strlen($idPrefix))
+                : $key;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/PreloadingSymfonyAdapterTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/PreloadingSymfonyAdapterTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Cache\Test\Unit\Frontend\Adapter;
+
+use Magento\Framework\Cache\Frontend\Adapter\PreloadingSymfonyAdapter;
+use Magento\Framework\Cache\FrontendInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test for the preloading wrapper of the Symfony cache adapter
+ */
+class PreloadingSymfonyAdapterTest extends TestCase
+{
+    /**
+     * @var FrontendInterface&MockObject
+     */
+    private $adapter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = $this->createMock(FrontendInterface::class);
+    }
+
+    /**
+     * Preload keys that include the ID prefix (as documented) must be looked up with the logical
+     * identifier so the underlying Symfony adapter, which applies the prefix itself, resolves them.
+     */
+    public function testPrefixedPreloadKeysAreLoadedWithLogicalIdentifier(): void
+    {
+        $this->adapter->expects($this->exactly(2))
+            ->method('load')
+            ->willReturnMap([
+                ['EAV_ENTITY_TYPES', 'eav'],
+                ['SYSTEM_DEFAULT', 'system'],
+            ]);
+
+        $adapter = new PreloadingSymfonyAdapter(
+            $this->adapter,
+            ['061_EAV_ENTITY_TYPES', '061_SYSTEM_DEFAULT'],
+            '061_'
+        );
+
+        $stats = $adapter->getPreloadStats();
+        $this->assertSame(2, $stats['preload_keys_configured']);
+        $this->assertSame(2, $stats['preload_keys_cached']);
+        $this->assertSame(['EAV_ENTITY_TYPES', 'SYSTEM_DEFAULT'], $stats['cached_keys']);
+    }
+
+    /**
+     * A preloaded value is served from local memory without hitting the underlying adapter again.
+     */
+    public function testLoadServesPreloadedValueFromLocalCache(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('load')
+            ->with('EAV_ENTITY_TYPES')
+            ->willReturn('eav');
+
+        $adapter = new PreloadingSymfonyAdapter($this->adapter, ['061_EAV_ENTITY_TYPES'], '061_');
+
+        $this->assertSame('eav', $adapter->load('EAV_ENTITY_TYPES'));
+    }
+
+    /**
+     * Keys configured without the prefix (the previously documented workaround) keep working.
+     */
+    public function testUnprefixedPreloadKeysAreLoadedUnchanged(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('load')
+            ->with('EAV_ENTITY_TYPES')
+            ->willReturn('eav');
+
+        $adapter = new PreloadingSymfonyAdapter($this->adapter, ['EAV_ENTITY_TYPES'], '061_');
+
+        $this->assertSame(['EAV_ENTITY_TYPES'], $adapter->getPreloadStats()['cached_keys']);
+    }
+
+    /**
+     * Keys that are not cached in the backend are not stored locally.
+     */
+    public function testMissingKeysAreNotCachedLocally(): void
+    {
+        $this->adapter->expects($this->once())
+            ->method('load')
+            ->with('EAV_ENTITY_TYPES')
+            ->willReturn(false);
+
+        $adapter = new PreloadingSymfonyAdapter($this->adapter, ['061_EAV_ENTITY_TYPES'], '061_');
+
+        $stats = $adapter->getPreloadStats();
+        $this->assertSame(1, $stats['preload_keys_configured']);
+        $this->assertSame(0, $stats['preload_keys_cached']);
+    }
+
+    /**
+     * Writing a normalized preload key refreshes its local copy.
+     */
+    public function testSaveUpdatesLocalCacheForNormalizedPreloadKey(): void
+    {
+        $this->adapter->method('load')->willReturn('old');
+        $this->adapter->expects($this->once())
+            ->method('save')
+            ->with('new', 'EAV_ENTITY_TYPES', [], null)
+            ->willReturn(true);
+
+        $adapter = new PreloadingSymfonyAdapter($this->adapter, ['061_EAV_ENTITY_TYPES'], '061_');
+        $adapter->save('new', 'EAV_ENTITY_TYPES');
+
+        $this->assertSame('new', $adapter->load('EAV_ENTITY_TYPES'));
+    }
+}


### PR DESCRIPTION
### Description (*)

Makes the Symfony cache adapter honor `preload_keys` that include the `id_prefix`, as the documentation instructs.

The [documentation](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cache/redis/redis-pg-cache#redis-preload-feature) tells you to prefix each preload key with the `id_prefix`:

> Keys should include the database prefix; for example, if the database prefix is `061_`, the preload key looks like: `061_SYSTEM_DEFAULT`

That is correct for the legacy Zend/Redis backend, which operated on raw Redis keys. The Symfony adapter, however, applies the `id_prefix` itself (it is the Redis pool namespace). So a preload key that already contains the prefix is looked up as `id_prefix` + `id_prefix` + key and never resolves. On top of that, the wrapper stored/served its local cache under the configured (prefixed) key, while the application loads with the logical (unprefixed) key, so even the local fast path and the write-through in `save()` never matched. The net effect is that the preload feature is a silent no-op whenever keys are configured per the documentation.

`Magento\Framework\App\Cache\Frontend\Factory` now passes the resolved `id_prefix` into `PreloadingSymfonyAdapter`, which normalizes each preload key back to its logical identifier before loading. Keys supplied without the prefix (the current workaround) keep working unchanged, so the change is backward compatible.

### Related Pull Requests

N/A

### Fixed Issues (*)

1. Fixes magento/magento2#40877

### Manual testing scenarios (*)

1. Configure Redis with the Symfony cache adapter and set `id_prefix` to `061_`.
2. Configure `preload_keys` with the prefix, as documented:
   ```php
   'preload_keys' => ['061_EAV_ENTITY_TYPES', '061_GLOBAL_PLUGIN_LIST', '061_DB_IS_UP_TO_DATE', '061_SYSTEM_DEFAULT'],
   ```
3. Warm the cache, then run the diagnostic script from the issue that dumps `getPreloadStats()`.
   - **Before:** `preload_keys_configured => 4`, `preload_keys_cached => 0`, `cached_keys => []`.
   - **After:** `preload_keys_cached` reflects the keys actually present in the cache, and `cached_keys` lists the logical identifiers (`EAV_ENTITY_TYPES`, ...).
4. Confirm keys configured without the prefix still preload (existing workaround stays valid).

### Questions or comments

Adds `PreloadingSymfonyAdapterTest` covering prefixed keys, unprefixed keys, the local-cache fast path, cache misses, and write-through.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all tests are executed on CI)
- [x] All changes are backward compatible unless a major version bump is planned. [Backward Compatibility Policy](https://developer.adobe.com/commerce/php/development/backward-compatibility/)
