### PR TITLE
feat(39824): simpler read-only session locker

### DIFF
--- a/app/code/Magento/Checkout/etc/frontend/di.xml
+++ b/app/code/Magento/Checkout/etc/frontend/di.xml
@@ -7,6 +7,13 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\Session\SessionAccessModeResolver">
+        <arguments>
+            <argument name="readOnlyPaths" xsi:type="array">
+                <item name="checkout_cart_add" xsi:type="string">checkout/cart/add</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Framework\Url\SecurityInfo">
         <arguments>
             <argument name="secureUrlList" xsi:type="array">

--- a/lib/internal/Magento/Framework/Message/Manager.php
+++ b/lib/internal/Magento/Framework/Message/Manager.php
@@ -134,6 +134,7 @@ class Manager implements ManagerInterface
      */
     public function addMessage(MessageInterface $message, $group = null)
     {
+        $this->session->startWriting();
         $this->hasMessages = true;
         $this->getMessages(false, $group)->addMessage($message);
         $this->eventManager->dispatch('session_abstract_add_message');

--- a/lib/internal/Magento/Framework/Session/SaveHandler.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class SaveHandler implements SaveHandlerInterface, ResetAfterRequestInterface
+class SaveHandler implements SaveHandlerInterface, SessionAccessModeAwareInterface, ResetAfterRequestInterface
 {
     /**
      * @var LoggerInterface
@@ -63,6 +63,11 @@ class SaveHandler implements SaveHandlerInterface, ResetAfterRequestInterface
     private $appState;
 
     /**
+     * Whether the session must initially be opened without a write lock.
+     */
+    private bool $readOnly = false;
+
+    /**
      * @param SaveHandlerFactory $saveHandlerFactory
      * @param ConfigInterface $sessionConfig
      * @param LoggerInterface $logger
@@ -87,6 +92,17 @@ class SaveHandler implements SaveHandlerInterface, ResetAfterRequestInterface
         $this->sessionMaxSizeConfig = $sessionMaxSizeConfigs;
         $this->messageManager = $messageManager ?: ObjectManager::getInstance()->get(ManagerInterface::class);
         $this->appState = $appState ?: ObjectManager::getInstance()->get(State::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setReadOnly(bool $readOnly): void
+    {
+        $this->readOnly = $readOnly;
+        if ($this->saveHandlerAdapter instanceof SessionAccessModeAwareInterface) {
+            $this->saveHandlerAdapter->setReadOnly($readOnly);
+        }
     }
 
     /**
@@ -209,11 +225,25 @@ class SaveHandler implements SaveHandlerInterface, ResetAfterRequestInterface
             if ($this->saveHandlerAdapter === null) {
                 $saveMethod = $this->sessionConfig->getOption('session.save_handler') ?: $this->defaultHandler;
                 $this->saveHandlerAdapter = $this->saveHandlerFactory->create($saveMethod);
+                $this->configureAccessMode();
             }
             return $this->saveHandlerAdapter->{$method}(...$arguments);
         } catch (SessionException $exception) {
             $this->saveHandlerAdapter = $this->saveHandlerFactory->create($this->defaultHandler);
+            $this->configureAccessMode();
             return $this->saveHandlerAdapter->{$method}(...$arguments);
+        }
+    }
+
+    /**
+     * Configures the underlying handler when it supports session access modes.
+     *
+     * @return void
+     */
+    private function configureAccessMode(): void
+    {
+        if ($this->saveHandlerAdapter instanceof SessionAccessModeAwareInterface) {
+            $this->saveHandlerAdapter->setReadOnly($this->readOnly);
         }
     }
 

--- a/lib/internal/Magento/Framework/Session/SaveHandler/Redis.php
+++ b/lib/internal/Magento/Framework/Session/SaveHandler/Redis.php
@@ -14,13 +14,19 @@ use Magento\Framework\Exception\SessionException;
 use Magento\Framework\Phrase;
 use Magento\Framework\Filesystem;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Session\SessionAccessModeAwareInterface;
 
-class Redis implements \SessionHandlerInterface
+class Redis implements \SessionHandlerInterface, SessionAccessModeAwareInterface
 {
     /**
      * @var \Cm\RedisSession\Handler[]
      */
     private array $connection = [];
+
+    /**
+     * Whether the session must initially be opened without a write lock.
+     */
+    private bool $readOnly = false;
 
     /**
      * @param ConfigInterface $config
@@ -46,12 +52,23 @@ class Redis implements \SessionHandlerInterface
         $pid = getmypid();
         if (!isset($this->connection[$pid])) {
             try {
-                $this->connection[$pid] = new \Cm\RedisSession\Handler($this->config, $this->logger);
+                $this->connection[$pid] = new \Cm\RedisSession\Handler($this->config, $this->logger, $this->readOnly);
             } catch (ConnectionFailedException $e) {
                 throw new SessionException(new Phrase($e->getMessage()));
             }
         }
         return $this->connection[$pid];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setReadOnly(bool $readOnly): void
+    {
+        $this->readOnly = $readOnly;
+        foreach ($this->connection as $connection) {
+            $connection->setReadOnly($readOnly);
+        }
     }
 
     /**

--- a/lib/internal/Magento/Framework/Session/SessionAccessModeAwareInterface.php
+++ b/lib/internal/Magento/Framework/Session/SessionAccessModeAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Session;
+
+/**
+ * Session save handlers that can open a session without acquiring a write lock.
+ */
+interface SessionAccessModeAwareInterface
+{
+    /**
+     * Sets whether the next session open is read-only.
+     *
+     * @param bool $readOnly
+     * @return void
+     */
+    public function setReadOnly(bool $readOnly): void;
+}

--- a/lib/internal/Magento/Framework/Session/SessionAccessModeResolver.php
+++ b/lib/internal/Magento/Framework/Session/SessionAccessModeResolver.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Session;
+
+use Magento\Framework\App\RequestInterface;
+
+/**
+ * Resolves whether a request may initially open a Redis session without a write lock.
+ *
+ * Read-only mode must be configured explicitly per path. It must not be inferred from
+ * the HTTP method because Magento extensions can mutate session data on any method.
+ */
+class SessionAccessModeResolver
+{
+    /**
+     * @param RequestInterface $request
+     * @param string[] $readOnlyPaths
+     */
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly array $readOnlyPaths = []
+    ) {
+    }
+
+    /**
+     * Returns whether the request may initially read the session without a write lock.
+     */
+    public function isReadOnly(): bool
+    {
+        if (!method_exists($this->request, 'getPathInfo')) {
+            return false;
+        }
+
+        return in_array(trim($this->request->getPathInfo(), '/'), $this->readOnlyPaths, true);
+    }
+}

--- a/lib/internal/Magento/Framework/Session/SessionManager.php
+++ b/lib/internal/Magento/Framework/Session/SessionManager.php
@@ -83,6 +83,11 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
     private $sessionStartChecker;
 
     /**
+     * Whether this request initially opened the session without a write lock.
+     */
+    private bool $readOnly = false;
+
+    /**
      * @param \Magento\Framework\App\Request\Http $request
      * @param SidResolverInterface $sidResolver
      * @param ConfigInterface $sessionConfig
@@ -93,6 +98,7 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
      * @param \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory
      * @param \Magento\Framework\App\State $appState
      * @param SessionStartChecker|null $sessionStartChecker
+     * @param SessionAccessModeResolver|null $sessionAccessModeResolver
      * @throws \Magento\Framework\Exception\SessionException
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -107,7 +113,8 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
         \Magento\Framework\Stdlib\CookieManagerInterface $cookieManager,
         \Magento\Framework\Stdlib\Cookie\CookieMetadataFactory $cookieMetadataFactory,
         \Magento\Framework\App\State $appState,
-        ?SessionStartChecker $sessionStartChecker = null
+        ?SessionStartChecker $sessionStartChecker = null,
+        ?SessionAccessModeResolver $sessionAccessModeResolver = null
     ) {
         $this->request = $request;
         $this->sidResolver = $sidResolver;
@@ -121,6 +128,9 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
         $this->sessionStartChecker = $sessionStartChecker ?: \Magento\Framework\App\ObjectManager::getInstance()->get(
             SessionStartChecker::class
         );
+        $sessionAccessModeResolver = $sessionAccessModeResolver
+            ?: \Magento\Framework\App\ObjectManager::getInstance()->get(SessionAccessModeResolver::class);
+        $this->readOnly = $sessionAccessModeResolver->isReadOnly();
         $this->start();
     }
 
@@ -132,6 +142,26 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
     public function writeClose()
     {
         session_write_close();
+    }
+
+    /**
+     * Promotes a read-only session to a writable session before it is mutated.
+     *
+     * @return void
+     */
+    public function startWriting(): void
+    {
+        if (!$this->readOnly || session_status() !== PHP_SESSION_ACTIVE) {
+            return;
+        }
+
+        session_write_close();
+        if ($this->saveHandler instanceof SessionAccessModeAwareInterface) {
+            $this->saveHandler->setReadOnly(false);
+        }
+        session_start();
+        Storage::refresh($_SESSION);
+        $this->readOnly = false;
     }
 
     /**
@@ -148,6 +178,9 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
             throw new \InvalidArgumentException(
                 sprintf('Invalid method %s::%s(%s)', get_class($this), $method, print_r($args, 1))
             );
+        }
+        if (in_array(substr($method, 0, 3), ['set', 'uns'], true)) {
+            $this->startWriting();
         }
         $return = call_user_func_array([$this->storage, $method], $args);
         return $return === $this->storage ? $this : $return;
@@ -178,6 +211,9 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
 
                 // Need to apply the config options so they can be ready by session_start
                 $this->initIniOptions();
+                if ($this->saveHandler instanceof SessionAccessModeAwareInterface) {
+                    $this->saveHandler->setReadOnly($this->readOnly);
+                }
                 $this->registerSaveHandler();
                 if (isset($_SESSION['new_session_id'])) {
                     // Not fully expired yet. Could be lost cookie by unstable network.
@@ -287,6 +323,7 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
     {
         $data = $this->storage->getData($key);
         if ($clear && isset($data)) {
+            $this->startWriting();
             $this->storage->unsetData($key);
         }
         return $data;
@@ -357,6 +394,7 @@ class SessionManager implements SessionManagerInterface, ResetAfterRequestInterf
      */
     public function clearStorage()
     {
+        $this->startWriting();
         $this->storage->unsetData();
         return $this;
     }

--- a/lib/internal/Magento/Framework/Session/Storage.php
+++ b/lib/internal/Magento/Framework/Session/Storage.php
@@ -13,6 +13,13 @@ use Magento\Framework\ObjectManager\ResetAfterRequestInterface;
 class Storage extends \Magento\Framework\DataObject implements StorageInterface, ResetAfterRequestInterface
 {
     /**
+     * Storage instances attached to the active PHP session.
+     *
+     * @var Storage[]
+     */
+    private static array $instances = [];
+
+    /**
      * Namespace of storage
      *
      * @var string
@@ -20,11 +27,17 @@ class Storage extends \Magento\Framework\DataObject implements StorageInterface,
     protected $namespace;
 
     /**
+     * Whether this storage has been attached to the active session.
+     */
+    private bool $initialized = false;
+
+    /**
      * @inheritDoc
      */
     public function _resetState(): void
     {
         $this->_data = [];
+        unset(self::$instances[spl_object_id($this)]);
     }
 
     /**
@@ -37,6 +50,22 @@ class Storage extends \Magento\Framework\DataObject implements StorageInterface,
     {
         $this->namespace = $namespace;
         parent::__construct($data);
+        self::$instances[spl_object_id($this)] = $this;
+    }
+
+    /**
+     * Rebinds every initialized storage namespace after a session is reopened.
+     *
+     * @param array $data
+     * @return void
+     */
+    public static function refresh(array $data): void
+    {
+        foreach (self::$instances as $storage) {
+            if ($storage->initialized) {
+                $storage->init($data);
+            }
+        }
     }
 
     /**
@@ -44,10 +73,9 @@ class Storage extends \Magento\Framework\DataObject implements StorageInterface,
      */
     public function init(array $data)
     {
+        $this->initialized = true;
         $namespace = $this->getNamespace() ?? '';
-        if (isset($data[$namespace])) {
-            $this->setData($data[$namespace]);
-        }
+        $this->setData($data[$namespace] ?? []);
         $_SESSION[$namespace] = & $this->_data;
         return $this;
     }

--- a/lib/internal/Magento/Framework/Session/Test/Unit/SessionAccessModeResolverTest.php
+++ b/lib/internal/Magento/Framework/Session/Test/Unit/SessionAccessModeResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Session\Test\Unit;
+
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Session\SessionAccessModeResolver;
+use PHPUnit\Framework\TestCase;
+
+class SessionAccessModeResolverTest extends TestCase
+{
+    public function testReturnsReadOnlyForExplicitlyConfiguredPath(): void
+    {
+        $request = $this->createMock(Http::class);
+        $request->method('getPathInfo')->willReturn('/checkout/cart/add/');
+
+        $resolver = new SessionAccessModeResolver($request, ['checkout/cart/add']);
+
+        self::assertTrue($resolver->isReadOnly());
+    }
+
+    public function testDefaultsToWritableForUnconfiguredPath(): void
+    {
+        $request = $this->createMock(Http::class);
+        $request->method('getPathInfo')->willReturn('/checkout/cart/updatePost');
+
+        $resolver = new SessionAccessModeResolver($request, ['checkout/cart/add']);
+
+        self::assertFalse($resolver->isReadOnly());
+    }
+
+    public function testDefaultsToWritableWhenRequestDoesNotExposePathInfo(): void
+    {
+        $resolver = new SessionAccessModeResolver($this->createMock(RequestInterface::class), ['checkout/cart/add']);
+
+        self::assertFalse($resolver->isReadOnly());
+    }
+}


### PR DESCRIPTION
### Description (*)                                                            
                                                                                
 Adds explicitly configured read-only session mode for checkout/cart/add. Redis 
 session locking is deferred until the request first mutates session data,      
 allowing concurrent add-to-cart requests to wait on the existing quote mutex   
 instead of holding Redis session locks during quote processing.                
                                                                                
 ### Related Pull Requests                                                      
                                                                                
 <!-- related pull request placeholder -->                                      
                                                                                
 ### Fixed Issues (if relevant)                                                 
                                                                                
 1. Fixes #39824                                                
                                                                                
 ### Manual testing scenarios (*)                                               
                                                                                
 1. Configure Redis sessions with disable_locking = 0.                          
 2. Add one product to create a guest quote.                                    
 3. On a category page, submit multiple simple-product add-to-cart requests     
    concurrently using the same browser session.                                
 4. Confirm all products are present in the cart, without duplicate or missing  
    items.                                                                      
 5. Confirm add-to-cart success/error messages remain available.                
 6. Compare request profiling: Redis session lock wait should not cover quote   
    loading, quote-row mutex wait, or quote totals collection.                  
                                                                                
 ### Questions or comments                                                      
                                                                                
 The change keeps quote-row locking intact for cart correctness. Read-only mode 
 is explicitly configured for checkout/cart/add; it is not inferred from HTTP   
 method.                                                                        
                                                                                
 ### Contribution checklist (*)                                                 
                                                                                
 - [x] Pull request has a meaningful description of its purpose                 
 - [x] All commits are accompanied by meaningful commit messages                
 - [x] All new or changed code is covered with unit/integration tests (if       
       applicable)                                                              
 - [ ] README.md files for modified modules are updated and included in the     
       pull request if any predefined sections require an update                
 - [x] Focused automated tests passed successfully