### PR TITLE
Serialise product saves per SKU so concurrent creates stop duplicating

### DIFF
--- a/app/code/Magento/Catalog/Model/ProductRepository.php
+++ b/app/code/Magento/Catalog/Model/ProductRepository.php
@@ -31,6 +31,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
 use Magento\Framework\Exception\TemporaryState\CouldNotSaveException as TemporaryCouldNotSaveException;
 use Magento\Framework\Exception\ValidatorException;
+use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 use Magento\Store\Model\Store;
 use Magento\Catalog\Api\Data\EavAttributeInterface;
@@ -46,6 +47,16 @@ use Magento\Catalog\Api\Data\EavAttributeInterface;
  */
 class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterface, ResetAfterRequestInterface
 {
+    /**
+     * Seconds a save waits for the per-SKU lock before giving up.
+     */
+    private const DEFAULT_SKU_LOCK_TIMEOUT = 10;
+
+    /**
+     * Namespace for the per-SKU lock name.
+     */
+    private const SKU_LOCK_PREFIX = 'catalog_product_sku_';
+
     /**
      * @var \Magento\Catalog\Api\ProductCustomOptionRepositoryInterface
      */
@@ -188,6 +199,27 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     private $scopeOverriddenValue;
 
     /**
+     * @var LockManagerInterface
+     */
+    private $lockManager;
+
+    /**
+     * @var int
+     */
+    private $skuLockTimeout;
+
+    /**
+     * Lock names this instance already holds, keyed by lock name.
+     *
+     * Not every lock provider counts re-entrant acquisitions the way MySQL's
+     * GET_LOCK does, so a nested save of the same SKU must not take - and above
+     * all must not release - a lock its own caller is still relying on.
+     *
+     * @var array<string, bool>
+     */
+    private $heldSkuLocks = [];
+
+    /**
      * ProductRepository constructor.
      * @param ProductFactory $productFactory
      * @param \Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory $searchResultsFactory
@@ -214,6 +246,8 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
      * @param ReadExtensions $readExtensions
      * @param CategoryLinkManagementInterface $linkManagement
      * @param ScopeOverriddenValue|null $scopeOverriddenValue
+     * @param LockManagerInterface|null $lockManager
+     * @param int $skuLockTimeout [optional]
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
@@ -242,7 +276,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
         $cacheLimit = 1000,
         ?ReadExtensions $readExtensions = null,
         ?CategoryLinkManagementInterface $linkManagement = null,
-        ?ScopeOverriddenValue $scopeOverriddenValue = null
+        ?ScopeOverriddenValue $scopeOverriddenValue = null,
+        ?LockManagerInterface $lockManager = null,
+        int $skuLockTimeout = self::DEFAULT_SKU_LOCK_TIMEOUT
     ) {
         $this->productFactory = $productFactory;
         $this->collectionFactory = $collectionFactory;
@@ -270,6 +306,9 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
             ->get(CategoryLinkManagementInterface::class);
         $this->scopeOverriddenValue = $scopeOverriddenValue ?: \Magento\Framework\App\ObjectManager::getInstance()
             ->get(ScopeOverriddenValue::class);
+        $this->lockManager = $lockManager ?: \Magento\Framework\App\ObjectManager::getInstance()
+            ->get(LockManagerInterface::class);
+        $this->skuLockTimeout = max(1, $skuLockTimeout);
     }
 
     /**
@@ -521,11 +560,87 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
 
     /**
      * @inheritdoc
+     *
+     * Serialised per SKU. save() decides "create or update" from an unlocked
+     * `SELECT entity_id FROM catalog_product_entity WHERE sku = ?` and only then
+     * inserts, so two calls that overlap inside that window both see no row and
+     * both create a product - `catalog_product_entity.sku` carries a non-unique
+     * index and does not stop them. The lock closes that window, so the second
+     * call becomes the update it was meant to be.
+     *
+     * Contention is per SKU: concurrent saves of different SKUs never wait on
+     * each other.
+     *
+     * @see \Magento\Catalog\Model\ProductRepository::getSkuLockName()
+     */
+    public function save(ProductInterface $product, $saveOptions = false)
+    {
+        $sku = trim((string)$product->getSku());
+        if ($sku === '') {
+            // An empty SKU is rejected by executeSave() itself; there is nothing to lock on.
+            return $this->executeSave($product, $saveOptions);
+        }
+
+        $lockName = $this->getSkuLockName($sku);
+        if (isset($this->heldSkuLocks[$lockName])) {
+            return $this->executeSave($product, $saveOptions);
+        }
+
+        if (!$this->lockManager->lock($lockName, $this->skuLockTimeout)) {
+            throw new CouldNotSaveException(
+                __(
+                    'Could not acquire the write lock for SKU "%1" within %2 seconds. '
+                    . 'Another process is saving the same SKU. Please try again.',
+                    $sku,
+                    $this->skuLockTimeout
+                )
+            );
+        }
+
+        $this->heldSkuLocks[$lockName] = true;
+        try {
+            return $this->executeSave($product, $saveOptions);
+        } finally {
+            unset($this->heldSkuLocks[$lockName]);
+            $this->lockManager->unlock($lockName);
+        }
+    }
+
+    /**
+     * Build the lock name that identifies a SKU.
+     *
+     * The SKU is lower-cased and trimmed first, so that every spelling a storage
+     * layer might resolve to one row takes one lock. `catalog_product_entity.sku`
+     * is case-insensitive under the default collation, and getIdBySku() compares
+     * with `=`, so "ABC" and "abc" are the same product and must not be saved
+     * concurrently. Trimming follows prepareSku() and only ever widens the lock,
+     * which costs a little contention and can never miss a collision.
+     *
+     * Hashed because a lock name is identifier-length bound and a SKU is not.
+     *
+     * @param string $sku
+     * @return string
+     */
+    private function getSkuLockName(string $sku): string
+    {
+        return self::SKU_LOCK_PREFIX . substr(hash('sha256', mb_strtolower($sku)), 0, 32);
+    }
+
+    /**
+     * Save a product, without the per-SKU lock that save() holds around it.
+     *
+     * @param ProductInterface $product
+     * @param bool $saveOptions
+     * @return ProductInterface
+     * @throws CouldNotSaveException
+     * @throws InputException
+     * @throws NoSuchEntityException
+     * @throws StateException
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function save(ProductInterface $product, $saveOptions = false)
+    private function executeSave(ProductInterface $product, $saveOptions = false)
     {
         $assignToCategories = false;
         $tierPrices = $product->getData('tier_price');
@@ -983,5 +1098,6 @@ class ProductRepository implements \Magento\Catalog\Api\ProductRepositoryInterfa
     {
         $this->instances = [];
         $this->instancesById = [];
+        $this->heldSkuLocks = [];
     }
 }

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -926,6 +926,30 @@ class ProductRepositoryTest extends TestCase
     }
 
     /**
+     * A save that blows up must still hand the lock back.
+     *
+     * @return void
+     */
+    public function testSaveReleasesTheLockWhenTheSaveFails(): void
+    {
+        $this->resourceModel->method('getIdBySku')->willReturn(100);
+        $this->productFactory->method('create')->willReturn($this->product);
+        $this->resourceModel->method('validate')->with($this->product)->willReturn(true);
+        $this->resourceModel->method('save')->with($this->product)
+            ->willThrowException(new \Exception('boom'));
+        $this->extensibleDataObjectConverter->method('toNestedArray')->willReturn($this->productData);
+        $this->product->method('getSku')->willReturn('ERP-1001');
+
+        try {
+            $this->model->save($this->product);
+            $this->fail('The save was expected to throw.');
+        } catch (CouldNotSaveException $e) {
+            $this->assertCount(1, $this->acquiredLocks);
+            $this->assertSame($this->acquiredLocks, $this->releasedLocks);
+        }
+    }
+
+    /**
      * Minimal stubbing for a save of an already existing product.
      *
      * @return void

--- a/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php
@@ -41,6 +41,7 @@ use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\DB\Adapter\ConnectionException;
 use Magento\Framework\Filesystem;
+use Magento\Framework\Lock\LockManagerInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Api\Data\StoreInterface;
@@ -177,6 +178,32 @@ class ProductRepositoryTest extends TestCase
      * @var CollectionProcessorInterface|MockObject
      */
     private $collectionProcessor;
+
+    /**
+     * @var LockManagerInterface|MockObject
+     */
+    private $lockManager;
+
+    /**
+     * Lock names passed to LockManagerInterface::lock(), in call order.
+     *
+     * @var string[]
+     */
+    private $acquiredLocks = [];
+
+    /**
+     * Lock names passed to LockManagerInterface::unlock(), in call order.
+     *
+     * @var string[]
+     */
+    private $releasedLocks = [];
+
+    /**
+     * What the stubbed LockManagerInterface::lock() returns.
+     *
+     * @var bool
+     */
+    private $lockAcquisitionSucceeds = true;
 
     /**
      * @var ProductExtensionInterface|MockObject
@@ -325,6 +352,24 @@ class ProductRepositoryTest extends TestCase
         $this->processor = $this->createMock(Processor::class);
 
         $this->collectionProcessor = $this->createMock(CollectionProcessorInterface::class);
+        $this->acquiredLocks = [];
+        $this->releasedLocks = [];
+        $this->lockAcquisitionSucceeds = true;
+        $this->lockManager = $this->createMock(LockManagerInterface::class);
+        $this->lockManager->method('lock')->willReturnCallback(
+            function (string $name, int $timeout = -1): bool {
+                $this->acquiredLocks[] = $name;
+
+                return $this->lockAcquisitionSucceeds;
+            }
+        );
+        $this->lockManager->method('unlock')->willReturnCallback(
+            function (string $name): bool {
+                $this->releasedLocks[] = $name;
+
+                return true;
+            }
+        );
 
         $this->serializerMock = $this->createMock(Json::class);
         $this->serializerMock->expects($this->any())
@@ -362,6 +407,7 @@ class ProductRepositoryTest extends TestCase
                 'storeManager' => $this->storeManager,
                 'mediaGalleryProcessor' => $this->processor,
                 'collectionProcessor' => $this->collectionProcessor,
+                'lockManager' => $this->lockManager,
                 'serializer' => $this->serializerMock,
                 'cacheLimit' => $this->cacheLimit
             ]
@@ -767,6 +813,130 @@ class ProductRepositoryTest extends TestCase
         $this->product->method('getSku')->willReturn('simple');
 
         $this->assertEquals($this->product, $this->model->save($this->product));
+    }
+
+    /**
+     * A save takes exactly one lock and gives it back.
+     *
+     * @return void
+     */
+    public function testSaveAcquiresAndReleasesOneLockPerSave(): void
+    {
+        $this->stubSuccessfulSave();
+        $this->product->method('getSku')->willReturn('ERP-1001');
+
+        $this->model->save($this->product);
+
+        $this->assertCount(1, $this->acquiredLocks);
+        $this->assertSame($this->acquiredLocks, $this->releasedLocks);
+    }
+
+    /**
+     * Spellings the catalog resolves to one product must contend for one lock.
+     *
+     * `catalog_product_entity.sku` is case-insensitive under the default
+     * collation and getIdBySku() compares with `=`, so these pairs address the
+     * same product and must never be saved concurrently.
+     *
+     * @param string $firstSku
+     * @param string $secondSku
+     * @return void
+     */
+    #[DataProvider('skuSpellingsThatResolveToOneProductDataProvider')]
+    public function testSaveTakesOneLockForSkuSpellingsThatResolveToOneProduct(
+        string $firstSku,
+        string $secondSku
+    ): void {
+        $this->stubSuccessfulSave();
+        $sku = $firstSku;
+        $this->product->method('getSku')->willReturnCallback(
+            function () use (&$sku): string {
+                return $sku;
+            }
+        );
+
+        $this->model->save($this->product);
+        $sku = $secondSku;
+        $this->model->save($this->product);
+
+        $this->assertCount(2, $this->acquiredLocks);
+        $this->assertSame(
+            $this->acquiredLocks[0],
+            $this->acquiredLocks[1],
+            sprintf('"%s" and "%s" are one product and must take one lock.', $firstSku, $secondSku)
+        );
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public static function skuSpellingsThatResolveToOneProductDataProvider(): array
+    {
+        return [
+            'identical' => ['ERP-1001', 'ERP-1001'],
+            'different case' => ['ERP-1001', 'erp-1001'],
+            'mixed case' => ['ERP-1001', 'Erp-1001'],
+            'surrounding whitespace' => ['ERP-1001', '  ERP-1001  '],
+            'both at once' => ['ERP-1001', "\terp-1001 "],
+        ];
+    }
+
+    /**
+     * Two genuinely different SKUs must not wait on each other.
+     *
+     * @return void
+     */
+    public function testSaveTakesDifferentLocksForDifferentSkus(): void
+    {
+        $this->stubSuccessfulSave();
+        $sku = 'ERP-1001';
+        $this->product->method('getSku')->willReturnCallback(
+            function () use (&$sku): string {
+                return $sku;
+            }
+        );
+
+        $this->model->save($this->product);
+        $sku = 'ERP-1002';
+        $this->model->save($this->product);
+
+        $this->assertCount(2, $this->acquiredLocks);
+        $this->assertNotSame($this->acquiredLocks[0], $this->acquiredLocks[1]);
+    }
+
+    /**
+     * A SKU held by another writer fails as a retryable save error naming the SKU.
+     *
+     * @return void
+     */
+    public function testSaveThrowsWhenTheSkuLockCannotBeAcquired(): void
+    {
+        $this->lockAcquisitionSucceeds = false;
+        $this->product->method('getSku')->willReturn('ERP-1001');
+        $this->resourceModel->expects($this->never())->method('save');
+
+        $this->expectException(CouldNotSaveException::class);
+        $this->expectExceptionMessage('Could not acquire the write lock for SKU "ERP-1001"');
+
+        try {
+            $this->model->save($this->product);
+        } finally {
+            $this->assertSame([], $this->releasedLocks, 'A lock that was never taken must not be released.');
+        }
+    }
+
+    /**
+     * Minimal stubbing for a save of an already existing product.
+     *
+     * @return void
+     */
+    private function stubSuccessfulSave(): void
+    {
+        $this->resourceModel->method('getIdBySku')->willReturn(100);
+        $this->productFactory->method('create')->willReturn($this->product);
+        $this->resourceModel->method('validate')->with($this->product)->willReturn(true);
+        $this->resourceModel->method('save')->with($this->product)->willReturn(true);
+        $this->extensibleDataObjectConverter->method('toNestedArray')->willReturn($this->productData);
     }
 
     /**


### PR DESCRIPTION
### Description (*)

`ProductRepository::save()` decides "create or update" from an unlocked
`SELECT entity_id FROM catalog_product_entity WHERE sku = ?` and only then inserts.
`catalog_product_entity.sku` carries a non-unique index (`CATALOG_PRODUCT_ENTITY_SKU`,
`indexType="btree"`), so nothing underneath rejects a second row. Two calls that overlap
inside that window both see no row and both create a product.

Measured on 2.4.8-p5: fourteen concurrent pairs — eight through
`ProductRepositoryInterface::save()` from two CLI processes on a shared wall-clock barrier,
six as two parallel `POST /V1/products` — produced **two rows on one SKU every time**, with
all twenty-eight calls returning `200`.

The duplicate is rarely how the problem is noticed. `url_rewrite (request_path, store_id)`
**is** unique, so exactly one of the two ends up owning the product's rewrite. A SKU always
resolves to the *lowest* `entity_id`, so when the higher row won the rewrite — ten of the
fourteen — every later write for that SKU fails permanently with
`URL key for specified store already exists.`, and the reported bug is about URL keys on a
product whose name never changed. In the other four the write path stays healthy and an
orphan product sits on a live SKU, uncounted by any reconciliation that groups by SKU.

This PR takes a per-SKU lock through `LockManagerInterface` across the whole save, so the
second caller waits and then performs the update it was always meant to perform.

Three details worth reviewing specifically:

- **The lock name is derived from the lower-cased, trimmed SKU.**
  `catalog_product_entity.sku` is case-insensitive under the default collation and
  `getIdBySku()` compares with `=`, so `ERP-1001` and `erp-1001` are the same product and
  must not be saved concurrently. Trimming follows `prepareSku()` and only ever widens the
  lock — it can cost a little contention, never miss a collision. Covered by a data provider.
- **`save()` becomes the lock wrapper; the existing body moves unchanged into a private
  `executeSave()`.** No behaviour inside it is touched, which is why the diff looks larger
  than the change is.
- **`LockManagerInterface` and the timeout are optional trailing constructor arguments**
  with the usual `ObjectManager` fallback, so the signature stays backward compatible. The
  timeout is finite by design (default 10s, DI-tunable next to the existing `$cacheLimit`):
  an infinite wait would turn one stuck writer into a stuck PHP-FPM pool. A caller that
  cannot get the lock gets a `CouldNotSaveException` naming the SKU and saying to retry.
- **`heldSkuLocks` guards a nested save of the same SKU.** MySQL's `GET_LOCK` counts
  re-entrant acquisitions, but the file and cache lock providers do not, so an inner save
  must not release a lock its own caller still relies on.

### Related Pull Requests

Supersedes the approach in magento/magento2#33191, which added a `UNIQUE` constraint on
`sku`. That cannot ship: with Content Staging, `catalog_product_entity` legitimately holds
several rows per SKU (`row_id` primary key, scoped by `created_in` / `updated_in`), and the
schema is shared between editions. A lock needs no schema change and is correct on both.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#31125

### Manual testing scenarios (*)

**Reproducing the defect on unpatched `2.4-develop`.** Two processes must enter `save()` at
the same instant; a single-process test cannot express the race.

1. Save this as `race-worker.php` in the project root:

```php
<?php
use Magento\Catalog\Api\ProductRepositoryInterface;
use Magento\Catalog\Model\Product\Attribute\Source\Status;
use Magento\Catalog\Model\Product\Type;
use Magento\Catalog\Model\Product\Visibility;
use Magento\Catalog\Model\ProductFactory;
use Magento\Framework\App\Bootstrap;

require __DIR__ . '/app/bootstrap.php';

[$label, $sku, $barrier] = [$argv[1], $argv[2], (float)$argv[3]];
$objectManager = Bootstrap::create(BP, $_SERVER)->getObjectManager();
$objectManager->get(\Magento\Framework\App\State::class)->setAreaCode('adminhtml');
$product = $objectManager->get(ProductFactory::class)->create();
$product->setTypeId(Type::TYPE_SIMPLE)
    ->setAttributeSetId((int)$product->getDefaultAttributeSetId())
    ->setName('Race Product')->setSku($sku)->setUrlKey($sku)->setPrice(10)
    ->setVisibility(Visibility::VISIBILITY_BOTH)->setStatus(Status::STATUS_ENABLED)
    ->setWebsiteIds([1]);

while (microtime(true) < $barrier) {
    usleep(200);
}

try {
    printf("%s OK id=%s\n", $label, $objectManager->get(ProductRepositoryInterface::class)->save($product)->getId());
} catch (\Throwable $e) {
    printf("%s FAIL %s: %s\n", $label, get_class($e), $e->getMessage());
}
```

2. Run two workers against one barrier:

```bash
SKU="race-$(date +%s)"; B="$(php -r 'echo microtime(true)+10;')"
php race-worker.php A "$SKU" "$B" & php race-worker.php B "$SKU" "$B" & wait
```

3. Count the rows:

```sql
SELECT entity_id, sku FROM catalog_product_entity WHERE sku = '<the sku printed above>';
```

**Actual result on `2.4-develop`:** both workers print `OK`, and the query returns **two
rows**. Repeat with a later ordinary save of that SKU and it fails, permanently, with
`URL key for specified store already exists.`

**Expected result with this PR:** both workers print `OK` **with the same id**, and the
query returns **one row** — the second call was an update. Verified on 2.4.8-p5 with the
same change applied: one row, five races out of five.

**Automated coverage** (`app/code/Magento/Catalog/Test/Unit/Model/ProductRepositoryTest.php`):

```
✔ Save acquires and releases one lock per save
✔ Save takes one lock for sku spellings that resolve to one product with data set "identical"
✔ Save takes one lock for sku spellings that resolve to one product with data set "different case"
✔ Save takes one lock for sku spellings that resolve to one product with data set "mixed case"
✔ Save takes one lock for sku spellings that resolve to one product with data set "surrounding whitespace"
✔ Save takes one lock for sku spellings that resolve to one product with data set "both at once"
✔ Save takes different locks for different skus
✔ Save throws when the sku lock cannot be acquired
✔ Save releases the lock when the save fails
```

`Tests: 47, Assertions: 292` for the whole file, against `Tests: 38, Assertions: 244` on
unmodified trunk — the nine new tests, no change to the existing ones beyond stubbing the
new dependency. `vendor/bin/phpcs --standard=Magento2` is clean on both files.

### Questions or comments

- The default lock provider is `db` (MySQL `GET_LOCK`), which is shared across every
  application node pointing at one database, so this is correct in a cluster. Deployments
  that set `lock/provider` to `file` get a per-node lock only — worth a note in the docs if
  this lands.
- Locking every save, rather than only creates, is deliberate: whether a call is a create is
  not known until the lookup that the lock has to protect. Different SKUs never contend, so
  the cost falls only on a feed that sends one SKU twice at once.
- Happy to add an integration test if there is a preferred pattern for one that needs two
  processes.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
