### PR TITLE
fix: export file deletion path validation

### DIFF
--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -27,7 +27,7 @@ class Delete extends ExportController implements HttpPostActionInterface
     /**
      * Url to this controller
      */
-    const URL = 'adminhtml/export_file/delete';
+    public const URL = 'adminhtml/export_file/delete';
 
     /**
      * @var Filesystem

--- a/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
+++ b/app/code/Magento/ImportExport/Controller/Adminhtml/Export/File/Delete.php
@@ -9,13 +9,15 @@ namespace Magento\ImportExport\Controller\Adminhtml\Export\File;
 
 use Magento\Backend\App\Action;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Exception\ValidatorException;
 use Magento\ImportExport\Controller\Adminhtml\Export as ExportController;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\Filesystem\Directory\WriteFactory;
+use Magento\ImportExport\Model\Export\FileInfo;
+use Throwable;
 
 /**
  * Controller that delete file by name.
@@ -38,19 +40,27 @@ class Delete extends ExportController implements HttpPostActionInterface
     private $writeFactory;
 
     /**
+     * @var FileInfo
+     */
+    private $fileInfo;
+
+    /**
      * Delete constructor.
      *
      * @param Action\Context $context
      * @param Filesystem $filesystem
      * @param WriteFactory $writeFactory
+     * @param FileInfo $fileInfo
      */
     public function __construct(
         Action\Context $context,
         Filesystem $filesystem,
-        WriteFactory $writeFactory
+        WriteFactory $writeFactory,
+        ?FileInfo $fileInfo = null
     ) {
         $this->filesystem = $filesystem;
         $this->writeFactory = $writeFactory;
+        $this->fileInfo = $fileInfo ?? ObjectManager::getInstance()->get(FileInfo::class);
         parent::__construct($context);
     }
 
@@ -72,13 +82,16 @@ class Delete extends ExportController implements HttpPostActionInterface
             }
             $directoryWrite = $this->filesystem->getDirectoryWrite(DirectoryList::VAR_IMPORT_EXPORT);
             try {
-                $directoryWrite->delete($directoryWrite->getAbsolutePath() . 'export/' . $fileName);
+                $fileName = $directoryWrite->getDriver()->getRealPathSafety(DIRECTORY_SEPARATOR . $fileName);
+                $path = 'export' . $fileName;
+                if (empty($fileName) || !$this->fileInfo->isExportFile($fileName)) {
+                    $this->messageManager->addErrorMessage(__('Please provide valid export file name'));
+
+                    return $resultRedirect;
+                }
+                $directoryWrite->delete($path);
                 $this->messageManager->addSuccessMessage(__('File %1 deleted', $fileName));
-            } catch (ValidatorException $exception) {
-                $this->messageManager->addErrorMessage(
-                    __('Sorry, but the data is invalid or the file is not uploaded.')
-                );
-            } catch (FileSystemException $exception) {
+            } catch (Throwable $exception) {
                 $this->messageManager->addErrorMessage(
                     __('Sorry, but the data is invalid or the file is not uploaded.')
                 );

--- a/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/Export/File/DeleteTest.php
+++ b/dev/tests/integration/testsuite/Magento/ImportExport/Controller/Adminhtml/Export/File/DeleteTest.php
@@ -81,6 +81,26 @@ class DeleteTest extends AbstractBackendController
     }
 
     /**
+     * Verify a traversal filename cannot delete files outside the export directory.
+     *
+     * @magentoConfigFixture default_store admin/security/use_form_key 1
+     */
+    public function testExecuteDoesNotDeleteFileOutsideExportDirectory(): void
+    {
+        $targetPath = 'traversal_test/' . $this->fileName;
+        $this->copyFile($targetPath);
+
+        $request = $this->getRequest();
+        $request->setParam('filename', '../' . $targetPath);
+        $request->setMethod(Http::METHOD_POST);
+
+        $this->dispatch('backend/admin/export_file/delete');
+
+        $this->assertTrue($this->varDirectory->isExist($targetPath));
+        $this->varDirectory->delete($targetPath);
+    }
+
+    /**
      * Copy csv file from sourceFilePath to destinationFilePath
      *
      * @param $destinationFilePath


### PR DESCRIPTION
## Summary

Restrict the Import/Export export-file deletion action to completed export files within `var/export`.

This brings the delete action in line with the sibling export-file download action, which already canonicalizes the requested filename and permits only valid export files beneath `var/export`

The action now follows the same validation pattern as the sibling download endpoint:

- Canonicalizes the requested filename.
- Requires the resolved file to exist under `var/export`.
- Accepts only configured export-file extensions.
- Deletes using the validated relative export path.

## Scope

This is intentionally a narrow Import/Export filesystem-boundary hardening change.

The existing filesystem directory abstraction already prevents paths from escaping Magento’s `var/` directory. Before this change, a relative filename could still resolve outside the intended `var/export` directory and target another file within `var/`.

After this change, the delete action is limited to valid completed export artifacts in `var/export`. It does not change access control, affect paths outside this Import/Export workflow, or alter normal export-file deletion behaviour.

## Test coverage

Adds an integration test confirming that a traversal-style filename cannot delete a CSV located outside `var/export`.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41029: fix: export file deletion path validation