### PR TITLE
Require guest-cart APIs to operate only on guest quotes

### DIFF
--- a/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GetGuestCart.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Quote\Model\GuestCart;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Get cart for guest users.
+ */
+class GetGuestCart
+{
+    /**
+     * Initialize dependencies
+     *
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(
+        private readonly CartRepositoryInterface $cartRepository
+    ) {
+    }
+
+    /**
+     * Get quote by masked cart ID only if it is a guest cart.
+     *
+     * @param string $maskedCartId
+     * @param int $quoteId
+     * @return Quote
+     * @throws NoSuchEntityException
+     */
+    public function execute(string $maskedCartId, int $quoteId): Quote
+    {
+        /** @var Quote $quote */
+        $quote = $this->cartRepository->get($quoteId);
+        $this->checkIsGuestCart((int) $quote->getCustomerId(), $maskedCartId);
+
+        return $quote;
+    }
+
+    /**
+     * Check if the cart is a guest cart.
+     *
+     * @param int $customerId
+     * @param string $maskedCartId
+     * @throws NoSuchEntityException
+     */
+    public function checkIsGuestCart(int $customerId, string $maskedCartId): void
+    {
+        if ($customerId !== 0) {
+            throw new NoSuchEntityException(
+                __("Could not find a cart with ID '%masked_cart_id'", ['masked_cart_id' => $maskedCartId])
+            );
+        }
+    }
+}

--- a/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestBillingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestBillingAddressManagementInterface;
 use Magento\Quote\Api\BillingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Billing address management service for guest carts.
@@ -26,36 +28,46 @@ class GuestBillingAddressManagement implements GuestBillingAddressManagementInte
     private $billingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote billing address service object.
      *
      * @param BillingAddressManagementInterface $billingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         BillingAddressManagementInterface $billingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->billingAddressManagement = $billingAddressManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address, $useForShipping = false)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return (int)$this->billingAddressManagement->assign($quoteIdMask->getQuoteId(), $address, $useForShipping);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->billingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartItemRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\Data\CartItemInterface;
 use Magento\Quote\Api\CartItemRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Item repository class for guest carts.
@@ -16,7 +18,7 @@ use Magento\Quote\Model\QuoteIdMaskFactory;
 class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemRepositoryInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartItemRepositoryInterface
+     * @var CartItemRepositoryInterface
      */
     protected $repository;
 
@@ -26,26 +28,35 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     protected $quoteIdMaskFactory;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a read service object.
      *
-     * @param \Magento\Quote\Api\CartItemRepositoryInterface $repository
+     * @param CartItemRepositoryInterface $repository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartItemRepositoryInterface $repository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartItemRepositoryInterface $repository,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->repository = $repository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $cartItemList = $this->repository->getList($quoteIdMask->getQuoteId());
         /** @var $item CartItemInterface */
         foreach ($cartItemList as $item) {
@@ -55,23 +66,25 @@ class GuestCartItemRepository implements \Magento\Quote\Api\GuestCartItemReposit
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function save(\Magento\Quote\Api\Data\CartItemInterface $cartItem)
+    public function save(CartItemInterface $cartItem)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartItem->getQuoteId(), 'masked_id');
+        $this->getGuestCart->execute($cartItem->getQuoteId(), (int) $quoteIdMask->getQuoteId());
         $cartItem->setQuoteId($quoteIdMask->getQuoteId());
         return $this->repository->save($cartItem);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function deleteById($cartId, $itemId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->repository->deleteById($quoteIdMask->getQuoteId(), $itemId);
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartManagement.php
@@ -12,6 +12,8 @@ use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\Data\PaymentInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Management class for guest carts.
@@ -36,25 +38,33 @@ class GuestCartManagement implements GuestCartManagementInterface
     protected $cartRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartManagementInterface $quoteManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
      * @param CartRepositoryInterface $cartRepository
+     * @param GetGuestCart|null $getGuestCart
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         CartManagementInterface $quoteManagement,
         QuoteIdMaskFactory $quoteIdMaskFactory,
-        CartRepositoryInterface $cartRepository
+        CartRepositoryInterface $cartRepository,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteManagement = $quoteManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function createEmptyCart()
     {
@@ -66,22 +76,24 @@ class GuestCartManagement implements GuestCartManagementInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function assignCustomer($cartId, $customerId, $storeId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->quoteManagement->assignCustomer($quoteIdMask->getQuoteId(), $customerId, $storeId);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function placeOrder($cartId, ?PaymentInterface $paymentMethod = null)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         $this->cartRepository->get($quoteIdMask->getQuoteId())
             ->setCheckoutMethod(CartManagementInterface::METHOD_GUEST);
         return $this->quoteManagement->placeOrder($quoteIdMask->getQuoteId(), $paymentMethod);

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartRepository.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart Repository class for guest carts.
@@ -26,26 +28,36 @@ class GuestCartRepository implements GuestCartRepositoryInterface
     protected $quoteRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param CartRepositoryInterface $quoteRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartRepositoryInterface $quoteRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->quoteRepository = $quoteRepository;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
-        return $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $quote = $this->quoteRepository->get($quoteIdMask->getQuoteId());
+        $this->getGuestCart->checkIsGuestCart((int)$quote->getCustomerId(), $cartId);
+        return $quote;
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalManagement.php
@@ -7,6 +7,9 @@ namespace Magento\Quote\Model\GuestCart;
 
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Api\GuestCartTotalManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Quote\Api\CartTotalManagementInterface;
 
 /**
  * @inheritDoc
@@ -14,7 +17,7 @@ use Magento\Quote\Api\GuestCartTotalManagementInterface;
 class GuestCartTotalManagement implements GuestCartTotalManagementInterface
 {
     /**
-     * @var \Magento\Quote\Api\CartTotalManagementInterface
+     * @var CartTotalManagementInterface
      */
     protected $cartTotalManagement;
 
@@ -24,19 +27,27 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
     protected $quoteIdMaskFactory;
 
     /**
-     * @param \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
+     * @param CartTotalManagementInterface $cartTotalManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
-        \Magento\Quote\Api\CartTotalManagementInterface $cartTotalManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        CartTotalManagementInterface $cartTotalManagement,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalManagement = $cartTotalManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function collectTotals(
         $cartId,
@@ -46,6 +57,7 @@ class GuestCartTotalManagement implements GuestCartTotalManagementInterface
         ?\Magento\Quote\Api\Data\TotalsAdditionalDataInterface $additionalData = null
     ) {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalManagement->collectTotals(
             $quoteIdMask->getQuoteId(),
             $paymentMethod,

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCartTotalRepository.php
@@ -10,6 +10,8 @@ use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\GuestCartTotalRepositoryInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Cart totals repository class for guest carts.
@@ -27,26 +29,35 @@ class GuestCartTotalRepository implements GuestCartTotalRepositoryInterface
     private $cartTotalRepository;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a cart totals data object.
      *
      * @param CartTotalRepositoryInterface $cartTotalRepository
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CartTotalRepositoryInterface $cartTotalRepository,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->cartTotalRepository = $cartTotalRepository;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->cartTotalRepository->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestCouponManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\GuestCouponManagementInterface;
 use Magento\Quote\Api\CouponManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Coupon management class for guest carts.
@@ -26,17 +28,25 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     private $couponManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a coupon read service object.
      *
      * @param CouponManagementInterface $couponManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         CouponManagementInterface $couponManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->couponManagement = $couponManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
@@ -46,6 +56,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->get($quoteIdMask->getQuoteId());
     }
 
@@ -56,6 +67,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->set($quoteIdMask->getQuoteId(), trim($couponCode));
     }
 
@@ -66,6 +78,7 @@ class GuestCouponManagement implements GuestCouponManagementInterface
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->couponManagement->remove($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestPaymentMethodManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Api\PaymentMethodManagementInterface;
 use Magento\Quote\Api\GuestPaymentMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
+use Magento\Framework\App\ObjectManager;
 
 /**
  * Payment method management class for guest carts.
@@ -26,46 +28,57 @@ class GuestPaymentMethodManagement implements GuestPaymentMethodManagementInterf
     protected $paymentMethodManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Initialize dependencies.
      *
      * @param PaymentMethodManagementInterface $paymentMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         PaymentMethodManagementInterface $paymentMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->paymentMethodManagement = $paymentMethodManagement;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function set($cartId, \Magento\Quote\Api\Data\PaymentInterface $method)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->set($quoteIdMask->getQuoteId(), $method);
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->paymentMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingAddressManagement.php
@@ -9,6 +9,8 @@ use Magento\Quote\Model\GuestCart\GuestShippingAddressManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Quote\Model\ShippingAddressManagementInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping address management class for guest carts.
@@ -26,36 +28,46 @@ class GuestShippingAddressManagement implements GuestShippingAddressManagementIn
     protected $shippingAddressManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a quote shipping address write service object.
      *
      * @param ShippingAddressManagementInterface $shippingAddressManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingAddressManagementInterface $shippingAddressManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingAddressManagement = $shippingAddressManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function assign($cartId, \Magento\Quote\Api\Data\AddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->assign($quoteIdMask->getQuoteId(), $address);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingAddressManagement->get($quoteIdMask->getQuoteId());
     }
 }

--- a/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
+++ b/app/code/Magento/Quote/Model/GuestCart/GuestShippingMethodManagement.php
@@ -13,6 +13,7 @@ use Magento\Quote\Api\ShipmentEstimationInterface;
 use Magento\Quote\Api\ShippingMethodManagementInterface;
 use Magento\Quote\Model\QuoteIdMask;
 use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Quote\Model\GuestCart\GetGuestCart;
 
 /**
  * Shipping method management class for guest carts.
@@ -38,56 +39,68 @@ class GuestShippingMethodManagement implements
     private $shipmentEstimationManagement;
 
     /**
+     * @var GetGuestCart|null
+     */
+    private $getGuestCart;
+
+    /**
      * Constructs a shipping method read service object.
      *
      * @param ShippingMethodManagementInterface $shippingMethodManagement
      * @param QuoteIdMaskFactory $quoteIdMaskFactory
+     * @param GetGuestCart|null $getGuestCart
      */
     public function __construct(
         ShippingMethodManagementInterface $shippingMethodManagement,
-        QuoteIdMaskFactory $quoteIdMaskFactory
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        ?GetGuestCart $getGuestCart = null
     ) {
         $this->shippingMethodManagement = $shippingMethodManagement;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->getGuestCart = $getGuestCart ?? ObjectManager::getInstance()->get(GetGuestCart::class);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function get($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->get($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getList($cartId)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->getList($quoteIdMask->getQuoteId());
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function set($cartId, $carrierCode, $methodCode)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->set($quoteIdMask->getQuoteId(), $carrierCode, $methodCode);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function estimateByAddress($cartId, \Magento\Quote\Api\Data\EstimateAddressInterface $address)
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
         return $this->shippingMethodManagement->estimateByAddress($quoteIdMask->getQuoteId(), $address);
     }
 
@@ -98,6 +111,7 @@ class GuestShippingMethodManagement implements
     {
         /** @var $quoteIdMask QuoteIdMask */
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $this->getGuestCart->execute($cartId, (int) $quoteIdMask->getQuoteId());
 
         return $this->getShipmentEstimationManagement()
             ->estimateByExtendedAddress((int) $quoteIdMask->getQuoteId(), $address);
@@ -105,8 +119,10 @@ class GuestShippingMethodManagement implements
 
     /**
      * Get shipment estimation management service
+     *
      * @return ShipmentEstimationInterface
      * @deprecated 100.0.7
+     * @see getShipmentEstimationManagement
      */
     private function getShipmentEstimationManagement()
     {


### PR DESCRIPTION
### Description (*)
Guest REST cart endpoints (`GuestCart*`) resolve a masked cart ID and act on the quote without verifying it is a guest cart (`customer_id === 0`). This change adds `GetGuestCart` and enforces that check on guest-cart repository/management classes so customer-owned carts cannot be accessed via guest APIs.

Replaces the guest-cart portion of #41015 (split for atomic review per maintainer feedback).

### Related Pull Requests
- Supersedes (partially): magento/magento2#41015

### Fixed Issues (if relevant)
1. Guest-cart authorization consistency / ownership validation

### Manual testing scenarios (*)
1. Create a customer cart and obtain its masked ID. Call `GET /V1/guest-carts/:maskedId` → expect not-found / rejection (no customer cart data).
2. Create a true guest cart masked ID → guest endpoints continue to work (get/items/coupon/address/payment/totals).

### Questions or comments
Split from #41015 to keep this PR single-area (Quote / GuestCart only).

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

Made with [Cursor](https://cursor.com)