### PR TITLE
Fix guest login captcha missing on billing-step for virtual-product-only carts

### DIFF
--- a/app/code/Magento/Captcha/Block/CheckoutLayoutProcessor.php
+++ b/app/code/Magento/Captcha/Block/CheckoutLayoutProcessor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2025 Adobe.
+ * Copyright 2025 Adobe
  * All Rights Reserved.
  */
 
@@ -38,6 +38,9 @@ class CheckoutLayoutProcessor implements LayoutProcessorInterface
             $jsLayout['components']['checkout']['children']['authentication']['children']['captcha'] = $captcha;
             $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
             ['shippingAddress']['children']['customer-email']['children']['additional-login-form-fields']
+            ['children']['captcha'] = $captcha;
+            $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+            ['payment']['children']['customer-email']['children']['additional-login-form-fields']
             ['children']['captcha'] = $captcha;
         }
         return $jsLayout;

--- a/app/code/Magento/Captcha/Test/Unit/Block/CheckoutLayoutProcessorTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Block/CheckoutLayoutProcessorTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Captcha\Test\Unit\Block;
+
+use Magento\Captcha\Block\CheckoutLayoutProcessor;
+use Magento\Captcha\Helper\Data as HelperCaptcha;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CheckoutLayoutProcessorTest extends TestCase
+{
+    /**
+     * @var HelperCaptcha|MockObject
+     */
+    private $helperMock;
+
+    /**
+     * @var CheckoutLayoutProcessor
+     */
+    private $processor;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->helperMock = $this->createMock(HelperCaptcha::class);
+        $this->processor = new CheckoutLayoutProcessor($this->helperMock);
+    }
+
+    /**
+     * The billing step is the checkout's entry point whenever the shipping step is skipped, e.g. for
+     * a virtual-product-only cart, so it must receive the login captcha too, not just the shipping step.
+     */
+    public function testProcessAddsCaptchaToBillingStepLoginFormWhenEnabled(): void
+    {
+        $this->helperMock->method('getConfig')->with('enable')->willReturn(true);
+
+        $result = $this->processor->process(['components' => ['checkout' => ['children' => []]]]);
+
+        $billingStepCaptcha = $result['components']['checkout']['children']['steps']['children']['billing-step']
+            ['children']['payment']['children']['customer-email']['children']['additional-login-form-fields']
+            ['children']['captcha'];
+        $shippingStepCaptcha = $result['components']['checkout']['children']['steps']['children']['shipping-step']
+            ['children']['shippingAddress']['children']['customer-email']['children']['additional-login-form-fields']
+            ['children']['captcha'];
+        $authenticationCaptcha = $result['components']['checkout']['children']['authentication']['children']['captcha'];
+
+        $expectedCaptcha = [
+            'component' => 'Magento_Captcha/js/view/checkout/loginCaptcha',
+            'displayArea' => 'additional-login-form-fields',
+            'formId' => 'user_login',
+            'configSource' => 'checkoutConfig',
+        ];
+        self::assertEquals($expectedCaptcha, $billingStepCaptcha);
+        self::assertEquals($expectedCaptcha, $shippingStepCaptcha);
+        self::assertEquals($expectedCaptcha, $authenticationCaptcha);
+    }
+
+    public function testProcessLeavesLayoutUnchangedWhenCaptchaDisabled(): void
+    {
+        $this->helperMock->method('getConfig')->with('enable')->willReturn(false);
+
+        $jsLayout = ['components' => ['checkout' => ['children' => []]]];
+
+        self::assertSame($jsLayout, $this->processor->process($jsLayout));
+    }
+}


### PR DESCRIPTION
### Description

`Magento\Captcha\Block\CheckoutLayoutProcessor::process()` injects the login captcha component into two places:
1. The `authentication` popup
2. The `shipping-step`'s `customer-email` login form

A cart that contains only virtual products skips the shipping step entirely and lands directly on the `billing-step`. That step also has its own `customer-email` login form (rendered above the payment methods), but it never received the captcha injection, so `formId` stayed `null` there and the login request failed with a validation error.

This adds the same captcha injection for `steps.billing-step.payment.customer-email.additional-login-form-fields`, mirroring the existing shipping-step injection. The target path was verified against the base checkout layout (`Magento_Checkout/view/frontend/layout/checkout_index_index.xml`), which already declares an empty `additional-login-form-fields` placeholder under `billing-step.payment.customer-email` for exactly this kind of module injection.

### Related Issue

Fixes #40974

### Manual testing scenarios

1. Enable login captcha for the checkout login form (`Stores > Configuration > Customers > Customer Configuration > CAPTCHA` or `Stores > Configuration > Security > Google reCAPTCHA` depending on version, form: `user_login`).
2. Add only virtual products to the cart as a guest and proceed to checkout (this skips straight to the billing/payment step).
3. Enter the email address of an existing customer in the checkout email field and attempt to log in.
4. Before this fix: the captcha widget is missing and the login request fails validation. After this fix: the captcha renders and login succeeds.

### Questions or comments

None.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility