### PR TITLE
Batch GraphQL stock_status and stop reloading configurables for only_x_left_in_stock (#40709)

### DIFF
--- a/app/code/Magento/CatalogInventoryGraphQl/Model/Resolver/OnlyXLeftInStockResolver.php
+++ b/app/code/Magento/CatalogInventoryGraphQl/Model/Resolver/OnlyXLeftInStockResolver.php
@@ -9,9 +9,11 @@ namespace Magento\CatalogInventoryGraphQl\Model\Resolver;
 
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\CatalogInventory\Model\Configuration;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -49,23 +51,6 @@ class OnlyXLeftInStockResolver implements ResolverInterface
             throw new LocalizedException(__('"model" value should be specified'));
         }
 
-        $product = $value['model'];
-        if ($product->getTypeId() === self::PRODUCT_TYPE_CONFIGURABLE) {
-            $variant = $this->productRepositoryInterface->get($product->getSku());
-            return $this->getOnlyXLeftQty($variant);
-        }
-        return $this->getOnlyXLeftQty($product);
-    }
-
-    /**
-     * Get product qty left when "Catalog > Inventory > Stock Options > Only X left Threshold" is greater than 0
-     *
-     * @param ProductInterface $product
-     *
-     * @return null|float
-     */
-    private function getOnlyXLeftQty(ProductInterface $product): ?float
-    {
         $thresholdQty = (float)$this->scopeConfig->getValue(
             Configuration::XML_PATH_STOCK_THRESHOLD_QTY,
             ScopeInterface::SCOPE_STORE
@@ -74,6 +59,47 @@ class OnlyXLeftInStockResolver implements ResolverInterface
             return null;
         }
 
+        return $this->getOnlyXLeftQty($this->getConfiguredProduct($value['model']), $thresholdQty);
+    }
+
+    /**
+     * Get the product the stock data belongs to
+     *
+     * @param ProductInterface $product
+     * @return ProductInterface
+     * @throws LocalizedException
+     */
+    private function getConfiguredProduct(ProductInterface $product): ProductInterface
+    {
+        if ($product->getTypeId() !== self::PRODUCT_TYPE_CONFIGURABLE || !$product instanceof Product) {
+            return $product;
+        }
+
+        // A configurable cart item carries the selected child in the "simple_product" custom option, which is also
+        // what Configurable::getSku() reports; outside a cart item there is no such option and no variant to resolve.
+        $option = $product->getCustomOption('simple_product');
+        $variant = $option instanceof DataObject ? $option->getProduct() : null;
+        if ($variant instanceof ProductInterface) {
+            return $variant;
+        }
+
+        if ($product->getSku() !== $product->getData('sku')) {
+            return $this->productRepositoryInterface->get($product->getSku());
+        }
+
+        return $product;
+    }
+
+    /**
+     * Get product qty left when "Catalog > Inventory > Stock Options > Only X left Threshold" is greater than 0
+     *
+     * @param ProductInterface $product
+     * @param float $thresholdQty
+     *
+     * @return null|float
+     */
+    private function getOnlyXLeftQty(ProductInterface $product, float $thresholdQty): ?float
+    {
         $stockItem = $this->stockRegistry->getStockItem($product->getId());
 
         $stockCurrentQty = $this->stockRegistry->getStockStatus(

--- a/app/code/Magento/CatalogInventoryGraphQl/Model/Resolver/StockStatus.php
+++ b/app/code/Magento/CatalogInventoryGraphQl/Model/Resolver/StockStatus.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogInventoryGraphQl\Model\Resolver;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Model\StockRegistryPreloader;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\BatchRequestItemInterface;
+use Magento\Framework\GraphQl\Query\Resolver\BatchResolverInterface;
+use Magento\Framework\GraphQl\Query\Resolver\BatchResponse;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Quote\Model\Quote\Item;
+
+/**
+ * Resolve the stock status of all products of a single response with one stock status query.
+ */
+class StockStatus implements BatchResolverInterface
+{
+    /**
+     * In Stock return code
+     */
+    private const IN_STOCK = "IN_STOCK";
+
+    /**
+     * Out of Stock return code
+     */
+    private const OUT_OF_STOCK = "OUT_OF_STOCK";
+
+    /**
+     * @param StockRegistryPreloader $stockRegistryPreloader
+     * @param StockConfigurationInterface $stockConfiguration
+     * @param StockStatusProvider $stockStatusProvider
+     */
+    public function __construct(
+        private readonly StockRegistryPreloader $stockRegistryPreloader,
+        private readonly StockConfigurationInterface $stockConfiguration,
+        private readonly StockStatusProvider $stockStatusProvider
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(ContextInterface $context, Field $field, array $requests): BatchResponse
+    {
+        $productIds = [];
+        foreach ($requests as $request) {
+            if (!$this->isCartItemRequest($request)) {
+                $productIds[] = (int)$this->getProduct($request)->getId();
+            }
+        }
+
+        $stockStatuses = [];
+        if ($productIds) {
+            $preloaded = $this->stockRegistryPreloader->preloadStockStatuses(
+                array_values(array_unique($productIds)),
+                (int)$this->stockConfiguration->getDefaultScopeId()
+            );
+            foreach ($preloaded as $stockStatus) {
+                $stockStatuses[(int)$stockStatus->getProductId()] = (int)$stockStatus->getStockStatus();
+            }
+        }
+
+        $response = new BatchResponse();
+        foreach ($requests as $request) {
+            if ($this->isCartItemRequest($request)) {
+                $response->addResponse(
+                    $request,
+                    $this->stockStatusProvider->resolve(
+                        $field,
+                        $context,
+                        $request->getInfo(),
+                        $request->getValue(),
+                        $request->getArgs()
+                    )
+                );
+                continue;
+            }
+
+            $productId = (int)$this->getProduct($request)->getId();
+            $response->addResponse(
+                $request,
+                empty($stockStatuses[$productId]) ? self::OUT_OF_STOCK : self::IN_STOCK
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Get the product a request has been made for
+     *
+     * @param BatchRequestItemInterface $request
+     * @return ProductInterface
+     * @throws LocalizedException
+     */
+    private function getProduct(BatchRequestItemInterface $request): ProductInterface
+    {
+        $value = $request->getValue() ?? [];
+        if (!array_key_exists('model', $value) || !$value['model'] instanceof ProductInterface) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        return $value['model'];
+    }
+
+    /**
+     * Cart items keep their own stock status semantics and are delegated to the single-item resolver
+     *
+     * @param BatchRequestItemInterface $request
+     * @return bool
+     * @throws LocalizedException
+     */
+    private function isCartItemRequest(BatchRequestItemInterface $request): bool
+    {
+        $this->getProduct($request);
+
+        return ($request->getValue()['cart_item'] ?? null) instanceof Item;
+    }
+}

--- a/app/code/Magento/CatalogInventoryGraphQl/Test/Unit/Model/Resolver/OnlyXLeftInStockResolverTest.php
+++ b/app/code/Magento/CatalogInventoryGraphQl/Test/Unit/Model/Resolver/OnlyXLeftInStockResolverTest.php
@@ -9,14 +9,15 @@ namespace Magento\CatalogInventoryGraphQl\Test\Unit\Model\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\CatalogInventoryGraphQl\Model\Resolver\OnlyXLeftInStockResolver;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\GraphQl\Model\Query\ContextInterface;
-use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\CatalogInventory\Api\StockRegistryInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Quote\Model\Quote\Item\Option;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\CatalogInventory\Api\Data\StockItemInterface;
 use Magento\CatalogInventory\Api\Data\StockStatusInterface;
@@ -26,13 +27,6 @@ use Magento\CatalogInventory\Api\Data\StockStatusInterface;
  */
 class OnlyXLeftInStockResolverTest extends TestCase
 {
-    /**
-     * Object Manager Instance
-     *
-     * @var ObjectManager
-     */
-    private $objectManager;
-
     /**
      * Testable Object
      *
@@ -66,6 +60,11 @@ class OnlyXLeftInStockResolverTest extends TestCase
     private $stockRegistryMock;
 
     /**
+     * @var ProductRepositoryInterface|MockObject
+     */
+    private $productRepositoryMock;
+
+    /**
      * @var Product|MockObject
      */
     private $productModelMock;
@@ -91,14 +90,13 @@ class OnlyXLeftInStockResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->objectManager = new ObjectManager($this);
-
         $this->contextMock = $this->createMock(ContextInterface::class);
         $this->fieldMock = $this->createMock(Field::class);
         $this->resolveInfoMock = $this->createMock(ResolveInfo::class);
         $this->productModelMock = $this->createMock(Product::class);
         $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
         $this->stockRegistryMock = $this->createMock(StockRegistryInterface::class);
+        $this->productRepositoryMock = $this->createMock(ProductRepositoryInterface::class);
         $this->storeMock = $this->createMock(StoreInterface::class);
         $this->stockItemMock = $this->createMock(StockItemInterface::class);
         $this->stockStatusMock = $this->createMock(StockStatusInterface::class);
@@ -110,12 +108,10 @@ class OnlyXLeftInStockResolverTest extends TestCase
             ->willReturn($this->stockStatusMock);
         $this->storeMock->expects($this->atMost(1))->method('getWebsiteId')->willReturn(1);
 
-        $this->resolver = $this->objectManager->getObject(
-            OnlyXLeftInStockResolver::class,
-            [
-                'scopeConfig' => $this->scopeConfigMock,
-                'stockRegistry' => $this->stockRegistryMock
-            ]
+        $this->resolver = new OnlyXLeftInStockResolver(
+            $this->scopeConfigMock,
+            $this->stockRegistryMock,
+            $this->productRepositoryMock
         );
     }
 
@@ -174,10 +170,65 @@ class OnlyXLeftInStockResolverTest extends TestCase
         $this->stockItemMock->expects($this->never())->method('getMinQty');
         $this->stockStatusMock->expects($this->never())->method('getQty');
         $this->stockRegistryMock->expects($this->never())->method('getStockItem');
+        $this->productRepositoryMock->expects($this->never())->method('get');
+        $this->productModelMock->expects($this->never())->method('getTypeId');
         $this->scopeConfigMock->method('getValue')->willReturn($thresholdQty);
 
         $this->assertEquals(
             null,
+            $this->resolver->resolve(
+                $this->fieldMock,
+                $this->contextMock,
+                $this->resolveInfoMock,
+                ['model' => $this->productModelMock]
+            )
+        );
+    }
+
+    public function testResolveConfigurableWithoutSelectedVariant()
+    {
+        $this->scopeConfigMock->method('getValue')->willReturn(200);
+        $this->productModelMock->method('getTypeId')->willReturn('configurable');
+        $this->productModelMock->method('getCustomOption')->with('simple_product')->willReturn(null);
+        $this->productModelMock->method('getSku')->willReturn('parent_configurable');
+        $this->productModelMock->method('getData')->with('sku')->willReturn('parent_configurable');
+        $this->productRepositoryMock->expects($this->never())->method('get');
+        $this->stockRegistryMock->expects($this->once())->method('getStockItem')->with(1)
+            ->willReturn($this->stockItemMock);
+        $this->stockItemMock->method('getMinQty')->willReturn(0);
+        $this->stockStatusMock->method('getQty')->willReturn(100);
+
+        $this->assertEquals(
+            100,
+            $this->resolver->resolve(
+                $this->fieldMock,
+                $this->contextMock,
+                $this->resolveInfoMock,
+                ['model' => $this->productModelMock]
+            )
+        );
+    }
+
+    public function testResolveConfigurableUsesSimpleProductOption()
+    {
+        $variantMock = $this->createMock(Product::class);
+        $variantMock->method('getId')->willReturn(42);
+        $variantMock->method('getStore')->willReturn($this->storeMock);
+
+        $optionMock = $this->createMock(Option::class);
+        $optionMock->method('getProduct')->willReturn($variantMock);
+
+        $this->scopeConfigMock->method('getValue')->willReturn(200);
+        $this->productModelMock->method('getTypeId')->willReturn('configurable');
+        $this->productModelMock->method('getCustomOption')->with('simple_product')->willReturn($optionMock);
+        $this->productRepositoryMock->expects($this->never())->method('get');
+        $this->stockRegistryMock->expects($this->once())->method('getStockItem')->with(42)
+            ->willReturn($this->stockItemMock);
+        $this->stockItemMock->method('getMinQty')->willReturn(0);
+        $this->stockStatusMock->method('getQty')->willReturn(7);
+
+        $this->assertEquals(
+            7,
             $this->resolver->resolve(
                 $this->fieldMock,
                 $this->contextMock,

--- a/app/code/Magento/CatalogInventoryGraphQl/Test/Unit/Model/Resolver/StockStatusTest.php
+++ b/app/code/Magento/CatalogInventoryGraphQl/Test/Unit/Model/Resolver/StockStatusTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogInventoryGraphQl\Test\Unit\Model\Resolver;
+
+use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Api\Data\StockStatusInterface;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Model\StockRegistryPreloader;
+use Magento\CatalogInventoryGraphQl\Model\Resolver\StockStatus;
+use Magento\CatalogInventoryGraphQl\Model\Resolver\StockStatusProvider;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ResolveRequest;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\GraphQl\Model\Query\ContextInterface;
+use Magento\Quote\Model\Quote\Item;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test class for \Magento\CatalogInventoryGraphQl\Model\Resolver\StockStatus
+ */
+class StockStatusTest extends TestCase
+{
+    /**
+     * @var StockStatus
+     */
+    private $resolver;
+
+    /**
+     * @var StockRegistryPreloader|MockObject
+     */
+    private $preloaderMock;
+
+    /**
+     * @var StockStatusProvider|MockObject
+     */
+    private $stockStatusProviderMock;
+
+    /**
+     * @var ContextInterface|MockObject
+     */
+    private $contextMock;
+
+    /**
+     * @var Field|MockObject
+     */
+    private $fieldMock;
+
+    /**
+     * @var ResolveInfo|MockObject
+     */
+    private $resolveInfoMock;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->preloaderMock = $this->createMock(StockRegistryPreloader::class);
+        $this->stockStatusProviderMock = $this->createMock(StockStatusProvider::class);
+        $this->contextMock = $this->createMock(ContextInterface::class);
+        $this->fieldMock = $this->createMock(Field::class);
+        $this->resolveInfoMock = $this->createMock(ResolveInfo::class);
+
+        $stockConfigurationMock = $this->createMock(StockConfigurationInterface::class);
+        $stockConfigurationMock->method('getDefaultScopeId')->willReturn(0);
+
+        $this->resolver = new StockStatus(
+            $this->preloaderMock,
+            $stockConfigurationMock,
+            $this->stockStatusProviderMock
+        );
+    }
+
+    public function testAllProductsArePreloadedWithASingleCall()
+    {
+        $requests = [
+            $this->createRequest(['model' => $this->createProduct(1)]),
+            $this->createRequest(['model' => $this->createProduct(2)]),
+            $this->createRequest(['model' => $this->createProduct(3)]),
+        ];
+
+        $this->preloaderMock->expects($this->once())
+            ->method('preloadStockStatuses')
+            ->with([1, 2, 3], 0)
+            ->willReturn([
+                $this->createStockStatus(1, 1),
+                $this->createStockStatus(2, 0),
+            ]);
+        $this->stockStatusProviderMock->expects($this->never())->method('resolve');
+
+        $response = $this->resolver->resolve($this->contextMock, $this->fieldMock, $requests);
+
+        $this->assertEquals('IN_STOCK', $response->findResponseFor($requests[0]));
+        $this->assertEquals('OUT_OF_STOCK', $response->findResponseFor($requests[1]));
+        $this->assertEquals('OUT_OF_STOCK', $response->findResponseFor($requests[2]));
+    }
+
+    public function testCartItemRequestsAreDelegated()
+    {
+        $cartItemValue = ['model' => $this->createProduct(1), 'cart_item' => $this->createMock(Item::class)];
+        $requests = [
+            $this->createRequest($cartItemValue),
+            $this->createRequest(['model' => $this->createProduct(2)]),
+        ];
+
+        $this->preloaderMock->expects($this->once())
+            ->method('preloadStockStatuses')
+            ->with([2], 0)
+            ->willReturn([$this->createStockStatus(2, 1)]);
+        $this->stockStatusProviderMock->expects($this->once())
+            ->method('resolve')
+            ->with($this->fieldMock, $this->contextMock, $this->resolveInfoMock, $cartItemValue, null)
+            ->willReturn('OUT_OF_STOCK');
+
+        $response = $this->resolver->resolve($this->contextMock, $this->fieldMock, $requests);
+
+        $this->assertEquals('OUT_OF_STOCK', $response->findResponseFor($requests[0]));
+        $this->assertEquals('IN_STOCK', $response->findResponseFor($requests[1]));
+    }
+
+    public function testCartItemOnlyBatchDoesNotPreload()
+    {
+        $requests = [
+            $this->createRequest(['model' => $this->createProduct(1), 'cart_item' => $this->createMock(Item::class)]),
+        ];
+
+        $this->preloaderMock->expects($this->never())->method('preloadStockStatuses');
+        $this->stockStatusProviderMock->expects($this->once())->method('resolve')->willReturn('IN_STOCK');
+
+        $response = $this->resolver->resolve($this->contextMock, $this->fieldMock, $requests);
+
+        $this->assertEquals('IN_STOCK', $response->findResponseFor($requests[0]));
+    }
+
+    public function testMissingModelIsRejected()
+    {
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('"model" value should be specified');
+
+        $this->resolver->resolve($this->contextMock, $this->fieldMock, [$this->createRequest([])]);
+    }
+
+    /**
+     * @param array $value
+     * @return ResolveRequest
+     */
+    private function createRequest(array $value): ResolveRequest
+    {
+        return new ResolveRequest($this->fieldMock, $this->contextMock, $this->resolveInfoMock, $value, null);
+    }
+
+    /**
+     * @param int $id
+     * @return Product|MockObject
+     */
+    private function createProduct(int $id)
+    {
+        $product = $this->createMock(Product::class);
+        $product->method('getId')->willReturn($id);
+
+        return $product;
+    }
+
+    /**
+     * @param int $productId
+     * @param int $status
+     * @return StockStatusInterface|MockObject
+     */
+    private function createStockStatus(int $productId, int $status)
+    {
+        $stockStatus = $this->createMock(StockStatusInterface::class);
+        $stockStatus->method('getProductId')->willReturn($productId);
+        $stockStatus->method('getStockStatus')->willReturn($status);
+
+        return $stockStatus;
+    }
+}

--- a/app/code/Magento/CatalogInventoryGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogInventoryGraphQl/etc/schema.graphqls
@@ -3,7 +3,7 @@
 
 interface ProductInterface {
     only_x_left_in_stock: Float @doc(description: "Remaining stock if it is below the value assigned to the Only X Left Threshold option in the Admin.") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\OnlyXLeftInStockResolver")
-    stock_status: ProductStockStatus @doc(description: "The stock status of the product.") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\StockStatusProvider")
+    stock_status: ProductStockStatus @doc(description: "The stock status of the product.") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\StockStatus")
     quantity: Float @doc(description: "Amount of available stock") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\QuantityResolver")
     min_sale_qty: Float @doc(description: "Minimum Qty Allowed in Shopping Cart") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\MinSaleQtyResolver")
     max_sale_qty: Float @doc(description: "Maximum Qty Allowed in Shopping Cart") @resolver(class: "Magento\\CatalogInventoryGraphQl\\Model\\Resolver\\MaxSaleQtyResolver")


### PR DESCRIPTION
### Description (*)

Two GraphQL resolvers in `CatalogInventoryGraphQl` issue per-product queries for every item of a `products` response.

- `stock_status` is a plain per-field resolver; `StockStatusProvider::resolve()` calls `StockStatusRepository::get()` for each product, which goes straight to the database and never consults `StockRegistryStorage`. 24 items, 24 queries.
- `only_x_left_in_stock` reloads every configurable item through `ProductRepositoryInterface::get($product->getSku())` before it checks the "Only X left Threshold" setting. That reload was added for configurable cart items, where `Configurable::getSku()` returns the selected child's SKU through the `simple_product` custom option. In a `products` query there is no such option, so the resolver reloads the product it already holds, at roughly 13 queries per configurable, and then returns `null` because the threshold is 0 by default.

The fix:

- A new `Magento\CatalogInventoryGraphQl\Model\Resolver\StockStatus` implements `BatchResolverInterface` and is now the `@resolver` of `ProductInterface.stock_status`. It preloads the statuses of all plain product requests in one query through the existing `StockRegistryPreloader` and maps them to `IN_STOCK` / `OUT_OF_STOCK` the same way as before (a product without a stock status row stays `OUT_OF_STOCK`). Requests carrying a `cart_item` are delegated unchanged to `StockStatusProvider::resolve()`, so the bundle and configured-variant logic for cart items is untouched. `StockStatusProvider` itself is not modified.
- `OnlyXLeftInStockResolver` reads the threshold first and returns `null` before touching the registry or the repository. For a configurable it takes the selected child from the `simple_product` custom option when present, otherwise it uses the product it was given; the repository is only consulted if the reported SKU differs from the entity SKU.

### Performance impact

Measured on a vanilla 2.4-develop install (performance toolkit `small` profile: 1200 products, legacy CatalogInventory, MSI disabled), request:

```graphql
{ products(filter:{}, pageSize: 24) { total_count items { sku stock_status only_x_left_in_stock } } }
```

24 items, 16 of them configurable. Wall time is the median of 7 fresh requests without the profiler; call counts and memory are from one PHP SPX run of the same request. The response body is byte-identical before and after.

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| SQL queries | 312 | 16 | -95% |
| `cataloginventory_stock_status` queries | 40 | 2 | |
| `cataloginventory_stock_item` queries | 16 | 0 | |
| Wall time (median of 7) | 168.9 ms | 81.2 ms | -52% |
| PHP function calls (SPX) | 585,735 | 128,250 | -78% |
| Peak memory (SPX) | 16.8 MB | 13.0 MB | -22% |

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40709

### Manual testing scenarios (*)

1. Enable the DB query log (`bin/magento dev:query-log:enable`) and send the GraphQL query above against a catalog with a few configurable products.
2. Count `cataloginventory_stock_status` queries in `var/debug/db.log`: one per response instead of one per item, and no product loads by SKU.
3. Set Stores > Configuration > Catalog > Inventory > Stock Options > Only X left Threshold to a value above the qty of a simple product and query `only_x_left_in_stock` for it: the remaining qty is returned as before.
4. Add a configurable product to a cart and query `cart { items { product { stock_status only_x_left_in_stock } } }`: values match the selected variant, as before.

### Questions or comments

Gates run locally: unit (16 tests, 98 assertions), PHPCS, PHPStan and the Static Tests `LiveCodeTest` on the changed files are clean. The module has no integration suite. The new unit test for `OnlyXLeftInStockResolver` fails without the fix and passes with it.

The Semantic Version Checker will report the new public class and the changed `@resolver` class on `ProductInterface.stock_status`; the GraphQL schema surface is unchanged. Third-party plugins on `StockStatusProvider::resolve()` keep applying to cart items but no longer to plain product items, since those are resolved in the batch.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
