### PR TITLE
Add AdapterInterface dialect helpers and replace MySQL with Postgres SQL and other SQL like RDBS

### DIFF
--- a/app/code/Magento/AsynchronousOperations/Model/BulkStatus.php
+++ b/app/code/Magento/AsynchronousOperations/Model/BulkStatus.php
@@ -126,8 +126,11 @@ class BulkStatus implements BulkStatusInterface
             OperationInterface::STATUS_TYPE_COMPLETE
         ];
         $select = $collection->getSelect();
-        $select->columns(['status' => $this->calculatedStatusSql->get($operationTableName)])
-            ->order(new \Zend_Db_Expr('FIELD(status, ' . implode(',', $statusesArray) . ')'));
+        $statusExpr = $this->calculatedStatusSql->get($operationTableName);
+        $select->columns(['status' => $statusExpr])
+            ->order(
+                $this->resourceConnection->getConnection()->getFieldSql((string) $statusExpr, $statusesArray)
+            );
         $collection->addFieldToFilter('user_id', $userId)
             ->addOrder('start_time');
 

--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkStatusTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/BulkStatusTest.php
@@ -284,6 +284,10 @@ class BulkStatusTest extends TestCase
         $bulkCollection->expects($this->once())->method('getSelect')->willReturn($selectMock);
         $selectMock->expects($this->once())->method('columns')->willReturnSelf();
         $selectMock->expects($this->once())->method('order')->willReturnSelf();
+        $this->resourceConnectionMock->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($this->connectionMock);
+        $this->connectionMock->expects($this->once())->method('getFieldSql')->willReturn('FIELD(status, 1, 2)');
         $this->bulkCollectionFactory->expects($this->once())->method('create')->willReturn($bulkCollection);
         $bulkCollection->expects($this->once())->method('addFieldToFilter')->with('user_id', $userId)->willReturnSelf();
         $bulkCollection->expects($this->once())->method('getItems')->willReturn([$this->bulkMock]);

--- a/app/code/Magento/Backup/Model/ResourceModel/Helper.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Helper.php
@@ -178,7 +178,8 @@ class Helper extends \Magento\Framework\DB\Helper
     {
         $dbConfig = $this->getConnection()->getConfig();
 
-        $versionRow = $this->getConnection()->fetchRow('SHOW VARIABLES LIKE \'version\'');
+        // PgCompat: getServerVersion() is portable (PDO ATTR_SERVER_VERSION).
+        $versionRow = ['Value' => $this->getConnection()->getServerVersion()];
         $hostName = !empty($dbConfig['unix_socket'])
             ? $dbConfig['unix_socket']
             : (!empty($dbConfig['host']) ? $dbConfig['host'] : 'localhost');

--- a/app/code/Magento/Backup/Model/ResourceModel/Helper.php
+++ b/app/code/Magento/Backup/Model/ResourceModel/Helper.php
@@ -178,7 +178,6 @@ class Helper extends \Magento\Framework\DB\Helper
     {
         $dbConfig = $this->getConnection()->getConfig();
 
-        // PgCompat: getServerVersion() is portable (PDO ATTR_SERVER_VERSION).
         $versionRow = ['Value' => $this->getConnection()->getServerVersion()];
         $hostName = !empty($dbConfig['unix_socket'])
             ? $dbConfig['unix_socket']

--- a/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
@@ -485,7 +485,12 @@ class Price implements DimensionalIndexerInterface
             [
                 'min_price' => new \Zend_Db_Expr('MIN(' . $minPrice . ')'),
                 'alt_price' => new \Zend_Db_Expr('MIN(price)'),
-                'max_price' => $connection->getCheckSql('group_type = 0', 'MAX(price)', 'SUM(price)'),
+                // PgCompat: group_type is functionally dependent on option_id within this
+                // GROUP BY, but MySQL's non-ONLY_FULL_GROUP_BY leniency allowed referencing
+                // it bare in the CASE condition anyway - Postgres requires it aggregated.
+                // MIN(group_type) is value-identical to group_type here (same table/row
+                // set as before), so this is a no-op on MySQL and a fix on Postgres.
+                'max_price' => $connection->getCheckSql('MIN(group_type) = 0', 'MAX(price)', 'SUM(price)'),
                 'tier_price' => new \Zend_Db_Expr('MIN(' . $tierPrice . ')'),
                 'alt_tier_price' => new \Zend_Db_Expr('MIN(tier_price)'),
             ]
@@ -734,33 +739,24 @@ class Price implements DimensionalIndexerInterface
             ]
         );
         $select = $this->stockStatusQueryProcessor->execute($select);
-        $query = str_replace('AS `idx`', 'AS `idx` USE INDEX (PRIMARY)', (string) $select);
-
-        $insertColumns = [
-            'entity_id',
-            'customer_group_id',
-            'website_id',
-            'option_id',
-            'selection_id',
-            'group_type',
-            'is_required',
-            'price',
-            'tier_price'
-        ];
-        $insertColumns = array_map(function ($item) use ($connection) {
-            return $connection->quoteIdentifier($item);
-        }, $insertColumns);
-        $updateValues = [];
-        foreach ($insertColumns as $column) {
-            $updateValues[] = sprintf("%s = VALUES(%s)", $column, $column);
-        }
-
-        $connection->query(sprintf(
-            "INSERT INTO `" . $this->getBundleSelectionTable() . "` (%s) %s ON DUPLICATE KEY UPDATE %s",
-            implode(",", $insertColumns),
-            $query,
-            implode(",", $updateValues)
-        ));
+        $connection->query(
+            $connection->insertFromSelect(
+                $select,
+                $this->getBundleSelectionTable(),
+                [
+                    'entity_id',
+                    'customer_group_id',
+                    'website_id',
+                    'option_id',
+                    'selection_id',
+                    'group_type',
+                    'is_required',
+                    'price',
+                    'tier_price',
+                ],
+                \Magento\Framework\DB\Adapter\AdapterInterface::INSERT_ON_DUPLICATE
+            )
+        );
     }
 
     /**

--- a/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Indexer/Price.php
@@ -485,7 +485,6 @@ class Price implements DimensionalIndexerInterface
             [
                 'min_price' => new \Zend_Db_Expr('MIN(' . $minPrice . ')'),
                 'alt_price' => new \Zend_Db_Expr('MIN(price)'),
-                // PgCompat: group_type is functionally dependent on option_id within this
                 // GROUP BY, but MySQL's non-ONLY_FULL_GROUP_BY leniency allowed referencing
                 // it bare in the CASE condition anyway - Postgres requires it aggregated.
                 // MIN(group_type) is value-identical to group_type here (same table/row

--- a/app/code/Magento/Bundle/Model/ResourceModel/Option/AreBundleOptionsSalable.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Option/AreBundleOptionsSalable.php
@@ -94,7 +94,8 @@ class AreBundleOptionsSalable
         );
         $isOptionSalableExpr = new \Zend_Db_Expr(
             sprintf(
-                'MAX(IFNULL(child_status_store.value, child_status_global.value) != %s)',
+                'MAX(CASE WHEN %s != %s THEN 1 ELSE 0 END)',
+                $connection->getIfNullSql('child_status_store.value', 'child_status_global.value'),
                 ProductStatus::STATUS_DISABLED
             )
         );

--- a/app/code/Magento/Bundle/Model/ResourceModel/Selection/Collection.php
+++ b/app/code/Magento/Bundle/Model/ResourceModel/Selection/Collection.php
@@ -324,7 +324,9 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
                 $minimalPriceExpression = self::INDEX_TABLE_ALIAS . '.price';
             } else {
                 $this->getCatalogRuleProcessor()->addPriceData($this, 'selection.product_id');
-                $minimalPriceExpression = 'LEAST(minimal_price, IFNULL(catalog_rule_price, minimal_price))';
+                $minimalPriceExpression = 'LEAST(minimal_price, '
+                    . $this->getConnection()->getIfNullSql('catalog_rule_price', 'minimal_price')
+                    . ')';
             }
             $orderByValue = new \Zend_Db_Expr(
                 '(' .

--- a/app/code/Magento/Bundle/Test/Unit/Model/ResourceModel/Indexer/PriceTest.php
+++ b/app/code/Magento/Bundle/Test/Unit/Model/ResourceModel/Indexer/PriceTest.php
@@ -154,40 +154,6 @@ class PriceTest extends TestCase
                         `is_required`       = VALUES(`is_required`),
                         `price`             = VALUES(`price`),
                         `tier_price`        = VALUES(`tier_price`)";
-        $processedQuery = "INSERT INTO `catalog_product_index_price_bundle_sel_temp` (,,,,,,,,) SELECT `i`.`entity_id`,
-       `i`.`customer_group_id`,
-       `i`.`website_id`,
-       `bo`.`option_id`,
-       `bs`.`selection_id`,
-       IF(bo.type = 'select' OR bo.type = 'radio', 0, 1) AS `group_type`,
-       `bo`.`required`                                   AS `is_required`,
-       LEAST(IF(i.special_price > 0 AND i.special_price < 100,
-            ROUND(idx.min_price * bs.selection_qty * (i.special_price / 100), 4), idx.min_price * bs.selection_qty),
-            IFNULL((IF(i.tier_percent IS NOT NULL,
-            ROUND((1 - i.tier_percent / 100) * idx.min_price * bs.selection_qty, 4), NULL)), idx.min_price *
-                                                                                    bs.selection_qty)) AS `price`,
-       IF(i.tier_percent IS NOT NULL, ROUND((1 - i.tier_percent / 100) * idx.min_price * bs.selection_qty, 4),
-          NULL)  AS `tier_price`
-        FROM `catalog_product_index_price_bundle_temp` AS `i`
-         INNER JOIN `catalog_product_entity` AS `parent_product` ON parent_product.entity_id = i.entity_id AND
-                                                (parent_product.created_in <= 1 AND parent_product.updated_in > 1)
-         INNER JOIN `catalog_product_bundle_option` AS `bo` ON bo.parent_id = parent_product.row_id
-         INNER JOIN `catalog_product_bundle_selection` AS `bs` ON bs.option_id = bo.option_id
-         INNER JOIN `catalog_product_index_price_replica` AS `idx` USE INDEX (PRIMARY)
-                    ON bs.product_id = idx.entity_id AND i.customer_group_id = idx.customer_group_id AND
-                       i.website_id = idx.website_id
-         INNER JOIN `cataloginventory_stock_status` AS `si` ON si.product_id = bs.product_id
-        WHERE (i.price_type = 0)
-            AND (si.stock_status = 1)
-        ON DUPLICATE KEY UPDATE `entity_id`         = VALUES(`entity_id`),
-                        `customer_group_id` = VALUES(`customer_group_id`),
-                        `website_id`        = VALUES(`website_id`),
-                        `option_id`         = VALUES(`option_id`),
-                        `selection_id`      = VALUES(`selection_id`),
-                        `group_type`        = VALUES(`group_type`),
-                        `is_required`       = VALUES(`is_required`),
-                        `price`             = VALUES(`price`),
-                        `tier_price`        = VALUES(`tier_price`) ON DUPLICATE KEY UPDATE  = VALUES(), = VALUES(), = VALUES(), = VALUES(), = VALUES(), = VALUES(), = VALUES(), = VALUES(), = VALUES()";
         //@codingStandardsIgnoreEnd
         $this->connectionMock->expects($this->exactly(3))
             ->method('getCheckSql')
@@ -232,8 +198,17 @@ class PriceTest extends TestCase
         $this->connectionMock->expects($this->once())->method('getIfNullSql');
         $this->connectionMock->expects($this->once())->method('getLeastSql');
         $this->connectionMock->method('select')->willReturn($select);
-        $this->connectionMock->expects($this->exactly(9))->method('quoteIdentifier');
-        $this->connectionMock->expects($this->once())->method('query')->with($processedQuery);
+        $insertSql = 'INSERT INTO catalog_product_index_price_bundle_sel_temp ... ON DUPLICATE KEY UPDATE';
+        $this->connectionMock->expects($this->once())
+            ->method('insertFromSelect')
+            ->with(
+                $select,
+                $this->isType('string'),
+                $this->isType('array'),
+                AdapterInterface::INSERT_ON_DUPLICATE
+            )
+            ->willReturn($insertSql);
+        $this->connectionMock->expects($this->once())->method('query')->with($insertSql);
 
         $pool = $this->createMock(EntityMetadataInterface::class);
         $pool->expects($this->once())->method('getLinkField')->willReturn($entity);

--- a/app/code/Magento/Catalog/Model/Attribute/ScopeOverriddenValue.php
+++ b/app/code/Magento/Catalog/Model/Attribute/ScopeOverriddenValue.php
@@ -144,9 +144,18 @@ class ScopeOverriddenValue
                 $storeIds[] = $storeId;
             }
             $selects = [];
+            // PgCompat: this select is UNION ALL'd (below) with one of these per EAV
+            // backend type table (varchar/int/decimal/text/datetime) - MySQL coerces the
+            // differently-typed "value" columns across branches implicitly, Postgres
+            // requires them to already share one type. Same fix as the other EAV
+            // union-cast sites (union-cast-eav-abstract-collection.patch,
+            // Eav\Model\ResourceModel\ReadHandler::execute(), ReadSnapshotPlugin).
             foreach ($attributeTables as $attributeTable => $attributeCodes) {
                 $select = $metadata->getEntityConnection()->select()
-                    ->from(['t' => $attributeTable], ['value' => 't.value', 'store_id' => 't.store_id'])
+                    ->from(
+                        ['t' => $attributeTable],
+                        ['value' => $metadata->getEntityConnection()->castToText('t.value'), 'store_id' => 't.store_id']
+                    )
                     ->join(
                         ['a' => $this->resourceConnection->getTableName('eav_attribute')],
                         'a.attribute_id = t.attribute_id',

--- a/app/code/Magento/Catalog/Model/Attribute/ScopeOverriddenValue.php
+++ b/app/code/Magento/Catalog/Model/Attribute/ScopeOverriddenValue.php
@@ -144,11 +144,6 @@ class ScopeOverriddenValue
                 $storeIds[] = $storeId;
             }
             $selects = [];
-            // PgCompat: this select is UNION ALL'd (below) with one of these per EAV
-            // backend type table (varchar/int/decimal/text/datetime) - MySQL coerces the
-            // differently-typed "value" columns across branches implicitly, Postgres
-            // requires them to already share one type. Same fix as the other EAV
-            // union-cast sites (union-cast-eav-abstract-collection.patch,
             // Eav\Model\ResourceModel\ReadHandler::execute(), ReadSnapshotPlugin).
             foreach ($attributeTables as $attributeTable => $attributeCodes) {
                 $select = $metadata->getEntityConnection()->select()

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -388,7 +388,11 @@ abstract class AbstractAction implements ResetAfterRequestInterface
                 [
                     'category_id' => 'cc.entity_id',
                     'product_id' => 'ccp.product_id',
-                    'position' => 'ccp.position',
+                    // PgCompat: bare ccp.position is non-aggregated under the GROUP BY
+                    // addFilteringByChildProductsToSelect() adds below; MIN() is a no-op
+                    // on MySQL (one ccp row per cc.entity_id/ccp.product_id group here)
+                    // and required by Postgres.
+                    'position' => new \Zend_Db_Expr('MIN(ccp.position)'),
                     'is_parent' => new \Zend_Db_Expr('1'),
                     'store_id' => new \Zend_Db_Expr($store->getId()),
                     'visibility' => new \Zend_Db_Expr(
@@ -639,8 +643,11 @@ abstract class AbstractAction implements ResetAfterRequestInterface
             [
                 'category_id' => 'cc.entity_id',
                 'product_id' => 'ccp.product_id',
+                // PgCompat: ccp2.position is non-aggregated under the GROUP BY
+                // addFilteringByChildProductsToSelect() adds below; MAX() is a no-op on
+                // MySQL (one ccp2 row per group here) and required by Postgres.
                 'position' => new \Zend_Db_Expr(
-                    $this->connection->getIfNullSql('ccp2.position', 'MIN(ccp.position) + 10000')
+                    $this->connection->getIfNullSql('MAX(ccp2.position)', 'MIN(ccp.position) + 10000')
                 ),
                 'is_parent' => new \Zend_Db_Expr('0'),
                 'store_id' => new \Zend_Db_Expr($store->getId()),
@@ -874,16 +881,26 @@ abstract class AbstractAction implements ResetAfterRequestInterface
                 $this->connection->getIfNullSql('cpvs.value', 'cpvd.value') . ' IN (?)',
                 $this->visibility->getVisibleInSiteIds()
             )->group(
-                'cp.entity_id'
+                // PgCompat: the visibility column below is a non-aggregated COALESCE
+                // expression selected under this GROUP BY - MySQL's non-ONLY_FULL_GROUP_BY
+                // leniency tolerated that; Postgres requires it grouped too. cpvs/cpvd are
+                // already filtered to at most one row per cp.entity_id (store_id/attribute_id
+                // predicates above), so this doesn't change which rows collapse together.
+                ['cp.entity_id', new \Zend_Db_Expr($this->connection->getIfNullSql('cpvs.value', 'cpvd.value'))]
             )->columns(
                 [
                     'category_id' => new \Zend_Db_Expr($store->getRootCategoryId()),
                     'product_id' => 'cp.entity_id',
+                    // PgCompat: ccp.product_id IS NOT NULL is a non-aggregated column
+                    // reference in the CASE condition under the GROUP BY above; COUNT(...)>0
+                    // is the aggregate-safe equivalent (true iff at least one non-null
+                    // ccp.product_id exists in the group, same truth value as the original
+                    // MySQL-tolerated condition).
                     'position' => new \Zend_Db_Expr(
-                        $this->connection->getCheckSql('ccp.product_id IS NOT NULL', 'MIN(ccp.position)', '10000')
+                        $this->connection->getCheckSql('COUNT(ccp.product_id) > 0', 'MIN(ccp.position)', '10000')
                     ),
                     'is_parent' => new \Zend_Db_Expr(
-                        $this->connection->getCheckSql('ccp.product_id IS NOT NULL', '1', '0')
+                        $this->connection->getCheckSql('COUNT(ccp.product_id) > 0', '1', '0')
                     ),
                     'store_id' => new \Zend_Db_Expr($store->getId()),
                     'visibility' => new \Zend_Db_Expr(

--- a/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Category/Product/AbstractAction.php
@@ -388,10 +388,6 @@ abstract class AbstractAction implements ResetAfterRequestInterface
                 [
                     'category_id' => 'cc.entity_id',
                     'product_id' => 'ccp.product_id',
-                    // PgCompat: bare ccp.position is non-aggregated under the GROUP BY
-                    // addFilteringByChildProductsToSelect() adds below; MIN() is a no-op
-                    // on MySQL (one ccp row per cc.entity_id/ccp.product_id group here)
-                    // and required by Postgres.
                     'position' => new \Zend_Db_Expr('MIN(ccp.position)'),
                     'is_parent' => new \Zend_Db_Expr('1'),
                     'store_id' => new \Zend_Db_Expr($store->getId()),
@@ -643,8 +639,6 @@ abstract class AbstractAction implements ResetAfterRequestInterface
             [
                 'category_id' => 'cc.entity_id',
                 'product_id' => 'ccp.product_id',
-                // PgCompat: ccp2.position is non-aggregated under the GROUP BY
-                // addFilteringByChildProductsToSelect() adds below; MAX() is a no-op on
                 // MySQL (one ccp2 row per group here) and required by Postgres.
                 'position' => new \Zend_Db_Expr(
                     $this->connection->getIfNullSql('MAX(ccp2.position)', 'MIN(ccp.position) + 10000')
@@ -881,20 +875,11 @@ abstract class AbstractAction implements ResetAfterRequestInterface
                 $this->connection->getIfNullSql('cpvs.value', 'cpvd.value') . ' IN (?)',
                 $this->visibility->getVisibleInSiteIds()
             )->group(
-                // PgCompat: the visibility column below is a non-aggregated COALESCE
-                // expression selected under this GROUP BY - MySQL's non-ONLY_FULL_GROUP_BY
-                // leniency tolerated that; Postgres requires it grouped too. cpvs/cpvd are
-                // already filtered to at most one row per cp.entity_id (store_id/attribute_id
-                // predicates above), so this doesn't change which rows collapse together.
                 ['cp.entity_id', new \Zend_Db_Expr($this->connection->getIfNullSql('cpvs.value', 'cpvd.value'))]
             )->columns(
                 [
                     'category_id' => new \Zend_Db_Expr($store->getRootCategoryId()),
                     'product_id' => 'cp.entity_id',
-                    // PgCompat: ccp.product_id IS NOT NULL is a non-aggregated column
-                    // reference in the CASE condition under the GROUP BY above; COUNT(...)>0
-                    // is the aggregate-safe equivalent (true iff at least one non-null
-                    // ccp.product_id exists in the group, same truth value as the original
                     // MySQL-tolerated condition).
                     'position' => new \Zend_Db_Expr(
                         $this->connection->getCheckSql('COUNT(ccp.product_id) > 0', 'MIN(ccp.position)', '10000')

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Eraser.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Eraser.php
@@ -109,7 +109,12 @@ class Eraser
             . 'product_table.' . $metadata->getLinkField(),
             []
         );
-        $select->where('IFNULL(status_attr.value, status_global_attr.value) = ?', Status::STATUS_DISABLED);
+        // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
+        // Postgres) instead of hardcoding MySQL's IFNULL() text.
+        $select->where(
+            $this->connection->getIfNullSql('status_attr.value', 'status_global_attr.value') . ' = ?',
+            Status::STATUS_DISABLED
+        );
 
         $result = $this->connection->query($select);
 

--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Eraser.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/Action/Eraser.php
@@ -109,8 +109,6 @@ class Eraser
             . 'product_table.' . $metadata->getLinkField(),
             []
         );
-        // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
-        // Postgres) instead of hardcoding MySQL's IFNULL() text.
         $select->where(
             $this->connection->getIfNullSql('status_attr.value', 'status_global_attr.value') . ' = ?',
             Status::STATUS_DISABLED

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -723,9 +723,13 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
         if (true === $addVisibilityFilter) {
             $select->where('cat_index.visibility in (?)', $this->catalogProductVisibility->getVisibleInSiteIds());
         }
-        if (count($categoryIds) > 1) {
-            $select->group('cat_index.category_id');
-        }
+        // PgCompat: was only grouped when count($categoryIds) > 1 - but this select
+        // always mixes a non-aggregated column (category_id) with an aggregate
+        // (count(...)), so the single-category case needs GROUP BY too. MySQL's
+        // non-ONLY_FULL_GROUP_BY mode tolerated the omission (trivially one group
+        // either way); Postgres requires it unconditionally. Grouping a single-value set
+        // is a no-op on both, so this fixes the real bug rather than working around it.
+        $select->group('cat_index.category_id');
 
         return $select;
     }

--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -723,8 +723,6 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
         if (true === $addVisibilityFilter) {
             $select->where('cat_index.visibility in (?)', $this->catalogProductVisibility->getVisibleInSiteIds());
         }
-        // PgCompat: was only grouped when count($categoryIds) > 1 - but this select
-        // always mixes a non-aggregated column (category_id) with an aggregate
         // (count(...)), so the single-category case needs GROUP BY too. MySQL's
         // non-ONLY_FULL_GROUP_BY mode tolerated the omission (trivially one group
         // either way); Postgres requires it unconditionally. Grouping a single-value set

--- a/app/code/Magento/Catalog/Model/ResourceModel/Collection/AbstractCollection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Collection/AbstractCollection.php
@@ -227,11 +227,6 @@ class AbstractCollection extends \Magento\Eav\Model\Entity\Collection\AbstractCo
         $storeId = $this->getStoreId();
         if ($storeId) {
             $connection = $this->getConnection();
-            // PgCompat: this select is UNION ALL'd with one of these per EAV backend
-            // type (varchar/int/decimal/text/datetime) in _loadAttributes() - MySQL
-            // coerces the differently-typed columns across branches implicitly,
-            // Postgres requires them to already share one type before the UNION. Same
-            // fix as the parent Eav\Model\Entity\Collection\AbstractCollection version
             // (union-cast-eav-abstract-collection.patch) this override replaces - that
             // patch only touched the parent method, missing this store-fallback
             // override entirely since it never calls parent in the $storeId branch.

--- a/app/code/Magento/Catalog/Model/ResourceModel/Collection/AbstractCollection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Collection/AbstractCollection.php
@@ -227,10 +227,26 @@ class AbstractCollection extends \Magento\Eav\Model\Entity\Collection\AbstractCo
         $storeId = $this->getStoreId();
         if ($storeId) {
             $connection = $this->getConnection();
-            $valueExpr = $connection->getCheckSql('t_s.value_id IS NULL', 't_d.value', 't_s.value');
+            // PgCompat: this select is UNION ALL'd with one of these per EAV backend
+            // type (varchar/int/decimal/text/datetime) in _loadAttributes() - MySQL
+            // coerces the differently-typed columns across branches implicitly,
+            // Postgres requires them to already share one type before the UNION. Same
+            // fix as the parent Eav\Model\Entity\Collection\AbstractCollection version
+            // (union-cast-eav-abstract-collection.patch) this override replaces - that
+            // patch only touched the parent method, missing this store-fallback
+            // override entirely since it never calls parent in the $storeId branch.
+            $valueExpr = $connection->getCheckSql(
+                't_s.value_id IS NULL',
+                $connection->castToText('t_d.value'),
+                $connection->castToText('t_s.value')
+            );
 
             $select->columns(
-                ['default_value' => 't_d.value', 'store_value' => 't_s.value', 'value' => $valueExpr]
+                [
+                    'default_value' => $connection->castToText('t_d.value'),
+                    'store_value' => $connection->castToText('t_s.value'),
+                    'value' => $valueExpr,
+                ]
             );
         } else {
             $select = parent::_addLoadAttributesSelectValues($select, $table, $type);

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection/JoinMinimalPosition.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection/JoinMinimalPosition.php
@@ -70,7 +70,11 @@ class JoinMinimalPosition
                     []
                 );
             }
-            $positions[] = $connection->getIfNullSql($table . '.position', '~0');
+            // PgCompat: '~0' (MySQL's max UNSIGNED BIGINT via bitwise-NOT-of-zero) means
+            // something entirely different on Postgres (signed integers - '~0' there is
+            // -1). Postgres' own bigint max serves the same "sort missing positions
+            // last" sentinel purpose.
+            $positions[] = $connection->getIfNullSql($table . '.position', '9223372036854775807');
         }
 
         // Ensures that position attribute is registered in _joinFields

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection/JoinMinimalPosition.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Collection/JoinMinimalPosition.php
@@ -70,8 +70,6 @@ class JoinMinimalPosition
                     []
                 );
             }
-            // PgCompat: '~0' (MySQL's max UNSIGNED BIGINT via bitwise-NOT-of-zero) means
-            // something entirely different on Postgres (signed integers - '~0' there is
             // -1). Postgres' own bigint max serves the same "sort missing positions
             // last" sentinel purpose.
             $positions[] = $connection->getIfNullSql($table . '.position', '9223372036854775807');

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -224,12 +224,6 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             ),
             []
         )->columns([
-            // PgCompat: was hardcoded MySQL backtick identifiers ('`value`.`label`' etc)
-            // passed as plain strings - getIfNullSql() just interpolates its arguments
-            // verbatim, so these reached Postgres as literal, invalid backtick syntax
-            // instead of going through quoteIdentifier(). Unquoted identifiers are valid
-            // input to getIfNullSql() on both adapters (they build "COALESCE(a, b)"
-            // directly from the given text), so plain dotted names are enough here.
             'label' => $this->getConnection()->getIfNullSql('value.label', 'default_value.label'),
             'position' => $this->getConnection()->getIfNullSql('value.position', 'default_value.position'),
             'disabled' => $this->getConnection()->getIfNullSql('value.disabled', 'default_value.disabled'),
@@ -242,10 +236,6 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         )->where(
             $mainTableAlias . '.disabled = 0'
         )->order(
-            // PgCompat: was a bare string - Select::order() quotes plain-string
-            // arguments as if they were a single identifier, mangling this multi-word
-            // CASE expression into invalid, partially-quoted garbage. Zend_Db_Expr marks
-            // it as a raw SQL fragment instead, which order() passes through unquoted.
             new \Zend_Db_Expr($positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC)
         );
 

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -224,9 +224,15 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
             ),
             []
         )->columns([
-            'label' => $this->getConnection()->getIfNullSql('`value`.`label`', '`default_value`.`label`'),
-            'position' => $this->getConnection()->getIfNullSql('`value`.`position`', '`default_value`.`position`'),
-            'disabled' => $this->getConnection()->getIfNullSql('`value`.`disabled`', '`default_value`.`disabled`'),
+            // PgCompat: was hardcoded MySQL backtick identifiers ('`value`.`label`' etc)
+            // passed as plain strings - getIfNullSql() just interpolates its arguments
+            // verbatim, so these reached Postgres as literal, invalid backtick syntax
+            // instead of going through quoteIdentifier(). Unquoted identifiers are valid
+            // input to getIfNullSql() on both adapters (they build "COALESCE(a, b)"
+            // directly from the given text), so plain dotted names are enough here.
+            'label' => $this->getConnection()->getIfNullSql('value.label', 'default_value.label'),
+            'position' => $this->getConnection()->getIfNullSql('value.position', 'default_value.position'),
+            'disabled' => $this->getConnection()->getIfNullSql('value.disabled', 'default_value.disabled'),
             'label_default' => 'default_value.label',
             'position_default' => 'default_value.position',
             'disabled_default' => 'default_value.disabled'
@@ -236,7 +242,11 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         )->where(
             $mainTableAlias . '.disabled = 0'
         )->order(
-            $positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC
+            // PgCompat: was a bare string - Select::order() quotes plain-string
+            // arguments as if they were a single identifier, mangling this multi-word
+            // CASE expression into invalid, partially-quoted garbage. Zend_Db_Expr marks
+            // it as a raw SQL fragment instead, which order() passes through unquoted.
+            new \Zend_Db_Expr($positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC)
         );
 
         return $select;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Gallery.php
@@ -236,7 +236,7 @@ class Gallery extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         )->where(
             $mainTableAlias . '.disabled = 0'
         )->order(
-            new \Zend_Db_Expr($positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC)
+            $positionCheckSql . ' ' . \Magento\Framework\DB\Select::SQL_ASC
         );
 
         return $select;

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
@@ -189,7 +189,11 @@ abstract class AbstractEav extends \Magento\Catalog\Model\ResourceModel\Product\
             'i.entity_id = cpw.product_id AND sw.website_id = cpw.website_id',
             []
         )->group(
-            ['parent_id', 'i.attribute_id', 'i.store_id', 'i.value', 'l.child_id']
+            // PgCompat: MySQL resolves a GROUP BY item against the SELECT alias list, so
+            // 'parent_id' here refers to the 'parent_id' => 'e.entity_id' column below;
+            // Postgres doesn't do alias resolution in GROUP BY, so it has to be the
+            // underlying expression directly.
+            ['e.entity_id', 'i.attribute_id', 'i.store_id', 'i.value', 'l.child_id']
         )->columns(
             [
                 'parent_id' => 'e.entity_id',

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Eav/AbstractEav.php
@@ -189,7 +189,6 @@ abstract class AbstractEav extends \Magento\Catalog\Model\ResourceModel\Product\
             'i.entity_id = cpw.product_id AND sw.website_id = cpw.website_id',
             []
         )->group(
-            // PgCompat: MySQL resolves a GROUP BY item against the SELECT alias list, so
             // 'parent_id' here refers to the 'parent_id' => 'e.entity_id' column below;
             // Postgres doesn't do alias resolution in GROUP BY, so it has to be the
             // underlying expression directly.

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
@@ -454,7 +454,12 @@ class DefaultPrice extends AbstractIndexer implements PriceInterface
         );
         $currentDate = 'cwd.website_date';
 
-        $maxUnsignedBigint = '~0';
+        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
+        // means something entirely different on Postgres, whose integers are signed -
+        // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
+        // is used as the "effectively unbounded" sentinel instead; it doesn't need to
+        // be the same numeric ceiling MySQL used, only larger than any real price.
+        $maxUnsignedBigint = '9223372036854775807';
         $specialFromDate = $connection->getDatePartSql($specialFrom);
         $specialToDate = $connection->getDatePartSql($specialTo);
         $specialFromExpr = "{$specialFrom} IS NULL OR {$specialFromDate} <= {$currentDate}";
@@ -838,7 +843,12 @@ class DefaultPrice extends AbstractIndexer implements PriceInterface
      */
     private function getTotalTierPriceExpression(\Zend_Db_Expr $priceExpression)
     {
-        $maxUnsignedBigint = '~0';
+        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
+        // means something entirely different on Postgres, whose integers are signed -
+        // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
+        // is used as the "effectively unbounded" sentinel instead; it doesn't need to
+        // be the same numeric ceiling MySQL used, only larger than any real price.
+        $maxUnsignedBigint = '9223372036854775807';
 
         return $this->getConnection()->getCheckSql(
             implode(

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/DefaultPrice.php
@@ -454,8 +454,6 @@ class DefaultPrice extends AbstractIndexer implements PriceInterface
         );
         $currentDate = 'cwd.website_date';
 
-        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
-        // means something entirely different on Postgres, whose integers are signed -
         // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
         // is used as the "effectively unbounded" sentinel instead; it doesn't need to
         // be the same numeric ceiling MySQL used, only larger than any real price.
@@ -843,8 +841,6 @@ class DefaultPrice extends AbstractIndexer implements PriceInterface
      */
     private function getTotalTierPriceExpression(\Zend_Db_Expr $priceExpression)
     {
-        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
-        // means something entirely different on Postgres, whose integers are signed -
         // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
         // is used as the "effectively unbounded" sentinel instead; it doesn't need to
         // be the same numeric ceiling MySQL used, only larger than any real price.

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -144,7 +144,12 @@ class BaseFinalPrice
         $specialTo = $this->joinAttributeProcessor->process($select, 'special_to_date');
         $currentDate = 'cwd.website_date';
 
-        $maxUnsignedBigint = '~0';
+        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
+        // means something entirely different on Postgres, whose integers are signed -
+        // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
+        // is used as the "effectively unbounded" sentinel instead; it doesn't need to
+        // be the same numeric ceiling MySQL used, only larger than any real price.
+        $maxUnsignedBigint = '9223372036854775807';
         $specialFromDate = $connection->getDatePartSql($specialFrom);
         $specialToDate = $connection->getDatePartSql($specialTo);
         $specialFromExpr = "{$specialFrom} IS NULL OR {$specialFromDate} <= {$currentDate}";
@@ -257,7 +262,12 @@ class BaseFinalPrice
      */
     private function getTotalTierPriceExpression(\Zend_Db_Expr $priceExpression)
     {
-        $maxUnsignedBigint = '~0';
+        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
+        // means something entirely different on Postgres, whose integers are signed -
+        // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
+        // is used as the "effectively unbounded" sentinel instead; it doesn't need to
+        // be the same numeric ceiling MySQL used, only larger than any real price.
+        $maxUnsignedBigint = '9223372036854775807';
 
         return $this->getConnection()->getCheckSql(
             implode(

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/Indexer/Price/Query/BaseFinalPrice.php
@@ -144,8 +144,6 @@ class BaseFinalPrice
         $specialTo = $this->joinAttributeProcessor->process($select, 'special_to_date');
         $currentDate = 'cwd.website_date';
 
-        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
-        // means something entirely different on Postgres, whose integers are signed -
         // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
         // is used as the "effectively unbounded" sentinel instead; it doesn't need to
         // be the same numeric ceiling MySQL used, only larger than any real price.
@@ -262,8 +260,6 @@ class BaseFinalPrice
      */
     private function getTotalTierPriceExpression(\Zend_Db_Expr $priceExpression)
     {
-        // PgCompat: '~0' (MySQL's bitwise-NOT-of-zero, the max UNSIGNED BIGINT value)
-        // means something entirely different on Postgres, whose integers are signed -
         // '~0' there is bitwise NOT of a signed int, i.e. -1. Postgres' own bigint max
         // is used as the "effectively unbounded" sentinel instead; it doesn't need to
         // be the same numeric ceiling MySQL used, only larger than any real price.

--- a/app/code/Magento/Catalog/Model/ResourceModel/Product/StatusBaseSelectProcessor.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Product/StatusBaseSelectProcessor.php
@@ -76,7 +76,10 @@ class StatusBaseSelectProcessor implements BaseSelectProcessorInterface
             []
         );
 
-        $select->where('IFNULL(status_attr.value, status_global_attr.value) = ?', Status::STATUS_ENABLED);
+        $select->where(
+            $select->getConnection()->getIfNullSql('status_attr.value', 'status_global_attr.value') . ' = ?',
+            Status::STATUS_ENABLED
+        );
 
         return $select;
     }

--- a/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
+++ b/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
@@ -73,10 +73,16 @@ class ReadSnapshotPlugin
         if ($globalAttributes) {
             $selects = [];
             foreach ($globalAttributes as $table => $attributeIds) {
+                // PgCompat: this select is UNION ALL'd (below) with one of these per EAV
+                // backend type table (varchar/int/decimal/text/datetime) - MySQL coerces
+                // the differently-typed "value" columns across branches implicitly,
+                // Postgres requires them to already share one type. Same fix as the
+                // other EAV union-cast sites (union-cast-eav-abstract-collection.patch,
+                // Eav\Model\ResourceModel\ReadHandler::execute()).
                 $select = $connection->select()
                     ->from(
                         ['t' => $table],
-                        ['value' => 't.value', 'attribute_id' => 't.attribute_id']
+                        ['value' => $connection->castToText('t.value'), 'attribute_id' => 't.attribute_id']
                     )
                     ->where($metadata->getLinkField() . ' = ?', $entityData[$metadata->getLinkField()])
                     ->where('attribute_id' . ' in (?)', $attributeIds)

--- a/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
+++ b/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
@@ -41,6 +41,8 @@ class ReadSnapshotPlugin
     }
 
     /**
+     * Merge global-scope catalog attribute values into the current-store snapshot.
+     *
      * @param ReadSnapshot $subject
      * @param array $entityData
      * @param string $entityType

--- a/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
+++ b/app/code/Magento/Catalog/Plugin/Model/ResourceModel/ReadSnapshotPlugin.php
@@ -73,11 +73,6 @@ class ReadSnapshotPlugin
         if ($globalAttributes) {
             $selects = [];
             foreach ($globalAttributes as $table => $attributeIds) {
-                // PgCompat: this select is UNION ALL'd (below) with one of these per EAV
-                // backend type table (varchar/int/decimal/text/datetime) - MySQL coerces
-                // the differently-typed "value" columns across branches implicitly,
-                // Postgres requires them to already share one type. Same fix as the
-                // other EAV union-cast sites (union-cast-eav-abstract-collection.patch,
                 // Eav\Model\ResourceModel\ReadHandler::execute()).
                 $select = $connection->select()
                     ->from(

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/GalleryTest.php
@@ -386,19 +386,19 @@ class GalleryTest extends TestCase
         $this->connection->expects($this->any())->method('getIfNullSql')->willReturnMap(
             [
                 [
-                    '`value`.`label`',
-                    '`default_value`.`label`',
-                    'IFNULL(`value`.`label`, `default_value`.`label`)'
+                    'value.label',
+                    'default_value.label',
+                    'IFNULL(value.label, default_value.label)'
                 ],
                 [
-                    '`value`.`position`',
-                    '`default_value`.`position`',
-                    'IFNULL(`value`.`position`, `default_value`.`position`)'
+                    'value.position',
+                    'default_value.position',
+                    'IFNULL(value.position, default_value.position)'
                 ],
                 [
-                    '`value`.`disabled`',
-                    '`default_value`.`disabled`',
-                    'IFNULL(`value`.`disabled`, `default_value`.`disabled`)'
+                    'value.disabled',
+                    'default_value.disabled',
+                    'IFNULL(value.disabled, default_value.disabled)'
                 ]
             ]
         );
@@ -432,9 +432,9 @@ class GalleryTest extends TestCase
             ->method('columns')
             ->with(
                 [
-                    'label' => 'IFNULL(`value`.`label`, `default_value`.`label`)',
-                    'position' => 'IFNULL(`value`.`position`, `default_value`.`position`)',
-                    'disabled' => 'IFNULL(`value`.`disabled`, `default_value`.`disabled`)',
+                    'label' => 'IFNULL(value.label, default_value.label)',
+                    'position' => 'IFNULL(value.position, default_value.position)',
+                    'disabled' => 'IFNULL(value.disabled, default_value.disabled)',
                     'label_default' => 'default_value.label',
                     'position_default' => 'default_value.position',
                     'disabled_default' => 'default_value.disabled'
@@ -466,7 +466,7 @@ class GalleryTest extends TestCase
             ->with(['entity' => $getTableReturnValue], 'main.value_id = entity.value_id', ['entity_id'])
             ->willReturn($this->select);
         $this->select->expects($this->once())->method('order')
-            ->with($positionCheckSql . ' ' . Select::SQL_ASC)
+            ->with(new \Zend_Db_Expr($positionCheckSql . ' ' . Select::SQL_ASC))
             ->willReturnSelf();
         $this->connection->expects($this->once())->method('fetchAll')
             ->with($this->select)

--- a/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/StatusBaseSelectProcessorTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ResourceModel/Product/StatusBaseSelectProcessorTest.php
@@ -65,6 +65,12 @@ class StatusBaseSelectProcessorTest extends TestCase
         $this->storeManager = $this->createMock(StoreManagerInterface::class);
         $this->select = $this->createMock(Select::class);
 
+        $connection = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
+        $connection->method('getIfNullSql')
+            ->with('status_attr.value', 'status_global_attr.value')
+            ->willReturn('IFNULL(status_attr.value, status_global_attr.value)');
+        $this->select->method('getConnection')->willReturn($connection);
+
         $this->statusBaseSelectProcessor =  (new ObjectManager($this))->getObject(StatusBaseSelectProcessor::class, [
             'eavConfig' => $this->eavConfig,
             'metadataPool' => $this->metadataPool,

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
@@ -129,10 +129,6 @@ class Websites extends \Magento\Ui\Component\Listing\Columns\Column
 
             $connection = $collection->getConnection();
             $select = $connection->select();
-            // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part
-            // of AdapterInterface, but every connection in this deployment is one of
-            // the two PgCompat providers, both of which implement it as a
-            // string_agg() equivalent.
             $select->from(
                 ['cpw' => $collection->getTable('catalog_product_website')],
                 ['product_id']

--- a/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
+++ b/app/code/Magento/Catalog/Ui/Component/Listing/Columns/Websites.php
@@ -127,7 +127,12 @@ class Websites extends \Magento\Ui\Component\Listing\Columns\Column
             /** @var \Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection $collection */
             $collection = $this->getContext()->getDataProvider()->getCollection();
 
-            $select = $collection->getConnection()->select();
+            $connection = $collection->getConnection();
+            $select = $connection->select();
+            // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part
+            // of AdapterInterface, but every connection in this deployment is one of
+            // the two PgCompat providers, both of which implement it as a
+            // string_agg() equivalent.
             $select->from(
                 ['cpw' => $collection->getTable('catalog_product_website')],
                 ['product_id']
@@ -135,9 +140,7 @@ class Websites extends \Magento\Ui\Component\Listing\Columns\Column
                 ['sw' => $collection->getTable('store_website')],
                 'cpw.website_id = sw.website_id',
                 [
-                    $this->websiteNames => new \Zend_Db_Expr(
-                        'GROUP_CONCAT(sw.name ORDER BY sw.website_id ASC SEPARATOR \',\')'
-                    )
+                    $this->websiteNames => $connection->getGroupConcatSql('sw.name', ',', 'sw.website_id ASC')
                 ]
             )->group(
                 'cpw.product_id'

--- a/app/code/Magento/CatalogRule/Model/Indexer/IndexerTableSwapper.php
+++ b/app/code/Magento/CatalogRule/Model/Indexer/IndexerTableSwapper.php
@@ -47,10 +47,6 @@ class IndexerTableSwapper implements IndexerTableSwapperInterface
             $originalTableName . '__temp' . $this->generateRandomSuffix()
         );
 
-        // PgCompat: `CREATE TABLE x LIKE y` is MySQL shorthand with no direct Postgres
-        // equivalent (`CREATE TABLE x (LIKE y INCLUDING ALL)` instead) - createTableLike()
-        // isn't part of AdapterInterface, but every connection in this deployment is one
-        // of the two PgCompat providers, both of which implement it.
         $this->resourceConnection->getConnection()->createTableLike(
             $temporaryTableName,
             $this->resourceConnection->getTableName($originalTableName)

--- a/app/code/Magento/CatalogRule/Model/Indexer/IndexerTableSwapper.php
+++ b/app/code/Magento/CatalogRule/Model/Indexer/IndexerTableSwapper.php
@@ -47,12 +47,13 @@ class IndexerTableSwapper implements IndexerTableSwapperInterface
             $originalTableName . '__temp' . $this->generateRandomSuffix()
         );
 
-        $this->resourceConnection->getConnection()->query(
-            sprintf(
-                'create table %s like %s',
-                $temporaryTableName,
-                $this->resourceConnection->getTableName($originalTableName)
-            )
+        // PgCompat: `CREATE TABLE x LIKE y` is MySQL shorthand with no direct Postgres
+        // equivalent (`CREATE TABLE x (LIKE y INCLUDING ALL)` instead) - createTableLike()
+        // isn't part of AdapterInterface, but every connection in this deployment is one
+        // of the two PgCompat providers, both of which implement it.
+        $this->resourceConnection->getConnection()->createTableLike(
+            $temporaryTableName,
+            $this->resourceConnection->getTableName($originalTableName)
         );
 
         return $temporaryTableName;

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -336,7 +336,12 @@ class DataProvider
         if ($backendType == 'datetime') {
             $expr = $this->connection->getDateFormatSql($field, '%Y-%m-%d %H:%i:%s');
         } else {
-            $expr = $field;
+            // PgCompat: the caller UNION ALL's one of these per EAV backend type
+            // (varchar/int/decimal/text) - MySQL coerces the differently-typed values
+            // implicitly, Postgres requires them to already share one type before the
+            // UNION. getDateFormatSql() above already returns a formatted string, so
+            // only this branch needs an explicit cast to match it.
+            $expr = $this->connection->castToText($field);
         }
 
         return $expr;

--- a/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
+++ b/app/code/Magento/CatalogSearch/Model/Indexer/Fulltext/Action/DataProvider.php
@@ -336,7 +336,6 @@ class DataProvider
         if ($backendType == 'datetime') {
             $expr = $this->connection->getDateFormatSql($field, '%Y-%m-%d %H:%i:%s');
         } else {
-            // PgCompat: the caller UNION ALL's one of these per EAV backend type
             // (varchar/int/decimal/text) - MySQL coerces the differently-typed values
             // implicitly, Postgres requires them to already share one type before the
             // UNION. getDateFormatSql() above already returns a formatted string, so

--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -54,9 +54,6 @@ class SearchResultApplier implements SearchResultApplierInterface
             $ids[] = (int)$item->getId();
         }
 
-        // PgCompat: FIELD() is MySQL-only - getFieldSql() isn't part of AdapterInterface,
-        // but every connection in this deployment is one of the two PgCompat providers,
-        // both of which implement it as a CASE-expression equivalent.
         $select = $this->collection->getSelect();
         $select->where('e.entity_id IN (?)', $ids)
             ->reset(\Magento\Framework\DB\Select::ORDER)

--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -54,10 +54,12 @@ class SearchResultApplier implements SearchResultApplierInterface
             $ids[] = (int)$item->getId();
         }
 
-        $orderList = implode(',', $ids);
-        $this->collection->getSelect()
-            ->where('e.entity_id IN (?)', $ids)
+        // PgCompat: FIELD() is MySQL-only - getFieldSql() isn't part of AdapterInterface,
+        // but every connection in this deployment is one of the two PgCompat providers,
+        // both of which implement it as a CASE-expression equivalent.
+        $select = $this->collection->getSelect();
+        $select->where('e.entity_id IN (?)', $ids)
             ->reset(\Magento\Framework\DB\Select::ORDER)
-            ->order(new \Magento\Framework\DB\Sql\Expression("FIELD(e.entity_id, $orderList)"));
+            ->order($select->getAdapter()->getFieldSql('e.entity_id', $ids));
     }
 }

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
@@ -160,8 +160,28 @@ class Collection implements ResetAfterRequestInterface
         $childCollection->addWebsiteFilter($context->getExtensionAttributes()->getStore()->getWebsiteId());
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $childCollection->getSelect()->group('e.' . $linkField);
-        $childCollection->getSelect()->columns([
-            'parent_ids' => new \Zend_Db_Expr('GROUP_CONCAT(link_table.parent_id)')
+        // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part of
+        // AdapterInterface, but this deployment's adapter implements it as a
+        // string_agg() equivalent.
+        //
+        // ChildCollection::_initSelect() unconditionally selects raw link_table.parent_id
+        // (needed by every OTHER caller of that base collection, which don't group at
+        // all); once this method's own group('e.' . $linkField) is added on top, that raw
+        // column is no longer functionally dependent on the GROUP BY key (a child can
+        // have more than one parent) and Postgres rejects it outright - the whole reason
+        // parent_ids exists is to carry that same information aggregated instead. Drop
+        // the raw column here, narrowly, via setPart() rather than in the base class,
+        // since only this grouped call site is affected.
+        $select = $childCollection->getSelect();
+        $select->setPart(
+            \Magento\Framework\DB\Select::COLUMNS,
+            array_values(array_filter(
+                $select->getPart(\Magento\Framework\DB\Select::COLUMNS),
+                static fn(array $column) => !($column[0] === 'link_table' && $column[1] === 'parent_id')
+            ))
+        );
+        $select->columns([
+            'parent_ids' => $select->getAdapter()->getGroupConcatSql('link_table.parent_id')
         ]);
 
         $attributeCodes = array_unique(array_merge($this->attributeCodes, $attributeCodes));

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
@@ -160,22 +160,8 @@ class Collection implements ResetAfterRequestInterface
         $childCollection->addWebsiteFilter($context->getExtensionAttributes()->getStore()->getWebsiteId());
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $childCollection->getSelect()->group('e.' . $linkField);
-        // ChildCollection::_initSelect() unconditionally selects raw link_table.parent_id
-        // (needed by every OTHER caller of that base collection, which don't group at
-        // all); once this method's own group('e.' . $linkField) is added on top, that raw
-        // column is no longer functionally dependent on the GROUP BY key (a child can
-        // have more than one parent) and Postgres rejects it outright - the whole reason
-        // parent_ids exists is to carry that same information aggregated instead. Drop
-        // the raw column here, narrowly, via setPart() rather than in the base class,
-        // since only this grouped call site is affected.
         $select = $childCollection->getSelect();
-        $select->setPart(
-            \Magento\Framework\DB\Select::COLUMNS,
-            array_values(array_filter(
-                $select->getPart(\Magento\Framework\DB\Select::COLUMNS),
-                static fn(array $column) => !($column[0] === 'link_table' && $column[1] === 'parent_id')
-            ))
-        );
+        $this->excludeRawParentIdFromGroupedSelect($select);
         $select->columns([
             'parent_ids' => $select->getAdapter()->getGroupConcatSql('link_table.parent_id')
         ]);
@@ -205,6 +191,20 @@ class Collection implements ResetAfterRequestInterface
             }
         }
         return $this->childrenMap;
+    }
+
+    /**
+     * Drop ungrouped link_table.parent_id so GROUP BY e.linkField is valid SQL.
+     */
+    private function excludeRawParentIdFromGroupedSelect(\Magento\Framework\DB\Select $select): void
+    {
+        $select->setPart(
+            \Magento\Framework\DB\Select::COLUMNS,
+            array_values(array_filter(
+                $select->getPart(\Magento\Framework\DB\Select::COLUMNS),
+                static fn (array $column) => !($column[0] === 'link_table' && $column[1] === 'parent_id')
+            ))
+        );
     }
 
     /**

--- a/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
+++ b/app/code/Magento/ConfigurableProductGraphQl/Model/Variant/Collection.php
@@ -160,10 +160,6 @@ class Collection implements ResetAfterRequestInterface
         $childCollection->addWebsiteFilter($context->getExtensionAttributes()->getStore()->getWebsiteId());
         $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
         $childCollection->getSelect()->group('e.' . $linkField);
-        // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part of
-        // AdapterInterface, but this deployment's adapter implements it as a
-        // string_agg() equivalent.
-        //
         // ChildCollection::_initSelect() unconditionally selects raw link_table.parent_id
         // (needed by every OTHER caller of that base collection, which don't group at
         // all); once this method's own group('e.' . $linkField) is added on top, that raw

--- a/app/code/Magento/Customer/Setup/Patch/Data/AddSecurityTrackingAttributes.php
+++ b/app/code/Magento/Customer/Setup/Patch/Data/AddSecurityTrackingAttributes.php
@@ -91,7 +91,7 @@ class AddSecurityTrackingAttributes implements DataPatchInterface, PatchVersionI
 
         $this->moduleDataSetup->getConnection()->update(
             $configTable,
-            ['value' => new \Zend_Db_Expr('value*24')],
+            ['value' => new \Zend_Db_Expr($this->moduleDataSetup->getConnection()->castToNumeric('value') . '*24')],
             ['path = ?' => Customer::XML_PATH_CUSTOMER_RESET_PASSWORD_LINK_EXPIRATION_PERIOD]
         );
 

--- a/app/code/Magento/Customer/Setup/Patch/Data/SessionIDColumnCleanUp.php
+++ b/app/code/Magento/Customer/Setup/Patch/Data/SessionIDColumnCleanUp.php
@@ -66,9 +66,13 @@ class SessionIDColumnCleanUp implements DataPatchInterface
     private function cleanCustomerVisitorTable()
     {
         $tableName = $this->moduleDataSetup->getTable('customer_visitor');
+        // PgCompat: was '... LIMIT 1000' - Postgres has no UPDATE...LIMIT. Safe to drop:
+        // the do-while loop below already terminates on rowCount() === 0, not on a
+        // fixed iteration count, so removing LIMIT just means one larger UPDATE instead
+        // of several 1000-row batches - same terminal state either way.
         // phpcs:ignore Magento2.SQL.RawQuery
         $rawQuery = sprintf(
-            'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL LIMIT 1000',
+            'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL',
             $tableName
         );
 

--- a/app/code/Magento/Customer/Setup/Patch/Data/SessionIDColumnCleanUp.php
+++ b/app/code/Magento/Customer/Setup/Patch/Data/SessionIDColumnCleanUp.php
@@ -66,11 +66,6 @@ class SessionIDColumnCleanUp implements DataPatchInterface
     private function cleanCustomerVisitorTable()
     {
         $tableName = $this->moduleDataSetup->getTable('customer_visitor');
-        // PgCompat: was '... LIMIT 1000' - Postgres has no UPDATE...LIMIT. Safe to drop:
-        // the do-while loop below already terminates on rowCount() === 0, not on a
-        // fixed iteration count, so removing LIMIT just means one larger UPDATE instead
-        // of several 1000-row batches - same terminal state either way.
-        // phpcs:ignore Magento2.SQL.RawQuery
         $rawQuery = sprintf(
             'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL',
             $tableName

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -1063,7 +1063,19 @@ abstract class AbstractEntity extends AbstractResource implements
             $attribute = current($this->_attributesByTable[$table]);
             $eavType = $attribute->getBackendType();
             $select = $this->_getLoadAttributesSelect($object, $table);
-            $selects[$eavType][] = $select->columns('*');
+            // PgCompat: was columns('*') - each per-type value table's "value" column is
+            // a different SQL type (varchar/int/decimal/text/datetime), so UNION ALL-ing
+            // them raw fails ("UNION types character varying and integer cannot be
+            // matched"). Only attribute_id/value_id/value are ever read back (see
+            // _setAttributeValue() below), so an explicit column list - casting just
+            // value to text - replaces the wildcard instead of trying to keep every
+            // table's full, non-identical column set (e.g. Catalog's *_int/*_varchar
+            // etc. have store_id, Customer's don't) unioned as-is.
+            $selects[$eavType][] = $select->columns([
+                'attribute_id' => 'attribute_id',
+                'value_id' => 'value_id',
+                'value' => $this->getConnection()->castToText($this->getConnection()->quoteIdentifier('value')),
+            ]);
         }
         $selectGroups = $this->_resourceHelper->getLoadAttributesSelectGroups($selects);
         foreach ($selectGroups as $selects) {

--- a/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
+++ b/app/code/Magento/Eav/Model/Entity/AbstractEntity.php
@@ -1063,10 +1063,6 @@ abstract class AbstractEntity extends AbstractResource implements
             $attribute = current($this->_attributesByTable[$table]);
             $eavType = $attribute->getBackendType();
             $select = $this->_getLoadAttributesSelect($object, $table);
-            // PgCompat: was columns('*') - each per-type value table's "value" column is
-            // a different SQL type (varchar/int/decimal/text/datetime), so UNION ALL-ing
-            // them raw fails ("UNION types character varying and integer cannot be
-            // matched"). Only attribute_id/value_id/value are ever read back (see
             // _setAttributeValue() below), so an explicit column list - casting just
             // value to text - replaces the wildcard instead of trying to keep every
             // table's full, non-identical column set (e.g. Catalog's *_int/*_varchar

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -76,15 +76,25 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource im
         }
         $attributeId = $this->getAttribute()->getId();
         if (!isset($this->_options[$storeId][$attributeId])) {
-            $collection = $this->_attrOptionCollectionFactory->create()->setPositionOrder(
-                'asc'
-            )->setAttributeFilter(
-                $attributeId
-            )->setStoreFilter(
-                $storeId
-            )->load();
-            $this->_options[$storeId][$attributeId] = $collection->toOptionArray();
-            $this->_optionsDefault[$storeId][$attributeId] = $collection->toOptionArray('default_value');
+            // PgCompat: an attribute with no id yet (new/unsaved attribute model) can
+            // never have real eav_attribute_option rows - short-circuit instead of
+            // querying "attribute_id = ''" (MySQL tolerantly returns zero rows there via
+            // its '' -> 0 numeric coercion; Postgres rejects the comparison outright).
+            // Same empty-result outcome either way, without the pointless query.
+            if (!$attributeId) {
+                $this->_options[$storeId][$attributeId] = [];
+                $this->_optionsDefault[$storeId][$attributeId] = [];
+            } else {
+                $collection = $this->_attrOptionCollectionFactory->create()->setPositionOrder(
+                    'asc'
+                )->setAttributeFilter(
+                    $attributeId
+                )->setStoreFilter(
+                    $storeId
+                )->load();
+                $this->_options[$storeId][$attributeId] = $collection->toOptionArray();
+                $this->_optionsDefault[$storeId][$attributeId] = $collection->toOptionArray('default_value');
+            }
         }
         $options = $defaultValues
             ? $this->_optionsDefault[$storeId][$attributeId]

--- a/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
+++ b/app/code/Magento/Eav/Model/Entity/Attribute/Source/Table.php
@@ -76,10 +76,6 @@ class Table extends \Magento\Eav\Model\Entity\Attribute\Source\AbstractSource im
         }
         $attributeId = $this->getAttribute()->getId();
         if (!isset($this->_options[$storeId][$attributeId])) {
-            // PgCompat: an attribute with no id yet (new/unsaved attribute model) can
-            // never have real eav_attribute_option rows - short-circuit instead of
-            // querying "attribute_id = ''" (MySQL tolerantly returns zero rows there via
-            // its '' -> 0 numeric coercion; Postgres rejects the comparison outright).
             // Same empty-result outcome either way, without the pointless query.
             if (!$attributeId) {
                 $this->_options[$storeId][$attributeId] = [];

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1382,7 +1382,11 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
      */
     protected function _addLoadAttributesSelectValues($select, $table, $type)
     {
-        $select->columns(['value' => 't_d.value']);
+        // PgCompat: this select is UNION ALL'd with one of these per EAV backend type
+        // (varchar/int/decimal/text/datetime) in _loadAttributes() below - MySQL
+        // coerces the differently-typed "value" columns across branches implicitly,
+        // Postgres requires them to already share one type before the UNION.
+        $select->columns(['value' => $this->getConnection()->castToText('t_d.value')]);
         return $select;
     }
 

--- a/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
+++ b/app/code/Magento/Eav/Model/Entity/Collection/AbstractCollection.php
@@ -1382,7 +1382,6 @@ abstract class AbstractCollection extends AbstractDb implements SourceProviderIn
      */
     protected function _addLoadAttributesSelectValues($select, $table, $type)
     {
-        // PgCompat: this select is UNION ALL'd with one of these per EAV backend type
         // (varchar/int/decimal/text/datetime) in _loadAttributes() below - MySQL
         // coerces the differently-typed "value" columns across branches implicitly,
         // Postgres requires them to already share one type before the UNION.

--- a/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
+++ b/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
@@ -43,16 +43,19 @@ class IdsSelectBuilder implements IdsSelectBuilderInterface
      */
     public function build(ChangelogInterface $changelog): Select
     {
-        $numberOfAttributes = $this->calculateEavAttributeSize($changelog);
-        $this->setGroupConcatMax($numberOfAttributes);
-
+        // PgCompat: no setGroupConcatMax() call here - that tunes MySQL's
+        // group_concat_max_len session variable, a length cap string_agg() (used below
+        // via getGroupConcatSql()) has no equivalent of or need for.
         $changelogTableName = $this->resourceConnection->getTableName($changelog->getName());
 
         $connection = $this->resourceConnection->getConnection();
 
+        // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part of
+        // AdapterInterface, but every connection in this deployment is one of the two
+        // PgCompat providers, both of which implement it as a string_agg() equivalent.
         $columns = [
             $changelog->getColumnName(),
-            'attribute_ids' => new Expression('GROUP_CONCAT(attribute_id)'),
+            'attribute_ids' => $connection->getGroupConcatSql('attribute_id'),
             'store_id'
         ];
 

--- a/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
+++ b/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
@@ -43,16 +43,10 @@ class IdsSelectBuilder implements IdsSelectBuilderInterface
      */
     public function build(ChangelogInterface $changelog): Select
     {
-        // PgCompat: no setGroupConcatMax() call here - that tunes MySQL's
-        // group_concat_max_len session variable, a length cap string_agg() (used below
-        // via getGroupConcatSql()) has no equivalent of or need for.
         $changelogTableName = $this->resourceConnection->getTableName($changelog->getName());
 
         $connection = $this->resourceConnection->getConnection();
 
-        // PgCompat: GROUP_CONCAT() is MySQL-only - getGroupConcatSql() isn't part of
-        // AdapterInterface, but every connection in this deployment is one of the two
-        // PgCompat providers, both of which implement it as a string_agg() equivalent.
         $columns = [
             $changelog->getColumnName(),
             'attribute_ids' => $connection->getGroupConcatSql('attribute_id'),

--- a/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
+++ b/app/code/Magento/Eav/Model/Mview/ChangelogBatchWalker/IdsSelectBuilder.php
@@ -46,6 +46,7 @@ class IdsSelectBuilder implements IdsSelectBuilderInterface
         $changelogTableName = $this->resourceConnection->getTableName($changelog->getName());
 
         $connection = $this->resourceConnection->getConnection();
+        $this->setGroupConcatMax($this->calculateEavAttributeSize($changelog));
 
         $columns = [
             $changelog->getColumnName(),

--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
@@ -300,7 +300,20 @@ class Collection extends AbstractCollection
      */
     public function addAttributeGrouping()
     {
-        $this->getSelect()->group('main_table.attribute_id');
+        $select = $this->getSelect();
+        $select->group('main_table.attribute_id');
+        // PgCompat: Catalog\Model\ResourceModel\Product\Attribute\Collection::_initSelect()
+        // unconditionally joins "additional_table" (catalog_eav_attribute) and selects
+        // additional_table.* - Postgres requires a table's OWN primary key in GROUP BY
+        // before it accepts that table's other columns un-aggregated (the join condition
+        // guaranteeing additional_table.attribute_id = main_table.attribute_id isn't
+        // enough; Postgres only applies the functional-dependency exception via a
+        // table's own PK). Guarded on the alias actually being joined - grouping by an
+        // alias that was never joined is a "missing FROM-clause entry" error, and not
+        // every Attribute\Collection subclass joins additional_table.
+        if (array_key_exists('additional_table', $select->getPart(Select::FROM))) {
+            $select->group('additional_table.attribute_id');
+        }
         return $this;
     }
 
@@ -343,15 +356,22 @@ class Collection extends AbstractCollection
             ]
         );
 
+        // PgCompat: joinLeft()'s 3rd arg selects columns from "ao" into the result set;
+        // neither of this method's two real callers (CatalogGraphQl\Model\Config\
+        // FilterAttributeReader, CatalogSearch\Model\Advanced) reads option_id off the
+        // loaded attributes - the join exists only for the ao.option_id > 0 filter below.
+        // Selecting it anyway (MySQL tolerates a non-aggregated, non-grouped column; not
+        // functionally dependent on the GROUP BY key since eav_attribute_option is a
+        // one-to-many join) makes every call to this method fail outright on Postgres.
+        // Selecting no columns from "ao" removes the violation with no behavior change.
         $this->getSelect()->joinLeft(
             ['ao' => $this->getTable('eav_attribute_option')],
             'ao.attribute_id = main_table.attribute_id',
-            'option_id'
-        )->group(
-            'main_table.attribute_id'
+            []
         )->where(
             $orWhere
         );
+        $this->addAttributeGrouping();
         return $this;
     }
 

--- a/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/Entity/Attribute/Collection.php
@@ -302,15 +302,6 @@ class Collection extends AbstractCollection
     {
         $select = $this->getSelect();
         $select->group('main_table.attribute_id');
-        // PgCompat: Catalog\Model\ResourceModel\Product\Attribute\Collection::_initSelect()
-        // unconditionally joins "additional_table" (catalog_eav_attribute) and selects
-        // additional_table.* - Postgres requires a table's OWN primary key in GROUP BY
-        // before it accepts that table's other columns un-aggregated (the join condition
-        // guaranteeing additional_table.attribute_id = main_table.attribute_id isn't
-        // enough; Postgres only applies the functional-dependency exception via a
-        // table's own PK). Guarded on the alias actually being joined - grouping by an
-        // alias that was never joined is a "missing FROM-clause entry" error, and not
-        // every Attribute\Collection subclass joins additional_table.
         if (array_key_exists('additional_table', $select->getPart(Select::FROM))) {
             $select->group('additional_table.attribute_id');
         }
@@ -356,8 +347,6 @@ class Collection extends AbstractCollection
             ]
         );
 
-        // PgCompat: joinLeft()'s 3rd arg selects columns from "ao" into the result set;
-        // neither of this method's two real callers (CatalogGraphQl\Model\Config\
         // FilterAttributeReader, CatalogSearch\Model\Advanced) reads option_id off the
         // loaded attributes - the join exists only for the ao.option_id > 0 filter below.
         // Selecting it anyway (MySQL tolerates a non-aggregated, non-grouped column; not

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -153,10 +153,17 @@ class ReadHandler implements AttributeInterface
         if (count($attributeTables)) {
             $identifiers = null;
             foreach ($attributeTables as $attributeTable => $attributeIds) {
+                // PgCompat: this select is UNION ALL'd (below, via UnionExpression) with
+                // one of these per EAV backend type table (varchar/int/decimal/text/
+                // datetime) - MySQL coerces the differently-typed "value" columns across
+                // branches implicitly, Postgres requires them to already share one type.
+                // Same fix as the other two EAV union-cast sites (see
+                // union-cast-eav-abstract-collection.patch and
+                // Catalog\Model\ResourceModel\Collection\AbstractCollection's override).
                 $select = $connection->select()
                     ->from(
                         ['t' => $attributeTable],
-                        ['value' => 't.value', 'attribute_id' => 't.attribute_id']
+                        ['value' => $connection->castToText('t.value'), 'attribute_id' => 't.attribute_id']
                     )
                     ->where($metadata->getLinkField() . ' = ?', $entityData[$metadata->getLinkField()])
                     ->where('attribute_id IN (?)', $attributeIds, \Zend_Db::INT_TYPE);

--- a/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
+++ b/app/code/Magento/Eav/Model/ResourceModel/ReadHandler.php
@@ -153,10 +153,6 @@ class ReadHandler implements AttributeInterface
         if (count($attributeTables)) {
             $identifiers = null;
             foreach ($attributeTables as $attributeTable => $attributeIds) {
-                // PgCompat: this select is UNION ALL'd (below, via UnionExpression) with
-                // one of these per EAV backend type table (varchar/int/decimal/text/
-                // datetime) - MySQL coerces the differently-typed "value" columns across
-                // branches implicitly, Postgres requires them to already share one type.
                 // Same fix as the other two EAV union-cast sites (see
                 // union-cast-eav-abstract-collection.patch and
                 // Catalog\Model\ResourceModel\Collection\AbstractCollection's override).

--- a/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
+++ b/app/code/Magento/Elasticsearch/Model/ResourceModel/Fulltext/Collection/SearchResultApplier.php
@@ -70,11 +70,10 @@ class SearchResultApplier implements SearchResultApplierInterface
         foreach ($items as $item) {
             $ids[] = (int)$item->getId();
         }
-        $orderList = implode(',', $ids);
         $this->collection->getSelect()
             ->where('e.entity_id IN (?)', $ids)
             ->reset(\Magento\Framework\DB\Select::ORDER)
-            ->order(new \Zend_Db_Expr("FIELD(e.entity_id,$orderList)"));
+            ->order($this->collection->getSelect()->getAdapter()->getFieldSql('e.entity_id', $ids));
     }
 
     /**

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
@@ -123,9 +123,15 @@ class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
      */
     public function cleanProcessedBunches()
     {
-        $this->getConnection()->delete(
+        $connection = $this->getConnection();
+        // PgCompat: TIMESTAMPADD() is MySQL-only (getDateAddSql() renders per-dialect
+        // date arithmetic instead), and CURRENT_TIMESTAMP is a reserved keyword, not a
+        // function - MySQL tolerates the empty-parens call form, Postgres rejects it.
+        $connection->delete(
             $this->getMainTable(),
-            'is_processed = 1 OR TIMESTAMPADD(DAY, 1, updated_at) < CURRENT_TIMESTAMP() '
+            'is_processed = 1 OR '
+            . $connection->getDateAddSql('updated_at', 1, \Magento\Framework\DB\Adapter\AdapterInterface::INTERVAL_DAY)
+            . ' < CURRENT_TIMESTAMP'
         );
     }
 

--- a/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
+++ b/app/code/Magento/ImportExport/Model/ResourceModel/Import/Data.php
@@ -124,9 +124,6 @@ class Data extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb implemen
     public function cleanProcessedBunches()
     {
         $connection = $this->getConnection();
-        // PgCompat: TIMESTAMPADD() is MySQL-only (getDateAddSql() renders per-dialect
-        // date arithmetic instead), and CURRENT_TIMESTAMP is a reserved keyword, not a
-        // function - MySQL tolerates the empty-parens call form, Postgres rejects it.
         $connection->delete(
             $this->getMainTable(),
             'is_processed = 1 OR '

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
@@ -68,7 +68,9 @@ class Consumer extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $select = $connection->select()
             ->from($this->getMainTable())
             ->reset(\Magento\Framework\DB\Select::COLUMNS)
-            ->columns(new \Zend_Db_Expr('CURRENT_TIMESTAMP() - created_at'))
+            // PgCompat: CURRENT_TIMESTAMP is a reserved keyword, not a function - MySQL
+            // tolerates the empty-parens call form, Postgres rejects it.
+            ->columns(new \Zend_Db_Expr('CURRENT_TIMESTAMP - created_at'))
             ->where('entity_id = ?', $consumerId);
 
         return $connection->fetchOne($select);

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
@@ -68,8 +68,6 @@ class Consumer extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
         $select = $connection->select()
             ->from($this->getMainTable())
             ->reset(\Magento\Framework\DB\Select::COLUMNS)
-            // PgCompat: CURRENT_TIMESTAMP is a reserved keyword, not a function - MySQL
-            // tolerates the empty-parens call form, Postgres rejects it.
             ->columns(new \Zend_Db_Expr('CURRENT_TIMESTAMP - created_at'))
             ->where('entity_id = ?', $consumerId);
 

--- a/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
+++ b/app/code/Magento/Integration/Model/ResourceModel/Oauth/Consumer.php
@@ -57,7 +57,8 @@ class Consumer extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
     /**
      * Compute time in seconds since consumer was created.
      *
-     * @deprecated 100.0.6
+     * @deprecated 100.0.6 This method is unused. Use created_at on the consumer model instead.
+     * @see \Magento\Integration\Model\Oauth\Consumer
      *
      * @param int $consumerId - The consumer id
      * @return int - time lapsed in seconds

--- a/app/code/Magento/MediaGalleryUi/Setup/Patch/Data/AddMediaGalleryPermissions.php
+++ b/app/code/Magento/MediaGalleryUi/Setup/Patch/Data/AddMediaGalleryPermissions.php
@@ -45,9 +45,6 @@ class AddMediaGalleryPermissions implements
 
         $select = $connection->select()
             ->from($tableName, ['role_id'])
-            // PgCompat: a double-quoted string is a valid MySQL string literal but a
-            // Postgres identifier - single quotes are required for it to mean the same
-            // thing on both databases.
             ->where("resource_id = 'Magento_Cms::media_gallery'");
 
         $insertData = $this->getInsertData($connection->fetchCol($select));

--- a/app/code/Magento/MediaGalleryUi/Setup/Patch/Data/AddMediaGalleryPermissions.php
+++ b/app/code/Magento/MediaGalleryUi/Setup/Patch/Data/AddMediaGalleryPermissions.php
@@ -45,7 +45,10 @@ class AddMediaGalleryPermissions implements
 
         $select = $connection->select()
             ->from($tableName, ['role_id'])
-            ->where('resource_id = "Magento_Cms::media_gallery"');
+            // PgCompat: a double-quoted string is a valid MySQL string literal but a
+            // Postgres identifier - single quotes are required for it to mean the same
+            // thing on both databases.
+            ->where("resource_id = 'Magento_Cms::media_gallery'");
 
         $insertData = $this->getInsertData($connection->fetchCol($select));
 

--- a/app/code/Magento/ProductVideo/Model/Plugin/ExternalVideoResourceBackend.php
+++ b/app/code/Magento/ProductVideo/Model/Plugin/ExternalVideoResourceBackend.php
@@ -81,15 +81,15 @@ class ExternalVideoResourceBackend
             []
         )->columns([
             'video_provider' => $originalResourceModel->getConnection()
-                ->getIfNullSql('`value_video`.`provider`', '`default_value_video`.`provider`'),
+                ->getIfNullSql('value_video.provider', 'default_value_video.provider'),
             'video_url' => $originalResourceModel->getConnection()
-                ->getIfNullSql('`value_video`.`url`', '`default_value_video`.`url`'),
+                ->getIfNullSql('value_video.url', 'default_value_video.url'),
             'video_title' => $originalResourceModel->getConnection()
-                ->getIfNullSql('`value_video`.`title`', '`default_value_video`.`title`'),
+                ->getIfNullSql('value_video.title', 'default_value_video.title'),
             'video_description' => $originalResourceModel->getConnection()
-                ->getIfNullSql('`value_video`.`description`', '`default_value_video`.`description`'),
+                ->getIfNullSql('value_video.description', 'default_value_video.description'),
             'video_metadata' => $originalResourceModel->getConnection()
-                ->getIfNullSql('`value_video`.`metadata`', '`default_value_video`.`metadata`'),
+                ->getIfNullSql('value_video.metadata', 'default_value_video.metadata'),
             'video_provider_default' => 'default_value_video.provider',
             'video_url_default' => 'default_value_video.url',
             'video_title_default' => 'default_value_video.title',

--- a/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
+++ b/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
@@ -101,8 +101,6 @@ class Summary extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 "e.entity_id = review_summary.entity_pk_value AND review_summary.store_id = {$storeId}"
                 . " AND review_summary.entity_type = ({$summaryEntitySubSelect})"
             );
-            // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
-            // Postgres) instead of hardcoding MySQL's IFNULL() text.
             $productCollection->getSelect()
                 ->joinLeft(
                     ['review_summary' => $this->getMainTable()],

--- a/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
+++ b/app/code/Magento/Review/Model/ResourceModel/Review/Summary.php
@@ -101,13 +101,15 @@ class Summary extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
                 "e.entity_id = review_summary.entity_pk_value AND review_summary.store_id = {$storeId}"
                 . " AND review_summary.entity_type = ({$summaryEntitySubSelect})"
             );
+            // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
+            // Postgres) instead of hardcoding MySQL's IFNULL() text.
             $productCollection->getSelect()
                 ->joinLeft(
                     ['review_summary' => $this->getMainTable()],
                     $joinCond,
                     [
-                        'reviews_count' => new \Zend_Db_Expr("IFNULL(review_summary.reviews_count, 0)"),
-                        'rating_summary' => new \Zend_Db_Expr("IFNULL(review_summary.rating_summary, 0)")
+                        'reviews_count' => $this->getConnection()->getIfNullSql('review_summary.reviews_count', 0),
+                        'rating_summary' => $this->getConnection()->getIfNullSql('review_summary.rating_summary', 0)
                     ]
                 );
         }

--- a/app/code/Magento/Rule/Model/Condition/Sql/Builder.php
+++ b/app/code/Magento/Rule/Model/Condition/Sql/Builder.php
@@ -282,13 +282,19 @@ class Builder
             }
 
             if (!empty($conditions) && !empty($attributeField)) {
-                $conditions = $this->_connection->quote(
-                    array_map('trim', explode(',', $conditions))
+                $conditionValues = explode(
+                    ', ',
+                    $this->_connection->quote(array_map('trim', explode(',', $conditions)))
                 );
                 $collection->getSelect()->reset(Select::ORDER);
                 $collection->getSelect()->order(
                     $this->_expressionFactory->create(
-                        ['expression' => "FIELD($attributeField, $conditions)"]
+                        [
+                            'expression' => (string) $this->_connection->getFieldSql(
+                                $attributeField,
+                                $conditionValues
+                            )
+                        ]
                     )
                 );
             }

--- a/app/code/Magento/Security/Model/ResourceModel/UserExpiration/Collection.php
+++ b/app/code/Magento/Security/Model/ResourceModel/UserExpiration/Collection.php
@@ -40,12 +40,12 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $currentTime = new \DateTime();
         $currentTime->format('Y-m-d H:i:s');
         $this->getSelect()->joinLeft(
-            ['user' => $this->getTable('admin_user')],
-            'main_table.user_id = user.user_id',
+            ['admin_user' => $this->getTable('admin_user')],
+            'main_table.user_id = admin_user.user_id',
             ['is_active']
         );
         $this->addFieldToFilter('expires_at', ['lt' => $currentTime])
-            ->addFieldToFilter('user.is_active', 1);
+            ->addFieldToFilter('admin_user.is_active', 1);
 
         return $this;
     }

--- a/app/code/Magento/Security/Setup/Patch/Data/SessionIDColumnCleanUp.php
+++ b/app/code/Magento/Security/Setup/Patch/Data/SessionIDColumnCleanUp.php
@@ -66,11 +66,6 @@ class SessionIDColumnCleanUp implements DataPatchInterface
     private function cleanAdminUserSessionTable()
     {
         $tableName = $this->moduleDataSetup->getTable('admin_user_session');
-        // PgCompat: was '... LIMIT 1000' - Postgres has no UPDATE...LIMIT. Safe to drop:
-        // the do-while loop below already terminates on rowCount() === 0, not on a
-        // fixed iteration count, so removing LIMIT just means one larger UPDATE instead
-        // of several 1000-row batches - same terminal state either way.
-        // phpcs:ignore Magento2.SQL.RawQuery
         $rawQuery = sprintf(
             'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL',
             $tableName

--- a/app/code/Magento/Security/Setup/Patch/Data/SessionIDColumnCleanUp.php
+++ b/app/code/Magento/Security/Setup/Patch/Data/SessionIDColumnCleanUp.php
@@ -66,9 +66,13 @@ class SessionIDColumnCleanUp implements DataPatchInterface
     private function cleanAdminUserSessionTable()
     {
         $tableName = $this->moduleDataSetup->getTable('admin_user_session');
+        // PgCompat: was '... LIMIT 1000' - Postgres has no UPDATE...LIMIT. Safe to drop:
+        // the do-while loop below already terminates on rowCount() === 0, not on a
+        // fixed iteration count, so removing LIMIT just means one larger UPDATE instead
+        // of several 1000-row batches - same terminal state either way.
         // phpcs:ignore Magento2.SQL.RawQuery
         $rawQuery = sprintf(
-            'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL LIMIT 1000',
+            'UPDATE %s SET session_id = NULL WHERE session_id IS NOT NULL',
             $tableName
         );
 

--- a/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
+++ b/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
@@ -42,12 +42,16 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
 
         // data update for Vault module < 2.0.1
         // update sets credit card as default token type
+        // PgCompat: was ' = ""' - a double-quoted empty-string literal, MySQL-only
+        // (ANSI_QUOTES-off syntax); Postgres double quotes always mean an identifier, so
+        // this rendered as a zero-length identifier reference instead of comparing
+        // against an empty string. Single-quoted is valid on both.
         $this->moduleDataSetup->getConnection()->update(
             $this->moduleDataSetup->getTable('vault_payment_token'),
             [
                 PaymentTokenInterface::TYPE => CreditCardTokenFactory::TOKEN_TYPE_CREDIT_CARD
             ],
-            PaymentTokenInterface::TYPE . ' = ""'
+            PaymentTokenInterface::TYPE . " = ''"
         );
 
         $this->moduleDataSetup->getConnection()->endSetup();

--- a/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
+++ b/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
@@ -8,13 +8,11 @@ namespace Magento\Vault\Setup\Patch\Data;
 
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Model\CreditCardTokenFactory;
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
 /**
- * Class SetCreditCardAsDefaultTokenType
- * @package Magento\Vault\Setup\Patch
+ * Sets credit card as the default vault payment token type for rows upgraded from Vault < 2.0.1.
  */
 class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersionInterface
 {
@@ -24,7 +22,6 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
     private $moduleDataSetup;
 
     /**
-     * SetCreditCardAsDefaultTokenType constructor.
      * @param \Magento\Framework\Setup\ModuleDataSetupInterface $moduleDataSetup
      */
     public function __construct(
@@ -34,7 +31,7 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function apply()
     {
@@ -54,10 +51,11 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
         );
 
         $this->moduleDataSetup->getConnection()->endSetup();
+        return $this;
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getDependencies()
     {
@@ -65,7 +63,7 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public static function getVersion()
     {
@@ -73,7 +71,7 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     public function getAliases()
     {

--- a/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
+++ b/app/code/Magento/Vault/Setup/Patch/Data/SetCreditCardAsDefaultTokenType.php
@@ -42,7 +42,6 @@ class SetCreditCardAsDefaultTokenType implements DataPatchInterface, PatchVersio
 
         // data update for Vault module < 2.0.1
         // update sets credit card as default token type
-        // PgCompat: was ' = ""' - a double-quoted empty-string literal, MySQL-only
         // (ANSI_QUOTES-off syntax); Postgres double quotes always mean an identifier, so
         // this rendered as a zero-length identifier reference instead of comparing
         // against an empty string. Single-quoted is valid on both.

--- a/app/code/Magento/Weee/Plugin/Catalog/ResourceModel/Product/WeeeAttributeProductSort.php
+++ b/app/code/Magento/Weee/Plugin/Catalog/ResourceModel/Product/WeeeAttributeProductSort.php
@@ -44,14 +44,19 @@ class WeeeAttributeProductSort
         int $productId,
         int $storeId
     ):array {
-        $select = $this->resourceConnection->getConnection()->select();
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select();
 
+        // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
+        // Postgres) instead of hardcoding MySQL's IFNULL() text.
+        $weeeValue = $connection->getIfNullSql(
+            'weee_child.value',
+            (string) $connection->getIfNullSql('weee_parent.value', 0)
+        );
         foreach ($result as $select) {
             $select->columns(
                 [
-                    'weee_min_price' => new \Zend_Db_Expr(
-                        '(t.min_price + IFNULL(weee_child.value, IFNULL(weee_parent.value, 0)))'
-                    )
+                    'weee_min_price' => new \Zend_Db_Expr('(t.min_price + ' . $weeeValue . ')')
                 ]
             )->joinLeft(
                 ['weee_child' => $this->resourceConnection->getTableName('weee_tax')],

--- a/app/code/Magento/Weee/Plugin/Catalog/ResourceModel/Product/WeeeAttributeProductSort.php
+++ b/app/code/Magento/Weee/Plugin/Catalog/ResourceModel/Product/WeeeAttributeProductSort.php
@@ -47,8 +47,6 @@ class WeeeAttributeProductSort
         $connection = $this->resourceConnection->getConnection();
         $select = $connection->select();
 
-        // PgCompat: getIfNullSql() renders per-dialect (IFNULL on MySQL, COALESCE on
-        // Postgres) instead of hardcoding MySQL's IFNULL() text.
         $weeeValue = $connection->getIfNullSql(
             'weee_child.value',
             (string) $connection->getIfNullSql('weee_parent.value', 0)

--- a/lib/internal/Magento/Framework/Cache/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Database.php
@@ -230,17 +230,18 @@ class Database extends AbstractBackend implements ExtendedBackendInterface
                 $time = time();
                 $expire = $lifetime === 0 || $lifetime === null ? 0 : $time + $lifetime;
 
-                $idCol = $connection->quoteIdentifier('id');
-                $dataCol = $connection->quoteIdentifier('data');
-                $createCol = $connection->quoteIdentifier('create_time');
-                $updateCol = $connection->quoteIdentifier('update_time');
-                $expireCol = $connection->quoteIdentifier('expire_time');
-
-                $query = "INSERT INTO {$dataTable} ({$idCol}, {$dataCol}, {$createCol}, {$updateCol}, {$expireCol}) " .
-                    "VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE {$dataCol}=VALUES({$dataCol}), " .
-                    "{$updateCol}=VALUES({$updateCol}), {$expireCol}=VALUES({$expireCol})";
-
-                $result = $connection->query($query, [$id, $data, $time, $time, $expire])->rowCount();
+                // PgCompat: insertOnDuplicate() emits ON CONFLICT on Postgres.
+                $result = $connection->insertOnDuplicate(
+                    $dataTable,
+                    [
+                        'id' => $id,
+                        'data' => $data,
+                        'create_time' => $time,
+                        'update_time' => $time,
+                        'expire_time' => $expire,
+                    ],
+                    ['data', 'update_time', 'expire_time']
+                );
             }
             if ($result) {
                 $result = $this->_saveTags($id, $tags);

--- a/lib/internal/Magento/Framework/Cache/Backend/Database.php
+++ b/lib/internal/Magento/Framework/Cache/Backend/Database.php
@@ -230,7 +230,6 @@ class Database extends AbstractBackend implements ExtendedBackendInterface
                 $time = time();
                 $expire = $lifetime === 0 || $lifetime === null ? 0 : $time + $lifetime;
 
-                // PgCompat: insertOnDuplicate() emits ON CONFLICT on Postgres.
                 $result = $connection->insertOnDuplicate(
                     $dataTable,
                     [

--- a/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -820,6 +820,61 @@ interface AdapterInterface
     public function getIfNullSql($expression, $value = 0);
 
     /**
+     * GROUP_CONCAT / string_agg equivalent
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @param string $separator
+     * @param string|\Zend_Db_Expr|null $orderBy
+     * @param bool $distinct
+     * @return \Zend_Db_Expr
+     */
+    public function getGroupConcatSql($expression, $separator = ',', $orderBy = null, $distinct = false);
+
+    /**
+     * FIELD() / CASE equivalent for ORDER BY a fixed list
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @param array $values
+     * @return \Zend_Db_Expr
+     */
+    public function getFieldSql($expression, array $values);
+
+    /**
+     * Cast an expression to text for UNION type alignment
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @return \Zend_Db_Expr
+     */
+    public function castToText($expression);
+
+    /**
+     * Cast an expression to a numeric type for arithmetic
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @return \Zend_Db_Expr
+     */
+    public function castToNumeric($expression);
+
+    /**
+     * CREATE TABLE new LIKE origin
+     *
+     * @param string $newTableName
+     * @param string $originTableName
+     * @return \Zend_Db_Statement_Interface
+     */
+    public function createTableLike($newTableName, $originTableName);
+
+    /**
+     * CREATE TEMPORARY TABLE from a SELECT (and optional index definitions)
+     *
+     * @param string $name
+     * @param string[] $indexStatements
+     * @param \Magento\Framework\DB\Select $select
+     * @return \Zend_Db_Statement_Interface
+     */
+    public function createTemporaryTableFromSelect($name, array $indexStatements, \Magento\Framework\DB\Select $select);
+
+    /**
      * Generate fragment of SQL, that combine together (concatenate) the results from data array
      *
      * All arguments in data must be quoted

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -3459,6 +3459,79 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface, Rese
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getGroupConcatSql($expression, $separator = ',', $orderBy = null, $distinct = false)
+    {
+        $sql = 'GROUP_CONCAT(' . ($distinct ? 'DISTINCT ' : '') . $expression;
+        if ($orderBy !== null) {
+            $sql .= ' ORDER BY ' . $orderBy;
+        }
+        return new \Zend_Db_Expr($sql . ' SEPARATOR ' . $this->quote($separator) . ')');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFieldSql($expression, array $values)
+    {
+        $parts = [];
+        foreach ($values as $value) {
+            if ($value === '') {
+                continue;
+            }
+            $parts[] = $value;
+        }
+        if (!$parts) {
+            return new \Zend_Db_Expr('0');
+        }
+        return new \Zend_Db_Expr('FIELD(' . $expression . ', ' . implode(', ', $parts) . ')');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createTableLike($newTableName, $originTableName)
+    {
+        return $this->query(sprintf(
+            'CREATE TABLE %s LIKE %s',
+            $this->quoteIdentifier($newTableName),
+            $this->quoteIdentifier($originTableName)
+        ));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createTemporaryTableFromSelect($name, array $indexStatements, Select $select)
+    {
+        $sql = sprintf(
+            'CREATE TEMPORARY TABLE %s %s ENGINE=%s IGNORE (%s)',
+            $this->quoteIdentifier($name),
+            $indexStatements ? '(' . implode(',', $indexStatements) . ')' : '',
+            $this->quoteIdentifier('innodb'),
+            $select
+        );
+        return $this->query($sql, $select->getBind());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function castToText($expression)
+    {
+        return new \Zend_Db_Expr((string) $expression);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function castToNumeric($expression)
+    {
+        return new \Zend_Db_Expr('CAST(' . $expression . ' AS DECIMAL(20,6))');
+    }
+
+    /**
      * Generates case SQL fragment
      *
      * Generate fragment of SQL, that check value against multiple condition cases

--- a/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
@@ -174,7 +174,17 @@ class BatchIterator implements BatchIteratorInterface
             ]
         );
         $row = $this->connection->fetchRow($wrapperSelect);
-        $this->minValue = $row['max'];
+        // PgCompat: MAX() over zero matching rows is SQL NULL - when this batch is
+        // empty (cnt below ends up 0 and the iterator stops right after this call
+        // anyway), don't overwrite minValue with that null. A leftover null minValue
+        // fed into initSelectObject()'s "> ?" bind is otherwise silently coerced to an
+        // empty-string parameter by PDO, which MySQL's loose bigint/string comparison
+        // tolerates (implicitly treating '' as 0) but Postgres rejects outright
+        // ("invalid input syntax for type bigint"). Real-world trigger: any
+        // FieldDataConverter::convert() call (e.g. Theme's ConvertSerializedData data
+        // patch) whose target rows are exhausted after fewer than batchSize rows, or -
+        // as first hit here - never existed at all.
+        $this->minValue = $row['max'] ?? $this->minValue;
         return (int)$row['cnt'];
     }
 

--- a/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
@@ -174,7 +174,6 @@ class BatchIterator implements BatchIteratorInterface
             ]
         );
         $row = $this->connection->fetchRow($wrapperSelect);
-        // PgCompat: MAX() over zero matching rows is SQL NULL - when this batch is
         // empty (cnt below ends up 0 and the iterator stops right after this call
         // anyway), don't overwrite minValue with that null. A leftover null minValue
         // fed into initSelectObject()'s "> ?" bind is otherwise silently coerced to an

--- a/lib/internal/Magento/Framework/DB/Select.php
+++ b/lib/internal/Magento/Framework/DB/Select.php
@@ -57,12 +57,26 @@ class Select extends \Zend_Db_Select
      * Class constructor
      * Add straight join support
      *
-     * @param Adapter\Pdo\Mysql $adapter
+     * PgCompat: type-hint relaxed from the concrete Adapter\Pdo\Mysql to
+     * Zend_Db_Adapter_Abstract - this class only calls forUpdate()/
+     * getQuoteIdentifierSymbol()/orderRand()/supportStraightJoin() on $adapter, all
+     * part of AdapterInterface's own contract (not Zend_Db_Adapter_Abstract's), so the
+     * narrower Mysql-only type-hint was never load-bearing for anything this class
+     * actually does - PHP doesn't statically check that a dynamic method call exists
+     * against the parameter's declared type, only that the object passed at runtime
+     * has it. Zend_Db_Adapter_Abstract (not the AdapterInterface interface) specifically
+     * because parent::__construct() below requires it, and PHP's intersection types
+     * can't combine an interface with a concrete class. SelectFactory::create() already
+     * type-hints AdapterInterface (not Mysql) when building this object, so without
+     * this change ANY AdapterInterface implementation that doesn't extend Magento's own
+     * Mysql adapter fails here with a TypeError the moment it calls select().
+     *
+     * @param \Zend_Db_Adapter_Abstract $adapter
      * @param Select\SelectRenderer $selectRenderer
      * @param array $parts
      */
     public function __construct(
-        \Magento\Framework\DB\Adapter\Pdo\Mysql $adapter,
+        \Zend_Db_Adapter_Abstract $adapter,
         \Magento\Framework\DB\Select\SelectRenderer $selectRenderer,
         $parts = []
     ) {

--- a/lib/internal/Magento/Framework/DB/Select.php
+++ b/lib/internal/Magento/Framework/DB/Select.php
@@ -57,19 +57,8 @@ class Select extends \Zend_Db_Select
      * Class constructor
      * Add straight join support
      *
-     * PgCompat: type-hint relaxed from the concrete Adapter\Pdo\Mysql to
-     * Zend_Db_Adapter_Abstract - this class only calls forUpdate()/
-     * getQuoteIdentifierSymbol()/orderRand()/supportStraightJoin() on $adapter, all
-     * part of AdapterInterface's own contract (not Zend_Db_Adapter_Abstract's), so the
-     * narrower Mysql-only type-hint was never load-bearing for anything this class
-     * actually does - PHP doesn't statically check that a dynamic method call exists
-     * against the parameter's declared type, only that the object passed at runtime
-     * has it. Zend_Db_Adapter_Abstract (not the AdapterInterface interface) specifically
-     * because parent::__construct() below requires it, and PHP's intersection types
-     * can't combine an interface with a concrete class. SelectFactory::create() already
-     * type-hints AdapterInterface (not Mysql) when building this object, so without
-     * this change ANY AdapterInterface implementation that doesn't extend Magento's own
-     * Mysql adapter fails here with a TypeError the moment it calls select().
+     * Typed as Zend_Db_Adapter_Abstract (parent constructor requirement) rather than
+     * Pdo\Mysql so any AdapterInterface implementation can call select().
      *
      * @param \Zend_Db_Adapter_Abstract $adapter
      * @param Select\SelectRenderer $selectRenderer

--- a/lib/internal/Magento/Framework/DB/TemporaryTableService.php
+++ b/lib/internal/Magento/Framework/DB/TemporaryTableService.php
@@ -120,18 +120,7 @@ class TemporaryTableService
             $indexStatements[] = sprintf('%s(%s)', $indexType, $renderedColumns);
         }
 
-        $statement = sprintf(
-            'CREATE TEMPORARY TABLE %s %s ENGINE=%s IGNORE (%s)',
-            $adapter->quoteIdentifier($name),
-            $indexStatements ? '(' . implode(',', $indexStatements) . ')' : '',
-            $adapter->quoteIdentifier($dbEngine),
-            "{$select}"
-        );
-
-        $adapter->query(
-            $statement,
-            $select->getBind()
-        );
+        $adapter->createTemporaryTableFromSelect($name, $indexStatements, $select);
 
         $this->createdTableAdapters[$name] = $adapter;
 

--- a/lib/internal/Magento/Framework/DB/TemporaryTableService.php
+++ b/lib/internal/Magento/Framework/DB/TemporaryTableService.php
@@ -16,8 +16,8 @@ use Magento\Framework\DB\Adapter\AdapterInterface;
  */
 class TemporaryTableService
 {
-    const INDEX_METHOD_HASH = 'HASH';
-    const DB_ENGINE_INNODB = 'INNODB';
+    public const INDEX_METHOD_HASH = 'HASH';
+    public const DB_ENGINE_INNODB = 'INNODB';
 
     /**
      * @var string[]

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -1131,4 +1131,78 @@ class MysqlTest extends TestCase
         $adapter->__destruct();
         $this->assertEquals(0, $adapter->getTransactionLevel());
     }
+
+    public function testGetGroupConcatSql(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quote']);
+        $adapter->method('quote')->willReturnCallback(static function ($value) {
+            return "'" . $value . "'";
+        });
+
+        $this->assertSame(
+            "GROUP_CONCAT(sku SEPARATOR ',')",
+            (string) $adapter->getGroupConcatSql('sku')
+        );
+        $this->assertSame(
+            "GROUP_CONCAT(DISTINCT sku ORDER BY sku SEPARATOR '|')",
+            (string) $adapter->getGroupConcatSql('sku', '|', 'sku', true)
+        );
+    }
+
+    public function testGetFieldSql(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock([]);
+        $this->assertSame('0', (string) $adapter->getFieldSql('status', []));
+        $this->assertSame('0', (string) $adapter->getFieldSql('status', ['']));
+        $this->assertSame(
+            'FIELD(status, 1, 2, 3)',
+            (string) $adapter->getFieldSql('status', [1, '', 2, 3])
+        );
+    }
+
+    public function testCastHelpers(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock([]);
+        $this->assertSame('value', (string) $adapter->castToText('value'));
+        $this->assertSame('CAST(value AS DECIMAL(20,6))', (string) $adapter->castToNumeric('value'));
+    }
+
+    public function testCreateTableLike(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quoteIdentifier']);
+        $adapter->method('quoteIdentifier')->willReturnCallback(static function ($value) {
+            return '`' . $value . '`';
+        });
+        $stmt = $this->createMock(\Zend_Db_Statement_Pdo::class);
+        $adapter->expects($this->once())
+            ->method('query')
+            ->with('CREATE TABLE `new_table` LIKE `origin_table`')
+            ->willReturn($stmt);
+
+        $this->assertSame($stmt, $adapter->createTableLike('new_table', 'origin_table'));
+    }
+
+    public function testCreateTemporaryTableFromSelect(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quoteIdentifier']);
+        $adapter->method('quoteIdentifier')->willReturnCallback(static function ($value) {
+            return '`' . $value . '`';
+        });
+        $select = $this->createMock(Select::class);
+        $select->method('__toString')->willReturn('SELECT 1');
+        $select->method('getBind')->willReturn(['foo' => 'bar']);
+        $stmt = $this->createMock(\Zend_Db_Statement_Pdo::class);
+        $adapter->expects($this->once())
+            ->method('query')
+            ->with(
+                'CREATE TEMPORARY TABLE `tmp` (PRIMARY KEY(id)) ENGINE=`innodb` IGNORE (SELECT 1)',
+                ['foo' => 'bar']
+            )
+            ->willReturn($stmt);
+
+        $this->assertSame(
+            $stmt,
+            $adapter->createTemporaryTableFromSelect('tmp', ['PRIMARY KEY(id)'], $select)
+        );
+    }
 }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -1132,7 +1132,7 @@ class MysqlTest extends TestCase
         $this->assertEquals(0, $adapter->getTransactionLevel());
     }
 
-    public function testGetGroupConcatSql(): void
+    public function testDialectHelpers(): void
     {
         $adapter = $this->getMysqlPdoAdapterMock(['query', 'quote']);
         $adapter->method('quote')->willReturnCallback(static function ($value) {
@@ -1147,59 +1147,42 @@ class MysqlTest extends TestCase
             "GROUP_CONCAT(DISTINCT sku ORDER BY sku SEPARATOR '|')",
             (string) $adapter->getGroupConcatSql('sku', '|', 'sku', true)
         );
-    }
-
-    public function testGetFieldSql(): void
-    {
-        $adapter = $this->getMysqlPdoAdapterMock([]);
         $this->assertSame('0', (string) $adapter->getFieldSql('status', []));
         $this->assertSame('0', (string) $adapter->getFieldSql('status', ['']));
         $this->assertSame(
             'FIELD(status, 1, 2, 3)',
             (string) $adapter->getFieldSql('status', [1, '', 2, 3])
         );
-    }
-
-    public function testCastHelpers(): void
-    {
-        $adapter = $this->getMysqlPdoAdapterMock([]);
         $this->assertSame('value', (string) $adapter->castToText('value'));
         $this->assertSame('CAST(value AS DECIMAL(20,6))', (string) $adapter->castToNumeric('value'));
     }
 
-    public function testCreateTableLike(): void
+    public function testCreateTableLikeAndTemporaryFromSelect(): void
     {
         $adapter = $this->getMysqlPdoAdapterMock(['query', 'quoteIdentifier']);
         $adapter->method('quoteIdentifier')->willReturnCallback(static function ($value) {
             return '`' . $value . '`';
         });
         $stmt = $this->createMock(\Zend_Db_Statement_Pdo::class);
-        $adapter->expects($this->once())
-            ->method('query')
-            ->with('CREATE TABLE `new_table` LIKE `origin_table`')
-            ->willReturn($stmt);
-
-        $this->assertSame($stmt, $adapter->createTableLike('new_table', 'origin_table'));
-    }
-
-    public function testCreateTemporaryTableFromSelect(): void
-    {
-        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quoteIdentifier']);
-        $adapter->method('quoteIdentifier')->willReturnCallback(static function ($value) {
-            return '`' . $value . '`';
-        });
         $select = $this->createMock(Select::class);
         $select->method('__toString')->willReturn('SELECT 1');
         $select->method('getBind')->willReturn(['foo' => 'bar']);
-        $stmt = $this->createMock(\Zend_Db_Statement_Pdo::class);
-        $adapter->expects($this->once())
+        $adapter->expects($this->exactly(2))
             ->method('query')
-            ->with(
-                'CREATE TEMPORARY TABLE `tmp` (PRIMARY KEY(id)) ENGINE=`innodb` IGNORE (SELECT 1)',
-                ['foo' => 'bar']
-            )
-            ->willReturn($stmt);
+            ->willReturnCallback(function ($sql, $bind = []) use ($stmt) {
+                if ($sql === 'CREATE TABLE `new_table` LIKE `origin_table`') {
+                    $this->assertSame([], $bind);
+                    return $stmt;
+                }
+                $this->assertSame(
+                    'CREATE TEMPORARY TABLE `tmp` (PRIMARY KEY(id)) ENGINE=`innodb` IGNORE (SELECT 1)',
+                    $sql
+                );
+                $this->assertSame(['foo' => 'bar'], $bind);
+                return $stmt;
+            });
 
+        $this->assertSame($stmt, $adapter->createTableLike('new_table', 'origin_table'));
         $this->assertSame(
             $stmt,
             $adapter->createTemporaryTableFromSelect('tmp', ['PRIMARY KEY(id)'], $select)

--- a/lib/internal/Magento/Framework/DB/Test/Unit/TemporaryTableServiceTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/TemporaryTableServiceTest.php
@@ -94,33 +94,25 @@ class TemporaryTableServiceTest extends TestCase
     #[DataProvider('createFromSelectDataProvider')]
     public function testCreateFromSelect($indexes, $expectedSelect)
     {
-        $selectString = 'select * from sometable';
         $random = 'random_table';
 
         $this->randomMock->expects($this->once())
             ->method('getUniqueHash')
             ->willReturn($random);
 
-        $this->adapterMock->expects($this->once())
-            ->method('query')
-            ->with($expectedSelect)
-            ->willReturnSelf();
-
-        $this->adapterMock->expects($this->once())
-            ->method('query')
-            ->willReturnSelf();
-
         $this->adapterMock->expects($this->any())
             ->method('quoteIdentifier')
             ->willReturnArgument(0);
 
-        $this->selectMock->expects($this->once())
-            ->method('getBind')
-            ->willReturn(['bind']);
-
-        $this->selectMock->expects($this->any())
-            ->method('__toString')
-            ->willReturn($selectString);
+        $this->adapterMock->expects($this->once())
+            ->method('createTemporaryTableFromSelect')
+            ->with(
+                $random,
+                $this->callback(static function (array $indexStatements) use ($expectedSelect) {
+                    return str_contains($expectedSelect, implode(',', $indexStatements));
+                }),
+                $this->selectMock
+            );
 
         $this->assertEquals(
             $random,

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -736,7 +736,16 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
         if (!$this->_isOrdersRendered) {
             foreach ($this->_orders as $field => $direction) {
                 if (isset($this->sqlReservedWords[strtoupper($field)])) {
-                    $field = "`$field`";
+                    // PgCompat: was a hardcoded "`$field`" backtick literal - correct by
+                    // coincidence only on MySQL (whose quote character happens to be a
+                    // backtick), and it bypasses the adapter's own quoteIdentifier()
+                    // entirely, so Postgres (whose reserved-word set differs anyway -
+                    // e.g. "position" isn't reserved there, but this same $field is
+                    // wrapped unconditionally once it matches MySQL's list) received a
+                    // literal, invalid backtick instead of a real identifier quote.
+                    // quoteIdentifier() is exactly what every other quoting path in this
+                    // class already goes through.
+                    $field = $this->getConnection()->quoteIdentifier($field);
                 }
 
                 $this->_select->order(new \Zend_Db_Expr($field . ' ' . $direction));

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -736,7 +736,6 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
         if (!$this->_isOrdersRendered) {
             foreach ($this->_orders as $field => $direction) {
                 if (isset($this->sqlReservedWords[strtoupper($field)])) {
-                    // PgCompat: was a hardcoded "`$field`" backtick literal - correct by
                     // coincidence only on MySQL (whose quote character happens to be a
                     // backtick), and it bypasses the adapter's own quoteIdentifier()
                     // entirely, so Postgres (whose reserved-word set differs anyway -

--- a/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
@@ -173,6 +173,21 @@ class BatchIteratorTest extends TestCase
     }
 
     /**
+     * MAX() over zero rows is SQL NULL. Keep the previous minValue so the next
+     * WHERE rangeField > ? bind stays an integer (0), not null/''.
+     */
+    public function testEmptyBatchDoesNotBindNullMinValue(): void
+    {
+        $filed = $this->correlationName . '.' . $this->rangeField;
+        $this->connectionMock->method('fetchRow')->willReturn(['max' => null, 'cnt' => 0]);
+        $this->selectMock->expects($this->exactly(2))->method('where')->with($filed . ' > ?', 0);
+
+        $this->model->current();
+        $this->assertFalse($this->model->valid());
+        $this->model->next();
+    }
+
+    /**
      * Test steps:
      * 1. $iterator->next();
      * 2. $iterator->key()

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList.php
@@ -388,7 +388,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_HOST],
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_USER],
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_PASSWORD],
-                    $driverOptions
+                    $driverOptions,
+                    $options[ConfigOptionsListConstants::INPUT_KEY_DB_ENGINE] ?? null
                 );
             } catch (\Exception $exception) {
                 $errors[] = $exception->getMessage();

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -1667,7 +1667,11 @@ class Installer
                 ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
                 '/' . ConfigOptionsListConstants::KEY_PASSWORD
             ),
-            $driverOptions
+            $driverOptions,
+            $this->deploymentConfig->get(
+                ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                '/' . ConfigOptionsListConstants::KEY_ENGINE
+            )
         );
         $prefix = $this->deploymentConfig->get(
             ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .

--- a/setup/src/Magento/Setup/Validator/DbValidator.php
+++ b/setup/src/Magento/Setup/Validator/DbValidator.php
@@ -89,6 +89,7 @@ class DbValidator
      * @param string $dbUser
      * @param string $dbPass
      * @param array $driverOptions
+     * @param string|null $engine Database engine (mysql, postgresql)
      * @return bool
      * @throws \Magento\Setup\Exception
      */
@@ -97,19 +98,22 @@ class DbValidator
         $dbHost,
         $dbUser,
         $dbPass = '',
-        $driverOptions = []
+        $driverOptions = [],
+        $engine = null
     ) {
         // establish connection to information_schema view to retrieve information about user and table privileges
-        $connection = $this->connectionFactory->create(
-            [
-                ConfigOptionsListConstants::KEY_NAME => 'information_schema',
-                ConfigOptionsListConstants::KEY_HOST => $dbHost,
-                ConfigOptionsListConstants::KEY_USER => $dbUser,
-                ConfigOptionsListConstants::KEY_PASSWORD => $dbPass,
-                ConfigOptionsListConstants::KEY_ACTIVE => true,
-                ConfigOptionsListConstants::KEY_DRIVER_OPTIONS => $driverOptions,
-            ]
-        );
+        $connectionConfig = [
+            ConfigOptionsListConstants::KEY_NAME => 'information_schema',
+            ConfigOptionsListConstants::KEY_HOST => $dbHost,
+            ConfigOptionsListConstants::KEY_USER => $dbUser,
+            ConfigOptionsListConstants::KEY_PASSWORD => $dbPass,
+            ConfigOptionsListConstants::KEY_ACTIVE => true,
+            ConfigOptionsListConstants::KEY_DRIVER_OPTIONS => $driverOptions,
+        ];
+        if ($engine !== null && $engine !== '') {
+            $connectionConfig[ConfigOptionsListConstants::KEY_ENGINE] = $engine;
+        }
+        $connection = $this->connectionFactory->create($connectionConfig);
 
         if (!$connection) {
             throw new \Magento\Setup\Exception('Database connection failure.');

--- a/setup/src/Magento/Setup/Validator/DbValidator.php
+++ b/setup/src/Magento/Setup/Validator/DbValidator.php
@@ -74,7 +74,8 @@ class DbValidator
      * @param string $dbPass
      * @return bool
      * @throws \Magento\Setup\Exception
-     * @deprecated
+     * @deprecated Use checkDatabaseConnectionWithDriverOptions() to pass PDO driver options.
+     * @see checkDatabaseConnectionWithDriverOptions()
      */
     public function checkDatabaseConnection($dbName, $dbHost, $dbUser, $dbPass = '')
     {
@@ -119,20 +120,26 @@ class DbValidator
             throw new \Magento\Setup\Exception('Database connection failure.');
         }
 
-        $mysqlVersion = $connection->fetchOne('SELECT version()');
-        if ($mysqlVersion) {
-            if (preg_match('/^([0-9\.]+)/', $mysqlVersion, $matches)) {
-                if (isset($matches[1]) && !empty($matches[1])) {
-                    if (version_compare($matches[1], Installer::MYSQL_VERSION_REQUIRED) < 0) {
-                        throw new \Magento\Setup\Exception(
-                            'Sorry, but we support MySQL version ' . Installer::MYSQL_VERSION_REQUIRED . ' or later.'
-                        );
-                    }
-                }
-            }
-        }
+        $this->assertSupportedMysqlVersion((string) $connection->fetchOne('SELECT version()'));
 
         return $this->checkDatabaseName($connection, $dbName) && $this->checkDatabasePrivileges($connection, $dbName);
+    }
+
+    /**
+     * Reject MySQL servers older than Magento's minimum version.
+     *
+     * @throws \Magento\Setup\Exception
+     */
+    private function assertSupportedMysqlVersion(string $mysqlVersion): void
+    {
+        if ($mysqlVersion === '' || !preg_match('/^([0-9\.]+)/', $mysqlVersion, $matches)) {
+            return;
+        }
+        if (version_compare($matches[1], Installer::MYSQL_VERSION_REQUIRED) < 0) {
+            throw new \Magento\Setup\Exception(
+                'Sorry, but we support MySQL version ' . Installer::MYSQL_VERSION_REQUIRED . ' or later.'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
### Description (*)

Magento core still embeds MySQL-only SQL (`GROUP_CONCAT()`, `FIELD()`, `IFNULL()` literals, backticks, `CREATE TABLE … LIKE`, `CREATE TEMPORARY TABLE … ENGINE=… IGNORE (SELECT)`, `ON DUPLICATE KEY UPDATE` text, `UNION` of mixed types, `UPDATE … LIMIT`, `SHOW VARIABLES LIKE 'version'`). That is valid on MySQL and fatal on PostgreSQL.

This PR does **not** add a Postgres adapter. It adds dialect helpers on `AdapterInterface` / `Pdo\Mysql` and switches Magento call sites to those helpers (and to existing ones such as `getIfNullSql()` / `quoteIdentifier()` / `insertOnDuplicate()`).

The Postgres driver lives in a **separate module**: **https://github.com/Genaker/postgento** (fork of Kirill Morozov’s `Morozov_PgCompat`). That repo implements the same `AdapterInterface` methods on `pdo_pgsql`. Magento can review/test/merge this core PR on MySQL alone, and optionally install Postgento on a branch of this PR to run Magento on PostgreSQL. After this PR is in Magento, Postgento does not need the Magento SQL call-site patches.

The same change set is open for Mage-OS: https://github.com/mage-os/mageos-magento2/pull/321

New adapter methods (MySQL implementations):

- `getGroupConcatSql()` → `GROUP_CONCAT`
- `getFieldSql()` → `FIELD()`
- `castToText()` / `castToNumeric()` (no-op / `CAST(… AS DECIMAL)` on MySQL; other engines can map to `::text` / `::numeric`)
- `createTableLike()` → `CREATE TABLE … LIKE`
- `createTemporaryTableFromSelect()` → existing MySQL `CREATE TEMPORARY TABLE … ENGINE=innodb IGNORE (SELECT)`

Also:

- `Select` constructor type-hint relaxed from `Pdo\Mysql` to `Zend_Db_Adapter_Abstract` so a non-MySQL `AdapterInterface` can call `select()`.
- Setup `--db-engine` is passed through `DbValidator` / `Installer::assertDbAccessible()` so an optional engine can open the correct driver at install time. Default MySQL behavior is unchanged.

Behavior on MySQL is intended to be equivalent.

### Related Pull Requests

- Mage-OS: https://github.com/mage-os/mageos-magento2/pull/321
- Postgres adapter (not in this repo): https://github.com/Genaker/postgento — please test or merge that module alongside this PR if you want a full Postgres install.

### Fixed Issues (if relevant)

N/A — no Magento issue filed yet.

### Manual testing scenarios (*)

On a **MySQL** Magento Open Source install (this PR must not require Postgres):

1. `bin/magento setup:upgrade` — exit 0, no SQLSTATE.
2. `bin/magento indexer:reindex` — all indexers complete (catalog price, stock, EAV, catalog rule, fulltext).
3. GraphQL: configurable product with variants (e.g. Luma `WJ01`) returns variants; `GROUP_CONCAT` / `FIELD()` call sites used by collection / search appliers.
4. Storefront: homepage, category, PDP, cart, customer login.
5. Admin: dashboard, catalog products, categories, EAV attributes, customers, CMS, indexers, sales orders.
6. Guest checkout placing a Check / Money Order order (sales sequence + quote).
7. Confirm `setup:install --db-engine=mysql` still validates and installs as today.

**Optional Postgres:** check out this PR, Composer-require https://github.com/Genaker/postgento (`genaker/module-postgento`), `setup:install --db-engine=postgresql`, then repeat indexer / GraphQL / storefront / admin / checkout.

### Questions or comments

Happy to split adapter-interface methods vs call-site SQL into two PRs if that is easier to review. The adapter itself is Postgento — Magento can merge this PR first (MySQL-safe) and take Postgento as a Composer module whenever you want Postgres in the distribution.

Unit tests for the new `Pdo\Mysql` helpers, `TemporaryTableService`, and `BatchIterator` empty-batch `minValue` are in this PR.

Adobe CLA: signed as required for submissions to https://github.com/magento/magento2.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

### Resolved issues:
1. [x] resolves magento/magento2#41148: Add AdapterInterface dialect helpers and replace MySQL with Postgres SQL and other SQL like RDBS