### PR TITLE
Resolve store information lazily in config directive (#37815)

### DIFF
--- a/app/code/Magento/Email/Model/Template/Filter.php
+++ b/app/code/Magento/Email/Model/Template/Filter.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\State;
 use Magento\Framework\Css\PreProcessor\Adapter\CssInliner;
+use Magento\Framework\DataObject;
 use Magento\Framework\Escaper;
 use Magento\Framework\Exception\MailException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -191,6 +192,11 @@ class Filter extends Template
      * @var StoreInformation
      */
     private $storeInformation;
+
+    /**
+     * @var DataObject[]
+     */
+    private $storeInformationObjects = [];
 
     /**
      * @var StateInterface
@@ -855,9 +861,6 @@ class Filter extends Template
         $configValue = '';
         $params = $this->getParameters($construction[2]);
         $storeId = $this->getStoreId();
-        $store = $this->_storeManager->getStore($storeId);
-        $storeInformationObj = $this->storeInformation
-            ->getStoreInformationObject($store);
         if (isset($params['path']) && $this->isAvailableConfigVariable($params['path'])) {
             $configValue = $this->_scopeConfig->getValue(
                 $params['path'],
@@ -865,14 +868,34 @@ class Filter extends Template
                 $storeId
             );
             if ($params['path'] == $this->storeInformation::XML_PATH_STORE_INFO_COUNTRY_CODE) {
-                $configValue = $storeInformationObj->getData('country');
+                $configValue = $this->getStoreInformationObject($storeId)->getData('country');
             } elseif ($params['path'] == $this->storeInformation::XML_PATH_STORE_INFO_REGION_CODE) {
-                $configValue = $storeInformationObj->getData('region') ?
-                    $storeInformationObj->getData('region') :
-                    $configValue;
+                $region = $this->getStoreInformationObject($storeId)->getData('region');
+                $configValue = $region ?: $configValue;
             }
         }
         return $configValue;
+    }
+
+    /**
+     * Retrieve store information object, resolving it at most once per store.
+     *
+     * Store information resolution loads country and region entities from the database, so it must only happen
+     * for the config paths that actually need it.
+     *
+     * @param int|string|null $storeId
+     * @return DataObject
+     * @throws NoSuchEntityException
+     */
+    private function getStoreInformationObject($storeId): DataObject
+    {
+        $cacheKey = (string)$storeId;
+        if (!isset($this->storeInformationObjects[$cacheKey])) {
+            $this->storeInformationObjects[$cacheKey] = $this->storeInformation
+                ->getStoreInformationObject($this->_storeManager->getStore($storeId));
+        }
+
+        return $this->storeInformationObjects[$cacheKey];
     }
 
     /**

--- a/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
+++ b/app/code/Magento/Email/Test/Unit/Model/Template/FilterTest.php
@@ -441,9 +441,8 @@ class FilterTest extends TestCase
             ->method('getValue')
             ->willReturn($scopeConfigValue);
 
-        $this->storeInformation->expects($this->once())
-            ->method('getStoreInformationObject')
-            ->willReturn(new DataObject([]));
+        $this->storeInformation->expects($this->never())
+            ->method('getStoreInformationObject');
 
         $this->assertEquals($scopeConfigValue, $this->getModel()->configDirective($construction));
     }
@@ -467,9 +466,8 @@ class FilterTest extends TestCase
             ->method('getValue')
             ->willReturn($scopeConfigValue);
 
-        $this->storeInformation->expects($this->once())
-            ->method('getStoreInformationObject')
-            ->willReturn(new DataObject([]));
+        $this->storeInformation->expects($this->never())
+            ->method('getStoreInformationObject');
 
         $this->assertEquals($scopeConfigValue, $this->getModel()->configDirective($construction));
     }
@@ -524,6 +522,41 @@ class FilterTest extends TestCase
             ->willReturn(new DataObject(['region_id' => '57', 'region' => 'Texas']));
 
         $this->assertEquals($expectedRegion, $this->getModel()->configDirective($construction));
+    }
+
+    /**
+     * Store information must be resolved only once, no matter how many store information directives are rendered.
+     *
+     * @throws NoSuchEntityException
+     */
+    public function testConfigDirectiveResolvesStoreInformationOnce()
+    {
+        $countryPath = 'general/store_information/country_id';
+        $regionPath = 'general/store_information/region_id';
+
+        $this->storeManager->expects($this->any())
+            ->method('getStore')
+            ->willReturn($this->store);
+        $this->store->expects($this->any())->method('getId')->willReturn(1);
+
+        $this->configVariables->expects($this->any())
+            ->method('getAvailableVars')
+            ->willReturn(['country' => $countryPath, 'region' => $regionPath]);
+
+        $this->storeInformation->expects($this->once())
+            ->method('getStoreInformationObject')
+            ->willReturn(new DataObject(['country' => 'United States', 'region' => 'Texas']));
+
+        $filter = $this->getModel();
+
+        $this->assertEquals(
+            'United States',
+            $filter->configDirective(["{{config path={$countryPath}}}", 'config', " path={$countryPath}"])
+        );
+        $this->assertEquals(
+            'Texas',
+            $filter->configDirective(["{{config path={$regionPath}}}", 'config', " path={$regionPath}"])
+        );
     }
 
     /**


### PR DESCRIPTION
### Description (*)

`Magento\Email\Model\Template\Filter::configDirective()` resolved the store information object **unconditionally**, before checking which config path was actually requested:

```php
$store = $this->_storeManager->getStore($storeId);
$storeInformationObj = $this->storeInformation->getStoreInformationObject($store);
if (isset($params['path']) && $this->isAvailableConfigVariable($params['path'])) {
    ...
```

`Magento\Store\Model\Information::getStoreInformationObject()` loads two entities from the database:

```php
if ($info->getRegionId()) {
    $info->setRegion($this->regionFactory->create()->load($info->getRegionId())->getName());
}
if ($info->getCountryId()) {
    $info->setCountry($this->countryFactory->create()->loadByCode($info->getCountryId())->getName());
}
```

Only two config paths need that data — `general/store_information/country_id` and `general/store_information/region_id`. Every other `{{config path="..."}}` directive paid for a region load plus a country load and then discarded the result. Because `Magento\Cms\Model\Template\Filter` extends this class, a CMS page or block with N `{{config}}` / `{{store}}` directives performed 2×N redundant entity loads on every uncached render.

This change:

1. Resolves the store information object **lazily** — only inside the two branches that consume it.
2. Memoizes it per store id, so a template using both the country and the region directive (or repeating either) resolves it once instead of once per directive.

Behaviour of the directive output is unchanged.

### Fixed Issues (if relevant)

Fixes magento/magento2#37815

### Manual testing scenarios (*)

1. Disable Block HTML and Full Page cache.
2. Create a CMS block containing many directives, e.g. 200 repetitions of:
   ```
   {{store url=""}}
   {{config path="web/secure/base_url"}}
   ```
3. Render the page and profile it (Blackfire / SPX / query log).
4. **Before:** `Magento\Directory\Model\Region::load` and `Magento\Directory\Model\Country::loadByCode` are called once per directive.
   **After:** neither is called at all for these paths.
5. Set Stores > Configuration > General > Store Information country and state/province, then render a CMS block with:
   ```
   {{config path="general/store_information/country_id"}}
   {{config path="general/store_information/region_id"}}
   ```
   Both still output the resolved country and region names, and the store information object is resolved once.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
