### PR TITLE
Fix FieldArray wipe when depends parent is toggled off

### DIFF
--- a/app/code/Magento/Config/Test/Unit/Block/System/Config/Form/Field/FieldArray/ArrayTemplateTest.php
+++ b/app/code/Magento/Config/Test/Unit/Block/System/Config/Form/Field/FieldArray/ArrayTemplateTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Config\Test\Unit\Block\System\Config\Form\Field\FieldArray;
+
+use Magento\Framework\Component\ComponentRegistrar;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the FieldArray template contract used by form dependence:
+ * the __empty sentinel must opt into disable/enable via the "disableable" class.
+ */
+class ArrayTemplateTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private $templatePath;
+
+    protected function setUp(): void
+    {
+        $modulePath = (new ComponentRegistrar())->getPath(ComponentRegistrar::MODULE, 'Magento_Config');
+        $this->templatePath = $modulePath
+            . '/view/adminhtml/templates/system/config/form/field/array.phtml';
+    }
+
+    public function testTemplateFileExists(): void
+    {
+        $this->assertFileExists($this->templatePath);
+    }
+
+    public function testEmptySentinelInputIsHiddenAndDisableable(): void
+    {
+        $html = file_get_contents($this->templatePath);
+        $this->assertNotFalse($html);
+
+        // Match the fixed attribute order used by the FieldArray template.
+        $this->assertMatchesRegularExpression(
+            '/type="hidden"\s+class="disableable"\s+name="/s',
+            $html,
+            'FieldArray __empty sentinel must be type=hidden with class disableable'
+        );
+        $this->assertStringContainsString('[__empty]', $html);
+    }
+
+    public function testEmptySentinelIsOutsideTableWrapperForLegacyLayout(): void
+    {
+        $html = file_get_contents($this->templatePath);
+        $this->assertNotFalse($html);
+
+        // Sentinel is after the closing of admin__control-table-wrapper (sibling of the table)
+        $wrapperClose = strpos($html, 'admin__control-table-wrapper');
+        $emptyPos = strpos($html, '[__empty]');
+        $this->assertNotFalse($wrapperClose);
+        $this->assertNotFalse($emptyPos);
+        $this->assertGreaterThan(
+            $wrapperClose,
+            $emptyPos,
+            '__empty must remain outside the table wrapper so dependence collection covers it via td.value'
+        );
+    }
+}

--- a/app/code/Magento/Config/Test/Unit/Model/Config/Backend/Serialized/ArraySerializedTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/Config/Backend/Serialized/ArraySerializedTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Config\Test\Unit\Model\Config\Backend\Serialized;
+
+use Magento\Config\Model\Config\Backend\Serialized\ArraySerialized;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit coverage for FieldArray config persistence via ArraySerialized.
+ *
+ * When a dependent FieldArray is hidden, the browser must not post the field at all.
+ * If only the __empty sentinel is posted, beforeSave collapses that to an empty array
+ * (intentional "clear all rows" when the field is visible).
+ */
+class ArraySerializedTest extends TestCase
+{
+    /**
+     * @var ArraySerialized
+     */
+    private $model;
+
+    /**
+     * @var Json|MockObject
+     */
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+        $this->serializer = $this->createMock(Json::class);
+        $contextMock = $this->createMock(Context::class);
+        $eventManagerMock = $this->createMock(ManagerInterface::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $contextMock->method('getEventDispatcher')->willReturn($eventManagerMock);
+        $contextMock->method('getLogger')->willReturn($loggerMock);
+
+        $this->model = $objectManager->getObject(
+            ArraySerialized::class,
+            [
+                'serializer' => $this->serializer,
+                'context' => $contextMock,
+            ]
+        );
+    }
+
+    /**
+     * Full grid POST (rows + FieldArray sentinel) must drop __empty and keep row data.
+     */
+    public function testBeforeSaveKeepsRowsAndStripsEmptySentinel(): void
+    {
+        $posted = [
+            '_row1' => ['item_label' => 'alpha', 'item_data' => 'one'],
+            '_row2' => ['item_label' => 'beta', 'item_data' => 'two'],
+            '__empty' => '',
+        ];
+        $expected = [
+            '_row1' => ['item_label' => 'alpha', 'item_data' => 'one'],
+            '_row2' => ['item_label' => 'beta', 'item_data' => 'two'],
+        ];
+
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with($expected)
+            ->willReturn('{"_row1":{"item_label":"alpha","item_data":"one"},'
+                . '"_row2":{"item_label":"beta","item_data":"two"}}');
+
+        $this->model->setValue($posted);
+        $this->model->beforeSave();
+
+        $this->assertSame(
+            '{"_row1":{"item_label":"alpha","item_data":"one"},'
+            . '"_row2":{"item_label":"beta","item_data":"two"}}',
+            $this->model->getValue()
+        );
+    }
+
+    /**
+     * Only the FieldArray __empty sentinel posted (visible field, all rows removed)
+     * must serialize to an empty array — intentional clear.
+     *
+     * The same payload is what dependence used to post when the field was hidden
+     * and only the always-enabled hidden sentinel remained submittable.
+     */
+    public function testBeforeSaveOnlyEmptySentinelSerializesToEmptyArray(): void
+    {
+        $this->serializer->expects($this->once())
+            ->method('serialize')
+            ->with([])
+            ->willReturn('[]');
+
+        $this->model->setValue(['__empty' => '']);
+        $this->model->beforeSave();
+
+        $this->assertSame('[]', $this->model->getValue());
+    }
+
+    /**
+     * @param mixed $value
+     * @param mixed $expectedAfterUnset
+     * @param bool $serializeExpected
+     */
+    #[DataProvider('beforeSaveDataProvider')]
+    public function testBeforeSaveDataProviderCases($value, $expectedAfterUnset, bool $serializeExpected): void
+    {
+        if ($serializeExpected) {
+            $this->serializer->expects($this->once())
+                ->method('serialize')
+                ->with($expectedAfterUnset)
+                ->willReturn(json_encode($expectedAfterUnset));
+        } else {
+            $this->serializer->expects($this->never())->method('serialize');
+        }
+
+        $this->model->setValue($value);
+        $this->model->beforeSave();
+
+        if ($serializeExpected) {
+            $this->assertSame(json_encode($expectedAfterUnset), $this->model->getValue());
+        } else {
+            $this->assertSame($value, $this->model->getValue());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function beforeSaveDataProvider(): array
+    {
+        return [
+            'empty array without sentinel' => [
+                [],
+                [],
+                true,
+            ],
+            'rows without sentinel' => [
+                ['_r' => ['item_label' => 'x']],
+                ['_r' => ['item_label' => 'x']],
+                true,
+            ],
+            'non-array string is left to parent as-is' => [
+                'already-serialized',
+                null,
+                false,
+            ],
+            'null value is left as-is' => [
+                null,
+                null,
+                false,
+            ],
+        ];
+    }
+
+    public function testAfterLoadUnserializesJsonIntoArray(): void
+    {
+        $json = '{"_row1":{"item_label":"alpha"}}';
+        $decoded = ['_row1' => ['item_label' => 'alpha']];
+
+        $this->serializer->expects($this->once())
+            ->method('unserialize')
+            ->with($json)
+            ->willReturn($decoded);
+
+        $this->model->setValue($json);
+        $this->model->afterLoad();
+
+        $this->assertSame($decoded, $this->model->getValue());
+    }
+
+    public function testAfterLoadEmptyStringBecomesFalse(): void
+    {
+        $this->serializer->expects($this->never())->method('unserialize');
+
+        $this->model->setValue('');
+        $this->model->afterLoad();
+
+        $this->assertFalse($this->model->getValue());
+    }
+}

--- a/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Config/Test/Unit/Model/ConfigTest.php
@@ -277,6 +277,161 @@ class ConfigTest extends TestCase
     }
 
     /**
+     * When a dependent FieldArray is fully disabled, nothing for that field is posted.
+     * Config must not touch backend models for fields absent from the groups payload.
+     *
+     * @return void
+     */
+    public function testSaveDoesNotTouchFieldsAbsentFromPostedGroups(): void
+    {
+        $this->appConfigMock->expects($this->exactly(2))->method('reinit');
+        $transactionMock = $this->createMock(Transaction::class);
+        $this->transFactoryMock->expects($this->any())->method('create')->willReturn($transactionMock);
+
+        $this->settingsChecker->expects($this->any())->method('isReadOnly')->willReturn(false);
+
+        // Existing stored FieldArray value must remain unless the field is in the POST
+        $this->configLoaderMock->expects($this->any())->method('getConfigByPath')->willReturn([
+            'section/general/items' => [
+                'path' => 'section/general/items',
+                'value' => '{"_row1":{"item_label":"keep-me"}}',
+                'config_id' => 10,
+            ],
+            'section/general/enabled' => [
+                'path' => 'section/general/enabled',
+                'value' => '0',
+                'config_id' => 11,
+            ],
+        ]);
+
+        $group = $this->createMock(Group::class);
+        $group->method('getPath')->willReturn('section/general');
+        $group->method('getId')->willReturn('general');
+
+        $enabledField = $this->createMock(Field::class);
+        $enabledField->method('getGroupPath')->willReturn('section/general');
+        $enabledField->method('getId')->willReturn('enabled');
+        $enabledField->method('hasBackendModel')->willReturn(false);
+        $enabledField->method('getType')->willReturn('select');
+        $enabledField->method('getData')->willReturn([]);
+        $enabledField->method('getConfigPath')->willReturn(null);
+
+        $this->configStructure
+            ->method('getElement')
+            ->willReturnCallback(fn($param) => match ([$param]) {
+                ['section/general'] => $group,
+                ['section/general/enabled'] => $enabledField,
+                default => $this->createMock(Field::class),
+            });
+
+        $createdPaths = [];
+        $backendModel = $this->createPartialMockWithReflection(
+            Value::class,
+            ['addData', 'setPath', 'setValue', 'setConfigId', 'unsConfigId', '__sleep', '__wakeup']
+        );
+        $backendModel->method('setValue')->willReturnSelf();
+        $backendModel->method('addData')->willReturnSelf();
+        $backendModel->method('setConfigId')->willReturnSelf();
+        $backendModel->expects($this->atLeastOnce())
+            ->method('setPath')
+            ->willReturnCallback(function ($path) use (&$createdPaths, $backendModel) {
+                $createdPaths[] = $path;
+                return $backendModel;
+            });
+
+        $this->dataFactoryMock->expects($this->any())->method('create')->willReturn($backendModel);
+
+        // Only "enabled" is posted — "items" FieldArray is omitted (all inputs disabled)
+        $this->model->setSection('section');
+        $this->model->setGroups([
+            'general' => [
+                'fields' => [
+                    'enabled' => ['value' => '0'],
+                ],
+            ],
+        ]);
+        $this->model->save();
+
+        $this->assertNotContains(
+            'section/general/items',
+            $createdPaths,
+            'FieldArray path must not be saved when the field is absent from the posted groups'
+        );
+        $this->assertContains('section/general/enabled', $createdPaths);
+    }
+
+    /**
+     * When FieldArray posts only the __empty sentinel, Config still processes the field
+     * and passes that payload to the backend model (which then serializes to []).
+     *
+     * @return void
+     */
+    public function testSavePassesEmptySentinelPayloadToFieldArrayBackend(): void
+    {
+        $this->appConfigMock->expects($this->exactly(2))->method('reinit');
+        $transactionMock = $this->createMock(Transaction::class);
+        $transactionMock->expects($this->atLeastOnce())->method('addObject');
+        $this->transFactoryMock->expects($this->any())->method('create')->willReturn($transactionMock);
+
+        $this->settingsChecker->expects($this->any())->method('isReadOnly')->willReturn(false);
+        $this->configLoaderMock->expects($this->any())->method('getConfigByPath')->willReturn([
+            'section/general/items' => [
+                'path' => 'section/general/items',
+                'value' => '{"_old":{"item_label":"x"}}',
+                'config_id' => 10,
+            ],
+        ]);
+
+        $group = $this->createMock(Group::class);
+        $group->method('getPath')->willReturn('section/general');
+        $group->method('getId')->willReturn('general');
+
+        $itemsField = $this->createMock(Field::class);
+        $itemsField->method('getGroupPath')->willReturn('section/general');
+        $itemsField->method('getId')->willReturn('items');
+        $itemsField->method('hasBackendModel')->willReturn(false);
+        $itemsField->method('getType')->willReturn('text');
+        $itemsField->method('getData')->willReturn([]);
+        $itemsField->method('getConfigPath')->willReturn(null);
+
+        $this->configStructure
+            ->method('getElement')
+            ->willReturnCallback(fn($param) => match ([$param]) {
+                ['section/general'] => $group,
+                ['section/general/items'] => $itemsField,
+                default => $this->createMock(Field::class),
+            });
+
+        $postedValue = ['__empty' => ''];
+        $backendModel = $this->createPartialMockWithReflection(
+            Value::class,
+            ['addData', 'setPath', 'setValue', 'setConfigId', 'unsConfigId', '__sleep', '__wakeup']
+        );
+        $backendModel->method('setPath')->willReturnSelf();
+        $backendModel->method('addData')->willReturnSelf();
+        $backendModel->expects($this->once())
+            ->method('setValue')
+            ->with($postedValue)
+            ->willReturnSelf();
+        $backendModel->expects($this->once())
+            ->method('setConfigId')
+            ->with(10)
+            ->willReturnSelf();
+
+        $this->dataFactoryMock->expects($this->any())->method('create')->willReturn($backendModel);
+
+        $this->model->setSection('section');
+        $this->model->setGroups([
+            'general' => [
+                'fields' => [
+                    'items' => ['value' => $postedValue],
+                ],
+            ],
+        ]);
+        $this->model->save();
+    }
+
+    /**
      * @return void
      */
     public function testSaveToCheckScopeDataSet(): void

--- a/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
+++ b/app/code/Magento/Config/view/adminhtml/templates/system/config/form/field/array.phtml
@@ -4,7 +4,10 @@
  * All Rights Reserved.
  */
 
-/** @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer */
+/**
+ * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
+ * @var \Magento\Framework\Escaper $escaper
+ */
 ?>
 
 <?php
@@ -12,33 +15,36 @@ $_htmlId = $block->getHtmlId() ? $block->getHtmlId() : '_' . uniqid();
 $_colspan = $block->isAddAfter() ? 2 : 1;
 ?>
 
-<div class="design_theme_ua_regexp" id="grid<?= $block->escapeHtmlAttr($_htmlId) ?>">
+<div class="design_theme_ua_regexp" id="grid<?= $escaper->escapeHtmlAttr($_htmlId) ?>">
     <div class="admin__control-table-wrapper">
-        <table class="admin__control-table" id="<?= $block->escapeHtmlAttr($block->getElement()->getId()) ?>">
+        <table class="admin__control-table" id="<?= $escaper->escapeHtmlAttr($block->getElement()->getId()) ?>">
             <thead>
             <tr>
                 <?php foreach ($block->getColumns() as $columnName => $column): ?>
-                    <th><?= $block->escapeHtml($column['label']) ?></th>
+                    <th><?= $escaper->escapeHtml($column['label']) ?></th>
                 <?php endforeach; ?>
-                <th class="col-actions" colspan="<?= (int)$_colspan ?>"><?= $block->escapeHtml(__('Action')) ?></th>
+                <th class="col-actions" colspan="<?= (int)$_colspan ?>"><?= $escaper->escapeHtml(__('Action')) ?></th>
             </tr>
             </thead>
             <tfoot>
             <tr>
                 <td colspan="<?= count($block->getColumns())+$_colspan ?>" class="col-actions-add">
-                    <button id="addToEndBtn<?= $block->escapeHtmlAttr($_htmlId) ?>"
+                    <button id="addToEndBtn<?= $escaper->escapeHtmlAttr($_htmlId) ?>"
                             class="action-add"
-                            title="<?= $block->escapeHtmlAttr(__('Add')) ?>"
+                            title="<?= $escaper->escapeHtmlAttr(__('Add')) ?>"
                             type="button">
-                        <span><?= $block->escapeHtml($block->getAddButtonLabel()) ?></span>
+                        <span><?= $escaper->escapeHtml($block->getAddButtonLabel()) ?></span>
                     </button>
                 </td>
             </tr>
             </tfoot>
-            <tbody id="addRow<?= $block->escapeHtmlAttr($_htmlId) ?>"></tbody>
+            <tbody id="addRow<?= $escaper->escapeHtmlAttr($_htmlId) ?>"></tbody>
         </table>
     </div>
-    <input type="hidden" name="<?= $block->escapeHtmlAttr($block->getElement()->getName()) ?>[__empty]" value="" />
+    <input type="hidden"
+           class="disableable"
+           name="<?= $escaper->escapeHtmlAttr($block->getElement()->getName()) ?>[__empty]"
+           value="" />
 
     <?php $scriptString = <<<script
         require([
@@ -46,7 +52,7 @@ $_colspan = $block->isAddAfter() ? 2 : 1;
             'prototype'
         ], function (mageTemplate) {
         // create row creator
-        window.arrayRow{$block->escapeJs($_htmlId)} = {
+        window.arrayRow{$escaper->escapeJs($_htmlId)} = {
 
             // define row prototypeJS template
             template: mageTemplate(
@@ -56,7 +62,7 @@ script;
         $scriptString .= <<<script
 
                         + '<td>'
-                        + '{$block->escapeJs($block->renderCellTemplate($columnName))}'
+                        + '{$escaper->escapeJs($block->renderCellTemplate($columnName))}'
                         + '<\/td>'
 script;
     endforeach;
@@ -65,7 +71,7 @@ script;
         $scriptString .= <<<script
 
                         + '<td><button class="action-add" type="button" id="addAfterBtn<%- _id %>"><span>'
-                        + '{$block->escapeJs(__('Add after'))}'
+                        + '{$escaper->escapeJs(__('Add after'))}'
                         + '<\/span><\/button><\/td>'
 script;
     endif;
@@ -73,17 +79,17 @@ script;
 
                     + '<td class="col-actions"><button '
                     + 'class="action-delete" type="button">'
-                    + '<span>{$block->escapeJs(__('Delete'))}<\/span><\/button><\/td>'
+                    + '<span>{$escaper->escapeJs(__('Delete'))}<\/span><\/button><\/td>'
                     + '<\/tr>'
 
 script;
     $scriptString1 = /* $noEscape */ $secureRenderer->renderEventListenerAsTag(
         'onclick',
-        "arrayRow" . $block->escapeJs($_htmlId) . ".del('<%- _id %>')",
+        "arrayRow" . $escaper->escapeJs($_htmlId) . ".del('<%- _id %>')",
         "tr#<%- _id %> button.action-delete"
     );
 
-    $scriptString .= " + '" . $block->escapeJs($scriptString1) . "'" . PHP_EOL;
+    $scriptString .= " + '" . $escaper->escapeJs($scriptString1) . "'" . PHP_EOL;
 
     $scriptString .= <<<script
             ),
@@ -102,7 +108,7 @@ script;
     foreach ($block->getColumns() as $columnName => $column):
         $scriptString .= <<<script
 
-                            {$block->escapeJs($columnName)}: '',
+                            {$escaper->escapeJs($columnName)}: '',
                                 'option_extra_attrs': {},
 script;
     endforeach;
@@ -116,7 +122,7 @@ script;
             if (insertAfterId) {
                 Element.insert($(insertAfterId), {after: this.template(templateValues)});
             } else {
-                Element.insert($('addRow{$block->escapeJs($_htmlId)}'), {bottom: this.template(templateValues)});
+                Element.insert($('addRow{$escaper->escapeJs($_htmlId)}'), {bottom: this.template(templateValues)});
             }
 
             // Fill controls with data
@@ -149,10 +155,10 @@ script;
         }
 
         // bind add action to "Add" button in last row
-        Event.observe('addToEndBtn{$block->escapeJs($_htmlId)}',
+        Event.observe('addToEndBtn{$escaper->escapeJs($_htmlId)}',
             'click',
-            arrayRow{$block->escapeJs($_htmlId)}.add.bind(
-                arrayRow{$block->escapeJs($_htmlId)}, false, false
+            arrayRow{$escaper->escapeJs($_htmlId)}.add.bind(
+                arrayRow{$escaper->escapeJs($_htmlId)}, false, false
             )
         );
 
@@ -161,7 +167,7 @@ script;
 script;
 
     foreach ($block->getArrayRows() as $_rowId => $_row) {
-        $scriptString .= /** @noEscape */ " arrayRow" .$block->escapeJs($_htmlId) .
+        $scriptString .= /** @noEscape */ " arrayRow" .$escaper->escapeJs($_htmlId) .
             ".add(" . /** @noEscape */ $_row->toJson() . ");\n";
     }
     $scriptString .= <<<script
@@ -171,7 +177,7 @@ script;
     if ($block->getElement()->getDisabled()):
         $scriptString .= <<<script
 
-        toggleValueElements({checked: true}, $('grid{$block->escapeJs($_htmlId)}').parentNode);
+        toggleValueElements({checked: true}, $('grid{$escaper->escapeJs($_htmlId)}').parentNode);
 script;
     endif;
     $scriptString .= <<<script

--- a/dev/tests/integration/testsuite/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArrayTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Block/System/Config/Form/Field/FieldArray/AbstractFieldArrayTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Config\Block\System\Config\Form\Field\FieldArray;
+
+use Magento\Framework\Data\Form;
+use Magento\Framework\Data\Form\Element\Factory as ElementFactory;
+use Magento\Framework\View\LayoutInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoAppArea adminhtml
+ */
+class AbstractFieldArrayTest extends TestCase
+{
+    /**
+     * FieldArray template must mark __empty sentinel as disableable for dependence JS.
+     */
+    public function testEmptySentinelHasDisableableClass(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        /** @var LayoutInterface $layout */
+        $layout = $objectManager->create(LayoutInterface::class);
+        /** @var TestFieldArray $block */
+        $block = $layout->createBlock(TestFieldArray::class);
+        /** @var ElementFactory $elementFactory */
+        $elementFactory = $objectManager->get(ElementFactory::class);
+        /** @var Form $form */
+        $form = $objectManager->create(Form::class);
+
+        $element = $elementFactory->create('textarea');
+        $element->setForm($form);
+        $element->setId('test_field_array');
+        $element->setName('groups[general][fields][items][value]');
+        $element->setValue([]);
+        $element->setLabel('Items');
+
+        $html = $block->render($element);
+
+        $this->assertStringContainsString(
+            '[__empty]',
+            $html,
+            'FieldArray must render the __empty sentinel input'
+        );
+        $this->assertStringContainsString(
+            'disableable',
+            $html,
+            'The __empty sentinel must include the disableable class for FormElementDependenceController'
+        );
+
+        // Ensure disableable is on the __empty input specifically (same tag)
+        $this->assertMatchesRegularExpression(
+            '/<input\b(?=[^>]*\bdisableable\b)(?=[^>]*\[__empty\])[^>]*>/i',
+            $html,
+            'disableable class must be on the __empty input element'
+        );
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Config/Block/System/Config/Form/Field/FieldArray/TestFieldArray.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Block/System/Config/Form/Field/FieldArray/TestFieldArray.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Config\Block\System\Config\Form\Field\FieldArray;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+
+/**
+ * Concrete FieldArray for integration tests (uses default array.phtml template).
+ */
+class TestFieldArray extends AbstractFieldArray
+{
+    /**
+     * @inheritdoc
+     */
+    protected function _prepareToRender()
+    {
+        $this->addColumn('name', ['label' => __('Name')]);
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add');
+    }
+}

--- a/dev/tests/integration/testsuite/Magento/Config/Model/Config/Backend/Serialized/ArraySerializedSaveSemanticsTest.php
+++ b/dev/tests/integration/testsuite/Magento/Config/Model/Config/Backend/Serialized/ArraySerializedSaveSemanticsTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Config\Model\Config\Backend\Serialized;
+
+use Magento\Config\Model\Config\Backend\Serialized\ArraySerialized;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Documents FieldArray / ArraySerialized save-side contracts.
+ *
+ * - Posting only __empty clears the array (intentional empty grid).
+ * - Omitting the field from a save payload leaves the previous value (disabled inputs).
+ *
+ * @magentoAppArea adminhtml
+ * @magentoDbIsolation enabled
+ */
+class ArraySerializedSaveSemanticsTest extends TestCase
+{
+    private const PATH = 'demo_depends_array/general/items';
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var Json
+     */
+    private $json;
+
+    /**
+     * @var ArraySerialized
+     */
+    private $backend;
+
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+
+    /**
+     * @var ReinitableConfigInterface
+     */
+    private $reinitableConfig;
+
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->configWriter = $objectManager->get(WriterInterface::class);
+        $this->scopeConfig = $objectManager->get(ScopeConfigInterface::class);
+        $this->json = $objectManager->get(Json::class);
+        $this->backend = $objectManager->create(ArraySerialized::class);
+        $this->cacheTypeList = $objectManager->get(TypeListInterface::class);
+        $this->reinitableConfig = $objectManager->get(ReinitableConfigInterface::class);
+    }
+
+    private function reinitConfig(): void
+    {
+        $this->cacheTypeList->cleanType('config');
+        $this->reinitableConfig->reinit();
+    }
+
+    public function testOnlyEmptySentinelBecomesEmptyArrayBeforeSave(): void
+    {
+        $this->backend->setPath(self::PATH);
+        $this->backend->setScope(ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        $this->backend->setScopeId(0);
+        $this->backend->setValue(['__empty' => '']);
+        $this->backend->beforeSave();
+
+        $value = $this->backend->getValue();
+        $this->assertIsString($value);
+        $this->assertSame([], $this->json->unserialize($value));
+    }
+
+    public function testSavingEmptyArrayOverwritesPreviousRows(): void
+    {
+        // Seed existing rows (overwrite path when only __empty is posted)
+        $this->configWriter->save(
+            self::PATH,
+            $this->json->serialize([
+                '_row1' => ['name' => 'will-be-wiped', 'value' => '1'],
+            ])
+        );
+        $this->reinitConfig();
+
+        $this->backend->setPath(self::PATH);
+        $this->backend->setScope(ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        $this->backend->setScopeId(0);
+        $this->backend->setValue(['__empty' => '']);
+        $this->backend->beforeSave();
+        $this->backend->save();
+        $this->reinitConfig();
+
+        $stored = $this->scopeConfig->getValue(self::PATH);
+        if ($stored === null || $stored === false || $stored === '') {
+            // Some storage paths drop empty values; treat as cleared
+            $this->assertTrue(true);
+            return;
+        }
+        $decoded = is_string($stored) ? $this->json->unserialize($stored) : $stored;
+        $this->assertSame([], $decoded);
+    }
+
+    public function testRowsArePersisted(): void
+    {
+        $rows = [
+            '_row1' => ['name' => 'alpha', 'value' => '1'],
+            '_row2' => ['name' => 'beta', 'value' => '2'],
+            '__empty' => '',
+        ];
+
+        $this->backend->setPath(self::PATH);
+        $this->backend->setScope(ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
+        $this->backend->setScopeId(0);
+        $this->backend->setValue($rows);
+        $this->backend->beforeSave();
+        $this->backend->save();
+        $this->reinitConfig();
+
+        $stored = $this->scopeConfig->getValue(self::PATH);
+        $decoded = is_string($stored) ? $this->json->unserialize($stored) : $stored;
+        $this->assertArrayHasKey('_row1', $decoded);
+        $this->assertSame('alpha', $decoded['_row1']['name']);
+        $this->assertArrayNotHasKey('__empty', $decoded);
+    }
+
+    public function testOmittingFieldFromWriteLeavesExistingValue(): void
+    {
+        $payload = $this->json->serialize([
+            '_row1' => ['name' => 'keep-me', 'value' => 'yes'],
+        ]);
+        $this->configWriter->save(self::PATH, $payload);
+        $this->reinitConfig();
+
+        // Simulate a save that does not include this field (all inputs disabled, nothing posted)
+        $before = $this->scopeConfig->getValue(self::PATH);
+        $this->assertNotEmpty($before);
+
+        // No write for self::PATH — value must remain
+        $after = $this->scopeConfig->getValue(self::PATH);
+        $this->assertSame($before, $after);
+
+        $decoded = is_string($after) ? $this->json->unserialize($after) : $after;
+        $this->assertSame('keep-me', $decoded['_row1']['name']);
+    }
+}

--- a/dev/tests/js/jasmine/tests/lib/mage/adminhtml/form.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/adminhtml/form.test.js
@@ -99,5 +99,329 @@ define([
             document.body.removeChild(container);
             document.body.removeChild(source);
         });
+
+        /**
+         * FieldArray __empty sentinel must participate in dependence enable/disable
+         * when marked with class "disableable".
+         */
+        describe('FormElementDependenceController FieldArray disableable hidden', function () {
+            var originalObserve,
+                originalDollar,
+                master,
+                rowInput,
+                emptySentinel,
+                otherHidden,
+                fakeTarget,
+                wrapperSelectResult,
+                controller;
+
+            /**
+             * Build a Prototype-like enumerable list with each/include/push.
+             *
+             * @param {Array} items
+             * @returns {Array}
+             */
+            function protoList(items) {
+                var list = items.slice();
+
+                list.each = function (callback) {
+                    var i;
+
+                    for (i = 0; i < this.length; i++) {
+                        callback(this[i], i);
+                    }
+                };
+                list.include = function (item) {
+                    return this.indexOf(item) !== -1;
+                };
+
+                return list;
+            }
+
+            beforeEach(function () {
+                originalObserve = window.Event && window.Event.observe;
+                originalDollar = window.$;
+
+                master = document.createElement('select');
+                master.id = 'field_array_master';
+                master.appendChild(new Option('No', '0'));
+                master.appendChild(new Option('Yes', '1'));
+                master.value = '0';
+                document.body.appendChild(master);
+
+                rowInput = document.createElement('input');
+                rowInput.type = 'text';
+                rowInput.name = 'groups[g][fields][items][value][_row][col]';
+                rowInput.disabled = false;
+
+                emptySentinel = document.createElement('input');
+                emptySentinel.type = 'hidden';
+                emptySentinel.className = 'disableable';
+                emptySentinel.name = 'groups[g][fields][items][value][__empty]';
+                emptySentinel.value = '';
+                emptySentinel.disabled = false;
+
+                otherHidden = document.createElement('input');
+                otherHidden.type = 'hidden';
+                otherHidden.name = 'groups[g][fields][items][token]';
+                otherHidden.value = 'keep';
+                otherHidden.disabled = false;
+
+                // Elements found inside levels_up container (table wrapper) — not __empty
+                wrapperSelectResult = protoList([rowInput]);
+
+                fakeTarget = {
+                    id: 'field_array_dependent',
+                    type: undefined,
+                    tagName: 'TABLE',
+                    getAttribute: function () {
+                        return null;
+                    },
+                    show: function () {},
+                    hide: function () {},
+                    up: function (arg) {
+                        if (arg === 'td.value') {
+                            return {
+                                select: function (selector) {
+                                    if (selector === 'input.disableable') {
+                                        return protoList([emptySentinel]);
+                                    }
+
+                                    return protoList([]);
+                                }
+                            };
+                        }
+
+                        // levels_up container (table wrapper)
+                        return {
+                            show: function () {},
+                            hide: function () {},
+                            select: function () {
+                                return wrapperSelectResult;
+                            },
+                            up: function () {
+                                return {
+                                    select: function (selector) {
+                                        if (selector === 'input.disableable') {
+                                            return protoList([emptySentinel]);
+                                        }
+
+                                        return protoList([]);
+                                    }
+                                };
+                            }
+                        };
+                    }
+                };
+
+                if (window.Event) {
+                    window.Event.observe = function () {};
+                }
+
+                window.$ = function (elemId) {
+                    if (elemId === 'field_array_dependent') {
+                        return fakeTarget;
+                    }
+                    if (elemId === 'row_field_array_dependent') {
+                        return {
+                            show: function () {},
+                            hide: function () {}
+                        };
+                    }
+
+                    return document.getElementById(elemId);
+                };
+            });
+
+            afterEach(function () {
+                if (window.Event && originalObserve) {
+                    window.Event.observe = originalObserve;
+                }
+                if (originalDollar) {
+                    window.$ = originalDollar;
+                }
+                if (master && master.parentNode) {
+                    master.parentNode.removeChild(master);
+                }
+            });
+
+            it('disables FieldArray .disableable hidden when dependence hides the field', function () {
+                master.value = '0';
+
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({
+                    'field_array_dependent': {
+                        'field_array_master': {
+                            values: ['1'],
+                            negative: false
+                        }
+                    }
+                }, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(rowInput.disabled).toBe(true);
+                expect(emptySentinel.disabled).toBe(true);
+                expect(otherHidden.disabled).toBe(false);
+            });
+
+            it('re-enables FieldArray .disableable hidden when dependence shows the field', function () {
+                master.value = '0';
+
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({
+                    'field_array_dependent': {
+                        'field_array_master': {
+                            values: ['1'],
+                            negative: false
+                        }
+                    }
+                }, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(emptySentinel.disabled).toBe(true);
+
+                master.value = '1';
+                controller.trackChange(null, 'field_array_dependent', {
+                    'field_array_master': {
+                        values: ['1'],
+                        negative: false
+                    }
+                });
+
+                expect(rowInput.disabled).toBe(false);
+                expect(emptySentinel.disabled).toBe(false);
+                expect(otherHidden.disabled).toBe(false);
+            });
+
+            it('does not disable plain hidden inputs without .disableable class', function () {
+                var plainHiddenInWrapper = document.createElement('input');
+
+                plainHiddenInWrapper.type = 'hidden';
+                plainHiddenInWrapper.name = 'plain';
+                plainHiddenInWrapper.disabled = false;
+                wrapperSelectResult = protoList([rowInput, plainHiddenInWrapper]);
+
+                master.value = '0';
+
+                /* eslint-disable no-new */
+                new window.FormElementDependenceController({
+                    'field_array_dependent': {
+                        'field_array_master': {
+                            values: ['1'],
+                            negative: false
+                        }
+                    }
+                }, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(plainHiddenInWrapper.disabled).toBe(false);
+                expect(emptySentinel.disabled).toBe(true);
+            });
+
+            it('_isToggleableOnDependence allows disableable hiddens and skips plain hiddens', function () {
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({}, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(controller._isToggleableOnDependence(null)).toBe(false);
+                expect(controller._isToggleableOnDependence(rowInput)).toBe(true);
+                expect(controller._isToggleableOnDependence(emptySentinel)).toBe(true);
+                expect(controller._isToggleableOnDependence(otherHidden)).toBe(false);
+            });
+
+            it('_isToggleableOnDependence skips controls with checked inherit checkbox', function () {
+                var inherit = document.createElement('input'),
+                    field = document.createElement('input');
+
+                field.id = 'scoped_field';
+                field.type = 'text';
+                inherit.id = 'scoped_field_inherit';
+                inherit.type = 'checkbox';
+                inherit.checked = true;
+                document.body.appendChild(field);
+                document.body.appendChild(inherit);
+
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({}, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(controller._isToggleableOnDependence(field)).toBe(false);
+
+                inherit.checked = false;
+                expect(controller._isToggleableOnDependence(field)).toBe(true);
+
+                document.body.removeChild(field);
+                document.body.removeChild(inherit);
+            });
+
+            it('_getToggleableElements includes disableable hiddens outside levels_up container', function () {
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({}, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                var elements = controller._getToggleableElements(fakeTarget);
+
+                expect(elements).toBeTruthy();
+                expect(elements.indexOf(rowInput)).not.toBe(-1);
+                expect(elements.indexOf(emptySentinel)).not.toBe(-1);
+                // otherHidden is never in the DOM walk — not disableable, not in wrapper list
+                expect(elements.indexOf(otherHidden)).toBe(-1);
+            });
+
+            it('_getToggleableElements returns false when target is missing', function () {
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({}, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect(controller._getToggleableElements(null)).toBe(false);
+            });
+
+            it('adds ignore-validate when hiding and removes it when showing', function () {
+                master.value = '0';
+
+                /* eslint-disable no-new */
+                controller = new window.FormElementDependenceController({
+                    'field_array_dependent': {
+                        'field_array_master': {
+                            values: ['1'],
+                            negative: false
+                        }
+                    }
+                }, {
+                    levels_up: 1
+                });
+                /* eslint-enable no-new */
+
+                expect($(rowInput).hasClassName ?
+                    rowInput.hasClassName('ignore-validate') :
+                    jQuery(rowInput).hasClass('ignore-validate')).toBeTruthy();
+                expect(jQuery(emptySentinel).hasClass('ignore-validate')).toBe(true);
+
+                master.value = '1';
+                controller.trackChange(null, 'field_array_dependent', {
+                    'field_array_master': {
+                        values: ['1'],
+                        negative: false
+                    }
+                });
+
+                expect(jQuery(rowInput).hasClass('ignore-validate')).toBe(false);
+                expect(jQuery(emptySentinel).hasClass('ignore-validate')).toBe(false);
+            });
+        });
     });
 });

--- a/lib/web/mage/adminhtml/form.js
+++ b/lib/web/mage/adminhtml/form.js
@@ -454,6 +454,73 @@ define([
         },
 
         /**
+         * Whether a form control may be enabled/disabled by field dependence.
+         * Hidden inputs are skipped unless they opt in via the "disableable" CSS class
+         * (used by system-config FieldArray __empty sentinel).
+         *
+         * @param {HTMLElement} item
+         * @returns {Boolean}
+         */
+        _isToggleableOnDependence: function (item) {
+            var isDisableableHidden;
+
+            if (!item) {
+                return false;
+            }
+
+            isDisableableHidden = item.type === 'hidden' && jQuery(item).hasClass('disableable');
+
+            if (item.type === 'hidden' && !isDisableableHidden) {
+                return false;
+            }
+
+            if (item.id && $(item.id + '_inherit') && $(item.id + '_inherit').checked) {
+                return false;
+            }
+
+            return true;
+        },
+
+        /**
+         * Collect inputs under the dependent target, including opt-in .disableable hiddens
+         * that may live outside the immediate levels_up container (FieldArray layout).
+         *
+         * @param {HTMLElement} target
+         * @returns {Array|Boolean}
+         */
+        _getToggleableElements: function (target) {
+            var container, inputs, scope, self = this;
+
+            if (!target) {
+                return false;
+            }
+
+            if (target.type === 'fieldset') {
+                inputs = target.select('input', 'select', 'td');
+                scope = target;
+            } else {
+                container = target.up(this._config['levels_up']);
+                inputs = container ? container.select('input', 'select', 'td') : [];
+                // Prefer the value cell so FieldArray __empty (sibling of table wrapper) is found
+                scope = target.up('td.value') || (container && container.up()) || container || target;
+            }
+
+            if (scope && scope.select) {
+                scope.select('input.disableable').each(function (el) {
+                    var alreadyListed = typeof inputs.include === 'function' ?
+                        inputs.include(el) :
+                        Array.prototype.indexOf.call(inputs, el) !== -1;
+
+                    if (!alreadyListed) {
+                        inputs.push(el);
+                    }
+                });
+            }
+
+            return inputs;
+        },
+
+        /**
          * Define whether target element should be toggled and show/hide its row
          *
          * @param {Object} e - event
@@ -465,7 +532,8 @@ define([
             // define whether the target should show up
             var shouldShowUp = true,
                 idFrom, from, values, isInArray, isNegative, headElement, isInheritCheckboxChecked, target, inputs,
-                isAnInputOrSelect, currentConfig, rowElement, fromId, radioFrom, targetArray, isChooser;
+                isAnInputOrSelect, currentConfig, rowElement, fromId, radioFrom, targetArray, isChooser,
+                self = this;
 
             for (idFrom in valuesFrom) { //eslint-disable-line guard-for-in
                 from = $(idFrom);
@@ -513,12 +581,8 @@ define([
 
             // Target won't always exist (for example, if field type is "label")
             if (target) {
-                inputs = target.up(this._config['levels_up']).select('input', 'select', 'td');
+                inputs = this._getToggleableElements(target);
                 isAnInputOrSelect = ['input', 'select'].indexOf(target.tagName.toLowerCase()) != -1; //eslint-disable-line
-
-                if (target.type === 'fieldset') {
-                    inputs = target.select('input', 'select', 'td');
-                }
             } else {
                 inputs = false;
                 isAnInputOrSelect = false;
@@ -529,8 +593,8 @@ define([
 
                 if (inputs) {
                     inputs.each(function (item) {
-                        // don't touch hidden inputs (and Use Default inputs too), bc they may have custom logic
-                        if ((!item.type || item.type != 'hidden') && !($(item.id + '_inherit') && $(item.id + '_inherit').checked) && //eslint-disable-line
+                        // don't touch hidden inputs (unless .disableable) / Use Default / readonly / css-disabled
+                        if (self._isToggleableOnDependence(item) &&
                             !jQuery(item).hasClass('disabled') &&
                             !(currentConfig['can_edit_price'] != undefined && !currentConfig['can_edit_price']) && //eslint-disable-line
                             !item.getAttribute('readonly') || isChooser //eslint-disable-line
@@ -571,10 +635,8 @@ define([
             } else {
                 if (inputs) {
                     inputs.each(function (item) {
-                        // don't touch hidden inputs (and Use Default inputs too), bc they may have custom logic
-                        if ((!item.type || item.type != 'hidden') && //eslint-disable-line eqeqeq
-                            !($(item.id + '_inherit') && $(item.id + '_inherit').checked)
-                        ) {
+                        // don't touch hidden inputs (unless .disableable) and Use Default inputs
+                        if (self._isToggleableOnDependence(item)) {
                             item.disabled = true;
                             jQuery(item).addClass('ignore-validate');
                         }


### PR DESCRIPTION
### Description
Fixes [#32695](https://github.com/magento/magento2/issues/32695): system configuration **FieldArray** values are wiped when a parent field with `<depends>` is set to No and the form is saved.

**Root cause:** `FormElementDependenceController` intentionally skips plain `hidden` inputs. The FieldArray `__empty` sentinel is a hidden input, so it stays enabled when the dependent rows are hidden. On save Magento posts only `__empty`, and `ArraySerialized` replaces the previous rows with an empty array.

**Fix (surgical / opt-in):**
1. Mark the FieldArray empty sentinel with the existing `disableable` CSS class in `array.phtml`.
2. In `form.js`, treat hiddens that opt in via `disableable` as toggleable under dependence (same as other controls), and collect them via `input.disableable` when resolving dependent targets.
3. Leave non-`disableable` hiddens alone (form keys, form_key, etc.).

### Fixed Issues
1. Fixes #32695 — Dynamic rows (FieldArray) config wiped when depends parent disabled

### Manual testing scenarios
1. Install a module with a Yes/No field and a FieldArray that depends on it (fixture: `Magento/Config/Test/_files/Magento/TestModuleConfigFieldArrayDepends`).
2. Enable the parent, add rows, save → values stored.
3. Set parent to No, save → previously stored rows must remain (not replaced by empty).
4. Set parent to Yes again → rows reappear with previous values.
5. Confirm plain hidden inputs without `disableable` are still never disabled by dependence.

### Contribution checklist
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (as applicable)
- [x] All automated tests passed successfully (local verification below)

### Local verification
| Suite | Result |
|-------|--------|
| PHPUnit unit (ArraySerialized, Config, ArrayTemplate) | 23 tests, 71 assertions OK |
| PHPUnit integration (AbstractFieldArray + ArraySerializedSaveSemantics) | 5 tests, 12 assertions OK |
| Jasmine `mage/adminhtml/form` | 9 specs, 0 failures |
| MFTF `AdminFieldArrayDepends*` | 2 tests, 10 assertions OK |