### PR TITLE
fix(wishlist): stop recalculating item count on every request

### DIFF
--- a/app/code/Magento/Wishlist/Helper/Data.php
+++ b/app/code/Magento/Wishlist/Helper/Data.php
@@ -235,7 +235,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         );
         if (!$this->_customerSession->hasWishlistItemCount() ||
             $currentDisplayType != $storedDisplayType ||
-            $this->_customerSession->hasDisplayOutOfStockProducts() ||
             $currentDisplayOutOfStockProducts != $storedDisplayOutOfStockProducts
         ) {
             $this->calculate();

--- a/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
@@ -16,6 +16,7 @@ use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Request\Http as RequestHttp;
 use Magento\Framework\Data\Helper\PostHelper;
 use Magento\Framework\DataObject;
+use Magento\Framework\Event\ManagerInterface as EventManagerInterface;
 use Magento\Framework\Registry;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\Url\EncoderInterface;
@@ -82,6 +83,9 @@ class DataTest extends TestCase
     /** @var  ScopeConfigInterface|MockObject */
     protected $scopeConfig;
 
+    /** @var  EventManagerInterface|MockObject */
+    protected $eventManager;
+
     /**
      * Set up mock objects for tested class
      *
@@ -120,6 +124,11 @@ class DataTest extends TestCase
         $this->context->expects($this->once())
             ->method('getScopeConfig')
             ->willReturn($this->scopeConfig);
+
+        $this->eventManager = $this->createMock(EventManagerInterface::class);
+        $this->context->expects($this->once())
+            ->method('getEventManager')
+            ->willReturn($this->eventManager);
 
         $this->wishlistProvider = $this->createMock(WishlistProviderInterface::class);
 
@@ -191,6 +200,48 @@ class DataTest extends TestCase
         $this->setPropertyValue($this->model, '_customerSession', $session);
 
         $this->assertEquals(3, $this->model->getItemCount());
+    }
+
+    /**
+     * getItemCount() must still recalculate when the out-of-stock display setting changed,
+     * proving the remaining value comparison alone (without the removed existence check)
+     * correctly detects this case.
+     *
+     * @return void
+     */
+    public function testGetItemCountRecalculatesWhenOutOfStockDisplaySettingChanged()
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap(
+                [
+                    ['wishlist/wishlist_link/use_qty', 'store', false],
+                    ['cataloginventory/options/show_out_of_stock', 'store', true],
+                ]
+            );
+
+        $session = $this->createPartialMockWithReflection(
+            Session::class,
+            [
+                'getWishlistDisplayType',
+                'getDisplayOutOfStockProducts',
+                'hasWishlistItemCount',
+                'hasDisplayOutOfStockProducts',
+                'getWishlistItemCount',
+                'isLoggedIn',
+                'setWishlistItemCount',
+            ]
+        );
+        $session->method('getWishlistDisplayType')->willReturn(false);
+        $session->method('getDisplayOutOfStockProducts')->willReturn(false);
+        $session->method('hasWishlistItemCount')->willReturn(true);
+        $session->method('hasDisplayOutOfStockProducts')->willReturn(false);
+        $session->method('getWishlistItemCount')->willReturn(5);
+        $session->expects($this->once())->method('isLoggedIn')->willReturn(false);
+        $session->expects($this->once())->method('setWishlistItemCount')->with(0);
+
+        $this->setPropertyValue($this->model, '_customerSession', $session);
+
+        $this->assertEquals(5, $this->model->getItemCount());
     }
 
     public function testGetAddToCartUrl()

--- a/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.TooManyFields)
  */
 class DataTest extends TestCase
 {

--- a/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Wishlist/Test/Unit/Helper/DataTest.php
@@ -10,6 +10,7 @@ namespace Magento\Wishlist\Test\Unit\Helper;
 use Magento\Catalog\Model\Product;
 use Magento\Customer\Model\Session;
 use Magento\Framework\App\ActionInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\App\Request\Http as RequestHttp;
@@ -78,6 +79,9 @@ class DataTest extends TestCase
     /** @var  Session|MockObject */
     protected $customerSession;
 
+    /** @var  ScopeConfigInterface|MockObject */
+    protected $scopeConfig;
+
     /**
      * Set up mock objects for tested class
      *
@@ -112,6 +116,11 @@ class DataTest extends TestCase
             ->method('getRequest')
             ->willReturn($this->requestMock);
 
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->context->expects($this->once())
+            ->method('getScopeConfig')
+            ->willReturn($this->scopeConfig);
+
         $this->wishlistProvider = $this->createMock(WishlistProviderInterface::class);
 
         $this->coreRegistry = $this->createMock(Registry::class);
@@ -141,6 +150,47 @@ class DataTest extends TestCase
                 'postDataHelper' => $this->postDataHelper
             ]
         );
+    }
+
+    /**
+     * getItemCount() must not recalculate when nothing relevant changed since the last call,
+     * even though hasDisplayOutOfStockProducts() only reports whether the value was ever set.
+     *
+     * @return void
+     */
+    public function testGetItemCountUsesCachedValueWhenNothingChanged()
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap(
+                [
+                    ['wishlist/wishlist_link/use_qty', 'store', false],
+                    ['cataloginventory/options/show_out_of_stock', 'store', true],
+                ]
+            );
+
+        $session = $this->createPartialMockWithReflection(
+            Session::class,
+            [
+                'getWishlistDisplayType',
+                'getDisplayOutOfStockProducts',
+                'hasWishlistItemCount',
+                'hasDisplayOutOfStockProducts',
+                'getWishlistItemCount',
+                'isLoggedIn',
+                'setWishlistItemCount',
+            ]
+        );
+        $session->method('getWishlistDisplayType')->willReturn(false);
+        $session->method('getDisplayOutOfStockProducts')->willReturn(true);
+        $session->method('hasWishlistItemCount')->willReturn(true);
+        $session->method('hasDisplayOutOfStockProducts')->willReturn(true);
+        $session->method('getWishlistItemCount')->willReturn(3);
+        $session->expects($this->never())->method('isLoggedIn');
+        $session->expects($this->never())->method('setWishlistItemCount');
+
+        $this->setPropertyValue($this->model, '_customerSession', $session);
+
+        $this->assertEquals(3, $this->model->getItemCount());
     }
 
     public function testGetAddToCartUrl()


### PR DESCRIPTION
### Description (*)

`Magento\Wishlist\Helper\Data::getItemCount()` decides whether to recalculate the customer's wishlist item count based on four conditions. Three of them correctly compare a stored value against the current one. The third, `hasDisplayOutOfStockProducts()`, only checks whether a value was ever stored, not whether it changed.

`calculate()` unconditionally calls `setDisplayOutOfStockProducts()` every time it runs, which means that condition becomes permanently `true` for the rest of the customer session after the very first call to `getItemCount()`. From that point on, this single condition forces a full recalculation on every subsequent call, regardless of whether the wishlist display type, the out-of-stock display setting, or the actual wishlist contents changed. The caching this method is supposed to provide is effectively disabled for the rest of the session.

This fix removes the faulty existence check. The remaining value comparison (`$currentDisplayOutOfStockProducts != $storedDisplayOutOfStockProducts`) already covers "changed since last time", including the first-ever call, since `!hasWishlistItemCount()` already forces recalculation then regardless.

Impact in practice: every `customer/section/load` request that includes the `wishlist` section (e.g. triggered by the default header mini-wishlist link) pays the full cost of the wishlist collection query and item resolution again, on every single request, for the rest of the customer's session, instead of reusing the cached count.

Two things worth noting about correctness, since removing a condition always raises the question of whether it silently changes behavior:

- Actual wishlist content changes (adding/removing an item) never went through these four conditions at all: `Controller/Index/Add.php`, `Controller/Index/Remove.php` and `Model/ItemCarrier.php` all call `calculate()` directly and unconditionally right after the action. The removed condition played no role there.
- The remaining value comparison for the out-of-stock display setting is covered by its own dedicated unit test (see below), proving it alone still forces a recalculation when that setting changes, independent of the removed check.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41151

### Manual testing scenarios (*)

1. Log in as a customer and open any storefront page so the `wishlist` customer-data section is requested at least once (e.g. via the default header wishlist link).
2. Without changing `Stores > Configuration > Customers > Wishlist > General Options > Display Wishlist Summary` or `Stores > Configuration > Catalog > Inventory > Product Stock Options > Display Out of Stock Products`, trigger the `wishlist` section again, e.g. by calling `customer/section/load?sections=wishlist` a second time, or by opening another page.
3. Before the fix: the wishlist item count is recalculated from scratch on every such call (visible via the Magento profiler / `dev/debug` query log as a repeated wishlist item collection query, and as consistently elevated response time for that request). After the fix: the cached value from the customer session is reused, and no wishlist collection query runs again, as long as nothing relevant changed.
4. Regression check: change `Display Wishlist Summary` or `Display Out of Stock Products`, or add/remove a wishlist item, and confirm the count still recalculates and reflects the change correctly, i.e. the cache is still invalidated when something actually changes.

### Questions or comments

None.

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)