### PR TITLE
Fix X-Magento-Vary emitted for every guest on non-default websites

### DIFF
--- a/app/code/Magento/Store/App/Action/Plugin/Context.php
+++ b/app/code/Magento/Store/App/Action/Plugin/Context.php
@@ -144,6 +144,10 @@ class Context
                 $defaultStoreCode = $request->getServerValue(StoreManager::PARAM_RUN_CODE);
                 $defaultStore = $this->storeManager->getStore($defaultStoreCode);
                 break;
+            case ScopeInterface::SCOPE_WEBSITE == $request->getServerValue(StoreManager::PARAM_RUN_TYPE):
+                $defaultWebsiteCode = $request->getServerValue(StoreManager::PARAM_RUN_CODE);
+                $defaultStore = $this->storeManager->getWebsite($defaultWebsiteCode)->getDefaultStore();
+                break;
             default:
                 $defaultStoreCode = $this->storeManager->getDefaultStoreView()->getCode();
                 $defaultStore = $this->storeManager->getStore($defaultStoreCode);

--- a/app/code/Magento/Store/Test/Unit/App/Action/Plugin/ContextTest.php
+++ b/app/code/Magento/Store/Test/Unit/App/Action/Plugin/ContextTest.php
@@ -1,0 +1,301 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Store\Test\Unit\App\Action\Plugin;
+
+use Magento\Framework\App\Action\AbstractAction;
+use Magento\Framework\App\Http\Context as HttpContext;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\Session\SessionManagerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
+use Magento\Store\App\Action\Plugin\Context as ContextPlugin;
+use Magento\Store\Api\StoreCookieManagerInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Store\Model\Website;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ContextTest extends TestCase
+{
+    use MockCreationTrait;
+
+    /**
+     * @var ContextPlugin
+     */
+    private $plugin;
+
+    /**
+     * @var SessionManagerInterface|MockObject
+     */
+    private $sessionMock;
+
+    /**
+     * @var HttpContext|MockObject
+     */
+    private $httpContextMock;
+
+    /**
+     * @var StoreManagerInterface|MockObject
+     */
+    private $storeManagerMock;
+
+    /**
+     * @var StoreCookieManagerInterface|MockObject
+     */
+    private $storeCookieManagerMock;
+
+    /**
+     * @var AbstractAction|MockObject
+     */
+    private $subjectMock;
+
+    /**
+     * @var HttpRequest|MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var Store|MockObject
+     */
+    private $currentStoreMock;
+
+    /**
+     * @var Store|MockObject
+     */
+    private $defaultStoreMock;
+
+    /**
+     * @var array
+     */
+    private $contextValues = [];
+
+    protected function setUp(): void
+    {
+        $this->sessionMock = $this->createPartialMockWithReflection(
+            SessionManagerInterface::class,
+            [
+                'start', 'writeClose', 'isSessionExists', 'getSessionId', 'getName', 'setName',
+                'destroy', 'clearStorage', 'getCookieDomain', 'getCookiePath', 'getCookieLifetime',
+                'setSessionId', 'regenerateId', 'expireSessionCookie', 'getSessionIdForHost',
+                'isValidForHost', 'isValidForPath', 'getCurrencyCode'
+            ]
+        );
+        $this->sessionMock->method('getCurrencyCode')->willReturn(null);
+
+        $this->httpContextMock = $this->createMock(HttpContext::class);
+        $this->contextValues = [];
+        $this->httpContextMock->method('setValue')
+            ->willReturnCallback(
+                function (string $name, $value, $default) {
+                    $this->contextValues[$name] = [$value, $default];
+                    return $this->httpContextMock;
+                }
+            );
+
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->storeCookieManagerMock = $this->createMock(StoreCookieManagerInterface::class);
+        $this->storeCookieManagerMock->method('getStoreCodeFromCookie')->willReturn(null);
+        $this->subjectMock = $this->createMock(AbstractAction::class);
+        $this->requestMock = $this->createMock(HttpRequest::class);
+        $this->requestMock->method('getParam')
+            ->willReturnCallback(
+                function ($name, $default = null) {
+                    return $default;
+                }
+            );
+
+        $this->currentStoreMock = $this->createMock(Store::class);
+        $this->currentStoreMock->method('getCode')->willReturn('second_website_store');
+        $this->currentStoreMock->method('getDefaultCurrencyCode')->willReturn('EUR');
+        $this->currentStoreMock->method('isUseStoreInUrl')->willReturn(false);
+
+        $this->defaultStoreMock = $this->createMock(Store::class);
+        $this->defaultStoreMock->method('getCode')->willReturn('default_website_store');
+        $this->defaultStoreMock->method('getDefaultCurrencyCode')->willReturn('USD');
+        $this->defaultStoreMock->method('isUseStoreInUrl')->willReturn(false);
+
+        $this->plugin = new ContextPlugin(
+            $this->sessionMock,
+            $this->httpContextMock,
+            $this->storeManagerMock,
+            $this->storeCookieManagerMock
+        );
+    }
+
+    /**
+     * MAGE_RUN_TYPE=website must use the default store view of the requested
+     * website as context default, not the global default store view.
+     *
+     * Otherwise the context value always differs from the default on every
+     * non-default website, the vary string is non-empty for every guest and
+     * X-Magento-Vary is sent on every response, which makes all cookieless
+     * requests uncacheable behind the official Varnish VCL.
+     */
+    public function testWebsiteRunTypeUsesWebsiteDefaultStoreAsContextDefault(): void
+    {
+        $this->mockRunParams(ScopeInterface::SCOPE_WEBSITE, 'second_website');
+        $this->storeManagerMock->method('getStore')->with(null)->willReturn($this->currentStoreMock);
+
+        $websiteMock = $this->createMock(Website::class);
+        $websiteMock->method('getDefaultStore')->willReturn($this->currentStoreMock);
+        $this->storeManagerMock->expects($this->once())
+            ->method('getWebsite')
+            ->with('second_website')
+            ->willReturn($websiteMock);
+        $this->storeManagerMock->expects($this->never())->method('getDefaultStoreView');
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+
+        $this->assertSame(
+            ['second_website_store', 'second_website_store'],
+            $this->contextValues[StoreManagerInterface::CONTEXT_STORE]
+        );
+        $this->assertSame(
+            ['EUR', 'EUR'],
+            $this->contextValues[HttpContext::CONTEXT_CURRENCY]
+        );
+    }
+
+    /**
+     * A store view other than the website default must still produce
+     * a vary against the default store view of the same website.
+     */
+    public function testWebsiteRunTypeVariesForNonDefaultStoreOfWebsite(): void
+    {
+        $this->mockRunParams(ScopeInterface::SCOPE_WEBSITE, 'second_website');
+        $this->storeManagerMock->method('getStore')->with(null)->willReturn($this->currentStoreMock);
+
+        $websiteDefaultStoreMock = $this->createMock(Store::class);
+        $websiteDefaultStoreMock->method('getCode')->willReturn('second_website_default_store');
+        $websiteDefaultStoreMock->method('getDefaultCurrencyCode')->willReturn('USD');
+
+        $websiteMock = $this->createMock(Website::class);
+        $websiteMock->method('getDefaultStore')->willReturn($websiteDefaultStoreMock);
+        $this->storeManagerMock->method('getWebsite')->with('second_website')->willReturn($websiteMock);
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+
+        $this->assertSame(
+            ['second_website_store', 'second_website_default_store'],
+            $this->contextValues[StoreManagerInterface::CONTEXT_STORE]
+        );
+        $this->assertSame(
+            ['EUR', 'USD'],
+            $this->contextValues[HttpContext::CONTEXT_CURRENCY]
+        );
+    }
+
+    /**
+     * MAGE_RUN_TYPE=store keeps resolving the default from MAGE_RUN_CODE.
+     */
+    public function testStoreRunTypeUsesRunCodeStoreAsContextDefault(): void
+    {
+        $this->mockRunParams(ScopeInterface::SCOPE_STORE, 'default_website_store');
+        $this->storeManagerMock->method('getStore')
+            ->willReturnCallback(
+                function ($storeId = null) {
+                    return $storeId === null ? $this->currentStoreMock : $this->defaultStoreMock;
+                }
+            );
+        $this->storeManagerMock->expects($this->never())->method('getWebsite');
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+
+        $this->assertSame(
+            ['second_website_store', 'default_website_store'],
+            $this->contextValues[StoreManagerInterface::CONTEXT_STORE]
+        );
+        $this->assertSame(
+            ['EUR', 'USD'],
+            $this->contextValues[HttpContext::CONTEXT_CURRENCY]
+        );
+    }
+
+    /**
+     * Without run params the global default store view stays the default.
+     */
+    public function testNoRunTypeFallsBackToGlobalDefaultStoreView(): void
+    {
+        $this->mockRunParams(null, null);
+        $this->storeManagerMock->method('getStore')
+            ->willReturnCallback(
+                function ($storeId = null) {
+                    return $storeId === null ? $this->currentStoreMock : $this->defaultStoreMock;
+                }
+            );
+        $this->storeManagerMock->expects($this->once())
+            ->method('getDefaultStoreView')
+            ->willReturn($this->defaultStoreMock);
+        $this->storeManagerMock->expects($this->never())->method('getWebsite');
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+
+        $this->assertSame(
+            ['second_website_store', 'default_website_store'],
+            $this->contextValues[StoreManagerInterface::CONTEXT_STORE]
+        );
+    }
+
+    /**
+     * Store code in URL: the current store is its own context default.
+     */
+    public function testStoreCodeInUrlUsesCurrentStoreAsContextDefault(): void
+    {
+        $storeInUrlMock = $this->createMock(Store::class);
+        $storeInUrlMock->method('getCode')->willReturn('second_website_store');
+        $storeInUrlMock->method('getDefaultCurrencyCode')->willReturn('EUR');
+        $storeInUrlMock->method('isUseStoreInUrl')->willReturn(true);
+
+        $this->storeManagerMock->method('getStore')->with(null)->willReturn($storeInUrlMock);
+        $this->storeManagerMock->expects($this->never())->method('getWebsite');
+        $this->storeManagerMock->expects($this->never())->method('getDefaultStoreView');
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+
+        $this->assertSame(
+            ['second_website_store', 'second_website_store'],
+            $this->contextValues[StoreManagerInterface::CONTEXT_STORE]
+        );
+    }
+
+    public function testDoesNothingWhenContextIsAlreadySet(): void
+    {
+        $this->httpContextMock->method('getValue')
+            ->with(StoreManagerInterface::CONTEXT_STORE)
+            ->willReturn('second_website_store');
+        $this->httpContextMock->expects($this->never())->method('setValue');
+        $this->storeManagerMock->expects($this->never())->method('getStore');
+
+        $this->plugin->beforeDispatch($this->subjectMock, $this->requestMock);
+    }
+
+    /**
+     * Mock MAGE_RUN_TYPE/MAGE_RUN_CODE server values.
+     *
+     * @param string|null $runType
+     * @param string|null $runCode
+     * @return void
+     */
+    private function mockRunParams(?string $runType, ?string $runCode): void
+    {
+        $this->requestMock->method('getServerValue')
+            ->willReturnCallback(
+                function ($name = null) use ($runType, $runCode) {
+                    if ($name === StoreManager::PARAM_RUN_TYPE) {
+                        return $runType;
+                    }
+                    if ($name === StoreManager::PARAM_RUN_CODE) {
+                        return $runCode;
+                    }
+                    return null;
+                }
+            );
+    }
+}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
On a multi-website installation routed with MAGE_RUN_TYPE=website (the most common multi-site setup), Magento\Store\App\Action\Plugin\Context::updateContext() falls into the default branch of its switch and uses the global default store view (StoreManagerInterface::getDefaultStoreView()) as the default value for the store and current_currency HTTP context entries.

On every website other than the default one, the context value therefore always differs from its declared default. Magento\Framework\App\Http\Context::getVaryString() is consequently non-empty for every guest, and X-Magento-Vary is sent on every response of those websites — including responses to requests that carried no cookies at all.

The official Varnish VCL shipped since 2.4.6 contains a cache-poisoning guard: a response that sets the X-Magento-Vary cookie for a request that did not send one is marked uncacheable (beresp.ttl = 0s, hit-for-pass). Combined with this bug, every cookieless request (first-time visitors, bots, crawlers) to a non-default website becomes hit-for-pass, and the FPC never populates for those websites. Only visitors who already received the vary cookie on a previous (uncached) response can be served from or fill the cache.

This was verified empirically on 2.4.9 (magento/module-store 101.1.9): the guest context data on a non-default website is `{"store":"<code>"}`, and its salted sha256 (Http\Context::getVaryString()) matches the observed X-Magento-Vary value byte for byte; a request with the cookie caches normally (MISS→HIT), the same request without it is permanently UNCACHEABLE.

The MAGE_RUN_TYPE=store branch of the same switch already does the right thing — it resolves the default from MAGE_RUN_CODE (introduced by MC-19712, "Full page cache issue with multiple stores"). This PR applies the same treatment to the MAGE_RUN_TYPE=website case: the context default is the default store view of the website given by MAGE_RUN_CODE (resolved via StoreManagerInterface::getWebsite(), same pattern as Magento\Store\Model\Store::getDefaultCurrencyCode() and CustomerImportExport\Model\Import\Customer), and the default currency is that store view's default currency. For a cookieless request this is exactly the store the request resolves to, so the context matches its defaults, the vary string is empty and the response is cacheable — while any explicitly selected non-default store view of the website still produces a correct vary.

Behavior is unchanged for: store-code-in-URL setups, MAGE_RUN_TYPE=store setups, and single-website setups without run params (the global default store view remains the fallback). An empty/absent MAGE_RUN_CODE degrades gracefully: getWebsite('') returns the current website.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
[magento/magento2#15828](https://github.com/magento/magento2/issues/15828)
[magento/magento2#32278](https://github.com/magento/magento2/issues/32278)
[magento/magento2#39880](https://github.com/magento/magento2/issues/39880)

### Manual testing scenarios (*)
1. Install Magento with two websites, each with its own store group and store view; keep website 1 as the default website. Serve both from Varnish using the official generated VCL (2.4.6+), routing by domain with MAGE_RUN_TYPE=website and MAGE_RUN_CODE=<website code> (e.g. via SetEnvIf/fastcgi params).
curl -sI https://<non-default-website-domain>/ (no cookies).
2. Before this fix: the response contains Set-Cookie: X-Magento-Vary=... and X-Magento-Cache-Debug: UNCACHEABLE (with debug VCL); repeating the request never yields a HIT — the FPC never populates for cookieless traffic on that website.
3. After this fix: no X-Magento-Vary cookie is set for a plain guest request; the first request is a MISS, the second a HIT.
Regression checks: the default website still caches (MISS→HIT); explicitly switching to a non-default store view of a website (e.g. ?___store=code) still sets X-Magento-Vary and is served as a separate cache object; MAGE_RUN_TYPE=store setups behave as before.

### Questions or comments
Disclaimer: Description in the PR and Automated tests are done with AI.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)