### PR TITLE
Fix Armenia postcode validation to accept 4-digit codes

### DIFF
--- a/app/code/Magento/Directory/etc/zip_codes.xml
+++ b/app/code/Magento/Directory/etc/zip_codes.xml
@@ -13,7 +13,7 @@
     </zip>
     <zip countryCode="AM">
         <codes>
-            <code id="pattern_1" active="true" example="123456">^[0-9]{6}$</code>
+            <code id="pattern_1" active="true" example="0010">^[0-9]{4}$</code>
         </codes>
     </zip>
     <zip countryCode="AR">

--- a/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
+++ b/dev/tests/integration/testsuite/Magento/Directory/Model/Country/Postcode/ValidatorTest.php
@@ -115,7 +115,7 @@ class ValidatorTest extends TestCase
     {
         return [
             ['AD', 'AD100'],  // $countryId, $validPostcode
-            ['AM', '123456'],
+            ['AM', '0010'],
             ['AR', '1234'], ['AS', '12345'], ['AT', '1234'], ['AU', '1234'], ['AX', '22101'],
             ['AZ', '1234'], ['AZ', '123456'], ['BA', '12345'], ['BB', 'BB10900'], ['BD', '1234'],
             ['BE', '1234'], ['BG', '1234'], ['BH', '323'], ['BH', '1209'], ['BM', 'MA 02'],
@@ -216,6 +216,63 @@ class ValidatorTest extends TestCase
             'NL five digits' => ['postCode' => '12345', 'countryId' => 'NL'],
             'NL leading zero' => ['postCode' => '0234', 'countryId' => 'NL'],
             'NL letters only' => ['postCode' => 'ABCD', 'countryId' => 'NL'],
+        ];
+    }
+
+    /**
+     * Test validate returns true for valid Armenia (AM) postcodes.
+     *
+     * Armenia replaced its Soviet-era 6-digit codes with 4-digit codes in 2006.
+     *
+     * @param string $postCode
+     * @param string $countryId
+     * @return void
+     */
+    #[DataProvider('getAmValidPostcodesDataProvider')]
+    public function testValidateReturnsTrueForAmValidPostcodes(string $postCode, string $countryId): void
+    {
+        $this->assertSame(true, $this->validator->validate($postCode, $countryId));
+    }
+
+    /**
+     * Data provider for valid AM postcodes.
+     *
+     * @return array<string, array{postCode: string, countryId: string}>
+     */
+    public static function getAmValidPostcodesDataProvider(): array
+    {
+        return [
+            'AM lowest code' => ['postCode' => '0001', 'countryId' => 'AM'],
+            'AM Yerevan code' => ['postCode' => '0010', 'countryId' => 'AM'],
+            'AM highest code' => ['postCode' => '4204', 'countryId' => 'AM'],
+        ];
+    }
+
+    /**
+     * Test validate returns false for invalid Armenia (AM) postcodes.
+     *
+     * @param string $postCode
+     * @param string $countryId
+     * @return void
+     */
+    #[DataProvider('getAmInvalidPostcodesDataProvider')]
+    public function testValidateReturnsFalseForAmInvalidPostcodes(string $postCode, string $countryId): void
+    {
+        $this->assertSame(false, $this->validator->validate($postCode, $countryId));
+    }
+
+    /**
+     * Data provider for invalid AM postcodes.
+     *
+     * @return array<string, array{postCode: string, countryId: string}>
+     */
+    public static function getAmInvalidPostcodesDataProvider(): array
+    {
+        return [
+            'AM legacy six digits' => ['postCode' => '375010', 'countryId' => 'AM'],
+            'AM too few digits' => ['postCode' => '001', 'countryId' => 'AM'],
+            'AM too many digits' => ['postCode' => '00100', 'countryId' => 'AM'],
+            'AM letters' => ['postCode' => 'AM10', 'countryId' => 'AM'],
         ];
     }
 }


### PR DESCRIPTION
### Description (*)

Armenia replaced its 6-digit Soviet-era postal codes (`375NNN`) with 4-digit codes (`NNNN`, range `0001`–`4204`) in 2006. The `AM` entry in `app/code/Magento/Directory/etc/zip_codes.xml` still only matches six digits, so every valid Armenian postcode is rejected — on the customer address form, in the admin, and at checkout.

This replaces the `AM` `pattern_1` regex with `^[0-9]{4}$` and updates the example to `0010`.

No 6-digit pattern is kept alongside it. The old format has not been valid since 2006, so retaining it would only let invalid codes through and would not help existing data (6-digit values stored for `AM` are zero-padded 4-digit codes, e.g. `000033` for `0033`, entered to satisfy the broken validator).

Both the PHP validators (`Magento\Directory\Model\Country\Postcode\Validator`) and the frontend validators read `Magento\Directory\Model\Country\Postcode\Config`, so this single change covers server-side validation and the patterns injected into `window.checkoutConfig.postCodes`.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41130: Armenia Postcode Validation is Incorrect

### Manual testing scenarios (*)

1. Set the store's allowed countries to include Armenia.
2. On the storefront, add a product to the cart and go to checkout.
3. Enter an Armenian shipping address with postcode `0010`.
4. **Before:** validation fails, stating the postcode should be 6 characters. **After:** the postcode is accepted.
5. Enter `375010` (legacy 6-digit format) — validation correctly fails.
6. Repeat via *Customer > Addresses* in the admin and the customer account address form for the same results.

### Questions or comments

The integration test `Magento\Directory\Model\Country\Postcode\ValidatorTest` is updated: the `AM` entry in `getPostcodesDataProvider` now uses `0010`, and dedicated `AM` valid/invalid data providers cover the range boundaries (`0001`, `4204`) and the rejected legacy format (`375010`).

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] All automated tests passed successfully (all builds are green)
