### PR TITLE
Keep sales PDF item rows from splitting across a page break

### DIFF
--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Creditmemo.php
@@ -210,7 +210,7 @@ class Creditmemo extends AbstractItems
                     $lines[][] = ['text' => $text, 'feed' => $leftBound + 5];
                 }
 
-                $drawItems[] = ['lines' => $lines, 'height' => 20, 'shift' => 5];
+                $drawItems[] = ['lines' => $lines, 'height' => 20];
             }
         }
 

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Invoice.php
@@ -250,7 +250,7 @@ class Invoice extends AbstractItems
                     $lines[][] = ['text' => $text, 'feed' => 40];
                 }
 
-                $draw[] = ['lines' => $lines, 'height' => 20, 'shift' => 5];
+                $draw[] = ['lines' => $lines, 'height' => 20];
             }
         }
 

--- a/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
+++ b/app/code/Magento/Bundle/Model/Sales/Order/Pdf/Items/Shipment.php
@@ -186,7 +186,7 @@ class Shipment extends AbstractItems
                     $lines[][] = ['text' => $text, 'feed' => 115];
                 }
 
-                $drawItems[] = ['lines' => $lines, 'height' => 20, 'shift' => 5];
+                $drawItems[] = ['lines' => $lines, 'height' => 20];
             }
         }
 

--- a/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/AbstractPdf.php
@@ -52,6 +52,16 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
     public const XML_PATH_SALES_PDF_CREDITMEMO_PUT_ORDER_ID = 'sales_pdf/creditmemo/put_order_id';
 
     /**
+     * Y coordinate a new page starts drawing at
+     */
+    private const PAGE_TOP_Y = 800;
+
+    /**
+     * Lowest Y coordinate a line of text may be drawn at
+     */
+    private const MIN_TEXT_Y = 15;
+
+    /**
      * Zend PDF object
      *
      * @var \Zend_Pdf
@@ -141,6 +151,16 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
      * @var array $pageSettings
      */
     private $pageSettings;
+
+    /**
+     * @var \Zend_Pdf_Page|null
+     */
+    private $lastCreatedPage;
+
+    /**
+     * @var int
+     */
+    private $lastCreatedPageTop = self::PAGE_TOP_Y;
 
     /**
      * @var Database
@@ -996,7 +1016,7 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         $pageSize = !empty($settings['page_size']) ? $settings['page_size'] : \Zend_Pdf_Page::SIZE_A4;
         $page = $this->_getPdf()->newPage($pageSize);
         $this->_getPdf()->pages[] = $page;
-        $this->y = 800;
+        $this->y = self::PAGE_TOP_Y;
 
         return $page;
     }
@@ -1063,8 +1083,10 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
                 $itemsProp['shift'] = $shift;
             }
 
-            if ($this->y - $itemsProp['shift'] < 15) {
-                $page = $this->newPage($pageSettings);
+            if ($this->y - $itemsProp['shift'] < self::MIN_TEXT_Y
+                && $this->fitsOnEmptyPage($page, $itemsProp['shift'])
+            ) {
+                $page = $this->createPage($pageSettings);
             }
             $page = $this->correctLines($lines, $page, $height);
         }
@@ -1121,6 +1143,41 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
     }
 
     /**
+     * Create a new page and remember the Y coordinate it starts drawing at.
+     *
+     * @param array $pageSettings
+     * @return \Zend_Pdf_Page
+     */
+    private function createPage(array $pageSettings): \Zend_Pdf_Page
+    {
+        $page = $this->newPage($pageSettings);
+        $this->lastCreatedPage = $page;
+        $this->lastCreatedPageTop = $this->y;
+
+        return $page;
+    }
+
+    /**
+     * Whether a block of the given height still fits when started from the top of an empty page.
+     *
+     * A taller block overflows wherever it starts, so breaking the page for it only leaves the
+     * rest of the current page empty - and leaves the page entirely empty when the block is the
+     * first thing drawn on it.
+     *
+     * @param \Zend_Pdf_Page $page
+     * @param int $blockHeight
+     * @return bool
+     */
+    private function fitsOnEmptyPage(\Zend_Pdf_Page $page, $blockHeight): bool
+    {
+        // Pages this class created start at a known coordinate, which a table header lowers.
+        // For any other page only the un-lowered coordinate newPage() sets is known.
+        $pageTop = $page === $this->lastCreatedPage ? $this->lastCreatedPageTop : self::PAGE_TOP_Y;
+
+        return $blockHeight <= $pageTop - self::MIN_TEXT_Y;
+    }
+
+    /**
      * Correct text.
      *
      * @param array $column
@@ -1137,8 +1194,8 @@ abstract class AbstractPdf extends \Magento\Framework\DataObject
         $lineSpacing = !empty($column['height']) ? $column['height'] : $height;
         $fontSize = empty($column['font_size']) ? 10 : $column['font_size'];
         foreach ($column['text'] as $part) {
-            if ($this->y - $top < 15) {
-                $page = $this->newPage($this->pageSettings);
+            if ($this->y - $top < self::MIN_TEXT_Y) {
+                $page = $this->createPage($this->pageSettings);
                 $top = 0;
             }
 

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Invoice/DefaultInvoice.php
@@ -165,7 +165,7 @@ class DefaultInvoice extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
             }
         }
 
-        $lineBlock = ['lines' => $lines, 'height' => 20, 'shift' => 5];
+        $lineBlock = ['lines' => $lines, 'height' => 20];
 
         $page = $pdf->drawLineBlocks($page, [$lineBlock], ['table_header' => true]);
         $this->setPage($page);

--- a/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
+++ b/app/code/Magento/Sales/Model/Order/Pdf/Items/Shipment/DefaultShipment.php
@@ -118,7 +118,7 @@ class DefaultShipment extends \Magento\Sales\Model\Order\Pdf\Items\AbstractItems
             }
         }
 
-        $lineBlock = ['lines' => $lines, 'height' => 20, 'shift' => 5];
+        $lineBlock = ['lines' => $lines, 'height' => 20];
 
         $page = $pdf->drawLineBlocks($page, [$lineBlock], ['table_header' => true]);
         $this->setPage($page);

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/AbstractTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/AbstractTest.php
@@ -289,6 +289,107 @@ class AbstractTest extends TestCase
     }
 
     /**
+     * A block is moved to a new page only when it can fit on one.
+     *
+     * A block taller than an empty page overflows wherever it starts, so breaking the page for it
+     * leaves the rest of the current page empty without keeping the block together.
+     *
+     * @param int $blockHeight
+     * @param int $expectedNewPages
+     * @return void
+     * @throws \ReflectionException
+     * @dataProvider blockHeightDataProvider
+     */
+    public function testDrawLineBlocksBreaksPageOnlyForABlockThatFits(
+        int $blockHeight,
+        int $expectedNewPages
+    ): void {
+        $paymentData = $this->createMock(Data::class);
+        $string = $this->createMock(StringUtils::class);
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $filesystem = $this->createMock(Filesystem::class);
+        $pdfConfig = $this->createMock(Config::class);
+        $pdfTotalFactory = $this->createMock(Factory::class);
+        $pdfItemsFactory = $this->createMock(ItemsFactory::class);
+        $localeMock = $this->createMock(TimezoneInterface::class);
+        $translate = $this->createMock(StateInterface::class);
+        $addressRenderer = $this->createMock(Renderer::class);
+        $taxHelper = $this->createMock(TaxHelper::class);
+        $fileStorageDatabase = $this->createMock(Database::class);
+        $rtlTextHandler = $this->createMock(RtlTextHandler::class);
+        $image = $this->createMock(Image::class);
+
+        $abstractPdfMock = $this->getMockBuilder(AbstractPdf::class)
+            ->setConstructorArgs([
+                $paymentData,
+                $string,
+                $scopeConfig,
+                $filesystem,
+                $pdfConfig,
+                $pdfTotalFactory,
+                $pdfItemsFactory,
+                $localeMock,
+                $translate,
+                $addressRenderer,
+                [],
+                $fileStorageDatabase,
+                $rtlTextHandler,
+                $image,
+                $taxHelper
+            ])
+            ->onlyMethods(['_setFontRegular', '_getPdf', 'getPdf'])
+            ->getMock();
+
+        $pageOne = $this->createMock(\Zend_Pdf_Page::class);
+        $pageTwo = $this->createMock(\Zend_Pdf_Page::class);
+        $zendFont = $this->createMock(\Zend_Pdf_Font::class);
+        $zendPdf = $this->createMock(\Zend_Pdf::class);
+
+        $zendPdf->expects($this->exactly($expectedNewPages))->method('newPage')->willReturn($pageTwo);
+        $abstractPdfMock->expects($this->atLeastOnce())->method('_setFontRegular')->willReturn($zendFont);
+        $abstractPdfMock->expects($this->any())->method('_getPdf')->willReturn($zendPdf);
+
+        // Half way down the page: too little room left for either block.
+        $abstractPdfMock->y = 400;
+
+        $expectedPage = $expectedNewPages === 0 ? $pageOne : $pageTwo;
+        $otherPage = $expectedNewPages === 0 ? $pageTwo : $pageOne;
+        $expectedPage->expects($this->once())
+            ->method('drawText')
+            ->with('single-line', 35, $this->anything(), 'UTF-8');
+        $otherPage->expects($this->never())->method('drawText');
+
+        $drawBlockLineData = [[
+            'lines' => [[['text' => ['single-line'], 'feed' => 35]]],
+            'height' => 20,
+            'shift' => $blockHeight
+        ]];
+
+        $reflectionMethod = new \ReflectionMethod(AbstractPdf::class, 'drawLineBlocks');
+        $resultPage = $reflectionMethod->invoke(
+            $abstractPdfMock,
+            $pageOne,
+            $drawBlockLineData,
+            ['table_header' => true]
+        );
+
+        $this->assertSame($expectedPage, $resultPage);
+    }
+
+    /**
+     * Block height against the 785pt an empty page has room for
+     *
+     * @return array[]
+     */
+    public function blockHeightDataProvider(): array
+    {
+        return [
+            'block that fits on an empty page is moved to one' => [500, 1],
+            'block taller than an empty page stays where it is' => [900, 0],
+        ];
+    }
+
+    /**
      * Generate the array for multiline block
      *
      * @param int $numberOfLines

--- a/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/AbstractTest.php
+++ b/app/code/Magento/Sales/Test/Unit/Model/Order/Pdf/AbstractTest.php
@@ -24,6 +24,7 @@ use Magento\Sales\Model\Order\Pdf\ItemsFactory;
 use Magento\Sales\Model\Order\Pdf\Total\DefaultTotal;
 use Magento\Sales\Model\Order\Pdf\Total\Factory;
 use Magento\Tax\Helper\Data as TaxHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
 
@@ -298,8 +299,8 @@ class AbstractTest extends TestCase
      * @param int $expectedNewPages
      * @return void
      * @throws \ReflectionException
-     * @dataProvider blockHeightDataProvider
      */
+    #[DataProvider('blockHeightDataProvider')]
     public function testDrawLineBlocksBreaksPageOnlyForABlockThatFits(
         int $blockHeight,
         int $expectedNewPages
@@ -381,7 +382,7 @@ class AbstractTest extends TestCase
      *
      * @return array[]
      */
-    public function blockHeightDataProvider(): array
+    public static function blockHeightDataProvider(): array
     {
         return [
             'block that fits on an empty page is moved to one' => [500, 1],


### PR DESCRIPTION
### Description (*)

`AbstractPdf::drawLineBlocks()` has a page-break check meant to move a whole item block to the next page when it no longer fits:

```php
if ($this->y - $itemsProp['shift'] < 15) {
    $page = $this->newPage($pageSettings);
}
```

Every core item renderer passes a hardcoded `'shift' => 5`, which makes the check effectively dead (it only fires in the last 20pt of a page). A block that does not fit is started anyway and broken mid-block, so a single item row splits across the page boundary: its name and option lines on one page, its SKU, qty, price, tax and subtotal columns on the next, aligned against the wrong item.

`Creditmemo\DefaultCreditmemo` already had `'shift' => 5` removed in ACP2E-4630 (545981ca0); this finishes that for the other five renderers. Removing it alone is not enough, because a block taller than a page then breaks at the top of a fresh page too, leaving an empty page and still overflowing. So the change also adds `fitsOnEmptyPage()` (do not break when the block cannot fit an empty page anyway) and records each new page's starting Y, so the check compares against the real top of the page (a table header lowers it). The two literals it relied on (`800`, `15`) become named constants.

### Related Pull Requests

Extends ACP2E-4630 (commit 545981ca0), which fixed the overlapping-text half of this code path and removed the hardcoded `shift` from the credit memo renderer only.

### Fixed Issues (if relevant)

None linked. Found while investigating multi-page invoice PDFs on 2.4.7-p10.

### Manual testing scenarios (*)

1. Order several items with a long custom-option list (about 10-12 options each) so one item block is a few hundred points tall. Invoice and Print, then repeat for a packing slip, a credit memo, and the Print Invoices mass action. Before: an item is cut in half at each page boundary. After: every boundary falls between items, each page starting with a complete item row.
2. Add one item with an option list longer than a whole page (about 25 options): page count must not increase, and no page may hold only the item-table header.
3. An invoice, packing slip or credit memo that already fits on one page must be unchanged.

### Verification

Re-run over real invoices, packing slips, credit memos, order prints and a 5-invoice mass action, plus synthetic option blocks sized just under and just over one page, comparing extracted per-page draw runs (page, y, x, string) rather than PDF bytes. After the change: no item row is split across a boundary, no page holds only the table header, and the page count never increases for a block taller than a page.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green) - the data-provider test now uses `#[DataProvider]` with a `static` provider so it runs under PHPUnit 12; relying on CI for the full suite.


### Resolved issues:
1. [x] resolves magento/magento2#41064: Keep sales PDF item rows from splitting across a page break
