### PR TITLE
Fix configurable/options quote item qty doubling in Quote::updateItem

### DIFF
--- a/app/code/Magento/Quote/Model/Quote.php
+++ b/app/code/Magento/Quote/Model/Quote.php
@@ -1831,6 +1831,12 @@ class Quote extends AbstractExtensibleModel implements \Magento\Quote\Api\Data\C
         $buyRequest = $this->_catalogProduct->addParamsToBuyRequest($buyRequest, $params);
 
         $buyRequest->setResetCount(true);
+        // The reset above is only applied by Item\Processor when the buy request carries the id of
+        // the item being updated. The request rebuilt from an options product (e.g. configurable)
+        // has none, so without this the item qty is doubled on re-add instead of reset-then-set.
+        if ($buyRequest->getId() === null) {
+            $buyRequest->setId($itemId);
+        }
         $resultItem = $this->addProduct($product, $buyRequest);
 
         if (is_string($resultItem)) {


### PR DESCRIPTION
### Description

`Magento\Quote\Model\Quote::updateItem()` calls `$buyRequest->setResetCount(true)` immediately before re-adding the item via `addProduct()`, so that `Quote\Item\Processor::prepare()` / `init()` zero the item's qty before `Item::addQty()` re-applies it. That reset guard is:

```php
$request->getResetCount() && !$candidate->getStickWithinParent() && $item->getId() == $request->getId()
```

For an **options product** (configurable / bundle / downloadable / custom-options) the buy request rebuilt by the type's `CartItemProcessor::convertToBuyRequest()` carries **no `id`** (only `super_attribute` + `qty`; `Catalog\Helper\Product::addParamsToBuyRequest()` adds only `_processing_params`). So `$request->getId()` is `null`, the id comparison never matches, the reset never fires, and `Item::addQty()` **accumulates** the parent qty (`1 → 2`) instead of resetting it.

`updateItem()` does correct the qty a few lines later (`$resultItem->setQty($buyRequest->getQty())`), but the `sales_quote_item_qty_set_after` validator runs **inside** `addProduct()` first. So when an active quote holding such an item is re-saved and that item's **salable qty is 1**, the salability check sees `requestedQty = 2 > available = 1` and throws *"Not enough items for sale"* (`Quote::addProductAdvanced()`) **before** the correction runs. The persisted qty stays 1, so the cart looks fine, but the operation fails.

This is easy to hit on storefronts that re-persist the quote on checkout load (e.g. Hyvä Checkout's `hyva_checkout_init_after` → `cartRepository->save()`), where it presents as *"Something went wrong while trying to load the checkout."* for every configurable variant sitting at its last unit.

**Why it surfaces now:** `ACSD-46869` changed `Quote\Item\CartItemPersister` to call `updateItem()` whenever the quote is active (previously only when the qty changed). Under the old guard an unchanged-qty re-save skipped `updateItem()` and the latent doubling never fired.

**Fix:** stamp the id of the item being updated onto the buy request, so `updateItem()`'s own `setResetCount(true)` actually takes effect:

```php
$buyRequest->setResetCount(true);
if ($buyRequest->getId() === null) {
    $buyRequest->setId($itemId);
}
$resultItem = $this->addProduct($product, $buyRequest);
```

The change is safe and narrowly scoped:
- `Processor::init()` creates a fresh item whose `getId()` is `null`, so a stamped id can only make the guard match the **existing** item being updated (`prepare()`), never mis-reset a newly created one.
- Healthy carts end identically — `updateItem()`'s trailing `setQty($buyRequest->getQty())` already targets the buy-request qty; only the phantom transient doubling is removed.
- A genuine last unit (available 1, requested 1) now succeeds; a real over-order (requested 2 vs available 1) still correctly throws.
- `ACSD-46869` is preserved: configurable option edits with an unchanged qty still persist, because `updateItem()` still runs and re-applies the options.

### Fixed Issues (related)

- #15494
- #18812
- #33425
- #38949

### Manual testing scenarios

Preconditions: a configurable product whose selected child's salable qty is **1**; backorders off.

1. Add the configurable variant to the cart at qty **1** → succeeds (a fresh item goes `0 → 1`).
2. Re-save the active quote (e.g. `POST/PUT` the item again via `V1/guest-carts/{cartId}/items`, or `$cartRepository->save($quote)` — what a checkout that re-persists on load does).
   - **Before:** HTTP 400 / `LocalizedException` *"Not enough items for sale"* (or *"Only 1 of 2 available"* when `cataloginventory/options/not_available_message = 1`); the salability check receives `requestedQty = 2` for `available = 1`.
   - **After:** succeeds; the item qty stays **1**.
3. Regression: cart qty **2** vs available **1** still throws; a plain simple product at salable qty 1 still checks out; editing a configurable's option with an unchanged qty still persists the new option.

<details>
<summary>Proposed integration test (not yet executed against CI — needs the child's MSI source qty set to 1 in the target env)</summary>

```php
/**
 * A configurable/options item must not have its qty doubled when the quote is re-saved
 * (Quote::updateItem re-adds it with a buy request that carries no item id).
 *
 * @magentoDataFixture Magento/ConfigurableProduct/_files/quote_with_configurable_product.php
 */
public function testUpdateItemDoesNotDoubleConfigurableQtyOnResave(): void
{
    // Set the selected child (simple_10) salable qty to exactly 1 in the target env
    // (via source-item save under MSI, or stock_data at fixture time).
    // ... stock setup ...

    $quote = $this->getQuoteByReservedOrderId->execute('test_cart_with_configurable');
    $this->assertEquals(1.0, $quote->getAllVisibleItems()[0]->getQty());

    // Re-persisting an active quote re-runs Quote::updateItem for the configurable line.
    $this->cartRepository->save($quote);

    $reloaded = $this->getQuoteByReservedOrderId->execute('test_cart_with_configurable');
    $this->assertEquals(
        1.0,
        $reloaded->getAllVisibleItems()[0]->getQty(),
        'Configurable qty must not be doubled when the quote is re-saved.'
    );
}
```

Note: the existing `QuoteTest::testAddProductUpdateItem` does not catch this because it uses an **unsaved** quote with `id => 0`, where `null == 0` makes the reset fire by accident. The reproduction requires a **persisted** quote (real item ids) whose child salable qty is 1.
</details>

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (proposed test above; not yet validated in CI)
- [x] All automated tests passed successfully (CI to run)
