### PR TITLE
Build flat table column and index maps in one array_merge call (#41098)

### DIFF
--- a/app/code/Magento/Catalog/Helper/Product/Flat/Indexer.php
+++ b/app/code/Magento/Catalog/Helper/Product/Flat/Indexer.php
@@ -246,7 +246,7 @@ class Indexer extends \Magento\Framework\App\Helper\AbstractHelper implements Re
     public function getFlatColumns()
     {
         if ($this->_columns === null) {
-            $this->_columns = $this->getFlatColumnsDdlDefinition();
+            $columnsPerAttribute = [$this->getFlatColumnsDdlDefinition()];
             foreach ($this->getAttributes() as $attribute) {
                 /** @var $attribute \Magento\Eav\Model\Entity\Attribute\AbstractAttribute */
                 $columns = $attribute->setFlatAddFilterableAttributes(
@@ -255,10 +255,10 @@ class Indexer extends \Magento\Framework\App\Helper\AbstractHelper implements Re
                     $this->isAddChildData()
                 )->getFlatColumns();
                 if ($columns !== null) {
-                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                    $this->_columns = array_merge($this->_columns, $columns);
+                    $columnsPerAttribute[] = $columns;
                 }
             }
+            $this->_columns = array_merge(...$columnsPerAttribute);
         }
         return $this->_columns;
     }
@@ -409,6 +409,7 @@ class Indexer extends \Magento\Framework\App\Helper\AbstractHelper implements Re
                 'fields' => ['attribute_set_id'],
             ];
 
+            $indexesPerAttribute = [$this->_indexes];
             foreach ($this->getAttributes() as $attribute) {
                 /** @var $attribute \Magento\Eav\Model\Entity\Attribute */
                 $indexes = $attribute->setFlatAddFilterableAttributes(
@@ -417,10 +418,10 @@ class Indexer extends \Magento\Framework\App\Helper\AbstractHelper implements Re
                     $this->isAddChildData()
                 )->getFlatIndexes();
                 if ($indexes !== null) {
-                    // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                    $this->_indexes = array_merge($this->_indexes, $indexes);
+                    $indexesPerAttribute[] = $indexes;
                 }
             }
+            $this->_indexes = array_merge(...$indexesPerAttribute);
         }
         return $this->_indexes;
     }


### PR DESCRIPTION
### Fixed Issues (if relevant)

1. Relates to magento/magento2#41098 — scope analysis and measurements for the whole pattern.
   That issue covers three modules, so this pull request is one of three and does not close it on its own.

### Description (*)

`Catalog\Helper\Product\Flat\Indexer::getFlatColumns()` and `::getFlatIndexes()` build the flat
table structure by merging each attribute's contribution into the map accumulated so far:

```php
$this->_columns = $this->getFlatColumnsDdlDefinition();
foreach ($this->getAttributes() as $attribute) {
    $columns = $attribute->...->getFlatColumns();
    if ($columns !== null) {
        $this->_columns = array_merge($this->_columns, $columns);   // copies the whole map
    }
}
```

`array_merge()` allocates a new array and copies both operands, so a loop of this shape copies
the entire partial map once per attribute. The work grows with the square of the attribute
count while the useful output grows linearly. Both loops run once per flat attribute, and the
methods are called per store while (re)building `catalog_product_flat_*`.

Both loops now collect the per-attribute maps and merge them once with argument unpacking:

```php
$columnsPerAttribute = [$this->getFlatColumnsDdlDefinition()];
foreach ($this->getAttributes() as $attribute) {
    $columns = $attribute->...->getFlatColumns();
    if ($columns !== null) {
        $columnsPerAttribute[] = $columns;
    }
}
$this->_columns = array_merge(...$columnsPerAttribute);
```

The merge order is unchanged, so a later attribute still overrides an earlier key exactly as
before. The `// phpcs:ignore Magento2.Performance.ForeachArrayMerge` annotations on both lines
are no longer needed.

#### Measured effect

Merge cost only (attribute loading excluded, so this isolates what the change touches), PHP
8.5, median of 5 runs, one column per attribute:

| flat attributes | accumulating merge | single merge |
|---|---|---|
| 200 | 0.18 ms | 0.006 ms |
| 500 | 1.05 ms | 0.015 ms |
| 1 000 | 4.13 ms | 0.032 ms |
| 2 000 | 16.04 ms | 0.060 ms |

Modest per call in absolute terms, and it is paid per store on every flat rebuild — a
multi-store installation with a wide attribute set pays it repeatedly. The shape is also the
thing the coding standard asks contributors not to write, so the annotations disappearing is
part of the point.

#### Related

`Magento2.Performance.ForeachArrayMerge` is the sniff meant to catch this shape, but it warns
on *every* `array_merge` inside a `for`/`foreach` body — including calls that copy a constant
amount of data — and never inspects `while`/`do` bodies. 2.4-develop carries 77
`phpcs:ignore Magento2.Performance.ForeachArrayMerge` annotations as a result, these two among
them.

magento/magento-coding-standard#503 narrows the sniff to the accumulating shape and adds
`while`/`do` coverage (126 raw detections in 2.4-develop → 74, plus one new true finding).
Reviewing and merging it would make the remaining suppressions meaningful again — input from
the core team there is very welcome.

### Manual testing scenarios (*)

1. Enable *Stores > Configuration > Catalog > Catalog > Storefront > Use Flat Catalog Product*.
2. Run `bin/magento indexer:reindex catalog_product_flat` and confirm the generated
   `catalog_product_flat_*` tables have the same columns and indexes as before the change
   (`SHOW CREATE TABLE catalog_product_flat_1`).
3. Add a filterable attribute to the default attribute set, reindex again, confirm the new
   column and its index appear.
4. `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/Catalog/Test/Unit/Helper/`
   — 44 tests green.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All automated tests passed successfully (all builds are green)
