### PR TITLE
Fix TypeError in Shipping::collectRates() when no carriers are configured

### DIFF
--- a/app/code/Magento/Shipping/Model/Shipping.php
+++ b/app/code/Magento/Shipping/Model/Shipping.php
@@ -239,6 +239,9 @@ class Shipping implements RateCollectorInterface
                 \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
                 $storeId
             );
+            if (!is_array($carriers)) {
+                $carriers = [];
+            }
 
             foreach ($carriers as $carrierCode => $carrierConfig) {
                 $this->collectCarrierRates($carrierCode, $request);

--- a/app/code/Magento/Shipping/Test/Unit/Model/ShippingTest.php
+++ b/app/code/Magento/Shipping/Test/Unit/Model/ShippingTest.php
@@ -160,6 +160,30 @@ class ShippingTest extends TestCase
     }
 
     /**
+     * No configured carriers should not cause a fatal error when collecting rates.
+     *
+     * @return void
+     */
+    public function testCollectRatesWithNoCarriersConfigured()
+    {
+        $request = new RateRequest();
+        $request->setOrig(true);
+
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->with(
+                'carriers',
+                \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+                $request->getStoreId()
+            )
+            ->willReturn(null);
+
+        $result = $this->shipping->collectRates($request);
+
+        $this->assertSame($this->shipping, $result);
+    }
+
+    /**
      * @return CarrierFactory|MockObject
      */
     private function getCarrierFactory()


### PR DESCRIPTION
### Description

`Magento\Shipping\Model\Shipping::collectRates()` iterates the carrier configuration without checking it is an array:

```php
$carriers = $this->_scopeConfig->getValue(
    'carriers',
    \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
    $storeId
);

foreach ($carriers as $carrierCode => $carrierConfig) {
```

`Magento\Config\App\Config\Type\System::getDataByPathParts()` returns `null`, not an empty array, when the requested key is absent from the merged scope data. That happens whenever no carrier module contributes a `carriers/*` node for the scope — for example with every shipping carrier disabled or uninstalled. On PHP 8 the `foreach` then throws a `TypeError` and checkout breaks. `ScopeConfigInterface::getValue()` is declared `@return mixed`, so callers cannot assume an array.

Note the asymmetry a few lines below in the same method: the `$limitCarrier` branch already normalises its value with `is_array()` before iterating. This applies the same guard to the branch that lacks it.

### This is the same bug that was half-fixed in 2021

magento/magento2#30830 reported exactly this failure ("disable all shipping carrier modules" → blank checkout, `array_keys(): argument #1 must be of type array, null given`). It was fixed by #30822, which guarded the identical `getValue('carriers', ...)` call sites in `Magento\Shipping\Model\Config::getActiveCarriers()` and `getAllCarriers()` — but did not touch `Shipping::collectRates()`, which has the same unguarded pattern and is still reachable today.

### Fixed Issues

No open issue; this is the remaining half of the defect reported in #30830, which was closed when #30822 fixed the sibling call sites.

### Manual testing scenarios

1. Disable every shipping carrier (`Stores > Configuration > Sales > Delivery Methods`, or uninstall the carrier modules).
2. Add a product to the cart and open checkout, or call `Shipping::collectRates()` with a request that has no `limitCarrier`.
3. **Before:** `TypeError: foreach() argument must be of type array|object, null given`. **After:** rate collection completes and returns no rates.

### Questions or comments

Gates run locally on `2.4-develop` (Warden, PHP 8.3):

- Unit: `Shipping/Test/Unit/Model/ShippingTest.php` — 3 tests pass, including a new case that mocks the config to return `null` and asserts `collectRates()` returns normally instead of throwing.
- PHPCS `Magento2`: clean. PHPStan level 1: no errors.
- Negative check: the new test errors against unpatched `Shipping.php` and passes with the fix.

No signature changes, so no Semantic Version Checker exposure.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41182: Fix TypeError in Shipping::collectRates() when no carriers are configured