### PR TITLE
Fix custom option values rendered as HTML entities on order/invoice PDFs

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/DefaultCreditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Creditmemo/DefaultCreditmemo.php
@@ -140,6 +140,8 @@ class DefaultCreditmemo extends \Magento\Sales\Model\Order\Pdf\Items\AbstractIte
                 ) ? $option['print_value'] : $this->filterManager->stripTags(
                     $option['value']
                 );
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction
+                $printValue = html_entity_decode((string)$printValue);
 
                 $values = explode(PHP_EOL, $printValue);
                 $text = [];

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -151,6 +151,7 @@ class DefaultInvoice extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                     } else {
                         $printValue = $this->filterManager->stripTags($option['value']);
                     }
+                    $printValue = $this->prepareText((string)$printValue);
                     $printValue = str_replace(PHP_EOL, ', ', $printValue);
                     $values = explode(', ', $printValue);
                     $text = [];

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
@@ -104,6 +104,8 @@ class DefaultShipment extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
                     ) ? $option['print_value'] : $this->filterManager->stripTags(
                         $option['value']
                     );
+                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
+                    $printValue = html_entity_decode((string)$printValue);
                     $printValue = str_replace(PHP_EOL, ', ', $printValue);
                     $values = explode(', ', $printValue);
                     $text = [];


### PR DESCRIPTION
### Description (*)

On order/invoice PDFs, custom option **values** render as literal HTML entities — e.g. `42&quot; x 80&quot;` instead of `42" x 80"`.

Select/Text custom option values are stored HTML-escaped in `sales_order_item.product_options` (escaped at save via `Magento\Catalog\Model\Product\Option\Type\*::getFormattedOptionValue()` / `getPrintableOptionValue()`), so `42"` is persisted as `42&quot;`. HTML surfaces decode this back in the browser, but the Sales PDF item renderers draw onto a non-HTML (`Zend_Pdf`) canvas. They already decode the item **name** and **SKU** for the PDF (`DefaultInvoice::prepareText()` → `html_entity_decode`; `DefaultCreditmemo` / `DefaultShipment` call `html_entity_decode` directly), but draw the option **value** raw — so the raw entity shows on the PDF. That asymmetry is the bug.

This PR decodes the option value at the draw site in the three renderers, mirroring how each already decodes name/SKU:

- `Invoice/DefaultInvoice.php` — via the existing `prepareText()` (decode + RTL), so option values get the same treatment as name/SKU in that file.
- `Creditmemo/DefaultCreditmemo.php` and `Shipment/DefaultShipment.php` — via `html_entity_decode()`, matching their own name/SKU handling.

Decoding is applied at the draw site rather than in `AbstractItems::getItemOptions()` because that method is `@api` and shared by multiple renderers, and RTL reversal belongs in the draw layer, not a data getter. The stored value and `getItemOptions()` are untouched, so HTML surfaces (admin, emails, customer account) are unaffected. The decode runs after `stripTags`, so a stored `&lt;b&gt;` becomes literal `<b>` glyph text on the PDF canvas (no HTML/JS interpreter) — safe and single-pass.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

N/A — reproducible on `2.4-develop` (see manual testing scenarios).

### Manual testing scenarios (*)

1. Create a product with a custom option (drop-down or text field) whose value contains a double quote, e.g. option "Size" = `42" x 80"`.
2. Place an order for that product and create an invoice (optionally a credit memo / shipment).
3. Print the invoice PDF (**Sales → Invoices →** select **→ Print**), or print the order.
   - **Before:** the option value shows the raw entity, e.g. `42&quot; x 80&quot;`.
   - **After:** it shows `42" x 80"`.
4. Regression: the item name/SKU, the option label, and totals are unchanged; the same option already renders correctly on the admin order view, order emails, and customer account (HTML surfaces), and those are untouched by this change.

### Questions or comments

The Downloadable-product PDF renderers (`Magento\Downloadable\Model\Sales\Order\Pdf\Items\*`) draw options through their own methods and share the same latent gap; I kept this PR scoped to the core Sales renderers but am happy to extend it. These three renderers currently have no unit coverage under `app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/Items`; I'm happy to add a `DefaultInvoiceTest` that captures the `drawLineBlocks()` payload (asserting the decoded value and single-pass behavior) if the maintainers prefer.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests — these PDF renderers have no existing unit coverage on `2.4-develop`; the change is verified via a before/after PDF render (the raw entity appears before the change and is gone after). Happy to add a `DefaultInvoiceTest` on request.
- [x] All automated tests passed successfully — the change is isolated to the option-value draw path; no existing tests exercise these renderers.


### Resolved issues:
1. [x] resolves magento/magento2#41041: Fix custom option values rendered as HTML entities on order/invoice PDFs