### PR TITLE
Apply MAGENTO_DC overrides to nested deployment configuration

### DIFF
--- a/lib/internal/Magento/Framework/App/DeploymentConfig.php
+++ b/lib/internal/Magento/Framework/App/DeploymentConfig.php
@@ -167,6 +167,7 @@ class DeploymentConfig
             $this->overrideData ?? [],
             $this->getEnvOverride()
         );
+        $this->data = array_replace_recursive($this->data, $this->getNestedEnvVars());
         $this->flatData = null;
     }
 
@@ -186,7 +187,6 @@ class DeploymentConfig
 
         // flatten data for config retrieval using get()
         $this->flatData = $this->flattenParams($this->data);
-        $this->flatData = $this->getEnvVars() + $this->flatData;
     }
 
     /**
@@ -209,7 +209,7 @@ class DeploymentConfig
      *
      * @return array
      */
-    private function getEnvVars(): array
+    private function getNestedEnvVars(): array
     {
         $envVars = [];
         // allow reading values from env variables by convention
@@ -223,7 +223,45 @@ class DeploymentConfig
             }
         }
 
-        return $envVars;
+        uksort(
+            $envVars,
+            static function (string $firstPath, string $secondPath): int {
+                $depthComparison = substr_count($firstPath, '/') <=> substr_count($secondPath, '/');
+                return $depthComparison ?: strcmp($firstPath, $secondPath);
+            }
+        );
+
+        $nestedEnvVars = [];
+        foreach ($envVars as $path => $value) {
+            $this->setNestedValue($nestedEnvVars, explode('/', $path), $value);
+        }
+
+        return $nestedEnvVars;
+    }
+
+    /**
+     * Set value in a nested array using path segments
+     *
+     * Deeper paths replace conflicting scalar parent values.
+     *
+     * @param array $data
+     * @param array $path
+     * @param mixed $value
+     * @return void
+     */
+    private function setNestedValue(array &$data, array $path, $value): void
+    {
+        $current = &$data;
+        $lastKey = array_pop($path);
+
+        foreach ($path as $key) {
+            if (!isset($current[$key]) || !is_array($current[$key])) {
+                $current[$key] = [];
+            }
+            $current = &$current[$key];
+        }
+
+        $current[$lastKey] = $value;
     }
 
     /**

--- a/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfigTest.php
+++ b/lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfigTest.php
@@ -309,8 +309,107 @@ class DeploymentConfigTest extends TestCase
         putenv('MAGENTO_DC_B__B__B=D');
         putenv('MAGENTO_DC_C=false');
         $this->assertSame('c', $this->deploymentConfig->get('a'));
+        $this->assertSame(['b' => ['b' => 'D']], $this->deploymentConfig->get('b'));
+        $this->assertSame(['b' => 'D'], $this->deploymentConfig->get('b/b'));
         $this->assertSame('D', $this->deploymentConfig->get('b/b/b'));
         $this->assertFalse($this->deploymentConfig->get('c'));
+    }
+
+    public function testNestedEnvVariablesOverrideAllConfigRepresentations(): void
+    {
+        $fileConnectionConfig = [
+            'host' => 'file-host',
+            'dbname' => 'file-database',
+            'username' => 'file-user',
+            'password' => 'file-password',
+            'active' => '0',
+            'model' => 'file-model',
+            'engine' => 'file-engine',
+            'driver_options' => [
+                1014 => true,
+                1002 => 'preserved-driver-option',
+            ],
+            'file_only' => 'preserved-value',
+        ];
+        $this->readerMock->expects($this->once())->method('load')->willReturn(
+            ['db' => ['connection' => ['default' => $fileConnectionConfig]]]
+        );
+
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__HOST=db');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__DBNAME=magento');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__USERNAME=magento');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__PASSWORD=magento');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__ACTIVE=1');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__MODEL=mysql4');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__ENGINE=innodb');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__INITSTATEMENTS=SET NAMES utf8;');
+        putenv('MAGENTO_DC_DB__CONNECTION__DEFAULT__DRIVER_OPTIONS__1014=false');
+
+        $configDataConnection = $this->deploymentConfig->getConfigData('db')['connection']['default'];
+        $connectionConfig = $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT);
+
+        $this->assertSame('db', $connectionConfig['host']);
+        $this->assertSame('magento', $connectionConfig['dbname']);
+        $this->assertSame('magento', $connectionConfig['username']);
+        $this->assertSame('magento', $connectionConfig['password']);
+        $this->assertSame('1', $connectionConfig['active']);
+        $this->assertSame('mysql4', $connectionConfig['model']);
+        $this->assertSame('innodb', $connectionConfig['engine']);
+        $this->assertSame('SET NAMES utf8;', $connectionConfig['initstatements']);
+        $this->assertFalse($connectionConfig['driver_options'][1014]);
+        $this->assertSame('preserved-driver-option', $connectionConfig['driver_options'][1002]);
+        $this->assertSame('preserved-value', $connectionConfig['file_only']);
+        $this->assertSame(
+            $connectionConfig,
+            $this->deploymentConfig->get()['db/connection/default']
+        );
+        $this->assertSame(
+            $connectionConfig,
+            $configDataConnection
+        );
+        $this->assertSame(
+            'db',
+            $this->deploymentConfig->get(ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT . '/host')
+        );
+        $this->assertFalse(
+            $this->deploymentConfig->get(
+                ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTION_DEFAULT_DRIVER_OPTIONS . '/1014'
+            )
+        );
+    }
+
+    public function testEnvVariablePrecedence(): void
+    {
+        $this->readerMock->expects($this->once())->method('load')->willReturn(['precedence' => 'file']);
+        $deploymentConfig = new DeploymentConfig($this->readerMock, ['precedence' => 'constructor']);
+        putenv('MAGENTO_DC__OVERRIDE={"precedence": "json"}');
+        putenv('MAGENTO_DC_PRECEDENCE=environment');
+
+        $this->assertSame('environment', $deploymentConfig->get('precedence'));
+        $this->assertSame('environment', $deploymentConfig->getConfigData('precedence'));
+    }
+
+    public function testNestedEnvVariablesAreReloadedAfterReset(): void
+    {
+        $this->readerMock->expects($this->exactly(2))->method('load')->willReturn([]);
+        putenv('MAGENTO_DC_A__B=first');
+
+        $this->assertSame(['b' => 'first'], $this->deploymentConfig->get('a'));
+        putenv('MAGENTO_DC_A__B=second');
+        $this->assertSame(['b' => 'first'], $this->deploymentConfig->get('a'));
+
+        $this->deploymentConfig->resetData();
+        $this->assertSame(['b' => 'second'], $this->deploymentConfig->get('a'));
+    }
+
+    public function testNestedEnvVariableWinsScalarParentConflict(): void
+    {
+        $this->readerMock->expects($this->once())->method('load')->willReturn([]);
+        putenv('MAGENTO_DC_A=parent');
+        putenv('MAGENTO_DC_A__B=child');
+
+        $this->assertSame(['b' => 'child'], $this->deploymentConfig->get('a'));
+        $this->assertSame('child', $this->deploymentConfig->get('a/b'));
     }
 
     public function testEnvVariablesSubstitution(): void


### PR DESCRIPTION
### Description (*)

Environment variables that use the `MAGENTO_DC_*` convention currently override only flattened leaf paths in `Magento\Framework\App\DeploymentConfig`.

For example, `MAGENTO_DC_DB__CONNECTION__DEFAULT__HOST=db` is returned by `DeploymentConfig::get('db/connection/default/host')`, while `DeploymentConfig::get('db/connection/default')` still contains the host from `app/etc/env.php`. Database consumers request the parent connection array, so they do not receive the environment overrides.

This pull request converts conventional environment paths into a nested structure and recursively applies it to the deployment configuration before the data is flattened. As a result, leaf paths, parent arrays, the complete flattened configuration, and `getConfigData()` expose the same effective values.

The existing override precedence is preserved:

1. Conventional `MAGENTO_DC_*` variables
2. `MAGENTO_DC__OVERRIDE`
3. Constructor override data
4. Deployment configuration files

Boolean normalization, numeric `driver_options` keys, configuration caching, and reloading through `resetData()` are also preserved. When scalar parent and nested environment declarations conflict, the nested path takes precedence.

Unit tests cover nested database overrides, parent and leaf reads, recursive sibling preservation, override precedence, boolean and numeric values, reset behavior, and conflicting parent/child declarations.

### Related Pull Requests

N/A.

<!-- related pull request placeholder -->

### Fixed Issues (if relevant)

N/A — no related issue was provided.

### Manual testing scenarios (*)

1. Start with an installed Magento instance whose `app/etc/env.php` contains a database connection with values different from the environment variables below.
2. Export conventional deployment configuration overrides:

   ```bash
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__HOST=db
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__DBNAME=magento
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__USERNAME=magento
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__PASSWORD=magento
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__ACTIVE=1
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__MODEL=mysql4
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__ENGINE=innodb
   export MAGENTO_DC_DB__CONNECTION__DEFAULT__DRIVER_OPTIONS__1014=false
   ```

3. Read both the parent connection configuration and representative leaf values:

   ```bash
   php -r 'require "app/bootstrap.php"; $bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER); $config = $bootstrap->getObjectManager()->get(\Magento\Framework\App\DeploymentConfig::class); var_export(["parent" => $config->get("db/connection/default"), "host" => $config->get("db/connection/default/host"), "driver_option" => $config->get("db/connection/default/driver_options/1014")]);'
   ```

4. Verify that `parent.host` and the leaf `host` both equal `db`, the remaining parent values match the exported variables, and `parent.driver_options[1014]` and `driver_option` are boolean `false`.
5. Remove the exported variables after testing.

Before this change, the leaf values reflect the environment while the parent array retains values from `app/etc/env.php`. After this change, both representations are consistent.

### Questions or comments

Local verification:

- `vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfigTest.php lib/internal/Magento/Framework/App/Test/Unit/ResourceConnection/ConfigTest.php`
- `vendor/bin/phpcs --standard=Magento2 lib/internal/Magento/Framework/App/DeploymentConfig.php lib/internal/Magento/Framework/App/Test/Unit/DeploymentConfigTest.php`
- `git diff --check`

The PHPUnit run completed with 32 tests and 119 assertions. It reported the pre-existing warning that `allure/allure.config.php` is not available in the local environment.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [ ] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update (not applicable)
- [ ] All automated tests passed successfully (all builds are green)
