### PR TITLE
Do not create cache_dir for non-filesystem cache backends (#41157)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/FactoryTest.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Cache\Frontend;
 
 use Magento\Framework\App\Area;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Cache\Backend\Redis;
 use Magento\Framework\Cache\FrontendInterface;
+use Magento\Framework\Filesystem;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class FactoryTest extends TestCase
 {
     /**
-     * Object Manager
+     * Object manager used to build the factory under test
      *
      * @var ObjectManagerInterface
      */
@@ -40,6 +42,19 @@ class FactoryTest extends TestCase
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->factory = $this->objectManager->create(Factory::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        $varDirectory = $this->objectManager->get(Filesystem::class)->getDirectoryWrite(DirectoryList::VAR_DIR);
+        foreach (['unused_cache_dir_41157', 'used_cache_dir_41157'] as $directory) {
+            if ($varDirectory->isExist($directory)) {
+                $varDirectory->delete($directory);
+            }
+        }
     }
 
     /**
@@ -99,5 +114,52 @@ class FactoryTest extends TestCase
         ];
 
         self::assertInstanceOf(FrontendInterface::class, $this->factory->create($options));
+    }
+
+    /**
+     * Verify a backend that does not store data on the filesystem does not create its configured cache_dir.
+     *
+     * @return void
+     */
+    public function testNonFilesystemBackendDoesNotCreateCacheDir(): void
+    {
+        $this->factory->create(
+            [
+                'backend' => 'database',
+                'backend_options' => ['cache_dir' => 'unused_cache_dir_41157'],
+                'id_prefix' => 'test_41157_',
+            ]
+        );
+
+        $varDirectory = Bootstrap::getObjectManager()->get(Filesystem::class)
+            ->getDirectoryWrite(DirectoryList::VAR_DIR);
+        self::assertFalse(
+            $varDirectory->isExist('unused_cache_dir_41157'),
+            'Cache directory must not be created for a backend that does not use the filesystem.'
+        );
+    }
+
+    /**
+     * Verify a filesystem backend still creates its configured cache_dir when data is actually saved.
+     *
+     * @return void
+     */
+    public function testFilesystemBackendCreatesCacheDirOnUse(): void
+    {
+        $cache = $this->factory->create(
+            [
+                'backend' => 'file',
+                'backend_options' => ['cache_dir' => 'used_cache_dir_41157'],
+                'id_prefix' => 'test_41157_',
+            ]
+        );
+        $cache->save('data', 'id_41157');
+
+        $varDirectory = Bootstrap::getObjectManager()->get(Filesystem::class)
+            ->getDirectoryWrite(DirectoryList::VAR_DIR);
+        self::assertTrue(
+            $varDirectory->isExist('used_cache_dir_41157'),
+            'Cache directory must be created by the filesystem backend on first use.'
+        );
     }
 }

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -490,6 +490,8 @@ class Factory
      * Resolve a cache_dir value to an absolute path.
      *
      * Absolute paths (e.g. /dev/shm/magento_l1) are required for L2 cache configuration and returned as-is.
+     * The directory itself is not created here: only the backend that actually stores data on the filesystem
+     * (Symfony FilesystemAdapter) creates it on first use, so non-file backends such as Redis leave var/ untouched.
      *
      * @param string $path
      * @return string
@@ -499,9 +501,7 @@ class Factory
         if (str_starts_with($path, DIRECTORY_SEPARATOR)) {
             return $path;
         }
-        $directory = $this->_filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
-        $directory->create($path);
-        return $directory->getAbsolutePath($path);
+        return $this->_filesystem->getDirectoryWrite(DirectoryList::VAR_DIR)->getAbsolutePath($path);
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/FactoryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/FactoryTest.php
@@ -293,18 +293,19 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * Test that relative cache_dir paths are resolved under VAR_DIR.
+     * Test that relative cache_dir paths are resolved under VAR_DIR without being created.
      *
      * Relative paths must go through the Magento filesystem abstraction:
-     * getDirectoryWrite(VAR_DIR) → create(path) → resolve to absolute path.
+     * getDirectoryWrite(VAR_DIR) → resolve to absolute path. The directory itself is created by the backend
+     * that actually uses it, so the factory must not create it.
      */
-    public function testResolveCacheDirRelativePathResolvedUnderVarDir(): void
+    public function testResolveCacheDirRelativePathResolvedUnderVarDirWithoutCreatingIt(): void
     {
         $relativePath = 'custom/cache/dir';
         $resolved     = '/var/www/html/var/' . $relativePath;
 
         $writeDirMock = $this->createMock(WriteInterface::class);
-        $writeDirMock->expects($this->once())->method('create')->with($relativePath)->willReturn(true);
+        $writeDirMock->expects($this->never())->method('create');
         $writeDirMock->expects($this->once())->method('getAbsolutePath')->with($relativePath)->willReturn($resolved);
 
         $filesystem = $this->createMock(Filesystem::class);
@@ -317,6 +318,39 @@ class FactoryTest extends TestCase
         $model->create([
             'backend'         => NullAdapter::class,
             'backend_options' => ['cache_dir' => $relativePath],
+            'id_prefix'       => 'test_',
+        ]);
+    }
+
+    /**
+     * Test that a non-filesystem backend does not create the configured cache_dir under var.
+     *
+     * With every cache frontend pointed at Redis, the hardcoded page_cache cache_dir coming from di.xml
+     * must not result in an empty var/page_cache directory being created.
+     */
+    public function testCreateWithNonFilesystemBackendDoesNotCreateCacheDir(): void
+    {
+        $varDirMock = $this->createMock(WriteInterface::class);
+        $varDirMock->expects($this->never())->method('create');
+        $varDirMock->expects($this->any())
+            ->method('getAbsolutePath')
+            ->with('page_cache')
+            ->willReturn('/var/www/html/var/page_cache');
+
+        $cacheDirMock = $this->createMock(WriteInterface::class);
+        $cacheDirMock->expects($this->any())->method('getAbsolutePath')->willReturn('/var/www/html/var/cache');
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->any())
+            ->method('getDirectoryWrite')
+            ->willReturnCallback(
+                fn ($directoryCode) => $directoryCode === DirectoryList::VAR_DIR ? $varDirMock : $cacheDirMock
+            );
+
+        $model = $this->buildModelWithFilesystem($filesystem);
+        $model->create([
+            'backend'         => 'redis',
+            'backend_options' => ['cache_dir' => 'page_cache', 'server' => '127.0.0.1'],
             'id_prefix'       => 'test_',
         ]);
     }


### PR DESCRIPTION
### Description (*)

When every cache frontend is configured with a non-file backend (e.g. `'backend' => 'redis'` for both `default` and `page_cache`), Magento still creates an empty `var/page_cache` directory on every `cache:flush`, `setup:upgrade` or first request. On deployments where CLI commands run as a deploy user and PHP-FPM as `www-data`, PHP-FPM then cannot write into that directory and the storefront fails with HTTP 500 before the logger is available.

**Root cause.** `app/etc/di.xml` hardcodes `backend_options.cache_dir = page_cache` for the `page_cache` frontend, and `Pool::_getCacheSettings()` intentionally keeps it when merging `env.php` (#22228). `Factory::resolveCacheDir()` then calls `getDirectoryWrite(VAR_DIR)->create($path)` unconditionally — before the backend type is resolved — so the directory is created for a Redis frontend that never uses it.

**Fix (minimal, backwards-compatible).** `Factory::resolveCacheDir()` no longer creates the directory; it only resolves the relative `cache_dir` to an absolute path under `var/`. The backend that actually uses the path creates it on first use: Symfony `FilesystemAdapter::init()` does `mkdir(..., 0777, true)`, and `SymfonyAdapterProvider::createFilesystemAdapter()` already creates the default `var/cache`. File backends therefore behave exactly as before; Redis/Valkey/Memcached/Database/APCu frontends leave `var/` untouched.

This is the smallest change that fixes the report. An alternative that makes the decision explicit in the factory (create the directory only when the resolved backend is file-based, with the check living in `SymfonyAdapterProvider`) is proposed in the linked PR — maintainers may prefer either; they are mutually exclusive.

### Related Pull Requests

- Alternative approach: https://github.com/magento/magento2/pull/41159

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41157

### Manual testing scenarios (*)

1. Configure `app/etc/env.php` with `'backend' => 'redis'` for both `cache.frontend.default` and `cache.frontend.page_cache` (`bin/magento setup:config:set --cache-backend=redis --page-cache=redis ...`).
2. Remove `var/page_cache` and `var/cache` if present.
3. Run `bin/magento cache:flush` and open any storefront page.
4. Before the fix: an empty `var/page_cache` directory is created. After the fix: neither `var/page_cache` nor `var/cache` exists.
5. Switch `page_cache` back to `'backend' => 'file'`, run `bin/magento cache:flush` and open a storefront page: `var/page_cache/<prefix>/...` is created and populated as before.

### Questions or comments

Only `Factory::resolveCacheDir()` changes; `_getBackendOptions()` still creates `var/cache` for the default file backend and for the local level of `remote_synchronized_cache`.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
