### PR TITLE
Makes phpunit tests compatible with newer versions of curl and icu.

### DIFF
--- a/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
+++ b/lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php
@@ -25,7 +25,8 @@ class CurlTest extends TestCase
         // Accommodate different libcurl version error messages:
         // - "Protocol telnet not supported or disabled in libcurl" (older versions)
         // - "Protocol \"telnet\" disabled" (newer versions)
-        $this->expectExceptionMessageMatches('/Protocol .?telnet.? (not supported or )?disabled( in libcurl)?/');
+        // - "Protocol \"telnet\" is disabled" (even newer versions >= 8.21)
+        $this->expectExceptionMessageMatches('/Protocol .?telnet.? (not supported or )?(is )?disabled( in libcurl)?/');
         $client = new Curl();
         $client->get('telnet://127.0.0.1/test');
     }

--- a/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
+++ b/lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
@@ -111,7 +111,7 @@ class FormatTest extends TestCase
      */
     public static function getPriceFormatDataProvider(): array
     {
-        $swissGroupSymbol = INTL_ICU_VERSION >= 59.1 ? '’' : '\'';
+        $swissGroupSymbol = INTL_ICU_VERSION >= 59.1 && INTL_ICU_VERSION <= 78.1 ? '’' : '\'';
         return [
             ['en_US', 'USD', ['decimalSymbol' => '.', 'groupSymbol' => ',']],
             ['de_DE', 'EUR', ['decimalSymbol' => ',', 'groupSymbol' => '.']],


### PR DESCRIPTION
### Description (*)
I ran the full phpunit test suite locally and saw 3 failures:
```
$ cd dev/tests/unit
$ php ../../../vendor/bin/phpunit -c phpunit.xml.dist
PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.8
...

There were 3 failures:

1) Magento\Cron\Test\Unit\Console\Command\CronCommandTest::testExecute
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-''
+'Ran jobs by schedule.\n
+'

app/code/Magento/Cron/Test/Unit/Console/Command/CronCommandTest.php:86

2) Magento\Framework\HTTP\Test\Unit\Client\CurlTest::testInvalidProtocol
Failed asserting that exception message 'Protocol "telnet" is disabled' matches '/Protocol .?telnet.? (not supported or )?disabled( in libcurl)?/'.

3) Magento\Framework\Locale\Test\Unit\FormatTest::testGetPriceFormat#2 with data ('de_CH', 'CHF', ['.', '’'])
Failed asserting that actual size 1 matches expected size 2.

lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php:105
```

- Issue 1: output of running cron command unit test gives a different output on local compared to on github, no idea why, I've giving up on trying to fix it
- Issue 2: curl has a change in commit https://github.com/curl/curl/commit/bc40e09f63889a8bc14fa8f7221921eb5b4a559e (in `lib/url.c‎` around line 1413) where the output of a disabled protocol changed, this was released in version 8.21 of curl
- Issue 3: ICU ships with the [CLDR library](https://cldr.unicode.org/) and that changes some details per locale every now and again. It appears the group symbol for Swiss locale's changed from `'` to `’` a while ago and now again back to `'` Here's what ChatGPT tells me about when exactly it changed:
<img width="1234" height="736" alt="Screenshot 2026-07-21 at 15 47 07" src="https://github.com/user-attachments/assets/0ad379fc-3687-430a-9adf-32ea06c5169b" />

### Related Pull Requests

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Make sure your PHP uses curl library version 8.21 or higher (`php -i | grep 'cURL Information'`)
2. Make sure your PHP uses the ICU library version 78.1 or higher (`php -i | grep 'ICU version'`)
3. Run the full unit test suite:
```
$ cd dev/tests/unit
$ php ../../../vendor/bin/phpunit -c phpunit.xml.dist ../../../lib/internal/Magento/Framework/HTTP/Test/Unit/Client/CurlTest.php ../../../lib/internal/Magento/Framework/Locale/Test/Unit/FormatTest.php
```
4. Expect no failures

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41042: Makes phpunit tests compatible with newer versions of curl and icu.