### PR TITLE
Drop the dangling source map reference from underscore.js (#38865)

### DIFF
--- a/lib/web/underscore.js
+++ b/lib/web/underscore.js
@@ -2081,4 +2081,3 @@
     return _;
 
 })));
-//# sourceMappingURL=underscore-umd.js.map


### PR DESCRIPTION
### Description (*)

`lib/web/underscore.js` is underscore's UMD distribution (`underscore-umd.js`) vendored into Magento under a different file name. The copy kept the build's trailing source map comment:

```js
})));
//# sourceMappingURL=underscore-umd.js.map
```

The map itself is not vendored — there is no `.map` file anywhere under `lib/web`. So any browser with developer tools open follows that comment and requests `underscore-umd.js.map` next to the deployed `underscore.js`, which Magento cannot resolve.

Reproduced on `2.4-develop` in developer mode:

```
$ curl -o /dev/null -w "%{http_code}" .../static/adminhtml/Magento/backend/en_US/underscore.js
200
$ curl -o /dev/null -w "%{http_code}" .../static/adminhtml/Magento/backend/en_US/underscore-umd.js.map
404

var/log/system.log:
main.ERROR:    Unable to resolve the source file for 'adminhtml/Magento/backend/en_US/underscore-umd.js.map'
main.CRITICAL: Unable to resolve the source file for 'adminhtml/Magento/backend/en_US/underscore-umd.js.map'
```

The message comes from `Magento\Framework\View\Asset\File::getSourceFile()`, reached through `Magento\Framework\App\StaticResource` when the map is requested. Because underscore is loaded on effectively every admin page, the log fills up with this entry during ordinary development.

This PR removes the dangling comment. Vendoring the upstream map instead was considered and rejected: it describes `underscore-umd.js` rather than the file Magento actually ships, and its `sources` point at `underscore-esm.js`, which is not vendored either — developer tools would then fail on the sources instead of the map.

After the change the deployed asset no longer advertises a map, so the request is never made and the log entry disappears.

Note for reviewers: 27 other vendored bundles under `lib/web` (hugerte skins, uppy, chartjs, less.min.js, vimeo player) carry the same kind of dangling `sourceMappingURL`. This PR deliberately stays with the reported file — those are separate third-party bundles and touching them is better done alongside their next library update.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38865: underscore-umd.js.map file is not generating

### Manual testing scenarios (*)

1. Install Magento in developer mode.
2. Open any admin page with browser developer tools open.
3. **Before:** the network panel shows a 404 for `.../en_US/underscore-umd.js.map`, and `var/log/system.log` / `var/log/debug.log` record `Unable to resolve the source file for '.../en_US/underscore-umd.js.map'`.
   **After:** no map request is made and no such entry is logged.
4. Confirm underscore itself still works — the deployed `underscore.js` loads and `_.VERSION` reports `1.13.7`.

### Questions or comments

The change removes one comment line from a vendored asset; no PHP is touched, so there is no unit or integration test in scope, and `lib/web/underscore.js` is not part of the ESLint whitelist (`dev/tests/static/testsuite/Magento/Test/Js/_files/whitelist/magento.txt`) since it is third-party code. Verification was done against a running instance as described above, plus a check that the library still parses and evaluates after the edit.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
