### PR TITLE
Store CAPTCHA images in the configured media storage (#33051)

### DIFF
--- a/app/code/Magento/Captcha/Cron/DeleteExpiredImages.php
+++ b/app/code/Magento/Captcha/Cron/DeleteExpiredImages.php
@@ -8,8 +8,10 @@ namespace Magento\Captcha\Cron;
 use Magento\Captcha\Cron\Magento\Framework\Filesystem\Io\File;
 use Magento\Captcha\Helper\Data;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
 use Magento\Framework\Filesystem\DriverPool;
 use Magento\Store\Model\StoreManager;
 
@@ -46,24 +48,32 @@ class DeleteExpiredImages
     protected $_fileInfo;
 
     /**
+     * @var TargetDirectory
+     */
+    private $targetDirectory;
+
+    /**
      * @param Data $helper
      * @param \Magento\Captcha\Helper\Adminhtml\Data $adminHelper
      * @param Filesystem $filesystem
      * @param StoreManager $storeManager
      * @param File $fileInfo
+     * @param TargetDirectory|null $targetDirectory
      */
     public function __construct(
         \Magento\Captcha\Helper\Data $helper,
         \Magento\Captcha\Helper\Adminhtml\Data $adminHelper,
         \Magento\Framework\Filesystem $filesystem,
         \Magento\Store\Model\StoreManager $storeManager,
-        \Magento\Framework\Filesystem\Io\File $fileInfo
+        \Magento\Framework\Filesystem\Io\File $fileInfo,
+        ?TargetDirectory $targetDirectory = null
     ) {
         $this->_helper = $helper;
         $this->_adminHelper = $adminHelper;
         $this->_mediaDirectory = $filesystem->getDirectoryWrite(DirectoryList::MEDIA, DriverPool::FILE);
         $this->_storeManager = $storeManager;
         $this->_fileInfo = $fileInfo;
+        $this->targetDirectory = $targetDirectory ?: ObjectManager::getInstance()->get(TargetDirectory::class);
     }
 
     /**
@@ -98,12 +108,14 @@ class DeleteExpiredImages
     ) {
         $expire = time() - (int)$helper->getConfig('timeout', $store) * 60;
         $imageDirectory = $this->_mediaDirectory->getRelativePath($helper->getImgDir($website));
-        foreach ($this->_mediaDirectory->read($imageDirectory) as $filePath) {
-            if ($this->_mediaDirectory->isFile($filePath)
+        // Images are generated locally, but stored in the configured media storage, which may be remote.
+        $mediaDirectory = $this->targetDirectory->getDirectoryWrite(DirectoryList::MEDIA);
+        foreach ($mediaDirectory->read($imageDirectory) as $filePath) {
+            if ($mediaDirectory->isFile($filePath)
                 && $this->_fileInfo->getPathInfo($filePath)['extension'] === 'png'
-                && $this->_mediaDirectory->stat($filePath)['mtime'] < $expire
+                && $mediaDirectory->stat($filePath)['mtime'] < $expire
             ) {
-                $this->_mediaDirectory->delete($filePath);
+                $mediaDirectory->delete($filePath);
             }
         }
     }

--- a/app/code/Magento/Captcha/Cron/DeleteExpiredImages.php
+++ b/app/code/Magento/Captcha/Cron/DeleteExpiredImages.php
@@ -5,7 +5,7 @@
  */
 namespace Magento\Captcha\Cron;
 
-use Magento\Captcha\Cron\Magento\Framework\Filesystem\Io\File;
+use Magento\Framework\Filesystem\Io\File;
 use Magento\Captcha\Helper\Data;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ObjectManager;
@@ -17,6 +17,8 @@ use Magento\Store\Model\StoreManager;
 
 /**
  * Captcha cron actions
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DeleteExpiredImages
 {

--- a/app/code/Magento/Captcha/Plugin/PublishImageToRemoteStorage.php
+++ b/app/code/Magento/Captcha/Plugin/PublishImageToRemoteStorage.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Captcha\Plugin;
+
+use Magento\Captcha\Model\DefaultModel;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
+use Magento\Framework\Filesystem\DriverPool;
+
+/**
+ * Moves the generated CAPTCHA image to the configured media storage.
+ *
+ * The image itself has to be rendered by GD to the local filesystem, as the underlying
+ * Laminas implementation writes it with native functions. When remote storage is enabled
+ * the media base URL is served from the remote storage, so the image has to be moved there,
+ * otherwise it is not reachable for the browser and every other application node.
+ *
+ * @see \Magento\Captcha\Helper\Data::getImgDir()
+ */
+class PublishImageToRemoteStorage
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var TargetDirectory
+     */
+    private $targetDirectory;
+
+    /**
+     * @param Filesystem $filesystem
+     * @param TargetDirectory $targetDirectory
+     */
+    public function __construct(Filesystem $filesystem, TargetDirectory $targetDirectory)
+    {
+        $this->filesystem = $filesystem;
+        $this->targetDirectory = $targetDirectory;
+    }
+
+    /**
+     * Move the locally generated image to the target media storage.
+     *
+     * @param DefaultModel $subject
+     * @param string $result
+     * @return string
+     * @throws FileSystemException
+     */
+    public function afterGenerate(DefaultModel $subject, $result)
+    {
+        $localDirectory = $this->filesystem->getDirectoryWrite(DirectoryList::MEDIA, DriverPool::FILE);
+        $targetDirectory = $this->targetDirectory->getDirectoryWrite(DirectoryList::MEDIA);
+
+        if (get_class($targetDirectory->getDriver()) === get_class($localDirectory->getDriver())) {
+            return $result;
+        }
+
+        $sourcePath = $subject->getImgDir() . $result . $subject->getSuffix();
+        if (!$localDirectory->getDriver()->isFile($sourcePath)) {
+            return $result;
+        }
+
+        $localDirectory->getDriver()->rename(
+            $sourcePath,
+            $targetDirectory->getAbsolutePath($localDirectory->getRelativePath($sourcePath)),
+            $targetDirectory->getDriver()
+        );
+
+        return $result;
+    }
+}

--- a/app/code/Magento/Captcha/Test/Unit/Cron/DeleteExpiredImagesTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Cron/DeleteExpiredImagesTest.php
@@ -11,6 +11,7 @@ use Magento\Captcha\Cron\DeleteExpiredImages;
 use Magento\Captcha\Helper\Adminhtml\Data as AdminhtmlData;
 use Magento\Captcha\Helper\Data;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
 use Magento\Framework\Filesystem\Directory\Write;
 use Magento\Framework\Filesystem\Directory\WriteInterface;
 use Magento\Framework\Filesystem\Io\File;
@@ -68,6 +69,11 @@ class DeleteExpiredImagesTest extends TestCase
     protected $_fileInfo;
 
     /**
+     * @var TargetDirectory|MockObject
+     */
+    protected $targetDirectory;
+
+    /**
      * @var int
      */
     public static $currentTime;
@@ -83,9 +89,17 @@ class DeleteExpiredImagesTest extends TestCase
         $this->_directory = $this->createMock(Write::class);
         $this->_storeManager = $this->createMock(StoreManager::class);
         $this->_fileInfo = $this->createMock(File::class);
+        $this->targetDirectory = $this->createMock(TargetDirectory::class);
 
         $this->_filesystem->expects(
             $this->once()
+        )->method(
+            'getDirectoryWrite'
+        )->willReturn(
+            $this->_directory
+        );
+        $this->targetDirectory->expects(
+            $this->any()
         )->method(
             'getDirectoryWrite'
         )->willReturn(
@@ -97,7 +111,8 @@ class DeleteExpiredImagesTest extends TestCase
             $this->_adminHelper,
             $this->_filesystem,
             $this->_storeManager,
-            $this->_fileInfo
+            $this->_fileInfo,
+            $this->targetDirectory
         );
     }
 

--- a/app/code/Magento/Captcha/Test/Unit/Plugin/PublishImageToRemoteStorageTest.php
+++ b/app/code/Magento/Captcha/Test/Unit/Plugin/PublishImageToRemoteStorageTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\Captcha\Test\Unit\Plugin;
+
+use Magento\Captcha\Model\DefaultModel;
+use Magento\Captcha\Plugin\PublishImageToRemoteStorage;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Filesystem\Driver\File as FileDriver;
+use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\Filesystem\DriverPool;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PublishImageToRemoteStorageTest extends TestCase
+{
+    private const IMAGE_ID = 'a1b2c3';
+
+    private const LOCAL_DIR = '/var/www/pub/media/captcha/base/';
+
+    /**
+     * @var Filesystem|MockObject
+     */
+    private $filesystem;
+
+    /**
+     * @var TargetDirectory|MockObject
+     */
+    private $targetDirectory;
+
+    /**
+     * @var WriteInterface|MockObject
+     */
+    private $localDirectory;
+
+    /**
+     * @var WriteInterface|MockObject
+     */
+    private $mediaDirectory;
+
+    /**
+     * @var FileDriver|MockObject
+     */
+    private $localDriver;
+
+    /**
+     * @var DefaultModel|MockObject
+     */
+    private $captcha;
+
+    /**
+     * @var PublishImageToRemoteStorage
+     */
+    private $plugin;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->createMock(Filesystem::class);
+        $this->targetDirectory = $this->createMock(TargetDirectory::class);
+        $this->localDirectory = $this->createMock(WriteInterface::class);
+        $this->mediaDirectory = $this->createMock(WriteInterface::class);
+        $this->localDriver = $this->createMock(FileDriver::class);
+        $this->captcha = $this->createMock(DefaultModel::class);
+
+        $this->filesystem->method('getDirectoryWrite')
+            ->with(DirectoryList::MEDIA, DriverPool::FILE)
+            ->willReturn($this->localDirectory);
+        $this->targetDirectory->method('getDirectoryWrite')
+            ->with(DirectoryList::MEDIA)
+            ->willReturn($this->mediaDirectory);
+        $this->localDirectory->method('getDriver')->willReturn($this->localDriver);
+
+        $this->captcha->method('getImgDir')->willReturn(self::LOCAL_DIR);
+        $this->captcha->method('getSuffix')->willReturn('.png');
+
+        $this->plugin = new PublishImageToRemoteStorage($this->filesystem, $this->targetDirectory);
+    }
+
+    /**
+     * The image is already in the right place when the media storage is the local filesystem.
+     */
+    public function testImageIsNotMovedWhenRemoteStorageIsDisabled(): void
+    {
+        $this->mediaDirectory->method('getDriver')->willReturn($this->localDriver);
+        $this->localDriver->expects($this->never())->method('rename');
+
+        $this->assertSame(self::IMAGE_ID, $this->plugin->afterGenerate($this->captcha, self::IMAGE_ID));
+    }
+
+    /**
+     * The image has to be moved to the media storage that serves the media base URL.
+     */
+    public function testImageIsMovedToRemoteStorage(): void
+    {
+        $remoteDriver = $this->createMock(DriverInterface::class);
+        $this->mediaDirectory->method('getDriver')->willReturn($remoteDriver);
+
+        $this->localDriver->method('isFile')
+            ->with(self::LOCAL_DIR . self::IMAGE_ID . '.png')
+            ->willReturn(true);
+        $this->localDirectory->method('getRelativePath')
+            ->with(self::LOCAL_DIR . self::IMAGE_ID . '.png')
+            ->willReturn('captcha/base/' . self::IMAGE_ID . '.png');
+        $this->mediaDirectory->method('getAbsolutePath')
+            ->with('captcha/base/' . self::IMAGE_ID . '.png')
+            ->willReturn('media/captcha/base/' . self::IMAGE_ID . '.png');
+
+        $this->localDriver->expects($this->once())
+            ->method('rename')
+            ->with(
+                self::LOCAL_DIR . self::IMAGE_ID . '.png',
+                'media/captcha/base/' . self::IMAGE_ID . '.png',
+                $remoteDriver
+            )
+            ->willReturn(true);
+
+        $this->assertSame(self::IMAGE_ID, $this->plugin->afterGenerate($this->captcha, self::IMAGE_ID));
+    }
+
+    /**
+     * Nothing to move when the image has not been rendered, e.g. when GD rendering has been suppressed.
+     */
+    public function testNothingIsMovedWhenImageDoesNotExist(): void
+    {
+        $remoteDriver = $this->createMock(DriverInterface::class);
+        $this->mediaDirectory->method('getDriver')->willReturn($remoteDriver);
+        $this->localDriver->method('isFile')->willReturn(false);
+
+        $this->localDriver->expects($this->never())->method('rename');
+
+        $this->assertSame(self::IMAGE_ID, $this->plugin->afterGenerate($this->captcha, self::IMAGE_ID));
+    }
+}

--- a/app/code/Magento/Captcha/etc/di.xml
+++ b/app/code/Magento/Captcha/etc/di.xml
@@ -5,8 +5,10 @@
  * All Rights Reserved.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Magento\Captcha\Api\CaptchaConfigPostProcessorInterface" type="Magento\Captcha\Model\Filter\CaptchaConfigPostProcessorComposite"/>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Captcha\Api\CaptchaConfigPostProcessorInterface"
+                type="Magento\Captcha\Model\Filter\CaptchaConfigPostProcessorComposite"/>
     <type name="Magento\Captcha\Model\DefaultModel">
         <arguments>
             <argument name="session" xsi:type="object">Magento\Customer\Model\Session</argument>

--- a/app/code/Magento/Captcha/etc/di.xml
+++ b/app/code/Magento/Captcha/etc/di.xml
@@ -11,6 +11,8 @@
         <arguments>
             <argument name="session" xsi:type="object">Magento\Customer\Model\Session</argument>
         </arguments>
+        <plugin name="publish_captcha_image_to_remote_storage"
+                type="Magento\Captcha\Plugin\PublishImageToRemoteStorage"/>
     </type>
     <type name="Magento\Captcha\Observer\CheckUserCreateObserver">
         <arguments>


### PR DESCRIPTION
### Description

With remote storage enabled, the CAPTCHA image is never reachable: the browser gets a 404 and the CAPTCHA cannot be solved. The same happens on a multi-node setup without shared storage, where the node that generates the image is not the node that serves it.

`Magento\Captcha\Helper\Data::getImgDir()` hardcodes the local driver:

```php
return $this->_filesystem->getDirectoryWrite(DirectoryList::MEDIA, Filesystem\DriverPool::FILE);
```

so the PNG is written to the local pod's disk. `getImgUrl()` however builds the URL from `$store->getBaseUrl(DirectoryList::MEDIA)`, and with remote storage that path is proxied to the bucket (see the `location /media/` block in `nginx.conf.sample`). The file and the URL point at two different places. `Cron\DeleteExpiredImages` pins the local driver in the same way, so it would also never reap anything written remotely.

### Fix

The image itself has to be rendered locally — `Laminas\Captcha\Image::generateImage()` writes it with native `imagepng()`, which cannot go through a Magento driver at all. So simply dropping `DriverPool::FILE` does not work: `AwsS3::getAbsolutePath()` returns a bucket-relative path rather than a stream wrapper, and `imagepng()` would silently create a bogus local file.

Instead a new `afterGenerate` plugin on `Magento\Captcha\Model\DefaultModel` moves the rendered image into the configured media storage. It compares the target media driver with the local `File` driver and returns untouched when they are the same, so behaviour is unchanged when remote storage is off. This is the same render-locally-then-`rename()` pattern the existing `Magento\RemoteStorage\Plugin\Image` uses.

The plugin depends only on `Magento\Framework\Filesystem\Directory\TargetDirectory`, which is framework-level and is re-pointed at the remote filesystem by `RemoteStorage/etc/di.xml`, so no new inter-module dependency is introduced.

`Cron\DeleteExpiredImages` now scans the target media directory as well, so remote objects are actually cleaned up. Its new constructor argument is optional with an `ObjectManager` fallback, so it is not a breaking change. No signature on `Captcha\Helper\Data` or `DefaultModel` was changed.

### Fixed Issues

Fixes magento/magento2#33051

### Manual testing scenarios

1. Configure remote storage (`remote_storage` in `app/etc/env.php`, AWS S3 driver) and make sure nginx proxies `/media/` to the bucket.
2. Enable CAPTCHA for the customer login form.
3. Open the login page.
4. **Before:** the CAPTCHA image 404s, so the form cannot be submitted. **After:** the image loads from the bucket and the CAPTCHA can be solved.
5. Let `captcha_delete_expired_images` run and confirm the objects are removed from the bucket.
6. With remote storage **disabled**, confirm the CAPTCHA still renders exactly as before and the image stays in `pub/media/captcha/<website>/`.

### Questions or comments

Verified locally on 2.4-develop (Warden, PHP 8.3):

- Unit: `Magento/Captcha/Test/Unit/` — 78 tests pass, including three new cases covering the drivers-equal no-op, the move when the drivers differ, and the missing-source-file case.
- PHPCS `Magento2` and PHPStan level 1: clean.
- Confirmed via `bin/magento dev:di:info Magento\Captcha\Model\DefaultModel` that the plugin is registered as an `after` plugin on `generate`.
- Smoke-tested the local-storage path end to end: `DefaultModel\Interceptor` is used, the image is written to `pub/media/captcha/base/`, and the plugin correctly does nothing.

Two things I could not verify here and would like a reviewer to confirm against a real bucket:

1. The remote path itself — I have no S3 bucket in this environment, so the `rename()` across drivers is covered by unit tests only. The MFTF `RemoteStorageAwsS3EnabledSuite` would be the natural home for end-to-end coverage.
2. A failed remote PUT currently propagates `FileSystemException` out of block rendering on the login page. That matches `RemoteStorage\Plugin\Image`, which also does not catch, but log-and-degrade is a defensible alternative here since the alternative is a broken login form. Happy to change it if maintainers prefer.

Cost note, so it is not a surprise: this adds one remote PUT per CAPTCHA render (and one DELETE from the cron). The read is done by the browser directly from the bucket or CDN, so no PHP-side GET is added.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
