### PR TITLE
Prevent Web API functional test installation from dropping an unrelated database (#36291)

### DIFF
--- a/dev/tests/api-functional/framework/Magento/TestFramework/WebApiApplication.php
+++ b/dev/tests/api-functional/framework/Magento/TestFramework/WebApiApplication.php
@@ -5,6 +5,13 @@
  */
 namespace Magento\TestFramework;
 
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\DeploymentConfig\Reader;
+use Magento\Framework\Config\ConfigOptionsListConstants;
+use Magento\Framework\Config\File\ConfigFilePool;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Filesystem\DriverPool;
+
 /**
  * Provides access to the application for the tests
  *
@@ -28,6 +35,8 @@ class WebApiApplication extends Application
      */
     public function install($cleanup)
     {
+        $this->assertInstallationTargetsConfiguredDatabase();
+
         if ($cleanup) {
             $this->cleanup();
         }
@@ -70,5 +79,68 @@ class WebApiApplication extends Application
     protected function getCustomDirs()
     {
         return [];
+    }
+
+    /**
+     * Verify that the installation is not about to destroy a database the tests are not configured to use.
+     *
+     * Unlike the integration tests framework, Web API functional tests do not have their own configuration
+     * directory - they reuse the "app/etc" of the installation that serves TESTS_BASE_URL. Both
+     * "setup:uninstall" and "setup:install" therefore operate on whatever "app/etc/env.php" points at. When
+     * that database differs from the one declared in TESTS_INSTALL_CONFIG_FILE, the installation silently
+     * drops all tables of an unrelated database instead of the configured test one.
+     *
+     * @return void
+     * @throws LocalizedException
+     */
+    private function assertInstallationTargetsConfiguredDatabase(): void
+    {
+        if (!$this->isInstalled()) {
+            return;
+        }
+
+        $configuredDbName = $this->getInstallConfig()['db-name'] ?? null;
+        $installedDbName = $this->getInstalledDbName();
+
+        if (!$configuredDbName || !$installedDbName || $configuredDbName === $installedDbName) {
+            return;
+        }
+
+        throw new LocalizedException(
+            __(
+                'Web API functional tests are configured to install Magento into the "%1" database, but the '
+                . 'installation in "%2" uses the "%3" database. Installing would drop all tables of "%3" and '
+                . 'overwrite its deployment configuration, because Web API functional tests reuse the '
+                . 'application they send requests to. Either configure the test installation to use the "%3" '
+                . 'database, or set TESTS_MAGENTO_INSTALLATION to "disabled" to run the tests against the '
+                . 'already installed application.',
+                $configuredDbName,
+                $this->_configDir,
+                $installedDbName
+            )
+        );
+    }
+
+    /**
+     * Retrieve the database name of the already installed application, if its deployment configuration exists.
+     *
+     * @return string|null
+     */
+    private function getInstalledDbName(): ?string
+    {
+        $configFilePool = new ConfigFilePool();
+        $envFile = $this->_configDir . '/' . $configFilePool->getPath(ConfigFilePool::APP_ENV);
+        // phpcs:ignore Magento2.Functions.DiscouragedFunction
+        if (!file_exists($envFile)) {
+            return null;
+        }
+
+        $reader = new Reader($this->dirList, new DriverPool(), $configFilePool);
+        $deploymentConfig = new DeploymentConfig($reader, []);
+
+        return $deploymentConfig->get(
+            ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT
+            . '/' . ConfigOptionsListConstants::KEY_NAME
+        );
     }
 }


### PR DESCRIPTION
### Description

Running the Web API functional tests with `TESTS_MAGENTO_INSTALLATION=enabled` drops all tables of the **live** database instead of the test database configured in `dev/tests/api-functional/config/install-config-mysql.php`.

**Root cause**

`WebApiApplication::getCustomDirs()` returns an empty array, so – unlike the integration tests framework, which installs into its own `dev/tests/integration/tmp/sandbox-*/etc` – the Web API framework resolves its configuration directory to `app/etc` of the installation that serves `TESTS_BASE_URL`.

As a result:

* `Application::cleanup()` runs `bin/magento setup:uninstall` with `--magento-init-params` that carry no directory overrides, so the command bootstraps the **deployed** `app/etc/env.php` and drops every table of the database that file points at — the developer's main database, not `magento_functional_tests`.
* `WebApiApplication::install()` then runs `setup:install`, which rewrites that same `app/etc/env.php` (including the encryption key) to the test database.

Both steps are inherent to the design: the tests send HTTP requests to the installation under `TESTS_BASE_URL`, so the framework must install *in place*. What is not acceptable is doing that silently against a database the test configuration never names.

**Fix**

`WebApiApplication::install()` now aborts before any destructive command when the database in `TESTS_INSTALL_CONFIG_FILE` differs from the database of the already installed application, with a message naming both databases and the two ways forward (align the install config, or set `TESTS_MAGENTO_INSTALLATION` to `disabled`).

When the two databases match — the case in CI and in a correctly configured local setup — nothing changes: `setup:uninstall` and `setup:install` run exactly as before.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#36291: API functional tests drop all tables from main database

### Manual testing scenarios

**Data loss is prevented (mismatching databases)**

1. Install Magento into database `magento` and confirm the tables exist.
2. Copy `dev/tests/api-functional/config/install-config-mysql.php.dist` to `install-config-mysql.php`, leaving `db-name` as `magento_functional_tests`.
3. Copy `phpunit_graphql.xml.dist` to `phpunit_graphql.xml` and set `TESTS_MAGENTO_INSTALLATION` to `enabled` (`TESTS_CLEANUP` stays `enabled`).
4. Run `cd dev/tests/api-functional && ../../../vendor/bin/phpunit -c phpunit_graphql.xml`.
5. **Before the fix:** the bootstrap runs `setup:uninstall` and all tables of `magento` are dropped.
   **After the fix:** the bootstrap fails immediately with

   > Web API functional tests are configured to install Magento into the "magento_functional_tests" database, but the installation in "/var/www/html/app/etc" uses the "magento" database. Installing would drop all tables of "magento" and overwrite its deployment configuration, because Web API functional tests reuse the application they send requests to. Either configure the test installation to use the "magento" database, or set TESTS_MAGENTO_INSTALLATION to "disabled" to run the tests against the already installed application.

   and the `magento` database is untouched (verified: table count unchanged).

**No false positive (matching databases)**

1. Set `db-name` in `install-config-mysql.php` to the database of the installed application.
2. Run the suite again — the bootstrap proceeds and issues `setup:uninstall`, `setup:install`, `indexer:set-mode realtime` and `indexer:reindex` in the same order as before this change.

**Installation disabled (default)**

With `TESTS_MAGENTO_INSTALLATION=disabled` (the shipped default) `install()` is never called, so the guard is not reached and existing workflows are unaffected.

### Questions or comments

The guard compares database names only. Host comparison was deliberately left out to avoid false positives from equivalent spellings (`localhost` vs `127.0.0.1`) that would break existing setups.

No automated test is included: `dev/tests/api-functional/framework` is not covered by any registered PHPUnit suite (`dev/tests/unit/phpunit.xml.dist` does not include it, and the framework has no `tests/unit` harness of its own, unlike `dev/tests/integration/framework`). Both branches of the guard were verified manually as described above. Happy to add a suite for the Web API framework if maintainers want that scope.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [ ] All new or changed code is covered with unit/integration tests (if applicable) — see "Questions or comments"
- [x] All automated tests passed successfully (all builds are green)
