### PR TITLE
Guard GraphQL schema-stitching config load against cache stampede

### DIFF
--- a/app/code/Magento/GraphQl/etc/di.xml
+++ b/app/code/Magento/GraphQl/etc/di.xml
@@ -48,6 +48,12 @@
         <arguments>
             <argument name="reader" xsi:type="object">Magento\Framework\GraphQlSchemaStitching\Reader</argument>
             <argument name="cacheId" xsi:type="string">Magento_Framework_GraphQlSchemaStitching_Config_Data</argument>
+            <argument name="lockGuardedCacheLoader" xsi:type="object">graphQlSchemaStitchingQueryLocker</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="graphQlSchemaStitchingQueryLocker" type="Magento\Framework\Cache\LockGuardedCacheLoader">
+        <arguments>
+            <argument name="locker" xsi:type="object">Magento\Framework\Lock\Proxy</argument>
         </arguments>
     </virtualType>
     <virtualType name="Magento\Framework\GraphQl\Config\SchemaLocator" type="Magento\Framework\Config\SchemaLocator">

--- a/lib/internal/Magento/Framework/Config/Data.php
+++ b/lib/internal/Magento/Framework/Config/Data.php
@@ -5,6 +5,7 @@
  */
 namespace Magento\Framework\Config;
 
+use Magento\Framework\Cache\LockGuardedCacheLoader;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\App\ObjectManager;
 
@@ -71,6 +72,13 @@ class Data implements \Magento\Framework\Config\DataInterface
     private $serializer;
 
     /**
+     * Optional mutex to prevent a cache stampede when regenerating expensive config data.
+     *
+     * @var LockGuardedCacheLoader|null
+     */
+    private $lockGuardedCacheLoader;
+
+    /**
      * Constructor
      *
      * @param ReaderInterface $reader
@@ -78,6 +86,7 @@ class Data implements \Magento\Framework\Config\DataInterface
      * @param string $cacheId
      * @param SerializerInterface|null $serializer
      * @param array|null $cacheTags
+     * @param LockGuardedCacheLoader|null $lockGuardedCacheLoader
      */
     public function __construct(
         ReaderInterface $reader,
@@ -85,6 +94,7 @@ class Data implements \Magento\Framework\Config\DataInterface
         $cacheId,
         ?SerializerInterface $serializer = null,
         ?array $cacheTags = null,
+        ?LockGuardedCacheLoader $lockGuardedCacheLoader = null,
     ) {
         $this->reader = $reader;
         $this->cache = $cache;
@@ -93,6 +103,9 @@ class Data implements \Magento\Framework\Config\DataInterface
         if ($cacheTags) {
             $this->cacheTags = $cacheTags;
         }
+        // Intentionally no ObjectManager fallback: null keeps the original unguarded behavior, so the
+        // mutex is only engaged for cache ids that explicitly opt in via DI.
+        $this->lockGuardedCacheLoader = $lockGuardedCacheLoader;
         $this->initData();
     }
 
@@ -103,15 +116,44 @@ class Data implements \Magento\Framework\Config\DataInterface
      */
     protected function initData()
     {
-        $data = $this->cache->load($this->cacheId);
-        if (false === $data) {
-            $data = $this->reader->read();
-            $this->cache->save($this->serializer->serialize($data), $this->cacheId, $this->cacheTags);
+        if ($this->lockGuardedCacheLoader === null) {
+            $data = $this->cache->load($this->cacheId);
+            if (false === $data) {
+                $data = $this->reader->read();
+                $this->cache->save($this->serializer->serialize($data), $this->cacheId, $this->cacheTags);
+            } else {
+                $data = $this->serializer->unserialize($data);
+            }
         } else {
-            $data = $this->serializer->unserialize($data);
+            $data = $this->loadWithLock();
         }
 
         $this->merge($data);
+    }
+
+    /**
+     * Load config data through the mutex so concurrent cold reads regenerate it once, not once per request
+     *
+     * @return array
+     */
+    private function loadWithLock(): array
+    {
+        $loadAction = function () {
+            $cachedData = $this->cache->load($this->cacheId);
+            // The loader treats only strict false as a miss; an empty serialized array is a valid hit.
+            return $cachedData === false ? false : $this->serializer->unserialize($cachedData);
+        };
+
+        $data = $this->lockGuardedCacheLoader->lockedLoadData(
+            $this->cacheId,
+            $loadAction,
+            fn () => $this->reader->read(),
+            function ($data) {
+                $this->cache->save($this->serializer->serialize($data), $this->cacheId, $this->cacheTags);
+            }
+        );
+
+        return (array)$data;
     }
 
     /**

--- a/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
+++ b/lib/internal/Magento/Framework/Config/Test/Unit/DataTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\Framework\Config\Test\Unit;
 
+use Magento\Framework\Cache\LockGuardedCacheLoader;
 use Magento\Framework\Config\CacheInterface;
 use Magento\Framework\Config\Data;
 use Magento\Framework\Config\ReaderInterface;
@@ -83,6 +84,33 @@ class DataTest extends TestCase
             $cacheId,
             $this->serializerMock
         );
+        $this->assertEquals($data, $config->get());
+        $this->assertEquals('b', $config->get('a'));
+    }
+
+    public function testGetConfigLoadedThroughLockWhenLockerProvided()
+    {
+        $data = ['a' => 'b'];
+        $cacheId = 'test';
+        $lockLoader = $this->createMock(LockGuardedCacheLoader::class);
+        // The whole read/generate/save must be delegated to the mutex, keyed by the cache id, instead
+        // of initData touching the cache/reader directly.
+        $this->cacheMock->expects($this->never())->method('load');
+        $this->readerMock->expects($this->never())->method('read');
+        $lockLoader->expects($this->once())
+            ->method('lockedLoadData')
+            ->with($cacheId, $this->isType('callable'), $this->isType('callable'), $this->isType('callable'))
+            ->willReturn($data);
+
+        $config = new Data(
+            $this->readerMock,
+            $this->cacheMock,
+            $cacheId,
+            $this->serializerMock,
+            null,
+            $lockLoader
+        );
+
         $this->assertEquals($data, $config->get());
         $this->assertEquals('b', $config->get('a'));
     }


### PR DESCRIPTION
### Description

The GraphQL schema-stitching config (cache id `Magento_Framework_GraphQlSchemaStitching_Config_Data`) is regenerated once per request when the cache is cold: the reporter measured ~40 full schema stitches for 100 simultaneous requests. The schema stitch is expensive, so a cache flush under traffic causes a stampede.

Root cause: `Magento\Framework\GraphQl\Config\Data` is a virtualType of `Magento\Framework\Config\Data`, whose `initData()` does an unguarded read-or-generate (`cache->load()`; on miss `reader->read()` + `cache->save()`) with no mutex. Nothing serializes concurrent cold reads.

This applies the same mutex pattern `Magento\Config\App\Config\Type\System` already uses: an optional `LockGuardedCacheLoader` is added to `Framework\Config\Data`. When it is injected, the read/generate/save runs through `lockedLoadData()`, so a single process regenerates the schema while the others wait briefly and then re-read the freshly cached value (honoring the existing `cache/allow_parallel_generation` deployment flag).

Scope and backward compatibility:
- The loader parameter is optional and trailing, defaulting to `null`, with **no** `ObjectManager` fallback. `null` preserves the exact current behavior, so every other config-data consumer of this `@api` class is byte-for-byte unchanged. This mirrors how `serializer` and `cacheTags` were previously added as optional trailing params to the same class.
- Only the `Magento\Framework\GraphQl\Config\Data` virtualType opts in, via `app/code/Magento/GraphQl/etc/di.xml`, using a locker virtualType declared in the GraphQl module itself (`graphQlSchemaStitchingQueryLocker`, `locker = Magento\Framework\Lock\Proxy`) so no cross-module dependency is introduced.
- `reset()` is intentionally left unchanged: its semantics differ from `System::clean()` (remove + re-read without re-save), and the issue is specifically the read stampede.

### Related Issue

Fixes #39494

### Manual testing scenarios

1. Flush cache (or delete the `*_MAGENTO_FRAMEWORK_GRAPHQLSCHEMASTITCHING_CONFIG_DATA` cache key) on an instance using Redis/Valkey cache.
2. Fire ~10-100 GraphQL requests simultaneously and monitor how many times the schema is stitched (e.g. a temporary log line in `Magento\Framework\GraphQlSchemaStitching\Common\Reader::read()`, or watch the Redis `hmset` for that key).
3. Before this change: the schema is regenerated many times (once per racing request). After this change: it is regenerated once (or a small fraction when `cache/allow_parallel_generation` is enabled), and the remaining requests read the cached result.

### Questions or comments

The reporter's secondary suggestions (moving more of the stitch to `di:compile`, per-usage `allow_parallel_generation`, APCu) are broader enhancements and are intentionally out of scope for this stampede fix.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility