### PR TITLE
Fix watermark opacity handling for empty and zero config values (#41196)

### DIFF
--- a/app/code/Magento/Catalog/Model/Product/Image.php
+++ b/app/code/Magento/Catalog/Model/Product/Image.php
@@ -597,7 +597,7 @@ class Image extends \Magento\Framework\Model\AbstractModel
         if ($height) {
             $this->setWatermarkHeight($height);
         }
-        if ($opacity) {
+        if (!in_array($opacity, [null, ''], true)) {
             $this->setWatermarkImageOpacity($opacity);
         }
         $filePath = $this->_getWatermarkFilePath();

--- a/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
+++ b/app/code/Magento/Catalog/Model/Product/Image/ParamsBuilder.php
@@ -200,6 +200,13 @@ class ParamsBuilder
                 ScopeInterface::SCOPE_STORE,
                 $scopeId
             );
+            $opacity = $opacity === '' ? null : $opacity;
+            $position = $position === '' ? null : $position;
+
+            if (is_numeric($opacity) && (float) $opacity === 0.0) {
+                return [];
+            }
+
             $width = !empty($size['0']) ? $size['0'] : null;
             $height = !empty($size['1']) ? $size['1'] : null;
 

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/ParamsBuilderTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/Image/ParamsBuilderTest.php
@@ -167,7 +167,7 @@ class ParamsBuilderTest extends TestCase
      */
     public static function buildDataProvider()
     {
-        return [
+        return array_merge(self::watermarkOpacityDataProvider(), [
             'watermark config' => [
                 1,
                 '1',
@@ -226,6 +226,56 @@ class ParamsBuilderTest extends TestCase
                     'watermark_width' => null,
                     'watermark_height' => null,
                     'keep_frame' => false
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * Provides watermark opacity edge cases for testBuild()
+     *
+     * @return array
+     */
+    private static function watermarkOpacityDataProvider(): array
+    {
+        return [
+            'watermark config with empty string opacity and position' => [
+                1,
+                '1',
+                true,
+                [
+                    'design/watermark/small_image_image' => 'stores/1/magento-logo.png',
+                    'design/watermark/small_image_size' => '60x40',
+                    'design/watermark/small_image_imageOpacity' => '',
+                    'design/watermark/small_image_position' => '',
+                ],
+                [
+                    'type' => 'small_image'
+                ],
+                [
+                    'watermark_file' => 'stores/1/magento-logo.png',
+                    'watermark_image_opacity' => null,
+                    'watermark_position' => null,
+                    'watermark_width' => '60',
+                    'watermark_height' => '40',
+                    'keep_frame' => true
+                ]
+            ],
+            'watermark config with zero opacity' => [
+                1,
+                '1',
+                true,
+                [
+                    'design/watermark/small_image_image' => 'stores/1/magento-logo.png',
+                    'design/watermark/small_image_size' => '60x40',
+                    'design/watermark/small_image_imageOpacity' => '0',
+                    'design/watermark/small_image_position' => 'bottom-right',
+                ],
+                [
+                    'type' => 'small_image'
+                ],
+                [
+                    'keep_frame' => true
                 ]
             ]
         ];

--- a/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/Product/ImageTest.php
@@ -29,6 +29,7 @@ use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManager;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Website;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -352,33 +353,9 @@ class ImageTest extends TestCase
      */
     public function testSetWatermark(): void
     {
-        $website = $this->createPartialMock(Website::class, ['getId', '__sleep']);
-        $website->method('getId')->willReturn(1);
-        $this->storeManager->method('getWebsite')->willReturn($website);
-        $this->mediaDirectory
-            ->method('isExist')
-            ->willReturnCallback(
-                function ($arg) {
-                    if (empty($arg)) {
-                        return null;
-                    } elseif ($arg == 'catalog/product/watermark//somefile.png') {
-                        return true;
-                    }
-                }
-            );
-        $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
-        $this->mediaDirectory->expects($this->any())->method('getAbsolutePath')
-            ->with('catalog/product/watermark//somefile.png')
-            ->willReturn($absolutePath);
+        $this->prepareWatermarkFile();
 
-        $imageProcessor = $this->createPartialMock(
-            FrameworkImage::class,
-            [
-                'keepAspectRatio', 'keepFrame', 'keepTransparency', 'constrainOnly', 'backgroundColor', 'quality',
-                'setWatermarkPosition', 'setWatermarkImageOpacity', 'setWatermarkWidth', 'setWatermarkHeight',
-                'watermark'
-            ]
-        );
+        $imageProcessor = $this->createWatermarkImageProcessorMock();
         $imageProcessor->expects($this->once())->method('setWatermarkPosition')->with('center')
             ->willReturn(true);
         $imageProcessor->expects($this->once())->method('setWatermarkImageOpacity')->with(50)
@@ -398,6 +375,77 @@ class ImageTest extends TestCase
             50
         );
         $this->assertSame($this->image, $result);
+    }
+
+    /**
+     * @param int|string|null $opacity
+     * @param int|string $expectedOpacity
+     * @return void
+     */
+    #[DataProvider('watermarkImageOpacityDataProvider')]
+    public function testSetWatermarkImageOpacity($opacity, $expectedOpacity): void
+    {
+        $this->prepareWatermarkFile();
+
+        $imageProcessor = $this->createWatermarkImageProcessorMock();
+        $imageProcessor->expects($this->once())->method('setWatermarkImageOpacity')->with($expectedOpacity)
+            ->willReturn(true);
+        $this->image->setImageProcessor($imageProcessor);
+
+        $this->image->setWatermark('/somefile.png', 'center', null, null, null, $opacity);
+    }
+
+    /**
+     * @return array
+     */
+    public static function watermarkImageOpacityDataProvider(): array
+    {
+        return [
+            'explicit zero is a fully transparent watermark' => [0, 0],
+            'explicit zero as string is a fully transparent watermark' => ['0', '0'],
+            'empty string falls back to the default opacity' => ['', 70],
+            'null falls back to the default opacity' => [null, 70],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    private function prepareWatermarkFile(): void
+    {
+        $website = $this->createPartialMock(Website::class, ['getId', '__sleep']);
+        $website->method('getId')->willReturn(1);
+        $this->storeManager->method('getWebsite')->willReturn($website);
+        $this->mediaDirectory
+            ->method('isExist')
+            ->willReturnCallback(
+                function ($arg) {
+                    if (empty($arg)) {
+                        return null;
+                    } elseif ($arg == 'catalog/product/watermark//somefile.png') {
+                        return true;
+                    }
+                }
+            );
+        $absolutePath = dirname(dirname(__DIR__)) . '/_files/catalog/product/watermark/somefile.png';
+        $this->mediaDirectory->expects($this->any())->method('getAbsolutePath')
+            ->with('catalog/product/watermark//somefile.png')
+            ->willReturn($absolutePath);
+    }
+
+    /**
+     * @return FrameworkImage|MockObject
+     */
+    private function createWatermarkImageProcessorMock()
+    {
+        return $this->createPartialMock(
+            FrameworkImage::class,
+            [
+                'keepAspectRatio', 'keepFrame', 'keepTransparency', 'constrainOnly', 'backgroundColor', 'quality',
+                'setWatermarkPosition', 'setWatermarkImageOpacity', 'setWatermarkWidth', 'setWatermarkHeight',
+                'watermark'
+            ]
+        );
     }
 
     /**

--- a/app/code/Magento/MediaStorage/Service/ImageResize.php
+++ b/app/code/Magento/MediaStorage/Service/ImageResize.php
@@ -447,7 +447,7 @@ class ImageResize
                 $image->setWatermarkPosition($imageParams['watermark_position']);
             }
 
-            if ($imageParams['watermark_image_opacity'] !== null) {
+            if (!in_array($imageParams['watermark_image_opacity'], [null, ''], true)) {
                 $image->setWatermarkImageOpacity($imageParams['watermark_image_opacity']);
             }
 


### PR DESCRIPTION
### Description

The Admin **Content > Design > Configuration > Product Image Watermarks > Image Opacity** field can be saved empty, and the stored config value is then an empty string, not `null`. That empty string was passed through `Magento\Catalog\Model\Product\Image\ParamsBuilder::getWatermark()` verbatim, and the two code paths that apply a watermark disagree about what it means:

* `Magento\MediaStorage\Service\ImageResize::generateResizedImage()` (used by `bin/magento catalog:images:resize` and by `get.php` regeneration) checked `$imageParams['watermark_image_opacity'] !== null`, so `''` passed the guard and `setWatermarkImageOpacity('')` was called. In `Magento\Framework\Image\Adapter\Gd2::imagecopymergeWithAlphaFix()` the value is used as `$pct` in `$transparency = (int) (127 - (($pct * 127) / 100))`; with a numeric-zero `$pct` that is `127`, i.e. the watermark is composited but fully invisible.
* `Magento\Catalog\Model\Product\Image::setWatermark()` guarded with `if ($opacity)`. An explicit `0` is falsy, so the setter was never called and the class default `$_watermarkImageOpacity = 70` won — a deliberately fully transparent watermark rendered at 70% for callers of that method.

Either way the `watermark_*` keys were merged into the params array, which `Magento\Catalog\Model\View\Asset\Image::getImageInfo()` md5-hashes into the cache directory name. A watermark that cannot affect a single pixel still fragmented `pub/media/catalog/product/cache/` and forced a re-encode of every image variant.

The fix settles one meaning for both edge values and makes every path honour it:

* **empty string** — folded into `null`, i.e. "not configured". `ParamsBuilder::getWatermark()` now normalises `''` to `null` for opacity and position, `Image::setWatermark()` treats both the same way, and `ImageResize::generateResizedImage()` no longer forwards `''` to the adapter. The watermark itself is still considered configured, so its params stay in the cache hash.
  Note what this does **not** do: an unset opacity still renders differently on the two paths, because `Magento\Framework\Image\Adapter\AbstractAdapter::$_watermarkImageOpacity` has no default of its own. On the resize path the setter is skipped, `Gd2::watermark()` receives `null` as `$pct`, and the watermark comes out fully transparent; on the `Image::setWatermark()` path the model's own default of `70` applies and it is visible. This PR removes the empty-string special case that made `''` behave unlike `null`; unifying the *unset* default across the two paths is a behavioural decision (which default is right — 70, or nothing?) that I would rather have a maintainer weigh in on than change silently here.
* **explicit numeric `0`** — "fully transparent": the watermark is a visual no-op, so `ParamsBuilder::getWatermark()` returns `[]`. No compositing call, and no watermark keys in the hash, so store views that differ only by a zero-opacity watermark override share one resized-image cache directory again.

`Image::setWatermark()`'s guard is now `!in_array($opacity, [null, ''], true)` — strict comparison, so `0` and `'0'` reach the setter and are rendered as transparent, matching the resize path.

Not addressed here, and worth a separate discussion: `watermark_file` is a scope-dependent relative path (`stores/2/watermark.png` vs `websites/1/watermark.png` vs `default/watermark.png`), so uploading the *same* watermark file in two scopes still yields two cache hashes. Hashing the watermark by file content instead would change the cache hash for every store that uses a watermark — a one-time full image-cache regeneration — so it needs a maintainer decision rather than a drive-by change.

### Fixed Issues

Fixes magento/magento2#41196

### Manual testing scenarios

1. Set up two store views, `default` and `store_b`, on one website.
2. In **Content > Design > Configuration** for `store_b`, upload a watermark for Small/Base/Thumbnail and set **Image Opacity** to `0`.
3. Run `bin/magento catalog:images:resize` and inspect `pub/media/catalog/product/cache/`.
   * Before: `store_b` gets its own hash directory per image size, and the images there carry an invisible watermark.
   * After: no extra hash directory for `store_b`, and no watermark compositing for that scope.
4. Repeat with **Image Opacity** left empty instead of `0`, and dump the params for that scope from `ParamsBuilder::build()`.
   * Before: `watermark_image_opacity` was `''`, which `ImageResize::generateResizedImage()` forwarded to `setWatermarkImageOpacity('')`, reaching `Gd2` as a numeric-zero `$pct`.
   * After: it is `null` and the setter is skipped, exactly as for a scope where the field was never touched. (As noted above, the resulting *render* for an unset opacity still differs between the two watermarking paths — that part is deliberately left alone.)
5. Set **Image Opacity** to a normal value such as `50` and confirm the watermark still renders at 50% and still participates in the cache hash.

### Local verification

* Unit — `Magento/Catalog/Test/Unit/Model/Product/`: 422 tests green, including the new data sets.
* Integration — `Magento/MediaStorage/`: green. `Magento/Catalog/`: 2 failures in `Magento\Catalog\Block\Product\ListProduct\SortingTest::testProductListOutOfStockSortOrderWithMysql`, reproduced identically on a clean `2.4-develop` checkout, so pre-existing and unrelated.
* PHPCS (`Magento2` standard) and PHPStan level 1 on the changed files: no findings.
* Static Tests (`LiveCodeTest`, PHPCS + PHPMD, warnings included) on the changed files: green. The `!in_array(...)` formulation and the extracted `watermarkOpacityDataProvider()` keep `setWatermark()`, `generateResizedImage()` and `buildDataProvider()` inside the PHPMD cyclomatic-complexity and method-length thresholds, without adding any `@SuppressWarnings`.
* Both new unit tests were verified to fail with the production change reverted and pass with it restored.
* No public or protected signature, interface or `@api` class was touched; the only additions the semantic version checker sees are the new test methods.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
