### PR TITLE
Stop setup:config:set from requiring writable pub/media (#38435)

### DIFF
--- a/lib/internal/Magento/Framework/Setup/FilePermissions.php
+++ b/lib/internal/Magento/Framework/Setup/FilePermissions.php
@@ -327,8 +327,8 @@ class FilePermissions
     /**
      * Checks writable directories for installation
      *
-     * @deprecated 100.1.0 Use getMissingWritablePathsForInstallation()
-     * to get all missing writable paths required for install.
+     * @deprecated 100.1.0 Checks directories only; use the replacement to also cover files required for install.
+     * @see getMissingWritablePathsForInstallation()
      * @return array
      */
     public function getMissingWritableDirectoriesForInstallation()

--- a/lib/internal/Magento/Framework/Setup/FilePermissions.php
+++ b/lib/internal/Magento/Framework/Setup/FilePermissions.php
@@ -280,6 +280,26 @@ class FilePermissions
     }
 
     /**
+     * Checks writable paths for saving the deployment configuration, returns paths that require write permission
+     *
+     * Saving the deployment configuration (setup:config:set) writes to app/etc only, so the other installation
+     * directories (var, pub/media, generated, pub/static) are not checked here.
+     *
+     * @return array List of paths that require write permission to save the deployment configuration
+     */
+    public function getMissingWritablePathsForDeploymentConfig()
+    {
+        if ($this->isWritable(DirectoryList::CONFIG)) {
+            return [];
+        }
+        $path = $this->directoryList->getPath(DirectoryList::CONFIG);
+        if ($this->checkRecursiveDirectories($path)) {
+            return [];
+        }
+        return $this->nonWritablePathsInDirectories[$path] ?? [$path];
+    }
+
+    /**
      * Checks writable paths for database upgrade, returns array of directory paths that requires write permission
      *
      * @return array List of directories that requires write permission for database upgrade

--- a/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
+++ b/lib/internal/Magento/Framework/Setup/Test/Unit/FilePermissionsTest.php
@@ -244,6 +244,57 @@ class FilePermissionsTest extends TestCase
     /**
      * @return void
      */
+    public function testGetMissingWritablePathsForDeploymentConfigWithWritableConfigDirectory(): void
+    {
+        $directoryMethods = ['isExist', 'isDirectory', 'isReadable', 'isWritable'];
+        foreach ($directoryMethods as $method) {
+            $this->directoryWriteMock->expects($this->once())
+                ->method($method)
+                ->willReturn(true);
+        }
+        $this->directoryListMock->expects($this->never())->method('getPath');
+
+        $this->assertEmpty($this->filePermissions->getMissingWritablePathsForDeploymentConfig());
+    }
+
+    /**
+     * A read-only app/etc whose entries are all writable is accepted; pub/media and the other installation
+     * directories are never looked at.
+     *
+     * @return void
+     */
+    public function testGetMissingWritablePathsForDeploymentConfigWithReadOnlyConfigDirectory(): void
+    {
+        $configPath = sys_get_temp_dir() . '/' . uniqid('magento-app-etc-', true);
+        mkdir($configPath);
+        try {
+            $directoryMethods = ['isExist', 'isDirectory', 'isReadable'];
+            foreach ($directoryMethods as $method) {
+                $this->directoryWriteMock->expects($this->once())
+                    ->method($method)
+                    ->willReturn(true);
+            }
+            $this->directoryWriteMock->expects($this->once())
+                ->method('isWritable')
+                ->willReturn(false);
+            $this->directoryListMock
+                ->method('getPath')
+                ->willReturnMap([
+                    [DirectoryList::CONFIG, $configPath],
+                    [DirectoryList::GENERATED_CODE, BP . '/generated/code'],
+                    [DirectoryList::GENERATED_METADATA, BP . '/generated/metadata'],
+                    [DirectoryList::SESSION, BP . '/var/session'],
+                ]);
+
+            $this->assertEmpty($this->filePermissions->getMissingWritablePathsForDeploymentConfig());
+        } finally {
+            rmdir($configPath);
+        }
+    }
+
+    /**
+     * @return void
+     */
     public function testGetMissingWritableDirectoriesForDbUpgrade(): void
     {
         $directoryMethods = ['isExist', 'isDirectory', 'isReadable', 'isWritable'];

--- a/setup/src/Magento/Setup/Model/ConfigModel.php
+++ b/setup/src/Magento/Setup/Model/ConfigModel.php
@@ -93,7 +93,7 @@ class ConfigModel
      */
     public function process($inputOptions)
     {
-        $this->checkInstallationFilePermissions();
+        $this->checkDeploymentConfigFilePermissions();
 
         $options = $this->collector->collectOptionsLists();
 
@@ -158,14 +158,14 @@ class ConfigModel
     }
 
     /**
-     * Check permissions of directories that are expected to be writable for installation
+     * Check permissions of paths that are expected to be writable for saving the deployment configuration
      *
      * @return void
      * @throws \Exception
      */
-    private function checkInstallationFilePermissions()
+    private function checkDeploymentConfigFilePermissions()
     {
-        $results = $this->filePermissions->getMissingWritablePathsForInstallation();
+        $results = $this->filePermissions->getMissingWritablePathsForDeploymentConfig();
         if ($results) {
             $errorMsg = "Missing write permissions to the following paths:" . PHP_EOL . implode(PHP_EOL, $results);
             throw new SetupException($errorMsg);

--- a/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
+++ b/setup/src/Magento/Setup/Test/Unit/Model/ConfigModelTest.php
@@ -209,8 +209,9 @@ class ConfigModelTest extends TestCase
     {
         $this->expectException('Exception');
         $this->expectExceptionMessage('Missing write permissions to the following paths:');
-        $this->filePermissions->expects($this->once())->method('getMissingWritablePathsForInstallation')
-            ->willReturn(['/a/ro/dir', '/media']);
+        $this->filePermissions->expects($this->once())->method('getMissingWritablePathsForDeploymentConfig')
+            ->willReturn(['/a/ro/dir/config.php']);
+        $this->filePermissions->expects($this->never())->method('getMissingWritablePathsForInstallation');
         $this->configModel->process([]);
     }
 }


### PR DESCRIPTION
### Description (*)

`bin/magento setup:config:set` fails when any file directly inside `pub/media` is not writable by the CLI user (read-only NFS/EFS mount, media owned by the web server user, a stray `chmod 444`):

```
Missing write permissions to the following paths:
/var/www/html/pub/media/logo.png
```

Root cause: `Magento\Setup\Model\ConfigModel::process()` runs `FilePermissions::getMissingWritablePathsForInstallation()` — the full `setup:install` precondition, which walks `app/etc`, `var`, `pub/media` and (outside production mode) `generated` and `pub/static`, one level deep. `setup:config:set` only ever writes `app/etc/env.php` / `app/etc/config.php`, so the state of `pub/media` is irrelevant to it.

Fix:

- New `FilePermissions::getMissingWritablePathsForDeploymentConfig()` — checks `app/etc` only, with the same semantics as the existing `getMissingWritableDirectoriesForDbUpgrade()` (directory writable → OK; otherwise its direct entries must be writable).
- `ConfigModel` uses it instead of the installation-wide check.
- `setup:install` is unchanged: `Installer::installDeploymentConfig()` still runs `checkInstallationFilePermissions()` before delegating to `ConfigModel`.

No public signatures changed; one public method added.

### Related Pull Requests

- #41153 — same class of problem for `setup:upgrade` / `setup:db-data:upgrade` with a read-only `app/etc` (#26292). Independent change.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#38435

### Manual testing scenarios (*)

1. Install Magento 2.4-develop.
2. Make one file in `pub/media` non-writable for the CLI user, e.g. `touch pub/media/logo.png && chmod 444 pub/media/logo.png` (must be a filesystem that honours permissions for that user).
3. Run `bin/magento setup:config:set --cache-id-prefix=test_ --no-interaction`
   - before: exit code 1, `Missing write permissions to the following paths: <root>/pub/media/logo.png`
   - after: exit code 0, `env.php` updated.
4. `chmod 555 app/etc && chmod 444 app/etc/*`, run the same command — still refused with `Missing write permissions to the following paths: <root>/app/etc` (the check that actually matters is kept).
5. `bin/magento setup:install ...` with a non-writable `pub/media` still fails the file permissions check as before.

### Questions or comments

Unit tests: `FilePermissionsTest` (writable `app/etc` → nothing reported and no other directory looked up; read-only `app/etc` with writable entries → nothing reported) and `ConfigModelTest` (installation-wide check no longer called). Both fail against `2.4-develop` without the fix.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined templates](https://github.com/magento/devdocs/wiki/Magento-module-README.md) (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
