### PR TITLE
Cache resolved child finders in CompositeUrlFinder (#40722)

### DIFF
--- a/app/code/Magento/UrlRewrite/Model/CompositeUrlFinder.php
+++ b/app/code/Magento/UrlRewrite/Model/CompositeUrlFinder.php
@@ -12,7 +12,7 @@ use Magento\Framework\ObjectManagerInterface;
 use Magento\UrlRewrite\Model\MergeDataProviderFactory;
 
 /**
- * Class CompositeUrlFinder
+ * Looks up url rewrites across all configured storage finders, sorted by priority
  */
 class CompositeUrlFinder implements UrlFinderInterface
 {
@@ -35,6 +35,16 @@ class CompositeUrlFinder implements UrlFinderInterface
      * @var ScopeConfigInterface
      */
     private $config;
+
+    /**
+     * @var bool
+     */
+    private $childrenSorted = false;
+
+    /**
+     * @var UrlFinderInterface[]
+     */
+    private $resolvedChildren = [];
 
     /**
      * @param array $children
@@ -72,8 +82,8 @@ class CompositeUrlFinder implements UrlFinderInterface
         $isDynamicRewrites = !$this->isCategoryRewritesEnabled();
 
         $mergeDataProvider = $this->mergeDataProviderFactory->create();
-        foreach ($this->getChildren() as $child) {
-            $urlFinder = $this->objectManager->get($child['class']);
+        foreach ($this->getChildren() as $key => $child) {
+            $urlFinder = $this->getChildFinder($key, $child);
             $rewrites = $urlFinder->findAllByData($data);
             if (!$isDynamicRewrites) {
                 return $rewrites;
@@ -88,8 +98,8 @@ class CompositeUrlFinder implements UrlFinderInterface
      */
     public function findOneByData(array $data)
     {
-        foreach ($this->getChildren() as $child) {
-            $urlFinder = $this->objectManager->get($child['class']);
+        foreach ($this->getChildren() as $key => $child) {
+            $urlFinder = $this->getChildFinder($key, $child);
             $rewrite = $urlFinder->findOneByData($data);
             if (!empty($rewrite)) {
                 return $rewrite;
@@ -105,12 +115,30 @@ class CompositeUrlFinder implements UrlFinderInterface
      */
     private function getChildren(): array
     {
-        uasort(
-            $this->children,
-            function ($first, $second) {
-                return (int)$first['sortOrder'] <=> (int)$second['sortOrder'];
-            }
-        );
+        if (!$this->childrenSorted) {
+            uasort(
+                $this->children,
+                function ($first, $second) {
+                    return (int)$first['sortOrder'] <=> (int)$second['sortOrder'];
+                }
+            );
+            $this->childrenSorted = true;
+        }
         return $this->children;
+    }
+
+    /**
+     * Resolve and cache the finder instance for a child configuration entry
+     *
+     * @param int|string $key
+     * @param array $child
+     * @return UrlFinderInterface
+     */
+    private function getChildFinder($key, array $child): UrlFinderInterface
+    {
+        if (!isset($this->resolvedChildren[$key])) {
+            $this->resolvedChildren[$key] = $this->objectManager->get($child['class']);
+        }
+        return $this->resolvedChildren[$key];
     }
 }

--- a/app/code/Magento/UrlRewrite/Test/Unit/Model/CompositeUrlFinderTest.php
+++ b/app/code/Magento/UrlRewrite/Test/Unit/Model/CompositeUrlFinderTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Copyright 2019 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\UrlRewrite\Test\Unit\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\UrlRewrite\Model\CompositeUrlFinder;
+use Magento\UrlRewrite\Model\MergeDataProvider;
+use Magento\UrlRewrite\Model\MergeDataProviderFactory;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CompositeUrlFinderTest extends TestCase
+{
+    /**
+     * @var ObjectManagerInterface|MockObject
+     */
+    private $objectManager;
+
+    /**
+     * @var MergeDataProviderFactory|MockObject
+     */
+    private $mergeDataProviderFactory;
+
+    /**
+     * @var ScopeConfigInterface|MockObject
+     */
+    private $config;
+
+    /**
+     * @var UrlFinderInterface|MockObject
+     */
+    private $defaultFinder;
+
+    /**
+     * @var UrlFinderInterface|MockObject
+     */
+    private $catalogFinder;
+
+    /**
+     * @var array
+     */
+    private $children;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->mergeDataProviderFactory = $this->createMock(MergeDataProviderFactory::class);
+        $this->config = $this->createMock(ScopeConfigInterface::class);
+        $this->defaultFinder = $this->createMock(UrlFinderInterface::class);
+        $this->catalogFinder = $this->createMock(UrlFinderInterface::class);
+
+        $this->children = [
+            'catalog' => [
+                'class' => 'Magento\CatalogUrlRewrite\Model\Storage\DbStorage',
+                'sortOrder' => 20,
+            ],
+            'default' => [
+                'class' => 'Magento\UrlRewrite\Model\Storage\DbStorage',
+                'sortOrder' => 10,
+            ],
+        ];
+
+        $this->objectManager->method('get')
+            ->willReturnMap(
+                [
+                    ['Magento\UrlRewrite\Model\Storage\DbStorage', $this->defaultFinder],
+                    ['Magento\CatalogUrlRewrite\Model\Storage\DbStorage', $this->catalogFinder],
+                ]
+            );
+    }
+
+    private function createFinder(): CompositeUrlFinder
+    {
+        return (new ObjectManager($this))->getObject(
+            CompositeUrlFinder::class,
+            [
+                'children' => $this->children,
+                'objectManager' => $this->objectManager,
+                'mergeDataProviderFactory' => $this->mergeDataProviderFactory,
+                'config' => $this->config,
+            ]
+        );
+    }
+
+    public function testFindOneByDataResolvesEachChildFinderOnlyOnce(): void
+    {
+        $this->objectManager->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['Magento\UrlRewrite\Model\Storage\DbStorage', $this->defaultFinder],
+                    ['Magento\CatalogUrlRewrite\Model\Storage\DbStorage', $this->catalogFinder],
+                ]
+            );
+
+        $this->defaultFinder->method('findOneByData')->willReturn(null);
+        $this->catalogFinder->method('findOneByData')->willReturn(null);
+
+        $finder = $this->createFinder();
+        $finder->findOneByData(['request_path' => 'first-lookup']);
+        $finder->findOneByData(['request_path' => 'second-lookup']);
+    }
+
+    public function testFindOneByDataQueriesChildrenInSortOrderAndReturnsFirstMatch(): void
+    {
+        $rewrite = $this->createMock(\Magento\UrlRewrite\Service\V1\Data\UrlRewrite::class);
+
+        $callOrder = [];
+        $this->defaultFinder->method('findOneByData')
+            ->willReturnCallback(function () use (&$callOrder, $rewrite) {
+                $callOrder[] = 'default';
+                return $rewrite;
+            });
+        $this->catalogFinder->method('findOneByData')
+            ->willReturnCallback(function () use (&$callOrder) {
+                $callOrder[] = 'catalog';
+                return null;
+            });
+
+        $finder = $this->createFinder();
+        $result = $finder->findOneByData(['request_path' => 'test']);
+
+        $this->assertSame($rewrite, $result);
+        $this->assertSame(['default'], $callOrder);
+    }
+
+    public function testFindAllByDataReturnsFirstFinderResultWhenCategoryRewritesEnabled(): void
+    {
+        $this->config->method('getValue')
+            ->with('catalog/seo/generate_category_product_rewrites')
+            ->willReturn(true);
+
+        $expected = [$this->createMock(\Magento\UrlRewrite\Service\V1\Data\UrlRewrite::class)];
+        $this->defaultFinder->method('findAllByData')->willReturn($expected);
+        $this->catalogFinder->expects($this->never())->method('findAllByData');
+
+        $this->mergeDataProviderFactory->method('create')
+            ->willReturn($this->createMock(MergeDataProvider::class));
+
+        $finder = $this->createFinder();
+        $result = $finder->findAllByData(['request_path' => 'test']);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testFindAllByDataMergesAllFindersWhenCategoryRewritesDisabled(): void
+    {
+        $this->config->method('getValue')
+            ->with('catalog/seo/generate_category_product_rewrites')
+            ->willReturn(false);
+
+        $defaultRewrites = [$this->createMock(\Magento\UrlRewrite\Service\V1\Data\UrlRewrite::class)];
+        $catalogRewrites = [$this->createMock(\Magento\UrlRewrite\Service\V1\Data\UrlRewrite::class)];
+        $this->defaultFinder->method('findAllByData')->willReturn($defaultRewrites);
+        $this->catalogFinder->method('findAllByData')->willReturn($catalogRewrites);
+
+        $mergeDataProvider = $this->createMock(MergeDataProvider::class);
+        $this->mergeDataProviderFactory->method('create')->willReturn($mergeDataProvider);
+
+        $mergeCallOrder = [];
+        $mergeDataProvider->method('merge')
+            ->willReturnCallback(function ($rewrites) use (&$mergeCallOrder, $defaultRewrites, $catalogRewrites) {
+                $mergeCallOrder[] = $rewrites === $defaultRewrites ? 'default' : ($rewrites === $catalogRewrites
+                    ? 'catalog'
+                    : 'unknown');
+            });
+        $merged = ['merged-result'];
+        $mergeDataProvider->method('getData')->willReturn($merged);
+
+        $finder = $this->createFinder();
+        $result = $finder->findAllByData(['request_path' => 'test']);
+
+        $this->assertSame(['default', 'catalog'], $mergeCallOrder);
+        $this->assertSame($merged, $result);
+    }
+}


### PR DESCRIPTION
### Description (*)

`Magento\UrlRewrite\Model\CompositeUrlFinder` is the frontend `UrlFinderInterface`. Every call to `findOneByData()` or `findAllByData()` re-sorted the configured children with `uasort()` and resolved each child finder again through `ObjectManagerInterface::get()`, although the children array is constructor-injected from `di.xml` and never changes.

The children are now sorted once, on first use, and each child finder is resolved once and reused for the lifetime of the instance. Constructor and public methods are unchanged.

### Performance impact

A single storefront request routes through `findOneByData()` once, so the saving per page load is one sort and two ObjectManager lookups. That is below measurement noise: on a category page and a configurable product page the PHP SPX call count is identical before and after, and the median wall time of 7 requests differs by a few milliseconds either way.

The repeated work matters where one instance is called in a loop: `CurrentUrlRewritesRegenerator` calls `findAllByData()` once per store view for every product whose URL rewrites are regenerated (`ProductScopeRewriteGenerator::generateForGlobalScope()`), so a product save or `catalog_url_rewrite_product` reindex on a store with N store views goes from N sorts and 2N lookups per product to one and two.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40722 (finding 107; finding 109 on `DbStorage` is a behaviour question and is not touched here)

### Manual testing scenarios (*)

1. Open any storefront page with a URL rewrite (category, product, CMS page): it resolves as before.
2. Disable Stores > Configuration > Catalog > Search Engine Optimization > Use Categories Path for Product URLs and reopen a product URL under a category path: the merged lookup across finders still works.
3. Save a product assigned to several store views: URL rewrites are regenerated as before.

### Questions or comments

Gates run locally: unit (UrlRewrite suite), integration (UrlRewrite suite), PHPCS, PHPStan and the Static Tests `LiveCodeTest` on the changed files are clean. The new unit test fails without the change and passes with it. No public signature changes.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
