### PR TITLE
Security hardening: guest-cart ownership, address upload auth, media protections

### DIFF
--- a/app/code/Magento/Csp/etc/config.xml
+++ b/app/code/Magento/Csp/etc/config.xml
@@ -13,7 +13,8 @@
                     <report_only>1</report_only>
                 </storefront>
                 <admin>
-                    <report_only>1</report_only>
+                    <!-- Enforce CSP in admin by default (defense-in-depth against stored XSS). -->
+                    <report_only>0</report_only>
                 </admin>
             </mode>
             <policies>

--- a/app/code/Magento/Customer/Controller/Address/File/Upload.php
+++ b/app/code/Magento/Customer/Controller/Address/File/Upload.php
@@ -7,17 +7,19 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Controller\Address\File;
 
+use Magento\Customer\Api\AddressMetadataInterface;
+use Magento\Customer\Model\FileProcessorFactory;
+use Magento\Customer\Model\FileUploader;
+use Magento\Customer\Model\FileUploaderFactory;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Api\CustomAttributesDataInterface;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\Api\CustomAttributesDataInterface;
-use Magento\Customer\Api\AddressMetadataInterface;
-use Magento\Customer\Model\FileUploader;
-use Magento\Customer\Model\FileUploaderFactory;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
-use Magento\Customer\Model\FileProcessorFactory;
 
 /**
  * Class for upload files for customer custom address attributes
@@ -45,24 +47,46 @@ class Upload extends Action implements HttpPostActionInterface
     private $fileProcessorFactory;
 
     /**
+     * @var CustomerSession
+     */
+    private $customerSession;
+
+    /**
      * @param Context $context
      * @param FileUploaderFactory $fileUploaderFactory
      * @param AddressMetadataInterface $addressMetadataService
      * @param LoggerInterface $logger
      * @param FileProcessorFactory $fileProcessorFactory
+     * @param CustomerSession $customerSession
      */
     public function __construct(
         Context $context,
         FileUploaderFactory $fileUploaderFactory,
         AddressMetadataInterface $addressMetadataService,
         LoggerInterface $logger,
-        FileProcessorFactory $fileProcessorFactory
+        FileProcessorFactory $fileProcessorFactory,
+        CustomerSession $customerSession
     ) {
         $this->fileUploaderFactory = $fileUploaderFactory;
         $this->addressMetadataService = $addressMetadataService;
         $this->logger = $logger;
         $this->fileProcessorFactory = $fileProcessorFactory;
+        $this->customerSession = $customerSession;
         parent::__construct($context);
+    }
+
+    /**
+     * Require an authenticated customer session (matches other Address controllers).
+     *
+     * @param RequestInterface $request
+     * @return \Magento\Framework\App\ResponseInterface
+     */
+    public function dispatch(RequestInterface $request)
+    {
+        if (!$this->customerSession->authenticate()) {
+            $this->_actionFlag->set('', 'no-dispatch', true);
+        }
+        return parent::dispatch($request);
     }
 
     /**

--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -105,12 +105,5 @@
                 <section_data_lifetime>60</section_data_lifetime>
             </online_customers>
         </customer>
-        <system>
-            <media_storage_configuration>
-                <allowed_resources>
-                    <customer_address_folder>customer_address</customer_address_folder>
-                </allowed_resources>
-            </media_storage_configuration>
-        </system>
     </default>
 </config>

--- a/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model\GuestCart;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Get cart for guest users.
+ */
+class GetGuestCart
+{
+    /**
+     * Initialize dependencies
+     *
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        private readonly CartRepositoryInterface $cartRepository
+    ) {
+    }
+
+    /**
+     * Get quote by masked cart ID only if it is a guest cart.
+     *
+     * @param string $maskedCartId
+     * @param int $quoteId
+     * @return Quote
+     * @throws NoSuchEntityException
+     */
+    public function execute(string $maskedCartId, int $quoteId): Quote
+    {
+        /** @var Quote $quote */
+        $quote = $this->cartRepository->get($quoteId);
+        $this->checkIsGuestCart((int) $quote->getCustomerId(), $maskedCartId);
+
+        return $quote;
+    }
+
+    /**
+     * Check if the cart is a guest cart.
+     *
+     * @param int $customerId
+     * @param string $maskedCartId
+     * @throws NoSuchEntityException
+     */
+    public function checkIsGuestCart(int $customerId, string $maskedCartId): void
+    {
+        if ($customerId !== 0) {
+            throw new NoSuchEntityException(
+                __("Could not find a cart with ID '%masked_cart_id'", ['masked_cart_id' => $maskedCartId])
+            );
+        }
+    }
+}

--- a/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestBillingAddressManagementInterface;
 use Magento\Quote\Api\BillingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Billing address management service for guest carts.
@@ -26,36 +28,46 @@ class GuestBillingAddressManagement implements GuestBillingAddressManagementInte
     private $billingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote billing address service object.
      *
      * @param BillingAddressManagementInterface $billingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         BillingAddressManagementInterface $billingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->billingAddressManagement = $billingAddressManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address, $useForShipping = false)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return (int)$this->billingAddressManagement->assign($quoteIdMask->getQuoteId(), $address, $useForShipping);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->billingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\Data\CartItemInterface;
 use Magento\Quote\Api\CartItemRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Item repository class for guest carts.
@@ -16,7 +18,7 @@ use Magento\Quote\Model\QuoteIdMaskFactory;
 class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemRepositoryInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartItemRepositoryInterface
+     * @var CartItemRepositoryInterface
      */
     protected $repository;
 
@@ -26,26 +28,35 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     protected $quoteIdMaskFactory;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a read service object.
      *
-     * @param \Magento\Quote\Api\CartItemRepositoryInterface $repository
+     * @param CartItemRepositoryInterface $repository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartItemRepositoryInterface $repository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartItemRepositoryInterface $repository,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->repository = $repository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $cartItemList = $this->repository->getList($quoteIdMask->getQuoteId());
         /** @var $item CartItemInterface */
         foreach ($cartItemList as $item) {
@@ -55,23 +66,25 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function save(\Magento\Quote\Api\Data\CartItemInterface $cartItem)
+    public function save(CartItemInterface $cartItem)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartItem->getQuoteId(), 'masked_id');
+        $this->getGuestCart->execute($cartItem->getQuoteId(), (int) $quoteIdMask->getQuoteId());
         $cartItem->setQuoteId($quoteIdMask->getQuoteId());
         return $this->repository->save($cartItem);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function deleteById($cartId, $itemId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->repository->deleteById($quoteIdMask->getQuoteId(), $itemId);
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
@@ -12,6 +12,8 @@ use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Management class for guest carts.
@@ -36,25 +38,33 @@ class GuestCartManagement implements GuestCartManagementInterface
     protected $cartRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartManagementInterface $quoteManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
      * @param CartRepositoryInterface $cartRepository
+     * @param GetGuestCart|null $getGuestCart
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         CartManagementInterface $quoteManagement,
         QuoteIdMaskFactory $quoteIdMaskFactory,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteManagement = $quoteManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function createEmptyCart()
     {
@@ -66,22 +76,24 @@ class GuestCartManagement implements GuestCartManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function assignCustomer($cartId, $customerId, $storeId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->quoteManagement->assignCustomer($quoteIdMask->getQuoteId(), $customerId, $storeId);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function placeOrder($cartId, ?PaymentInterface $paymentMethod = null)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $this->cartRepository->get($quoteIdMask->getQuoteId())
             ->setCheckoutMethod(CartManagementInterface::METHOD_GUEST);
         return $this->quoteManagement->placeOrder($quoteIdMask->getQuoteId(), $paymentMethod);

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Repository class for guest carts.
@@ -26,26 +28,36 @@ class GuestCartRepository implements GuestCartRepositoryInterface
     protected $quoteRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartRepositoryInterface $quoteRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartRepositoryInterface $quoteRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteRepository = $quoteRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
-        return $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $this->getGuestCart->checkIsGuestCart((int)$quote->getCustomerId(), $cartId);
+        return $quote;
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
@@ -7,6 +7,9 @@ namespace Magento\Quote\Model\GuestCart;
 
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\GuestCartTotalManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Quote\Api\CartTotalManagementInterface;
 
 /**
  * @inheritDoc
@@ -14,7 +17,7 @@ use Magento\Quote\Api\GuestCartTotalManagementInterface;
 class GuestCartTotalManagement implements GuestCartTotalManagementInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartTotalManagementInterface
+     * @var CartTotalManagementInterface
      */
     protected $cartTotalManagement;
 
@@ -24,19 +27,27 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
     protected $quoteIdMaskFactory;
 
     /**
-     * @param \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
+     * @param CartTotalManagementInterface $cartTotalManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartTotalManagementInterface $cartTotalManagement,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalManagement = $cartTotalManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function collectTotals(
         $cartId,
@@ -46,6 +57,7 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
         ?\Magento\Quote\Api\Data\TotalsAdditionalDataInterface $additionalData = null
     ) {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalManagement->collectTotals(
             $quoteIdMask->getQuoteId(),
             $paymentMethod,

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
@@ -10,6 +10,8 @@ use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\GuestCartTotalRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart totals repository class for guest carts.
@@ -27,26 +29,35 @@ class GuestCartTotalRepository implements GuestCartTotalRepositoryInterface
     private $cartTotalRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a cart totals data object.
      *
      * @param CartTotalRepositoryInterface $cartTotalRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartTotalRepositoryInterface $cartTotalRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalRepository = $cartTotalRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalRepository->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCouponManagementInterface;
 use Magento\Quote\Api\CouponManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Coupon management class for guest carts.
@@ -26,17 +28,25 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     private $couponManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a coupon read service object.
      *
      * @param CouponManagementInterface $couponManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CouponManagementInterface $couponManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->couponManagement = $couponManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
@@ -46,6 +56,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->get($quoteIdMask->getQuoteId());
     }
 
@@ -56,6 +67,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->set($quoteIdMask->getQuoteId(), trim($couponCode));
     }
 
@@ -66,6 +78,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->remove($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\PaymentMethodManagementInterface;
 use Magento\Quote\Api\GuestPaymentMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Payment method management class for guest carts.
@@ -26,46 +28,57 @@ class GuestPaymentMethodManagement implements GuestPaymentMethodManagementInterf
     protected $paymentMethodManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param PaymentMethodManagementInterface $paymentMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         PaymentMethodManagementInterface $paymentMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->paymentMethodManagement = $paymentMethodManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function set($cartId, \Magento\Quote\Api\Data\PaymentInterface $method)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->set($quoteIdMask->getQuoteId(), $method);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\ShippingAddressManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping address management class for guest carts.
@@ -26,36 +28,46 @@ class GuestShippingAddressManagement implements GuestShippingAddressManagementIn
     protected $shippingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote shipping address write service object.
      *
      * @param ShippingAddressManagementInterface $shippingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingAddressManagementInterface $shippingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingAddressManagement = $shippingAddressManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->assign($quoteIdMask->getQuoteId(), $address);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
@@ -13,6 +13,7 @@ use Magento\Quote\Api\ShipmentEstimationInterface;
 use Magento\Quote\Api\ShippingMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping method management class for guest carts.
@@ -38,56 +39,68 @@ class GuestShippingMethodManagement implements
     private $shipmentEstimationManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a shipping method read service object.
      *
      * @param ShippingMethodManagementInterface $shippingMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingMethodManagementInterface $shippingMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingMethodManagement = $shippingMethodManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function set($cartId, $carrierCode, $methodCode)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->set($quoteIdMask->getQuoteId(), $carrierCode, $methodCode);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function estimateByAddress($cartId, \Magento\Quote\Api\Data\EstimateAddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->estimateByAddress($quoteIdMask->getQuoteId(), $address);
     }
 
@@ -98,6 +111,7 @@ class GuestShippingMethodManagement implements
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
 
         return $this->getShipmentEstimationManagement()
             ->estimateByExtendedAddress((int) $quoteIdMask->getQuoteId(), $address);
@@ -105,8 +119,10 @@ class GuestShippingMethodManagement implements
 
     /**
      * Get shipment estimation management service
+     *
      * @return ShipmentEstimationInterface
      * @deprecated 100.0.7
+     * @see getShipmentEstimationManagement
      */
     private function getShipmentEstimationManagement()
     {

--- a/app/code/Magento/QuoteGraphQl/Model/Resolver/EstimateShippingMethods.php
+++ b/app/code/Magento/QuoteGraphQl/Model/Resolver/EstimateShippingMethods.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\QuoteGraphQl\Model\Resolver;
 
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Api\ExtensibleDataObjectConverter;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -21,6 +22,7 @@ use Magento\Quote\Api\ShipmentEstimationInterface;
 use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
 use Magento\Quote\Model\Quote\AddressFactory;
 use Magento\Quote\Model\Cart\ShippingMethodConverter;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 use Magento\QuoteGraphQl\Model\ErrorMapper;
 use Magento\QuoteGraphQl\Model\FormatMoneyTypeData;
 
@@ -31,6 +33,11 @@ use Magento\QuoteGraphQl\Model\FormatMoneyTypeData;
 class EstimateShippingMethods implements ResolverInterface
 {
     /**
+     * @var GetCartForUser
+     */
+    private GetCartForUser $getCartForUser;
+
+    /**
      * @param MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId
      * @param CartRepositoryInterface $cartRepository
      * @param AddressFactory $addressFactory
@@ -39,6 +46,7 @@ class EstimateShippingMethods implements ResolverInterface
      * @param ShippingMethodConverter $shippingMethodConverter
      * @param FormatMoneyTypeData $formatMoneyTypeData
      * @param ErrorMapper $errorMapper
+     * @param GetCartForUser|null $getCartForUser
      */
     public function __construct(
         private MaskedQuoteIdToQuoteIdInterface $maskedQuoteIdToQuoteId,
@@ -48,8 +56,10 @@ class EstimateShippingMethods implements ResolverInterface
         private ExtensibleDataObjectConverter $dataObjectConverter,
         private ShippingMethodConverter $shippingMethodConverter,
         private FormatMoneyTypeData $formatMoneyTypeData,
-        private ErrorMapper $errorMapper
+        private ErrorMapper $errorMapper,
+        ?GetCartForUser $getCartForUser = null
     ) {
+        $this->getCartForUser = $getCartForUser ?? ObjectManager::getInstance()->get(GetCartForUser::class);
     }
 
     /**
@@ -58,14 +68,18 @@ class EstimateShippingMethods implements ResolverInterface
     public function resolve(Field $field, $context, ResolveInfo $info, ?array $value = null, ?array $args = null)
     {
         $this->validateInput($args);
+        $maskedCartId = $args['input']['cart_id'];
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         try {
-            $cart = $this->cartRepository->get($this->maskedQuoteIdToQuoteId->execute($args['input']['cart_id']));
+            // Enforce cart ownership consistently with EstimateTotals / other cart resolvers.
+            $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+            $cart = $this->cartRepository->get($this->maskedQuoteIdToQuoteId->execute($maskedCartId));
         } catch (NoSuchEntityException $ex) {
             throw new GraphQlInputException(
                 __(
                     'Could not find a cart with ID "%masked_id"',
                     [
-                        'masked_id' => $args['input']['cart_id']
+                        'masked_id' => $maskedCartId
                     ]
                 ),
                 $ex,

--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -141,6 +141,13 @@
                     <svgz>svgz</svgz>
                     <xml>xml</xml>
                     <xhtml>xhtml</xhtml>
+                    <hta>hta</hta>
+                    <mhtml>mhtml</mhtml>
+                    <mht>mht</mht>
+                    <htc>htc</htc>
+                    <xht>xht</xht>
+                    <shtm>shtm</shtm>
+                    <php8>php8</php8>
                 </protected_extensions>
                 <public_files_valid_paths>
                     <protected>

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -189,6 +189,10 @@ location /media/customer/ {
     deny all;
 }
 
+location /media/customer_address/ {
+    deny all;
+}
+
 location /media/downloadable/ {
     deny all;
 }


### PR DESCRIPTION
### Description (*)
Security hardening for Magento Open Source aligned with Google Patch Rewards / recent Adobe security guidance:

1. **Guest cart ownership** — Guest REST cart endpoints (`GuestCart*`) now verify the masked cart resolves to a guest quote (`customer_id === 0`) via new `GetGuestCart`, preventing use of guest APIs against customer-owned carts.
2. **Customer address file upload auth** — `customer/address_file/upload` now requires an authenticated customer session (same pattern as other Address controllers). Previously this controller extended `Action` directly with no `authenticate()`.
3. **Protected upload extensions** — Expand `general/file/protected_extensions` with `hta`, `mhtml`, `mht`, `htc`, `xht`, `shtm`, `php8`.
4. **customer_address media hardening** — Remove `customer_address` from Customer module `allowed_resources`; add `deny all` for `/media/customer_address/` in `nginx.conf.sample` (operators with custom nginx must apply the deny rule manually).
5. **GraphQL consistency** — `estimateShippingMethods` now calls `GetCartForUser` like `EstimateTotals`.
6. **Admin CSP** — Default admin CSP to enforcing mode (`report_only=0`) for defense-in-depth.

These changes are intended as security improvements suitable for the [Google Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) (Magento is Tier 1 in-scope).

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Hardens guest-cart authorization consistency (related class of issues addressed in APSB26-73)
2. Closes unauthenticated storefront address file-upload controller gap (residual auth issue)

### Manual testing scenarios (*)
1. **Guest cart ownership**
   - Create a customer cart; obtain its masked ID.
   - Call `GET /V1/guest-carts/:maskedId` → expect not-found / rejection (not customer cart data).
   - Create a true guest cart masked ID → guest endpoints continue to work.
2. **Address file upload auth**
   - With a custom address `file`/`image` attribute configured, `POST /customer/address_file/upload` while logged out → expect redirect/login (no file written).
   - Repeat while logged in as customer → upload succeeds as before.
3. **Protected extensions**
   - Attempt upload of a blocked extension (e.g. `.hta`, `.php8`) via MediaStorage uploader path → rejected by `NotProtectedExtension`.
4. **nginx sample**
   - Confirm `nginx.conf.sample` contains `location /media/customer_address/ { deny all; }`.
5. **GraphQL estimateShippingMethods**
   - Authenticated customer calling estimate with another customer’s masked cart ID → authorization error (consistent with other cart resolvers).
6. **Admin CSP**
   - Fresh install / config: admin CSP is not report-only by default.

### Questions or comments
- Live nginx configs are not auto-updated by this PR; merchants must add the `/media/customer_address/` deny rule if they do not use the sample file.
- If Adobe prefers private handling for any subset of these changes, happy to adjust per maintainer guidance / HackerOne process.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

Made with [Cursor](https://cursor.com)