### PR TITLE
#41006: Preserve admin order create payment form when available methods are unchanged

### DIFF
--- a/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderPaymentFormPreservedOnShippingMethodChangeTest.xml
+++ b/app/code/Magento/Sales/Test/Mftf/Test/AdminCreateOrderPaymentFormPreservedOnShippingMethodChangeTest.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCreateOrderPaymentFormPreservedOnShippingMethodChangeTest">
+        <annotations>
+            <features value="Sales"/>
+            <stories value="Admin order create payment form is preserved when available payment methods are unchanged"/>
+            <title value="Payment form DOM survives a shipping method change during admin order create"/>
+            <description value="When the set of available payment methods does not change, changing the shipping method during admin order create must not destroy and re-render the payment form DOM. Client-side initialized payment forms and data entered into them would otherwise be lost. The invariant asserted here is DOM identity: a client-set attribute placed on the selected payment method input survives the reload only when the DOM node is preserved. The user-visible symptom (retained Purchase Order number) is asserted as a secondary check."/>
+            <severity value="MAJOR"/>
+            <group value="sales"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set payment/purchaseorder/active 1" stepKey="enablePurchaseOrder"/>
+            <createData entity="Simple_US_Customer" stepKey="simpleCustomer"/>
+            <createData entity="SimpleProduct2" stepKey="simpleProduct"/>
+            <actionGroup ref="AdminLoginActionGroup" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set payment/purchaseorder/active 0" stepKey="disablePurchaseOrder"/>
+            <actionGroup ref="AdminLogoutActionGroup" stepKey="logout"/>
+            <deleteData createDataKey="simpleCustomer" stepKey="deleteSimpleCustomer"/>
+            <deleteData createDataKey="simpleProduct" stepKey="deleteSimpleProduct"/>
+        </after>
+
+        <!-- Start a new order for the existing customer and add a product. -->
+        <actionGroup ref="AdminNavigateToNewOrderPageExistingCustomerActionGroup" stepKey="navigateToNewOrderWithExistingCustomer">
+            <argument name="customer" value="$$simpleCustomer$$"/>
+        </actionGroup>
+        <actionGroup ref="AddSimpleProductToOrderActionGroup" stepKey="addSimpleProductToOrder">
+            <argument name="product" value="$$simpleProduct$$"/>
+            <argument name="productQty" value="1"/>
+        </actionGroup>
+
+        <!-- Select the Purchase Order payment method and enter a PO number. -->
+        <actionGroup ref="SelectPurchaseOrderPaymentMethodActionGroup" stepKey="selectPurchaseOrderPayment">
+            <argument name="purchaseOrderNumber" value="PreservedPONumber42"/>
+        </actionGroup>
+
+        <!-- Leave the Purchase Order number field so its pending change-event request
+             completes before the shipping method interaction starts. -->
+        <click selector="{{AdminOrderFormPaymentSection.header}}" stepKey="unfocusPaymentForm"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForPaymentDataSaved"/>
+
+        <!-- Mark the selected payment method input on the client side. The marker exists
+             only in the browser DOM and is NOT persisted server-side, so it survives a
+             reload only if the DOM node itself is preserved (i.e. not replaced by re-render). -->
+        <executeJS function="document.getElementById('p_method_purchaseorder').setAttribute('data-client-state', 'preserved')" stepKey="markPaymentInput"/>
+
+        <!-- Change the shipping method with a real click (selectOption would toggle the radio
+             without firing its click handler). setShippingMethod always reloads the
+             billing_method area, which on unfixed code destroys and replaces the payment
+             form DOM. -->
+        <click selector="{{AdminOrderFormPaymentSection.getShippingMethods}}" stepKey="openShippingMethods"/>
+        <waitForElementVisible selector="{{AdminOrderFormPaymentSection.flatRateOption}}" stepKey="waitForShippingOptions"/>
+        <click selector="{{AdminOrderFormPaymentSection.flatRateOption}}" stepKey="selectFlatRateShipping"/>
+
+        <!-- The Shipping &amp; Handling totals row renders from the same loadBlock response
+             that reloads the billing_method area — its appearance proves the reload completed. -->
+        <waitForElementVisible selector="{{AdminOrderFormTotalSection.total('Shipping &amp; Handling')}}" stepKey="waitForBillingMethodReload"/>
+        <waitForLoadingMaskToDisappear stepKey="waitForReloadedAreasToSettle"/>
+
+        <!-- Primary assertion (DOM identity): the client-set marker is present only if the
+             payment form DOM node survived the billing_method reload. Fails without the fix. -->
+        <seeElement selector="input#p_method_purchaseorder[data-client-state='preserved']" stepKey="assertPaymentDomPreserved"/>
+
+        <!-- Secondary assertion (user-visible symptom): the entered PO number is still shown. -->
+        <seeInField selector="{{AdminOrderFormPaymentSection.fieldPurchaseOrderNumber}}" userInput="PreservedPONumber42" stepKey="assertPurchaseOrderNumberRetained"/>
+    </test>
+</tests>

--- a/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
+++ b/app/code/Magento/Sales/view/adminhtml/web/order/create/scripts.js
@@ -1278,7 +1278,9 @@
             for (var i = 0; i < this.loadingAreas.length; i++) {
                 var id = this.loadingAreas[i];
                 if ($(this.getAreaId(id))) {
-                    if ((id in response) && id !== 'message' || response[id]) {
+                    if (((id in response) && id !== 'message' || response[id]) &&
+                        this.shouldUpdateArea(id, response[id])
+                    ) {
                         $(this.getAreaId(id)).update(response[id]);
                     }
                     if ($(this.getAreaId(id)).callback) {
@@ -1286,6 +1288,43 @@
                     }
                 }
             }
+        },
+
+        /**
+         * Checks if the received content for an area should replace the current one.
+         * The payment methods form is kept as-is when the set of available methods
+         * has not changed, so that client-side initialized payment forms (hosted
+         * fields, iframes) and data entered into them survive unrelated reloads.
+         *
+         * @param {String} id
+         * @param {String} html
+         * @return {Boolean}
+         */
+        shouldUpdateArea: function (id, html) {
+            if (id !== 'billing_method' || !this.paymentMethod) {
+                return true;
+            }
+
+            return this.getPaymentMethodCodes(html) !== this.getPaymentMethodCodes($(this.getAreaId(id)).innerHTML);
+        },
+
+        /**
+         * Extracts the list of available payment method codes from payment form HTML.
+         *
+         * @param {String} html
+         * @return {String}
+         */
+        getPaymentMethodCodes: function (html) {
+            var container = document.createElement('div');
+
+            container.innerHTML = html;
+
+            return Array.prototype.map.call(
+                container.querySelectorAll('input[name="payment[method]"]'),
+                function (input) {
+                    return input.value;
+                }
+            ).sort().join(',');
         },
 
         prepareArea: function (area) {

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Sales/adminhtml/js/order/create/scripts.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Sales/adminhtml/js/order/create/scripts.test.js
@@ -572,5 +572,50 @@ define([
             });
         });
 
+        describe('loadAreaResponseHandler()', function () {
+            it('keeps the payment form DOM when available payment methods did not change', function () {
+                init();
+                order.paymentMethod = 'payment1';
+                document.getElementById('order-billing_method').innerHTML =
+                    '<input name="payment[method]" value="payment1" type="radio"/><span id="marker"/>';
+                order.loadingAreas = ['billing_method'];
+
+                order.loadAreaResponseHandler({
+                    billing_method: '<input name="payment[method]" value="payment1" type="radio"/>'
+                });
+
+                expect(document.getElementById('marker')).not.toBeNull();
+            });
+
+            it('replaces the payment form when available payment methods changed', function () {
+                init();
+                order.paymentMethod = 'payment1';
+                document.getElementById('order-billing_method').innerHTML =
+                    '<input name="payment[method]" value="payment1" type="radio"/><span id="marker"/>';
+                order.loadingAreas = ['billing_method'];
+
+                order.loadAreaResponseHandler({
+                    billing_method: '<input name="payment[method]" value="payment1" type="radio"/>' +
+                        '<input name="payment[method]" value="payment2" type="radio"/>'
+                });
+
+                expect(document.getElementById('marker')).toBeNull();
+            });
+
+            it('replaces the payment form when no payment method is selected', function () {
+                init();
+                order.paymentMethod = null;
+                document.getElementById('order-billing_method').innerHTML =
+                    '<input name="payment[method]" value="payment1" type="radio"/><span id="marker"/>';
+                order.loadingAreas = ['billing_method'];
+
+                order.loadAreaResponseHandler({
+                    billing_method: '<input name="payment[method]" value="payment1" type="radio"/>'
+                });
+
+                expect(document.getElementById('marker')).toBeNull();
+            });
+        });
+
     });
 });


### PR DESCRIPTION
### Description (*)

In Admin → Sales → Create New Order, changing the Shipping Method triggers `loadArea(['shipping_method', 'totals', 'billing_method'], …)` (address edits and the "shipping same as billing" toggle reload `billing_method` too). `loadAreaResponseHandler()` replaces the section's DOM unconditionally — even when the returned fragment is equivalent to what is already rendered.

For the offline methods bundled with Open Source this is invisible: their state is persisted on the quote and the re-rendered form comes back pre-selected and pre-filled. For payment integrations whose form is initialized client-side (hosted fields / iframe / tokenized card elements), the replacement is destructive in a way no re-initialization can repair: card data typed by the admin exists only inside the gateway's iframe (by PCI design it is never round-tripped through the quote). The gateway JS re-mounts after the replacement — as a fresh, empty form. Every shipping method change wipes the card data the admin just entered, and client-side token/nonce state is invalidated.

The fix skips replacing the `billing_method` area when a payment method is currently selected and the set of available payment method codes in the incoming fragment (`input[name="payment[method]"]` values, parsed in a detached — inert — element) is identical to the set already rendered. When availability genuinely changes (minimum-order-amount rules, country- or shipping-dependent payment restrictions), the area re-renders exactly as before. Payment availability is additionally re-validated server-side at order submission, as today.

### Related Pull Requests

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41006

### Automated test coverage

- **Jasmine**: 3 new specs for `loadAreaResponseHandler()` covering skip-when-unchanged, re-render-when-changed, and re-render-when-nothing-selected (`dev/tests/js/jasmine/.../order/create/scripts.test.js`)
- **MFTF**: `AdminCreateOrderPaymentFormPreservedOnShippingMethodChangeTest` — asserts DOM identity via a client-set attribute on the payment method input (not persisted server-side, so it survives the `billing_method` reload only when the DOM is preserved; field-value assertions alone cannot prove this, as values are restored from the quote on re-render). Verified locally: passes with the fix, fails at `assertPaymentDomPreserved` without it.

### Manual testing scenarios (*)

1. Enable at least two shipping methods (e.g. Flat Rate, Free Shipping) and at least two payment methods (e.g. Check / Money Order, Purchase Order)
2. Admin → Sales → Orders → Create New Order; select a customer, add a product
3. Select *Purchase Order*, enter a PO number
4. In the browser console, tag the live form node: `document.querySelector('#order-billing_method input[name="payment[method]"]:checked').__keep = 1`
5. Select a Shipping Method (then change it to the other one)
6. Before this change: the tagged node is gone after each shipping change — the whole payment form DOM was replaced (with a client-side initialized card form, entered card data is destroyed with it)
7. After this change: `document.querySelector('#order-billing_method input[name="payment[method]"]:checked').__keep` is still `1` — the DOM survived, selection and entered inputs intact
8. Regression check: trigger a genuine availability change (e.g. enable a payment method restricted by minimum order amount and cross the threshold, or restrict a method to a country and change the address) — the payment section still re-renders and reflects the new availability

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
