### PR TITLE
Keep grid filters when adding a partially deselected selection (#38582)

### DIFF
--- a/app/code/Magento/Ui/view/base/web/js/form/components/insert-listing.js
+++ b/app/code/Magento/Ui/view/base/web/js/form/components/insert-listing.js
@@ -276,7 +276,14 @@ define([
             _.extend(selectionsData, this.params || {}, selections.params);
 
             if (selections[itemsType] && selections[itemsType].length) {
-                selectionsData.filters = {};
+                /**
+                 * In exclude mode the request is constrained by 'nin' on the excluded ids only,
+                 * so the applied grid filters must be preserved - otherwise the whole
+                 * unfiltered collection (minus excluded ids) would be requested.
+                 */
+                if (!selections.excludeMode) {
+                    selectionsData.filters = {};
+                }
                 selectionsData['filters_modifier'] = {};
                 selectionsData['filters_modifier'][this.indexField] = {
                     'condition_type': filterType,

--- a/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/components/insert-listing.test.js
+++ b/dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/components/insert-listing.test.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+/* eslint-disable max-nested-callbacks */
+define([
+    'Magento_Ui/js/form/components/insert-listing'
+], function (Constr) {
+    'use strict';
+
+    describe('Magento_Ui/js/form/components/insert-listing', function () {
+        describe('"updateFromServerData" method', function () {
+            var context,
+                requestedData;
+
+            beforeEach(function () {
+                requestedData = null;
+
+                context = {
+                    indexField: 'entity_id',
+                    params: {},
+                    requestConfig: {
+                        method: 'POST'
+                    },
+
+                    /**
+                     * Captures the payload the component would send to the server.
+                     *
+                     * @param {Object} data
+                     * @returns {Object}
+                     */
+                    requestData: function (data) {
+                        requestedData = data;
+
+                        return {
+                            /** Stub */
+                            done: function () {
+                                return this;
+                            },
+
+                            /** Stub */
+                            fail: function () {
+                                return this;
+                            }
+                        };
+                    },
+
+                    /** Stub */
+                    setExternalValue: function () {},
+
+                    /** Stub */
+                    loading: function () {},
+
+                    /** Stub */
+                    onError: function () {}
+                };
+            });
+
+            it('keeps applied grid filters when rows are excluded from the selection', function () {
+                var selections = {
+                    excluded: ['1', '2'],
+                    selected: [],
+                    excludeMode: true,
+                    params: {
+                        filters: {
+                            name: 'Bag'
+                        },
+                        namespace: 'product_listing'
+                    }
+                };
+
+                Constr.prototype.updateFromServerData.call(context, selections, 'excluded');
+
+                expect(requestedData.filters).toEqual({
+                    name: 'Bag'
+                });
+                expect(requestedData['filters_modifier']['entity_id']).toEqual({
+                    'condition_type': 'nin',
+                    value: ['1', '2']
+                });
+            });
+
+            it('resets applied grid filters when rows are explicitly selected', function () {
+                var selections = {
+                    excluded: [],
+                    selected: ['1', '2'],
+                    excludeMode: false,
+                    params: {
+                        filters: {
+                            name: 'Bag'
+                        },
+                        namespace: 'product_listing'
+                    }
+                };
+
+                Constr.prototype.updateFromServerData.call(context, selections, 'selected');
+
+                expect(requestedData.filters).toEqual({});
+                expect(requestedData['filters_modifier']['entity_id']).toEqual({
+                    'condition_type': 'in',
+                    value: ['1', '2']
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Description (*)

When a grid is embedded in a form through `insertListing` (Related Products, Up-Sells and Cross-Sells being the most visible case), selecting rows and then deselecting a few of them switches the selections provider into **exclude mode**: the selection is expressed as "everything matching the current filters, except these ids".

`Magento\Ui\view\base\web\js\form\components\insert-listing.js::updateFromServerData()` builds the request for the selected rows and, whenever there is a non-empty id list, clears the filtering state that was just imported from the grid:

```js
_.extend(selectionsData, this.params || {}, selections.params);

if (selections[itemsType] && selections[itemsType].length) {
    selectionsData.filters = {};                       // <- applied grid filters dropped
    selectionsData['filters_modifier'] = {};
    selectionsData['filters_modifier'][this.indexField] = {
        'condition_type': filterType,                  // 'nin' in exclude mode
        value: selections[itemsType]
    };
}

selectionsData.paging = {
    notLimits: 1
};
```

In include mode this is harmless — the explicit `in` list fully constrains the result. In exclude mode the only remaining constraint is `nin` on the handful of excluded ids, so together with `paging.notLimits = 1` the modal requests the **entire product collection minus the excluded ids** instead of the filtered subset. On a catalog with thousands of products the response is huge, the grid never finishes rendering and the product form appears to hang.

This also explains the two workarounds reported in the issue: adding all filtered rows without deselecting any keeps `excluded` empty so the branch is never entered, and raising the page limit so that every selected row is present on the current page makes `canUpdateFromClientData()` return `true`, skipping the server request entirely.

The fix keeps the applied filters in exclude mode and leaves include-mode behaviour untouched.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38582 — Related/up-sells/cross-sells products are not being added and product edit page gets break

### Manual testing scenarios (*)

1. Install a Magento instance with a large catalog (4000+ products, e.g. `setup/performance-toolkit/profiles/ce/medium.xml`).
2. Open any product in the admin panel and go to **Related Products, Up-Sells, and Cross-Sells** → **Add Related Products**.
3. Apply a filter that matches ~60 products.
4. Click **Select All**, then deselect a few products from the filtered list.
5. Click **Add Selected Products**.

Expected result: only the remaining filtered products are added and the form stays responsive.
Actual result before the fix: the request returns the whole catalog minus the deselected ids and the product edit page hangs.

The same scenario applies to Up-Sells and Cross-Sells, and to any other `insertListing`-based modal.

### Questions or comments

Automated coverage is added in `dev/tests/js/jasmine/tests/app/code/Magento/Ui/base/js/form/components/insert-listing.test.js`, asserting that the request payload keeps the grid filters in exclude mode and still resets them in include mode. Verified that the new exclude-mode expectation fails against the unpatched component.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
