### PR TITLE
Fix: checkout no longer duplicates an existing customer address (#32294)

### DIFF
--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -11,6 +11,8 @@ use Magento\Checkout\Api\Data\PaymentDetailsInterface;
 use Magento\Checkout\Api\Data\ShippingInformationInterface;
 use Magento\Checkout\Api\ShippingInformationManagementInterface;
 use Magento\Customer\Api\AddressRepositoryInterface;
+use Magento\Customer\Api\Data\AddressInterface as CustomerAddressInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
@@ -115,6 +117,23 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
     private $quoteAddressValidationService;
 
     /**
+     * @var SearchCriteriaBuilder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var AddressRepositoryInterface
+     */
+    private $customerAddressRepository;
+
+    /**
+     * Address book of the customer the cart belongs to, loaded once per saveAddressInformation() call.
+     *
+     * @var CustomerAddressInterface[]|null
+     */
+    private $customerAddressBook;
+
+    /**
      * @param PaymentMethodManagementInterface $paymentMethodManagement
      * @param PaymentDetailsFactory $paymentDetailsFactory
      * @param CartTotalRepositoryInterface $cartTotalsRepository
@@ -129,6 +148,8 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
      * @param ShippingFactory|null $shippingFactory
      * @param AddressComparatorInterface|null $addressComparator
      * @param QuoteAddressValidationService|null $quoteAddressValidationService
+     * @param SearchCriteriaBuilder|null $searchCriteriaBuilder
+     * @param AddressRepositoryInterface|null $customerAddressRepository
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -145,7 +166,9 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
         ?ShippingAssignmentFactory $shippingAssignmentFactory = null,
         ?ShippingFactory $shippingFactory = null,
         ?AddressComparatorInterface $addressComparator = null,
-        ?QuoteAddressValidationService $quoteAddressValidationService = null
+        ?QuoteAddressValidationService $quoteAddressValidationService = null,
+        ?SearchCriteriaBuilder $searchCriteriaBuilder = null,
+        ?AddressRepositoryInterface $customerAddressRepository = null
     ) {
         $this->paymentMethodManagement = $paymentMethodManagement;
         $this->paymentDetailsFactory = $paymentDetailsFactory;
@@ -166,6 +189,10 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
             ?? ObjectManager::getInstance()->get(AddressComparatorInterface::class);
         $this->quoteAddressValidationService = $quoteAddressValidationService ?: ObjectManager::getInstance()
             ->get(QuoteAddressValidationService::class);
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: ObjectManager::getInstance()
+            ->get(SearchCriteriaBuilder::class);
+        $this->customerAddressRepository = $customerAddressRepository ?: ObjectManager::getInstance()
+            ->get(AddressRepositoryInterface::class);
     }
 
     /**
@@ -182,6 +209,8 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
         $cartId,
         ShippingInformationInterface $addressInformation
     ): PaymentDetailsInterface {
+        $this->customerAddressBook = null;
+
         /** @var Quote $quote */
         $quote = $this->quoteRepository->getActive($cartId);
         $this->validateQuote($quote);
@@ -322,7 +351,10 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
     }
 
     /**
-     * Update customer shipping address ID if the address is the same as the quote shipping address.
+     * Update customer shipping address ID
+     *
+     * Reuses the ID of the quote shipping address, or of an entry that is already saved in the
+     * customer's address book, so that a duplicate address is not created.
      *
      * @param Quote $quote
      * @param AddressInterface $address
@@ -330,17 +362,26 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
      */
     private function updateCustomerShippingAddressId(Quote $quote, AddressInterface $address): void
     {
+        if ($address->getCustomerAddressId()) {
+            return;
+        }
+
         $quoteShippingAddress = $quote->getShippingAddress();
-        if (!$address->getCustomerAddressId() &&
-            $quoteShippingAddress->getCustomerAddressId() &&
+        if ($quoteShippingAddress->getCustomerAddressId() &&
             $this->addressComparator->isEqual($address, $quoteShippingAddress)
         ) {
             $address->setCustomerAddressId($quoteShippingAddress->getCustomerAddressId());
+            return;
         }
+
+        $this->linkToExistingCustomerAddress($quote, $address);
     }
 
     /**
-     * Update customer billing address ID if the address is the same as the quote billing address.
+     * Update customer billing address ID
+     *
+     * Reuses the ID of the quote billing address, or of an entry that is already saved in the
+     * customer's address book, so that a duplicate address is not created.
      *
      * @param Quote $quote
      * @param AddressInterface $billingAddress
@@ -353,6 +394,220 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
             $this->addressComparator->isEqual($billingAddress, $quoteBillingAddress)
         ) {
             $billingAddress->setCustomerAddressId($quoteBillingAddress->getCustomerAddressId());
+            return;
         }
+
+        $this->linkToExistingCustomerAddress($quote, $billingAddress);
+    }
+
+    /**
+     * Point the address at a matching address book entry instead of letting a duplicate be created.
+     *
+     * Addresses the case where a customer uses "Add new address" and manually re-enters the details
+     * of an address that is already stored in their address book.
+     *
+     * @param Quote $quote
+     * @param AddressInterface $address
+     * @return void
+     */
+    private function linkToExistingCustomerAddress(Quote $quote, AddressInterface $address): void
+    {
+        // Only an address that is about to be written to the address book can produce a duplicate.
+        if (!$address->getSaveInAddressBook()) {
+            return;
+        }
+
+        $matchingAddressId = $this->findMatchingCustomerAddressId($quote, $address);
+        if (!$matchingAddressId) {
+            return;
+        }
+
+        $address->setCustomerAddressId($matchingAddressId);
+        // The entry already exists, so there is nothing left to write. Skipping the write also keeps
+        // the data that is not part of the comparison - custom attributes, default billing/shipping
+        // flags - on the stored address untouched.
+        $address->setSaveInAddressBook(0);
+        // QuoteManagement::_prepareCustomerQuote() re-saves the address as a new one whenever
+        // getCustomerId() is empty, regardless of the save-in-address-book flag or the address ID
+        // set above - exportCustomerAddress() does not carry customer_address_id over as the id of
+        // the exported object. Setting the owner here closes that gate and keeps the order pointed
+        // at the existing address book entry instead of a freshly duplicated one.
+        $address->setCustomerId((int)$quote->getCustomerId());
+    }
+
+    /**
+     * Search the customer's address book for an address equal to the given quote address.
+     *
+     * @param Quote $quote
+     * @param AddressInterface $address
+     * @return int|null
+     */
+    private function findMatchingCustomerAddressId(Quote $quote, AddressInterface $address): ?int
+    {
+        $customerId = (int)$quote->getCustomerId();
+        if (!$customerId) {
+            return null;
+        }
+
+        $addressData = $this->extractQuoteAddressData($address);
+        foreach ($this->getCustomerAddressBook($customerId) as $customerAddress) {
+            if ($this->isSameAddress($addressData, $this->extractCustomerAddressData($customerAddress))) {
+                return (int)$customerAddress->getId();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Load the address book of the given customer, once per saveAddressInformation() call.
+     *
+     * @param int $customerId
+     * @return CustomerAddressInterface[]
+     */
+    private function getCustomerAddressBook(int $customerId): array
+    {
+        if ($this->customerAddressBook !== null) {
+            return $this->customerAddressBook;
+        }
+
+        // Addresses of the customer_address EAV entity reference their owner through parent_id;
+        // customer_id is not an attribute of that collection and is rejected by the collection processor.
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter('parent_id', $customerId)
+            ->create();
+
+        try {
+            $addresses = $this->customerAddressRepository->getList($searchCriteria)->getItems();
+        } catch (\Exception $e) {
+            // A failed lookup only means the duplicate cannot be detected, so checkout continues.
+            $this->logger->error($e);
+            $addresses = [];
+        }
+
+        // An address book that already contains duplicates must always resolve to the same entry.
+        usort(
+            $addresses,
+            static fn (CustomerAddressInterface $left, CustomerAddressInterface $right)
+                => (int)$left->getId() <=> (int)$right->getId()
+        );
+        $this->customerAddressBook = $addresses;
+
+        return $this->customerAddressBook;
+    }
+
+    /**
+     * Bring a quote address to the form used for comparison.
+     *
+     * @param AddressInterface $address
+     * @return array
+     */
+    private function extractQuoteAddressData(AddressInterface $address): array
+    {
+        return [
+            'prefix' => $this->normalize($address->getPrefix()),
+            'firstname' => $this->normalize($address->getFirstname()),
+            'middlename' => $this->normalize($address->getMiddlename()),
+            'lastname' => $this->normalize($address->getLastname()),
+            'suffix' => $this->normalize($address->getSuffix()),
+            'company' => $this->normalize($address->getCompany()),
+            'street' => $this->normalizeStreet($address->getStreet()),
+            'city' => $this->normalize($address->getCity()),
+            'region_id' => $this->normalize($address->getRegionId()),
+            'region' => $this->normalize($address->getRegion()),
+            'postcode' => $this->normalize($address->getPostcode()),
+            'country_id' => $this->normalize($address->getCountryId()),
+            'telephone' => $this->normalize($address->getTelephone()),
+            'fax' => $this->normalize($address->getFax()),
+            'vat_id' => $this->normalize($address->getVatId()),
+        ];
+    }
+
+    /**
+     * Bring an address book entry to the form used for comparison.
+     *
+     * @param CustomerAddressInterface $address
+     * @return array
+     */
+    private function extractCustomerAddressData(CustomerAddressInterface $address): array
+    {
+        $region = $address->getRegion();
+
+        return [
+            'prefix' => $this->normalize($address->getPrefix()),
+            'firstname' => $this->normalize($address->getFirstname()),
+            'middlename' => $this->normalize($address->getMiddlename()),
+            'lastname' => $this->normalize($address->getLastname()),
+            'suffix' => $this->normalize($address->getSuffix()),
+            'company' => $this->normalize($address->getCompany()),
+            'street' => $this->normalizeStreet($address->getStreet()),
+            'city' => $this->normalize($address->getCity()),
+            'region_id' => $this->normalize($address->getRegionId()),
+            'region' => $this->normalize($region === null ? null : $region->getRegion()),
+            'postcode' => $this->normalize($address->getPostcode()),
+            'country_id' => $this->normalize($address->getCountryId()),
+            'telephone' => $this->normalize($address->getTelephone()),
+            'fax' => $this->normalize($address->getFax()),
+            'vat_id' => $this->normalize($address->getVatId()),
+        ];
+    }
+
+    /**
+     * Compare two addresses that were brought to their comparable form.
+     *
+     * @param array $quoteAddressData
+     * @param array $customerAddressData
+     * @return bool
+     */
+    private function isSameAddress(array $quoteAddressData, array $customerAddressData): bool
+    {
+        // A region is stored as an id for countries with a predefined region list and as free text
+        // for the remaining ones. Where both sides carry an id it decides, and the text - which the
+        // checkout does not always fill in - is left out of the comparison.
+        if ($quoteAddressData['region_id'] !== '' && $customerAddressData['region_id'] !== '') {
+            if ($quoteAddressData['region_id'] !== $customerAddressData['region_id']) {
+                return false;
+            }
+            unset($quoteAddressData['region'], $customerAddressData['region']);
+        }
+        unset($quoteAddressData['region_id'], $customerAddressData['region_id']);
+
+        return $quoteAddressData == $customerAddressData;
+    }
+
+    /**
+     * Bring a single address field to a comparable form.
+     *
+     * The value is cast rather than type hinted because REST and GraphQL payloads deliver numeric
+     * postcodes and phone numbers as integers, which would fail the strict types of this file.
+     *
+     * @param mixed $value
+     * @return string
+     */
+    private function normalize($value): string
+    {
+        return mb_strtolower(trim((string)$value));
+    }
+
+    /**
+     * Bring the street of an address to a comparable form.
+     *
+     * The number of stored lines differs between an address entered in checkout and one loaded from
+     * the address book, so empty lines are dropped and the remaining ones are re-indexed.
+     *
+     * @param string[]|string|null $street
+     * @return string[]
+     */
+    private function normalizeStreet($street): array
+    {
+        $lines = [];
+        foreach ((array)$street as $line) {
+            $line = $this->normalize($line);
+            if ($line !== '') {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
     }
 }

--- a/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/ShippingInformationManagement.php
@@ -122,11 +122,6 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
     private $searchCriteriaBuilder;
 
     /**
-     * @var AddressRepositoryInterface
-     */
-    private $customerAddressRepository;
-
-    /**
      * Address book of the customer the cart belongs to, loaded once per saveAddressInformation() call.
      *
      * @var CustomerAddressInterface[]|null
@@ -149,7 +144,6 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
      * @param AddressComparatorInterface|null $addressComparator
      * @param QuoteAddressValidationService|null $quoteAddressValidationService
      * @param SearchCriteriaBuilder|null $searchCriteriaBuilder
-     * @param AddressRepositoryInterface|null $customerAddressRepository
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -167,8 +161,7 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
         ?ShippingFactory $shippingFactory = null,
         ?AddressComparatorInterface $addressComparator = null,
         ?QuoteAddressValidationService $quoteAddressValidationService = null,
-        ?SearchCriteriaBuilder $searchCriteriaBuilder = null,
-        ?AddressRepositoryInterface $customerAddressRepository = null
+        ?SearchCriteriaBuilder $searchCriteriaBuilder = null
     ) {
         $this->paymentMethodManagement = $paymentMethodManagement;
         $this->paymentDetailsFactory = $paymentDetailsFactory;
@@ -191,8 +184,6 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
             ->get(QuoteAddressValidationService::class);
         $this->searchCriteriaBuilder = $searchCriteriaBuilder ?: ObjectManager::getInstance()
             ->get(SearchCriteriaBuilder::class);
-        $this->customerAddressRepository = $customerAddressRepository ?: ObjectManager::getInstance()
-            ->get(AddressRepositoryInterface::class);
     }
 
     /**
@@ -478,7 +469,7 @@ class ShippingInformationManagement implements ShippingInformationManagementInte
             ->create();
 
         try {
-            $addresses = $this->customerAddressRepository->getList($searchCriteria)->getItems();
+            $addresses = $this->addressRepository->getList($searchCriteria)->getItems();
         } catch (\Exception $e) {
             // A failed lookup only means the duplicate cannot be detected, so checkout continues.
             $this->logger->error($e);

--- a/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
@@ -12,6 +12,11 @@ use Magento\Checkout\Api\Data\ShippingInformationInterface;
 use Magento\Checkout\Model\PaymentDetailsFactory;
 use Magento\Checkout\Model\ShippingInformationManagement;
 use Magento\Checkout\Model\AddressComparatorInterface;
+use Magento\Customer\Api\Data\AddressInterface as CustomerAddressInterface;
+use Magento\Customer\Api\Data\AddressSearchResultsInterface;
+use Magento\Customer\Api\Data\RegionInterface;
+use Magento\Framework\Api\SearchCriteria;
+use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -151,6 +156,16 @@ class ShippingInformationManagementTest extends TestCase
     private $addressComparatorMock;
 
     /**
+     * @var SearchCriteriaBuilder|MockObject
+     */
+    private $searchCriteriaBuilderMock;
+
+    /**
+     * @var AddressRepositoryInterface|MockObject
+     */
+    private $customerAddressRepositoryMock;
+
+    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -178,6 +193,8 @@ class ShippingInformationManagementTest extends TestCase
         $this->totalsCollectorMock = $this->createMock(TotalsCollector::class);
         $this->addressComparatorMock = $this->createMock(AddressComparatorInterface::class);
         $quoteAddressValidationServiceMock = $this->createMock(QuoteAddressValidationService::class);
+        $this->searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
+        $this->customerAddressRepositoryMock = $this->createMock(AddressRepositoryInterface::class);
 
         $this->model = new ShippingInformationManagement(
             $this->paymentMethodManagementMock,
@@ -193,7 +210,9 @@ class ShippingInformationManagementTest extends TestCase
             $this->shippingAssignmentFactoryMock,
             $this->shippingFactoryMock,
             $this->addressComparatorMock,
-            $quoteAddressValidationServiceMock
+            $quoteAddressValidationServiceMock,
+            $this->searchCriteriaBuilderMock,
+            $this->customerAddressRepositoryMock
         );
     }
 
@@ -597,6 +616,142 @@ class ShippingInformationManagementTest extends TestCase
             ->willReturn($cartTotalsMock);
 
         $this->assertEquals(
+            $paymentDetailsMock,
+            $this->model->saveAddressInformation($cartId, $addressInformationMock)
+        );
+    }
+
+    /**
+     * A new address equal to one already in the address book is linked to it instead of being duplicated
+     *
+     * @return void
+     */
+    public function testSaveAddressInformationReusesMatchingCustomerAddress(): void
+    {
+        $cartId = self::STUB_CART_ID;
+        $carrierCode = self::STUB_CARRIER_CODE;
+        $shippingMethod = self::STUB_SHIPPING_METHOD;
+        $existingAddressId = 7;
+
+        // The address the customer typed into the "Add new address" form. The postcode arrives as an
+        // integer, which is what a REST payload delivers, and the street carries a trailing empty line.
+        $this->shippingAddressMock = $this->createPartialMockWithReflection(
+            Address::class,
+            [
+                'getCountryId',
+                'getShippingMethod',
+                'getShippingRateByCode',
+                'getCustomerAddressId',
+                'setCustomerAddressId',
+                'getSaveInAddressBook',
+                'setSaveInAddressBook',
+                'setLimitCarrier',
+                'getPrefix',
+                'getFirstname',
+                'getMiddlename',
+                'getLastname',
+                'getSuffix',
+                'getCompany',
+                'getStreet',
+                'getCity',
+                'getRegionId',
+                'getRegion',
+                'getPostcode',
+                'getTelephone',
+                'getFax',
+                'getVatId',
+            ]
+        );
+        $this->shippingAddressMock->method('getCountryId')->willReturn('US');
+        $this->shippingAddressMock->method('getSaveInAddressBook')->willReturn(1);
+        $this->shippingAddressMock->method('getFirstname')->willReturn('John');
+        $this->shippingAddressMock->method('getLastname')->willReturn('Doe');
+        $this->shippingAddressMock->method('getStreet')->willReturn(['Green str, 67', '']);
+        $this->shippingAddressMock->method('getCity')->willReturn('CityM');
+        $this->shippingAddressMock->method('getRegionId')->willReturn(1);
+        $this->shippingAddressMock->method('getRegion')->willReturn(null);
+        $this->shippingAddressMock->method('getPostcode')->willReturn(75477);
+        $this->shippingAddressMock->method('getTelephone')->willReturn('3468676');
+        // Empty before the lookup, resolved to the existing entry afterwards.
+        $this->shippingAddressMock->method('getCustomerAddressId')
+            ->willReturnOnConsecutiveCalls(null, $existingAddressId);
+
+        // The very same address, as it is already stored in the address book. It differs only in the
+        // way the equal values are represented: string postcode, no trailing street line, upper case.
+        $regionMock = $this->createMock(RegionInterface::class);
+        $regionMock->method('getRegion')->willReturn('Alabama');
+        $existingAddressMock = $this->createMock(CustomerAddressInterface::class);
+        $existingAddressMock->method('getId')->willReturn($existingAddressId);
+        $existingAddressMock->method('getFirstname')->willReturn('John');
+        $existingAddressMock->method('getLastname')->willReturn('Doe');
+        $existingAddressMock->method('getStreet')->willReturn(['Green Str, 67']);
+        $existingAddressMock->method('getCity')->willReturn('CityM');
+        $existingAddressMock->method('getCountryId')->willReturn('US');
+        $existingAddressMock->method('getRegionId')->willReturn(1);
+        $existingAddressMock->method('getRegion')->willReturn($regionMock);
+        $existingAddressMock->method('getPostcode')->willReturn('75477');
+        $existingAddressMock->method('getTelephone')->willReturn('3468676');
+
+        $searchResultsMock = $this->createMock(AddressSearchResultsInterface::class);
+        $searchResultsMock->method('getItems')->willReturn([$existingAddressMock]);
+        $this->searchCriteriaBuilderMock->method('addFilter')->willReturnSelf();
+        $this->searchCriteriaBuilderMock->method('create')
+            ->willReturn($this->createMock(SearchCriteria::class));
+        $this->customerAddressRepositoryMock->expects($this->once())
+            ->method('getList')
+            ->willReturn($searchResultsMock);
+
+        // The existing entry is reused and nothing is written to the address book.
+        $this->shippingAddressMock->expects($this->once())
+            ->method('setCustomerAddressId')
+            ->with($existingAddressId);
+        $this->shippingAddressMock->expects($this->once())
+            ->method('setSaveInAddressBook')
+            ->with(0);
+
+        $quoteShippingAddressMock = $this->createPartialMockWithReflection(
+            Address::class,
+            ['getCustomerAddressId', 'getShippingMethod', 'getShippingRateByCode']
+        );
+        $quoteShippingAddressMock->method('getCustomerAddressId')->willReturn(null);
+        $quoteShippingAddressMock->method('getShippingMethod')->willReturn($shippingMethod);
+        $quoteShippingAddressMock->method('getShippingRateByCode')->with($shippingMethod)->willReturn('rates');
+
+        /** @var ShippingInformationInterface|MockObject $addressInformationMock */
+        $addressInformationMock = $this->createMock(ShippingInformationInterface::class);
+        $addressInformationMock->method('getShippingAddress')->willReturn($this->shippingAddressMock);
+        $addressInformationMock->method('getShippingCarrierCode')->willReturn($carrierCode);
+        $addressInformationMock->method('getShippingMethodCode')->willReturn($shippingMethod);
+        $addressInformationMock->method('getBillingAddress')->willReturn(null);
+
+        // getCustomerId() is served by the magic getter of the model, so it has to be declared explicitly.
+        $this->quoteMock = $this->createPartialMockWithReflection(
+            Quote::class,
+            [
+                'getItemsCount',
+                'getCustomerId',
+                'getShippingAddress',
+                'setIsMultiShipping',
+                'getIsVirtual',
+                'getExtensionAttributes',
+                'setExtensionAttributes',
+            ]
+        );
+        $this->quoteRepositoryMock->method('getActive')->with($cartId)->willReturn($this->quoteMock);
+        $this->quoteMock->method('getItemsCount')->willReturn(self::STUB_ITEMS_COUNT);
+        $this->quoteMock->method('getCustomerId')->willReturn(42);
+        $this->quoteMock->method('getIsVirtual')->willReturn(false);
+        $this->quoteMock->method('getShippingAddress')->willReturn($quoteShippingAddressMock);
+
+        $this->setShippingAssignmentsMocks($carrierCode . '_' . $shippingMethod);
+
+        $paymentDetailsMock = $this->createMock(PaymentDetailsInterface::class);
+        $this->paymentDetailsFactoryMock->method('create')->willReturn($paymentDetailsMock);
+        $this->paymentMethodManagementMock->method('getList')->with($cartId)->willReturn([]);
+        $this->cartTotalsRepositoryMock->method('get')->with($cartId)
+            ->willReturn($this->createMock(TotalsInterface::class));
+
+        $this->assertSame(
             $paymentDetailsMock,
             $this->model->saveAddressInformation($cartId, $addressInformationMock)
         );

--- a/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
+++ b/app/code/Magento/Checkout/Test/Unit/Model/ShippingInformationManagementTest.php
@@ -161,11 +161,6 @@ class ShippingInformationManagementTest extends TestCase
     private $searchCriteriaBuilderMock;
 
     /**
-     * @var AddressRepositoryInterface|MockObject
-     */
-    private $customerAddressRepositoryMock;
-
-    /**
      * @inheritdoc
      */
     protected function setUp(): void
@@ -194,7 +189,6 @@ class ShippingInformationManagementTest extends TestCase
         $this->addressComparatorMock = $this->createMock(AddressComparatorInterface::class);
         $quoteAddressValidationServiceMock = $this->createMock(QuoteAddressValidationService::class);
         $this->searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
-        $this->customerAddressRepositoryMock = $this->createMock(AddressRepositoryInterface::class);
 
         $this->model = new ShippingInformationManagement(
             $this->paymentMethodManagementMock,
@@ -211,8 +205,7 @@ class ShippingInformationManagementTest extends TestCase
             $this->shippingFactoryMock,
             $this->addressComparatorMock,
             $quoteAddressValidationServiceMock,
-            $this->searchCriteriaBuilderMock,
-            $this->customerAddressRepositoryMock
+            $this->searchCriteriaBuilderMock
         );
     }
 
@@ -697,7 +690,7 @@ class ShippingInformationManagementTest extends TestCase
         $this->searchCriteriaBuilderMock->method('addFilter')->willReturnSelf();
         $this->searchCriteriaBuilderMock->method('create')
             ->willReturn($this->createMock(SearchCriteria::class));
-        $this->customerAddressRepositoryMock->expects($this->once())
+        $this->addressRepositoryMock->expects($this->once())
             ->method('getList')
             ->willReturn($searchResultsMock);
 

--- a/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementDuplicateAddressTest.php
+++ b/dev/tests/integration/testsuite/Magento/Checkout/Model/ShippingInformationManagementDuplicateAddressTest.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Checkout\Model;
+
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Api\PaymentInformationManagementInterface;
+use Magento\Checkout\Api\ShippingInformationManagementInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Address\CollectionFactory as AddressCollectionFactory;
+use Magento\Quote\Api\CartItemRepositoryInterface;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Quote\Api\Data\AddressInterfaceFactory;
+use Magento\Quote\Api\Data\CartItemInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Checks that checkout does not duplicate an address that the customer already has.
+ *
+ * @see https://github.com/magento/magento2/issues/32294
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation enabled
+ */
+class ShippingInformationManagementDuplicateAddressTest extends TestCase
+{
+    private const CUSTOMER_ID = 1;
+
+    /**
+     * The single address created by the Magento/Customer/_files/customer_address.php fixture.
+     */
+    private const EXISTING_ADDRESS_ID = 1;
+
+    /**
+     * @var CartManagementInterface
+     */
+    private $cartManagement;
+
+    /**
+     * @var CartItemRepositoryInterface
+     */
+    private $cartItemRepository;
+
+    /**
+     * @var ShippingInformationManagementInterface
+     */
+    private $shippingInformationManagement;
+
+    /**
+     * @var PaymentInformationManagementInterface
+     */
+    private $paymentInformationManagement;
+
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
+     * @var AddressInterfaceFactory
+     */
+    private $addressFactory;
+
+    /**
+     * @var AddressCollectionFactory
+     */
+    private $addressCollectionFactory;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+
+        $this->cartManagement = $objectManager->create(CartManagementInterface::class);
+        $this->cartItemRepository = $objectManager->create(CartItemRepositoryInterface::class);
+        $this->shippingInformationManagement = $objectManager->create(ShippingInformationManagementInterface::class);
+        $this->paymentInformationManagement = $objectManager->create(PaymentInformationManagementInterface::class);
+        $this->customerRepository = $objectManager->create(CustomerRepositoryInterface::class);
+        $this->addressFactory = $objectManager->create(AddressInterfaceFactory::class);
+        $this->addressCollectionFactory = $objectManager->get(AddressCollectionFactory::class);
+        $this->orderRepository = $objectManager->create(OrderRepositoryInterface::class);
+    }
+
+    /**
+     * An address re-entered through "Add new address" is linked to the stored one instead of duplicated.
+     *
+     * @magentoDataFixture Magento/Customer/_files/customer.php
+     * @magentoDataFixture Magento/Customer/_files/customer_address.php
+     * @magentoDataFixture Magento/Catalog/_files/product_virtual_in_stock.php
+     * @magentoConfigFixture current_store carriers/flatrate/active 1
+     * @magentoConfigFixture current_store payment/checkmo/active 1
+     *
+     * @return void
+     */
+    public function testAddressEqualToAnExistingOneIsNotDuplicated(): void
+    {
+        $this->assertSame(1, $this->countCustomerAddresses(), 'The fixture has to provide one address.');
+
+        $quoteId = $this->createCartWithItem();
+        $order = $this->placeOrder($quoteId, $this->createAddressEqualToTheStoredOne());
+
+        $this->assertSame(
+            1,
+            $this->countCustomerAddresses(),
+            'Re-entering a stored address must not add another entry to the address book.'
+        );
+        // The fixture product is virtual, so a virtual order carries no shipping address; the same
+        // address object was submitted as both billing and shipping, so billing is checked instead.
+        $this->assertEquals(
+            self::EXISTING_ADDRESS_ID,
+            $order->getBillingAddress()->getCustomerAddressId(),
+            'The order has to reference the address that already existed.'
+        );
+    }
+
+    /**
+     * A genuinely new address is still added to the address book.
+     *
+     * @magentoDataFixture Magento/Customer/_files/customer.php
+     * @magentoDataFixture Magento/Customer/_files/customer_address.php
+     * @magentoDataFixture Magento/Catalog/_files/product_virtual_in_stock.php
+     * @magentoConfigFixture current_store carriers/flatrate/active 1
+     * @magentoConfigFixture current_store payment/checkmo/active 1
+     *
+     * @return void
+     */
+    public function testDifferentAddressIsStillAddedToTheAddressBook(): void
+    {
+        $this->assertSame(1, $this->countCustomerAddresses(), 'The fixture has to provide one address.');
+
+        $address = $this->createAddressEqualToTheStoredOne();
+        $address->setStreet(['Blue str, 12']);
+
+        $quoteId = $this->createCartWithItem();
+        $this->placeOrder($quoteId, $address);
+
+        $this->assertSame(
+            2,
+            $this->countCustomerAddresses(),
+            'An address that differs from the stored one still has to be saved.'
+        );
+    }
+
+    /**
+     * Build the address the customer types into the "Add new address" form.
+     *
+     * The values are the ones of the Magento/Customer/_files/customer_address.php fixture, written the
+     * way a customer would type them a second time: different case, padded street, extra empty line.
+     *
+     * @return AddressInterface
+     */
+    private function createAddressEqualToTheStoredOne(): AddressInterface
+    {
+        $customer = $this->customerRepository->getById(self::CUSTOMER_ID);
+
+        /** @var AddressInterface $address */
+        $address = $this->addressFactory->create();
+        $address->setFirstname('john')
+            ->setLastname('SMITH')
+            ->setCompany('CompanyName')
+            ->setStreet([' Green str, 67 ', ''])
+            ->setCity('CityM')
+            ->setRegionId(1)
+            ->setCountryId('US')
+            ->setPostcode('75477')
+            ->setTelephone('3468676')
+            ->setEmail($customer->getEmail())
+            ->setSaveInAddressBook(1);
+
+        return $address;
+    }
+
+    /**
+     * Create a cart for the fixture customer and put a shippable product into it.
+     *
+     * @return int
+     */
+    private function createCartWithItem(): int
+    {
+        $quoteId = (int)$this->cartManagement->createEmptyCartForCustomer(self::CUSTOMER_ID);
+
+        /** @var CartItemInterface $cartItem */
+        $cartItem = Bootstrap::getObjectManager()->create(CartItemInterface::class);
+        $cartItem->setSku('virtual-product')
+            ->setQty(1)
+            ->setQuoteId($quoteId);
+        $this->cartItemRepository->save($cartItem);
+
+        return $quoteId;
+    }
+
+    /**
+     * Submit the address and place the order, which is where the address book is written.
+     *
+     * @param int $quoteId
+     * @param AddressInterface $shippingAddress
+     * @return \Magento\Sales\Api\Data\OrderInterface
+     */
+    private function placeOrder(int $quoteId, AddressInterface $shippingAddress)
+    {
+        /** @var ShippingInformationInterface $addressInformation */
+        $addressInformation = Bootstrap::getObjectManager()->create(ShippingInformationInterface::class);
+        $addressInformation->setShippingAddress($shippingAddress)
+            ->setBillingAddress($shippingAddress)
+            ->setShippingCarrierCode('flatrate')
+            ->setShippingMethodCode('flatrate');
+
+        $this->shippingInformationManagement->saveAddressInformation($quoteId, $addressInformation);
+
+        /** @var PaymentInterface $payment */
+        $payment = Bootstrap::getObjectManager()->create(PaymentInterface::class);
+        $payment->setMethod('checkmo');
+        $orderId = $this->paymentInformationManagement->savePaymentInformationAndPlaceOrder($quoteId, $payment);
+
+        return $this->orderRepository->get((int)$orderId);
+    }
+
+    /**
+     * Count the rows the customer actually has in customer_address_entity.
+     *
+     * A fresh collection is used on purpose so that the assertion reads the database rather than the
+     * address registry, which still holds the state from before the order was placed.
+     *
+     * @return int
+     */
+    private function countCustomerAddresses(): int
+    {
+        return (int)$this->addressCollectionFactory->create()
+            ->addAttributeToFilter('parent_id', self::CUSTOMER_ID)
+            ->getSize();
+    }
+}


### PR DESCRIPTION
Description:
When a logged-in customer re-enters, via "Add new address" in checkout, the details of an address that is already saved in their address book, Magento creates a duplicate `customer_address_entity` row instead of reusing the existing one.

This happens for two independent reasons:

1. `Magento\Checkout\Model\ShippingInformationManagement` only compared the submitted address against the address currently attached to the quote (`Quote::getShippingAddress()`/`getBillingAddress()`), not against the customer's full address book. Any address that was not already the active quote address was always treated as new.
2. Even after a match is found and `customer_address_id` is set on the quote address, `Magento\Quote\Model\QuoteManagement::_prepareCustomerQuote()` (called on order placement) still re-saves the address as a new one. Its gate only checks `getSaveInAddressBook()` / `getCustomerId()`, not the address ID, and `Quote\Model\Quote\Address::exportCustomerAddress()` does not carry `customer_address_id` over as the `id` of the exported `Customer\Api\Data\AddressInterface` object, so the address always looks new to `AddressRepository::save()`.

The fix, contained to `ShippingInformationManagement`:

- Before falling back to creating a new address, the submitted shipping/billing address is now also compared against every address already saved in the customer's address book (`AddressRepositoryInterface::getList()` filtered by `parent_id`), not just the one currently on the quote.
- Comparison is done field by field (firstname, lastname, middlename, prefix, suffix, company, street, city, region/region_id, postcode, country, telephone, fax, vat_id), with values normalized (trimmed, lower-cased, numeric/string-safe) so that formatting differences (extra whitespace, case, empty street lines, numeric vs. string postcode/phone from REST/GraphQL payloads) don't cause false negatives.
- When a match is found, the address is linked to it via `customer_address_id`, `save_in_address_book` is cleared, and `customer_id` is set on the address object so that `QuoteManagement::_prepareCustomerQuote()` does not re-save it as a new entry during order placement.
- The address book lookup is skipped entirely when the submitted address is not going to be written to the address book (`save_in_address_book` is falsy), which keeps the common case (customer picks an existing address, or is a guest) free of the extra address-book query.
- A genuinely different address is still saved as a new address book entry as before; nothing about that path changed.

No public API signatures changed. The constructor gained two additional optional (nullable, `ObjectManager`-backed) dependencies, which is backward compatible with existing instantiations and DI configuration.

Fixed Issues:

1. Fixes magento/magento2#32294

Manual testing scenarios:
  1. Create a customer account and save one address in the address book (Customer Account → Address Book).
  2. Log in as that customer and add a product to the cart, proceed to checkout.
  3. On the Shipping step, click "New Address" and manually type in the exact same details as the address already saved (same name, street, city, region, postcode, country, phone).
  4. Complete checkout and place the order (any shipping method / payment method, e.g. Check/Money order).
  5. Go to Customer Account → Address Book and confirm only one address is listed (no duplicate was created), and that the placed order references the original address. 
  6. Repeat steps 2–4, but this time enter an address that genuinely differs from the saved one (different street). Confirm a new address is added to the address book as expected — the fix does not prevent legitimate new addresses from being saved.
  7. Repeat the "duplicate" scenario (steps 2–4) with billing and shipping addresses set independently (uncheck "Ship to this address" on the Review step,or use different billing/shipping in the Shipping/Payment steps) to confirm both addresses are correctly linked to the existing entries rather than duplicated.
  8. Repeat the "duplicate" scenario as a guest checkout (no logged-in customer) and confirm the order still completes normally, with no error, and no unexpected address is created for any customer account.
  9. Test with an address that differs from the saved one only by letter case or extra surrounding whitespace in a field (e.g. "kyiv" vs "Kyiv") and confirm it is still recognized as the same address and not duplicated.

Questions or comments:
The two "not found in this codebase" gaps this PR closes (address-book-wide comparison, and `_prepareCustomerQuote` re-saving matched addresses) were both confirmed with a dedicated integration test (`ShippingInformationManagementDuplicateAddressTest`) that places a full order end-to-end and asserts on
  the `customer_address_entity` row count, in addition to unit test coverage on the comparison logic. 

 Contribution checklist:
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
