### PR TITLE
magento2/magento#40281: Revoke public FPC headers when full_page disabled mid-request

### DIFF
--- a/app/code/Magento/PageCache/Model/Layout/LayoutPlugin.php
+++ b/app/code/Magento/PageCache/Model/Layout/LayoutPlugin.php
@@ -9,6 +9,7 @@ namespace Magento\PageCache\Model\Layout;
 
 use Magento\Framework\App\MaintenanceMode;
 use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\Response\Http as ResponseHttp;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\View\Layout;
@@ -80,10 +81,15 @@ class LayoutPlugin
      * @param Layout $subject
      * @param mixed $result
      * @return mixed
+     * @see https://github.com/magento/magento2/issues/40281 - revoke headers if FPC was disabled mid-request
      */
     public function afterGetOutput(Layout $subject, $result)
     {
-        if ($subject->isCacheable() && $this->config->isEnabled()) {
+        if (!$subject->isCacheable()) {
+            return $result;
+        }
+
+        if ($this->config->isEnabled()) {
             $tags = [];
             $isVarnish = $this->config->getType() === Config::VARNISH;
 
@@ -99,8 +105,34 @@ class LayoutPlugin
             $tags = array_unique(array_merge([], ...$tags));
             $tags = $this->pageCacheTagsPreprocessor->process($tags);
             $this->response->setHeader('X-Magento-Tags', implode(',', $tags));
+        } else {
+            $this->revokePublicCacheHeaders();
         }
 
         return $result;
+    }
+
+    /**
+     * Replace Magento public FPC Cache-Control with no-cache when full page cache is no longer enabled.
+     *
+     * @return void
+     * @see \Magento\Framework\App\PageCache\Kernel::process()
+     */
+    private function revokePublicCacheHeaders(): void
+    {
+        if (!$this->response instanceof ResponseHttp) {
+            return;
+        }
+
+        $header = $this->response->getHeader('Cache-Control');
+        if (!$header) {
+            return;
+        }
+
+        $value = (string)$header->getFieldValue();
+        // Same detection as Kernel::process() for FPC-storeable responses.
+        if (preg_match('/public.*s-maxage=(\d+)/', $value)) {
+            $this->response->setNoCacheHeaders();
+        }
     }
 }

--- a/app/code/Magento/PageCache/Test/Unit/Model/Layout/LayoutPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/Layout/LayoutPluginTest.php
@@ -7,10 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\PageCache\Test\Unit\Model\Layout;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
+use Laminas\Http\Header\HeaderInterface;
 use Magento\Framework\App\MaintenanceMode;
 use Magento\Framework\App\Response\Http;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
 use Magento\Framework\View\Layout;
 use Magento\PageCache\Model\Config;
@@ -32,7 +31,7 @@ class LayoutPluginTest extends TestCase
     private $model;
 
     /**
-     * @var ResponseInterface|MockObject
+     * @var Http|MockObject
      */
     private $responseMock;
 
@@ -42,7 +41,7 @@ class LayoutPluginTest extends TestCase
     private $layoutMock;
 
     /**
-     * @var ScopeConfigInterface|MockObject
+     * @var Config|MockObject
      */
     private $configMock;
 
@@ -138,10 +137,15 @@ class LayoutPluginTest extends TestCase
 
         $this->configMock->expects($this->any())->method('getType')->willReturn($configCacheType);
 
+        // When FPC is off for a cacheable layout, revoke may inspect Cache-Control.
+        $this->responseMock->method('getHeader')->willReturn(false);
+
         if ($layoutIsCacheable && $cacheState) {
             $this->responseMock->expects($this->once())->method('setHeader')->with('X-Magento-Tags', $expectedTags);
+            $this->responseMock->expects($this->never())->method('setNoCacheHeaders');
         } else {
             $this->responseMock->expects($this->never())->method('setHeader');
+            $this->responseMock->expects($this->never())->method('setNoCacheHeaders');
         }
         $output = $this->model->afterGetOutput($this->layoutMock, $html);
         $this->assertSame($output, $html);
@@ -187,5 +191,123 @@ class LayoutPluginTest extends TestCase
                 100,
             ],
         ];
+    }
+
+    /**
+     * Issue #40281: public headers set while FPC was on must be revoked when FPC is off at getOutput.
+     */
+    public function testAfterGetOutputRevokesPublicHeadersWhenFullPageCacheDisabledMidRequest(): void
+    {
+        $html = 'html';
+        $this->layoutMock->expects($this->once())->method('isCacheable')->willReturn(true);
+        $this->configMock->expects($this->once())->method('isEnabled')->willReturn(false);
+
+        $cacheControlHeader = $this->createMock(HeaderInterface::class);
+        $cacheControlHeader->method('getFieldValue')
+            ->willReturn('public, max-age=86400, s-maxage=86400');
+
+        $this->responseMock->expects($this->once())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn($cacheControlHeader);
+        $this->responseMock->expects($this->once())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->assertSame($html, $this->model->afterGetOutput($this->layoutMock, $html));
+    }
+
+    /**
+     * Do not force no-cache when response was never marked public.
+     */
+    public function testAfterGetOutputDoesNotRevokeWhenNoPublicHeadersPresent(): void
+    {
+        $html = 'html';
+        $this->layoutMock->expects($this->once())->method('isCacheable')->willReturn(true);
+        $this->configMock->expects($this->once())->method('isEnabled')->willReturn(false);
+
+        $this->responseMock->expects($this->once())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn(false);
+        $this->responseMock->expects($this->never())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->assertSame($html, $this->model->afterGetOutput($this->layoutMock, $html));
+    }
+
+    /**
+     * Private/no-store Cache-Control must not be rewritten when FPC is disabled.
+     */
+    public function testAfterGetOutputDoesNotRevokeNonPublicCacheControl(): void
+    {
+        $html = 'html';
+        $this->layoutMock->expects($this->once())->method('isCacheable')->willReturn(true);
+        $this->configMock->expects($this->once())->method('isEnabled')->willReturn(false);
+
+        $cacheControlHeader = $this->createMock(HeaderInterface::class);
+        $cacheControlHeader->method('getFieldValue')
+            ->willReturn('no-store, no-cache, must-revalidate, max-age=0');
+
+        $this->responseMock->expects($this->once())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn($cacheControlHeader);
+        $this->responseMock->expects($this->never())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->assertSame($html, $this->model->afterGetOutput($this->layoutMock, $html));
+    }
+
+    /**
+     * Align with Kernel::process(): bare "public" without s-maxage is not treated as FPC-storeable.
+     */
+    public function testAfterGetOutputDoesNotRevokePublicWithoutSMaxAge(): void
+    {
+        $html = 'html';
+        $this->layoutMock->expects($this->once())->method('isCacheable')->willReturn(true);
+        $this->configMock->expects($this->once())->method('isEnabled')->willReturn(false);
+
+        $cacheControlHeader = $this->createMock(HeaderInterface::class);
+        $cacheControlHeader->method('getFieldValue')->willReturn('public, max-age=86400');
+
+        $this->responseMock->expects($this->once())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn($cacheControlHeader);
+        $this->responseMock->expects($this->never())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->assertSame($html, $this->model->afterGetOutput($this->layoutMock, $html));
+    }
+
+    /**
+     * Full race sequence: public headers while FPC is on, then revoke when FPC is off at getOutput.
+     *
+     * @see https://github.com/magento/magento2/issues/40281
+     */
+    public function testAfterGenerateElementsThenDisableFpcThenAfterGetOutputRevokesInOneSequence(): void
+    {
+        $html = 'html';
+        $ttl = 86400;
+
+        $this->layoutMock->method('isCacheable')->willReturn(true);
+        $this->maintenanceModeMock->method('isOn')->willReturn(false);
+        $this->configMock->method('getTtl')->willReturn($ttl);
+        $this->configMock->method('isEnabled')->willReturnOnConsecutiveCalls(true, false);
+
+        $this->responseMock->expects($this->once())->method('setPublicHeaders')->with($ttl);
+
+        $cacheControlHeader = $this->createMock(HeaderInterface::class);
+        $cacheControlHeader->method('getFieldValue')
+            ->willReturn('public, max-age=86400, s-maxage=86400');
+        $this->responseMock->expects($this->once())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn($cacheControlHeader);
+        $this->responseMock->expects($this->once())->method('setNoCacheHeaders');
+        $this->responseMock->expects($this->never())->method('setHeader');
+
+        $this->model->afterGenerateElements($this->layoutMock);
+        $this->assertSame($html, $this->model->afterGetOutput($this->layoutMock, $html));
     }
 }

--- a/dev/tests/integration/testsuite/Magento/PageCache/Model/Layout/LayoutPluginStaleCacheRaceTest.php
+++ b/dev/tests/integration/testsuite/Magento/PageCache/Model/Layout/LayoutPluginStaleCacheRaceTest.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\PageCache\Model\Layout;
+
+use Magento\Framework\App\Cache\StateInterface;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\Cache\Backend\ExtendedBackendInterface;
+use Magento\Framework\Cache\Backend\RemoteSynchronizedCache;
+use Magento\Framework\Cache\CompositeStaleCacheNotifier;
+use Magento\Framework\Cache\StaleCacheNotifierInterface;
+use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\View\Layout;
+use Magento\PageCache\Model\Cache\Type as FullPageCacheType;
+use Magento\PageCache\Model\Config;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration coverage for GitHub issue #40281.
+ *
+ * When use_stale_cache disables full_page mid-request after public headers were set,
+ * LayoutPlugin must revoke public Cache-Control so Varnish does not store an unpurgeable page.
+ *
+ * @magentoAppArea frontend
+ * @magentoAppIsolation enabled
+ */
+class LayoutPluginStaleCacheRaceTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var StateInterface
+     */
+    private $cacheState;
+
+    /**
+     * @var bool
+     */
+    private $originalFullPageState;
+
+    /**
+     * @var LayoutPlugin
+     */
+    private $layoutPlugin;
+
+    /**
+     * @var HttpResponse
+     */
+    private $response;
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->cacheState = $this->objectManager->get(StateInterface::class);
+        $this->originalFullPageState = $this->cacheState->isEnabled(FullPageCacheType::TYPE_IDENTIFIER);
+        $this->cacheState->setEnabled(FullPageCacheType::TYPE_IDENTIFIER, true);
+
+        $this->response = $this->objectManager->get(HttpResponse::class);
+        $this->config = $this->objectManager->get(Config::class);
+        $this->layoutPlugin = $this->objectManager->create(LayoutPlugin::class, [
+            'response' => $this->response,
+            'config' => $this->config,
+        ]);
+
+        $this->response->clearHeaders();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        if (isset($this->cacheState)) {
+            $this->cacheState->setEnabled(FullPageCacheType::TYPE_IDENTIFIER, $this->originalFullPageState);
+        }
+        if (isset($this->response)) {
+            $this->response->clearHeaders();
+        }
+    }
+
+    /**
+     * Happy path: when full page cache stays enabled for the whole request,
+     * public headers and X-Magento-Tags are both set.
+     *
+     * @magentoConfigFixture default/system/full_page_cache/caching_application 2
+     * @magentoConfigFixture default/system/full_page_cache/ttl 86400
+     */
+    public function testPublicHeadersAndTagsAreSetWhenFullPageCacheStaysEnabled(): void
+    {
+        $layout = $this->createCacheableLayoutWithIdentityBlock(['cat_p_1', 'cat_c_2']);
+
+        $this->assertTrue($this->config->isEnabled());
+
+        $this->layoutPlugin->afterGenerateElements($layout);
+        $this->layoutPlugin->afterGetOutput($layout, 'html');
+
+        $this->assertPublicCacheControl();
+        $this->assertXMagentoTagsContain(['cat_p_1', 'cat_c_2']);
+    }
+
+    /**
+     * Issue #40281 race:
+     *
+     * 1. afterGenerateElements sees FPC enabled → sets public Cache-Control
+     * 2. Stale-cache notifier disables full_page for the rest of the request
+     * 3. afterGetOutput sees FPC disabled → revokes public headers, does not set tags
+     *
+     * @magentoConfigFixture default/system/full_page_cache/caching_application 2
+     * @magentoConfigFixture default/system/full_page_cache/ttl 86400
+     */
+    public function testStaleCacheNotificationBetweenLayoutPluginsMustNotLeavePublicHeadersWithoutTags(): void
+    {
+        $layout = $this->createCacheableLayoutWithIdentityBlock(['cat_p_1', 'cat_c_2']);
+
+        $this->assertTrue($this->config->isEnabled());
+        $this->layoutPlugin->afterGenerateElements($layout);
+        $this->assertPublicCacheControl('Public headers must be set while FPC is enabled');
+
+        $this->objectManager->get(CompositeStaleCacheNotifier::class)
+            ->cacheLoaderIsUsingStaleCache();
+
+        $this->assertFalse(
+            $this->config->isEnabled(),
+            'Stale-cache notification must disable full_page for the current request'
+        );
+
+        $this->layoutPlugin->afterGetOutput($layout, 'html');
+
+        $this->assertNotPublicCacheControl();
+        $this->assertXMagentoTagsMissing();
+    }
+
+    /**
+     * End-to-end chain: RemoteSynchronizedCache stale load → notifier → FPC off → no-cache headers.
+     *
+     * @magentoConfigFixture default/system/full_page_cache/caching_application 2
+     * @magentoConfigFixture default/system/full_page_cache/ttl 86400
+     */
+    public function testRemoteSynchronizedStaleCacheLoadDisablesFullPageAndRevokesPublicHeaders(): void
+    {
+        $layout = $this->createCacheableLayoutWithIdentityBlock(['cat_p_1']);
+
+        $this->layoutPlugin->afterGenerateElements($layout);
+        $this->assertTrue($this->config->isEnabled());
+        $this->assertPublicCacheControl();
+
+        $backend = $this->createRemoteSynchronizedCacheBackendWithForcedStalePath();
+        $loaded = $backend->load('some_cache_id');
+        $this->assertSame(
+            'stale-local-payload',
+            $loaded,
+            'Stale local payload must be returned when remote is empty and lock is held'
+        );
+        $this->assertFalse(
+            $this->config->isEnabled(),
+            'Full page cache must be disabled for the request after stale-cache notification'
+        );
+
+        $this->layoutPlugin->afterGetOutput($layout, 'html');
+
+        $this->assertNotPublicCacheControl();
+        $this->assertXMagentoTagsMissing();
+    }
+
+    /**
+     * Proves RuntimeStaleCacheStateModifier is wired to disable only full_page.
+     */
+    public function testStaleCacheNotifierDisablesFullPageCacheTypeOnly(): void
+    {
+        $this->assertTrue($this->cacheState->isEnabled(FullPageCacheType::TYPE_IDENTIFIER));
+
+        /** @var StaleCacheNotifierInterface $notifier */
+        $notifier = $this->objectManager->get(CompositeStaleCacheNotifier::class);
+        $notifier->cacheLoaderIsUsingStaleCache();
+
+        $this->assertFalse($this->cacheState->isEnabled(FullPageCacheType::TYPE_IDENTIFIER));
+        $this->assertFalse($this->config->isEnabled());
+    }
+
+    /**
+     * @param string[] $identities
+     * @return Layout&MockObject
+     */
+    private function createCacheableLayoutWithIdentityBlock(array $identities): Layout
+    {
+        $identityBlock = new class ($identities) implements IdentityInterface {
+            /**
+             * @param string[] $identities
+             */
+            public function __construct(private array $identities)
+            {
+            }
+
+            /**
+             * @inheritdoc
+             */
+            public function getIdentities()
+            {
+                return $this->identities;
+            }
+
+            public function getTtl(): int
+            {
+                return 0;
+            }
+        };
+
+        /** @var Layout&MockObject $layout */
+        $layout = $this->createStub(Layout::class);
+        $layout->method('isCacheable')->willReturn(true);
+        $layout->method('getAllBlocks')->willReturn([$identityBlock]);
+
+        return $layout;
+    }
+
+    /**
+     * Build RemoteSynchronizedCache that hits the stale-cache + failed-lock branch.
+     */
+    private function createRemoteSynchronizedCacheBackendWithForcedStalePath(): RemoteSynchronizedCache
+    {
+        /** @var ExtendedBackendInterface&MockObject $local */
+        $local = $this->createStub(ExtendedBackendInterface::class);
+        /** @var ExtendedBackendInterface&MockObject $remote */
+        $remote = $this->createStub(ExtendedBackendInterface::class);
+
+        $local->method('load')->willReturn('stale-local-payload');
+
+        $remote->method('load')->willReturnCallback(
+            static function (string $id) {
+                if (str_ends_with($id, ':hash')) {
+                    return false;
+                }
+                if (str_starts_with($id, 'rsl::')) {
+                    return 'lock-held-by-another-process';
+                }
+                return false;
+            }
+        );
+
+        return new RemoteSynchronizedCache(
+            [
+                'remote_backend' => $remote,
+                'local_backend' => $local,
+                'use_stale_cache' => true,
+            ]
+        );
+    }
+
+    private function assertPublicCacheControl(string $message = ''): void
+    {
+        $cacheControl = $this->getHeaderValue('cache-control');
+        $this->assertNotNull($cacheControl, $message ?: 'cache-control header must be present');
+        $this->assertStringContainsString(
+            'public',
+            strtolower((string)$cacheControl),
+            $message ?: 'cache-control must be public for cacheable FPC pages'
+        );
+    }
+
+    private function assertNotPublicCacheControl(): void
+    {
+        $cacheControl = $this->getHeaderValue('cache-control');
+        $this->assertNotNull($cacheControl, 'cache-control header must be present after revoke');
+        $this->assertStringNotContainsString(
+            'public',
+            strtolower((string)$cacheControl),
+            'Public Cache-Control must be revoked when FPC is disabled mid-request'
+        );
+        $this->assertMatchesRegularExpression(
+            '/no-store|no-cache/i',
+            (string)$cacheControl,
+            'Response must use no-cache headers so Varnish does not store the page'
+        );
+
+        // Full setNoCacheHeaders() contract (pragma + cache-control + expires).
+        $pragma = $this->getHeaderValue('pragma');
+        $this->assertNotNull($pragma, 'pragma header must be present after revoke');
+        $this->assertStringContainsString(
+            'no-cache',
+            strtolower((string)$pragma),
+            'pragma must be no-cache after public headers are revoked'
+        );
+
+        $expires = $this->getHeaderValue('expires');
+        $this->assertNotNull($expires, 'expires header must be present after revoke');
+        $expiresTimestamp = strtotime((string)$expires);
+        $this->assertNotFalse($expiresTimestamp, 'expires header must be a parseable date');
+        $this->assertLessThan(
+            time(),
+            $expiresTimestamp,
+            'expires must be in the past after setNoCacheHeaders()'
+        );
+    }
+
+    /**
+     * @param string[] $expectedTags
+     */
+    private function assertXMagentoTagsContain(array $expectedTags): void
+    {
+        $header = $this->response->getHeader('X-Magento-Tags');
+        $this->assertNotFalse($header, 'X-Magento-Tags header must be present');
+        $actual = array_filter(explode(',', (string)$header->getFieldValue()));
+        foreach ($expectedTags as $tag) {
+            $this->assertContains($tag, $actual, "X-Magento-Tags must contain {$tag}");
+        }
+    }
+
+    private function assertXMagentoTagsMissing(): void
+    {
+        $tagsHeader = $this->response->getHeader('X-Magento-Tags');
+        $this->assertTrue(
+            $tagsHeader === false
+            || $tagsHeader === null
+            || $tagsHeader->getFieldValue() === ''
+            || $tagsHeader->getFieldValue() === null,
+            'X-Magento-Tags must not be set when FPC is disabled mid-request'
+        );
+    }
+
+    private function getHeaderValue(string $name): ?string
+    {
+        $header = $this->response->getHeader($name);
+        if (!$header) {
+            return null;
+        }
+        $value = $header->getFieldValue();
+        return $value === false ? null : (string)$value;
+    }
+}


### PR DESCRIPTION
### Description
Fixes a race condition where full page cache can be disabled mid-request after public Cache-Control headers are already set (`use_stale_cache` / `RemoteSynchronizedCache` → `RuntimeStaleCacheStateModifier`), so `LayoutPlugin::afterGetOutput` skips `X-Magento-Tags` while the response remains publicly cacheable.

Varnish can then store pages that Magento cannot purge by tag (stale prices/stock until TTL or Varnish restart).

**Fix:** In `LayoutPlugin::afterGetOutput`, when the layout is cacheable but FPC is no longer enabled, revoke Magento public FPC headers that match the same shape as `Kernel::process()` (`public` + `s-maxage`) via `setNoCacheHeaders()`.

### Fixed Issues
1. Fixes #40281

### Manual testing scenarios
1. Enable FPC (Varnish or built-in) and configure two-level cache with `use_stale_cache`.
2. Warm local + remote cache; flush remote only; force lock failure so stale cache notifies and disables `full_page` mid-request after layout generation.
3. Confirm response is not left with `Cache-Control: public` without `X-Magento-Tags` (expects full no-cache suite after the race).
4. Happy path: FPC stays enabled for the whole request — public headers and `X-Magento-Tags` still set.

### Automated tests
- Unit: `app/code/Magento/PageCache/Test/Unit/Model/Layout/LayoutPluginTest.php`
- Integration: `dev/tests/integration/testsuite/Magento/PageCache/Model/Layout/LayoutPluginStaleCacheRaceTest.php`

### Questions or comments
Detection intentionally mirrors `Kernel::process()` (`/public.*s-maxage=(\d+)/`) so only Magento-style public FPC headers (from `setPublicHeaders()`) are revoked. Intentional no-cache/private responses are left alone.

### Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (if applicable)