### PR TITLE
Add database adapter dialect helpers for PostgreSQL support

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php
@@ -820,6 +820,61 @@ interface AdapterInterface
     public function getIfNullSql($expression, $value = 0);
 
     /**
+     * GROUP_CONCAT / string_agg equivalent
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @param string $separator
+     * @param string|\Zend_Db_Expr|null $orderBy
+     * @param bool $distinct
+     * @return \Zend_Db_Expr
+     */
+    public function getGroupConcatSql($expression, $separator = ',', $orderBy = null, $distinct = false);
+
+    /**
+     * FIELD() / CASE equivalent for ORDER BY a fixed list
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @param array $values
+     * @return \Zend_Db_Expr
+     */
+    public function getFieldSql($expression, array $values);
+
+    /**
+     * Cast an expression to text for UNION type alignment
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @return \Zend_Db_Expr
+     */
+    public function castToText($expression);
+
+    /**
+     * Cast an expression to a numeric type for arithmetic
+     *
+     * @param string|\Zend_Db_Expr $expression
+     * @return \Zend_Db_Expr
+     */
+    public function castToNumeric($expression);
+
+    /**
+     * CREATE TABLE new LIKE origin
+     *
+     * @param string $newTableName
+     * @param string $originTableName
+     * @return \Zend_Db_Statement_Interface
+     */
+    public function createTableLike($newTableName, $originTableName);
+
+    /**
+     * CREATE TEMPORARY TABLE from a SELECT (and optional index definitions)
+     *
+     * @param string $name
+     * @param string[] $indexStatements
+     * @param \Magento\Framework\DB\Select $select
+     * @return \Zend_Db_Statement_Interface
+     */
+    public function createTemporaryTableFromSelect($name, array $indexStatements, \Magento\Framework\DB\Select $select);
+
+    /**
      * Generate fragment of SQL, that combine together (concatenate) the results from data array
      *
      * All arguments in data must be quoted

--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -3459,6 +3459,79 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface, Rese
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getGroupConcatSql($expression, $separator = ',', $orderBy = null, $distinct = false)
+    {
+        $sql = 'GROUP_CONCAT(' . ($distinct ? 'DISTINCT ' : '') . $expression;
+        if ($orderBy !== null) {
+            $sql .= ' ORDER BY ' . $orderBy;
+        }
+        return new \Zend_Db_Expr($sql . ' SEPARATOR ' . $this->quote($separator) . ')');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getFieldSql($expression, array $values)
+    {
+        $parts = [];
+        foreach ($values as $value) {
+            if ($value === '') {
+                continue;
+            }
+            $parts[] = $value;
+        }
+        if (!$parts) {
+            return new \Zend_Db_Expr('0');
+        }
+        return new \Zend_Db_Expr('FIELD(' . $expression . ', ' . implode(', ', $parts) . ')');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createTableLike($newTableName, $originTableName)
+    {
+        return $this->query(sprintf(
+            'CREATE TABLE %s LIKE %s',
+            $this->quoteIdentifier($newTableName),
+            $this->quoteIdentifier($originTableName)
+        ));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createTemporaryTableFromSelect($name, array $indexStatements, Select $select)
+    {
+        $sql = sprintf(
+            'CREATE TEMPORARY TABLE %s %s ENGINE=%s IGNORE (%s)',
+            $this->quoteIdentifier($name),
+            $indexStatements ? '(' . implode(',', $indexStatements) . ')' : '',
+            $this->quoteIdentifier('innodb'),
+            $select
+        );
+        return $this->query($sql, $select->getBind());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function castToText($expression)
+    {
+        return new \Zend_Db_Expr((string) $expression);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function castToNumeric($expression)
+    {
+        return new \Zend_Db_Expr('CAST(' . $expression . ' AS DECIMAL(20,6))');
+    }
+
+    /**
      * Generates case SQL fragment
      *
      * Generate fragment of SQL, that check value against multiple condition cases

--- a/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
+++ b/lib/internal/Magento/Framework/DB/Query/BatchIterator.php
@@ -174,7 +174,16 @@ class BatchIterator implements BatchIteratorInterface
             ]
         );
         $row = $this->connection->fetchRow($wrapperSelect);
-        $this->minValue = $row['max'];
+        // empty (cnt below ends up 0 and the iterator stops right after this call
+        // anyway), don't overwrite minValue with that null. A leftover null minValue
+        // fed into initSelectObject()'s "> ?" bind is otherwise silently coerced to an
+        // empty-string parameter by PDO, which MySQL's loose bigint/string comparison
+        // tolerates (implicitly treating '' as 0) but Postgres rejects outright
+        // ("invalid input syntax for type bigint"). Real-world trigger: any
+        // FieldDataConverter::convert() call (e.g. Theme's ConvertSerializedData data
+        // patch) whose target rows are exhausted after fewer than batchSize rows, or -
+        // as first hit here - never existed at all.
+        $this->minValue = $row['max'] ?? $this->minValue;
         return (int)$row['cnt'];
     }
 

--- a/lib/internal/Magento/Framework/DB/Select.php
+++ b/lib/internal/Magento/Framework/DB/Select.php
@@ -57,12 +57,15 @@ class Select extends \Zend_Db_Select
      * Class constructor
      * Add straight join support
      *
-     * @param Adapter\Pdo\Mysql $adapter
+     * Typed as Zend_Db_Adapter_Abstract (parent constructor requirement) rather than
+     * Pdo\Mysql so any AdapterInterface implementation can call select().
+     *
+     * @param \Zend_Db_Adapter_Abstract $adapter
      * @param Select\SelectRenderer $selectRenderer
      * @param array $parts
      */
     public function __construct(
-        \Magento\Framework\DB\Adapter\Pdo\Mysql $adapter,
+        \Zend_Db_Adapter_Abstract $adapter,
         \Magento\Framework\DB\Select\SelectRenderer $selectRenderer,
         $parts = []
     ) {

--- a/lib/internal/Magento/Framework/DB/TemporaryTableService.php
+++ b/lib/internal/Magento/Framework/DB/TemporaryTableService.php
@@ -16,8 +16,8 @@ use Magento\Framework\DB\Adapter\AdapterInterface;
  */
 class TemporaryTableService
 {
-    const INDEX_METHOD_HASH = 'HASH';
-    const DB_ENGINE_INNODB = 'INNODB';
+    public const INDEX_METHOD_HASH = 'HASH';
+    public const DB_ENGINE_INNODB = 'INNODB';
 
     /**
      * @var string[]
@@ -120,18 +120,7 @@ class TemporaryTableService
             $indexStatements[] = sprintf('%s(%s)', $indexType, $renderedColumns);
         }
 
-        $statement = sprintf(
-            'CREATE TEMPORARY TABLE %s %s ENGINE=%s IGNORE (%s)',
-            $adapter->quoteIdentifier($name),
-            $indexStatements ? '(' . implode(',', $indexStatements) . ')' : '',
-            $adapter->quoteIdentifier($dbEngine),
-            "{$select}"
-        );
-
-        $adapter->query(
-            $statement,
-            $select->getBind()
-        );
+        $adapter->createTemporaryTableFromSelect($name, $indexStatements, $select);
 
         $this->createdTableAdapters[$name] = $adapter;
 

--- a/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/Adapter/Pdo/MysqlTest.php
@@ -1131,4 +1131,61 @@ class MysqlTest extends TestCase
         $adapter->__destruct();
         $this->assertEquals(0, $adapter->getTransactionLevel());
     }
+
+    public function testDialectHelpers(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quote']);
+        $adapter->method('quote')->willReturnCallback(static function ($value) {
+            return "'" . $value . "'";
+        });
+
+        $this->assertSame(
+            "GROUP_CONCAT(sku SEPARATOR ',')",
+            (string) $adapter->getGroupConcatSql('sku')
+        );
+        $this->assertSame(
+            "GROUP_CONCAT(DISTINCT sku ORDER BY sku SEPARATOR '|')",
+            (string) $adapter->getGroupConcatSql('sku', '|', 'sku', true)
+        );
+        $this->assertSame('0', (string) $adapter->getFieldSql('status', []));
+        $this->assertSame('0', (string) $adapter->getFieldSql('status', ['']));
+        $this->assertSame(
+            'FIELD(status, 1, 2, 3)',
+            (string) $adapter->getFieldSql('status', [1, '', 2, 3])
+        );
+        $this->assertSame('value', (string) $adapter->castToText('value'));
+        $this->assertSame('CAST(value AS DECIMAL(20,6))', (string) $adapter->castToNumeric('value'));
+    }
+
+    public function testCreateTableLikeAndTemporaryFromSelect(): void
+    {
+        $adapter = $this->getMysqlPdoAdapterMock(['query', 'quoteIdentifier']);
+        $adapter->method('quoteIdentifier')->willReturnCallback(static function ($value) {
+            return '`' . $value . '`';
+        });
+        $stmt = $this->createMock(\Zend_Db_Statement_Pdo::class);
+        $select = $this->createMock(Select::class);
+        $select->method('__toString')->willReturn('SELECT 1');
+        $select->method('getBind')->willReturn(['foo' => 'bar']);
+        $adapter->expects($this->exactly(2))
+            ->method('query')
+            ->willReturnCallback(function ($sql, $bind = []) use ($stmt) {
+                if ($sql === 'CREATE TABLE `new_table` LIKE `origin_table`') {
+                    $this->assertSame([], $bind);
+                    return $stmt;
+                }
+                $this->assertSame(
+                    'CREATE TEMPORARY TABLE `tmp` (PRIMARY KEY(id)) ENGINE=`innodb` IGNORE (SELECT 1)',
+                    $sql
+                );
+                $this->assertSame(['foo' => 'bar'], $bind);
+                return $stmt;
+            });
+
+        $this->assertSame($stmt, $adapter->createTableLike('new_table', 'origin_table'));
+        $this->assertSame(
+            $stmt,
+            $adapter->createTemporaryTableFromSelect('tmp', ['PRIMARY KEY(id)'], $select)
+        );
+    }
 }

--- a/lib/internal/Magento/Framework/DB/Test/Unit/TemporaryTableServiceTest.php
+++ b/lib/internal/Magento/Framework/DB/Test/Unit/TemporaryTableServiceTest.php
@@ -101,26 +101,19 @@ class TemporaryTableServiceTest extends TestCase
             ->method('getUniqueHash')
             ->willReturn($random);
 
-        $this->adapterMock->expects($this->once())
-            ->method('query')
-            ->with($expectedSelect)
-            ->willReturnSelf();
-
-        $this->adapterMock->expects($this->once())
-            ->method('query')
-            ->willReturnSelf();
-
         $this->adapterMock->expects($this->any())
             ->method('quoteIdentifier')
             ->willReturnArgument(0);
 
-        $this->selectMock->expects($this->once())
-            ->method('getBind')
-            ->willReturn(['bind']);
-
-        $this->selectMock->expects($this->any())
-            ->method('__toString')
-            ->willReturn($selectString);
+        $this->adapterMock->expects($this->once())
+            ->method('createTemporaryTableFromSelect')
+            ->with(
+                $random,
+                $this->callback(static function (array $indexStatements) use ($expectedSelect) {
+                    return str_contains($expectedSelect, implode(',', $indexStatements));
+                }),
+                $this->selectMock
+            );
 
         $this->assertEquals(
             $random,

--- a/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
+++ b/lib/internal/Magento/Framework/Data/Collection/AbstractDb.php
@@ -736,7 +736,15 @@ abstract class AbstractDb extends \Magento\Framework\Data\Collection
         if (!$this->_isOrdersRendered) {
             foreach ($this->_orders as $field => $direction) {
                 if (isset($this->sqlReservedWords[strtoupper($field)])) {
-                    $field = "`$field`";
+                    // coincidence only on MySQL (whose quote character happens to be a
+                    // backtick), and it bypasses the adapter's own quoteIdentifier()
+                    // entirely, so Postgres (whose reserved-word set differs anyway -
+                    // e.g. "position" isn't reserved there, but this same $field is
+                    // wrapped unconditionally once it matches MySQL's list) received a
+                    // literal, invalid backtick instead of a real identifier quote.
+                    // quoteIdentifier() is exactly what every other quoting path in this
+                    // class already goes through.
+                    $field = $this->getConnection()->quoteIdentifier($field);
                 }
 
                 $this->_select->order(new \Zend_Db_Expr($field . ' ' . $direction));

--- a/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
+++ b/lib/internal/Magento/Framework/Test/Unit/DB/Query/BatchIteratorTest.php
@@ -218,4 +218,19 @@ class BatchIteratorTest extends TestCase
         $this->assertEquals($this->selectMock, $this->model->current());
         $this->assertEquals(2, $this->model->key());
     }
+
+    /**
+     * MAX() over zero rows is SQL NULL. Keep the previous minValue so the next
+     * WHERE rangeField > ? bind stays an integer (0), not null/''.
+     */
+    public function testEmptyBatchDoesNotBindNullMinValue(): void
+    {
+        $filed = $this->correlationName . '.' . $this->rangeField;
+        $this->connectionMock->method('fetchRow')->willReturn(['max' => null, 'cnt' => 0]);
+        $this->selectMock->expects($this->exactly(2))->method('where')->with($filed . ' > ?', 0);
+
+        $this->model->current();
+        $this->assertFalse($this->model->valid());
+        $this->model->next();
+    }
 }

--- a/setup/src/Magento/Setup/Model/ConfigOptionsList.php
+++ b/setup/src/Magento/Setup/Model/ConfigOptionsList.php
@@ -388,7 +388,8 @@ class ConfigOptionsList implements ConfigOptionsListInterface
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_HOST],
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_USER],
                     $options[ConfigOptionsListConstants::INPUT_KEY_DB_PASSWORD],
-                    $driverOptions
+                    $driverOptions,
+                    $options[ConfigOptionsListConstants::INPUT_KEY_DB_ENGINE] ?? null
                 );
             } catch (\Exception $exception) {
                 $errors[] = $exception->getMessage();

--- a/setup/src/Magento/Setup/Model/Installer.php
+++ b/setup/src/Magento/Setup/Model/Installer.php
@@ -1667,7 +1667,11 @@ class Installer
                 ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
                 '/' . ConfigOptionsListConstants::KEY_PASSWORD
             ),
-            $driverOptions
+            $driverOptions,
+            $this->deploymentConfig->get(
+                ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .
+                '/' . ConfigOptionsListConstants::KEY_ENGINE
+            )
         );
         $prefix = $this->deploymentConfig->get(
             ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT .

--- a/setup/src/Magento/Setup/Validator/DbValidator.php
+++ b/setup/src/Magento/Setup/Validator/DbValidator.php
@@ -89,6 +89,7 @@ class DbValidator
      * @param string $dbUser
      * @param string $dbPass
      * @param array $driverOptions
+     * @param string|null $engine Database engine (mysql, postgresql)
      * @return bool
      * @throws \Magento\Setup\Exception
      */
@@ -97,38 +98,46 @@ class DbValidator
         $dbHost,
         $dbUser,
         $dbPass = '',
-        $driverOptions = []
+        $driverOptions = [],
+        $engine = null
     ) {
-        // establish connection to information_schema view to retrieve information about user and table privileges
-        $connection = $this->connectionFactory->create(
-            [
-                ConfigOptionsListConstants::KEY_NAME => 'information_schema',
-                ConfigOptionsListConstants::KEY_HOST => $dbHost,
-                ConfigOptionsListConstants::KEY_USER => $dbUser,
-                ConfigOptionsListConstants::KEY_PASSWORD => $dbPass,
-                ConfigOptionsListConstants::KEY_ACTIVE => true,
-                ConfigOptionsListConstants::KEY_DRIVER_OPTIONS => $driverOptions,
-            ]
-        );
+        $connectionConfig = [
+            ConfigOptionsListConstants::KEY_NAME => 'information_schema',
+            ConfigOptionsListConstants::KEY_HOST => $dbHost,
+            ConfigOptionsListConstants::KEY_USER => $dbUser,
+            ConfigOptionsListConstants::KEY_PASSWORD => $dbPass,
+            ConfigOptionsListConstants::KEY_ACTIVE => true,
+            ConfigOptionsListConstants::KEY_DRIVER_OPTIONS => $driverOptions,
+        ];
+        if ($engine !== null && $engine !== '') {
+            $connectionConfig[ConfigOptionsListConstants::KEY_ENGINE] = $engine;
+        }
+        $connection = $this->connectionFactory->create($connectionConfig);
 
         if (!$connection) {
             throw new \Magento\Setup\Exception('Database connection failure.');
         }
 
-        $mysqlVersion = $connection->fetchOne('SELECT version()');
-        if ($mysqlVersion) {
-            if (preg_match('/^([0-9\.]+)/', $mysqlVersion, $matches)) {
-                if (isset($matches[1]) && !empty($matches[1])) {
-                    if (version_compare($matches[1], Installer::MYSQL_VERSION_REQUIRED) < 0) {
-                        throw new \Magento\Setup\Exception(
-                            'Sorry, but we support MySQL version ' . Installer::MYSQL_VERSION_REQUIRED . ' or later.'
-                        );
-                    }
-                }
-            }
-        }
+        $this->assertSupportedMysqlVersion((string) $connection->fetchOne('SELECT version()'));
 
         return $this->checkDatabaseName($connection, $dbName) && $this->checkDatabasePrivileges($connection, $dbName);
+    }
+
+    /**
+     * Reject MySQL servers older than Magento's minimum version.
+     *
+     * @throws \Magento\Setup\Exception
+     */
+    private function assertSupportedMysqlVersion(string $mysqlVersion): void
+    {
+        if ($mysqlVersion === '' || !preg_match('/^([0-9\.]+)/', $mysqlVersion, $matches)) {
+            return;
+        }
+        if (version_compare($matches[1], Installer::MYSQL_VERSION_REQUIRED) < 0) {
+            throw new \Magento\Setup\Exception(
+                'Sorry, but we support MySQL version ' . Installer::MYSQL_VERSION_REQUIRED . ' or later.'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## What this PR does

Adds database adapter dialect helpers to enable PostgreSQL support via a separate module (Postgento). This is the core Magento changes needed - the actual PostgreSQL driver lives in a separate module: https://github.com/Genaker/postgento

## Changes

### AdapterInterface (lib/internal/Magento/Framework/DB/Adapter/AdapterInterface.php)
Added new methods:
- `getGroupConcatSql()` - GROUP_CONCAT / string_agg equivalent
- `getFieldSql()` - FIELD() / CASE equivalent for ORDER BY a fixed list  
- `castToText()` - Cast expression to text for UNION type alignment
- `castToNumeric()` - Cast expression to numeric type for arithmetic
- `createTableLike()` - CREATE TABLE new LIKE origin
- `createTemporaryTableFromSelect()` - CREATE TEMPORARY TABLE from a SELECT

### MySQL Implementation (lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php)
Implemented all new methods with MySQL-specific SQL.

### Select (lib/internal/Magento/Framework/DB/Select.php)
Relaxed constructor type-hint from `Pdo\Mysql` to `Zend_Db_Adapter_Abstract` so any AdapterInterface implementation can call `select()`.

### TemporaryTableService (lib/internal/Magento/Framework/DB/TemporaryTableService.php)
Updated to use the new adapter method `createTemporaryTableFromSelect()`.

### BatchIterator (lib/internal/Magento/Framework/DB/Query/BatchIterator.php)
Fixed empty batch handling - keeps previous minValue when MAX() returns NULL to avoid binding null/empty string.

### AbstractDb (lib/internal/Magento/Framework/Data/Collection/AbstractDb.php)
Replaced literal backticks with `quoteIdentifier()` for reserved words.

### Setup Validators (setup/src/Magento/Setup/Validator/DbValidator.php, Installer.php, ConfigOptionsList.php)
Added `--db-engine` option support to pass through DbValidator/Installer.

## Testing
- Unit tests added for new dialect helpers in MysqlTest.php
- TemporaryTableServiceTest updated to mock new adapter method
- BatchIteratorTest added test for empty batch null handling

## Related
- Postgento (PostgreSQL adapter): https://github.com/Genaker/postgento
- Mage-OS PR: https://github.com/mage-os/mageos-magento2/pull/321

### Resolved issues:
1. [x] resolves magento/magento2#41177: Add database adapter dialect helpers for PostgreSQL support