### PR TITLE
Controlled exception if /products/{sku}/media misses content

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
@@ -129,11 +129,7 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
     public function create($sku, ProductAttributeMediaGalleryEntryInterface $entry)
     {
         /** @var $entry ProductAttributeMediaGalleryEntryInterface */
-        $entryContent = $entry->getContent();
-
-        if ($entryContent === null || !$this->contentValidator->isValid($entryContent)) {
-            throw new InputException(__('The image content is invalid. Verify the content and try again.'));
-        }
+        $this->validateEntryContent($entry->getContent());
         $product = $this->productRepository->get($sku, true);
 
         $existingMediaGalleryEntries = $product->getMediaGalleryEntries();
@@ -170,6 +166,19 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
             }
         }
         throw new StateException(__('The new media gallery entry failed to save.'));
+    }
+
+    /**
+     * Validate media gallery entry content
+     *
+     * @param ImageContentInterface|null $entryContent
+     * @throws InputException
+     */
+    private function validateEntryContent(?ImageContentInterface $entryContent): void
+    {
+        if ($entryContent === null || !$this->contentValidator->isValid($entryContent)) {
+            throw new InputException(__('The image content is invalid. Verify the content and try again.'));
+        }
     }
 
     /**

--- a/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
+++ b/app/code/Magento/Catalog/Model/Product/Gallery/GalleryManagement.php
@@ -131,7 +131,7 @@ class GalleryManagement implements \Magento\Catalog\Api\ProductAttributeMediaGal
         /** @var $entry ProductAttributeMediaGalleryEntryInterface */
         $entryContent = $entry->getContent();
 
-        if (!$this->contentValidator->isValid($entryContent)) {
+        if ($entryContent === null || !$this->contentValidator->isValid($entryContent)) {
             throw new InputException(__('The image content is invalid. Verify the content and try again.'));
         }
         $product = $this->productRepository->get($sku, true);

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Gallery/GalleryManagementTest.php
@@ -159,6 +159,20 @@ class GalleryManagementTest extends TestCase
     /**
      * @return void
      */
+    public function testCreateWithMissingContentThrowsInputException(): void
+    {
+        $this->expectException('Magento\Framework\Exception\InputException');
+        $this->expectExceptionMessage('The image content is invalid. Verify the content and try again.');
+        $this->mediaGalleryEntryMock->method('getContent')->willReturn(null);
+
+        $this->contentValidatorMock->expects($this->never())->method('isValid');
+
+        $this->model->create('sku', $this->mediaGalleryEntryMock);
+    }
+
+    /**
+     * @return void
+     */
     public function testCreateWithInvalidImageException(): void
     {
         $this->expectException('Magento\Framework\Exception\InputException');


### PR DESCRIPTION
### Description (*)
When a caller omits `content` while performing a REST request to /products/{sku}/media (for example,
supplying only a `file` URL, external image URLs are not supported by this endpoint), `getContent()`
returns `null` and PHP throws an uncaught `TypeError` instead of the `InputException` this method
already throws for invalid content, surfacing as an unhandled 500 instead of a 400.

`Magento\Framework\Api\ImageContentValidator::isValid(): Argument #1 ($imageContent) must be of type Magento\Framework\Api\Data\ImageContentInterface, null given, called in /commerce/vendor/magento/module-catalog/Model/Product/Gallery/GalleryManagement.php on line 125 `

The targeted code `ProductAttributeMediaGalleryManagementInterface::create()` (`POST /V1/products/:sku/media`)
passes `entry->getContent()` straight into `ImageContentValidatorInterface::isValid()`, whose
parameter is a non-nullable `ImageContentInterface`.

This PR includes a fix that adds a `null` check to the existing validation condition in `create()`. Because `||`
short-circuits, `ImageContentValidatorInterface::isValid()` is never called with `null`, so the
`TypeError` can no longer occur and the method falls back to the `InputException` it already raises
for invalid content.

### Related Pull Requests
None.

### Fixed Issues (if relevant)
None.

### Manual testing scenarios (*)
1. Create or use an existing product (e.g. SKU `test-product`).
2. `POST /V1/products/test-product/media` with a body where `entry` omits `content` entirely, e.g.:
   ```json
   { "entry": { "media_type": "image", "label": "Test", "types": ["image"] } }
4. Request fails with 400 Bad Request and message
"The image content is invalid. Verify the content and try again."
5. Confirm existing behavior is unchanged: a request with valid base64 content still succeeds,
and a request with invalid (non-base64) content still returns the same 400 as before.

Questions or comments

None.

Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update (N/A — no README changes needed)
- [ ] All automated tests passed successfully (all builds are green) — pending CI run