### PR TITLE
magento/magento2#39974: Fix admin product gallery media URL in multi-…

### DIFF
--- a/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
+++ b/app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php
@@ -19,7 +19,9 @@ use Magento\Framework\View\Element\AbstractBlock;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Backend\Block\DataProviders\ImageUploadConfig as ImageUploadConfigDataProvider;
+use Magento\Framework\UrlInterface;
 use Magento\MediaStorage\Helper\File\Storage\Database;
+use Magento\Store\Model\Store;
 
 /**
  * Block for gallery content.
@@ -180,8 +182,13 @@ class Content extends \Magento\Backend\Block\Widget
         ) {
             $mediaDir = $this->_filesystem->getDirectoryRead(DirectoryList::MEDIA);
             $images = $this->sortImagesByPosition($value['images']);
+            // The admin renders its own preview of a file that is shared by every store view, so the
+            // media base URL is taken from the admin scope instead of the selected store view. A URL
+            // pointing at another website domain is rejected by the admin Content Security Policy.
+            $mediaBaseUrl = $this->_storeManager->getStore(Store::DEFAULT_STORE_ID)
+                ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
             foreach ($images as &$image) {
-                $image['url'] = $this->_mediaConfig->getMediaUrl($image['file']);
+                $image['url'] = $mediaBaseUrl . $this->_mediaConfig->getMediaShortUrl($image['file']);
                 if ($this->fileStorageDatabase->checkDbUsage() &&
                     !$mediaDir->isFile($this->_mediaConfig->getMediaPath($image['file']))
                 ) {

--- a/dev/tests/integration/testsuite/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
+++ b/dev/tests/integration/testsuite/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
@@ -13,8 +13,10 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Gallery\UpdateHandler;
 use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Registry;
+use Magento\Framework\UrlInterface;
 use Magento\Store\Api\StoreRepositoryInterface;
 use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
 use Magento\TestFramework\Helper\Bootstrap;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -136,6 +138,37 @@ class ContentTest extends \PHPUnit\Framework\TestCase
                 'isProductNew' => false,
             ],
         ];
+    }
+
+    /**
+     * Media URLs in the admin gallery must be built from the admin scope.
+     *
+     * Selecting a store view in the store switcher must not make the admin load images from that
+     * store view base URL: the file is the same on disk, and a cross-origin URL is rejected by the
+     * admin Content Security Policy.
+     *
+     * @magentoDataFixture Magento/Catalog/_files/product_with_image.php
+     * @magentoDataFixture Magento/Store/_files/second_store.php
+     * @magentoConfigFixture fixture_second_store_store web/unsecure/base_url http://sample-second.com/
+     * @magentoConfigFixture fixture_second_store_store web/secure/base_url http://sample-second.com/
+     * @magentoAppIsolation enabled
+     * @return void
+     */
+    public function testGetImagesJsonUsesAdminScopeMediaUrl(): void
+    {
+        $storeManager = Bootstrap::getObjectManager()->get(StoreManagerInterface::class);
+        $storeId = (int)$this->storeRepository->get('fixture_second_store')->getId();
+        // Repeats what Magento\Catalog\Controller\Adminhtml\Product\Edit does on a store switch.
+        $storeManager->setCurrentStore('fixture_second_store');
+        $this->registry->register('current_product', $this->getProduct($storeId));
+
+        $images = json_decode($this->block->getImagesJson());
+        $image = array_shift($images);
+
+        $adminMediaUrl = $storeManager->getStore(Store::DEFAULT_STORE_ID)
+            ->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
+        $this->assertStringStartsWith($adminMediaUrl, $image->url);
+        $this->assertStringNotContainsString('sample-second.com', $image->url);
     }
 
     /**


### PR DESCRIPTION
### Description (*)

In a multi-website installation whose websites use different domains, the product gallery in the Admin
stops rendering images once the store switcher is set to a store view that belongs to another website.

`Magento\Catalog\Block\Adminhtml\Product\Helper\Form\Gallery\Content::getImagesJson()` builds each image
URL with `Magento\Catalog\Model\Product\Media\Config::getMediaUrl()`, which resolves the media base URL
from the current store. `Magento\Catalog\Controller\Adminhtml\Product\Edit` sets the current store to the
store view selected in the store switcher, so an Admin page served from the first domain asks the browser
to load images from the second one. The Admin Content Security Policy lists `'self'`, which is the Admin
origin, so the browser rejects the request.

The gallery in the Admin is an editing preview of a file that every store view shares, so this pull request
resolves the media base URL from the Admin scope (`Store::DEFAULT_STORE_ID`) instead of the selected store
view. The block already receives `StoreManagerInterface` through `Magento\Backend\Block\Template\Context`,
and `Media\Config::getMediaShortUrl()` still assembles the path, so no public API is changed and no path
logic is duplicated.

Note on visibility: `csp/mode/admin/report_only` is `1` by default, so out of the box the browser only
reports the violation and the image still renders. The images fail to load once the Admin policy is
enforced, which is how the issue was reported.

### Related Pull Requests

N/A

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39974

### Manual testing scenarios (*)

1. Install Magento Open Source from the `2.4-develop` branch.
2. Serve the installation from a second domain as well, so that two domains reach the same instance.
3. In the Admin, go to **Stores > All Stores** and create a second website, store and store view.
4. Go to **Stores > Configuration > General > Web**, switch the scope to the second website and set both
   **Base URL** and **Secure Base URL** to the second domain. Save.
5. Enforce the Admin Content Security Policy, otherwise the violation is only reported and the image still
   renders. Add to `app/etc/env.php`:

   ```php
   'system' => [
       'default' => [
           'csp' => ['mode' => ['admin' => ['report_only' => 0]]],
       ],
   ],
   ```

   Then run `bin/magento app:config:import` and `bin/magento cache:flush`.
6. Create a product, upload an image in **Images And Videos**, and assign the product to both websites under
   **Product in Websites**. Save.
7. Open the product in the Admin on the first domain, open the browser console, switch the store switcher to
   the store view of the second website, and scroll to **Images And Videos**.

**Actual result before the fix:** the image is not rendered and the console reports

```
Loading the image 'https://<second-domain>/media/catalog/product/<path>' violates the following
Content Security Policy directive: "img-src ... 'self' 'unsafe-inline'". The action has been blocked.
```

**Expected result after the fix:** the image is rendered, no Content Security Policy violation is reported,
and the image URL points at the Admin domain.

### Questions or comments

The block resolves its element and product through the layout and the registry, so the behaviour is covered
by an integration test rather than a unit test. The new test fails on the current implementation and passes
with the change.

Local verification:

```
cd dev/tests/integration
../../../vendor/bin/phpunit testsuite/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
```

Without the change:

```
1) ...ContentTest::testGetImagesJsonUsesAdminScopeMediaUrl
Failed asserting that 'http://sample-second.com/media/catalog/product/m/a/magento_image.jpg'
starts with "http://localhost/media/".
FAILURES! Tests: 1, Assertions: 1, Failures: 1.
```

With the change, the whole class passes:

```
OK (8 tests, 43 assertions)
```

Coding standard:

```
vendor/bin/phpcs --standard=Magento2 \
  app/code/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/Content.php \
  dev/tests/integration/testsuite/Magento/Catalog/Block/Adminhtml/Product/Helper/Form/Gallery/ContentTest.php
```

reports no violations.

### Contribution checklist (*)

 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update — not applicable, the change does not affect the Structure or Observer sections of `Magento_Catalog`
 - [x] All automated tests passed successfully (all builds are green)