### PR TITLE
Build cache tag id lists in one array_merge call (#41098)

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapters/FilesystemTagAdapter.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapters/FilesystemTagAdapter.php
@@ -180,13 +180,12 @@ class FilesystemTagAdapter implements TagAdapterInterface
             return [];
         }
 
-        $ids = [];
+        $idsPerTag = [];
         foreach ($tags as $tag) {
-            // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-            $ids = array_merge($ids, $this->getTagIds($tag));
+            $idsPerTag[] = $this->getTagIds($tag);
         }
 
-        return array_values(array_unique($ids));
+        return array_values(array_unique(array_merge(...$idsPerTag)));
     }
 
     /**
@@ -218,7 +217,7 @@ class FilesystemTagAdapter implements TagAdapterInterface
      */
     private function getAllIds(): array
     {
-        $allIds = [];
+        $idsPerTag = [];
         $tagFiles = glob($this->tagDirectory . '*');
 
         if ($tagFiles === false) {
@@ -227,14 +226,11 @@ class FilesystemTagAdapter implements TagAdapterInterface
 
         foreach ($tagFiles as $file) {
             if (is_file($file)) {
-                $tag = basename($file);
-                $ids = $this->getTagIds($tag);
-                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $allIds = array_merge($allIds, $ids);
+                $idsPerTag[] = $this->getTagIds(basename($file));
             }
         }
 
-        return array_values(array_unique($allIds));
+        return array_values(array_unique(array_merge(...$idsPerTag)));
     }
 
     /**

--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapters/RedisTagAdapter.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapters/RedisTagAdapter.php
@@ -408,19 +408,16 @@ LUA;
         // Matches Zend's implementation to prevent Redis slowdowns
         // @see vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php line 777-778
         if (count($tags) > self::SUNION_CHUNK_SIZE) {
-            $allIds = [];
+            $idsPerChunk = [];
             $chunks = array_chunk($tags, self::SUNION_CHUNK_SIZE);
 
             foreach ($chunks as $chunk) {
                 $tagKeys = array_map([$this, 'getTagKey'], $chunk);
                 $chunkIds = $this->redis->sUnion($tagKeys);
-                $chunkIds = is_array($chunkIds) ? $chunkIds : [];
-
-                // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $allIds = array_merge($allIds, $chunkIds);
+                $idsPerChunk[] = is_array($chunkIds) ? $chunkIds : [];
             }
 
-            return array_unique($allIds);
+            return array_unique(array_merge(...$idsPerChunk));
         }
 
         $tagKeys = array_map([$this, 'getTagKey'], $tags);


### PR DESCRIPTION
### Fixed Issues (if relevant)

1. Relates to magento/magento2#41098 — scope analysis and measurements for the whole pattern.
   That issue covers three modules, so this pull request is one of three and does not close it on its own.

### Description (*)

Cleaning the cache by tags goes through `Symfony::clean()`, which calls
`TagAdapterInterface::getIdsMatchingAnyTags()` (`CLEANING_MODE_MATCHING_ANY_TAG`) or
`::getIdsNotMatchingTags()` (`CLEANING_MODE_NOT_MATCHING_TAG`). Three of those loops merged
each tag's id list into an accumulator on every iteration:

```php
$ids = [];
foreach ($tags as $tag) {
    $ids = array_merge($ids, $this->getTagIds($tag));   // copies everything collected so far
}
```

`array_merge()` allocates a new array and copies both operands, so a loop of this shape
copies the whole partial result once per iteration — the total work grows with the square of
the number of tags, not linearly. `FilesystemTagAdapter::getAllIds()` does it once per tag
file in the cache directory, and a store that invalidates by entity tags accumulates a large
number of those.

The three loops now collect the per-tag lists and merge them once with argument unpacking:

```php
$idsPerTag = [];
foreach ($tags as $tag) {
    $idsPerTag[] = $this->getTagIds($tag);
}

return array_values(array_unique(array_merge(...$idsPerTag)));
```

Same arrays, same order, same de-duplication — only the number of copies changes. The
`// phpcs:ignore Magento2.Performance.ForeachArrayMerge` annotations that were needed to keep
these lines quiet are gone.

`RedisTagAdapter::getIdsMatchingAnyTags()` gets the same treatment for its chunked `SUNION`
path (chunks of 500 tags, so the loop runs once per 500 tags).

#### Measured effect

`FilesystemTagAdapter` against a synthetic tag directory (20 ids per tag), PHP 8.5, median of
5 runs for 5 000 tags, single run for 20 000:

| tags | method | before | after | |
|---|---|---|---|---|
| 5 000 | `getIdsMatchingAnyTags()` | 3 097 ms | 1 013 ms | 3.1× |
| 5 000 | `getIdsNotMatchingTags()` | 1 998 ms | 395 ms | 5.1× |
| 20 000 | `getIdsMatchingAnyTags()` | 33 271 ms | 4 185 ms | 7.9× |
| 20 000 | `getIdsNotMatchingTags()` | 27 823 ms | 1 686 ms | 16.5× |

The remaining time is file reads and `array_unique()`, which this change does not touch. The
benchmark script is a plain PHP file that instantiates the adapter with a stub
`CacheItemPoolInterface` and a temporary tag directory — happy to add it to the description
if that helps review.

#### Related

The sniff that is supposed to catch this shape, `Magento2.Performance.ForeachArrayMerge`,
warns on *every* `array_merge` inside a `for`/`foreach` body — including calls that copy a
constant amount of data — and never looks inside `while`/`do` bodies at all. That is why
2.4-develop carries 77 `phpcs:ignore Magento2.Performance.ForeachArrayMerge` annotations,
and why these three loops were annotated instead of fixed.

magento/magento-coding-standard#503 narrows the sniff to the accumulating shape and adds
`while`/`do` coverage (126 raw detections in 2.4-develop → 74, one new true finding). Reviewing
and merging it would make the remaining suppressions in this repository meaningful again — the
core team's input there is very welcome.

### Manual testing scenarios (*)

1. Configure the Symfony filesystem cache adapter, warm the cache so that the tag directory
   holds a large number of tag files.
2. Invalidate by tag (`bin/magento cache:clean <type>`, or save a product so `catalog_product_*`
   tags are cleaned) and confirm exactly the same cache entries are removed as before.
3. `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist lib/internal/Magento/Framework/Cache/Test/Unit/`
   — 336 tests green, including `FilesystemTagAdapterTest` and `RedisTagAdapterTest`.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (all builds are green)
