### PR TITLE
Fixes deprecated usages in phpunit tests which will no longer work in…

### DIFF
--- a/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Aggregation/DataProviderFactoryTest.php
+++ b/app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Aggregation/DataProviderFactoryTest.php
@@ -86,7 +86,7 @@ class DataProviderFactoryTest extends TestCase
             ->getMock();
         $this->objectManager->expects($this->once())
             ->method('create')
-            ->with($this->isType('string'), ['queryContainer' => $queryContainer, 'aggregationFieldName' => null])
+            ->with($this->isString(), ['queryContainer' => $queryContainer, 'aggregationFieldName' => null])
             ->willReturn($recreatedDataProvider);
         $result = $this->factory->create($dataProvider, $queryContainer);
         $this->assertNotSame($dataProvider, $result);

--- a/app/code/Magento/Persistent/Test/Unit/Model/ResourceModel/ExpiredPersistentQuotesCollectionTest.php
+++ b/app/code/Magento/Persistent/Test/Unit/Model/ResourceModel/ExpiredPersistentQuotesCollectionTest.php
@@ -86,7 +86,7 @@ class ExpiredPersistentQuotesCollectionTest extends TestCase
             ->willReturnSelf();
 
         $quoteCollectionMock->method('setPageSize')
-            ->with($this->isType('integer'))
+            ->with($this->isInt())
             ->willReturnSelf();
 
         $dbSelectMock1 = $this->createMock(Select::class);

--- a/app/code/Magento/Tax/Test/Unit/Model/Sales/Total/Quote/CommonTaxCollectorTest.php
+++ b/app/code/Magento/Tax/Test/Unit/Model/Sales/Total/Quote/CommonTaxCollectorTest.php
@@ -852,7 +852,7 @@ class CommonTaxCollectorTest extends TestCase
         );
         $addressItem->method('getTaxCalculationItemId')->willReturn('code-1');
         $addressItem->method('getId')->willReturn(123);
-        $addressItem->expects($this->once())->method('setAppliedTaxes')->with($this->isType('array'));
+        $addressItem->expects($this->once())->method('setAppliedTaxes')->with($this->isArray());
 
         $address = $this->getMockBuilder(QuoteAddress::class)
             ->onlyMethods(['getQuote'])->disableOriginalConstructor()->getMock();

--- a/lib/internal/Magento/Framework/App/Test/Unit/Filesystem/DirectoryResolverTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Filesystem/DirectoryResolverTest.php
@@ -66,7 +66,7 @@ class DirectoryResolverTest extends TestCase
         $rootPath = '/path/root';
         $directoryConfig = 'directory_config';
         $directory = $this->createStub(WriteInterface::class);
-        $driver = $this->createStub(DriverInterface::class);
+        $driver = $this->createMock(DriverInterface::class);
         $directory->method('getDriver')->willReturn($driver);
         $driver->method('getRealPathSafety')->with($path)->willReturnArgument(0);
         $this->filesystem->expects($this->atLeastOnce())->method('getDirectoryWrite')->with($directoryConfig)

--- a/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php
@@ -44,7 +44,7 @@ class RouterListTest extends TestCase
             'anotherRouter' => ['class' => 'AnotherClass', 'disable' => false, 'sortOrder' => 15]
         ];
 
-        $this->objectManagerMock = $this->createStub(ObjectManagerInterface::class);
+        $this->objectManagerMock = $this->createMock(ObjectManagerInterface::class);
         $this->model = new RouterList($this->objectManagerMock, $this->routerList);
     }
 


### PR DESCRIPTION
… PHPUnit version 13 or higher.

### Description (*)
When you run the full phpunit test suite locally, it outputs 7 deprecation problems of code that will no longer work on PHPUnit 13 or higher (note the extra flag `--display-phpunit-deprecations`):

```
$ cd dev/tests/unit
$ php ../../../vendor/bin/phpunit -c phpunit.xml.dist --display-phpunit-deprecations
PHPUnit 12.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.8
...

7 tests triggered 7 PHPUnit deprecations:

1) Magento\Elasticsearch\Test\Unit\SearchAdapter\Aggregation\DataProviderFactoryTest::testCreateQueryAwareDataProvider
isType('string') is deprecated and will be removed in PHPUnit 13. Please use the isString() method instead.

app/code/Magento/Elasticsearch/Test/Unit/SearchAdapter/Aggregation/DataProviderFactoryTest.php:71

2) Magento\Persistent\Test\Unit\Model\ResourceModel\ExpiredPersistentQuotesCollectionTest::testGetExpiredPersistentQuotes
isType('integer') is deprecated and will be removed in PHPUnit 13. Please use the isInt() method instead.

app/code/Magento/Persistent/Test/Unit/Model/ResourceModel/ExpiredPersistentQuotesCollectionTest.php:56

3) Magento\Tax\Test\Unit\Model\Sales\Total\Quote\CommonTaxCollectorTest::testProcessAppliedTaxesSetsItemsAppliedTaxesAndItem
isType('array') is deprecated and will be removed in PHPUnit 13. Please use the isArray() method instead.

app/code/Magento/Tax/Test/Unit/Model/Sales/Total/Quote/CommonTaxCollectorTest.php:842

4) Magento\Framework\App\Test\Unit\Filesystem\DirectoryResolverTest::testValidatePath#0 with data ('/path/root/for/validation', true)
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

lib/internal/Magento/Framework/App/Test/Unit/Filesystem/DirectoryResolverTest.php:64

5) Magento\Framework\App\Test\Unit\Filesystem\DirectoryResolverTest::testValidatePath#1 with data ('/path/invalid/for/validation', false)
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

lib/internal/Magento/Framework/App/Test/Unit/Filesystem/DirectoryResolverTest.php:64

6) Magento\Framework\App\Test\Unit\RouterListTest::testCurrent
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php:54

7) Magento\Framework\App\Test\Unit\RouterListTest::testNext
Using with*() on a test stub has no effect and is deprecated.
With PHPUnit 13, it will not be possible to use with() on a test stub.

lib/internal/Magento/Framework/App/Test/Unit/RouterListTest.php:68
```

This PR fixes those.

### Related Pull Requests

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
1. Run the full unit test suite:
$ cd dev/tests/unit
$ php ../../../vendor/bin/phpunit -c phpunit.xml.dist --display-phpunit-deprecations
2. Expect no deprecation output (ignore errors or failures, those are out of scope here)

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41040: Fixes deprecated usages in phpunit tests which will no longer work in…