### PR TITLE
Use the default front controller for URLs generated outside a web request (#25976)

### DIFF
--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -704,12 +704,11 @@ class Store extends AbstractExtensibleModel implements
             if ($this->_isCustomEntryPoint()) {
                 $indexFileName = 'index.php';
             } else {
-                $indexFileName = '';
-                if ($this->_request->getOriginalPathInfo()) {
-                    $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME');
-                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
-                    $indexFileName = basename($scriptFilename);
-                }
+                $scriptFilename = $this->_request->getOriginalPathInfo() ?
+                    $this->_request->getServer('SCRIPT_FILENAME') :
+                    '/server.php';
+                // phpcs:ignore Magento2.Functions.DiscouragedFunction
+                $indexFileName = is_string($scriptFilename) ? basename($scriptFilename) : '';
             }
             $url .= $indexFileName . '/';
         }

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -704,9 +704,9 @@ class Store extends AbstractExtensibleModel implements
             if ($this->_isCustomEntryPoint()) {
                 $indexFileName = 'index.php';
             } else {
-                $scriptFilename = $this->_request->getOriginalPathInfo() ?
+                $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME') !== 'bin/magento' ?
                     $this->_request->getServer('SCRIPT_FILENAME') :
-                    '/server.php';
+                    '';
                 // phpcs:ignore Magento2.Functions.DiscouragedFunction
                 $indexFileName = is_string($scriptFilename) ? basename($scriptFilename) : '';
             }

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -704,11 +704,13 @@ class Store extends AbstractExtensibleModel implements
             if ($this->_isCustomEntryPoint()) {
                 $indexFileName = 'index.php';
             } else {
-                $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME') !== 'bin/magento' ?
-                    $this->_request->getServer('SCRIPT_FILENAME') :
-                    '';
+                $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME');
                 // phpcs:ignore Magento2.Functions.DiscouragedFunction
                 $indexFileName = is_string($scriptFilename) ? basename($scriptFilename) : '';
+                if (!str_ends_with(strtolower($indexFileName), '.php')) {
+                    // The running script is not a web entry point (CLI, cron, unknown) - use the default one
+                    $indexFileName = 'index.php';
+                }
             }
             $url .= $indexFileName . '/';
         }

--- a/app/code/Magento/Store/Model/Store.php
+++ b/app/code/Magento/Store/Model/Store.php
@@ -704,9 +704,12 @@ class Store extends AbstractExtensibleModel implements
             if ($this->_isCustomEntryPoint()) {
                 $indexFileName = 'index.php';
             } else {
-                $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME');
-                // phpcs:ignore Magento2.Functions.DiscouragedFunction
-                $indexFileName = is_string($scriptFilename) ? basename($scriptFilename) : '';
+                $indexFileName = '';
+                if ($this->_request->getOriginalPathInfo()) {
+                    $scriptFilename = $this->_request->getServer('SCRIPT_FILENAME');
+                    // phpcs:ignore Magento2.Functions.DiscouragedFunction
+                    $indexFileName = basename($scriptFilename);
+                }
             }
             $url .= $indexFileName . '/';
         }

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -465,6 +465,10 @@ class StoreTest extends TestCase
                 return $expectedPath == $path ? $url . $path . '/' : null;
             });
         $this->requestMock->expects($this->any())
+            ->method('getDistroBaseUrl')
+            ->willReturn('http://distro.com/');
+
+        $this->requestMock->expects($this->any())
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
             ->willReturn('bin/magento');
@@ -513,7 +517,7 @@ class StoreTest extends TestCase
                 true,
                 false,
                 'web/secure/base_link_url',
-                'web/secure/base_link_url/'
+                'http://distro.com/web/secure/base_link_url/'
             ],
         ];
     }

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -412,7 +412,7 @@ class StoreTest extends TestCase
             });
         $this->requestMock->expects($this->once())
             ->method('getOriginalPathInfo')
-            ->willReturn('web/unsecure/base_link_url/test_script.php/');
+            ->willReturn('test.html');
         $this->requestMock->expects($this->once())
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
@@ -438,20 +438,35 @@ class StoreTest extends TestCase
     }
 
     /**
-     * @return void
+     * @dataProvider getCliBaseUrlDataProvider
+     *
+     * @covers \Magento\Store\Model\Store::getBaseUrl
+     * @covers \Magento\Store\Model\Store::getCode
+     * @covers \Magento\Store\Model\Store::_updatePathUseRewrites
+     * @covers \Magento\Store\Model\Store::getConfig
+     *
+     * @param string $type
+     * @param boolean $secure
+     * @param boolean $isCustomEntryPoint
+     * @param string $expectedPath
+     * @param string $expectedBaseUrl
      */
-    public function testGetBaseUrlFromCli()
-    {
-        $expectedPath = 'web/unsecure/base_link_url';
-        $expectedBaseUrl = 'http://domain.com/web/unsecure/base_link_url/';
+    public function testGetBaseUrlFromCli(
+        $type,
+        $secure,
+        $isCustomEntryPoint,
+        $expectedPath,
+        $expectedBaseUrl
+    ) {
         /** @var \Magento\Framework\App\Config\ReinitableConfigInterface $configMock */
         $configMock = $this->getMockForAbstractClass(ReinitableConfigInterface::class);
         $configMock->expects($this->atLeastOnce())
             ->method('getValue')
-            ->willReturnCallback(function ($path, $scope, $scopeCode) use ($expectedPath) {
-                return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
+            ->willReturnCallback(function ($path, $scope, $scopeCode) use ($secure, $expectedPath) {
+                $url = $secure ? '{{base_url}}' : 'http://domain.com/';
+                return $expectedPath == $path ? $url . $path . '/' : null;
             });
-        $this->requestMock->expects($this->once())
+        $this->requestMock->expects($this->any())
             ->method('getOriginalPathInfo')
             ->willReturn('');
 
@@ -460,7 +475,7 @@ class StoreTest extends TestCase
             Store::class,
             [
                 'config' => $configMock,
-                'isCustomEntryPoint' => false,
+                'isCustomEntryPoint' => $isCustomEntryPoint,
                 'request' => $this->requestMock
             ]
         );
@@ -470,8 +485,38 @@ class StoreTest extends TestCase
 
         $this->assertEquals(
             $expectedBaseUrl,
-            $model->getBaseUrl(UrlInterface::URL_TYPE_LINK, false)
+            $model->getBaseUrl($type, $secure)
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function getCliBaseUrlDataProvider()
+    {
+        return [
+            [
+                UrlInterface::URL_TYPE_LINK,
+                false,
+                false,
+                'web/unsecure/base_link_url',
+                'http://domain.com/web/unsecure/base_link_url/server.php/'
+            ],
+            [
+                UrlInterface::URL_TYPE_DIRECT_LINK,
+                false,
+                false,
+                'web/unsecure/base_link_url',
+                'http://domain.com/web/unsecure/base_link_url/server.php/'
+            ],
+            [
+                UrlInterface::URL_TYPE_LINK,
+                true,
+                false,
+                'web/secure/base_link_url',
+                'web/secure/base_link_url/server.php/'
+            ],
+        ];
     }
 
     public function testGetBaseUrlWrongType()

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -98,7 +98,6 @@ class StoreTest extends TestCase
             'getDistroBaseUrl',
             'isSecure',
             'getServer',
-            'getOriginalPathInfo'
         ]);
 
         $this->filesystemMock = $this->createMock(Filesystem::class);
@@ -410,8 +409,7 @@ class StoreTest extends TestCase
             ->willReturnCallback(function ($path, $scope, $scopeCode) use ($expectedPath) {
                 return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
             });
-
-        $this->requestMock->expects($this->exactly(2))
+        $this->requestMock->expects($this->once())
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
             ->willReturn('test_script.php');
@@ -436,42 +434,34 @@ class StoreTest extends TestCase
     }
 
     /**
-     * @dataProvider getCliBaseUrlDataProvider
+     * Entry point appended to the base URL when web server rewrites are disabled
      *
      * @covers \Magento\Store\Model\Store::getBaseUrl
-     * @covers \Magento\Store\Model\Store::getCode
      * @covers \Magento\Store\Model\Store::_updatePathUseRewrites
-     * @covers \Magento\Store\Model\Store::getConfig
      *
-     * @param string $type
-     * @param boolean $secure
-     * @param boolean $isCustomEntryPoint
-     * @param string $expectedPath
+     * @param string|null $scriptFilename
+     * @param bool $isCustomEntryPoint
      * @param string $expectedBaseUrl
+     * @return void
      */
-    public function testGetBaseUrlFromCli(
-        $type,
-        $secure,
+    #[DataProvider('getBaseUrlEntryPointDataProvider')]
+    public function testGetBaseUrlEntryPointResolution(
+        $scriptFilename,
         $isCustomEntryPoint,
-        $expectedPath,
         $expectedBaseUrl
     ) {
-        /** @var \Magento\Framework\App\Config\ReinitableConfigInterface $configMock */
-        $configMock = $this->getMockForAbstractClass(ReinitableConfigInterface::class);
+        $expectedPath = 'web/unsecure/base_link_url';
+        /** @var ReinitableConfigInterface $configMock */
+        $configMock = $this->createMock(ReinitableConfigInterface::class);
         $configMock->expects($this->atLeastOnce())
             ->method('getValue')
-            ->willReturnCallback(function ($path, $scope, $scopeCode) use ($secure, $expectedPath) {
-                $url = $secure ? '{{base_url}}' : 'http://domain.com/';
-                return $expectedPath == $path ? $url . $path . '/' : null;
+            ->willReturnCallback(function ($path, $scope, $scopeCode) use ($expectedPath) {
+                return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
             });
-        $this->requestMock->expects($this->any())
-            ->method('getDistroBaseUrl')
-            ->willReturn('http://distro.com/');
-
         $this->requestMock->expects($this->any())
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
-            ->willReturn('bin/magento');
+            ->willReturn($scriptFilename);
 
         /** @var Store $model */
         $model = $this->objectManagerHelper->getObject(
@@ -488,36 +478,47 @@ class StoreTest extends TestCase
 
         $this->assertEquals(
             $expectedBaseUrl,
-            $model->getBaseUrl($type, $secure)
+            $model->getBaseUrl(UrlInterface::URL_TYPE_LINK, false)
         );
     }
 
     /**
      * @return array
      */
-    public function getCliBaseUrlDataProvider()
+    public static function getBaseUrlEntryPointDataProvider()
     {
+        $baseUrl = 'http://domain.com/web/unsecure/base_link_url/';
+
         return [
-            [
-                UrlInterface::URL_TYPE_LINK,
+            'web request through the default entry point' => [
+                '/var/www/html/pub/index.php',
                 false,
-                false,
-                'web/unsecure/base_link_url',
-                'http://domain.com/web/unsecure/base_link_url/'
+                $baseUrl . 'index.php/',
             ],
-            [
-                UrlInterface::URL_TYPE_DIRECT_LINK,
+            'web request through a custom entry point script' => [
+                '/var/www/html/pub/custom_entry.php',
                 false,
-                false,
-                'web/unsecure/base_link_url',
-                'http://domain.com/web/unsecure/base_link_url/'
+                $baseUrl . 'custom_entry.php/',
             ],
-            [
-                UrlInterface::URL_TYPE_LINK,
+            'console command executed via bin/magento' => [
+                '/var/www/html/bin/magento',
+                false,
+                $baseUrl . 'index.php/',
+            ],
+            'entry point forced by the custom_entry_point parameter' => [
+                '/var/www/html/bin/magento',
                 true,
+                $baseUrl . 'index.php/',
+            ],
+            'empty SCRIPT_FILENAME' => [
+                '',
                 false,
-                'web/secure/base_link_url',
-                'http://distro.com/web/secure/base_link_url/'
+                $baseUrl . 'index.php/',
+            ],
+            'missing SCRIPT_FILENAME' => [
+                null,
+                false,
+                $baseUrl . 'index.php/',
             ],
         ];
     }

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -410,10 +410,8 @@ class StoreTest extends TestCase
             ->willReturnCallback(function ($path, $scope, $scopeCode) use ($expectedPath) {
                 return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
             });
-        $this->requestMock->expects($this->once())
-            ->method('getOriginalPathInfo')
-            ->willReturn('test.html');
-        $this->requestMock->expects($this->once())
+
+        $this->requestMock->expects($this->exactly(2))
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
             ->willReturn('test_script.php');
@@ -467,8 +465,9 @@ class StoreTest extends TestCase
                 return $expectedPath == $path ? $url . $path . '/' : null;
             });
         $this->requestMock->expects($this->any())
-            ->method('getOriginalPathInfo')
-            ->willReturn('');
+            ->method('getServer')
+            ->with('SCRIPT_FILENAME')
+            ->willReturn('bin/magento');
 
         /** @var Store $model */
         $model = $this->objectManagerHelper->getObject(
@@ -500,21 +499,21 @@ class StoreTest extends TestCase
                 false,
                 false,
                 'web/unsecure/base_link_url',
-                'http://domain.com/web/unsecure/base_link_url/server.php/'
+                'http://domain.com/web/unsecure/base_link_url/'
             ],
             [
                 UrlInterface::URL_TYPE_DIRECT_LINK,
                 false,
                 false,
                 'web/unsecure/base_link_url',
-                'http://domain.com/web/unsecure/base_link_url/server.php/'
+                'http://domain.com/web/unsecure/base_link_url/'
             ],
             [
                 UrlInterface::URL_TYPE_LINK,
                 true,
                 false,
                 'web/secure/base_link_url',
-                'web/secure/base_link_url/server.php/'
+                'web/secure/base_link_url/'
             ],
         ];
     }

--- a/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
+++ b/app/code/Magento/Store/Test/Unit/Model/StoreTest.php
@@ -98,6 +98,7 @@ class StoreTest extends TestCase
             'getDistroBaseUrl',
             'isSecure',
             'getServer',
+            'getOriginalPathInfo'
         ]);
 
         $this->filesystemMock = $this->createMock(Filesystem::class);
@@ -410,9 +411,49 @@ class StoreTest extends TestCase
                 return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
             });
         $this->requestMock->expects($this->once())
+            ->method('getOriginalPathInfo')
+            ->willReturn('web/unsecure/base_link_url/test_script.php/');
+        $this->requestMock->expects($this->once())
             ->method('getServer')
             ->with('SCRIPT_FILENAME')
             ->willReturn('test_script.php');
+
+        /** @var Store $model */
+        $model = $this->objectManagerHelper->getObject(
+            Store::class,
+            [
+                'config' => $configMock,
+                'isCustomEntryPoint' => false,
+                'request' => $this->requestMock
+            ]
+        );
+        $model->setCode('scopeCode');
+
+        $this->setUrlModifier($model);
+
+        $this->assertEquals(
+            $expectedBaseUrl,
+            $model->getBaseUrl(UrlInterface::URL_TYPE_LINK, false)
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetBaseUrlFromCli()
+    {
+        $expectedPath = 'web/unsecure/base_link_url';
+        $expectedBaseUrl = 'http://domain.com/web/unsecure/base_link_url/';
+        /** @var \Magento\Framework\App\Config\ReinitableConfigInterface $configMock */
+        $configMock = $this->getMockForAbstractClass(ReinitableConfigInterface::class);
+        $configMock->expects($this->atLeastOnce())
+            ->method('getValue')
+            ->willReturnCallback(function ($path, $scope, $scopeCode) use ($expectedPath) {
+                return $expectedPath == $path ? 'http://domain.com/' . $path . '/' : null;
+            });
+        $this->requestMock->expects($this->once())
+            ->method('getOriginalPathInfo')
+            ->willReturn('');
 
         /** @var Store $model */
         $model = $this->objectManagerHelper->getObject(


### PR DESCRIPTION
### Description

With **Use Web Server Rewrites** disabled, URLs generated outside a web request get the console binary as their entry point — `https://example.com/magento/catalog/...` instead of `https://example.com/index.php/catalog/...`. This affects anything that builds URLs from the CLI: transactional emails sent by cron, sitemap generation, indexers, custom commands.

`Magento\Store\Model\Store::_updatePathUseRewrites()` takes the entry point straight from the running script:

```php
$scriptFilename = $this->_request->getServer('SCRIPT_FILENAME');
$indexFileName = is_string($scriptFilename) ? basename($scriptFilename) : '';
```

Under `bin/magento` that basename is `magento`, which is not a front controller at all.

### Fix

Rather than trying to detect the execution context, this validates the result: if the resolved entry point is not a `.php` script it cannot be a web front controller, so fall back to `index.php` — exactly the value the `_isCustomEntryPoint()` branch two lines above already produces.

```php
if (!str_ends_with(strtolower($indexFileName), '.php')) {
    // The running script is not a web entry point (CLI, cron, unknown) - use the default one
    $indexFileName = 'index.php';
}
```

A `.php` filename is passed through byte-for-byte, so every real web request — `pub/index.php`, `pub/get.php`, `pub/static.php`, `pub/cron.php`, and any custom entry point — is untouched. This also fixes the empty case, which previously emitted a double slash (`https://example.com/link//`).

That `index.php` is the right answer here is already encoded in the test framework: `dev/tests/integration/framework/Magento/TestFramework/Bootstrap/Environment.php:24` fakes `SCRIPT_FILENAME = 'index.php'` precisely because the real CLI value is unusable, and `Magento/Framework/UrlTest.php:45` asserts `http://localhost/index.php/`.

### Why not detect the CLI directly

`PHP_SAPI === 'cli'` looks like the obvious fix and there is core precedent for it, but it is wrong for this method: the unit and integration suites all run under the `cli` SAPI while deliberately emulating web requests. `StoreTest::testGetBaseUrlEntryPoint` and the integration `testGetBaseUrlForCustomEntryPoint` both assert web behaviour from a CLI process, so a SAPI check would break them and make the branch untestable.

Setting `Store::CUSTOM_ENTRY_POINT_PARAM` from the console entry point was the other candidate. The natural hook is `Magento\Framework\Console\Cli`, but referencing `Magento\Store\Model\Store` from `lib/internal/Magento/Framework` is forbidden by the library dependency static test, and doing it in `bin/magento` means writing to `$_SERVER`. It would also fix nothing for third-party scripts that bootstrap Magento themselves.

### This PR continues #34639

Rebased onto current `2.4-develop`, preserving the commits of @rmsundar1 and @engcom-Bravo.

One correction worth recording, since it is why the original stalled. @ihor-sviziev's "It doesn't look real example" was right: the branch tested `SCRIPT_FILENAME !== 'bin/magento'`, a strict comparison against a relative literal, while the real CLI value is an absolute path such as `/var/www/html/bin/magento` — so the condition never matched and the fix never fired. That comparison was not @rmsundar1's original approach; his commit used `getOriginalPathInfo()` as the "not a web request" signal (right instinct, wrong signal — it is legitimately empty for a homepage request), and the literal was introduced later while chasing test failures. Both are replaced here.

### Fixed Issues

Fixes magento/magento2#25976

### Manual testing scenarios

1. Set **Stores > Configuration > General > Web > Search Engine Optimization > Use Web Server Rewrites** to **No**.
2. From the CLI, generate a URL — e.g. run a cron job that sends a transactional email containing a store link, or `bin/magento sitemap:generate`.
3. **Before:** links contain `/magento/`. **After:** links contain `/index.php/`.
4. Load any storefront page and confirm URLs are unchanged (still `/index.php/...` from a normal web request).
5. Configure a custom entry point (e.g. `custom_entry.php`) and confirm it is still used verbatim for web requests.

### Questions or comments

Gates run locally on `2.4-develop` (Warden, PHP 8.3):

- Unit: `Store/Test/Unit/Model/StoreTest.php` — 49 tests pass, including a new six-case data provider covering a default web entry point, a custom web entry point, an absolute CLI path, the custom-entry-point flag, and empty/missing `SCRIPT_FILENAME`.
- Integration: `Magento/Store/Model/StoreTest.php` + `Magento/Framework/UrlTest.php` — 96 tests pass. These are the ones that emulate web requests from a CLI process, so they are the real regression check for this change.
- PHPCS `Magento2`: clean. PHPStan level 1: no errors.
- Negative check: three of the six new cases fail against unpatched `Store.php` (yielding `magento/` and `//`) and pass with the fix; the other three pass both before and after, pinning the no-change guarantee for web requests.

No signature changes — `Store` stays `@api`-compatible, with no new constructor parameter or DI wiring.

One theoretical case for a second opinion: hosting where the front controller has no `.php` extension would now get `index.php` instead of that name. I could not construct such a setup for Magento (all shipped entry points are `.php`, and rewrite-based extensionless URLs still report the `.php` file in `SCRIPT_FILENAME`), and `index.php` is the correct front controller there anyway — but it is the one behaviour change outside CLI beyond the empty-value case.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
