### PR TITLE
Support partial paths in config:show (#39610)

### DIFF
--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -13,6 +13,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\App\Scope\ValidatorInterface;
 use Magento\Framework\Console\Cli;
+use Magento\Framework\Exception\ValidatorException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -181,10 +182,6 @@ class ConfigShowCommand extends Command
             $configValue = $this->emulatedAreaProcessor->process(function () {
                 return $this->localeEmulator->emulate(function () {
                     $this->scopeValidator->isValid($this->scope, $this->scopeCode);
-                    if ($this->inputPath) {
-                        $pathValidator = $this->pathValidatorFactory->create();
-                        $pathValidator->validate($this->inputPath);
-                    }
 
                     $configPath = $this->pathResolver
                         ->resolve($this->inputPath, $this->scope, $this->scopeCode);
@@ -194,12 +191,18 @@ class ConfigShowCommand extends Command
                             ->resolve($this->inputPath, $this->scope, strtolower($this->scopeCode));
                         $value = $this->configSource->get($configPath);
                         if (!$value) {
-                            $value = $this->configSource->get(strtolower($configPath));
+                            $value = $this->configSource->get(strtolower((string)$configPath));
                         }
                     }
                     return $value;
                 });
             });
+
+            if (empty($configValue)) {
+                throw new ValidatorException(
+                    __('The "%1" path doesn\'t exist. Verify and try again.', $this->inputPath)
+                );
+            }
 
             $this->outputResult($output, $configValue, $this->inputPath);
             return Cli::RETURN_SUCCESS;

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -26,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @api
  * @since 101.0.0
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.UnusedPrivateField)
  */
 class ConfigShowCommand extends Command
 {
@@ -86,6 +87,9 @@ class ConfigShowCommand extends Command
 
     /**
      * @var PathValidatorFactory
+     * @deprecated The path is no longer pre-validated here; an invalid/partial path is now detected
+     * by checking the resolved configuration value instead. Kept only for backward compatibility of the
+     * constructor signature.
      */
     private $pathValidatorFactory;
 
@@ -104,7 +108,7 @@ class ConfigShowCommand extends Command
      * @param ConfigSourceInterface $configSource
      * @param ConfigPathResolver $pathResolver
      * @param ValueProcessor $valueProcessor
-     * @param PathValidatorFactory|null $pathValidatorFactory
+     * @param PathValidatorFactory|null $pathValidatorFactory @deprecated unused, kept for BC
      * @param EmulatedAdminhtmlAreaProcessor|null $emulatedAreaProcessor
      * @param LocaleEmulatorInterface|null $localeEmulator
      * @internal param ScopeConfigInterface $appConfig

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -86,10 +86,11 @@ class ConfigShowCommand extends Command
     private $inputPath;
 
     /**
+     * Unused since partial paths became supported: the path is no longer pre-validated against the
+     * system.xml structure, an unknown path is detected from the resolved value instead. Retained
+     * so the constructor signature stays backward compatible.
+     *
      * @var PathValidatorFactory
-     * @deprecated The path is no longer pre-validated here; an invalid/partial path is now detected
-     * by checking the resolved configuration value instead. Kept only for backward compatibility of the
-     * constructor signature.
      */
     private $pathValidatorFactory;
 

--- a/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
+++ b/app/code/Magento/Config/Console/Command/ConfigShowCommand.php
@@ -202,7 +202,10 @@ class ConfigShowCommand extends Command
                 });
             });
 
-            if (empty($configValue)) {
+            // ConfigSourceInterface::get() returns '' or [] when the path holds nothing.
+            // Do not use empty() here: a stored "0" is a legitimate value for every
+            // disabled flag in the tree (web/seo/use_rewrites and friends).
+            if ($configValue === null || $configValue === '' || $configValue === []) {
                 throw new ValidatorException(
                     __('The "%1" path doesn\'t exist. Verify and try again.', $this->inputPath)
                 );

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
@@ -166,6 +166,58 @@ class ConfigShowCommandTest extends TestCase
     }
 
     /**
+     * A stored "0" is a real value, not a missing path.
+     *
+     * Every disabled flag in the config tree is stored as "0", so treating a falsy
+     * value as "path doesn't exist" would break `config:show web/seo/use_rewrites`
+     * and everything like it.
+     *
+     * @return void
+     */
+    public function testExecuteWithFalsyConfigValue(): void
+    {
+        $resolvedConfigPath = 'someScope/someScopeCode/web/seo/use_rewrites';
+
+        $this->scopeValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with(self::SCOPE, self::SCOPE_CODE)
+            ->willReturn(true);
+        $this->pathResolverMock->expects($this->any())
+            ->method('resolve')
+            ->willReturn($resolvedConfigPath);
+        $this->configSourceMock->expects($this->any())
+            ->method('get')
+            ->willReturn('0');
+        $this->valueProcessorMock->expects($this->once())
+            ->method('process')
+            ->with(self::SCOPE, self::SCOPE_CODE, '0', self::CONFIG_PATH)
+            ->willReturn('0');
+        $this->emulatedAreProcessorMock->expects($this->once())
+            ->method('process')
+            ->willReturnCallback(function ($function) {
+                return $function();
+            });
+        $this->localeEmulatorMock->expects($this->once())
+            ->method('emulate')
+            ->willReturnCallback(function ($callback) {
+                return $callback();
+            });
+
+        $tester = $this->getConfigShowCommandTester(
+            self::CONFIG_PATH,
+            self::SCOPE,
+            self::SCOPE_CODE
+        );
+
+        $this->assertEquals(
+            Cli::RETURN_SUCCESS,
+            $tester->getStatusCode(),
+            'A stored "0" must be reported as a value, not as a missing path'
+        );
+        $this->assertStringContainsString('0', $tester->getDisplay());
+    }
+
+    /**
      * Test not valid scope or scope code
      *
      * @return void

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
@@ -3,7 +3,6 @@
  * Copyright 2017 Adobe
  * All Rights Reserved.
  */
-
 declare(strict_types=1);
 
 namespace Magento\Config\Test\Unit\Console\Command;

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
@@ -3,6 +3,7 @@
  * Copyright 2017 Adobe
  * All Rights Reserved.
  */
+
 declare(strict_types=1);
 
 namespace Magento\Config\Test\Unit\Console\Command;
@@ -89,7 +90,8 @@ class ConfigShowCommandTest extends TestCase
         $this->configSourceMock = $this->createMock(ConfigSourceInterface::class);
         $this->pathValidatorMock = $this->createMock(PathValidator::class);
         $pathValidatorFactoryMock = $this->createMock(PathValidatorFactory::class);
-        $pathValidatorFactoryMock->expects($this->atMost(1))
+        // The command no longer pre-validates the path via PathValidator, so it must never be created.
+        $pathValidatorFactoryMock->expects($this->never())
             ->method('create')
             ->willReturn($this->pathValidatorMock);
 
@@ -202,12 +204,25 @@ class ConfigShowCommandTest extends TestCase
     }
 
     /**
-     * Test get config value for not existed path.
+     * Test that a path which resolves to no configuration value (e.g. a made up or invalid
+     * partial path) still produces an error, even though it is no longer rejected up front by
+     * PathValidator.
      *
      * @return void
      */
     public function testConfigPathNotExist(): void
     {
+        $this->scopeValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with(ScopeConfigInterface::SCOPE_TYPE_DEFAULT, '')
+            ->willReturn(true);
+        $this->pathResolverMock->expects($this->exactly(2))
+            ->method('resolve')
+            ->willReturn('default//' . self::CONFIG_PATH);
+        $this->configSourceMock->expects($this->exactly(3))
+            ->method('get')
+            ->willReturn(null);
+
         $this->emulatedAreProcessorMock->expects($this->once())
             ->method('process')
             ->willReturnCallback(function ($function) {
@@ -258,7 +273,8 @@ class ConfigShowCommandTest extends TestCase
     }
 
     /**
-     * Test that design configuration paths are validated correctly using Theme PathValidator
+     * Test that design configuration paths are still resolved correctly now that the command
+     * no longer runs them through PathValidator before resolving.
      *
      * @return void
      */
@@ -277,7 +293,8 @@ class ConfigShowCommandTest extends TestCase
         // Use Theme PathValidator mock instead of base PathValidator
         $themePathValidatorMock = $this->createMock(\Magento\Theme\Model\Config\PathValidator::class);
         $pathValidatorFactoryMock = $this->createMock(PathValidatorFactory::class);
-        $pathValidatorFactoryMock->expects($this->atMost(1))
+        // The command no longer pre-validates the path, so PathValidator must never be created/invoked.
+        $pathValidatorFactoryMock->expects($this->never())
             ->method('create')
             ->willReturn($themePathValidatorMock);
 
@@ -302,7 +319,7 @@ class ConfigShowCommandTest extends TestCase
             ->with(ScopeConfigInterface::SCOPE_TYPE_DEFAULT, '')
             ->willReturn(true);
 
-        $themePathValidatorMock->expects($this->once())
+        $themePathValidatorMock->expects($this->never())
             ->method('validate')
             ->with($designPath)
             ->willReturn(true);

--- a/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
+++ b/app/code/Magento/Config/Test/Unit/Console/Command/ConfigShowCommandTest.php
@@ -209,14 +209,6 @@ class ConfigShowCommandTest extends TestCase
      */
     public function testConfigPathNotExist(): void
     {
-        $exception = new LocalizedException(
-            __('The  "%1" path doesn\'t exist. Verify and try again.', self::CONFIG_PATH)
-        );
-
-        $this->pathValidatorMock->expects($this->once())
-            ->method('validate')
-            ->with(self::CONFIG_PATH)
-            ->willThrowException($exception);
         $this->emulatedAreProcessorMock->expects($this->once())
             ->method('process')
             ->willReturnCallback(function ($function) {
@@ -236,7 +228,7 @@ class ConfigShowCommandTest extends TestCase
             $tester->getStatusCode()
         );
         $this->assertStringContainsString(
-            __('The  "%1" path doesn\'t exist. Verify and try again.', self::CONFIG_PATH)->render(),
+            __('The "%1" path doesn\'t exist. Verify and try again.', self::CONFIG_PATH)->render(),
             $tester->getDisplay()
         );
     }


### PR DESCRIPTION
### Description

`bin/magento config:show` rejects partial configuration paths. `config:show catalog/frontend` fails even though the path resolves to a perfectly valid subtree, because `ConfigShowCommand::execute()` runs the path through `Magento\Config\Model\Config\PathValidator` first, and that validator only accepts complete field paths registered in the `system.xml` structure.

This removes the pre-validation and instead reports an unknown path from the resolved value, so partial paths print their subtree while a genuinely unknown path still fails with `ValidatorException`.

This PR continues #39711 by @rogerdz, rebased onto current `2.4-develop`. Their commits and authorship are preserved. The PR was approved by @Den4ik in March 2025 and then never picked up by triage — it never received a `Progress:` label.

### Changes made on top of the original

**A stored `"0"` is a value, not a missing path.** The original replaced the validator with an `empty($configValue)` guard. Every disabled flag in the config tree is stored as `"0"`, so that would have made `config:show web/seo/use_rewrites` — and everything like it — fail with *"The path doesn't exist"*. `ConfigSourceInterface::get()` is documented as returning `string|array`, and returns `''` or `[]` for a missing path, so the check is now explicitly against `null`/`''`/`[]`. Added a regression test for it.

**`PathValidatorFactory` is retained.** It is now unused, but the constructor parameter stays so the signature remains backward compatible; the class-level `@SuppressWarnings(PHPMD.UnusedPrivateField)` documents why.

**Test coverage tightened.** The shared mock now asserts `PathValidator` is *never* invoked, so a future change cannot silently reintroduce the pre-validation, and `testConfigPathNotExist` mocks the resolution explicitly instead of relying on PHPUnit's implicit null return.

### Fixed Issues

Fixes magento/magento2#39610

### Manual testing scenarios

1. `bin/magento config:show catalog/frontend`
   **Before:** *The "catalog/frontend" path doesn't exist. Verify and try again.* **After:** the subtree under that path is printed.
2. `bin/magento config:show web/seo/use_rewrites` on a store where rewrites are disabled — confirm it prints `0` rather than reporting a missing path.
3. `bin/magento config:show some/made/up/path` — confirm it still fails with *The path doesn't exist*.
4. `bin/magento config:show web/secure/base_url --scope=websites --scope-code=base` — confirm scoped lookups still work.

### Questions or comments

One deliberate behaviour change for reviewers to weigh: `config:show` no longer validates the path against the `system.xml` structure at all, only that it resolves to something. A path that is not a declared field but happens to have a stored value in `core_config_data` will now be printed where it previously errored. That is the direct consequence of supporting partial paths, and matches what the issue asks for, but it is a real widening of what the command accepts.

Gates run locally on `2.4-develop` (Warden, PHP 8.3):

- Unit: `Config/Test/Unit/Console/Command/ConfigShowCommandTest.php` — 8 tests pass.
- PHPCS `Magento2`: clean. PHPStan level 1: no errors.
- Negative check: 6 of the 8 tests fail against the unpatched command and all pass with the fix.

`ConfigShowCommand` is `@api`, but only method bodies change — no signature is touched.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
