### PR TITLE
Add index on catalog_product_entity.type_id (#37431)

### DIFF
--- a/app/code/Magento/Catalog/etc/db_schema.xml
+++ b/app/code/Magento/Catalog/etc/db_schema.xml
@@ -31,6 +31,9 @@
         <index referenceId="CATALOG_PRODUCT_ENTITY_SKU" indexType="btree">
             <column name="sku"/>
         </index>
+        <index referenceId="CATALOG_PRODUCT_ENTITY_TYPE_ID" indexType="btree">
+            <column name="type_id"/>
+        </index>
     </table>
     <table name="catalog_product_entity_datetime" resource="default" engine="innodb"
            comment="Catalog Product Datetime Attribute Backend Table">
@@ -504,9 +507,9 @@
             <column name="category_id"/>
             <column name="product_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="CAT_CTGR_PRD_PRD_ID_CAT_PRD_ENTT_ENTT_ID" table="catalog_category_product"
-                    column="product_id" referenceTable="catalog_product_entity" referenceColumn="entity_id"
-                    onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CAT_CTGR_PRD_PRD_ID_CAT_PRD_ENTT_ENTT_ID"
+                    table="catalog_category_product" column="product_id" referenceTable="catalog_product_entity"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
         <constraint xsi:type="foreign" referenceId="CAT_CTGR_PRD_CTGR_ID_CAT_CTGR_ENTT_ENTT_ID"
                     table="catalog_category_product" column="category_id" referenceTable="catalog_category_entity"
                     referenceColumn="entity_id" onDelete="CASCADE"/>
@@ -579,10 +582,12 @@
         <constraint xsi:type="foreign" referenceId="CATALOG_COMPARE_ITEM_PRODUCT_ID_CATALOG_PRODUCT_ENTITY_ENTITY_ID"
                     table="catalog_compare_item" column="product_id" referenceTable="catalog_product_entity"
                     referenceColumn="entity_id" onDelete="CASCADE"/>
-        <constraint xsi:type="foreign" referenceId="CATALOG_COMPARE_ITEM_STORE_ID_STORE_STORE_ID" table="catalog_compare_item"
-                    column="store_id" referenceTable="store" referenceColumn="store_id" onDelete="SET NULL"/>
-        <constraint xsi:type="foreign" referenceId="CATALOG_COMPARE_ITEM_LIST_ID_CATALOG_COMPARE_LIST_LIST_ID" table="catalog_compare_item"
-                    column="list_id" referenceTable="catalog_compare_list" referenceColumn="list_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CATALOG_COMPARE_ITEM_STORE_ID_STORE_STORE_ID"
+                    table="catalog_compare_item" column="store_id" referenceTable="store" referenceColumn="store_id"
+                    onDelete="SET NULL"/>
+        <constraint xsi:type="foreign" referenceId="CATALOG_COMPARE_ITEM_LIST_ID_CATALOG_COMPARE_LIST_LIST_ID"
+                    table="catalog_compare_item" column="list_id" referenceTable="catalog_compare_list"
+                    referenceColumn="list_id" onDelete="CASCADE"/>
         <index referenceId="CATALOG_COMPARE_ITEM_PRODUCT_ID" indexType="btree">
             <column name="product_id"/>
         </index>
@@ -598,7 +603,8 @@
             <column name="store_id"/>
         </index>
     </table>
-    <table name="catalog_compare_list" resource="default" engine="innodb" comment="Catalog Compare List with hash Table">
+    <table name="catalog_compare_list" resource="default" engine="innodb"
+           comment="Catalog Compare List with hash Table">
         <column xsi:type="int" name="list_id" padding="10" unsigned="true" nullable="false"
                 identity="true" comment="Compare List ID"/>
         <column xsi:type="varchar" name="list_id_mask" nullable="true" length="32" comment="Masked ID"/>
@@ -630,9 +636,9 @@
         <constraint xsi:type="foreign" referenceId="CATALOG_PRODUCT_WEBSITE_WEBSITE_ID_STORE_WEBSITE_WEBSITE_ID"
                     table="catalog_product_website" column="website_id" referenceTable="store_website"
                     referenceColumn="website_id" onDelete="CASCADE"/>
-        <constraint xsi:type="foreign" referenceId="CAT_PRD_WS_PRD_ID_CAT_PRD_ENTT_ENTT_ID" table="catalog_product_website"
-                    column="product_id" referenceTable="catalog_product_entity" referenceColumn="entity_id"
-                    onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CAT_PRD_WS_PRD_ID_CAT_PRD_ENTT_ENTT_ID"
+                    table="catalog_product_website" column="product_id" referenceTable="catalog_product_entity"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
         <index referenceId="CATALOG_PRODUCT_WEBSITE_WEBSITE_ID" indexType="btree">
             <column name="website_id"/>
         </index>
@@ -659,9 +665,9 @@
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="link_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="CAT_PRD_LNK_LNKED_PRD_ID_CAT_PRD_ENTT_ENTT_ID" table="catalog_product_link"
-                    column="linked_product_id" referenceTable="catalog_product_entity" referenceColumn="entity_id"
-                    onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CAT_PRD_LNK_LNKED_PRD_ID_CAT_PRD_ENTT_ENTT_ID"
+                    table="catalog_product_link" column="linked_product_id" referenceTable="catalog_product_entity"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
         <constraint xsi:type="foreign" referenceId="CATALOG_PRODUCT_LINK_PRODUCT_ID_CATALOG_PRODUCT_ENTITY_ENTITY_ID"
                     table="catalog_product_link" column="product_id" referenceTable="catalog_product_entity"
                     referenceColumn="entity_id" onDelete="CASCADE"/>
@@ -911,9 +917,9 @@
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="option_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="CAT_PRD_OPT_PRD_ID_CAT_PRD_ENTT_ENTT_ID" table="catalog_product_option"
-                    column="product_id" referenceTable="catalog_product_entity" referenceColumn="entity_id"
-                    onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CAT_PRD_OPT_PRD_ID_CAT_PRD_ENTT_ENTT_ID"
+                    table="catalog_product_option" column="product_id" referenceTable="catalog_product_entity"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
         <index referenceId="CATALOG_PRODUCT_OPTION_PRODUCT_ID" indexType="btree">
             <column name="product_id"/>
         </index>
@@ -1260,8 +1266,9 @@
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="website_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="CAT_PRD_IDX_WS_WS_ID_STORE_WS_WS_ID" table="catalog_product_index_website"
-                    column="website_id" referenceTable="store_website" referenceColumn="website_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="CAT_PRD_IDX_WS_WS_ID_STORE_WS_WS_ID"
+                    table="catalog_product_index_website" column="website_id" referenceTable="store_website"
+                    referenceColumn="website_id" onDelete="CASCADE"/>
         <index referenceId="CATALOG_PRODUCT_INDEX_WEBSITE_WEBSITE_DATE" indexType="btree">
             <column name="website_date"/>
         </index>

--- a/app/code/Magento/Catalog/etc/db_schema_whitelist.json
+++ b/app/code/Magento/Catalog/etc/db_schema_whitelist.json
@@ -12,7 +12,8 @@
         },
         "index": {
             "CATALOG_PRODUCT_ENTITY_ATTRIBUTE_SET_ID": true,
-            "CATALOG_PRODUCT_ENTITY_SKU": true
+            "CATALOG_PRODUCT_ENTITY_SKU": true,
+            "CATALOG_PRODUCT_ENTITY_TYPE_ID": true
         },
         "constraint": {
             "PRIMARY": true,


### PR DESCRIPTION
### Description (*)

`catalog_product_entity.type_id` has no index. Core filters on it in the configurable and downloadable export row customizers, the admin widget product chooser, the low-stock report collection and the product frontend action synchronizer, and every one of those is a full table scan.

This adds a btree index on `type_id` and whitelists it. Declarative schema has no prefix-length support (`index.xsd` only knows a column `name`), so this is a full-column index.

Measured on a copy of the table grown to 307,200 rows (4,096 configurable, 303,104 simple), MySQL 8.0, medians of 3 from `SHOW PROFILES`:

| Query | before | after | plan before | plan after |
|---|---|---|---|---|
| `COUNT(*) WHERE type_id='configurable'` | 13.9 ms | 0.42 ms | ALL, 304,569 rows | ref, 4,096 rows, Using index |
| `entity_id, sku WHERE type_id='configurable' ORDER BY entity_id LIMIT 200` | 0.99 ms | 0.19 ms | index PRIMARY | ref, Using index condition |
| `COUNT(*) WHERE type_id='simple'` | 15.6 ms | 20.7 ms | ALL | ref, 305,991 rows, Using index |

The last row is the trade-off: for the dominant value the optimizer prefers the 130-byte key over the clustered scan and gets slower. Core never filters on `type_id='simple'` alone, and a prefix index that would shrink that cost is not expressible in declarative schema.

Line wrapping elsewhere in `db_schema.xml` is there because the Static Tests build fails on pre-existing line-length warnings in any touched file.

Local gates: unit and static pass. In the Catalog integration suite, `SortingTest::testProductListOutOfStockSortOrderWithMysql` fails identically on a clean `2.4-develop` checkout in the same environment, so it is not related to this change.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#37431

### Manual testing scenarios (*)

1. `bin/magento setup:upgrade` on an existing install, then `SHOW INDEX FROM catalog_product_entity` shows `CATALOG_PRODUCT_ENTITY_TYPE_ID`.
2. `bin/magento setup:db-declaration:generate-whitelist --module-name=Magento_Catalog` produces no diff.
3. `EXPLAIN SELECT COUNT(*) FROM catalog_product_entity WHERE type_id='configurable'` uses the new key.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
