### PR TITLE
39762 [Head links] Reorder of links when minification is enabled if o…

### DIFF
--- a/app/code/Magento/Csp/Plugin/AddDefaultPropertiesToGroupPlugin.php
+++ b/app/code/Magento/Csp/Plugin/AddDefaultPropertiesToGroupPlugin.php
@@ -112,12 +112,12 @@ class AddDefaultPropertiesToGroupPlugin
                     $properties['attributes']['integrity'] = $hash;
                     $properties['attributes']['crossorigin'] = 'anonymous';
                 } else {
-                    $properties['_sri_fallback_group'] = spl_object_hash($asset);
+                    $properties['_sri_fallback_group'] = spl_object_id($asset);
                 }
             }
         } catch (\Exception $e) {
             // Skip adding SRI attributes on failure - assets still load normally
-            $properties['_sri_fallback_group'] = spl_object_hash($asset);
+            $properties['_sri_fallback_group'] = spl_object_id($asset);
             $this->logger->warning(
                 'SRI: Failed to get integrity hash for asset',
                 [

--- a/app/code/Magento/Csp/Plugin/AddDefaultPropertiesToGroupPlugin.php
+++ b/app/code/Magento/Csp/Plugin/AddDefaultPropertiesToGroupPlugin.php
@@ -111,10 +111,13 @@ class AddDefaultPropertiesToGroupPlugin
                 if ($hash) {
                     $properties['attributes']['integrity'] = $hash;
                     $properties['attributes']['crossorigin'] = 'anonymous';
+                } else {
+                    $properties['_sri_fallback_group'] = spl_object_hash($asset);
                 }
             }
         } catch (\Exception $e) {
             // Skip adding SRI attributes on failure - assets still load normally
+            $properties['_sri_fallback_group'] = spl_object_hash($asset);
             $this->logger->warning(
                 'SRI: Failed to get integrity hash for asset',
                 [

--- a/app/code/Magento/Csp/Test/Unit/Plugin/AddDefaultPropertiesToGroupPluginTest.php
+++ b/app/code/Magento/Csp/Test/Unit/Plugin/AddDefaultPropertiesToGroupPluginTest.php
@@ -151,6 +151,8 @@ class AddDefaultPropertiesToGroupPluginTest extends TestCase
         $result = $this->plugin->beforeGetFilteredProperties($subjectMock, $assetMock, []);
 
         $this->assertArrayNotHasKey('attributes', $result[1]);
+        $this->assertArrayHasKey('_sri_fallback_group', $result[1]);
+        $this->assertNotEmpty($result[1]['_sri_fallback_group']);
     }
 
     /**
@@ -253,5 +255,7 @@ class AddDefaultPropertiesToGroupPluginTest extends TestCase
         $result = $this->plugin->beforeGetFilteredProperties($subjectMock, $assetMock, []);
 
         $this->assertArrayNotHasKey('attributes', $result[1]);
+        $this->assertArrayHasKey('_sri_fallback_group', $result[1]);
+        $this->assertNotEmpty($result[1]['_sri_fallback_group']);
     }
 }


### PR DESCRIPTION
### Description (*)
This Pull Request fixes **Issue #39762**, which causes a strict chronological order violation for JavaScript files defined in the XML layout when JS minification (`dev/js/minify_files`) is enabled.

**Cause of the issue:**
When `dev/js/minify_files` is enabled in production mode, `Magento\Csp\Plugin\AddDefaultPropertiesToGroupPlugin` attempts to generate SRI `integrity` hashes for all JS assets. Assets that successfully receive an integrity hash are assigned unique properties and placed into newly created property groups by `GroupedCollection`. 

However, assets that fail to generate a hash (for example, JS dependencies that do not have a physical `.min.js` file natively but are requested by Magento's minification system during deployment) fall back to receiving empty properties `[]`. 

As a result, `GroupedCollection` mistakenly merges these non-hashed assets into the very first "empty" property group it can find (which is often created by much earlier scripts). This causes the non-hashed dependency to "jump" to the top of the `<head>` section, breaking script dependencies and violating the explicitly defined chronological layout order.

**Solution:**
We updated `AddDefaultPropertiesToGroupPlugin` so that if an asset fails to generate an integrity hash (either because it resolves to `null` or throws an `Exception`), we assign it a unique internal grouping ID (`_sri_fallback_group = spl_object_hash($asset)`). 

This ensures that `GroupedCollection` handles each un-hashed asset uniquely, preventing it from merging into earlier un-hashed groups. As a result, the original XML chronological order is perfectly preserved. The unit test `AddDefaultPropertiesToGroupPluginTest` has been expanded to cover these scenarios.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#39762

### Manual testing scenarios (*)

#### 1. Prerequisites (Setup Test Module)
Create a simple test module to reproduce the exact layout condition.

**File 1: `app/code/Test/SRI/registration.php`**
```php
<?php
\Magento\Framework\Component\ComponentRegistrar::register(
    \Magento\Framework\Component\ComponentRegistrar::MODULE,
    'Test_SRI',
    __DIR__
);
```

**File 2: `app/code/Test/SRI/etc/module.xml`**
```xml
<?xml version="1.0"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
    <module name="Test_SRI" />
</config>
```

**File 3: `app/code/Test/SRI/view/frontend/layout/default.xml`**
```xml
<?xml version="1.0"?>
<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
    <head>
        <link src="Test_SRI::js/early_no_hash.js"/>
        <link src="Test_SRI::js/test.min.js"/>
        <link src="Test_SRI::js/test.dependency.js"/>
    </head>
</page>
```

**File 4: `app/code/Test/SRI/view/frontend/web/js/test.min.js`**
```javascript
console.log('Main file loaded');
```

**File 5: `app/code/Test/SRI/view/frontend/web/js/test.dependency.js`**
```javascript
console.log('Dependency loaded');
```

**File 6: `app/code/Test/SRI/view/frontend/web/js/early_no_hash.js`**
```javascript
console.log('Early no hash script loaded');
```

#### 2. Environment Configuration
Run the following commands to enable the module and configure the environment:
```bash
bin/magento module:enable Test_SRI
bin/magento setup:upgrade
bin/magento config:set dev/js/minify_files 1
bin/magento deploy:mode:set production
bin/magento setup:static-content:deploy -f
bin/magento cache:clean
```
*(Note: The issue only reproduces in Production Mode because SRI integrity hashes are typically only generated there).*

#### 3. How to reproduce the Bug (Without the PR applied)
1. Ensure the PR is **NOT** applied yet.
2. Open the storefront homepage (or any page) in your browser.
3. View the page source and check the `<head>` tag.
4. **Expected Incorrect Behavior (Bug):** You will see that `test.dependency.min.js` is rendered **BEFORE** `test.min.js`.
```html
<script type="text/javascript" src=".../early_no_hash.min.js"></script>
<script type="text/javascript" src=".../test.dependency.min.js"></script>
<script type="text/javascript" integrity="sha256-..." src=".../test.min.js"></script>
```

#### 4. How to Verify the Fix (With the PR applied)
1. Apply this PR.
2. Run `bin/magento cache:clean` (You do not need to re-deploy static content).
3. Refresh the storefront homepage.
4. **Expected Correct Behavior (Fixed):** The scripts maintain their strict chronological order exactly as defined in the `default.xml` layout.
```html
<script type="text/javascript" src=".../early_no_hash.min.js"></script>
<script type="text/javascript" integrity="sha256-..." src=".../test.min.js"></script>
<script type="text/javascript" src=".../test.dependency.min.js"></script>
```

### Questions or comments
If you have any questions about the tests or the unique internal grouping ID strategy used in `AddDefaultPropertiesToGroupPlugin.php`, please let me know!

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)