### PR TITLE
Register capture notification moves order out of Payment Review (#35382)

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
@@ -42,7 +42,7 @@ class RegisterCaptureNotificationCommand implements CommandInterface
     public function execute(OrderPaymentInterface $payment, $amount, OrderInterface $order)
     {
         $state = $order->getState();
-        if (!$state || $state === Order::STATE_NEW || $state === Order::STATE_PENDING_PAYMENT) {
+        if (!$state || $state === Order::STATE_NEW || $state === Order::STATE_PENDING_PAYMENT || $state === Order::STATE_PAYMENT_REVIEW) {   
             $state = Order::STATE_PROCESSING;
         }
 

--- a/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
@@ -42,7 +42,8 @@ class RegisterCaptureNotificationCommand implements CommandInterface
     public function execute(OrderPaymentInterface $payment, $amount, OrderInterface $order)
     {
         $state = $order->getState();
-        if (!$state || $state === Order::STATE_NEW || $state === Order::STATE_PENDING_PAYMENT || $state === Order::STATE_PAYMENT_REVIEW) {   
+        if (!$state || $state === Order::STATE_NEW || $state === Order::STATE_PENDING_PAYMENT
+            || $state === Order::STATE_PAYMENT_REVIEW) {
             $state = Order::STATE_PROCESSING;
         }
 

--- a/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
+++ b/app/code/Magento/Sales/Model/Order/Payment/State/RegisterCaptureNotificationCommand.php
@@ -75,6 +75,7 @@ class RegisterCaptureNotificationCommand implements CommandInterface
      * Sets the state and status of the order
      *
      * @deprecated 100.1.9 Replaced by a StatusResolver class call.
+     * @see \Magento\Sales\Model\Order\StatusResolver::getOrderStatusByState()
      *
      * @param Order $order
      * @param string $status

--- a/dev/tests/integration/testsuite/Magento/Sales/Model/Order/Payment/RegisterCaptureNotificationCommandTest.php
+++ b/dev/tests/integration/testsuite/Magento/Sales/Model/Order/Payment/RegisterCaptureNotificationCommandTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Sales\Model\Order\Payment;
+
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\Checkout\Test\Fixture\PlaceOrder as PlaceOrderFixture;
+use Magento\Checkout\Test\Fixture\SetBillingAddress as SetBillingAddressFixture;
+use Magento\Checkout\Test\Fixture\SetDeliveryMethod as SetDeliveryMethodFixture;
+use Magento\Checkout\Test\Fixture\SetGuestEmail as SetGuestEmailFixture;
+use Magento\Checkout\Test\Fixture\SetPaymentMethod as SetPaymentMethodFixture;
+use Magento\Checkout\Test\Fixture\SetShippingAddress as SetShippingAddressFixture;
+use Magento\Quote\Test\Fixture\AddProductToCart as AddProductToCartFixture;
+use Magento\Quote\Test\Fixture\GuestCart as GuestCartFixture;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers registration of a capture notification for an order stuck in the "Payment Review" state.
+ *
+ * @see \Magento\Sales\Model\Order\Payment\State\RegisterCaptureNotificationCommand
+ */
+#[
+    DbIsolation(true),
+    DataFixture(ProductFixture::class, as: 'product'),
+    DataFixture(GuestCartFixture::class, as: 'cart'),
+    DataFixture(AddProductToCartFixture::class, ['cart_id' => '$cart.id$', 'product_id' => '$product.id$']),
+    DataFixture(SetBillingAddressFixture::class, ['cart_id' => '$cart.id$']),
+    DataFixture(SetShippingAddressFixture::class, ['cart_id' => '$cart.id$']),
+    DataFixture(SetGuestEmailFixture::class, ['cart_id' => '$cart.id$']),
+    DataFixture(SetDeliveryMethodFixture::class, ['cart_id' => '$cart.id$']),
+    DataFixture(SetPaymentMethodFixture::class, ['cart_id' => '$cart.id$']),
+    DataFixture(PlaceOrderFixture::class, ['cart_id' => '$cart.id$'], 'order'),
+]
+class RegisterCaptureNotificationCommandTest extends TestCase
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $objectManager = Bootstrap::getObjectManager();
+        $this->orderRepository = $objectManager->create(OrderRepositoryInterface::class);
+        $this->fixtures = DataFixtureStorageManager::getStorage();
+    }
+
+    /**
+     * An order left in "Payment Review" (e.g. a PayPal order pending PayPal's own risk review) must move to
+     * "Processing" once the capture notification finally arrives, instead of staying stuck forever.
+     */
+    public function testOrderTransitionsFromPaymentReviewToProcessingOnCaptureNotification(): void
+    {
+        $orderId = $this->fixtures->get('order')->getId();
+        $order = $this->orderRepository->get($orderId);
+        $order->setState(Order::STATE_PAYMENT_REVIEW);
+        $order->setStatus($order->getConfig()->getStateDefaultStatus(Order::STATE_PAYMENT_REVIEW));
+        $this->orderRepository->save($order);
+
+        $order = $this->orderRepository->get($orderId);
+        $payment = $order->getPayment();
+        $payment->setIsTransactionPending(false);
+        $payment->setIsFraudDetected(false);
+        $payment->registerCaptureNotification((float)$order->getBaseTotalDue());
+        $this->orderRepository->save($order);
+
+        $order = $this->orderRepository->get($orderId);
+        $this->assertEquals(
+            Order::STATE_PROCESSING,
+            $order->getState(),
+            'Order stuck in "Payment Review" must transition to "Processing" once the capture is confirmed.'
+        );
+        $this->assertEquals(
+            $order->getConfig()->getStateDefaultStatus(Order::STATE_PROCESSING),
+            $order->getStatus()
+        );
+    }
+}


### PR DESCRIPTION
### Description

An order left in the `Payment Review` state never returned to `Processing` when a capture notification arrived, so orders held for payment review stayed stuck even after the payment was captured.

`Magento\Sales\Model\Order\Payment\State\RegisterCaptureNotificationCommand::execute()` promotes an order to `STATE_PROCESSING` only when the current state is empty, `STATE_NEW` or `STATE_PENDING_PAYMENT`. `STATE_PAYMENT_REVIEW` was not in that list, so the capture notification updated the payment but left the order state untouched.

This adds `STATE_PAYMENT_REVIEW` to that condition.

This does **not** weaken payment review. The `getIsTransactionPending()` and `getIsFraudDetected()` checks further down the same method run *after* the promotion and set the state back to `STATE_PAYMENT_REVIEW` (with `STATUS_FRAUD` in the fraud case). So a payment that is still pending at the gateway, or flagged as fraudulent, cannot be promoted — only a clean capture notification results in `Processing`.

This PR continues #35383 by @itmsenior, rebased onto current `2.4-develop`, with the integration coverage that was missing. The original commits and authorship are preserved; @engcom-Charlie's static-test fix from that PR is included as well.

### Related Pull Requests

Continues https://github.com/magento/magento2/pull/35383

### Fixed Issues

Fixes magento/magento2#35382

### Manual testing scenarios

1. Configure a payment method that places orders into `Payment Review` (for example PayPal with a pending/under-review result), or set an existing order's state to `payment_review`.
2. Trigger the capture notification for that order, e.g. via the gateway IPN, or by calling `Magento\Sales\Model\Order\Payment::registerCaptureNotification()` with the amount due.
3. **Before:** the order remains in `Payment Review`.
   **After:** the order moves to `Processing` with the configured default status for that state.
4. Repeat with the payment flagged as fraudulent (`setIsFraudDetected(true)`) or still pending (`setIsTransactionPending(true)`) and confirm the order stays in `Payment Review` in both cases.

### Questions or comments

Gates run locally on `2.4-develop`:

- Unit: pass.
- Integration: `Magento/Sales/` shows the same 1 error and 4 failures on this branch as on a clean `2.4-develop` checkout (all pre-existing: three abstract-class warnings, `GridTest::testRefreshBySchedule` timing, and unrelated cases). The new test passes.
- PHPCS `Magento2`: 0 errors. One pre-existing warning on the `@deprecated` tag of `setOrderStateAndStatus()`, untouched by this change.
- PHPStan level 1: no errors.
- Negative check on the new test: red without the fix (order stays `payment_review`), green with it.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
