### PR TITLE
Retry MariaDB snapshot-isolation error 1020 as a deadlock

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -333,6 +333,10 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface, Rese
             1205 => LockWaitException::class,
             // SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock
             1213 => DeadlockException::class,
+            // SQLSTATE[HY000]: General error: 1020 Record has changed since last read (MariaDB
+            // innodb_snapshot_isolation, ON by default since 11.6.2 - MDEV-35124). Resolved by
+            // restarting the transaction, same as a deadlock, so it is retried the same way.
+            1020 => DeadlockException::class,
             // SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
             1062 => DuplicateException::class,
             // SQLSTATE[42S02]: Base table or view not found: 1146

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\Framework\DB\Test\Unit\Adapter\Pdo;
 
 use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Adapter\DeadlockException;
 use Magento\Framework\DB\Adapter\Pdo\Mysql as PdoMysqlAdapter;
 use Magento\Framework\DB\LoggerInterface;
 use Magento\Framework\DB\Select;
@@ -1059,6 +1060,27 @@ class MysqlTest extends TestCase
             [new \Zend_Db_Statement_Exception('', 0, $pdoException)],
             [new \Exception()],
         ];
+    }
+
+    /**
+     * MariaDB error 1020 (record changed since last read, under innodb_snapshot_isolation) is resolved by
+     * restarting the transaction, so the adapter must surface it as a DeadlockException to be retried.
+     *
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testSnapshotIsolationErrorIsWrappedAsDeadlock(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock([]);
+
+        $pdoException = new \PDOException('Record has changed since last read');
+        $pdoException->errorInfo = [1 => 1020];
+        $queryExecutor = static function () use ($pdoException) {
+            throw $pdoException;
+        };
+
+        $this->expectException(DeadlockException::class);
+        $this->invokeModelMethod($adapter, 'performQuery', [$queryExecutor]);
     }
 
     public function testDestruct(): void


### PR DESCRIPTION
### Description

MariaDB enables `innodb_snapshot_isolation` by default since 11.6.2 ([MDEV-35124](https://jira.mariadb.org/browse/MDEV-35124)), which is now reachable on the officially supported MariaDB 11.8 (since 2.4.8-p5) and 12.3 (since 2.4.9). Under it, a locking read on a row that a committed concurrent transaction has changed no longer succeeds silently — it fails with error 1020 (`Record has changed since last read ...; try restarting transaction`) and rolls the whole transaction back. MariaDB's guidance is to restart the transaction, i.e. it is semantically equivalent to a deadlock (1213).

`Magento\Framework\DB\Adapter\Pdo\Mysql::$exceptionMap` maps 2006 / 2013 / 1205 / 1213 / 1062 / 1146 to typed exceptions but not 1020, so error 1020 surfaced as a generic exception that `DeadlockRecoveryExecutor` (and other deadlock-aware retry paths, which catch `DeadlockException`/`LockWaitException`) would not retry. The result is frequent, avoidable failures during concurrent catalog writes / price reindex under load on supported MariaDB versions.

This maps 1020 to `DeadlockException`, so it is retried the same way as 1213 wherever deadlock recovery is already applied, instead of requiring operators to work around it with `innodb_snapshot_isolation=OFF`.

### Related Issue

Fixes #41047

### Manual testing scenarios

1. On MariaDB >= 11.6.2 (e.g. 11.8) with `innodb_snapshot_isolation=ON` (the default), run a workload with concurrent catalog writes that trigger a price reindex under load.
2. Before this change: the reindex intermittently aborts with `SQLSTATE[HY000]: General error: 1020 Record has changed since last read in table '...'`, with no retry.
3. After this change: error 1020 is surfaced as a `DeadlockException` and retried by the existing deadlock-recovery path, so the operation completes without operator intervention.

### Questions or comments

The reporter (and MariaDB's own documentation) classify 1020 as "restart the transaction", which matches Magento's deadlock semantics rather than lock-wait; hence the mapping to `DeadlockException` (same as 1213) rather than `LockWaitException`.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility