### PR TITLE
magento/magento2#32066: Fix duplicate customer prefix/suffix dropdown options

### DIFF
--- a/app/code/Magento/Customer/Block/Widget/Name.php
+++ b/app/code/Magento/Customer/Block/Widget/Name.php
@@ -108,8 +108,12 @@ class Name extends AbstractWidget
         if ($this->getObject() && !empty($prefixOptions)) {
             $prefixOption = $this->getObject()->getPrefix();
             $oldPrefix = $this->escapeHtml(trim($prefixOption ?? ''));
-            if ($prefixOption !== null && !isset($prefixOptions[$oldPrefix]) && !isset($prefixOptions[$prefixOption])) {
-                $prefixOptions[$oldPrefix] = $oldPrefix;
+            // Options are a numerically indexed list of values; check membership by value.
+            if ($prefixOption !== null
+                && !in_array($oldPrefix, $prefixOptions, true)
+                && !in_array((string)$prefixOption, $prefixOptions, true)
+            ) {
+                $prefixOptions[] = $oldPrefix;
             }
         }
         return $prefixOptions;
@@ -166,8 +170,12 @@ class Name extends AbstractWidget
         if ($this->getObject() && !empty($suffixOptions)) {
             $suffixOption = $this->getObject()->getSuffix();
             $oldSuffix = $this->escapeHtml(trim($suffixOption ?? ''));
-            if ($suffixOption !== null && !isset($suffixOptions[$oldSuffix]) && !isset($suffixOptions[$suffixOption])) {
-                $suffixOptions[$oldSuffix] = $oldSuffix;
+            // Options are a numerically indexed list of values; check membership by value.
+            if ($suffixOption !== null
+                && !in_array($oldSuffix, $suffixOptions, true)
+                && !in_array((string)$suffixOption, $suffixOptions, true)
+            ) {
+                $suffixOptions[] = $oldSuffix;
             }
         }
         return $suffixOptions;

--- a/app/code/Magento/Customer/Test/Unit/Block/Widget/NameTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Widget/NameTest.php
@@ -256,7 +256,7 @@ class NameTest extends TestCase
     /**
      * @return void
      */
-    public function testGetPrefixOptionsNotEmpty(): void
+    public function testGetPrefixOptionsAppendsMissingValue(): void
     {
         /**
          * Added some padding so that the trim() call on Customer::getPrefix() will remove it. Also added
@@ -269,11 +269,12 @@ class NameTest extends TestCase
 
         $this->_block->setObject($customer);
 
-        $prefixOptions = ['Mrs' => 'Mrs', 'Ms' => 'Ms', 'Miss' => 'Miss'];
+        // Numerically indexed list matching Options::prepareNamePrefixSuffixOptions()
+        $prefixOptions = ['Mrs', 'Ms', 'Miss'];
 
         $prefix = '&lt;' . self::PREFIX . '&gt;';
         $expectedOptions = $prefixOptions;
-        $expectedOptions[$prefix] = $prefix;
+        $expectedOptions[] = $prefix;
 
         $this->_options->expects(
             $this->once()
@@ -285,6 +286,30 @@ class NameTest extends TestCase
         $this->_escaper->expects($this->once())->method('escapeHtml')->willReturn($prefix);
 
         $this->assertSame($expectedOptions, $this->_block->getPrefixOptions());
+    }
+
+    /**
+     * When the saved prefix is already present in the options list, do not append a duplicate entry.
+     *
+     * @return void
+     */
+    public function testGetPrefixOptionsDoesNotDuplicateExistingValue(): void
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->expects($this->once())->method('getPrefix')->willReturn(self::PREFIX);
+        $this->_block->setObject($customer);
+
+        $prefixOptions = [' ', 'Mr', 'Mrs', 'Ms'];
+
+        $this->_options->expects($this->once())
+            ->method('getNamePrefixOptions')
+            ->willReturn($prefixOptions);
+        $this->_escaper->expects($this->once())
+            ->method('escapeHtml')
+            ->with(self::PREFIX)
+            ->willReturn(self::PREFIX);
+
+        $this->assertSame($prefixOptions, $this->_block->getPrefixOptions());
     }
 
     /**
@@ -311,7 +336,7 @@ class NameTest extends TestCase
     /**
      * @return void
      */
-    public function testGetSuffixOptionsNotEmpty(): void
+    public function testGetSuffixOptionsAppendsMissingValue(): void
     {
         /**
          * Added padding and special characters to show that trim() works on Customer::getSuffix() and that
@@ -323,11 +348,11 @@ class NameTest extends TestCase
         $customer->expects($this->once())->method('getSuffix')->willReturn('  <' . self::SUFFIX . '>  ');
         $this->_block->setObject($customer);
 
-        $suffixOptions = ['Sr' => 'Sr'];
+        $suffixOptions = ['Sr'];
 
         $suffix = '&lt;' . self::SUFFIX . '&gt;';
         $expectedOptions = $suffixOptions;
-        $expectedOptions[$suffix] = $suffix;
+        $expectedOptions[] = $suffix;
 
         $this->_options->expects(
             $this->once()
@@ -339,6 +364,30 @@ class NameTest extends TestCase
         $this->_escaper->expects($this->once())->method('escapeHtml')->willReturn($suffix);
 
         $this->assertSame($expectedOptions, $this->_block->getSuffixOptions());
+    }
+
+    /**
+     * When the saved suffix is already present in the options list, do not append a duplicate entry.
+     *
+     * @return void
+     */
+    public function testGetSuffixOptionsDoesNotDuplicateExistingValue(): void
+    {
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->expects($this->once())->method('getSuffix')->willReturn(self::SUFFIX);
+        $this->_block->setObject($customer);
+
+        $suffixOptions = [' ', 'Jr', 'Sr'];
+
+        $this->_options->expects($this->once())
+            ->method('getNameSuffixOptions')
+            ->willReturn($suffixOptions);
+        $this->_escaper->expects($this->once())
+            ->method('escapeHtml')
+            ->with(self::SUFFIX)
+            ->willReturn(self::SUFFIX);
+
+        $this->assertSame($suffixOptions, $this->_block->getSuffixOptions());
     }
 
     /**


### PR DESCRIPTION
### Description (*)
Fixes duplicate name **prefix** / **suffix** options on the customer account edit form after a value is saved and the page is reloaded.

`Magento\Customer\Model\Options` returns a **numerically indexed list** of option values. `Name::getPrefixOptions()` / `getSuffixOptions()` still used `isset($options[$value])` (key lookup) and re-appended the current customer value with a string key. The template iterates values, so the selected option appeared twice.

**Change:** treat options as a list — membership via `in_array(..., true)`, append missing legacy values with `$options[] = ...`. Same for suffix. Unit tests updated to use list-shaped options and cover the no-duplicate path.

### Fixed Issues (if relevant)
1. Fixes magento/magento2#32066

### Manual testing scenarios (*)
1. Admin → Stores → Configuration → Customers → Customer Configuration → Name and Address Options:
   - Show Prefix = Optional (or Required)
   - Prefix Dropdown Options = `Mr;Mrs;Ms`
2. Login as customer → Account Information → select prefix `Mr` → Save → reload page.
3. **Expected:** Each prefix appears once; `Mr` is selected (no duplicate `Mr`).
4. Change prefix to `Mrs` → Save → reload.
5. **Expected:** `Mrs` is selected and saved; options still unique.
6. (Optional) Customer with legacy prefix not in config (e.g. `Dr`): open edit page → `Dr` appears **once** and is selected.
7. Repeat analogous checks for suffix with options `Jr;Sr`.

### Questions or comments
- Supersedes incomplete approach in open PR #32125 (which removed append entirely and broke changing prefix per reporter feedback).
- Admin free-text prefix UI (separate from this dropdown bug) is out of scope.

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (all builds are green)