### PR TITLE
Require customer session for address file uploads

### DIFF
--- a/app/code/Magento/Customer/Controller/Address/File/Upload.php
+++ b/app/code/Magento/Customer/Controller/Address/File/Upload.php
@@ -7,17 +7,19 @@ declare(strict_types=1);
 
 namespace Magento\Customer\Controller\Address\File;
 
+use Magento\Customer\Api\AddressMetadataInterface;
+use Magento\Customer\Model\FileProcessorFactory;
+use Magento\Customer\Model\FileUploader;
+use Magento\Customer\Model\FileUploaderFactory;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Api\CustomAttributesDataInterface;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
-use Magento\Framework\Api\CustomAttributesDataInterface;
-use Magento\Customer\Api\AddressMetadataInterface;
-use Magento\Customer\Model\FileUploader;
-use Magento\Customer\Model\FileUploaderFactory;
+use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Psr\Log\LoggerInterface;
-use Magento\Customer\Model\FileProcessorFactory;
 
 /**
  * Class for upload files for customer custom address attributes
@@ -45,24 +47,46 @@ class Upload extends Action implements HttpPostActionInterface
     private $fileProcessorFactory;
 
     /**
+     * @var CustomerSession
+     */
+    private $customerSession;
+
+    /**
      * @param Context $context
      * @param FileUploaderFactory $fileUploaderFactory
      * @param AddressMetadataInterface $addressMetadataService
      * @param LoggerInterface $logger
      * @param FileProcessorFactory $fileProcessorFactory
+     * @param CustomerSession $customerSession
      */
     public function __construct(
         Context $context,
         FileUploaderFactory $fileUploaderFactory,
         AddressMetadataInterface $addressMetadataService,
         LoggerInterface $logger,
-        FileProcessorFactory $fileProcessorFactory
+        FileProcessorFactory $fileProcessorFactory,
+        CustomerSession $customerSession
     ) {
         $this->fileUploaderFactory = $fileUploaderFactory;
         $this->addressMetadataService = $addressMetadataService;
         $this->logger = $logger;
         $this->fileProcessorFactory = $fileProcessorFactory;
+        $this->customerSession = $customerSession;
         parent::__construct($context);
+    }
+
+    /**
+     * Require an authenticated customer session (matches other Address controllers).
+     *
+     * @param RequestInterface $request
+     * @return \Magento\Framework\App\ResponseInterface
+     */
+    public function dispatch(RequestInterface $request)
+    {
+        if (!$this->customerSession->authenticate()) {
+            $this->_actionFlag->set('', 'no-dispatch', true);
+        }
+        return parent::dispatch($request);
     }
 
     /**


### PR DESCRIPTION
### Description (*)
`Magento\Customer\Controller\Address\File\Upload` (`customer/address_file/upload`) extends `Action` directly and does not call `Session::authenticate()`, unlike other Address controllers that use `Customer\Controller\Address::dispatch()`.

This PR injects `CustomerSession` and enforces authentication in `dispatch()` so anonymous clients cannot write files under `media/customer_address/`.

Replaces the upload-auth portion of #41015 (split for atomic review).

### Related Pull Requests
- Supersedes (partially): magento/magento2#41015

### Fixed Issues (if relevant)
1. Missing authentication on storefront address file upload controller

### Manual testing scenarios (*)
1. With a custom address `file`/`image` attribute configured, `POST /customer/address_file/upload` while logged out → expect login/redirect; no file written.
2. Repeat while logged in as a customer → upload succeeds as before.

### Questions or comments
Single-file / single-controller change for focused review.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

Made with [Cursor](https://cursor.com)