### PR TITLE
Enforce Content-Security-Policy in admin by default

### DIFF
--- a/app/code/Magento/Csp/etc/config.xml
+++ b/app/code/Magento/Csp/etc/config.xml
@@ -13,7 +13,8 @@
                     <report_only>1</report_only>
                 </storefront>
                 <admin>
-                    <report_only>1</report_only>
+                    <!-- Enforce CSP in admin by default (defense-in-depth against stored XSS). -->
+                    <report_only>0</report_only>
                 </admin>
             </mode>
             <policies>


### PR DESCRIPTION
### Description (*)
Admin CSP currently defaults to `report_only=1`, so CSP does not block anything in admin. This PR defaults admin to enforcing mode (`report_only=0`) for defense-in-depth against stored XSS.

Storefront remains report-only by default.

Replaces the CSP portion of #41015 (split for atomic review).

### Related Pull Requests
- Supersedes (partially): magento/magento2#41015

### Fixed Issues (if relevant)
1. Admin CSP report-only default weakens XSS defense-in-depth

### Manual testing scenarios (*)
1. Fresh install / default config: admin CSP is enforcing (not report-only).
2. Storefront CSP remains report-only unless merchant changes config.
3. Merchants with heavy custom admin JS may need CSP allowlist tuning.

### Questions or comments
Config-only change in `Magento_Csp`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

Made with [Cursor](https://cursor.com)