### PR TITLE
validate redirect target against downloadable domains in setResource

### DIFF
--- a/app/code/Magento/Downloadable/Helper/Download.php
+++ b/app/code/Magento/Downloadable/Helper/Download.php
@@ -6,6 +6,7 @@
 
 namespace Magento\Downloadable\Helper;
 
+use Magento\Downloadable\Model\Url\DomainValidator;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\File\Mime;
@@ -111,6 +112,11 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
     private $mime;
 
     /**
+     * @var DomainValidator
+     */
+    private $domainValidator;
+
+    /**
      * @param \Magento\Framework\App\Helper\Context $context
      * @param File $downloadableFile
      * @param \Magento\MediaStorage\Helper\File\Storage\Database $coreFileStorageDb
@@ -118,6 +124,7 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\Framework\Session\SessionManagerInterface $session
      * @param Filesystem\File\ReadFactory $fileReadFactory
      * @param Mime|null $mime
+     * @param DomainValidator|null $domainValidator
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -126,7 +133,8 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Framework\Session\SessionManagerInterface $session,
         \Magento\Framework\Filesystem\File\ReadFactory $fileReadFactory,
-        ?Mime $mime = null
+        ?Mime $mime = null,
+        ?DomainValidator $domainValidator = null
     ) {
         parent::__construct($context);
         $this->_downloadableFile = $downloadableFile;
@@ -135,6 +143,7 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_session = $session;
         $this->fileReadFactory = $fileReadFactory;
         $this->mime = $mime ?? ObjectManager::getInstance()->get(Mime::class);
+        $this->domainValidator = $domainValidator ?? ObjectManager::getInstance()->get(DomainValidator::class);
     }
 
     /**
@@ -262,11 +271,18 @@ class Download extends \Magento\Framework\App\Helper\AbstractHelper
         * check header for urls
         */
         if ($linkType === self::LINK_TYPE_URL) {
+            $context = stream_context_create(['http' => ['follow_location' => 0]]);
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
-            $headers = array_change_key_case(get_headers($this->_resourceFile, 1), CASE_LOWER);
+            $headers = array_change_key_case(get_headers($this->_resourceFile, 1, $context), CASE_LOWER);
             if (isset($headers['location'])) {
-                $this->_resourceFile  = is_array($headers['location']) ? current($headers['location'])
+                $location = is_array($headers['location']) ? current($headers['location'])
                     : $headers['location'];
+                if (!$this->domainValidator->isValid($location)) {
+                    throw new \InvalidArgumentException(
+                        'Requested link redirects to a domain that is not in the list of downloadable domains'
+                    );
+                }
+                $this->_resourceFile = $location;
             }
         }
 

--- a/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Helper/DownloadTest.php
@@ -10,6 +10,7 @@ namespace Magento\Downloadable\Test\Unit\Helper;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Downloadable\Helper\Download as DownloadHelper;
 use Magento\Downloadable\Helper\File as DownloadableFile;
+use Magento\Downloadable\Model\Url\DomainValidator;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\File\Mime;
 use Magento\Framework\Filesystem;
@@ -69,6 +70,11 @@ class DownloadTest extends TestCase
      */
     private $mime;
 
+    /**
+     * @var DomainValidator|MockObject
+     */
+    private $domainValidator;
+
     protected function setUp(): void
     {
         require_once __DIR__ . '/../_files/download_mock.php';
@@ -83,6 +89,7 @@ class DownloadTest extends TestCase
         $this->sessionManager = $this->createMock(SessionManagerInterface::class);
         $this->fileReadFactory = $this->createMock(ReadFactory::class);
         $this->mime = $this->createMock(Mime::class);
+        $this->domainValidator = $this->createMock(DomainValidator::class);
 
         $this->_helper = (new ObjectManager($this))->getObject(
             DownloadHelper::class,
@@ -91,7 +98,8 @@ class DownloadTest extends TestCase
                 'filesystem'       => $this->_filesystemMock,
                 'session'          => $this->sessionManager,
                 'fileReadFactory'  => $this->fileReadFactory,
-                'mime' => $this->mime
+                'mime' => $this->mime,
+                'domainValidator' => $this->domainValidator
             ]
         );
     }
@@ -100,6 +108,39 @@ class DownloadTest extends TestCase
     {
         $this->expectException('InvalidArgumentException');
         $this->_helper->setResource('/some/path/../file', DownloadHelper::LINK_TYPE_FILE);
+    }
+
+    #[DataProvider('dataProviderForTestSetResourceUrlNotAllowedRedirect')]
+    public function testSetResourceUrlNotAllowedRedirect($location)
+    {
+        self::$headers = ['302 Found', 'location' => $location];
+        $this->domainValidator->expects($this->once())->method('isValid')->with($location)->willReturn(false);
+
+        $this->expectException('InvalidArgumentException');
+        $this->_helper->setResource(self::URL, DownloadHelper::LINK_TYPE_URL);
+    }
+
+    /**
+     * @return array
+     */
+    public static function dataProviderForTestSetResourceUrlNotAllowedRedirect()
+    {
+        return [
+            ['http://169.254.169.254/latest/meta-data/'],
+            ['/etc/passwd'],
+        ];
+    }
+
+    public function testSetResourceUrlAllowedRedirect()
+    {
+        $location = 'http://example.com/other.file';
+        self::$headers = ['302 Found', 'location' => $location];
+        $this->domainValidator->expects($this->once())->method('isValid')->with($location)->willReturn(true);
+        $this->_handleMock->method('stat')->willReturn(['size' => self::FILE_SIZE, 'type' => self::MIME_TYPE]);
+        $this->fileReadFactory->expects($this->once())->method('create')->willReturn($this->_handleMock);
+
+        $this->_helper->setResource(self::URL, DownloadHelper::LINK_TYPE_URL);
+        $this->assertEquals('other.file', $this->_helper->getFilename());
     }
 
     public function testGetFileSizeNoResource()


### PR DESCRIPTION
### Description (*)

A `url` type downloadable link or sample is checked against the `downloadable_domains` allow list when it is saved, but `Downloadable\Helper\Download::setResource()` then follows the `Location` header the remote host returns and adopts it as the resource to fetch without checking it again, so the allow list only covers the first hop. A host that is on the list (or one that later gets compromised, or one with an open redirect) can point the store at anything: `Location: http://169.254.169.254/latest/meta-data/...` reaches cloud metadata, and because `get_headers()` follows redirects on its own the internal request goes out even before the value is used. A relative `Location` such as `/etc/passwd` is worse, since it carries no scheme, `_getHandle()` passes an empty driver code and `DriverPool::getDriver()` falls back to the local file driver, so the file is read off disk. Either way the bytes are streamed back by `downloadable/download/sample`, which guests can reach.

The check belongs in the helper because that is where the redirect is resolved, so this validates the target with the same `DomainValidator` the save path uses and turns off `follow_location` so nothing is fetched before that. Redirects that stay inside the allow list keep working.

### Manual testing scenarios (*)

1. Add a domain you control to the allow list: `bin/magento downloadable:domains:add example.com`.
2. Create a downloadable product with a sample of type URL pointing at `http://example.com/sample.zip`, and make that URL answer `302` with `Location: http://169.254.169.254/latest/meta-data/`.
3. As a guest, open the sample download link on the product page. Before this change the metadata response is downloaded; after it the request is rejected and the storefront shows the generic download error.
4. Repeat with `Location: /etc/passwd` — before this change the local file is returned, after it the request is rejected.
5. Point the same URL at a `302` to `http://example.com/other.zip` and confirm the download still succeeds.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41063: validate redirect target against downloadable domains in setResource