### PR TITLE
Fix silent fallback to file sessions when session/save is set to Valkey

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -318,11 +318,23 @@
         </arguments>
     </type>
     <preference for="Magento\Framework\Session\SaveHandlerInterface" type="Magento\Framework\Session\SaveHandler" />
+    <virtualType name="Magento\Framework\Session\SaveHandler\Valkey\Logger" type="Magento\Framework\Session\SaveHandler\Redis\Logger">
+        <arguments>
+            <argument name="config" xsi:type="object">Magento\Framework\Session\SaveHandler\Valkey\Config</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Magento\Framework\Session\SaveHandler\Valkey" type="Magento\Framework\Session\SaveHandler\Redis">
+        <arguments>
+            <argument name="config" xsi:type="object">Magento\Framework\Session\SaveHandler\Valkey\Config</argument>
+            <argument name="logger" xsi:type="object">Magento\Framework\Session\SaveHandler\Valkey\Logger</argument>
+        </arguments>
+    </virtualType>
     <type name="Magento\Framework\Session\SaveHandlerFactory">
         <arguments>
             <argument name="handlers" xsi:type="array">
                 <item name="db" xsi:type="string">Magento\Framework\Session\SaveHandler\DbTable</item>
                 <item name="redis" xsi:type="string">Magento\Framework\Session\SaveHandler\Redis</item>
+                <item name="valkey" xsi:type="string">Magento\Framework\Session\SaveHandler\Valkey</item>
             </argument>
         </arguments>
     </type>

--- a/lib/internal/Magento/Framework/Session/SaveHandler/Valkey/Config.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Valkey/Config.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Magento\Framework\Session\SaveHandler\Valkey;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\DeploymentConfig;
+use Magento\Framework\App\State;
+use Magento\Framework\Session\SaveHandler\Redis\Config as RedisConfig;
+use Magento\Setup\Model\ConfigOptionsList\Session as SessionConfig;
+
+/**
+ * Valkey session save handler
+ */
+class Config extends RedisConfig
+{
+    public function __construct(
+        private readonly DeploymentConfig $deploymentConfig,
+        private readonly State $appState,
+        ScopeConfigInterface $scopeConfig
+    ) {
+        parent::__construct($deploymentConfig, $appState, $scopeConfig);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLogLevel()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_LOG_LEVEL) ?? parent::getLogLevel();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHost()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_HOST) ?? parent::getHost();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPort()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_PORT) ?? parent::getPort();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDatabase()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_DATABASE) ?? parent::getDatabase();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPassword()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_PASSWORD) ?? parent::getPassword();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTimeout()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_TIMEOUT) ?? parent::getTimeout();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRetries()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_RETRIES) ?? parent::getRetries();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPersistentIdentifier()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_PERSISTENT_IDENTIFIER) ?? parent::getPersistentIdentifier();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCompressionThreshold()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_COMPRESSION_THRESHOLD) ?? parent::getCompressionThreshold();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCompressionLibrary()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_COMPRESSION_LIBRARY) ?? parent::getCompressionLibrary();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMaxConcurrency()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_MAX_CONCURRENCY) ?? parent::getMaxConcurrency();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMinLifetime()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_MIN_LIFETIME) ?? parent::getMinLifetime();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDisableLocking()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_DISABLE_LOCKING) ?? parent::getDisableLocking();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBotLifetime()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_BOT_LIFETIME) ?? parent::getBotLifetime();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBotFirstLifetime()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_BOT_FIRST_LIFETIME) ?? parent::getBotFirstLifetime();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFirstLifetime()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_FIRST_LIFETIME) ?? parent::getFirstLifetime();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBreakAfter()
+    {
+        return $this->deploymentConfig->get('session/valkey/break_after_' . $this->appState->getAreaCode()) ?? parent::getBreakAfter();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSentinelServers()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_SENTINEL_SERVERS) ?? parent::getSentinelServers();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSentinelMaster()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_SENTINEL_MASTER) ?? parent::getSentinelMaster();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSentinelVerifyMaster()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_SENTINEL_VERIFY_MASTER) ?? parent::getSentinelVerifyMaster();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSentinelConnectRetries()
+    {
+        return $this->deploymentConfig->get(SessionConfig::CONFIG_PATH_SESSION_VALKEY_SENTINEL_CONNECT_RETRIES) ?? parent::getSentinelConnectRetries();
+    }
+}


### PR DESCRIPTION
### Description (*)
`Magento\Framework\Session\SaveHandlerFactory` registers only the `db` and `redis` session save handlers (`app/etc/di.xml`). However, `bin/magento setup:config:set --session-save=valkey` is a documented, supported command that writes `session/save = valkey` plus a `session/valkey` connection group to `app/etc/env.php`.

Because `valkey` is missing from the `handlers` map, falls back to the default `files` handler **with no log entry**, so sessions are written to `var/session` even though the store is configured for Valkey. The failure is invisible to operators.

The 2.4.9 Valkey work added `Magento\Framework\Cache\Backend\Valkey` and the `--session-save=valkey` / `--session-save-valkey-*` CLI options, but the matching session `SaveHandlerFactory` registration was never added.

This PR registers the `valkey` save handler, reusing the Redis-compatible session handler and reading connection parameters from the `session/valkey`/`session/redis` deployment-config group.

### Related Pull Requests
None.

### Fixed Issues (if relevant)
None.

### Manual testing scenarios (*)
1. On a 2.4.9 install with Valkey running, configure Valkey sessions:
```
bin/magento setup:config:set --session-save=valkey \
--session-save-valkey-host=127.0.0.1 \
--session-save-valkey-port=6379 \
--session-save-valkey-db=2 
bin/magento cache:flush
```
2. Open the storefront and create a session (add to cart / log in).
3. **Before:** new files appear under `var/session`, and `valkey-cli -n 2 --scan` returns no session keys — silent fallback to files.
4. **After:** sessions are stored in Valkey — `valkey-cli -n 2 --scan` returns `sess_*` keys and `valkey-cli -n 2 dbsize` grows, while `var/session` stops growing.
5. Regression: `--session-save=redis`, `--session-save=db`, and `--session-save=files` continue to work unchanged.

### Questions or comments
None.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41108: Fix silent fallback to file sessions when session/save is set to Valkey