### PR TITLE
41036 Fix AttributeSet pagination inconsistency when no sort_orders are provided

### DIFF
--- a/app/code/Magento/Eav/etc/di.xml
+++ b/app/code/Magento/Eav/etc/di.xml
@@ -154,11 +154,18 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\Eav\Model\Api\SearchCriteria\CollectionProcessor\AttributeSetSortingProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor\SortingProcessor">
+        <arguments>
+            <argument name="defaultOrders" xsi:type="array">
+                <item name="attribute_set_id" xsi:type="string">ASC</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <virtualType name="Magento\Eav\Model\Api\SearchCriteria\AttributeSetCollectionProcessor" type="Magento\Framework\Api\SearchCriteria\CollectionProcessor">
         <arguments>
             <argument name="processors" xsi:type="array">
                 <item name="filters" xsi:type="object">Magento\Eav\Model\Api\SearchCriteria\CollectionProcessor\AttributeSetFilterProcessor</item>
-                <item name="sorting" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\SortingProcessor</item>
+                <item name="sorting" xsi:type="object">Magento\Eav\Model\Api\SearchCriteria\CollectionProcessor\AttributeSetSortingProcessor</item>
                 <item name="pagination" xsi:type="object">Magento\Framework\Api\SearchCriteria\CollectionProcessor\PaginationProcessor</item>
             </argument>
         </arguments>

--- a/dev/tests/api-functional/testsuite/Magento/Eav/Api/AttributeSetRepositoryTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/Eav/Api/AttributeSetRepositoryTest.php
@@ -285,4 +285,45 @@ class AttributeSetRepositoryTest extends WebapiAbstract
         }
         return $attributeSet;
     }
+
+    /**
+     * @magentoApiDataFixture Magento/Eav/_files/attribute_set_for_search.php
+     */
+    public function testGetListWithoutSortOrder()
+    {
+        /** @var SearchCriteriaBuilder $searchCriteriaBuilder */
+        $searchCriteriaBuilder = Bootstrap::getObjectManager()
+            ->create(SearchCriteriaBuilder::class);
+
+        $searchCriteriaBuilder->setPageSize(20);
+        $searchCriteriaBuilder->setCurrentPage(1);
+
+        $searchData = $searchCriteriaBuilder->create()->__toArray();
+        $requestData = ['searchCriteria' => $searchData];
+
+        $serviceInfo = [
+            'rest' => [
+                'resourcePath' => '/V1/eav/attribute-sets/list' . '?' . http_build_query($requestData),
+                'httpMethod' => \Magento\Framework\Webapi\Rest\Request::HTTP_METHOD_GET,
+            ],
+            'soap' => [
+                'service' => 'eavAttributeSetRepositoryV1',
+                'serviceVersion' => 'V1',
+                'operation' => 'eavAttributeSetRepositoryV1GetList',
+            ],
+        ];
+
+        $searchResult = $this->_webApiCall($serviceInfo, $requestData);
+
+        $this->assertGreaterThan(1, $searchResult['total_count']);
+
+        $items = $searchResult['items'];
+        for ($i = 1; $i < count($items); $i++) {
+            $this->assertGreaterThan(
+                $items[$i - 1]['attribute_set_id'],
+                $items[$i]['attribute_set_id'],
+                'Items are not sorted by attribute_set_id ASC'
+            );
+        }
+    }
 }

--- a/dev/tests/integration/testsuite/Magento/Eav/Model/AttributeSetRepositoryTest.php
+++ b/dev/tests/integration/testsuite/Magento/Eav/Model/AttributeSetRepositoryTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2023 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Eav\Model;
+
+use Magento\Eav\Api\AttributeSetRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+class AttributeSetRepositoryTest extends TestCase
+{
+    /**
+     * @var AttributeSetRepositoryInterface
+     */
+    private $repository;
+
+    /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->repository = $objectManager->get(AttributeSetRepositoryInterface::class);
+        $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+    }
+
+    /**
+     * @magentoDataFixture Magento/Eav/_files/attribute_set_for_search.php
+     */
+    public function testGetListWithoutSortOrder()
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->setPageSize(20)
+            ->setCurrentPage(1)
+            ->create();
+
+        $searchResult = $this->repository->getList($searchCriteria);
+        
+        $this->assertGreaterThan(1, $searchResult->getTotalCount());
+
+        $items = array_values($searchResult->getItems());
+        for ($i = 1; $i < count($items); $i++) {
+            $this->assertGreaterThan(
+                $items[$i - 1]->getAttributeSetId(),
+                $items[$i]->getAttributeSetId(),
+                'Items are not sorted by attribute_set_id ASC'
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When calling the `GET /V1/products/attribute-sets/sets/list` REST API endpoint with `searchCriteria[currentPage]` and `searchCriteria[pageSize]`, but without providing any explicit `sortOrders`, the result set is non-deterministic. Because no default `ORDER BY` is applied to the database query, MySQL/MariaDB returns rows in an arbitrary order across paginated queries (LIMIT/OFFSET). This causes some attribute sets to be duplicated across different pages, while others are completely omitted.

This PR adds a default sorting configuration for `AttributeSetCollectionProcessor` via `di.xml`. By injecting the `defaultOrders` argument (setting `attribute_set_id` ASC), the core `SortingProcessor` now enforces a consistent and deterministic default order. This guarantees correct pagination behavior without modifying core PHP business logic.

I have also included Web API and Integration tests to cover this behavior and prevent regressions.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#41036

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
**Pre-condition:**
Ensure your Magento instance has multiple attribute sets (e.g., standard Sample Data).

1. Send a REST API request to fetch the **first page** of attribute sets without providing sort orders:
   ```bash
   curl -g -X GET "http://<your-magento-domain>/rest/default/V1/products/attribute-sets/sets/list?searchCriteria[pageSize]=5&searchCriteria[currentPage]=1" \
   -H "Authorization: Bearer <admin_token>"
   ```
2. Send a REST API request to fetch the **second page**:
   ```bash
   curl -g -X GET "http://<your-magento-domain>/rest/default/V1/products/attribute-sets/sets/list?searchCriteria[pageSize]=5&searchCriteria[currentPage]=2" \
   -H "Authorization: Bearer <admin_token>"
   ```
3. Verify the `items` array in both responses.
   - **Before this fix:** Some `attribute_set_id`s could appear on both pages, and some might be completely missing.
   - **After this fix:** The `attribute_set_id`s are strictly ordered in ascending order across the pages (e.g. `4, 9, 10, 11, 12` on page 1, and `13, 14, 15` on page 2) with no duplicates or skipped records.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
The implementation utilizes the native `Magento\Framework\Api\SearchCriteria\CollectionProcessor\SortingProcessor` default sorting capability via `di.xml`, ensuring architectural best practices.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)