### PR TITLE
38697 Kazakh Locale missing in Config.php

### DIFF
--- a/lib/internal/Magento/Framework/Locale/Config.php
+++ b/lib/internal/Magento/Framework/Locale/Config.php
@@ -70,6 +70,7 @@ class Config implements \Magento\Framework\Locale\ConfigInterface
         'it_IT', /*Italian (Italy)*/
         'ja_JP', /*Japanese (Japan)*/
         'ka_GE', /*Georgian (Georgia)*/
+        'kk_KZ', /*Kazakh (Kazakhstan)*/
         'km_KH', /*Khmer (Cambodia)*/
         'ko_KR', /*Korean (South Korea)*/
         'lo_LA', /*Lao (Laos)*/


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->
<!-- Title idea: Fix #38697: Add missing Kazakh Locale (kk_KZ) to Framework Config -->

### Description (*)
This pull request adds the missing Kazakh (`kk_KZ`) locale to the `$_allowedLocales` array in `\Magento\Framework\Locale\Config`. 
Previously, this locale was absent from the configuration, making it impossible to fully configure the store for Kazakhstan without custom patches.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#38697

### Manual testing scenarios (*)
1. Log in to the Magento Admin panel.
2. Go to **Stores** > Settings > **Configuration**.
3. Under the **General** tab, select **General**.
4. Expand the **Locale Options** section.
5. Open the **Locale** dropdown list.
6. Verify that **Kazakh (Kazakhstan)** is now available as a selectable option.
7. Select it and click **Save Config** to ensure it saves without errors.

### Questions or comments
N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)