### PR TITLE
Batch product_count resolution against the category product index (#41214)

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Category/ProductsCountProvider.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Category/ProductsCountProvider.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Category;
+
+use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogInventory\Api\Data\StockStatusInterface;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\Status as StockStatusResource;
+use Magento\CatalogInventory\Model\Stock;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Sql\Expression;
+
+/**
+ * Count visible products of multiple categories with a single query against the category product index.
+ */
+class ProductsCountProvider
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @var TableMaintainer
+     */
+    private $tableMaintainer;
+
+    /**
+     * @var Visibility
+     */
+    private $catalogProductVisibility;
+
+    /**
+     * @var StockConfigurationInterface
+     */
+    private $stockConfiguration;
+
+    /**
+     * @var StockStatusResource
+     */
+    private $stockStatusResource;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param TableMaintainer $tableMaintainer
+     * @param Visibility $catalogProductVisibility
+     * @param StockConfigurationInterface $stockConfiguration
+     * @param StockStatusResource $stockStatusResource
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        TableMaintainer $tableMaintainer,
+        Visibility $catalogProductVisibility,
+        StockConfigurationInterface $stockConfiguration,
+        StockStatusResource $stockStatusResource
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->tableMaintainer = $tableMaintainer;
+        $this->catalogProductVisibility = $catalogProductVisibility;
+        $this->stockConfiguration = $stockConfiguration;
+        $this->stockStatusResource = $stockStatusResource;
+    }
+
+    /**
+     * Get the number of visible products per category id
+     *
+     * Enabled status, website membership and per store visibility are already materialized in the category product
+     * index, so only the stock status still needs a join, and only when out of stock products are hidden.
+     *
+     * @param int $storeId
+     * @param int[] $categoryIds
+     * @param bool $isAnchor Anchor categories count the whole subtree, others only directly assigned products
+     * @return int[] Category id to products count, categories without matching rows are omitted
+     */
+    public function getProductsCounts(int $storeId, array $categoryIds, bool $isAnchor): array
+    {
+        if (!$categoryIds) {
+            return [];
+        }
+
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select()
+            ->from(['cat_index' => $this->tableMaintainer->getMainTable($storeId)], [])
+            ->columns(
+                [
+                    'category_id' => 'cat_index.category_id',
+                    'products_count' => new Expression('COUNT(DISTINCT cat_index.product_id)'),
+                ]
+            )
+            ->where('cat_index.store_id = ?', $storeId)
+            ->where('cat_index.category_id IN (?)', $categoryIds)
+            ->where('cat_index.visibility IN (?)', $this->catalogProductVisibility->getVisibleInSiteIds())
+            ->group('cat_index.category_id');
+
+        if (!$isAnchor) {
+            $select->where('cat_index.is_parent = ?', 1);
+        }
+
+        if (!$this->stockConfiguration->isShowOutOfStock()) {
+            $select->join(
+                ['stock_status_index' => $this->stockStatusResource->getMainTable()],
+                'stock_status_index.product_id = cat_index.product_id'
+                . ' AND ' . $connection->quoteInto(
+                    'stock_status_index.website_id = ?',
+                    (int)$this->stockConfiguration->getDefaultScopeId()
+                )
+                . ' AND ' . $connection->quoteInto('stock_status_index.stock_id = ?', Stock::DEFAULT_STOCK_ID),
+                []
+            )->where('stock_status_index.stock_status = ?', StockStatusInterface::STATUS_IN_STOCK);
+        }
+
+        return array_map('intval', $connection->fetchPairs($select));
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/BatchProductsCount.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/BatchProductsCount.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\CatalogGraphQl\Model\Category\ProductsCountProvider;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\BatchRequestItemInterface;
+use Magento\Framework\GraphQl\Query\Resolver\BatchResolverInterface;
+use Magento\Framework\GraphQl\Query\Resolver\BatchResponse;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Store\Model\Store;
+
+/**
+ * Retrieves products count for all categories requested in a single GraphQL request
+ */
+class BatchProductsCount implements BatchResolverInterface
+{
+    /**
+     * @var ProductsCountProvider
+     */
+    private $productsCountProvider;
+
+    /**
+     * @var ProductsCount
+     */
+    private $productsCount;
+
+    /**
+     * @param ProductsCountProvider $productsCountProvider
+     * @param ProductsCount $productsCount
+     */
+    public function __construct(ProductsCountProvider $productsCountProvider, ProductsCount $productsCount)
+    {
+        $this->productsCountProvider = $productsCountProvider;
+        $this->productsCount = $productsCount;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(ContextInterface $context, Field $field, array $requests): BatchResponse
+    {
+        $response = new BatchResponse();
+        $groups = [];
+        $assignments = [];
+
+        /** @var BatchRequestItemInterface $request */
+        foreach ($requests as $request) {
+            $value = $request->getValue();
+            if (!isset($value['model'])) {
+                throw new GraphQlInputException(__('"model" value should be specified'));
+            }
+            /** @var Category $category */
+            $category = $value['model'];
+            $storeId = (int)$category->getStoreId();
+            if ($storeId === Store::DEFAULT_STORE_ID) {
+                $response->addResponse(
+                    $request,
+                    $this->productsCount->resolve($field, $context, $request->getInfo(), $value, $request->getArgs())
+                );
+                continue;
+            }
+            $categoryId = (int)$category->getId();
+            $isAnchor = (bool)$category->getIsAnchor();
+            $groupKey = $storeId . '/' . (int)$isAnchor;
+            $groups[$groupKey]['store_id'] = $storeId;
+            $groups[$groupKey]['is_anchor'] = $isAnchor;
+            $groups[$groupKey]['category_ids'][$categoryId] = $categoryId;
+            $assignments[] = [$request, $groupKey, $categoryId];
+        }
+
+        $counts = [];
+        foreach ($groups as $groupKey => $group) {
+            $counts[$groupKey] = $this->productsCountProvider->getProductsCounts(
+                $group['store_id'],
+                array_values($group['category_ids']),
+                $group['is_anchor']
+            );
+        }
+
+        foreach ($assignments as [$request, $groupKey, $categoryId]) {
+            $response->addResponse($request, $counts[$groupKey][$categoryId] ?? 0);
+        }
+
+        return $response;
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Category/ProductsCountProviderTest.php
+++ b/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Category/ProductsCountProviderTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Test\Unit\Model\Category;
+
+use Magento\Catalog\Model\Indexer\Category\Product\TableMaintainer;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogGraphQl\Model\Category\ProductsCountProvider;
+use Magento\CatalogInventory\Api\StockConfigurationInterface;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\Status as StockStatusResource;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see ProductsCountProvider
+ */
+class ProductsCountProviderTest extends TestCase
+{
+    /**
+     * @var ResourceConnection|MockObject
+     */
+    private ResourceConnection $resourceConnection;
+
+    /**
+     * @var StockConfigurationInterface|MockObject
+     */
+    private StockConfigurationInterface $stockConfiguration;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private AdapterInterface $connection;
+
+    /**
+     * @var Select|MockObject
+     */
+    private Select $select;
+
+    /**
+     * @var array<string, array>
+     */
+    private array $calls = ['from' => [], 'columns' => [], 'where' => [], 'group' => [], 'join' => []];
+
+    /**
+     * @var ProductsCountProvider
+     */
+    private ProductsCountProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->stockConfiguration = $this->createMock(StockConfigurationInterface::class);
+        $this->connection = $this->createMock(AdapterInterface::class);
+        $this->select = $this->createMock(Select::class);
+
+        $tableMaintainer = $this->createMock(TableMaintainer::class);
+        $tableMaintainer->method('getMainTable')->willReturnCallback(
+            fn (int $storeId): string => 'catalog_category_product_index_store' . $storeId
+        );
+        $visibility = $this->createMock(Visibility::class);
+        $visibility->method('getVisibleInSiteIds')->willReturn([2, 3, 4]);
+        $stockStatusResource = $this->createMock(StockStatusResource::class);
+        $stockStatusResource->method('getMainTable')->willReturn('cataloginventory_stock_status');
+
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
+        $this->connection->method('select')->willReturn($this->select);
+        $this->connection->method('quoteInto')->willReturnCallback(
+            fn (string $text, $value): string => str_replace('?', (string)$value, $text)
+        );
+
+        foreach (array_keys($this->calls) as $method) {
+            $this->select->method($method)->willReturnCallback(
+                function (...$arguments) use ($method): Select {
+                    while ($arguments !== [] && end($arguments) === null) {
+                        array_pop($arguments);
+                    }
+                    $this->calls[$method][] = $arguments;
+                    return $this->select;
+                }
+            );
+        }
+
+        $this->provider = new ProductsCountProvider(
+            $this->resourceConnection,
+            $tableMaintainer,
+            $visibility,
+            $this->stockConfiguration,
+            $stockStatusResource
+        );
+    }
+
+    public function testNonAnchorCategoriesAreCountedByDirectAssignmentWithStockJoin(): void
+    {
+        $this->stockConfiguration->method('isShowOutOfStock')->willReturn(false);
+        $this->stockConfiguration->method('getDefaultScopeId')->willReturn(0);
+        $this->connection->expects($this->once())
+            ->method('fetchPairs')
+            ->with($this->select)
+            ->willReturn(['3' => '5', '4' => '0']);
+
+        $this->assertSame([3 => 5, 4 => 0], $this->provider->getProductsCounts(1, [3, 4], false));
+
+        $this->assertSame(
+            [[['cat_index' => 'catalog_category_product_index_store1'], []]],
+            $this->calls['from']
+        );
+        $this->assertSame([['cat_index.category_id']], $this->calls['group']);
+        $this->assertSame(
+            [
+                [
+                    ['stock_status_index' => 'cataloginventory_stock_status'],
+                    'stock_status_index.product_id = cat_index.product_id'
+                    . ' AND stock_status_index.website_id = 0'
+                    . ' AND stock_status_index.stock_id = 1',
+                    [],
+                ],
+            ],
+            $this->calls['join']
+        );
+        $this->assertSame(
+            [
+                ['cat_index.store_id = ?', 1],
+                ['cat_index.category_id IN (?)', [3, 4]],
+                ['cat_index.visibility IN (?)', [2, 3, 4]],
+                ['cat_index.is_parent = ?', 1],
+                ['stock_status_index.stock_status = ?', 1],
+            ],
+            $this->calls['where']
+        );
+    }
+
+    public function testAnchorCategoriesWithOutOfStockShownSkipIsParentAndStockJoin(): void
+    {
+        $this->stockConfiguration->method('isShowOutOfStock')->willReturn(true);
+        $this->connection->expects($this->once())->method('fetchPairs')->willReturn([]);
+
+        $this->assertSame([], $this->provider->getProductsCounts(2, [7], true));
+
+        $this->assertSame([], $this->calls['join']);
+        $this->assertSame(
+            [
+                ['cat_index.store_id = ?', 2],
+                ['cat_index.category_id IN (?)', [7]],
+                ['cat_index.visibility IN (?)', [2, 3, 4]],
+            ],
+            $this->calls['where']
+        );
+    }
+
+    public function testEmptyCategoryListIsNotQueried(): void
+    {
+        $this->connection->expects($this->never())->method('fetchPairs');
+
+        $this->assertSame([], $this->provider->getProductsCounts(1, [], true));
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Category/BatchProductsCountTest.php
+++ b/app/code/Magento/CatalogGraphQl/Test/Unit/Model/Resolver/Category/BatchProductsCountTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Test\Unit\Model\Resolver\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\CatalogGraphQl\Model\Category\ProductsCountProvider;
+use Magento\CatalogGraphQl\Model\Resolver\Category\BatchProductsCount;
+use Magento\CatalogGraphQl\Model\Resolver\Category\ProductsCount;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\BatchRequestItemInterface;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see BatchProductsCount
+ */
+class BatchProductsCountTest extends TestCase
+{
+    /**
+     * @var ProductsCountProvider|MockObject
+     */
+    private ProductsCountProvider $productsCountProvider;
+
+    /**
+     * @var ProductsCount|MockObject
+     */
+    private ProductsCount $productsCount;
+
+    /**
+     * @var ContextInterface|MockObject
+     */
+    private ContextInterface $context;
+
+    /**
+     * @var Field|MockObject
+     */
+    private Field $field;
+
+    /**
+     * @var ObjectManager
+     */
+    private ObjectManager $objectManager;
+
+    /**
+     * @var BatchProductsCount
+     */
+    private BatchProductsCount $resolver;
+
+    protected function setUp(): void
+    {
+        $this->productsCountProvider = $this->createMock(ProductsCountProvider::class);
+        $this->productsCount = $this->createMock(ProductsCount::class);
+        $this->context = $this->createMock(ContextInterface::class);
+        $this->field = $this->createMock(Field::class);
+        $this->objectManager = new ObjectManager($this);
+
+        $this->resolver = new BatchProductsCount($this->productsCountProvider, $this->productsCount);
+    }
+
+    public function testCategoriesOfTwoStoresAreCountedWithOneQueryPerStore(): void
+    {
+        $requests = [
+            $this->createRequest(3, 1, true),
+            $this->createRequest(4, 1, true),
+            $this->createRequest(3, 2, true),
+        ];
+        $calls = [];
+        $this->productsCountProvider->expects($this->exactly(2))
+            ->method('getProductsCounts')
+            ->willReturnCallback(
+                function (int $storeId, array $categoryIds, bool $isAnchor) use (&$calls): array {
+                    $calls[] = [$storeId, $categoryIds, $isAnchor];
+                    return $storeId === 1 ? [3 => 7, 4 => 2] : [3 => 5];
+                }
+            );
+
+        $response = $this->resolver->resolve($this->context, $this->field, $requests);
+
+        $this->assertSame([[1, [3, 4], true], [2, [3], true]], $calls);
+        $this->assertSame(7, $response->findResponseFor($requests[0]));
+        $this->assertSame(2, $response->findResponseFor($requests[1]));
+        $this->assertSame(5, $response->findResponseFor($requests[2]));
+    }
+
+    public function testAnchorAndNonAnchorCategoriesAreCountedSeparately(): void
+    {
+        $requests = [
+            $this->createRequest(3, 1, true),
+            $this->createRequest(4, 1, false),
+        ];
+        $calls = [];
+        $this->productsCountProvider->expects($this->exactly(2))
+            ->method('getProductsCounts')
+            ->willReturnCallback(
+                function (int $storeId, array $categoryIds, bool $isAnchor) use (&$calls): array {
+                    $calls[] = [$storeId, $categoryIds, $isAnchor];
+                    return $isAnchor ? [3 => 9] : [4 => 1];
+                }
+            );
+
+        $response = $this->resolver->resolve($this->context, $this->field, $requests);
+
+        $this->assertSame([[1, [3], true], [1, [4], false]], $calls);
+        $this->assertSame(9, $response->findResponseFor($requests[0]));
+        $this->assertSame(1, $response->findResponseFor($requests[1]));
+    }
+
+    public function testCategoryWithoutIndexRowsResolvesToZero(): void
+    {
+        $request = $this->createRequest(11, 1, true);
+        $this->productsCountProvider->method('getProductsCounts')->willReturn([]);
+
+        $response = $this->resolver->resolve($this->context, $this->field, [$request]);
+
+        $this->assertSame(0, $response->findResponseFor($request));
+    }
+
+    public function testAdminStoreFallsBackToCollectionResolver(): void
+    {
+        $request = $this->createRequest(3, 0, true);
+        $this->productsCountProvider->expects($this->never())->method('getProductsCounts');
+        $this->productsCount->expects($this->once())->method('resolve')->willReturn(42);
+
+        $response = $this->resolver->resolve($this->context, $this->field, [$request]);
+
+        $this->assertSame(42, $response->findResponseFor($request));
+    }
+
+    public function testMissingCategoryModelIsRejected(): void
+    {
+        $request = $this->createMock(BatchRequestItemInterface::class);
+        $request->method('getValue')->willReturn([]);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('"model" value should be specified');
+
+        $this->resolver->resolve($this->context, $this->field, [$request]);
+    }
+
+    /**
+     * @param int $categoryId
+     * @param int $storeId
+     * @param bool $isAnchor
+     * @return BatchRequestItemInterface|MockObject
+     */
+    private function createRequest(int $categoryId, int $storeId, bool $isAnchor): BatchRequestItemInterface
+    {
+        /** @var Category $category */
+        $category = $this->objectManager->getObject(Category::class);
+        $category->setData(
+            [
+                'id' => $categoryId,
+                'entity_id' => $categoryId,
+                'store_id' => $storeId,
+                'is_anchor' => $isAnchor ? 1 : 0,
+            ]
+        );
+
+        $request = $this->createMock(BatchRequestItemInterface::class);
+        $request->method('getValue')->willReturn(['model' => $category]);
+        $request->method('getArgs')->willReturn([]);
+        $request->method('getInfo')->willReturn($this->createMock(ResolveInfo::class));
+
+        return $request;
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -265,7 +265,7 @@ interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model
     level: Int @doc(description: "The depth of the category within the tree.")
     created_at: String @deprecated(reason: "The field should not be used on the storefront.") @doc(description: "The timestamp indicating when the category was created.")
     updated_at: String @deprecated(reason: "The field should not be used on the storefront.") @doc(description: "The timestamp indicating when the category was updated.")
-    product_count: Int @doc(description: "The number of products in the category that are marked as visible. By default, in complex products, parent products are visible, but their child products are not.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\ProductsCount")
+    product_count: Int @doc(description: "The number of products in the category that are marked as visible. By default, in complex products, parent products are visible, but their child products are not.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\BatchProductsCount")
     default_sort_by: String @doc(description: "The attribute to use for sorting.")
     products(
         pageSize: Int = 20 @doc(description: "The maximum number of results to return at once. The default value is 20."),


### PR DESCRIPTION
### Description (*)

`Magento\CatalogGraphQl\Model\Resolver\Category\ProductsCount` resolves `product_count` one category at a time: it builds a full product collection for the category, runs the collection processors and calls `getSize()`. Every `product_count` field in a response therefore costs one `COUNT(DISTINCT e.entity_id)` with joins on the category index, the stock status index, two `catalog_product_entity_int` attribute tables and `catalog_product_website`. On a store with ~60k products this query averaged 0.6 s and ran ~98,000 times in a week from a single PWA product-detail operation.

The category product index `catalog_category_product_index_store{N}` already materializes enabled status, website membership and per-store visibility, so the joins on the attribute and website tables add nothing to the count. This PR adds:

- `Model\Category\ProductsCountProvider`, which counts all requested categories of one store with one `GROUP BY category_id` query on the index table (resolved through `TableMaintainer`, never a hardcoded suffix). The `is_parent = 1` predicate for non-anchor categories and the `cataloginventory_stock_status` join when "Display Out of Stock Products" is disabled are kept, so the numbers match the old count.
- `Model\Resolver\Category\BatchProductsCount`, a `BatchResolverInterface` that groups the requests of a response by store and anchor flag and calls the provider once per group. Requests for the admin store (`store_id = 0`) are delegated to the existing `ProductsCount` resolver, because that path uses a different table and filter set.
- `schema.graphqls`: `CategoryInterface.product_count` now points at the batch resolver. `ProductsCount` is unchanged and still wired for the admin scope.

### Performance impact

Measured on a vanilla 2.4-develop install (performance toolkit `small` profile: 1200 products, 33 categories). Wall time is the median of 7 fresh requests without the profiler; call counts and memory are from one PHP SPX run of the same request. Response bodies are byte-identical before and after.

Query 1, three levels of `categoryList` with `product_count` (31 fields):

```graphql
{ categoryList(filters: {ids: {eq: "2"}}) { children { id product_count children { id product_count children { id product_count } } } } }
```

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| SQL queries | 52 | 22 | -58% |
| `product_count` queries | 31 `COUNT(DISTINCT e.entity_id)` | 2 `GROUP BY category_id` | |
| Wall time (median of 7) | 94.6 ms | 86.0 ms | -9% |
| PHP function calls (SPX) | 284,766 | 168,111 | -41% |

Query 2, product listing with categories (24 `product_count` fields over 12 items):

```graphql
{ products(filter: {category_id: {eq: "3"}}, pageSize: 12) { items { sku categories { id product_count } } } }
```

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| SQL queries | 68 | 45 | -34% |
| `product_count` queries | 24 `COUNT(DISTINCT e.entity_id)` | 1 `GROUP BY category_id` | |
| Wall time (median of 7) | 122.0 ms | 89.5 ms | -27% |
| PHP function calls (SPX) | 264,858 | 179,971 | -32% |

The remaining per-item queries in query 2 come from the `categories` resolver itself and are outside this change. On a small catalog the count query is cheap, so the wall-time gain is modest here; the production numbers in the issue show what the per-category query costs on a large catalog.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41214

### Manual testing scenarios (*)

1. Enable the DB query log and send the two queries above: the log contains `GROUP BY cat_index.category_id` queries on `catalog_category_product_index_store1` and no `COUNT(DISTINCT e.entity_id)`.
2. Compare `product_count` values with the ones returned before the change for an anchor category, a non-anchor category, a category with out-of-stock products and a category with no products: identical (0 for the empty category).
3. Set Stores > Configuration > Catalog > Inventory > Stock Options > Display Out of Stock Products to Yes: the stock join disappears from the logged query and the counts include out-of-stock products, as before.

### Questions or comments

Gates run locally: unit (CatalogGraphQl suite, 70 tests), integration (CatalogGraphQl suite), PHPCS, PHPStan and the Static Tests `LiveCodeTest` on the changed files are clean. The API-functional tests that pin the count semantics (`CategoryProductsCountTest`, `CategoryAnchorTest`, `CategoryListTest`, `CategoryTreeTest`) need the WebAPI build.

Batching happens per GraphQL execution level: a three-level `categoryList` produces one query per level, a flat product listing one query per response.

The Semantic Version Checker will report two new classes and the changed `@resolver` class on `CategoryInterface.product_count`. Plugins on `ProductsCount::resolve()` no longer run for storefront requests, only for the admin-scope fallback.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
- [x] All automated tests passed successfully (all builds are green)
