### PR TITLE
Harden customer_address media upload and serving protections

### DIFF
--- a/app/code/Magento/Customer/etc/config.xml
+++ b/app/code/Magento/Customer/etc/config.xml
@@ -105,12 +105,5 @@
                 <section_data_lifetime>60</section_data_lifetime>
             </online_customers>
         </customer>
-        <system>
-            <media_storage_configuration>
-                <allowed_resources>
-                    <customer_address_folder>customer_address</customer_address_folder>
-                </allowed_resources>
-            </media_storage_configuration>
-        </system>
     </default>
 </config>

--- a/app/code/Magento/Store/etc/config.xml
+++ b/app/code/Magento/Store/etc/config.xml
@@ -141,6 +141,13 @@
                     <svgz>svgz</svgz>
                     <xml>xml</xml>
                     <xhtml>xhtml</xhtml>
+                    <hta>hta</hta>
+                    <mhtml>mhtml</mhtml>
+                    <mht>mht</mht>
+                    <htc>htc</htc>
+                    <xht>xht</xht>
+                    <shtm>shtm</shtm>
+                    <php8>php8</php8>
                 </protected_extensions>
                 <public_files_valid_paths>
                     <protected>

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -189,6 +189,10 @@ location /media/customer/ {
     deny all;
 }
 
+location /media/customer_address/ {
+    deny all;
+}
+
 location /media/downloadable/ {
     deny all;
 }


### PR DESCRIPTION
### Description (*)
Hardens customer-address media handling in one focused area:

1. Expand `general/file/protected_extensions` with `hta`, `mhtml`, `mht`, `htc`, `xht`, `shtm`, `php8`.
2. Remove `customer_address` from Customer module media `allowed_resources`.
3. Add `location /media/customer_address/ { deny all; }` to `nginx.conf.sample`.

Replaces the media-hardening portion of #41015 (split for atomic review).

### Related Pull Requests
- Supersedes (partially): magento/magento2#41015

### Fixed Issues (if relevant)
1. Customer address media / dangerous upload extension hardening

### Manual testing scenarios (*)
1. Confirm `Store/etc/config.xml` includes the new protected extensions.
2. Confirm Customer `config.xml` no longer registers `customer_address` under `allowed_resources`.
3. Confirm `nginx.conf.sample` denies `/media/customer_address/`.
4. Note: live custom nginx configs must add the deny rule manually (sample only).

### Questions or comments
Operators not using `nginx.conf.sample` need to apply the deny rule themselves.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

Made with [Cursor](https://cursor.com)