### PR TITLE
Fix 400 Bad Request on guest virtual checkout when setting payment

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/action/set-payment-information-extended.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/action/set-payment-information-extended.js
@@ -55,7 +55,7 @@ define([
             serviceUrl = urlBuilder.createUrl('/guest-carts/:cartId/set-payment-information', {
                 cartId: quote.getQuoteId()
             });
-            payload.email = quote.guestEmail;
+            payload.email = quote.guestEmail || '';
         } else {
             serviceUrl = urlBuilder.createUrl('/carts/mine/set-payment-information', {});
         }


### PR DESCRIPTION
### Description (*)
Fixes an intermittent HTTP 400 Bad Request error on guest checkout for virtual products (or checkouts without a shipping step) when only a single payment method is available.

#### Root Cause
On a guest virtual checkout (where the shipping step is absent), the payment step renders immediately upon page load. If there is only **one payment method available**, `Magento_Checkout/js/model/payment-service::setPaymentMethods()` automatically selects it via `selectPaymentMethod(filteredMethods[0])`:
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/web/js/model/payment-service.js#L54

This triggers a call to save payment information before the guest user has typed an email address into the checkout form. At this point, `quote.guestEmail` is still `undefined` or `null`.

When sending the REST API request to `/V1/guest-carts/:cartId/set-payment-information`, `JSON.stringify()` drops keys with `undefined` values (or omits non-string types). 

Since `\Magento\Quote\Api\GuestPaymentInformationManagementInterface::savePaymentInformation()` defines `$email` as a required scalar parameter without a default value, Magento's Webapi `ServiceInputProcessor` fails validation and throws an `InputException`: `"email" is required. Enter and try again.`

Passing `quote.guestEmail || ''` ensures that `"email": ""` is present in the payload, satisfying Webapi requirements when `quote.guestEmail` is still `undefined` or `null`, until the user actually inputs their email address.

### Related Issue (#)
N/A

### Fixed Issues (if relevant)
1. Fixes HTTP 400 error on guest virtual checkout when a single payment method is auto-selected upon initial page load.

### Manual testing scenarios (*)
1. Ensure the store configuration has only **one active payment method** available for guest checkout.
2. Add a virtual product to the shopping cart as a guest user.
3. Open a clean/incognito session and proceed to Checkout (`/checkout/#payment`).
4. Open Browser DevTools -> **Console** and **Network** tabs.
5. Observe the initial POST request to `/rest/default/V1/guest-carts/{cart_id}/set-payment-information`.

#### Actual Result (Before fix)
The request returns **HTTP 400 Bad Request** with response body:
`{"message":"\"%fieldName\" is required. Enter and try again.","parameters":{"fieldName":"email"}}`

#### Expected Result (After fix)
The request completes successfully without Webapi payload schema validation failure.

### Questions or comments
N/A

### Contribution checklist (*)
- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests pass locally

### Resolved issues:
1. [x] resolves magento/magento2#41112: Fix 400 Bad Request on guest virtual checkout when setting payment