### PR TITLE
#39579: Fix ArgumentCountError in DbStorage array_merge when entity I…

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
+++ b/app/code/Magento/UrlRewrite/Model/Storage/DbStorage.php
@@ -220,7 +220,7 @@ class DbStorage extends AbstractStorage
         foreach ($uniqueEntities as $storeId => $entityTypes) {
             foreach ($entityTypes as $entityType => $entities) {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $requestPaths = array_merge(...$entities);
+                $requestPaths = empty($entities) ? [] : array_merge(...array_values($entities));
                 $requestPathFilter = '';
                 if (!empty($requestPaths)) {
                     $requestPathFilter = ' AND ' . $this->connection->quoteIdentifier(UrlRewrite::REQUEST_PATH)
@@ -273,7 +273,7 @@ class DbStorage extends AbstractStorage
             $newRequestPaths = [];
             foreach ($entityTypes as $entityType => $entities) {
                 // phpcs:ignore Magento2.Performance.ForeachArrayMerge
-                $requestPaths = array_merge(...$entities);
+                $requestPaths = empty($entities) ? [] : array_merge(...array_values($entities));
                 if (empty($requestPaths)) {
                     continue;
                 }

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php
@@ -487,6 +487,28 @@ class DbStorageTest extends TestCase
     }
 
     /**
+     * A missing entity ID casts to a string array key, which PHP 8 misreads as
+     * a named argument when spread into array_merge().
+     *
+     * @return void
+     */
+    public function testReplaceWithoutEntityIdDoesNotThrowError(): void
+    {
+        $url = $this->createMock(UrlRewrite::class);
+        $url->method('toArray')->willReturn(['row1']);
+        $url->method('getEntityType')->willReturn('some-type');
+        $url->method('getEntityId')->willReturn(null);
+        $url->method('getStoreId')->willReturn('store_id_1');
+        $url->method('getRequestPath')->willReturn('some/request/path');
+        $this->connectionMock->method('quoteIdentifier')->willReturnArgument(0);
+        $this->select->method($this->anything())->willReturnSelf();
+        $this->resource->method('getTableName')->with(DbStorage::TABLE_NAME)->willReturn('table_name');
+        $this->connectionMock->method('fetchOne')->willReturn(false);
+
+        $this->assertEquals([$url], $this->storage->replace([$url]));
+    }
+
+    /**
      * @return void
      */
     public function testReplaceIfThrewExceptionOnDuplicateUrl(): void


### PR DESCRIPTION
### Description (*)

Normalize array keys with `array_values()` before the `array_merge()` spread in `deleteOldUrls()` and `checkDuplicates()`. A missing `ENTITY_ID` produces a `null` array key, which PHP casts to the string key `""`, making PHP 8 interpret the spread as a named argument and throw `ArgumentCountError`.

Root cause: when a `UrlRewrite` is built without `ENTITY_ID`, `prepareUniqueEntities()` stores it under `$entityId = null`, and PHP casts that `null` key to `""`. The resulting `$entities` array in `DbStorage::deleteOldUrls()` / `DbStorage::checkDuplicates()` is then string-keyed (`["" => [...]]`), and spreading a string-keyed array into `array_merge(...$entities)` makes PHP 8 read it as a named argument, throwing `ArgumentCountError: array_merge() does not accept unknown named parameters`.

There is an existing open PR (#40665) for this issue that changes the call to `array_merge([], ...$entities)`. That only guards against a *different* edge case — an empty `$entities` array (0 elements) — and does not fix the reported scenario: prepending `[]` doesn't change how PHP interprets the string-keyed element being spread, so the original `ArgumentCountError` still reproduces with that fix applied. `array_values()` resolves the actual root cause by resetting all array keys to sequential integers before the spread, which covers both the string-key case from a missing `ENTITY_ID` and the empty-array case.

### Related Pull Requests

None. Supersedes the approach in #40665, which does not fix the reported `ArgumentCountError` (see Description above for why).

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39579

### Manual testing scenarios (*)

1. Create a `\Magento\UrlRewrite\Service\V1\Data\UrlRewrite` **without** `ENTITY_ID`, e.g.:
   ```php
   $urw = new UrlRewrite([
       UrlRewrite::REQUEST_PATH => 'some/request/path',
       UrlRewrite::TARGET_PATH => 'some/target/path',
       UrlRewrite::ENTITY_TYPE => 'some-type',
       UrlRewrite::STORE_ID => $someStoreId,
   ]);
   ```
2. Call `\Magento\UrlRewrite\Model\StorageInterface::replace([$urw])`.
3. Before the fix: `ArgumentCountError: array_merge() does not accept unknown named parameters` is thrown from `DbStorage.php:223`.
4. After the fix: `replace()` completes without error.
5. Automated coverage: `app/code/Magento/UrlRewrite/Test/Unit/Model/Storage/DbStorageTest.php::testReplaceWithoutEntityIdDoesNotThrowError` reproduces this exact scenario.

### Questions or comments

#40665 is currently open for the same issue and has been approved, but its `array_merge([], ...$entities)` change does not resolve the reported crash — I verified this by reproducing the exact `ArgumentCountError` with that fix applied. Happy to discuss consolidating on whichever approach maintainers prefer.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
