### PR TITLE
Return categories from the loaded collection in CategoryList::getList (#40700)

### DIFF
--- a/app/code/Magento/Catalog/Model/CategoryList.php
+++ b/app/code/Magento/Catalog/Model/CategoryList.php
@@ -77,19 +77,14 @@ class CategoryList implements CategoryListInterface
         /** @var Collection $collection */
         $collection = $this->categoryCollectionFactory->create();
         $this->extensionAttributesJoinProcessor->process($collection);
+        $collection->addAttributeToSelect('*');
         $this->collectionProcessor->process($searchCriteria, $collection);
-
-        $items = [];
-        foreach ($collection->getData() as $categoryData) {
-            $items[] = $this->categoryRepository->get(
-                $categoryData[$collection->getEntity()->getIdFieldName()]
-            );
-        }
+        $collection->load();
 
         /** @var CategorySearchResultsInterface $searchResult */
         $searchResult = $this->categorySearchResultsFactory->create();
         $searchResult->setSearchCriteria($searchCriteria);
-        $searchResult->setItems($items);
+        $searchResult->setItems($collection->getItems());
         $searchResult->setTotalCount($collection->getSize());
         return $searchResult;
     }

--- a/app/code/Magento/Catalog/Model/Config.php
+++ b/app/code/Magento/Catalog/Model/Config.php
@@ -202,7 +202,9 @@ class Config extends \Magento\Eav\Model\Config
             return $this;
         }
 
-        $attributeSetCollection = $this->_setCollectionFactory->create()->load();
+        $attributeSetCollection = $this->_setCollectionFactory->create()
+            ->addFieldToSelect(['entity_type_id', 'attribute_set_name'])
+            ->load();
 
         $this->_attributeSetsById = [];
         $this->_attributeSetsByName = [];
@@ -271,7 +273,9 @@ class Config extends \Magento\Eav\Model\Config
             return $this;
         }
 
-        $attributeSetCollection = $this->_groupCollectionFactory->create()->load();
+        $attributeSetCollection = $this->_groupCollectionFactory->create()
+            ->addFieldToSelect(['attribute_set_id', 'attribute_group_name'])
+            ->load();
 
         $this->_attributeGroupsById = [];
         $this->_attributeGroupsByName = [];

--- a/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/CategoryListTest.php
@@ -18,7 +18,6 @@ use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
 use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\DataObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -92,18 +91,17 @@ class CategoryListTest extends TestCase
 
         $categoryFirst = $this->createMock(Category::class);
         $categorySecond = $this->createMock(Category::class);
+        $items = [$categoryIdFirst => $categoryFirst, $categoryIdSecond => $categorySecond];
 
         /** @var SearchCriteriaInterface|MockObject $searchCriteria */
         $searchCriteria = $this->createMock(SearchCriteriaInterface::class);
 
         $collection = $this->createMock(Collection::class);
+        $collection->expects($this->once())->method('addAttributeToSelect')->with('*');
+        $collection->expects($this->once())->method('load');
+        $collection->expects($this->once())->method('getItems')->willReturn($items);
         $collection->expects($this->once())->method('getSize')->willReturn($totalCount);
-        $collection->expects($this->once())->method('getData')->willReturn(
-            [['entity_id' => $categoryIdFirst], ['entity_id' => $categoryIdSecond]]
-        );
-        $collection->method('getEntity')->willReturn(
-            new DataObject(['id_field_name' => 'entity_id'])
-        );
+        $collection->expects($this->never())->method('getData');
 
         $this->collectionProcessorMock->expects($this->once())
             ->method('process')
@@ -111,13 +109,10 @@ class CategoryListTest extends TestCase
 
         $searchResult = $this->createMock(CategorySearchResultsInterface::class);
         $searchResult->expects($this->once())->method('setSearchCriteria')->with($searchCriteria);
-        $searchResult->expects($this->once())->method('setItems')->with([$categoryFirst, $categorySecond]);
+        $searchResult->expects($this->once())->method('setItems')->with($items);
         $searchResult->expects($this->once())->method('setTotalCount')->with($totalCount);
 
-        $this->categoryRepository->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnMap([[$categoryIdFirst, $categoryFirst], [$categoryIdSecond, $categorySecond]])
-            ->willReturn($categoryFirst);
+        $this->categoryRepository->expects($this->never())->method('get');
 
         $this->categorySearchResultsFactory->expects($this->once())->method('create')->willReturn($searchResult);
         $this->categoryCollectionFactory->expects($this->once())->method('create')->willReturn($collection);

--- a/app/code/Magento/Catalog/Test/Unit/Model/ConfigTest.php
+++ b/app/code/Magento/Catalog/Test/Unit/Model/ConfigTest.php
@@ -56,8 +56,12 @@ class ConfigTest extends TestCase
         $setItem->expects($this->once())->method('getAttributeSetName')->willReturn('name');
         $setCollection = $this->createPartialMock(
             Collection::class,
-            ['load']
+            ['addFieldToSelect', 'load']
         );
+        $setCollection->expects($this->once())
+            ->method('addFieldToSelect')
+            ->with(['entity_type_id', 'attribute_set_name'])
+            ->willReturnSelf();
         $setCollection->expects($this->once())->method('load')->willReturn([1 => $setItem]);
         $setCollectionFactory->method('create')->willReturn($setCollection);
         $model->loadAttributeSets();
@@ -100,8 +104,12 @@ class ConfigTest extends TestCase
         $setItem->expects($this->once())->method('getAttributeGroupName')->willReturn('name');
         $groupCollection = $this->createPartialMock(
             \Magento\Eav\Model\ResourceModel\Entity\Attribute\Group\Collection::class,
-            ['load']
+            ['addFieldToSelect', 'load']
         );
+        $groupCollection->expects($this->once())
+            ->method('addFieldToSelect')
+            ->with(['attribute_set_id', 'attribute_group_name'])
+            ->willReturnSelf();
         $groupCollection->expects($this->once())->method('load')->willReturn([1 => $setItem]);
         $groupCollectionFactory
             ->method('create')->willReturn($groupCollection);


### PR DESCRIPTION
### Description (*)

`Magento\Catalog\Model\CategoryList::getList()` builds a category collection, applies the extension-attribute join processor and the search criteria, then throws the collection away: it reads only the ids from `getData()` and loads every category again through `CategoryRepositoryInterface::get()`. Each of those loads is a full EAV load (entity row, one query per attribute backend table, plus the EntityManager read pipeline), so `GET /V1/categories/list` costs about seven queries per returned category. The same method serves the layered-navigation category aggregation in GraphQL, the admin global search and the media gallery category filter.

The fix mirrors `ProductRepository::getList()`: select all attributes on the collection, load it once and return its items. `Config::loadAttributeSets()` and `loadAttributeGroups()` also stop selecting every column of the attribute-set and attribute-group tables and fetch only the two columns their loops read.

What a caller observes stays the same. Static columns, EAV attributes with store fallback, `custom_attributes` and lazily loaded children are identical between a repository-loaded category and a collection item; the REST payload for 50 categories is byte-identical before and after. Two differences are worth knowing: extension attributes declared through `<join>` directives on `CategoryInterface` are now actually populated (they were discarded before), and the returned objects are no longer the repository's shared cached instances.

### Performance impact

Measured on a vanilla 2.4-develop install (performance toolkit `small` profile, 33 categories). Wall time is the median of 7 fresh requests without the profiler; call counts and memory are from one PHP SPX run of the same request.

```
GET /rest/V1/categories/list?searchCriteria[pageSize]=50
```

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| SQL queries | 177 | 46 | -74% |
| Single-category loads (`catalog_category_entity ... WHERE entity_id = N`) | 33 | 0 | |
| Wall time (median of 7) | 110.1 ms | 68.1 ms | -38% |
| PHP function calls (SPX) | 503,399 | 140,012 | -72% |
| Peak memory (SPX) | 11.7 MB | 9.9 MB | -15% |

The 33 remaining per-category queries come from the lazy `children` field (`Category::getChildren()`), which is outside this change.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#40700 (findings 1 and 4; findings 2 and 7 are left for separate work)

### Manual testing scenarios (*)

1. `GET /rest/V1/categories/list?searchCriteria[pageSize]=50` with an admin token: same payload as before, including `custom_attributes`.
2. With the DB query log enabled, the log shows one `SELECT e.* FROM catalog_category_entity AS e` plus a handful of attribute selects with `entity_id IN (...)`, and no single-row category loads.
3. Storefront GraphQL `products(filter: {category_id: {eq: "3"}}) { aggregations { attribute_code options { label value } } }` with the category filter enabled in layered navigation: the category aggregation is unchanged.

### Questions or comments

Gates run locally: unit (`CategoryListTest`, `ConfigTest`), integration (`CategoryRepositoryTest`, `CategoryTest`, `CategoryTreeTest`, `ConfigTest`), PHPCS, PHPStan and the Static Tests `LiveCodeTest` on the changed files are clean. Both new unit assertions fail without the change and pass with it. The API-functional `Magento\Catalog\Api\CategoryListTest` covers the changed path and needs the WebAPI build.

The `$categoryRepository` constructor argument of `CategoryList` is no longer used by `getList()` but is kept to avoid a signature change. No public signature changes; `Config` is an `@api` class but only method bodies changed.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
