### PR TITLE
Validate numeric region ownership in AbstractAddress::getRegionId()

### DIFF
--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -475,8 +475,7 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
             } else {
                 $regionModel = $this->getRegionModel((int)$region);
 
-                if (
-                    $regionModel->getId()
+                if ($regionModel->getId()
                     && (string)$regionModel->getCountryId() === (string)$this->getCountryId()
                 ) {
                     $regionId = (int)$regionModel->getId();

--- a/app/code/Magento/Customer/Model/Address/AbstractAddress.php
+++ b/app/code/Magento/Customer/Model/Address/AbstractAddress.php
@@ -469,12 +469,21 @@ class AbstractAddress extends AbstractExtensibleModel implements AddressModelInt
                 (string)$region,
                 (string)$this->getCountryId()
             );
+
             if ($regionId) {
-                $this->setData('region_id', $regionId);
                 $this->unsRegion();
             } else {
-                $this->setData('region_id', $region);
+                $regionModel = $this->getRegionModel((int)$region);
+
+                if (
+                    $regionModel->getId()
+                    && (string)$regionModel->getCountryId() === (string)$this->getCountryId()
+                ) {
+                    $regionId = (int)$regionModel->getId();
+                }
             }
+
+            $this->setData('region_id', $regionId);
         } else {
             $regionId = $this->getRegionIdByCode(
                 (string)$this->getRegionCode(),

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -302,7 +302,7 @@ class AbstractAddressTest extends TestCase
 
         $this->assertSame(80, $this->model->getRegionId());
         $this->assertSame(80, $this->model->getData('region_id'));
-        $this->assertNull($this->model->getData('region'));
+        $this->assertSame('BAW', $this->model->getData('region'));
     }
 
     #[DataProvider('unresolvedRegionProvider')]

--- a/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Model/Address/AbstractAddressTest.php
@@ -192,6 +192,196 @@ class AbstractAddressTest extends TestCase
         $this->assertEquals(0, $this->model->getRegionId());
     }
 
+    #[DataProvider('numericRegionProvider')]
+    public function testGetRegionIdValidatesNumericRegionCountry(
+        string $countryId,
+        string $region,
+        ?string $regionCountryId,
+        ?int $expectedRegionId
+    ): void {
+        $regionByCode = $this->createPartialMockWithReflection(
+            Region::class,
+            ['__wakeup', 'loadByCode', 'getId']
+        );
+        $regionByCode->method('loadByCode')
+            ->willReturnSelf();
+        $regionByCode->method('getId')
+            ->willReturn(null);
+
+        $regionById = $this->createPartialMockWithReflection(
+            Region::class,
+            ['getCountryId', '__wakeup', 'load', 'getId']
+        );
+        $regionById->method('getId')
+            ->willReturn((int)$region);
+        $regionById->method('getCountryId')
+            ->willReturn($regionCountryId);
+
+        $this->regionFactoryMock->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($regionByCode, $regionById);
+
+        $this->model->setData('country_id', $countryId);
+        $this->model->setData('region', $region);
+
+        $this->assertSame($expectedRegionId, $this->model->getRegionId());
+        $this->assertSame($expectedRegionId, $this->model->getData('region_id'));
+    }
+
+    public static function numericRegionProvider(): array
+    {
+        return [
+            'DE region for DE' => ['DE', '80', 'DE', 80],
+            'DE region for NL' => ['NL', '80', 'DE', null],
+            'DE region for LU' => ['LU', '80', 'DE', null],
+            'DE region for AT' => ['AT', '80', 'DE', null],
+            'DE region for CH' => ['CH', '80', 'DE', null],
+            'CH region for CH' => ['CH', '104', 'CH', 104],
+        ];
+    }
+
+    public function testGetRegionIdKeepsNumericRegionForValidRegionId(): void
+    {
+        $regionByCode = $this->createPartialMockWithReflection(
+            Region::class,
+            ['__wakeup', 'loadByCode', 'getId']
+        );
+        $regionByCode->method('loadByCode')
+            ->with('80', 'DE')
+            ->willReturnSelf();
+        $regionByCode->method('getId')
+            ->willReturn(null);
+
+        $regionById = $this->createPartialMockWithReflection(
+            Region::class,
+            ['getCountryId', 'getName', 'getCode', '__wakeup', 'load', 'getId']
+        );
+        $regionById->method('getId')
+            ->willReturn(80);
+        $regionById->method('getCountryId')
+            ->willReturn('DE');
+        $regionById->method('getName')
+            ->willReturn('Baden-Württemberg');
+        $regionById->method('getCode')
+            ->willReturn('BAW');
+
+        $this->regionFactoryMock->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($regionByCode, $regionById);
+
+        $this->model->setData('country_id', 'DE');
+        $this->model->setData('region', '80');
+
+        $this->assertSame(80, $this->model->getRegionId());
+        $this->assertSame(80, $this->model->getData('region_id'));
+        $this->assertSame('80', $this->model->getData('region'));
+
+        $this->assertSame('Baden-Württemberg', $this->model->getRegion());
+        $this->assertSame('Baden-Württemberg', $this->model->getData('region'));
+        $this->assertSame('BAW', $this->model->getRegionCode());
+    }
+
+    public function testGetRegionIdResolvesRegionCode(): void
+    {
+        $region = $this->createPartialMockWithReflection(
+            Region::class,
+            ['__wakeup', 'loadByCode', 'getId']
+        );
+        $region->method('loadByCode')
+            ->with('BAW', 'DE')
+            ->willReturnSelf();
+        $region->method('getId')
+            ->willReturn(80);
+
+        $this->regionFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($region);
+
+        $this->model->setData('country_id', 'DE');
+        $this->model->setData('region', 'BAW');
+
+        $this->assertSame(80, $this->model->getRegionId());
+        $this->assertSame(80, $this->model->getData('region_id'));
+        $this->assertNull($this->model->getData('region'));
+    }
+
+    #[DataProvider('unresolvedRegionProvider')]
+    public function testGetRegionIdKeepsUnresolvedRegionIdNull(?string $region): void
+    {
+        $regionModel = $this->createPartialMockWithReflection(
+            Region::class,
+            ['__wakeup', 'loadByCode', 'getId']
+        );
+        $regionModel->method('loadByCode')
+            ->willReturnSelf();
+        $regionModel->method('getId')
+            ->willReturn(null);
+
+        $this->regionFactoryMock->expects($this->atMost(1))
+            ->method('create')
+            ->willReturn($regionModel);
+
+        $this->model->setData('country_id', 'NL');
+        $this->model->setData('region', $region);
+
+        $this->assertNull($this->model->getRegionId());
+        $this->assertNull($this->model->getData('region_id'));
+    }
+
+    public static function unresolvedRegionProvider(): array
+    {
+        return [
+            'name' => ['Some Province'],
+            'null' => [null],
+        ];
+    }
+
+    public function testGetRegionIdPreservesExistingValue(): void
+    {
+        $this->regionFactoryMock->expects($this->never())
+            ->method('create');
+
+        $this->model->setData('country_id', 'NL');
+        $this->model->setData('region', '80');
+        $this->model->setData('region_id', 123);
+
+        $this->assertSame(123, $this->model->getRegionId());
+        $this->assertSame(123, $this->model->getData('region_id'));
+    }
+
+    public function testGetRegionIdKeepsInvalidNumericRegionValue(): void
+    {
+        $regionByCode = $this->createPartialMockWithReflection(
+            Region::class,
+            ['__wakeup', 'loadByCode', 'getId']
+        );
+        $regionByCode->method('loadByCode')
+            ->with('80', 'NL')
+            ->willReturnSelf();
+        $regionByCode->method('getId')
+            ->willReturn(null);
+
+        $regionById = $this->createPartialMockWithReflection(
+            Region::class,
+            ['getCountryId', '__wakeup', 'load', 'getId']
+        );
+        $regionById->method('getId')
+            ->willReturn(80);
+        $regionById->method('getCountryId')
+            ->willReturn('DE');
+
+        $this->regionFactoryMock->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnOnConsecutiveCalls($regionByCode, $regionById);
+
+        $this->model->setData('country_id', 'NL');
+        $this->model->setData('region', '80');
+
+        $this->assertNull($this->model->getRegionId());
+        $this->assertNull($this->model->getData('region_id'));
+        $this->assertSame('80', $this->model->getData('region'));
+    }
+
     public function testGetRegionCodeWithRegion()
     {
         $countryId = 2;


### PR DESCRIPTION
## Background

The underlying `getRegionId()` behavior predates the recent Magento security updates.

We started seeing the resulting inconsistent address state block checkout after applying the July 2026 Magento security hardening associated with APSB26-73.

One relevant change in that update moves the `validateQuoteAddress` plugin from the REST-specific DI scope:

```text
vendor/magento/module-quote/etc/webapi_rest/di.xml
```

to the global quote DI scope:

```text
vendor/magento/module-quote/etc/di.xml
```

Previously:

```xml
<type name="Magento\Quote\Model\Quote">
    <plugin name="validateQuoteAddress" type="Magento\Quote\Plugin\QuoteAddress" />
</type>
```

was registered only for REST requests.

After the security update, the plugin is registered globally for:

```text
Magento\Quote\Model\Quote
```

so quote address validation is applied to additional PHP and checkout flows that call `setShippingAddress()` or `setBillingAddress()`, not only REST-specific flows.

This security change does not create the invalid `region_id`, and `Magento\Quote\Plugin\QuoteAddress` itself is not responsible for validating whether a region belongs to a country.

The inconsistent state can already exist before validation:

```text
country_id = NL
region_id  = null
region     = "80"
```

and `AbstractAddress::getRegionId()` can then materialize the country-mismatched ID:

```text
country_id = NL
region_id  = 80
region     = "80"
```

### Persisted data observed

We also found already persisted addresses where `region_id` belonged to a different country than the address itself.

The following query can be used to identify these records in quote addresses:

```sql
SELECT
    qa.address_id,
    qa.quote_id,
    qa.address_type,
    qa.country_id,
    qa.region_id,
    qa.region,
    dcr.country_id AS region_country_id,
    dcr.code,
    dcr.default_name,
    qa.updated_at
FROM quote_address AS qa
INNER JOIN directory_country_region AS dcr
    ON dcr.region_id = qa.region_id
WHERE qa.region_id IS NOT NULL
  AND qa.country_id IS NOT NULL
  AND qa.country_id <> dcr.country_id
ORDER BY qa.updated_at DESC;
```

In our database this returned, among others, combinations such as:

```text
address country   region_id   actual region country
AT                80          DE
NL                80          DE
LU                80          DE
```

Region ID `80` is:

```text
DE / BAW / Baden-Württemberg
```

The same inconsistency was also present in saved customer addresses:

```sql
SELECT
    cae.entity_id,
    cae.country_id,
    cae.region_id,
    cae.region,
    dcr.country_id AS region_country_id,
    dcr.code,
    dcr.default_name,
    cae.updated_at
FROM customer_address_entity AS cae
INNER JOIN directory_country_region AS dcr
    ON dcr.region_id = cae.region_id
WHERE cae.region_id IS NOT NULL
  AND cae.country_id IS NOT NULL
  AND cae.country_id <> dcr.country_id
ORDER BY cae.updated_at DESC;
```

Historical mismatched customer address records were present as far back as 2024 and 2025.

This provides database-level evidence that invalid country/region combinations existed before the July 2026 security hardening.

The mismatch is ultimately rejected later by Magento address validation during quote/order validation.

In our case this became visible as:

```text
Invalid value "80" for field regionId.
```

The relevant sequence is therefore:

```text
numeric region value
→ AbstractAddress::getRegionId() can materialize a country-mismatched region_id
→ inconsistent address state can be persisted
→ hardened checkout/quote flow reaches address validation
→ country/region mismatch is rejected
→ checkout fails
```

Therefore the security hardening should be considered the point at which the existing data-integrity issue became visible in our checkout, not the origin of the invalid state.


### Resolved issues:
1. [x] resolves magento/magento2#41184: Validate numeric region ownership in AbstractAddress::getRegionId()