### PR TITLE
Allow setup:upgrade and setup:db-data:upgrade to run with a read-only app/etc (#26292)

### DIFF
--- a/lib/internal/Magento/Framework/Setup/FilePermissions.php
+++ b/lib/internal/Magento/Framework/Setup/FilePermissions.php
@@ -311,6 +311,7 @@ class FilePermissions
      *
      * @deprecated 100.1.0 Use getMissingWritablePathsForInstallation()
      * to get all missing writable paths required for install.
+     * @see getMissingWritablePathsForInstallation()
      * @return array
      */
     public function getMissingWritableDirectoriesForInstallation()

--- a/lib/internal/Magento/Framework/Setup/FilePermissions.php
+++ b/lib/internal/Magento/Framework/Setup/FilePermissions.php
@@ -282,12 +282,14 @@ class FilePermissions
     /**
      * Checks writable paths for database upgrade, returns array of directory paths that requires write permission
      *
+     * Database upgrade only writes to var/. Deployment configuration (app/etc) is not touched, so it may stay
+     * read-only, which is the expected state for immutable/read-only deployments.
+     *
      * @return array List of directories that requires write permission for database upgrade
      */
     public function getMissingWritableDirectoriesForDbUpgrade()
     {
         $writableDirectories = [
-            DirectoryList::CONFIG,
             DirectoryList::VAR_DIR
         ];
 

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
@@ -248,12 +248,45 @@ class FilePermissionsTest extends TestCase
     {
         $directoryMethods = ['isExist', 'isDirectory', 'isReadable', 'isWritable'];
         foreach ($directoryMethods as $method) {
-            $this->directoryWriteMock->expects($this->exactly(2))
+            $this->directoryWriteMock->expects($this->once())
                 ->method($method)
                 ->willReturn(true);
         }
 
         $this->assertEmpty($this->filePermissions->getMissingWritableDirectoriesForDbUpgrade());
+    }
+
+    /**
+     * Database upgrade must not require a writable app/etc (read-only deployments keep config.php and env.php
+     * read-only).
+     *
+     * @return void
+     */
+    public function testGetMissingWritableDirectoriesForDbUpgradeDoesNotRequireWritableConfigDirectory(): void
+    {
+        $readOnlyConfigDirectory = $this->createMock(Write::class);
+        $readOnlyConfigDirectory->method('isExist')->willReturn(true);
+        $readOnlyConfigDirectory->method('isDirectory')->willReturn(true);
+        $readOnlyConfigDirectory->method('isReadable')->willReturn(true);
+        $readOnlyConfigDirectory->method('isWritable')->willReturn(false);
+
+        $this->directoryWriteMock->method('isExist')->willReturn(true);
+        $this->directoryWriteMock->method('isDirectory')->willReturn(true);
+        $this->directoryWriteMock->method('isReadable')->willReturn(true);
+        $this->directoryWriteMock->method('isWritable')->willReturn(true);
+
+        $filesystemMock = $this->createMock(Filesystem::class);
+        $filesystemMock->method('getDirectoryWrite')
+            ->willReturnCallback(
+                fn (string $code) => $code === DirectoryList::CONFIG
+                    ? $readOnlyConfigDirectory
+                    : $this->directoryWriteMock
+            );
+        $this->directoryListMock->expects($this->never())->method('getPath');
+
+        $filePermissions = new FilePermissions($filesystemMock, $this->directoryListMock, $this->stateMock);
+
+        $this->assertEmpty($filePermissions->getMissingWritableDirectoriesForDbUpgrade());
     }
 
     /**

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -503,7 +503,7 @@ class Installer
                 $result[$module] = 1;
             }
         }
-        if (!$dryRun) {
+        if (!$dryRun && $result !== $currentModules) {
             $this->deploymentConfigWriter->saveConfig([ConfigFilePool::APP_CONFIG => ['modules' => $result]], true);
         }
         return $result;

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
@@ -68,7 +68,7 @@ namespace Magento\Setup\Test\Unit\Model {
     use Magento\Setup\Validator\DbValidator;
     use PHPUnit\Framework\MockObject\MockObject;
     use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
+    use PHPUnit\Framework\Attributes\DataProvider;
     use ReflectionException;
 
     /**
@@ -355,7 +355,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
          * @param array $logMetaMessages
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-    #[DataProvider('installDataProvider')]
+        #[DataProvider('installDataProvider')]
         public function testInstall(array $request, array $logMessages, array $logMetaMessages)
         {
             $this->moduleList->method('getOne')
@@ -680,7 +680,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
          * @throws LocalizedException
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-    #[DataProvider('installWithOrderIncrementPrefixDataProvider')]
+        #[DataProvider('installWithOrderIncrementPrefixDataProvider')]
         public function testInstallWithOrderIncrementPrefix(array $request, array $logMessages, array $logMetaMessages)
         {
             $this->moduleList->method('getOne')
@@ -950,7 +950,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
          * @throws \Magento\Framework\Exception\RuntimeException
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-    #[DataProvider('installWithInvalidRemoteStorageConfigurationDataProvider')]
+        #[DataProvider('installWithInvalidRemoteStorageConfigurationDataProvider')]
         public function testInstallWithInvalidRemoteStorageConfiguration(bool $isDeploymentConfigWritable)
         {
             $request = self::$request;
@@ -1369,7 +1369,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
          * @throws \Magento\Framework\Exception\RuntimeException
          * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
          */
-    #[DataProvider('installWithInvalidRemoteStorageConfigurationWithEarlyExceptionDataProvider')]
+        #[DataProvider('installWithInvalidRemoteStorageConfigurationWithEarlyExceptionDataProvider')]
         public function testInstallWithInvalidRemoteStorageConfigurationWithEarlyException(\Exception $exception)
         {
             $request = self::$request;

--- a/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php
@@ -1694,6 +1694,37 @@ use PHPUnit\Framework\Attributes\DataProvider;
             $installer->updateModulesSequence(true);
         }
 
+        public function testUpdateModulesSequenceSkipsConfigWriteWhenModulesUnchanged(): void
+        {
+            $this->cleanupFiles->expects($this->never())->method('clearCodeGeneratedClasses');
+            $installer = $this->prepareForUpdateModulesTestsWithCurrentModules(
+                ['Foo_One' => 1, 'Bar_Two' => 0, 'New_Module' => 1]
+            );
+            $this->configWriter->expects($this->never())->method('saveConfig');
+
+            $installer->updateModulesSequence(true);
+        }
+
+        public function testUpdateModulesSequenceWritesConfigWhenModuleOrderChanged(): void
+        {
+            $this->cleanupFiles->expects($this->never())->method('clearCodeGeneratedClasses');
+            $installer = $this->prepareForUpdateModulesTestsWithCurrentModules(
+                ['Bar_Two' => 0, 'Foo_One' => 1, 'New_Module' => 1]
+            );
+            $this->configWriter->expects($this->once())
+                ->method('saveConfig')
+                ->with(
+                    [
+                        ConfigFilePool::APP_CONFIG => [
+                            'modules' => ['Foo_One' => 1, 'Bar_Two' => 0, 'New_Module' => 1]
+                        ]
+                    ],
+                    true
+                );
+
+            $installer->updateModulesSequence(true);
+        }
+
         /**
          * @return void
          * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -1851,6 +1882,34 @@ use PHPUnit\Framework\Attributes\DataProvider;
             $this->configWriter->expects($this->once())->method('saveConfig')->with($expectedModules);
 
             return $newObject;
+        }
+
+        /**
+         * Prepare mocks for update modules tests with the given `modules` section already present in config.php
+         *
+         * @param array $currentModules
+         * @return Installer
+         */
+        private function prepareForUpdateModulesTestsWithCurrentModules(array $currentModules): Installer
+        {
+            $cacheManager = $this->createMock(Manager::class);
+            $cacheManager->expects($this->once())->method('getAvailableTypes')->willReturn(['foo', 'bar']);
+            $cacheManager->expects($this->once())->method('clean');
+            $this->objectManager->expects($this->any())
+                ->method('get')
+                ->willReturnMap([[Manager::class, $cacheManager]]);
+            $this->moduleLoader->expects($this->once())
+                ->method('load')
+                ->willReturn(['Foo_One' => [], 'Bar_Two' => [], 'New_Module' => []]);
+            $this->config->expects($this->atLeastOnce())
+                ->method('get')
+                ->with(ConfigOptionsListConstants::KEY_MODULES)
+                ->willReturn(true);
+            $this->configReader->expects($this->once())
+                ->method('load')
+                ->willReturn(['modules' => $currentModules]);
+
+            return $this->createObject(false, false);
         }
 
         /**


### PR DESCRIPTION
<!---
Thank you for contributing to Magento.
To help us process this pull request we recommend that you add the following information:
 - Summary of the pull request,
 - Issue(s) related to the changes made,
 - Manual testing scenarios
-->

### Description (*)

`setup:upgrade --keep-generated` and `setup:db-data:upgrade` cannot run when `app/etc` is read-only, which is the expected state for immutable deployments (prebuilt container images, Kubernetes, `chmod 444 app/etc/*`). Two independent causes, one commit each:

1. **`Installer::updateModulesSequence()` always rewrites `app/etc/config.php`.**
   `createModulesConfig()` recomputes the `modules` array and calls `Writer::saveConfig()` unconditionally, even when the result is byte-for-byte what is already deployed. On a read-only `config.php` this fails with `The "config.php" deployment config file isn't writable.`
   Fix: only call `saveConfig()` when the computed module list differs (`!==`, so a changed module sequence still triggers a write) from the current `modules` section.

2. **`FilePermissions::getMissingWritableDirectoriesForDbUpgrade()` requires `app/etc` to be writable.**
   `Installer::installDataFixtures()` runs this precondition, so `setup:db-data:upgrade` (and the data phase of `setup:upgrade`) aborts with `Missing write permissions to the following paths: <root>/app/etc` before touching the database. The DB upgrade itself writes only to the database and `var/`.
   Fix: drop `DirectoryList::CONFIG` from the list; `var/` is still required. A patch that genuinely needs to write deployment configuration (e.g. `Magento\Backend\Setup\Patch\Data\MigrateRedisBackendConfig`) still gets a precise error from `DeploymentConfig\Writer` at the moment of the write instead of a blanket refusal up front.

No public signatures changed.

### Related Pull Requests

- #32605 addresses the `cache_types` / `env.php` side of #26292 and is on hold; this PR is independent of it.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#26292

### Manual testing scenarios (*)

1. Install Magento 2.4-develop, run `bin/magento setup:upgrade` once so `config.php` is in sync.
2. `chmod 555 app/etc && chmod 444 app/etc/*`
3. `bin/magento setup:upgrade --keep-generated`
   - before: `Upgrade failed: The "config.php" deployment config file isn't writable.`
   - after: `Upgrade completed successfully.`
4. `bin/magento setup:db-data:upgrade`
   - before: `Missing write permissions to the following paths: /var/www/html/app/etc`
   - after: completes, exit code 0.
5. Restore permissions, enable/disable a module (`bin/magento module:disable Magento_Wishlist`), run `bin/magento setup:upgrade --keep-generated` — `config.php` is rewritten as before.

### Questions or comments

Unit tests: `setup/src/Magento/Setup/Test/Unit/Model/InstallerTest.php` (write skipped when unchanged, write performed when module order changes) and `lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php` (read-only `app/etc` not reported). Both new tests fail against `2.4-develop` without the fix.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined templates](https://github.com/magento/devdocs/wiki/Magento-module-README.md) (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
