### PR TITLE
Add has_options and required_options to GraphQL ProductInterface (#32793)

### DIFF
--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -126,6 +126,8 @@ interface ProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\
     canonical_url: String @doc(description: "The relative canonical URL. This value is returned only if the system setting 'Use Canonical Link Meta Tag For Products' is enabled.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CanonicalUrl")
     media_gallery: [MediaGalleryInterface] @doc(description: "An array of media gallery objects.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\MediaGallery")
     custom_attributesV2(filters: AttributeFilterInput): ProductCustomAttributes @doc(description: "Product custom attributes.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductCustomAttributes")
+    has_options: Boolean @doc(description: "Indicates whether additional options have been created for the product.")
+    required_options: Boolean @doc(description: "Indicates whether the product has required options.")
 }
 
 interface PhysicalProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\\ProductInterfaceTypeResolverComposite") @doc(description: "Contains attributes specific to tangible products.") {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2021 Adobe
+ * All Rights Reserved.
  */
 declare(strict_types=1);
 

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
@@ -7,14 +7,21 @@ declare(strict_types=1);
 
 namespace Magento\GraphQl\Catalog;
 
+use Exception;
 use Magento\TestFramework\TestCase\GraphQlAbstract;
 
+/**
+ * Test for checking has_options & required_options attributes in Products query.
+ */
 class ProductHasOptionsTest extends GraphQlAbstract
 {
     /**
      * @magentoApiDataFixture Magento/Catalog/_files/product_simple_with_custom_options.php
+     *
+     * @return void
+     * @throws Exception
      */
-    public function testHasOptionsAndRequiredOptionsAttribute()
+    public function testHasOptionsAndRequiredOptionsAttribute(): void
     {
         $productSku = 'simple_with_custom_options';
         $query = <<<QUERY
@@ -22,7 +29,7 @@ class ProductHasOptionsTest extends GraphQlAbstract
   products(filter: {sku: {eq: "{$productSku}"}}) {
     items {
       sku
-	  has_options
+      has_options
       required_options
     }
   }
@@ -30,7 +37,7 @@ class ProductHasOptionsTest extends GraphQlAbstract
 QUERY;
         $response = $this->graphQlQuery($query);
 
-        self::assertArrayHasKey('has_options', $response['products']['items'][0]);
-        self::assertArrayHasKey('required_options', $response['products']['items'][0]);
+        $this->assertArrayHasKey('has_options', $response['products']['items'][0]);
+        $this->assertArrayHasKey('required_options', $response['products']['items'][0]);
     }
 }

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Catalog;
+
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+class ProductHasOptionsTest extends GraphQlAbstract
+{
+    /**
+     * @magentoApiDataFixture Magento/Catalog/_files/product_simple_with_custom_options.php
+     */
+    public function testHasOptionsAndRequiredOptionsAttribute()
+    {
+        $productSku = 'simple_with_custom_options';
+        $query = <<<QUERY
+{
+  products(filter: {sku: {eq: "{$productSku}"}}) {
+    items {
+      sku
+	  has_options
+      required_options
+    }
+  }
+}
+QUERY;
+        $response = $this->graphQlQuery($query);
+
+        self::assertArrayHasKey('has_options', $response['products']['items'][0]);
+        self::assertArrayHasKey('required_options', $response['products']['items'][0]);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
@@ -16,14 +16,14 @@ use Magento\TestFramework\TestCase\GraphQlAbstract;
 class ProductHasOptionsTest extends GraphQlAbstract
 {
     /**
-     * @magentoApiDataFixture Magento/Catalog/_files/product_simple_with_custom_options.php
+     * @magentoApiDataFixture Magento/Catalog/_files/product_with_options.php
      *
      * @return void
      * @throws Exception
      */
     public function testHasOptionsAndRequiredOptionsAttribute(): void
     {
-        $productSku = 'simple_with_custom_options';
+        $productSku = 'simple';
         $query = <<<QUERY
 {
   products(filter: {sku: {eq: "{$productSku}"}}) {

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Catalog/ProductHasOptionsTest.php
@@ -37,7 +37,11 @@ class ProductHasOptionsTest extends GraphQlAbstract
 QUERY;
         $response = $this->graphQlQuery($query);
 
-        $this->assertArrayHasKey('has_options', $response['products']['items'][0]);
-        $this->assertArrayHasKey('required_options', $response['products']['items'][0]);
+        $item = $response['products']['items'][0];
+        $this->assertSame($productSku, $item['sku']);
+        $this->assertArrayHasKey('has_options', $item);
+        $this->assertArrayHasKey('required_options', $item);
+        $this->assertTrue($item['has_options']);
+        $this->assertTrue($item['required_options']);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description (*)

Continues #33125 by @karyna-t (Atwix), which was approved by two maintainers in July 2021 and never merged. The branch fell behind `2.4-develop` and conflicted on `schema.graphqls`; this PR carries the original commits rebased onto the current base.

`has_options` and `required_options` are columns of `catalog_product_entity` and are exposed through `ProductInterface` in REST, but not in GraphQL. The `products` filter and sort inputs already accept both fields, so a client can filter by them without being able to read them back. This adds both as `Boolean` fields on `ProductInterface`. No resolver is needed: the product model already carries the values from the collection load.

Changes on top of the original PR:

- rebased on `2.4-develop`, conflict in `ProductInterface` resolved (the fields now follow `custom_attributesV2`)
- the API-functional test asserts the resolved values (`true`/`true` for the fixture product with three required custom options), not only the presence of the keys

@cpartica asked in the original review whether this belongs on `CustomizableProductInterface` instead. The two columns exist on every product type (bundles and configurables set `required_options` without custom options), and the filter and sort inputs already expose them on the generic `ProductInterface`, so placing the output fields on the same interface keeps the schema consistent.

### Related Pull Requests

- #33125 (original, by @karyna-t)

### Fixed Issues (if relevant)

1. Fixes magento/magento2#32793

### Manual testing scenarios (*)

1. Create a simple product with a required custom option
2. Send `{ products(filter: {sku: {eq: "<sku>"}}) { items { sku has_options required_options } } }` to `/graphql`
3. Both fields resolve to `true`; for a product without options both resolve to `false`

### Questions or comments

Gates run locally on the rebased branch: PHPCS on the test file is clean, Static Tests (LiveCodeTest) result is reported in the first comment. The API-functional test needs the WebAPI build; please run it here.

The Semantic Version Checker will flag the two added interface fields as a minor GraphQL schema change (additive only).

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined templates](https://github.com/magento/devdocs/wiki/Magento-module-README.md) (if applicable)
- [x] All automated tests passed successfully (all builds are green)
