### PR TITLE
Fix 41133 Frontend Order Cancellation fails for translated strings in CSV

### DIFF
--- a/app/code/Magento/OrderCancellationUi/view/frontend/templates/cancel-order-modal.phtml
+++ b/app/code/Magento/OrderCancellationUi/view/frontend/templates/cancel-order-modal.phtml
@@ -17,7 +17,7 @@
             <select id="cancel-order-reason-<?=/* @noEscape */ $block->getOrder()->getId() ?>"
                     class="cancel-order-reason" name="reason">
                 <?php foreach ($block->getReasons() as $key => $description): ?>
-                    <option value="<?= $escaper->escapeHtml(__($description)) ?>">
+                    <option value="<?= $escaper->escapeHtml($description) ?>">
                         <?= $escaper->escapeHtml(__($description)) ?>
                     </option>
                 <?php endforeach; ?>

--- a/app/code/Magento/OrderCancellationUi/view/frontend/web/js/cancel-order-modal.js
+++ b/app/code/Magento/OrderCancellationUi/view/frontend/web/js/cancel-order-modal.js
@@ -30,7 +30,7 @@ define([
                     /** @inheritdoc */
                     click: function () {
                         let thisModal = this,
-                            reason = $('#cancel-order-reason-' + order_id).find(':selected').text(),
+                            reason = $('#cancel-order-reason-' + order_id).val(),
                             mutation = `
 mutation cancelOrder($order_id: ID!, $reason: String!) {
   cancelOrder(input: {order_id: $order_id, reason: $reason}) {


### PR DESCRIPTION
### Description (*)
When the "Cancel Order" functionality is enabled on the frontend and cancellation reasons are translated in a store view (e.g., via i18n CSV), the order cancellation fails with an "Order cancellation reason is invalid" error.

This happens because the `value` attribute of the `<option>` tag in the modal template (`cancel-order-modal.phtml`) is wrapped in the `__()` translation function. Furthermore, the JavaScript (`cancel-order-modal.js`) reads the translated `.text()` of the selected option instead of its underlying `.val()`. As a result, the GraphQL `cancelOrder` mutation receives the translated string (e.g., "Інше" instead of "Other") and fails the backend validation, which expects the original English reason string.

This PR fixes the issue by:
1. Removing the `__()` translation wrapper from the `value` attribute in `cancel-order-modal.phtml` so it holds the original system value, while keeping the translation for the visible label.
2. Updating `cancel-order-modal.js` to read the `.val()` of the selected option instead of its `.text()`.

### Related Pull Requests
N/A

### Fixed Issues (if relevant)
1. Fixes magento/magento2#41133

### Manual testing scenarios (*)
1. Log into the Magento Admin and navigate to **Stores > Settings > Configuration > Sales > Sales > Order Cancellation**. Set **Enable Order Cancellation on Frontend** to **Yes**.
2. Create a new Store View (e.g., `UA`) and set its Locale to a different language (e.g., Ukrainian) under **Stores > Settings > Configuration > General > General > Locale Options**.
3. Create a translation CSV file for the chosen locale (e.g., `uk_UA.csv`) and add translations for the default cancellation reasons, for example: `"Other","Інше"`.
4. Flush the Magento cache (`bin/magento cache:clean config block_html layout full_page`).
5. Go to the frontend, switch to the translated Store View, log into a customer account, and place a new order.
6. Navigate to **My Account > My Orders** and click the **Cancel Order** link for the newly created order.
7. In the cancellation modal, select a translated reason (e.g., "Інше") and click **Confirm**.
8. **Expected Result:** The order is successfully canceled, the page reloads, and the order status changes to "Canceled".
   **Actual Result (before PR):** The modal shows a red error message: "Order cancellation reason is invalid."

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)