### PR TITLE
Create cache_dir only for file-based cache backends (#41157)

### DIFF
--- a/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/FactoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Framework/App/Cache/Frontend/FactoryTest.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 namespace Magento\Framework\App\Cache\Frontend;
 
 use Magento\Framework\App\Area;
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Cache\Backend\Redis;
 use Magento\Framework\Cache\FrontendInterface;
+use Magento\Framework\Filesystem;
 use Magento\Framework\ObjectManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 class FactoryTest extends TestCase
 {
     /**
-     * Object Manager
+     * Object manager used to build the factory under test
      *
      * @var ObjectManagerInterface
      */
@@ -40,6 +42,21 @@ class FactoryTest extends TestCase
     {
         $this->objectManager = Bootstrap::getObjectManager();
         $this->factory = $this->objectManager->create(Factory::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        $varDirectory = Bootstrap::getObjectManager()
+            ->get(Filesystem::class)
+            ->getDirectoryWrite(DirectoryList::VAR_DIR);
+        foreach (['unused_cache_dir_41157', 'used_cache_dir_41157'] as $directory) {
+            if ($varDirectory->isExist($directory)) {
+                $varDirectory->delete($directory);
+            }
+        }
     }
 
     /**
@@ -99,5 +116,55 @@ class FactoryTest extends TestCase
         ];
 
         self::assertInstanceOf(FrontendInterface::class, $this->factory->create($options));
+    }
+
+    /**
+     * A frontend backed by a non file-based backend must not create its configured cache_dir.
+     *
+     * @return void
+     */
+    public function testNonFilesystemBackendDoesNotCreateCacheDir(): void
+    {
+        $this->factory->create(
+            [
+                'backend' => 'database',
+                'backend_options' => ['cache_dir' => 'unused_cache_dir_41157'],
+                'id_prefix' => 'test_41157_',
+            ]
+        );
+
+        $varDirectory = Bootstrap::getObjectManager()
+            ->get(Filesystem::class)
+            ->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        self::assertFalse(
+            $varDirectory->isExist('unused_cache_dir_41157'),
+            'Cache directory must not be created for a backend that does not store cache entries on disk.'
+        );
+    }
+
+    /**
+     * A frontend backed by the file backend must still get its cache_dir created.
+     *
+     * @return void
+     */
+    public function testFilesystemBackendCreatesCacheDir(): void
+    {
+        $this->factory->create(
+            [
+                'backend' => 'file',
+                'backend_options' => ['cache_dir' => 'used_cache_dir_41157'],
+                'id_prefix' => 'test_41157_',
+            ]
+        );
+
+        $varDirectory = Bootstrap::getObjectManager()
+            ->get(Filesystem::class)
+            ->getDirectoryWrite(DirectoryList::VAR_DIR);
+
+        self::assertTrue(
+            $varDirectory->isExist('used_cache_dir_41157'),
+            'Cache directory must be created for a file-based backend.'
+        );
     }
 }

--- a/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
+++ b/lib/internal/Magento/Framework/App/Cache/Frontend/Factory.php
@@ -470,18 +470,26 @@ class Factory
     /**
      * Prepare and cache directory paths for cache storage
      *
+     * The cache_dir value of every section is always resolved to an absolute path, but the directory itself
+     * is only created when the backend owning that section is file-based. Frontends configured with Redis,
+     * Valkey, Memcached, Database or APCu therefore no longer leave empty directories behind in var/.
+     *
      * @param array $options
      * @return void
      */
     private function prepareCacheDirectories(array &$options): void
     {
-        foreach (['backend_options', 'slow_backend_options'] as $section) {
+        foreach (['backend_options' => 'backend', 'slow_backend_options' => 'slow_backend'] as $section => $key) {
             if (!empty($options[$section]['cache_dir'])) {
                 $cacheDir = $options[$section]['cache_dir'];
-                if (!isset($this->cachedDirectories[$cacheDir])) {
-                    $this->cachedDirectories[$cacheDir] = $this->resolveCacheDir($cacheDir);
+                $create = $this->adapterProvider->isFilesystemBackend($options[$key] ?? $this->_defaultBackend);
+                // Memoize on path + creation decision, so a resolve-only hit for a non-file backend cannot
+                // suppress directory creation for a later file-based frontend using the same cache_dir.
+                $cacheKey = $cacheDir . '|' . ($create ? '1' : '0');
+                if (!isset($this->cachedDirectories[$cacheKey])) {
+                    $this->cachedDirectories[$cacheKey] = $this->resolveCacheDir($cacheDir, $create);
                 }
-                $options[$section]['cache_dir'] = $this->cachedDirectories[$cacheDir];
+                $options[$section]['cache_dir'] = $this->cachedDirectories[$cacheKey];
             }
         }
     }
@@ -489,18 +497,23 @@ class Factory
     /**
      * Resolve a cache_dir value to an absolute path.
      *
-     * Absolute paths (e.g. /dev/shm/magento_l1) are required for L2 cache configuration and returned as-is.
+     * Absolute paths (e.g. /dev/shm/magento_l1) are required for L2 cache configuration and returned as-is;
+     * they are never created here. Relative paths are resolved under var/ and only created when $create is
+     * true, i.e. when the backend that owns the option section actually stores cache entries on disk.
      *
      * @param string $path
+     * @param bool $create
      * @return string
      */
-    private function resolveCacheDir(string $path): string
+    private function resolveCacheDir(string $path, bool $create): string
     {
         if (str_starts_with($path, DIRECTORY_SEPARATOR)) {
             return $path;
         }
         $directory = $this->_filesystem->getDirectoryWrite(DirectoryList::VAR_DIR);
-        $directory->create($path);
+        if ($create) {
+            $directory->create($path);
+        }
         return $directory->getAbsolutePath($path);
     }
 

--- a/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/FactoryTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/Cache/Frontend/FactoryTest.php
@@ -322,6 +322,71 @@ class FactoryTest extends TestCase
     }
 
     /**
+     * Test that a non file-based backend resolves cache_dir but never creates the directory.
+     *
+     * Reproduces the empty var/page_cache directory created for Redis-backed frontends.
+     */
+    public function testCreateWithNonFilesystemBackendDoesNotCreateCacheDir(): void
+    {
+        $varDirMock = $this->createMock(WriteInterface::class);
+        $varDirMock->expects($this->never())->method('create');
+        $varDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->with('page_cache')
+            ->willReturn('/var/www/html/var/page_cache');
+
+        $model = $this->buildModelWithFilesystem($this->createFilesystemMockWithVarDir($varDirMock));
+        $model->create([
+            'backend'         => 'redis',
+            'backend_options' => ['cache_dir' => 'page_cache', 'server' => '127.0.0.1'],
+            'id_prefix'       => 'test_',
+        ]);
+    }
+
+    /**
+     * Test that a file-based backend still creates the resolved cache directory.
+     */
+    public function testCreateWithFilesystemBackendCreatesCacheDir(): void
+    {
+        $varDirMock = $this->createMock(WriteInterface::class);
+        $varDirMock->expects($this->once())->method('create')->with('page_cache')->willReturn(true);
+        $varDirMock->expects($this->once())
+            ->method('getAbsolutePath')
+            ->with('page_cache')
+            ->willReturn('/var/www/html/var/page_cache');
+
+        $model = $this->buildModelWithFilesystem($this->createFilesystemMockWithVarDir($varDirMock));
+        $model->create([
+            'backend'         => 'file',
+            'backend_options' => ['cache_dir' => 'page_cache'],
+            'id_prefix'       => 'test_',
+        ]);
+    }
+
+    /**
+     * Create a Filesystem mock returning the given VAR_DIR writer and a permissive writer for var/cache.
+     *
+     * @param WriteInterface $varDirMock
+     * @return Filesystem|MockObject
+     */
+    private function createFilesystemMockWithVarDir(WriteInterface $varDirMock)
+    {
+        $cacheDirMock = $this->createMock(WriteInterface::class);
+        $cacheDirMock->expects($this->any())->method('getAbsolutePath')->willReturn('/var/www/html/var/cache');
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->expects($this->any())
+            ->method('getDirectoryWrite')
+            ->willReturnCallback(
+                static fn (string $code): WriteInterface => $code === DirectoryList::VAR_DIR
+                    ? $varDirMock
+                    : $cacheDirMock
+            );
+
+        return $filesystem;
+    }
+
+    /**
      * Build Factory with a specific filesystem mock; all other deps use defaults.
      *
      * @param Filesystem $filesystem
@@ -349,6 +414,14 @@ class FactoryTest extends TestCase
 
         $adapterProviderMock = $this->createMock(SymfonyAdapterProvider::class);
         $adapterProviderMock->expects($this->any())->method('createTagAdapter')->willReturn($adapterMock);
+        // Mirror the real adapter type map: unknown backend types fall back to the filesystem adapter.
+        $adapterProviderMock->expects($this->any())
+            ->method('isFilesystemBackend')
+            ->willReturnCallback(static fn (string $type): bool => !in_array(
+                strtolower($type),
+                ['redis', 'valkey', 'memcached', 'libmemcached', 'database', 'apc', 'apcu', 'two_levels', 'twolevel'],
+                true
+            ));
 
         return new Factory($objectManager, $filesystem, $resource, $adapterProviderMock);
     }

--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
@@ -119,6 +119,34 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
     }
 
     /**
+     * Resolve a configured backend type to the canonical Symfony adapter type
+     *
+     * Unknown backend types fall back to the filesystem adapter.
+     *
+     * @param string $backendType
+     * @return string
+     */
+    private function resolveAdapterType(string $backendType): string
+    {
+        return $this->adapterTypeMap[strtolower($backendType)] ?? 'filesystem';
+    }
+
+    /**
+     * Check whether the given backend type resolves to the filesystem adapter
+     *
+     * Only the filesystem adapter stores cache entries in a cache_dir on disk, so callers can use this
+     * to decide whether a cache directory has to exist at all. Unknown backend types fall back to the
+     * filesystem adapter in createAdapter(), so they are reported as file-based too.
+     *
+     * @param string $backendType
+     * @return bool
+     */
+    public function isFilesystemBackend(string $backendType): bool
+    {
+        return $this->resolveAdapterType($backendType) === 'filesystem';
+    }
+
+    /**
      * Create Symfony cache adapter based on backend type and options
      *
      * @param string $backendType
@@ -135,8 +163,7 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
         ?int $defaultLifetime = null
     ): CacheItemPoolInterface {
         // Optimize: Use pre-built map instead of switch
-        $backendTypeLower = strtolower($backendType);
-        $resolvedType = $this->adapterTypeMap[$backendTypeLower] ?? 'filesystem';
+        $resolvedType = $this->resolveAdapterType($backendType);
 
         // Create adapter based on resolved type with fallback to filesystem
         try {
@@ -180,8 +207,7 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
         array $backendOptions = []
     ): TagAdapterInterface {
         // Resolve backend type
-        $backendTypeLower = strtolower($backendType);
-        $resolvedType = $this->adapterTypeMap[$backendTypeLower] ?? 'filesystem';
+        $resolvedType = $this->resolveAdapterType($backendType);
 
         // Check if Lua scripts are enabled (separate flags for different operations)
         $useLua = !empty($backendOptions['use_lua']) && $backendOptions['use_lua'] === '1';

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Cache\Test\Unit\Frontend\Adapter;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Cache\Frontend\Adapter\SymfonyAdapterProvider;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Serialize\Serializer\Serialize;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SymfonyAdapterProviderTest extends TestCase
+{
+    /**
+     * @var SymfonyAdapterProvider
+     */
+    private SymfonyAdapterProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new SymfonyAdapterProvider(
+            $this->createMock(Filesystem::class),
+            $this->createMock(ResourceConnection::class),
+            $this->createMock(Serialize::class)
+        );
+    }
+
+    /**
+     * Only backend types resolving to the filesystem adapter are reported as file-based.
+     *
+     * @param string $backendType
+     * @param bool $expected
+     * @return void
+     */
+    #[DataProvider('isFilesystemBackendDataProvider')]
+    public function testIsFilesystemBackend(string $backendType, bool $expected): void
+    {
+        $this->assertSame($expected, $this->provider->isFilesystemBackend($backendType));
+    }
+
+    /**
+     * @return array[]
+     */
+    public static function isFilesystemBackendDataProvider(): array
+    {
+        return [
+            'file' => ['file', true],
+            'file uppercase' => ['FILE', true],
+            'redis' => ['redis', false],
+            'valkey' => ['valkey', false],
+            'memcached' => ['memcached', false],
+            'libmemcached' => ['libmemcached', false],
+            'database' => ['database', false],
+            'apcu' => ['apcu', false],
+            'two levels' => ['two_levels', false],
+            'unknown falls back to filesystem' => ['Some\Unknown\Backend', true],
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)

When every cache frontend is configured with a non-file backend (e.g. `'backend' => 'redis'` for both `default` and `page_cache`), Magento still creates an empty `var/page_cache` directory on every `cache:flush`, `setup:upgrade` or first request. On deployments where CLI commands run as a deploy user and PHP-FPM as `www-data`, PHP-FPM then cannot write into that directory and the storefront fails with HTTP 500 before the logger is available.

**Root cause.** `app/etc/di.xml` hardcodes `backend_options.cache_dir = page_cache` for the `page_cache` frontend, and `Pool::_getCacheSettings()` intentionally keeps it when merging `env.php` (#22228). `Factory::prepareCacheDirectories()` then calls `getDirectoryWrite(VAR_DIR)->create($path)` unconditionally — before the backend type is resolved — so the directory is created for a Redis frontend that never uses it.

**Fix (explicit).** The factory now creates `cache_dir` only when the backend owning that option is file-based. The decision is delegated to a new `SymfonyAdapterProvider::isFilesystemBackend(string $backendType): bool`, which reuses the provider's own backend → adapter map (including its "unknown type falls back to filesystem" rule), so the factory and the provider cannot disagree. `backend_options.cache_dir` is checked against `backend`, `slow_backend_options.cache_dir` against `slow_backend`. Relative paths are still resolved to absolute paths for every backend (options remain backwards-compatible); only the `mkdir` is gated.

A smaller alternative — dropping the eager `create()` entirely and relying on Symfony's `FilesystemAdapter` to create its own directory on first use — is proposed in the linked PR. The two are mutually exclusive; this one keeps directory creation under Magento's filesystem abstraction and makes the rule visible in code.

### Related Pull Requests

- Alternative approach: https://github.com/magento/magento2/pull/41158

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41157

### Manual testing scenarios (*)

1. Configure `app/etc/env.php` with `'backend' => 'redis'` for both `cache.frontend.default` and `cache.frontend.page_cache` (`bin/magento setup:config:set --cache-backend=redis --page-cache=redis ...`).
2. Remove `var/page_cache` and `var/cache` if present.
3. Run `bin/magento cache:flush` and open any storefront page.
4. Before the fix: an empty `var/page_cache` directory is created. After the fix: neither `var/page_cache` nor `var/cache` exists.
5. Switch `page_cache` back to `'backend' => 'file'`, run `bin/magento cache:flush`: `var/page_cache` is created immediately, as before.

### Questions or comments

`SymfonyAdapterProvider` is not `@api`; adding a public method is a MINOR change for the Semantic Version Checker. No existing signature changes.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
