### PR TITLE
Add correctly named getCustomerRegisterUrl() and deprecate the typo (#36735)

### DIFF
--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -119,8 +119,10 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
 
     /**
      * Get customer register url
+     *
      * @deprecated
      * @see getCustomerRegisterUrl
+     *
      * @return string
      */
     public function getCustomerRegisterUrlUrl()
@@ -130,6 +132,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
 
     /**
      * Get customer register url
+     *
      * @return string
      */
     public function getCustomerRegisterUrl()

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -119,7 +119,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
 
     /**
      * Get customer register url
-     * @deprecated
+     * @deprecated due to requirements
      * @return string
      */
     public function getCustomerRegisterUrlUrl()

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -119,13 +119,13 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
 
     /**
      * Get customer register url
-     * @deprecated due to requirements
+     * @deprecated
      * @see getCustomerRegisterUrl
      * @return string
      */
     public function getCustomerRegisterUrlUrl()
     {
-        return $this->getUrl('customer/account/create');
+        return $this->getCustomerRegisterUrl();
     }
 
     /**

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -132,7 +132,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
      * Get customer register url
      * @return string
      */
-    private function getCustomerRegisterUrl()
+    public function getCustomerRegisterUrl()
     {
         return $this->getUrl('customer/account/create');
     }

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -74,7 +74,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
     {
         return [
             'autocomplete' => $this->escapeHtml($this->isAutocompleteEnabled()),
-            'customerRegisterUrl' => $this->escapeUrl($this->getCustomerRegisterUrlUrl()),
+            'customerRegisterUrl' => $this->escapeUrl($this->getCustomerRegisterUrl()),
             'customerForgotPasswordUrl' => $this->escapeUrl($this->getCustomerForgotPasswordUrl()),
             'baseUrl' => $this->escapeUrl($this->getBaseUrl()),
             'customerLoginUrl' => $this->getUrl('customer/ajax/login'),
@@ -122,7 +122,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
      *
      * @return string
      */
-    public function getCustomerRegisterUrlUrl()
+    public function getCustomerRegisterUrl()
     {
         return $this->getUrl('customer/account/create');
     }

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -119,10 +119,19 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
 
     /**
      * Get customer register url
-     *
+     * @deprecated
      * @return string
      */
-    public function getCustomerRegisterUrl()
+    public function getCustomerRegisterUrlUrl()
+    {
+        return $this->getUrl('customer/account/create');
+    }
+
+    /**
+     * Get customer register url
+     * @return string
+     */
+    private function getCustomerRegisterUrl()
     {
         return $this->getUrl('customer/account/create');
     }

--- a/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
+++ b/app/code/Magento/Customer/Block/Account/AuthenticationPopup.php
@@ -120,6 +120,7 @@ class AuthenticationPopup extends \Magento\Framework\View\Element\Template
     /**
      * Get customer register url
      * @deprecated due to requirements
+     * @see getCustomerRegisterUrl
      * @return string
      */
     public function getCustomerRegisterUrlUrl()

--- a/app/code/Magento/Customer/Test/Unit/Block/Account/AuthenticationPopupTest.php
+++ b/app/code/Magento/Customer/Test/Unit/Block/Account/AuthenticationPopupTest.php
@@ -247,4 +247,20 @@ class AuthenticationPopupTest extends TestCase
 
         $this->assertEquals(json_encode($result), $this->model->getSerializedConfig());
     }
+
+    /**
+     * Deprecated getCustomerRegisterUrlUrl() must keep returning the same value as its replacement.
+     */
+    public function testGetCustomerRegisterUrlUrlIsDeprecatedAliasForGetCustomerRegisterUrl(): void
+    {
+        $this->urlBuilderMock->expects($this->any())
+            ->method('getUrl')
+            ->with('customer/account/create', [])
+            ->willReturn('customer/account/create/url');
+
+        $this->assertEquals(
+            $this->model->getCustomerRegisterUrl(),
+            $this->model->getCustomerRegisterUrlUrl()
+        );
+    }
 }


### PR DESCRIPTION
### Description

`Magento\Customer\Block\Account\AuthenticationPopup::getCustomerRegisterUrlUrl()` has a doubled "Url" in its name. It is still there on `2.4-develop` (`AuthenticationPopup.php:126`).

The method is public on an `@api` block, so it cannot simply be renamed. This adds a correctly named `getCustomerRegisterUrl()`, has the old method delegate to it, and marks the old one `@deprecated` with a `@see` pointing at the replacement.

This PR continues #36794 by @Vasudev-22 (Partner: EY), rebased onto current `2.4-develop`. Their commits and authorship are preserved.

### The one review point that was never resolved

@Den4ik and @hostep both reviewed the original PR and every point was addressed except this one, from @hostep:

> I think this one should be `public` instead of `private`, because the original method was also public? [...] won't we cause confusion with callers of the original method when we mark that one as deprecated and give no new method as alternative to call?

I agree, and this PR makes the replacement public. Deprecating a public method while offering only a private replacement leaves external callers with nowhere to migrate, which defeats the purpose of the deprecation. Adding a public method is additive; it is renaming or removing one that breaks backward compatibility.

### Fixed Issues

Fixes magento/magento2#36735

### Manual testing scenarios

1. Open any storefront page with the authentication popup enabled.
2. Confirm the "Create an Account" link in the popup still resolves to `customer/account/create`.
3. Call both `getCustomerRegisterUrl()` and the deprecated `getCustomerRegisterUrlUrl()` on the block and confirm they return the same URL.

### Questions or comments

Note for the Semantic Version Checker build: this adds a public method to a class annotated `@api @since 100.0.2`. That is an additive (minor) change rather than a breaking one, but it will show up in the SVC report, so flagging it explicitly rather than letting it surprise a reviewer. No existing signature is changed and the deprecated method is retained.

Gates run locally on `2.4-develop` (Warden, PHP 8.3):

- Unit: `Customer/Test/Unit/Block/Account/` — 33 tests pass, including a new case asserting the deprecated method and its replacement return the same URL.
- PHPCS `Magento2`: clean. PHPStan level 1: no errors.
- Negative check on the new test: red against the unpatched block, green with the fix.

`git grep` across the repository finds no remaining caller of the old name outside its own declaration; the block's `getConfig()` was already updated to the new name in @Vasudev-22's original commits.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
