### PR TITLE
magento/magento2#38611: Fix datepicker validation error missing  in custom date form field

### DIFF
--- a/app/code/Magento/Bundle/view/frontend/web/js/validation.js
+++ b/app/code/Magento/Bundle/view/frontend/web/js/validation.js
@@ -16,6 +16,11 @@ define([
                 // logic for date-picker error placement
                 if (element.hasClass('_has-datepicker')) {
                     errorPlacement = element.siblings('button');
+
+                    //fallback if datepicker has no calendar button sibling
+                    if (!errorPlacement.length) {
+                        errorPlacement = element;
+                    }
                 }
                 // logic for field wrapper
                 fieldWrapper = element.closest('.addon');

--- a/dev/tests/js/jasmine/tests/lib/mage/validation.test.js
+++ b/dev/tests/js/jasmine/tests/lib/mage/validation.test.js
@@ -1314,4 +1314,31 @@ define([
                 .call($.validator.prototype, 'html,php', el1, null)).toEqual(false);
         });
     });
+
+    describe('Testing errorPlacement for datepicker field', function () {
+        it('places the error next to the calendar button when one is present', function () {
+            var wrapper = $('<div/>'),
+                element = $('<input type="text" class="_has-datepicker"/>'),
+                button = $('<button type="button"/>'),
+                error = $('<div class="mage-error"/>');
+
+            wrapper.append(element).append(button);
+
+            $.mage.validation.prototype.options.errorPlacement.call({}, error, element);
+
+            expect(button.next().is(error)).toEqual(true);
+        });
+
+        it('falls back to placing the error next to the field itself when there is no calendar button', function () {
+            var wrapper = $('<div/>'),
+                element = $('<input type="text" class="_has-datepicker"/>'),
+                error = $('<div class="mage-error"/>');
+
+            wrapper.append(element);
+
+            $.mage.validation.prototype.options.errorPlacement.call({}, error, element);
+
+            expect(element.next().is(error)).toEqual(true);
+        });
+    });
 });

--- a/lib/web/mage/validation.js
+++ b/lib/web/mage/validation.js
@@ -1991,6 +1991,11 @@ define([
                 // logic for date-picker error placement
                 if (element.hasClass('_has-datepicker')) {
                     errorPlacement = element.siblings('button');
+
+                    //fallback if datepicker has no calendar button sibling
+                    if (!errorPlacement.length) {
+                        errorPlacement = element;
+                    }
                 }
                 // logic for field wrapper
                 fieldWrapper = element.closest('.addon');


### PR DESCRIPTION
Fix datepicker validation error message not displayed when calendar button is absent  

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

The client-side `errorPlacement()` callback in `mage.validation` (`lib/web/mage/validation.js`) places the "required field" error message next to a datepicker field's calendar button:                                     
                                                                                                                                                                                                                              
  ///js                                                                                                                                                                                                                       
  if (element.hasClass('_has-datepicker')) {                                                                                                                                                                                  
      errorPlacement = element.siblings('button');                                                                                                                                                                            
  }                                                                                                                                                                                                                           
  ...                                                                                                                                                                                                                         
  errorPlacement.after(error);                                                                                                                                                                                                
    //// end js                                                                                                                                                                                                                          
  When a datepicker is initialized without a calendar button (showOn: 'focus' instead of 'both'/'button' — a documented, valid jQuery UI datepicker configuration), element.siblings('button') returns an empty jQuery        
  collection. Calling .after(error) on an empty collection is a silent no-op, so the error message is never inserted into the DOM at all — the field is marked invalid (red border only), but the user never sees why.        
                                                                                                                                                                                                                              
  The fix adds a fallback: if no calendar-button sibling exists, place the error next to the field itself, matching the existing fallback pattern already used a few lines below for the checkbox/radio case.                 
                                                                                                                                                                                                                              
  The exact same buggy logic is duplicated in app/code/Magento/Bundle/view/frontend/web/js/validation.js, which registers itself as a global RequireJS mixin for mage/validation                                              
  (app/code/Magento/Bundle/view/frontend/requirejs-config.js) and overrides errorPlacement on every page where Magento_Bundle is enabled — i.e. virtually every storefront page, regardless of whether bundle products are    
  involved. Since this mixin runs after the base widget, it is the version that actually executes in practice, so the same fallback was applied there as well to make the fix effective on a real storefront.    

### Related Pull Requests
<!-- related pull request placeholder -->
no
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes magento/magento2#38611
2.            
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->

1. Add a text field to any storefront form using mage.validation, initialized as a jQuery UI datepicker with showOn: 'focus' and no calendar button (e.g. $('#my-date').datepicker({ showOn: 'focus' })), with              
     data-validate='{"required-entry":true}'.                                                                                                                                                                                 
  2. Leave the field empty and submit the form.                                                                                                                                                                               
  3. Before the fix: the field gets a red/invalid border but no error message is shown anywhere near it.                                                                                                                      
  4. After the fix: "This is a required field." appears directly after the field, the same way it does for a datepicker field that does have a calendar button.                                                               
  5. Repeat with a datepicker that does have a calendar button (showOn: 'both') to confirm no regression — the message still appears next to the button as before. 

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->

 While testing on the storefront "Create New Customer Account" page specifically, I found that error messages there are additionally swallowed by an unrelated, pre-existing issue in                                        
  Magento_Customer/js/block-submit-on-send.js, which removes all .mage-error nodes on every submit event handler (including the one that just inserted them). That's a separate bug from this one and is not addressed by this
  PR — happy to file/fix it separately if useful.             

### Contribution checklist (*)
 - [*] Pull request has a meaningful description of its purpose
 - [*] All commits are accompanied by meaningful commit messages
 - [*] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
