### PR TITLE
Split monolithic designLoader plugin into design, translation and design change plugins (#29735)

### DIFF
--- a/app/code/Magento/Theme/Plugin/AbstractDesignLoaderPlugin.php
+++ b/app/code/Magento/Theme/Plugin/AbstractDesignLoaderPlugin.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Plugin;
+
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\Config\Dom\ValidationException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Framework\Message\MessageInterface;
+use Magento\Framework\View\DesignLoader;
+
+/**
+ * Loads a single part of the design before the Action is executed
+ *
+ * Handles Exceptions raised while the design configuration is being loaded.
+ */
+abstract class AbstractDesignLoaderPlugin
+{
+    /**
+     * @var DesignLoader
+     */
+    protected $designLoader;
+
+    /**
+     * @var MessageManagerInterface
+     */
+    protected $messageManager;
+
+    /**
+     * @param DesignLoader $designLoader
+     * @param MessageManagerInterface $messageManager
+     */
+    public function __construct(
+        DesignLoader $designLoader,
+        MessageManagerInterface $messageManager
+    ) {
+        $this->designLoader = $designLoader;
+        $this->messageManager = $messageManager;
+    }
+
+    /**
+     * Load the part of the design this plugin is responsible for
+     *
+     * @return void
+     */
+    abstract protected function loadPart(): void;
+
+    /**
+     * Initialize the part of the design this plugin is responsible for
+     *
+     * @param ActionInterface $subject
+     * @return void
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function beforeExecute(ActionInterface $subject)
+    {
+        try {
+            $this->loadPart();
+        } catch (LocalizedException $e) {
+            if ($e->getPrevious() instanceof ValidationException) {
+                /** @var MessageInterface $message */
+                $message = $this->messageManager
+                    ->createMessage(MessageInterface::TYPE_ERROR)
+                    ->setText($e->getMessage());
+                $this->messageManager->addUniqueMessages([$message]);
+            }
+        }
+    }
+}

--- a/app/code/Magento/Theme/Plugin/ApplyDesignChangePlugin.php
+++ b/app/code/Magento/Theme/Plugin/ApplyDesignChangePlugin.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Plugin;
+
+/**
+ * Applies store design change and user-agent design exception before the Action is executed
+ *
+ * Can be disabled for a specific Action that renders no themed output.
+ */
+class ApplyDesignChangePlugin extends AbstractDesignLoaderPlugin
+{
+    /**
+     * Apply store design change or user-agent design exception
+     *
+     * @return void
+     */
+    protected function loadPart(): void
+    {
+        $this->designLoader->applyDesignChange();
+    }
+}

--- a/app/code/Magento/Theme/Plugin/LoadDesignPlugin.php
+++ b/app/code/Magento/Theme/Plugin/LoadDesignPlugin.php
@@ -6,59 +6,18 @@
 
 namespace Magento\Theme\Plugin;
 
-use Magento\Framework\App\ActionInterface;
-use Magento\Framework\Config\Dom\ValidationException;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
-use Magento\Framework\Message\MessageInterface;
-use Magento\Framework\View\DesignLoader;
-
 /**
  * Handling Exceptions on Design Loading
  */
-class LoadDesignPlugin
+class LoadDesignPlugin extends AbstractDesignLoaderPlugin
 {
     /**
-     * @var DesignLoader
-     */
-    private $designLoader;
-
-    /**
-     * @var MessageManagerInterface
-     */
-    private $messageManager;
-
-    /**
-     * @param DesignLoader $designLoader
-     * @param MessageManagerInterface $messageManager
-     */
-    public function __construct(
-        DesignLoader $designLoader,
-        MessageManagerInterface $messageManager
-    ) {
-        $this->designLoader = $designLoader;
-        $this->messageManager = $messageManager;
-    }
-
-    /**
-     * Initialize design
+     * Load the design of the current area
      *
-     * @param ActionInterface $subject
      * @return void
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function beforeExecute(ActionInterface $subject)
+    protected function loadPart(): void
     {
-        try {
-            $this->designLoader->load();
-        } catch (LocalizedException $e) {
-            if ($e->getPrevious() instanceof ValidationException) {
-                /** @var MessageInterface $message */
-                $message = $this->messageManager
-                    ->createMessage(MessageInterface::TYPE_ERROR)
-                    ->setText($e->getMessage());
-                $this->messageManager->addUniqueMessages([$message]);
-            }
-        }
+        $this->designLoader->loadDesign();
     }
 }

--- a/app/code/Magento/Theme/Plugin/LoadDesignPlugin.php
+++ b/app/code/Magento/Theme/Plugin/LoadDesignPlugin.php
@@ -3,6 +3,7 @@
  * Copyright 2020 Adobe
  * All Rights Reserved.
  */
+declare(strict_types=1);
 
 namespace Magento\Theme\Plugin;
 

--- a/app/code/Magento/Theme/Plugin/LoadTranslationPlugin.php
+++ b/app/code/Magento/Theme/Plugin/LoadTranslationPlugin.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Plugin;
+
+/**
+ * Loads translations of the current area before the Action is executed
+ *
+ * Can be disabled for a specific Action that renders no translated output.
+ */
+class LoadTranslationPlugin extends AbstractDesignLoaderPlugin
+{
+    /**
+     * Load translations of the current area
+     *
+     * @return void
+     */
+    protected function loadPart(): void
+    {
+        $this->designLoader->loadTranslation();
+    }
+}

--- a/app/code/Magento/Theme/Test/Unit/Plugin/ApplyDesignChangePluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/ApplyDesignChangePluginTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Test\Unit\Plugin;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\View\DesignLoader;
+use Magento\Theme\Plugin\ApplyDesignChangePlugin;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ApplyDesignChangePluginTest extends TestCase
+{
+    public function testBeforeExecute(): void
+    {
+        /** @var MockObject|ActionInterface $actionMock */
+        $actionMock = $this->createMock(Action::class);
+
+        /** @var MockObject|DesignLoader $designLoaderMock */
+        $designLoaderMock = $this->createMock(DesignLoader::class);
+
+        /** @var MockObject|ManagerInterface $messageManagerMock */
+        $messageManagerMock = $this->createMock(ManagerInterface::class);
+
+        $plugin = new ApplyDesignChangePlugin($designLoaderMock, $messageManagerMock);
+
+        $designLoaderMock->expects($this->once())->method('applyDesignChange');
+        $designLoaderMock->expects($this->never())->method('load');
+        $plugin->beforeExecute($actionMock);
+    }
+}

--- a/app/code/Magento/Theme/Test/Unit/Plugin/LoadDesignPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/LoadDesignPluginTest.php
@@ -7,7 +7,11 @@ namespace Magento\Theme\Test\Unit\Plugin;
 
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\ActionInterface;
+use Magento\Framework\Config\Dom\ValidationException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\Message\MessageInterface;
+use Magento\Framework\Phrase;
 use Magento\Framework\View\DesignLoader;
 use Magento\Theme\Plugin\LoadDesignPlugin;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,7 +32,38 @@ class LoadDesignPluginTest extends TestCase
 
         $plugin = new LoadDesignPlugin($designLoaderMock, $messageManagerMock);
 
-        $designLoaderMock->expects($this->once())->method('load');
+        $designLoaderMock->expects($this->once())->method('loadDesign');
+        $designLoaderMock->expects($this->never())->method('load');
+        $plugin->beforeExecute($actionMock);
+    }
+
+    public function testBeforeExecuteAddsMessageOnInvalidDesignConfig()
+    {
+        /** @var MockObject|ActionInterface $actionMock */
+        $actionMock = $this->createMock(Action::class);
+
+        /** @var MockObject|DesignLoader $designLoaderMock */
+        $designLoaderMock = $this->createMock(DesignLoader::class);
+        $designLoaderMock->expects($this->once())
+            ->method('loadDesign')
+            ->willThrowException(
+                new LocalizedException(new Phrase('Invalid design config'), new ValidationException('Invalid XML'))
+            );
+
+        /** @var MockObject|MessageInterface $messageMock */
+        $messageMock = $this->createMock(MessageInterface::class);
+        $messageMock->expects($this->once())->method('setText')->with('Invalid design config')->willReturnSelf();
+
+        /** @var MockObject|ManagerInterface $messageManagerMock */
+        $messageManagerMock = $this->createMock(ManagerInterface::class);
+        $messageManagerMock->expects($this->once())
+            ->method('createMessage')
+            ->with(MessageInterface::TYPE_ERROR)
+            ->willReturn($messageMock);
+        $messageManagerMock->expects($this->once())->method('addUniqueMessages')->with([$messageMock]);
+
+        $plugin = new LoadDesignPlugin($designLoaderMock, $messageManagerMock);
+
         $plugin->beforeExecute($actionMock);
     }
 }

--- a/app/code/Magento/Theme/Test/Unit/Plugin/LoadDesignPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/LoadDesignPluginTest.php
@@ -3,6 +3,8 @@
  * Copyright 2020 Adobe
  * All Rights Reserved.
  */
+declare(strict_types=1);
+
 namespace Magento\Theme\Test\Unit\Plugin;
 
 use Magento\Framework\App\Action\Action;

--- a/app/code/Magento/Theme/Test/Unit/Plugin/LoadTranslationPluginTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Plugin/LoadTranslationPluginTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Test\Unit\Plugin;
+
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\ActionInterface;
+use Magento\Framework\Message\ManagerInterface;
+use Magento\Framework\View\DesignLoader;
+use Magento\Theme\Plugin\LoadTranslationPlugin;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LoadTranslationPluginTest extends TestCase
+{
+    public function testBeforeExecute(): void
+    {
+        /** @var MockObject|ActionInterface $actionMock */
+        $actionMock = $this->createMock(Action::class);
+
+        /** @var MockObject|DesignLoader $designLoaderMock */
+        $designLoaderMock = $this->createMock(DesignLoader::class);
+
+        /** @var MockObject|ManagerInterface $messageManagerMock */
+        $messageManagerMock = $this->createMock(ManagerInterface::class);
+
+        $plugin = new LoadTranslationPlugin($designLoaderMock, $messageManagerMock);
+
+        $designLoaderMock->expects($this->once())->method('loadTranslation');
+        $designLoaderMock->expects($this->never())->method('load');
+        $plugin->beforeExecute($actionMock);
+    }
+}

--- a/app/code/Magento/Theme/etc/adminhtml/di.xml
+++ b/app/code/Magento/Theme/etc/adminhtml/di.xml
@@ -38,6 +38,8 @@
                 type="Magento\Theme\Plugin\DesignProcessorFacade"/>
     </type>
     <type name="Magento\Framework\App\ActionInterface">
-        <plugin name="designLoader" type="Magento\Theme\Plugin\LoadDesignPlugin"/>
+        <plugin name="designLoader" type="Magento\Theme\Plugin\LoadDesignPlugin" sortOrder="10"/>
+        <plugin name="translationLoader" type="Magento\Theme\Plugin\LoadTranslationPlugin" sortOrder="20"/>
+        <plugin name="designChangeLoader" type="Magento\Theme\Plugin\ApplyDesignChangePlugin" sortOrder="30"/>
     </type>
 </config>

--- a/app/code/Magento/Theme/etc/frontend/di.xml
+++ b/app/code/Magento/Theme/etc/frontend/di.xml
@@ -36,6 +36,8 @@
         </arguments>
     </type>
     <type name="Magento\Framework\App\ActionInterface">
-        <plugin name="designLoader" type="Magento\Theme\Plugin\LoadDesignPlugin"/>
+        <plugin name="designLoader" type="Magento\Theme\Plugin\LoadDesignPlugin" sortOrder="10"/>
+        <plugin name="translationLoader" type="Magento\Theme\Plugin\LoadTranslationPlugin" sortOrder="20"/>
+        <plugin name="designChangeLoader" type="Magento\Theme\Plugin\ApplyDesignChangePlugin" sortOrder="30"/>
     </type>
 </config>

--- a/lib/internal/Magento/Framework/View/DesignLoader.php
+++ b/lib/internal/Magento/Framework/View/DesignLoader.php
@@ -55,4 +55,50 @@ class DesignLoader
         $area->load(\Magento\Framework\App\Area::PART_TRANSLATE);
         $area->detectDesign($this->_request);
     }
+
+    /**
+     * Load design part of the current area
+     *
+     * @return void
+     */
+    public function loadDesign(): void
+    {
+        $this->getArea()->load(\Magento\Framework\App\Area::PART_DESIGN);
+    }
+
+    /**
+     * Load translations of the current area
+     *
+     * Must be called after the design part is loaded, because theme translation
+     * files are resolved from the design theme.
+     *
+     * @return void
+     */
+    public function loadTranslation(): void
+    {
+        $this->getArea()->load(\Magento\Framework\App\Area::PART_TRANSLATE);
+    }
+
+    /**
+     * Apply store design change or user-agent design exception
+     *
+     * Must be called after the translations are loaded to keep the design change
+     * from affecting the set of loaded translation files.
+     *
+     * @return void
+     */
+    public function applyDesignChange(): void
+    {
+        $this->getArea()->detectDesign($this->_request);
+    }
+
+    /**
+     * Get the area of the current application scope
+     *
+     * @return \Magento\Framework\App\AreaInterface
+     */
+    private function getArea(): \Magento\Framework\App\AreaInterface
+    {
+        return $this->_areaList->getArea($this->appState->getAreaCode());
+    }
 }

--- a/lib/internal/Magento/Framework/View/DesignLoader.php
+++ b/lib/internal/Magento/Framework/View/DesignLoader.php
@@ -3,27 +3,23 @@
  * Copyright 2014 Adobe
  * All Rights Reserved.
  */
+declare(strict_types=1);
+
 namespace Magento\Framework\View;
 
 class DesignLoader
 {
     /**
-     * Request
-     *
      * @var \Magento\Framework\App\RequestInterface
      */
     protected $_request;
 
     /**
-     * Application
-     *
      * @var \Magento\Framework\App\AreaList
      */
     protected $_areaList;
 
     /**
-     * Layout
-     *
      * @var \Magento\Framework\App\State
      */
     protected $appState;

--- a/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
+++ b/lib/internal/Magento/Framework/View/Test/Unit/DesignLoaderTest.php
@@ -71,4 +71,46 @@ class DesignLoaderTest extends TestCase
             );
         $this->_model->load($this->_requestMock);
     }
+
+    /**
+     * @return void
+     */
+    public function testLoadDesign(): void
+    {
+        $area = $this->createMock(Area::class);
+        $this->appState->expects($this->once())->method('getAreaCode')->willReturn('area');
+        $this->_areaListMock->expects($this->once())->method('getArea')->with('area')->willReturn($area);
+        $area->expects($this->once())->method('load')->with(Area::PART_DESIGN)->willReturnSelf();
+        $area->expects($this->never())->method('detectDesign');
+
+        $this->_model->loadDesign();
+    }
+
+    /**
+     * @return void
+     */
+    public function testLoadTranslation(): void
+    {
+        $area = $this->createMock(Area::class);
+        $this->appState->expects($this->once())->method('getAreaCode')->willReturn('area');
+        $this->_areaListMock->expects($this->once())->method('getArea')->with('area')->willReturn($area);
+        $area->expects($this->once())->method('load')->with(Area::PART_TRANSLATE)->willReturnSelf();
+        $area->expects($this->never())->method('detectDesign');
+
+        $this->_model->loadTranslation();
+    }
+
+    /**
+     * @return void
+     */
+    public function testApplyDesignChange(): void
+    {
+        $area = $this->createMock(Area::class);
+        $this->appState->expects($this->once())->method('getAreaCode')->willReturn('area');
+        $this->_areaListMock->expects($this->once())->method('getArea')->with('area')->willReturn($area);
+        $area->expects($this->never())->method('load');
+        $area->expects($this->once())->method('detectDesign')->with($this->_requestMock);
+
+        $this->_model->applyDesignChange();
+    }
 }


### PR DESCRIPTION
### Description (*)

`Magento\Theme\Plugin\LoadDesignPlugin`, declared as the single `designLoader` plugin on `Magento\Framework\App\ActionInterface` (frontend and adminhtml), triggers `Magento\Framework\View\DesignLoader::load()`, which bundles three unrelated responsibilities into one call:

```php
$area->load(Area::PART_DESIGN);
$area->load(Area::PART_TRANSLATE);
$area->detectDesign($this->_request);
```

Consequence: an Action that renders no layout and no translated output — a JSON/AJAX endpoint, a lightweight custom controller — still pays for loading the full translation dictionary and for design-change detection on every request. The only escape hatch today is `<plugin name="designLoader" disabled="true"/>`, which also removes design initialization, so the Action loses the design it may still need (e.g. for image resizing via the theme view configuration).

This PR splits the monolith into three independently disable-able plugins, without changing any default behavior:

| Plugin | `sortOrder` | Does |
| --- | --- | --- |
| `designLoader` | 10 | `Area::PART_DESIGN` |
| `translationLoader` | 20 | `Area::PART_TRANSLATE` |
| `designChangeLoader` | 30 | `Area::detectDesign()` |

A developer can now keep design initialization and opt out of just the expensive parts:

```xml
<type name="My\Module\Controller\Ajax\Index">
    <plugin name="translationLoader" disabled="true"/>
    <plugin name="designChangeLoader" disabled="true"/>
</type>
```

**Why this split, and why the sort orders are explicit** — the current execution order is load-bearing and is preserved exactly:

1. `PART_DESIGN` must run first: `Area::_initDesign()` sets the area and the default design theme.
2. `PART_TRANSLATE` must run second: `Area::_initTranslate()` → `Translate::loadData()` resolves theme translation files from the design theme set in step 1.
3. `detectDesign()` must run last: it may change the design (store design change or user-agent design exception) *after* translations were already resolved against the default theme. Moving it earlier would silently change which translation files are loaded on stores that use design changes or design exceptions.

`Area::_loadPart()` is idempotent (guarded by `$this->_loadedParts`), so splitting the calls across three plugins cannot cause double loading.

`DesignLoader::load()` is unchanged and still performs all three steps in the same order and with a single `AreaList::getArea()` call — existing callers (`Magento\Backend\App\Action\Plugin\LoadDesignPlugin`, `Magento\Catalog\Ui\DataProvider\Product\Listing\Collector\Image`) are unaffected. Three granular methods were added next to it: `loadDesign()`, `loadTranslation()`, `applyDesignChange()`.

The `LocalizedException` / `Magento\Framework\Config\Dom\ValidationException` handling that turned an invalid design configuration into an admin error message was moved to `Magento\Theme\Plugin\AbstractDesignLoaderPlugin` and is shared by all three plugins, so the behavior is identical no matter which part fails. `LoadDesignPlugin`'s public constructor signature is unchanged.

Scope note: the `designLoader` plugin on `ActionInterface` is declared only in `Theme/etc/frontend/di.xml` and `Theme/etc/adminhtml/di.xml`. `webapi_rest`, `webapi_soap` and `graphql` are out of scope — the plugin was never declared there (GraphQL has its own `Magento\CatalogGraphQl\Plugin\DesignLoader`).

### Fixed Issues (if relevant)

1. Fixes magento/magento2#29735: Design loader plugin adds overhead to every controller

### Manual testing scenarios (*)

1. Install a vanilla instance, open a frontend category page and a product page — design, translations and the store's design change apply exactly as before.
2. Configure a **Design Change** for the store (Content → Design → Schedule) and confirm the scheduled theme is applied on the frontend.
3. Configure a **User Agent Exception** for a theme (Content → Design → Configuration → Other Settings → Search Engine Optimization / Design Exception) and confirm the exception theme is applied for the matching user agent.
4. Open the admin panel — the admin theme and admin translations render as before.
5. Break the design configuration so it raises a `ValidationException` and confirm the admin still renders with the error message added, instead of a fatal error.
6. Declare a custom controller with `translationLoader` and `designChangeLoader` disabled, and confirm it executes without loading translations (verify via `Magento\Framework\TranslateInterface` not being populated, or via profiler `load_area:frontend.translate` disappearing from the profile) while design-dependent code still works.

### Magento Health Index

The Health Index build is red while Unit, Integration, Static, WebAPI and SVC are all green. I compared the changed files against base with the full PHPMD ruleset (`cleancode,codesize,controversial,design,naming,unusedcode`): five findings on both sides, all pre-existing `CamelCasePropertyName` on legacy underscore-prefixed properties, none introduced here; zero coupling or complexity findings on the new plugins, and no duplicated logic between them — the shared boilerplate lives in `AbstractDesignLoaderPlugin` and each concrete plugin is a three-line `loadPart()` override. I believe the index is reacting to one class becoming four (file/class count on a pure split) rather than to any quality regression, and would appreciate a maintainer's read on whether it can be waived.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)

