### PR TITLE
Release LowestPriceOptionsProvider linked-product cache on state reset

### DIFF
--- a/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
+++ b/app/code/Magento/ConfigurableProduct/Pricing/Price/LowestPriceOptionsProvider.php
@@ -9,12 +9,13 @@ use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\ResourceModel\Product\LinkedProductSelectBuilderInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Retrieve list of products where each product contains lower price than others at least for one possible price type
  */
-class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
+class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface, ResetAfterRequestInterface
 {
     /**
      * @var ResourceConnection
@@ -41,7 +42,7 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
      *
      * @var array
      */
-    private $linkedProductMap;
+    private $linkedProductMap = [];
 
     /**
      * @param ResourceConnection $resourceConnection
@@ -82,5 +83,17 @@ class LowestPriceOptionsProvider implements LowestPriceOptionsProviderInterface
                 ->getItems();
         }
         return $this->linkedProductMap[$key];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * The map retains loaded child product collections for the lifetime of the process, so release it between
+     * requests/batches to keep long-running consumers (application server, queue consumers, feed generation CLI)
+     * from accumulating stale product models.
+     */
+    public function _resetState(): void
+    {
+        $this->linkedProductMap = [];
     }
 }

--- a/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/LowestPriceOptionsProviderTest.php
+++ b/app/code/Magento/ConfigurableProduct/Test/Unit/Pricing/Price/LowestPriceOptionsProviderTest.php
@@ -67,7 +67,7 @@ class LowestPriceOptionsProviderTest extends TestCase
     {
         $this->connection = $this->createMock(AdapterInterface::class);
         $this->resourceConnection = $this->createPartialMock(ResourceConnection::class, ['getConnection']);
-        $this->resourceConnection->expects($this->once())->method('getConnection')->willReturn($this->connection);
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
         $this->linkedProductSelectBuilder = $this->createPartialMock(
             LinkedProductSelectBuilderInterface::class,
             ['build']
@@ -77,7 +77,7 @@ class LowestPriceOptionsProviderTest extends TestCase
             ['addAttributeToSelect', 'addIdFilter', 'getItems']
         );
         $this->collectionFactory = $this->createPartialMock(CollectionFactory::class, ['create']);
-        $this->collectionFactory->expects($this->once())->method('create')->willReturn($this->productCollection);
+        $this->collectionFactory->method('create')->willReturn($this->productCollection);
         $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
         $this->storeMock = $this->createMock(StoreInterface::class);
 
@@ -116,5 +116,31 @@ class LowestPriceOptionsProviderTest extends TestCase
         $this->storeMock->method('getId')->willReturn(Store::DEFAULT_STORE_ID);
 
         $this->assertEquals($linkedProducts, $this->model->getProducts($product));
+    }
+
+    public function testResetStateClearsCachedLinkedProducts()
+    {
+        $productId = 1;
+        $storeId = 1;
+        $firstLoad = ['first', 'load'];
+        $secondLoad = ['second', 'load'];
+        $product = $this->createMock(Product::class);
+        $product->method('getId')->willReturn($productId);
+        $product->method('getStoreId')->willReturn($storeId);
+        $this->linkedProductSelectBuilder->method('build')->with($productId)->willReturn([]);
+        $this->productCollection->method('addAttributeToSelect')->willReturnSelf();
+        $this->productCollection->method('addIdFilter')->willReturnSelf();
+        // getItems() is only reached on an actual load; a cached resolution never calls it.
+        $this->productCollection->expects($this->exactly(2))
+            ->method('getItems')
+            ->willReturnOnConsecutiveCalls($firstLoad, $secondLoad);
+
+        // First resolution loads and caches.
+        $this->assertEquals($firstLoad, $this->model->getProducts($product));
+        // Second resolution of the same product is served from cache (still the first load's items).
+        $this->assertEquals($firstLoad, $this->model->getProducts($product));
+        // After a state reset the cache is dropped, so the next resolution loads again.
+        $this->model->_resetState();
+        $this->assertEquals($secondLoad, $this->model->getProducts($product));
     }
 }


### PR DESCRIPTION
### Description

`Magento\ConfigurableProduct\Pricing\Price\LowestPriceOptionsProvider` caches loaded configurable child product collections in a private `$linkedProductMap`, keyed by store + product id. There is no eviction or reset path for that map, so it retains child product models for the entire lifetime of the PHP process. In long-running workloads (application server / stateful mode, queue consumers, feed-generation CLI) the retained heap grows with every batch, and `ProductRepository::cleanCache()` does not release it because the map lives on a different service.

This change makes the provider implement `Magento\Framework\ObjectManager\ResetAfterRequestInterface` and clears `$linkedProductMap` in `_resetState()`, the same way other stateful pricing providers already expose cache teardown (e.g. `Magento\ConfigurableProductGraphQl\Model\Resolver\Product\Price\Provider`).

Why this approach rather than adding a reset method to the interface (as floated in the issue):
- `LowestPriceOptionsProviderInterface` is `@api`; adding a method to it would be a backward-incompatible change for every implementer. Implementing `ResetAfterRequestInterface` on the concrete class keeps the public contract intact.
- `_resetState()` plugs into the framework's existing reset lifecycle, so the cache is dropped automatically between requests in application-server mode and between queue-consumer messages, and CLI consumers can call `_resetState()` themselves between bounded batches.

### Related Issue

Fixes #41075

### Manual testing scenarios

1. In a long-running CLI process, iterate over many configurable products and resolve a configurable final price for each (e.g. `$product->getFinalPrice()`), releasing collections and calling `ProductRepository::cleanCache()` between batches.
2. Track `memory_get_usage()` per batch. Before this change, retained heap attributed to `LowestPriceOptionsProvider::$linkedProductMap` grows monotonically.
3. Call `$lowestPriceOptionsProvider->_resetState()` at the end of each batch. After this change, the linked-product map is released and heap stays bounded across batches, while normal per-request behaviour is unchanged.

### Questions or comments

None.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility