### PR TITLE
Stop logging aggregated GraphQL client input errors as server errors

### DIFF
--- a/lib/internal/Magento/Framework/GraphQl/Query/ErrorHandler.php
+++ b/lib/internal/Magento/Framework/GraphQl/Query/ErrorHandler.php
@@ -53,12 +53,17 @@ class ErrorHandler implements ErrorHandlerInterface
         }
 
         foreach ($errors as $error) {
-            $this->log($error);
+            $isClientInputError = $this->isClientInputError($error);
+            if (!$isClientInputError) {
+                $this->logger->error($error);
+            }
             $previousError = $error->getPrevious();
             if ($previousError instanceof AggregateExceptionInterface && !empty($previousError->getErrors())) {
                 $aggregatedErrors = $previousError->getErrors();
                 foreach ($aggregatedErrors as $aggregatedError) {
-                    $this->logger->error($aggregatedError);
+                    if (!$isClientInputError) {
+                        $this->logger->error($aggregatedError);
+                    }
                     $formattedErrors[] = $formatter($aggregatedError);
                 }
             } else {
@@ -69,19 +74,15 @@ class ErrorHandler implements ErrorHandlerInterface
     }
 
     /**
-     * Log error.
+     * Check whether the error was caused by invalid client input and therefore must not be logged.
      *
      * @param Error $error
-     * @return void
+     * @return bool
      */
-    private function log(Error $error): void
+    private function isClientInputError(Error $error): bool
     {
         $extensions = $error->getExtensions();
-        $category = $extensions['category'] ?? null;
-        if (GraphQlInputException::EXCEPTION_CATEGORY === $category) {
-            return;
-        }
 
-        $this->logger->error($error);
+        return GraphQlInputException::EXCEPTION_CATEGORY === ($extensions['category'] ?? null);
     }
 }

--- a/lib/internal/Magento/Framework/GraphQl/Test/Unit/Query/ErrorHandlerTest.php
+++ b/lib/internal/Magento/Framework/GraphQl/Test/Unit/Query/ErrorHandlerTest.php
@@ -9,6 +9,8 @@ namespace Magento\Framework\GraphQl\Test\Unit\Query;
 
 use GraphQL\Error\Error;
 use Magento\Framework\App\State as AppState;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlServerException;
 use Magento\Framework\GraphQl\Query\ErrorHandler;
@@ -54,6 +56,12 @@ class ErrorHandlerTest extends TestCase
     {
         $inputException = new GraphQlInputException(__('Input error'));
         $serverException = new GraphQlServerException(__('Server error'));
+        $aggregatedInputException = (new GraphQlInputException(__('Input error')))
+            ->addError(new LocalizedException(__('Child input error 1')))
+            ->addError(new LocalizedException(__('Child input error 2')));
+        $aggregatedServerException = (new InputException(__('Aggregate error')))
+            ->addError(__('Child error 1'))
+            ->addError(__('Child error 2'));
         return [
             [
                 [new Error('Error 1'), new Error('Error 2')], AppState::MODE_DEVELOPER, 2
@@ -73,6 +81,35 @@ class ErrorHandlerTest extends TestCase
             [
                 [new Error('Error 1', previous: $serverException)], AppState::MODE_DEVELOPER, 1
             ],
+            [
+                [new Error('Error 1', previous: $aggregatedInputException)], AppState::MODE_DEVELOPER, 0
+            ],
+            [
+                [new Error('Error 1', previous: $aggregatedServerException)], AppState::MODE_DEVELOPER, 3
+            ],
         ];
+    }
+
+    public function testHandleReportsAggregatedClientInputErrorsWithoutLogging(): void
+    {
+        $childErrors = [
+            new LocalizedException(__('Child input error 1')),
+            new LocalizedException(__('Child input error 2')),
+        ];
+        $exception = new GraphQlInputException(__('Input error'));
+        foreach ($childErrors as $childError) {
+            $exception->addError($childError);
+        }
+        $this->appStateMock->expects(self::atLeastOnce())
+            ->method('getMode')
+            ->willReturn(AppState::MODE_DEVELOPER);
+        $this->loggerMock->expects(self::never())->method('error');
+
+        $formattedErrors = $this->errorHandler->handle(
+            [new Error('Error 1', previous: $exception)],
+            fn ($error) => $error
+        );
+
+        self::assertSame($childErrors, $formattedErrors);
     }
 }


### PR DESCRIPTION
### Description

`Magento\Framework\GraphQl\Query\ErrorHandler` intentionally does not log GraphQL errors that were caused by invalid client input: `log()` returned early when the error carried `extensions['category'] === GraphQlInputException::EXCEPTION_CATEGORY`.

That decision was not honoured for aggregate exceptions. `GraphQlInputException` implements `AggregateExceptionInterface`, so it can carry child errors added through `addError()`. When it does, `handle()` logged every child error with `$this->logger->error($aggregatedError)` directly, bypassing the suppression that had just been applied to the parent error.

The result is inconsistent by the shape of the exception rather than by its cause: a `GraphQlInputException` **without** child errors is suppressed, while the very same exception **with** child errors is written to the exception log at ERROR level. Mutations that report user errors this way — and bots probing the endpoint with invalid input — produce continuous ERROR noise for requests the server correctly rejected as client errors.

The suppression decision is now computed once per error and applied to both logging calls. Errors that are not client input errors keep being logged exactly as before, including their aggregated child errors.

**The formatted response is unchanged.** Every error that was formatted before is still formatted, in the same order — only the logging is affected.

### Related Issues

Related to #34973 (broader request to keep client-safe GraphQL exceptions out of the exception log). This PR fixes only the narrow inconsistency inside `ErrorHandler` described above and does not change how any other exception category is logged.

### Manual testing scenarios

1. Install Magento in production mode.
2. Execute a GraphQL mutation whose resolver throws a `GraphQlInputException` that carries child errors added via `addError()`.
3. **Before this change:** `var/log/exception.log` (or the configured exception handler) contains one ERROR entry per child error.
4. **After this change:** no entry is logged, and the GraphQL response still contains all child error messages.
5. Verify no over-suppression: trigger an error whose previous exception is a non-client aggregate (for example `Magento\Framework\Exception\InputException` with child errors) and confirm the parent and each child error are still logged.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests (extended `Magento\Framework\GraphQl\Test\Unit\Query\ErrorHandlerTest`, including a case proving non-client aggregates are still logged)
- [x] All automated tests passed successfully (all tests are executed on GitHub Actions)
