### PR TITLE
Fix for custom redirect and slash

### DIFF
--- a/app/code/Magento/UrlRewrite/Controller/Router.php
+++ b/app/code/Magento/UrlRewrite/Controller/Router.php
@@ -143,6 +143,10 @@ class Router implements RouterInterface
         if ($rewrite->getEntityType() !== Rewrite::ENTITY_TYPE_CUSTOM
             || ($prefix = substr((string)$target, 0, 6)) !== 'http:/' && $prefix !== 'https:'
         ) {
+            if (strpos('/', $target) === 0 && strlen($target) === 1) {
+                // If target is '/', then we make it an empty string to avoid double slashes in the URL
+                $target = '';
+            }
             $target = $this->url->getUrl('', ['_direct' => $target, '_query' => $request->getParams()]);
         }
         return $this->redirect($request, $target, $rewrite->getRedirectType());

--- a/app/code/Magento/UrlRewrite/Test/Unit/Controller/RouterTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Controller/RouterTest.php
@@ -303,6 +303,51 @@ class RouterTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testMatchWithCustomRedirectToBaseUrl()
+    {
+        $queryParams = [];
+        $redirectType = 301;
+        $requestPath = 'some-test1';
+        $targetPath = '/';
+        $redirectUrl = 'redirect-url';
+        $this->storeManager->method('getStore')
+            ->willReturn($this->store);
+        $this->request->method('getPathInfo')
+            ->willReturn($requestPath);
+        $this->request->method('getRequestString')
+            ->willReturn($requestPath);
+        $urlRewrite = $this->createMock(UrlRewrite::class);
+        $urlRewrite->method('getEntityType')->willReturn('custom');
+        $urlRewrite->method('getRedirectType')->willReturn($redirectType);
+        $urlRewrite->method('getRequestPath')->willReturn($requestPath);
+        $urlRewrite->method('getTargetPath')->willReturn($targetPath);
+        $this->urlFinder->method('findOneByData')->willReturn($urlRewrite);
+        $this->response->expects($this->once())
+            ->method('setRedirect')
+            ->with($redirectUrl, $redirectType);
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn($queryParams);
+        $this->url->expects($this->once())
+            ->method('getUrl')
+            ->with(
+                '',
+                ['_direct' => '', '_query' => $queryParams]
+            )
+            ->willReturn($redirectUrl);
+        $this->request->expects($this->once())
+            ->method('setDispatched')
+            ->with(true);
+        $this->actionFactory->expects($this->once())
+            ->method('create')
+            ->with(Redirect::class);
+
+        $this->router->match($this->request);
+    }
+
+    /**
      * @param string $requestPath
      * @param string $targetPath
      * @param bool $shouldRedirect


### PR DESCRIPTION
Fix the double slash in custom redirects to the base URL

### Description (*)

Custom URL rewrites with `/` as the target path currently generate a redirect URL with a double slash. For example, requesting `https://first.magento.test/some-test1/` redirects to `https://first.magento.test//` when `some-test1` is configured as a custom permanent redirect to `/`.

This pull request normalizes the root target to an empty direct path before Magento builds the redirect URL. This prevents the base URL's trailing slash and the target slash from being combined.

A unit test covers the custom permanent redirect scenario and verifies that the URL builder receives an empty `_direct` value and that its generated URL is passed to the redirect response.

### Related Pull Requests

N/A.

### Fixed Issues (if relevant)

N/A — no related issue was provided.

### Manual testing scenarios (*)

1. In the Admin, go to **Marketing > SEO & Search > URL Rewrites**.
2. Create a custom URL rewrite for the **Default Store View** with these values:
   - **Request Path:** `some-test1`
   - **Target Path:** `/`
   - **Redirect Type:** `Permanent (301)`
3. Save the URL rewrite.
4. Open `https://first.magento.test/some-test1/` in a browser.
5. Verify that the response is a `301` redirect to `https://first.magento.test/`, not `https://first.magento.test//`.

### Questions or comments

Local verification:

- `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Magento/UrlRewrite/Test/Unit/Controller/RouterTest.php`
- `vendor/bin/phpcs --standard=Magento2 app/code/Magento/UrlRewrite/Test/Unit/Controller/RouterTest.php`

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update (not applicable)
- [ ] All automated tests passed successfully (all builds are green)
