### PR TITLE
Generate base global scope plugin-list config during setup:di:compile (fixes #40407)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/Interception/PluginListGeneratorTest.php
@@ -23,14 +23,22 @@ class PluginListGeneratorTest extends TestCase
     /**
      * Generated plugin list config for frontend scope
      */
-    const CACHE_ID_FRONTEND = 'primary|global|frontend|plugin-list';
+    private const CACHE_ID_FRONTEND = 'primary|global|frontend|plugin-list';
 
     /**
      * Generated plugin list config for dummy scope
      */
-    const CACHE_ID_DUMMY = 'primary|global|dummy|plugin-list';
+    private const CACHE_ID_DUMMY = 'primary|global|dummy|plugin-list';
 
-    private $cacheIds = [self::CACHE_ID_FRONTEND, self::CACHE_ID_DUMMY];
+    /**
+     * Generated plugin list config for the base global scope
+     */
+    private const CACHE_ID_GLOBAL = 'primary|global|plugin-list';
+
+    /**
+     * @var string[]
+     */
+    private $cacheIds = [self::CACHE_ID_FRONTEND, self::CACHE_ID_DUMMY, self::CACHE_ID_GLOBAL];
 
     /**
      * @var PluginListGenerator
@@ -141,6 +149,45 @@ class PluginListGeneratorTest extends TestCase
             $globalPlugin,
             $configDataDummy[2]['Magento\\Framework\\App\\Response\\Http_sendResponse___self'][1],
             'Plugin configurations are not equal. "dummy" scope should contain plugins from "global" scope'
+        );
+    }
+
+    /**
+     * The base "global" scope plugin-list file must be generated even when "global" is not supplied first.
+     *
+     * In production, setup:di:compile passes scopes sorted alphabetically, so "global" is not the first scope.
+     * Previously the base "global" scope was marked as loaded while generating an earlier area scope and then
+     * skipped, so its own "primary|global|plugin-list" file was never written and area scopes generated before
+     * "global" did not inherit the global plugin data. This asserts both are now correct regardless of order.
+     *
+     * @see https://github.com/magento/magento2/issues/40407
+     */
+    public function testBaseGlobalScopeConfigIsGeneratedRegardlessOfScopeOrder()
+    {
+        // "global" is intentionally not the first scope, mirroring the alphabetically sorted production order.
+        // "dummy" is placed after "global" so that a cache miss on "global" would also leave "dummy" without
+        // the inherited global plugin data.
+        $scopes = ['frontend', 'global', 'dummy'];
+        $globalPlugin = 'genericHeaderPlugin';
+        $this->model->write($scopes);
+
+        $configDataGlobal = $this->model->load(self::CACHE_ID_GLOBAL);
+        $this->assertNotEmpty(
+            $configDataGlobal,
+            'The base "primary|global|plugin-list" config must be generated for the global scope.'
+        );
+        $this->assertContains(
+            $globalPlugin,
+            $configDataGlobal[2]['Magento\\Framework\\App\\Response\\Http_sendResponse___self'][1],
+            'The generated global scope config must contain global scope plugins.'
+        );
+
+        // Area scopes generated before "global" must still inherit the global plugin data.
+        $configDataDummy = $this->model->load(self::CACHE_ID_DUMMY);
+        $this->assertContains(
+            $globalPlugin,
+            $configDataDummy[2]['Magento\\Framework\\App\\Response\\Http_sendResponse___self'][1],
+            '"dummy" scope generated before "global" must still contain plugins from the "global" scope.'
         );
     }
 

--- a/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
+++ b/lib/internal/Magento/Framework/Interception/PluginListGenerator.php
@@ -87,6 +87,7 @@ class PluginListGenerator implements ConfigWriterInterface, ConfigLoaderInterfac
      */
     public function write(array $scopes): void
     {
+        $scopes = $this->prioritizeBaseScopes($scopes);
         foreach ($scopes as $scope) {
             $this->scopeConfig->setCurrentScope($scope);
             if (false === isset($this->loadedScopes[$scope])) {
@@ -132,6 +133,31 @@ class PluginListGenerator implements ConfigWriterInterface, ConfigLoaderInterfac
                 }
             }
         }
+    }
+
+    /**
+     * Move base priority scopes (e.g. "global") to the front of the processing order.
+     *
+     * At runtime a request with no active area scope (CLI, cron, early bootstrap) asks for the base scope
+     * plugin-list, e.g. "primary|global|plugin-list". If a base scope is processed after an area scope it is
+     * marked as loaded as a side effect of the area scope generation and then skipped by the loaded-scopes
+     * guard in write(), so its own file is never generated and its plugin data is not carried over to the
+     * area scopes. Generating the base scopes first keeps the compile-time cache IDs and plugin data in sync
+     * with runtime regardless of the order in which scopes are supplied (see issue #40407).
+     *
+     * @param array $scopes
+     * @return array
+     */
+    private function prioritizeBaseScopes(array $scopes): array
+    {
+        $baseScopes = [];
+        foreach ($this->scopePriorityScheme as $baseScope) {
+            if (in_array($baseScope, $scopes, true)) {
+                $baseScopes[] = $baseScope;
+            }
+        }
+
+        return array_merge($baseScopes, array_values(array_diff($scopes, $baseScopes)));
     }
 
     /**


### PR DESCRIPTION
### Description

Fixes #40407

The plugin-list metadata files generated by `setup:di:compile` for the base **global** scope were never produced. As a result, every request running in the global scope — CLI commands, cron, and any early-bootstrap code that runs before an area scope is set — missed the pre-compiled metadata and fell back to parsing the plugin XML at runtime, defeating the purpose of the compiled `generated/metadata/*plugin-list.php` files.

#### Root cause

`Magento\Framework\Interception\PluginListGenerator::write()` iterates the supplied scopes and, for each one, marks the scopes it depends on (`primary`, `global`) as *loaded* as a side effect of `loadScopedVirtualTypes()`.

In production, `setup:di:compile` supplies the scopes **alphabetically sorted** (via `Operation\PluginListGenerator::doOperation()`), so an area scope such as `adminhtml` or `frontend` is processed **before** `global`. By the time the loop reaches `global`, it has already been marked as loaded, so the loaded-scopes guard skips it:

```php
if (false === isset($this->loadedScopes[$scope])) { // false for 'global' -> skipped
```

Two consequences follow:
1. The `primary|global|plugin-list` config file is **never written**, so runtime requests in the global scope always miss it.
2. Area scopes generated **before** `global` do not receive the carried-over global plugin data (`globalScopePluginData` is only populated when the `global` scope is actually processed).

The area-scope cache IDs themselves (`primary|global|<area>|plugin-list`) already matched runtime and were **not** the problem.

#### Fix

Generate the base priority scopes (`global`) **before** the area scopes, regardless of the order in which scopes are supplied. This keeps the compile-time cache IDs and plugin data in sync with what `PluginList::_loadScopedData()` requests at runtime. The change is contained to `PluginListGenerator::write()` and does not alter the already-correct area-scope generation.

### Manual testing scenarios

1. Deploy in production mode and run `bin/magento setup:di:compile`.
2. Inspect `generated/metadata/`:
   - **Before:** no `primary|global|plugin-list.php` file exists.
   - **After:** `primary|global|plugin-list.php` is present.
3. Flush cache (`bin/magento cache:flush`) and make a request in the global scope (e.g. run any `bin/magento` command). The pre-compiled global config is now loaded instead of the plugin XML being re-parsed.

### Questions or comments

- No backward-incompatible changes. The public signature of `PluginListGenerator::write()` is unchanged.
- The `primary` scope remains intentionally excluded from production compilation (developer-mode only), as before.

### Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (added `PluginListGeneratorTest::testBaseGlobalScopeConfigIsGeneratedRegardlessOfScopeOrder`)
- [x] All automated tests passed successfully (all tests are green)
