### PR TITLE
fix: Typo in email_template.template_styles column comment

### DIFF
--- a/app/code/Magento/Email/etc/db_schema.xml
+++ b/app/code/Magento/Email/etc/db_schema.xml
@@ -12,7 +12,7 @@
                 comment="Template ID"/>
         <column xsi:type="varchar" name="template_code" nullable="false" length="150" comment="Template Name"/>
         <column xsi:type="text" name="template_text" nullable="false" comment="Template Content"/>
-        <column xsi:type="text" name="template_styles" nullable="true" comment="Templste Styles"/>
+        <column xsi:type="text" name="template_styles" nullable="true" comment="Template Styles"/>
         <column xsi:type="int" name="template_type" unsigned="true" nullable="true" identity="false"
                 comment="Template Type"/>
         <column xsi:type="varchar" name="template_subject" nullable="false" length="200" comment="Template Subject"/>


### PR DESCRIPTION
"Templste" should be "Template"

### Description (*)
Fixing a typo in the column description for `email_template.template_styles`.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios (*)
Run setup:upgrade and check the column in your database.

### Questions or comments
N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41125: fix: Typo in email_template.template_styles column comment