### PR TITLE
Fix cron:remove silently failing when the tasks block is the last crontab entry

### DIFF
--- a/lib/internal/Magento/Framework/Crontab/CrontabManager.php
+++ b/lib/internal/Magento/Framework/Crontab/CrontabManager.php
@@ -191,6 +191,10 @@ class CrontabManager implements CrontabManagerInterface
             return '';
         }
 
+        if ($content !== '' && !str_ends_with($content, PHP_EOL)) {
+            $content .= PHP_EOL;
+        }
+
         return $content;
     }
 


### PR DESCRIPTION
### Description

`bin/magento cron:remove` reports success but leaves the crontab unchanged when the Magento tasks block is the last entry and doesn't have an extra newline after it.

This happens because `cleanMagentoSection()` matches on the block end marker followed by `PHP_EOL`, but `Shell::execute()` returns `implode(PHP_EOL, $output)` from `exec()`, which never ends in a newline. So when the block is last, the pattern can't match and nothing gets removed.

On our CI platform this makes crons stack up, since the old ones never get removed even though `cron:remove` says they were.

The fix was really simple. We just pad the contents with a newline at the end if it doesn't already have one, inside `getCrontabContent()`.

### Manual testing scenarios

Without the fix, you can verify this is in fact a problem if your crontab content does not have an extra trailing newline at the end:

```console
$ crontab -l
#~ MAGENTO START 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
* * * * * /usr/bin/php8.5 /mnt/jrc-data/www/example.com/releases/2026-09-01-001/bin/magento cron:run >> /mnt/jrc-data/www/example.com/releases/2026-09-01-001/var/log/magento.cron.log 2>&1
#~ MAGENTO END 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
$ bin/magento cron:remove
Magento cron tasks have been removed
$ crontab -l
#~ MAGENTO START 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
* * * * * /usr/bin/php8.5 /mnt/jrc-data/www/example.com/releases/2026-09-01-001/bin/magento cron:run >> /mnt/jrc-data/www/example.com/releases/2026-09-01-001/var/log/magento.cron.log 2>&1
#~ MAGENTO END 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
$
```

Without the fix, you can verify that adding an extra new line at the end of the content fixes the issue:

```console
$ crontab -l
#~ MAGENTO START 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
* * * * * /usr/bin/php8.5 /mnt/jrc-data/www/example.com/releases/2026-09-01-001/bin/magento cron:run >> /mnt/jrc-data/www/example.com/releases/2026-09-01-001/var/log/magento.cron.log 2>&1
#~ MAGENTO END 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
$ crontab -e # Adding a new line
crontab: installing new crontab
$ crontab -l
#~ MAGENTO START 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
* * * * * /usr/bin/php8.5 /mnt/jrc-data/www/example.com/releases/2026-09-01-001/bin/magento cron:run >> /mnt/jrc-data/www/example.com/releases/2026-09-01-001/var/log/magento.cron.log 2>&1
#~ MAGENTO END 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7

$ bin/magento cron:remove
Magento cron tasks have been removed
$ crontab -l

$
```

Finally, with the fix in place, you can see it successfully removes the cron entry even though there is no extra new line character at the end of the file.

```console
$ crontab -l
#~ MAGENTO START 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
* * * * * /usr/bin/php8.5 /mnt/jrc-data/www/example.com/releases/2026-09-01-001/bin/magento cron:run >> /mnt/jrc-data/www/example.com/releases/2026-09-01-001/var/log/magento.cron.log 2>&1
#~ MAGENTO END 76724da21bc6e4e14e60ad26bdf9be9d1a26d99e97c3a2a3c51a48366535fbc7
$ bin/magento cron:remove
Magento cron tasks have been removed
$ crontab -l

$
```

### Resolved issues:
1. [x] resolves magento/magento2#41188: Fix cron:remove silently failing when the tasks block is the last crontab entry