### PR TITLE
Fix watermark transparency with the ImageMagick adapter

### DIFF
--- a/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
+++ b/lib/internal/Magento/Framework/Image/Adapter/ImageMagick.php
@@ -576,7 +576,7 @@ class ImageMagick extends AbstractAdapter
      * @param int $positionX
      * @param int $positionY
      * @param \Imagick $watermark
-     * @param bool $compositeChannels
+     * @param int $compositeChannels
      */
     private function addTiledWatermark($positionX, $positionY, \Imagick $watermark, $compositeChannels): void
     {
@@ -604,9 +604,9 @@ class ImageMagick extends AbstractAdapter
      * @param int $positionX
      * @param int $positionY
      * @param \Imagick $watermark
-     * @param bool $compositeChannels
+     * @param int $compositeChannels
      */
-    private function addSingleWatermark($positionX, int $positionY, \Imagick $watermark, bool $compositeChannels): void
+    private function addSingleWatermark($positionX, int $positionY, \Imagick $watermark, int $compositeChannels): void
     {
         $this->_imageHandler->compositeImage(
             $watermark,


### PR DESCRIPTION
### Description (*)

`Magento\Framework\Image\Adapter\ImageMagick::watermark()` builds an **integer** channel mask:

```php
$compositeChannels = \Imagick::CHANNEL_ALL;          // 134217727
$compositeChannels &= ~(\Imagick::CHANNEL_OPACITY);  // 134217711
```

and hands it to `addSingleWatermark()`, whose signature typed it as `bool`. The file has no `declare(strict_types=1)`, so PHP silently coerces `134217711` to `true`, and `Imagick::compositeImage()` receives channel `1` — i.e. `Imagick::CHANNEL_RED`. Only the red channel takes part in the composite and the remaining channels are written with out-of-band values, so the transparent areas of the watermark are replaced by a solid colour block (pure red with ImageMagick 7.1.2).

Telling detail: `addTiledWatermark()` immediately above receives the same argument **without any type hint**, which is exactly why `tile` positioning still works. That asymmetry strongly suggests the `bool` is a typo.

Introduced in c509a4e (#26036, a PHPCS-only refactor that split the too-long `watermark()` method into the two helpers), shipped in 2.4.0 and present in every 2.4.x since, including `2.4-develop`. The GD2 adapter is not affected.

This PR types the parameter as `int` and corrects the two `@param bool $compositeChannels` docblocks.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41137

### Manual testing scenarios (*)

1. Set `dev/image/default_adapter` to `IMAGEMAGICK`.
2. Content > Design > Configuration > edit a theme > Product Image Watermarks: upload a PNG watermark **with a transparent background**, size `165x100`, opacity `100`, position `Bottom Right`.
3. Run `rm -rf pub/media/catalog/product/cache && bin/magento catalog:images:resize && bin/magento cache:flush`
4. Open any product page.
5. Before this change the whole watermark rectangle is a solid colour block. After it, the transparent areas of the watermark leave the product image untouched, matching the GD2 rendering.

Standalone check, no Magento install required:

```php
$mask = Imagick::CHANNEL_ALL & ~Imagick::CHANNEL_OPACITY; // 134217711

$dst = new Imagick();
$dst->newImage(400, 300, new ImagickPixel('white'));
$dst->setImageAlphaChannel(Imagick::ALPHACHANNEL_ACTIVATE); // state left by ImageMagick::resize()

$wm = new Imagick('watermark.png'); // PNG with a transparent background

$dst->compositeImage($wm, Imagick::COMPOSITE_OVER, 235, 200, (bool) $mask); // before: solid colour block
$dst->compositeImage($wm, Imagick::COMPOSITE_OVER, 235, 200, $mask);        // after: transparency preserved
```

### Questions or comments

The value written to the channels left out of the mask is not stable across ImageMagick builds, which would explain the different colours reported over the years. These two look like the same root cause and were both closed without a fix:

- magento/magento2#29497 — *"Imagemagick Black pixels instead of watermark in magento 2.4.0"*, closed as *Cannot Reproduce*; the reporter noted *"Using PHP GD2 solves the problem"*.
- magento/magento2#38855 — *"Watermark turning images cyan"*, reported S0, closed as *needs update*.

Happy to add an integration test covering watermark transparency for both adapters if you would like one.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
