### PR TITLE
Use tax-display-aware selectors in cart ensure-subtotal-sync

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/cart/ensure-subtotal-sync.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/cart/ensure-subtotal-sync.js
@@ -46,9 +46,24 @@ define([
         function getCentralSubtotal()
         {
             // Sum of row totals on the table
-            let sum = 0;
+            let sum = 0,
+                $prices = $root.find(
+                    '#shopping-cart-table .col.subtotal .price-excluding-tax .cart-price'
+                );
 
-            $root.find('#shopping-cart-table .col.subtotal .price-excluding-tax .cart-price').each(function () {
+            // Including-tax display renders .price-including-tax only; both-prices mode
+            // keeps excl-tax first so central and summary stay on the same tax basis.
+            if (!$prices.length) {
+                $prices = $root.find(
+                    '#shopping-cart-table .col.subtotal .price-including-tax .cart-price'
+                );
+            }
+
+            if (!$prices.length) {
+                $prices = $root.find('#shopping-cart-table .col.subtotal .cart-price');
+            }
+
+            $prices.each(function () {
                 const text = $(this).text(), val = parsePrice(text);
 
                 if (!isNaN(val)) {


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

### Description (*)

`Magento_Checkout/js/cart/ensure-subtotal-sync` compares the sum of cart-table row subtotals with the Knockout summary subtotal, and when they differ it reloads the cart via `GET /checkout/cart/?ajax=1`.

`getCentralSubtotal()` only selected `.price-excluding-tax .cart-price`. With **Display Prices / Display Subtotal = Including Tax** (`tax/cart_display/* = 2`), Magento's row price template renders `.price-including-tax .cart-price` only. The central sum stays `0`, the summary is non-zero, and Magento always treats the cart as out of sync after paint — even when the visible amounts already match.

This change prefers excl-tax prices when present (both-prices mode), then falls back to incl-tax, then bare `.cart-price`.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#41100

### Manual testing scenarios (*)

1. Set `Stores > Configuration > Sales > Tax > Shopping Cart Display Settings`:
   - Display Prices = Including Tax
   - Display Subtotal = Including Tax
2. Flush config + full page cache.
3. Add a simple product to the cart and open `/checkout/cart/`.
4. In DevTools Network, confirm there is **no** `GET /checkout/cart/?ajax=1` after Knockout totals render.
5. Confirm table row subtotals still match the summary Subtotal.
6. Repeat with Display Prices / Subtotal = **Excluding Tax** and confirm behavior is unchanged (still no false sync reload when amounts match).
7. Optional: Display Both Prices — central sum should use excl-tax nodes and still match the summary basis Magento shows for Subtotal.

### Questions or comments

Reproduced on Magento 2.4.9 and confirmed the same selector exists on current `2.4-develop`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)