### PR TITLE
#40704: Prevent full table scan in sales order child collections for orders without an id

### DIFF
--- a/app/code/Magento/Sales/Model/ResourceModel/Order/Collection/AbstractCollection.php
+++ b/app/code/Magento/Sales/Model/ResourceModel/Order/Collection/AbstractCollection.php
@@ -67,6 +67,9 @@ abstract class AbstractCollection extends \Magento\Sales\Model\ResourceModel\Col
             if ($orderId) {
                 $this->addFieldToFilter($this->_orderField, $orderId);
             } else {
+                // An order without an ID has no related entities. Filter on an ID that can never match, so that
+                // resetting the loaded state (clear(), _reset()) cannot turn this into an unfiltered table scan.
+                $this->addFieldToFilter($this->_orderField, 0);
                 $this->_totalRecords = 0;
                 $this->_setIsLoaded(true);
             }

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/ResourceModel/Order/Collection/AbstractCollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/ResourceModel/Order/Collection/AbstractCollectionTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\ResourceModel\Order\Collection;
+
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Sales\Api\Data\OrderInterfaceFactory;
+use Magento\Sales\Model\ResourceModel\Order\Invoice\CollectionFactory as InvoiceCollectionFactory;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class AbstractCollectionTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+    }
+
+    /**
+     * An order without an ID has no related entities, even after the loaded state of the collection is reset.
+     *
+     * @magentoDataFixture Magento/Sales/_files/invoice.php
+     */
+    public function testSetOrderFilterKeepsCollectionEmptyForOrderWithoutId(): void
+    {
+        $order = $this->objectManager->get(OrderInterfaceFactory::class)->create();
+
+        $collection = $this->objectManager->get(InvoiceCollectionFactory::class)
+            ->create()
+            ->setOrderFilter($order);
+
+        $this->assertSame(0, $collection->getSize());
+        $this->assertCount(0, $collection->getItems());
+
+        $collection->clear();
+
+        $this->assertSame(0, $collection->getSize());
+        $this->assertCount(0, $collection->getItems());
+    }
+}


### PR DESCRIPTION
### Description

`Magento\Sales\Model\ResourceModel\Order\Collection\AbstractCollection::setOrderFilter()` handles an order without an ID by faking the loaded state instead of constraining the select:

```php
} else {
    $this->_totalRecords = 0;
    $this->_setIsLoaded(true);
}
```

No condition is added to `_select`, so the select still matches every row of `sales_invoice` / `sales_shipment` / `sales_creditmemo`. As long as nothing touches the loaded state, the collection behaves correctly. But any reset of that state re-opens the unfiltered select:

- `Magento\Framework\Data\Collection::clear()` sets `_isCollectionLoaded = false` and `_totalRecords = null`
- `Magento\Framework\Data\Collection\AbstractDb::_reset()` sets `_isCollectionLoaded = false`

After either of those, the next `load()` or `getSize()` runs against the whole table — a full table scan returning unrelated invoices, shipments or credit memos for an order that has none.

### Fixed Issues

Reported by @ln8711 in https://github.com/magento/magento2/issues/40704#issuecomment-5207435819 while reviewing #40731.

Related to #40704.

### Manual testing scenarios

1. Have at least one invoice in the database.
2. Build a collection for an order that has no ID:

```php
$order = $orderFactory->create();
$collection = $invoiceCollectionFactory->create()->setOrderFilter($order);
$collection->clear();
var_dump($collection->getSize(), count($collection->getItems()));
```

Before: `getSize()` reports the total number of invoices in the table and `getItems()` returns them.
After: both report `0`, and the emitted SQL carries `parent_id = 0`.

### Questions or comments

The `_setIsLoaded(true)` shortcut is kept on purpose — it keeps the common "new order, no children yet" path free of any query during order placement. The added filter only guarantees that a reset cannot degrade into a table scan.

Covered by a new integration test in `Magento\Sales\Model\ResourceModel\Order\Collection\AbstractCollectionTest`.
