### PR TITLE
Speed up single product-category link writes (#37739)

### DIFF
--- a/app/code/Magento/Catalog/Model/Category.php
+++ b/app/code/Magento/Catalog/Model/Category.php
@@ -1140,11 +1140,19 @@ class Category extends \Magento\Catalog\Model\AbstractModel implements
         }
         $productIndexer = $this->indexerRegistry->get(Indexer\Category\Product::INDEXER_ID);
 
-        if (!empty($this->getAffectedProductIds())
-                || $this->dataHasChangedFor('is_anchor')
-                || $this->dataHasChangedFor('is_active')) {
+        if ($this->dataHasChangedFor('is_anchor') || $this->dataHasChangedFor('is_active')) {
             if (!$productIndexer->isScheduled()) {
                 $productIndexer->reindexList($this->getPathIds());
+            }
+        } elseif (!empty($this->getAffectedProductIds())) {
+            /**
+             * Only the product assignments have changed. Reindexing the whole category path includes the root
+             * category and therefore rebuilds the index for the entire catalog, while reindexing the affected
+             * products rebuilds exactly the index rows the changed assignments can affect.
+             */
+            $productCategoryIndexer = $this->indexerRegistry->get(Indexer\Product\Category::INDEXER_ID);
+            if (!$productCategoryIndexer->isScheduled()) {
+                $productCategoryIndexer->reindexList($this->getAffectedProductIds());
             }
         }
     }

--- a/app/code/Magento/Catalog/Model/CategoryLinkRepository.php
+++ b/app/code/Magento/Catalog/Model/CategoryLinkRepository.php
@@ -9,8 +9,11 @@ namespace Magento\Catalog\Model;
 use Magento\Catalog\Api\CategoryLinkRepositoryInterface;
 use Magento\Catalog\Api\CategoryListDeleteBySkuInterface;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Api\Data\CategoryInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\ResourceModel\Product;
+use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
@@ -20,6 +23,16 @@ use Magento\Framework\Exception\InputException;
  */
 class CategoryLinkRepository implements CategoryLinkRepositoryInterface, CategoryListDeleteBySkuInterface
 {
+    /**
+     * Category data key holding the product id to position map
+     */
+    private const PRODUCTS_POSITION_KEY = 'products_position';
+
+    /**
+     * Category data key holding the product positions submitted for saving
+     */
+    private const POSTED_PRODUCTS_KEY = 'posted_products';
+
     /**
      * @var CategoryRepository
      */
@@ -36,18 +49,26 @@ class CategoryLinkRepository implements CategoryLinkRepositoryInterface, Categor
     private $productResource;
 
     /**
+     * @var CategoryLink
+     */
+    private $categoryLinkResource;
+
+    /**
      * @param CategoryRepositoryInterface $categoryRepository
      * @param ProductRepositoryInterface $productRepository
      * @param Product $productResource
+     * @param CategoryLink|null $categoryLinkResource
      */
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
         ProductRepositoryInterface $productRepository,
-        ?Product $productResource = null
+        ?Product $productResource = null,
+        ?CategoryLink $categoryLinkResource = null
     ) {
         $this->categoryRepository = $categoryRepository;
         $this->productRepository = $productRepository;
         $this->productResource = $productResource ?? ObjectManager::getInstance()->get(Product::class);
+        $this->categoryLinkResource = $categoryLinkResource ?? ObjectManager::getInstance()->get(CategoryLink::class);
     }
 
     /**
@@ -57,7 +78,7 @@ class CategoryLinkRepository implements CategoryLinkRepositoryInterface, Categor
     {
         $category = $this->categoryRepository->get($productLink->getCategoryId());
         $product = $this->productRepository->get($productLink->getSku());
-        $productPositions = $category->getProductsPosition();
+        $productPositions = $this->narrowDownProductsPosition($category, $product);
         $productPositions[$product->getId()] = $productLink->getPosition();
         $category->setPostedProducts($productPositions);
         try {
@@ -72,6 +93,8 @@ class CategoryLinkRepository implements CategoryLinkRepositoryInterface, Categor
                 ),
                 $e
             );
+        } finally {
+            $this->resetProductsPosition($category);
         }
         return true;
     }
@@ -91,30 +114,34 @@ class CategoryLinkRepository implements CategoryLinkRepositoryInterface, Categor
     {
         $category = $this->categoryRepository->get($categoryId);
         $product = $this->productRepository->get($sku);
-        $productPositions = $category->getProductsPosition();
+        $productPositions = $this->narrowDownProductsPosition($category, $product);
 
-        $productID = $product->getId();
-        if (!isset($productPositions[$productID])) {
-            throw new InputException(__("The category doesn't contain the specified product."));
-        }
-        $backupPosition = $productPositions[$productID];
-        unset($productPositions[$productID]);
-
-        $category->setPostedProducts($productPositions);
         try {
-            $category->save();
-        } catch (\Exception $e) {
-            throw new CouldNotSaveException(
-                __(
-                    'Could not save product "%product" with position %position to category %category',
-                    [
-                        "product" => $product->getId(),
-                        "position" => $backupPosition,
-                        "category" => $category->getId()
-                    ]
-                ),
-                $e
-            );
+            $productID = $product->getId();
+            if (!isset($productPositions[$productID])) {
+                throw new InputException(__("The category doesn't contain the specified product."));
+            }
+            $backupPosition = $productPositions[$productID];
+            unset($productPositions[$productID]);
+
+            $category->setPostedProducts($productPositions);
+            try {
+                $category->save();
+            } catch (\Exception $e) {
+                throw new CouldNotSaveException(
+                    __(
+                        'Could not save product "%product" with position %position to category %category',
+                        [
+                            "product" => $product->getId(),
+                            "position" => $backupPosition,
+                            "category" => $category->getId()
+                        ]
+                    ),
+                    $e
+                );
+            }
+        } finally {
+            $this->resetProductsPosition($category);
         }
         return true;
     }
@@ -157,5 +184,41 @@ class CategoryLinkRepository implements CategoryLinkRepositoryInterface, Categor
         }
 
         return true;
+    }
+
+    /**
+     * Narrow down the category product positions map to the single product being linked or unlinked.
+     *
+     * The category save compares the posted products with the products currently assigned to the category. Loading
+     * every assignment of the category is prohibitively expensive for large categories, while a single link change
+     * only ever needs the assignment of the product it touches. The narrowed down map is pre-seeded on the category
+     * so that the comparison performed during the save stays limited to that product.
+     *
+     * @param CategoryInterface $category
+     * @param ProductInterface $product
+     * @return array
+     */
+    private function narrowDownProductsPosition(CategoryInterface $category, ProductInterface $product): array
+    {
+        $productsPosition = [];
+        $categoryLinks = $this->categoryLinkResource->getCategoryLinks($product, [(int)$category->getId()]);
+        foreach ($categoryLinks as $categoryLink) {
+            $productsPosition[$product->getId()] = $categoryLink['position'];
+        }
+        $category->setData(self::PRODUCTS_POSITION_KEY, $productsPosition);
+
+        return $productsPosition;
+    }
+
+    /**
+     * Drop the narrowed down data from the category so that a later reuse of the instance is not affected by it.
+     *
+     * @param CategoryInterface $category
+     * @return void
+     */
+    private function resetProductsPosition(CategoryInterface $category): void
+    {
+        $category->unsetData(self::PRODUCTS_POSITION_KEY);
+        $category->unsetData(self::POSTED_PRODUCTS_KEY);
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryLinkRepositoryTest.php
@@ -14,6 +14,7 @@ use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\CategoryLinkRepository;
 use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Product;
+use Magento\Catalog\Model\ResourceModel\Product\CategoryLink;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
@@ -54,6 +55,11 @@ class CategoryLinkRepositoryTest extends TestCase
     private $productResourceMock;
 
     /**
+     * @var CategoryLink|MockObject
+     */
+    private $categoryLinkResourceMock;
+
+    /**
      * Initialize required data
      */
     protected function setUp(): void
@@ -62,10 +68,12 @@ class CategoryLinkRepositoryTest extends TestCase
         $this->categoryRepositoryMock = $this->createMock(CategoryRepositoryInterface::class);
         $this->productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
         $this->productLinkMock = $this->createMock(CategoryProductLinkInterface::class);
+        $this->categoryLinkResourceMock = $this->createMock(CategoryLink::class);
         $this->model = new CategoryLinkRepository(
             $this->categoryRepositoryMock,
             $this->productRepositoryMock,
-            $this->productResourceMock
+            $this->productResourceMock,
+            $this->categoryLinkResourceMock
         );
     }
 
@@ -83,21 +91,26 @@ class CategoryLinkRepositoryTest extends TestCase
         $productPositions = [$productId => $productPosition];
         $categoryMock = $this->createPartialMockWithReflection(
             Category::class,
-            ['getPostedProducts', 'setPostedProducts', 'getProductsPosition', 'save']
+            ['getPostedProducts', 'setPostedProducts', 'getProductsPosition', 'save', 'getId']
         );
         $productMock = $this->createMock(ProductModel::class);
+        $categoryMock->method('getId')->willReturn($categoryId);
         $this->productLinkMock->expects($this->once())->method('getCategoryId')->willReturn($categoryId);
         $this->productLinkMock->expects($this->once())->method('getSku')->willReturn($sku);
         $this->categoryRepositoryMock->expects($this->once())->method('get')->with($categoryId)
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($sku)->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn([]);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])->willReturn([]);
         $productMock->expects($this->once())->method('getId')->willReturn($productId);
         $this->productLinkMock->expects($this->once())->method('getPosition')->willReturn($productPosition);
         $categoryMock->expects($this->once())->method('setPostedProducts')->with($productPositions);
         $categoryMock->expects($this->once())->method('save');
 
         $this->assertTrue($this->model->save($this->productLinkMock));
+        $this->assertNull($categoryMock->getData('products_position'));
+        $this->assertNull($categoryMock->getData('posted_products'));
     }
 
     /**
@@ -122,11 +135,13 @@ class CategoryLinkRepositoryTest extends TestCase
         $this->categoryRepositoryMock->expects($this->once())->method('get')->with($categoryId)
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($sku)->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn([]);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])->willReturn([]);
         $productMock->expects($this->exactly(2))->method('getId')->willReturn($productId);
         $this->productLinkMock->expects($this->exactly(2))->method('getPosition')->willReturn($productPosition);
         $categoryMock->expects($this->once())->method('setPostedProducts')->with($productPositions);
-        $categoryMock->expects($this->once())->method('getId')->willReturn($categoryId);
+        $categoryMock->expects($this->exactly(2))->method('getId')->willReturn($categoryId);
         $categoryMock->expects($this->once())->method('save')->willThrowException(new \Exception());
 
         $this->expectExceptionMessage('Could not save product "55" with position 1 to category 42');
@@ -154,12 +169,17 @@ class CategoryLinkRepositoryTest extends TestCase
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
             ->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn($productPositions);
-        $productMock->expects($this->once())->method('getId')->willReturn($productId);
+        $categoryMock->method('getId')->willReturn($categoryId);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])
+            ->willReturn([['category_id' => $categoryId, 'position' => $productPositions[$productId]]]);
+        $productMock->expects($this->exactly(2))->method('getId')->willReturn($productId);
         $categoryMock->expects($this->once())->method('setPostedProducts')->with([]);
         $categoryMock->expects($this->once())->method('save');
 
         $this->assertTrue($this->model->deleteByIds($categoryId, $productSku));
+        $this->assertNull($categoryMock->getData('products_position'));
     }
 
     /**
@@ -182,10 +202,13 @@ class CategoryLinkRepositoryTest extends TestCase
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
             ->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn($productPositions);
-        $productMock->expects($this->exactly(2))->method('getId')->willReturn($productId);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])
+            ->willReturn([['category_id' => $categoryId, 'position' => $productPositions[$productId]]]);
+        $productMock->expects($this->exactly(3))->method('getId')->willReturn($productId);
         $categoryMock->expects($this->once())->method('setPostedProducts')->with([]);
-        $categoryMock->expects($this->once())->method('getId')->willReturn($categoryId);
+        $categoryMock->expects($this->exactly(2))->method('getId')->willReturn($categoryId);
         $categoryMock->expects($this->once())->method('save')->willThrowException(new \Exception());
 
         $this->expectExceptionMessage('Could not save product "55" with position 1 to category 42');
@@ -203,7 +226,6 @@ class CategoryLinkRepositoryTest extends TestCase
         $categoryId = 42;
         $productSku = 'testSku';
         $productId = 60;
-        $productPositions = [55 => 1];
         $this->productLinkMock->expects($this->once())->method('getCategoryId')->willReturn($categoryId);
         $this->productLinkMock->expects($this->once())->method('getSku')->willReturn($productSku);
         $categoryMock = $this->createPartialMockWithReflection(
@@ -215,7 +237,10 @@ class CategoryLinkRepositoryTest extends TestCase
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
             ->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn($productPositions);
+        $categoryMock->method('getId')->willReturn($categoryId);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])->willReturn([]);
         $productMock->expects($this->once())->method('getId')->willReturn($productId);
         $categoryMock->expects($this->never())->method('save');
 
@@ -246,8 +271,12 @@ class CategoryLinkRepositoryTest extends TestCase
             ->willReturn($categoryMock);
         $this->productRepositoryMock->expects($this->once())->method('get')->with($productSku)
             ->willReturn($productMock);
-        $categoryMock->expects($this->once())->method('getProductsPosition')->willReturn($productPositions);
-        $productMock->expects($this->once())->method('getId')->willReturn($productId);
+        $categoryMock->method('getId')->willReturn($categoryId);
+        $categoryMock->expects($this->never())->method('getProductsPosition');
+        $this->categoryLinkResourceMock->expects($this->once())->method('getCategoryLinks')
+            ->with($productMock, [$categoryId])
+            ->willReturn([['category_id' => $categoryId, 'position' => $productPositions[$productId]]]);
+        $productMock->expects($this->exactly(2))->method('getId')->willReturn($productId);
         $categoryMock->expects($this->once())->method('setPostedProducts')->with([]);
         $categoryMock->expects($this->once())->method('save');
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryTest.php
@@ -13,6 +13,7 @@ use Magento\Catalog\Model\Category;
 use Magento\Catalog\Model\Config;
 use Magento\Catalog\Model\Indexer\Category\Flat\State;
 use Magento\Catalog\Model\Indexer\Category\Product;
+use Magento\Catalog\Model\Indexer\Product\Category as ProductCategoryIndexer;
 use Magento\Catalog\Model\ResourceModel\Category\Tree;
 use Magento\Catalog\Model\ResourceModel\Category\TreeFactory;
 use Magento\CatalogUrlRewrite\Model\CategoryUrlPathGenerator;
@@ -115,6 +116,11 @@ class CategoryTest extends TestCase
     private $productIndexer;
 
     /**
+     * @var IndexerInterface|MockObject
+     */
+    private $productCategoryIndexer;
+
+    /**
      * @var CategoryUrlPathGenerator|MockObject
      */
     private $categoryUrlPathGenerator;
@@ -180,6 +186,7 @@ class CategoryTest extends TestCase
         $this->flatState = $this->createMock(State::class);
         $this->flatIndexer = $this->createMock(IndexerInterface::class);
         $this->productIndexer = $this->createMock(IndexerInterface::class);
+        $this->productCategoryIndexer = $this->createMock(IndexerInterface::class);
         $this->categoryUrlPathGenerator = $this->createMock(
             CategoryUrlPathGenerator::class
         );
@@ -397,18 +404,21 @@ class CategoryTest extends TestCase
             ->willReturn($flatScheduled);
         $this->flatIndexer->expects($this->exactly($expectedFlatReindexCalls))->method('reindexList')->with(['123']);
 
-        $this->productIndexer->expects($this->exactly(1))
+        $this->productIndexer->expects($this->never())->method('reindexList');
+
+        $this->productCategoryIndexer->expects($this->exactly(1))
             ->method('isScheduled')
             ->willReturn($productScheduled);
-        $this->productIndexer->expects($this->exactly($expectedProductReindexCall))
+        $this->productCategoryIndexer->expects($this->exactly($expectedProductReindexCall))
             ->method('reindexList')
-            ->with($pathIds);
+            ->with($affectedProductIds);
 
         $this->indexerRegistry
             ->method('get')
             ->willReturnCallback(fn($param) => match ([$param]) {
                 [State::INDEXER_ID] => $this->flatIndexer,
-                [Product::INDEXER_ID] => $this->productIndexer
+                [Product::INDEXER_ID] => $this->productIndexer,
+                [ProductCategoryIndexer::INDEXER_ID] => $this->productCategoryIndexer
             });
         $this->category->reindex();
     }
@@ -419,15 +429,16 @@ class CategoryTest extends TestCase
     public static function reindexFlatDisabledTestDataProvider(): array
     {
         return [
-            [false, null, null, null, null, null, 0],
-            [true, null, null, null, null, null,  0],
-            [false, [], null, null, null, null, 0],
-            [false, ["1", "2"], null, null, null, null, 1],
-            [false, null, 1, null, null, null, 1],
-            [false, ["1", "2"], 0, 1, null, null,  1],
-            [false, null, 1, 1, null, null, 0],
-            [false, ["1", "2"], null, null, 0, 1,  1],
-            [false, ["1", "2"], null, null, 1, 0,  1]
+            'nothing changed' => [false, null, null, null, null, null, 0, 0],
+            'nothing changed, scheduled' => [true, null, null, null, null, null, 0, 0],
+            'empty affected products' => [false, [], null, null, null, null, 0, 0],
+            'only products changed' => [false, ["1", "2"], null, null, null, null, 0, 1],
+            'only products changed, scheduled' => [true, ["1", "2"], null, null, null, null, 0, 0],
+            'anchor removed' => [false, null, 1, null, null, null, 1, 0],
+            'anchor changed with products' => [false, ["1", "2"], 0, 1, null, null, 1, 0],
+            'anchor untouched' => [false, null, 1, 1, null, null, 0, 0],
+            'activated with products' => [false, ["1", "2"], null, null, 0, 1, 1, 0],
+            'deactivated with products' => [false, ["1", "2"], null, null, 1, 0, 1, 0]
         ];
     }
 
@@ -436,6 +447,9 @@ class CategoryTest extends TestCase
      * @param array $affectedIds
      * @param int|string $isAnchorOrig
      * @param int|string $isAnchor
+     * @param int|string $isActiveOrig
+     * @param int|string $isActive
+     * @param int $expectedPathReindexCall
      * @param int $expectedProductReindexCall
      *
      * @return void
@@ -448,6 +462,7 @@ class CategoryTest extends TestCase
         $isAnchor,
         $isActiveOrig,
         $isActive,
+        $expectedPathReindexCall,
         $expectedProductReindexCall
     ): void {
         $this->category->setAffectedProductIds($affectedIds);
@@ -467,14 +482,23 @@ class CategoryTest extends TestCase
         $this->productIndexer
             ->method('isScheduled')
             ->willReturn($productScheduled);
-        $this->productIndexer->expects($this->exactly($expectedProductReindexCall))
+        $this->productIndexer->expects($this->exactly($expectedPathReindexCall))
             ->method('reindexList')
             ->with($pathIds);
 
+        $this->productCategoryIndexer
+            ->method('isScheduled')
+            ->willReturn($productScheduled);
+        $this->productCategoryIndexer->expects($this->exactly($expectedProductReindexCall))
+            ->method('reindexList')
+            ->with($affectedIds);
+
         $this->indexerRegistry
             ->method('get')
-            ->with(Product::INDEXER_ID)
-            ->willReturn($this->productIndexer);
+            ->willReturnCallback(fn($param) => match ([$param]) {
+                [Product::INDEXER_ID] => $this->productIndexer,
+                [ProductCategoryIndexer::INDEXER_ID] => $this->productCategoryIndexer
+            });
 
         $this->category->reindex();
     }

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryLinkRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryLinkRepositoryTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Tests that a single product to category link is written without discarding the rest of the category product list.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 #[
     AppArea('adminhtml'),

--- a/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryLinkRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Model/CategoryLinkRepositoryTest.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Catalog\Model;
+
+use Magento\Catalog\Api\CategoryLinkRepositoryInterface;
+use Magento\Catalog\Api\Data\CategoryProductLinkInterfaceFactory;
+use Magento\Catalog\Test\Fixture\AssignProducts as AssignProductsFixture;
+use Magento\Catalog\Test\Fixture\Category as CategoryFixture;
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\TestFramework\Fixture\AppArea;
+use Magento\TestFramework\Fixture\Config;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Fixture\DbIsolation;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that a single product to category link is written without discarding the rest of the category product list.
+ */
+#[
+    AppArea('adminhtml'),
+    DbIsolation(true),
+]
+class CategoryLinkRepositoryTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @var CategoryLinkRepositoryInterface
+     */
+    private $categoryLinkRepository;
+
+    /**
+     * @var CategoryProductLinkInterfaceFactory
+     */
+    private $productLinkFactory;
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->objectManager = Bootstrap::getObjectManager();
+        $this->categoryLinkRepository = $this->objectManager->get(CategoryLinkRepositoryInterface::class);
+        $this->productLinkFactory = $this->objectManager->get(CategoryProductLinkInterfaceFactory::class);
+        $this->resourceConnection = $this->objectManager->get(ResourceConnection::class);
+        $this->fixtures = $this->objectManager->get(DataFixtureStorageManager::class)->getStorage();
+        parent::setUp();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function tearDown(): void
+    {
+        $this->objectManager->removeSharedInstance(CategoryRepository::class);
+        parent::tearDown();
+    }
+
+    /**
+     * Saving a single link must not drop the products already assigned to the category.
+     *
+     * @return void
+     */
+    #[
+        DataFixture(ProductFixture::class, as: 'p1'),
+        DataFixture(ProductFixture::class, as: 'p2'),
+        DataFixture(ProductFixture::class, as: 'p3'),
+        DataFixture(CategoryFixture::class, as: 'category'),
+        DataFixture(
+            AssignProductsFixture::class,
+            ['category' => '$category$', 'products' => ['$p1$', '$p2$']]
+        ),
+    ]
+    public function testSaveKeepsExistingAssignments(): void
+    {
+        $category = $this->fixtures->get('category');
+        $product = $this->fixtures->get('p3');
+
+        $this->assertTrue($this->saveLink((int)$category->getId(), (string)$product->getSku(), 7));
+
+        $positions = $this->getAssignedPositions((int)$category->getId());
+        $this->assertCount(3, $positions);
+        $this->assertArrayHasKey((int)$this->fixtures->get('p1')->getId(), $positions);
+        $this->assertArrayHasKey((int)$this->fixtures->get('p2')->getId(), $positions);
+        $this->assertSame(7, $positions[(int)$product->getId()]);
+    }
+
+    /**
+     * Saving a link for an already assigned product must only update its position.
+     *
+     * @return void
+     */
+    #[
+        DataFixture(ProductFixture::class, as: 'p1'),
+        DataFixture(ProductFixture::class, as: 'p2'),
+        DataFixture(CategoryFixture::class, as: 'category'),
+        DataFixture(
+            AssignProductsFixture::class,
+            ['category' => '$category$', 'products' => ['$p1$', '$p2$']]
+        ),
+    ]
+    public function testSaveUpdatesPositionOfAssignedProduct(): void
+    {
+        $category = $this->fixtures->get('category');
+        $product = $this->fixtures->get('p1');
+
+        $this->assertTrue($this->saveLink((int)$category->getId(), (string)$product->getSku(), 11));
+
+        $positions = $this->getAssignedPositions((int)$category->getId());
+        $this->assertCount(2, $positions);
+        $this->assertSame(11, $positions[(int)$product->getId()]);
+    }
+
+    /**
+     * Removing a single link must not drop the other products assigned to the category.
+     *
+     * @return void
+     */
+    #[
+        DataFixture(ProductFixture::class, as: 'p1'),
+        DataFixture(ProductFixture::class, as: 'p2'),
+        DataFixture(CategoryFixture::class, as: 'category'),
+        DataFixture(
+            AssignProductsFixture::class,
+            ['category' => '$category$', 'products' => ['$p1$', '$p2$']]
+        ),
+    ]
+    public function testDeleteByIdsKeepsOtherAssignments(): void
+    {
+        $category = $this->fixtures->get('category');
+        $product = $this->fixtures->get('p1');
+
+        $this->assertTrue(
+            $this->categoryLinkRepository->deleteByIds((int)$category->getId(), $product->getSku())
+        );
+
+        $this->assertSame(
+            [(int)$this->fixtures->get('p2')->getId()],
+            array_keys($this->getAssignedPositions((int)$category->getId()))
+        );
+    }
+
+    /**
+     * The category save pipeline must still run, so that the category based product url rewrite is generated.
+     *
+     * @return void
+     */
+    #[
+        Config('catalog/seo/generate_category_product_rewrites', 1),
+        DataFixture(ProductFixture::class, as: 'product'),
+        DataFixture(CategoryFixture::class, as: 'category'),
+    ]
+    public function testSaveGeneratesCategoryProductUrlRewrite(): void
+    {
+        $category = $this->fixtures->get('category');
+        $product = $this->fixtures->get('product');
+
+        $this->saveLink((int)$category->getId(), (string)$product->getSku(), 1);
+
+        /** @var UrlFinderInterface $urlFinder */
+        $urlFinder = $this->objectManager->get(UrlFinderInterface::class);
+        $rewrites = $urlFinder->findAllByData(
+            [
+                UrlRewrite::ENTITY_ID => $product->getId(),
+                UrlRewrite::ENTITY_TYPE => ProductUrlRewriteGenerator::ENTITY_TYPE,
+            ]
+        );
+
+        $categoryBasedRewrites = [];
+        foreach ($rewrites as $rewrite) {
+            if (str_contains((string)$rewrite->getRequestPath(), '/')) {
+                $categoryBasedRewrites[] = $rewrite->getRequestPath();
+            }
+        }
+
+        $this->assertNotEmpty(
+            $categoryBasedRewrites,
+            'A category based url rewrite is expected for the newly assigned product.'
+        );
+    }
+
+    /**
+     * Assign the product to the category through the repository under test.
+     *
+     * @param int $categoryId
+     * @param string $sku
+     * @param int $position
+     * @return bool
+     */
+    private function saveLink(int $categoryId, string $sku, int $position): bool
+    {
+        $productLink = $this->productLinkFactory->create();
+        $productLink->setCategoryId($categoryId);
+        $productLink->setSku($sku);
+        $productLink->setPosition($position);
+
+        return $this->categoryLinkRepository->save($productLink);
+    }
+
+    /**
+     * Read the product id to position map straight from the link table.
+     *
+     * @param int $categoryId
+     * @return array
+     */
+    private function getAssignedPositions(int $categoryId): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select()
+            ->from($this->resourceConnection->getTableName('catalog_category_product'), ['product_id', 'position'])
+            ->where('category_id = ?', $categoryId);
+
+        $positions = [];
+        foreach ($connection->fetchAll($select) as $row) {
+            $positions[(int)$row['product_id']] = (int)$row['position'];
+        }
+
+        return $positions;
+    }
+}


### PR DESCRIPTION
### Description

Assigning a single product to a category through `CategoryLinkRepositoryInterface::save()` is disproportionately slow, and the cost grows with the size of the category and of the catalog rather than with the one row being written.

Two causes, both in the path taken for a single link:

**1. The whole assignment map is loaded and diffed to write one row.**
`CategoryLinkRepository::save()` calls `$category->getProductsPosition()`, which selects every row of `catalog_category_product` for that category, merges the one new product in, and hands the full map back to `ResourceModel\Category::_saveCategoryProducts()`, which re-reads it and diffs two complete arrays to derive a single insert. That is O(N) in the category size for a one-row write.

**2. The follow-up reindex covers the entire catalog.**
`Category::reindex()` ran `catalog_category_product` over `$this->getPathIds()`. `getPathIds()` always contains the root category, and `Indexer\Category\Product\Action\Rows::execute()` expands every id it receives to its full path when building `limitationByCategories`. Passing the root therefore rebuilds `catalog_category_product_index` for the whole catalog — on every single link save, in the default realtime indexer mode.

### Fix

`CategoryLinkRepository::save()` and `deleteByIds()` no longer call `getProductsPosition()`. A new private helper reads just the affected link through `ResourceModel\Product\CategoryLink::getCategoryLinks()` and pre-seeds the category's `products_position` with that one-entry map, so the diff is over one element instead of N. A `finally` block clears `products_position` / `posted_products` afterwards so the instance cached by `CategoryRepository` is not left holding a partial map.

`Category::reindex()` now splits the condition. `is_anchor` / `is_active` changes still reindex by path, which is correct — those affect the whole subtree. When only the product assignments changed, it reindexes `catalog_product_category` with the affected **product** ids instead. `Indexer\Product\Category\Action\Rows` deletes and rebuilds exactly the index rows for those products across all stores and registers the same cache tags, so coverage and invalidation are equivalent while being bounded by the products touched. This mirrors what `CategoryLinkManagement::assignProductToCategories()` already does.

`$category->save()` is still called. Nothing is bypassed: `catalog_category_save_before` / `_after`, the `catalog_category_change_products` event, `CategoryProcessUrlRewriteSavingObserver` (which generates the category-based product URL rewrite), cache-tag invalidation and any third-party observer or plugin all still run. Bypassing the save would have meant skipping URL rewrite generation, which lives in `CatalogUrlRewrite` and cannot be reached from `Catalog` without inverting a module dependency — that would be an architectural change rather than a bug fix.

`deleteBySkus()` is deliberately untouched; it is already a bulk operation, so the full-map load is amortised there.

### Measurements

Local 2.4-develop, Warden, PHP 8.3, MariaDB 11.4. Catalog generated with the `small` performance profile: 1200 products, 32 categories. One category holding 1199 products; `catalog_category_product` indexer in its default realtime mode. Each run is a fresh PHP process, timing only the `save()` call.

| | median | range |
|---|---|---|
| 2.4-develop | 137.9 ms | 126.4 – 221.6 ms |
| this PR | 46.9 ms | 43.2 – 62.1 ms |

Roughly 3× at 1200 products, and the gap widens with catalog size because the baseline's reindex scope is the whole catalog while this PR's is one product. Isolating just the two reindex calls on the same data:

```
reindexList(catalog_category_product, pathIds incl. root):  78.6 ms
reindexList(catalog_product_category, single product id):    6.4 ms
```

The resulting index state is identical — `catalog_category_product_index_store1` gains exactly the one expected row in both cases.

### A correctness issue found while measuring

On 2.4-develop, calling `deleteByIds()` and then `save()` for the same product within one process intermittently loses the link: `catalog_category_product` gets no row and `save()` reports no error. In 5 fresh runs the baseline dropped the link in 2 of them; with this PR the link was written in 5 of 5.

The cause is the same shared state the first fix addresses. `deleteByIds()` populates `products_position` on the `Category` instance that `CategoryRepository` keeps in its runtime cache; the following `save()` receives that stale instance and diffs against a map that already reflects the delete, producing an empty change set. Clearing the two data keys after each operation removes it.

### Fixed Issues

Fixes magento/magento2#37739

### Manual testing scenarios

1. Generate a catalog with a category holding a few thousand products (`bin/magento setup:performance:generate-fixtures setup/performance-toolkit/profiles/ce/small.xml` is enough to see it).
2. Leave `catalog_category_product` in "Update on Save".
3. Assign one further product to that category via `POST /V1/categories/{categoryId}/products` or `CategoryLinkRepositoryInterface::save()` and time the call.
4. **Before:** the call rebuilds `catalog_category_product_index` for the entire catalog. **After:** only the affected product's index rows are rebuilt.
5. Confirm the product appears on the category page immediately, and that a category-based URL rewrite for it exists in `url_rewrite`.
6. Repeat with `is_anchor` or `is_active` toggled on the category and confirm the subtree is still reindexed by path.

### Questions or comments

Gates run locally:

- Unit: `Catalog/Test/Unit/Model/CategoryTest.php` + `CategoryLinkRepositoryTest.php` — 34 tests pass.
- Integration: `Magento/Catalog/Model/` 831 tests, `Magento/Catalog/Model/Indexer/` 46 tests, `Magento/CatalogUrlRewrite/` 52 tests — all pass (only the pre-existing abstract-class warnings).
- PHPCS `Magento2`: clean. PHPStan level 1: no errors.
- Negative check: both new unit test files go red against unpatched `Category.php` / `CategoryLinkRepository.php` and green with the fix.

Two things worth a reviewer's attention:

- `Category::reindex()` also runs on admin category saves, not just API link writes. The `isScheduled()` guard on the product-only path now consults `catalog_product_category` rather than `catalog_category_product`. If those two indexers are in different modes the reindex defers instead of running inline. `CategoryLinkManagement` already behaves this way, but it is a behaviour change worth confirming is acceptable.
- Third-party observers reading `getPostedProducts()` during a category save triggered from this path will now see only the touched product. `getChangedProductIds()` and `getAffectedProductIds()` are unchanged, which is what core consumers use.

`CategoryLinkRepository::__construct()` gained an optional fourth argument with an `ObjectManager` fallback, matching the existing `$productResource` pattern, so it is not a breaking change.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
