### PR TITLE
Align stock item lock and qty update on the primary key (#39417)

### DIFF
--- a/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock.php
+++ b/app/code/Magento/CatalogInventory/Model/ResourceModel/Stock.php
@@ -83,7 +83,8 @@ class Stock extends AbstractDb implements QtyCounterInterface
 
     /**
      * @var StoreManagerInterface
-     * @deprecated 100.1.0
+     * @deprecated 100.1.0 Not used anymore
+     * @see Nothing
      */
     protected $storeManager;
 
@@ -142,6 +143,8 @@ class Stock extends AbstractDb implements QtyCounterInterface
         foreach ($this->getConnection()->query($preSelect)->fetchAll() as $item) {
             $itemIds[] = (int)$item['item_id'];
         }
+        //InnoDB grants row locks in index order; ascending item_id makes that order equal for every transaction
+        sort($itemIds);
 
         $select = $this->getConnection()->select()->from(['si' => $itemTable])
             ->where('item_id IN (?)', $itemIds, \Zend_Db::INT_TYPE)
@@ -178,18 +181,32 @@ class Stock extends AbstractDb implements QtyCounterInterface
         }
 
         $connection = $this->getConnection();
+        $itemTable = $this->getTable('cataloginventory_stock_item');
+
+        $itemsQty = [];
+        $preSelect = $connection->select()->from($itemTable, ['item_id', 'product_id'])
+            ->where('website_id = ?', $websiteId)
+            ->where('product_id IN(?)', array_keys($items), \Zend_Db::INT_TYPE);
+        foreach ($connection->fetchAll($preSelect) as $item) {
+            $itemsQty[(int)$item['item_id']] = $items[$item['product_id']];
+        }
+        if (empty($itemsQty)) {
+            return;
+        }
+        ksort($itemsQty);
+
         $conditions = [];
-        foreach ($items as $productId => $qty) {
-            $case = $connection->quoteInto('?', $productId);
+        foreach ($itemsQty as $itemId => $qty) {
+            $case = $connection->quoteInto('?', $itemId);
             $result = $connection->quoteInto("qty{$operator}?", $qty);
             $conditions[$case] = $result;
         }
 
-        $value = $connection->getCaseSql('product_id', $conditions, 'qty');
-        $where = ['product_id IN (?)' => array_keys($items), 'website_id = ?' => $websiteId];
+        $value = $connection->getCaseSql('item_id', $conditions, 'qty');
+        $where = ['item_id IN (?)' => array_keys($itemsQty)];
 
         $connection->beginTransaction();
-        $connection->update($this->getTable('cataloginventory_stock_item'), ['qty' => $value], $where);
+        $connection->update($itemTable, ['qty' => $value], $where);
         $connection->commit();
     }
 

--- a/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/StockTest.php
+++ b/app/code/Magento/CatalogInventory/Test/Unit/Model/ResourceModel/StockTest.php
@@ -139,6 +139,7 @@ class StockTest extends TestCase
         foreach ($items as $item) {
             $itemIds[] = $item['item_id'];
         }
+        sort($itemIds);
         $this->selectMock->expects($this->exactly(3))
             ->method('from')
             ->willReturnCallback(function ($arg1, $arg2) {
@@ -233,7 +234,129 @@ class StockTest extends TestCase
                     ],
                 ],
                 [['item_id' => 1], ['item_id' => 2], ['item_id' => 3]]
+            ],
+            'item ids returned out of order' => [
+                0,
+                [1, 2, 3],
+                [
+                    1 => ['product_id' => 1],
+                    2 => ['product_id' => 2],
+                    3 => ['product_id' => 3]
+                ],
+                [
+                    1 => [
+                        'product_id' => 1,
+                        'type_id' => 'simple'
+                    ],
+                    2 => [
+                        'product_id' => 2,
+                        'type_id' => 'simple'
+                    ],
+                    3 => [
+                        'product_id' => 3,
+                        'type_id' => 'simple'
+                    ],
+                ],
+                [['item_id' => 3], ['item_id' => 1], ['item_id' => 2]]
             ]
         ];
+    }
+
+    /**
+     * Stock item rows must be addressed by primary key, in ascending order.
+     *
+     * @return void
+     */
+    public function testCorrectItemsQtyUpdatesRowsByItemId(): void
+    {
+        $this->stock->method('getTable')
+            ->with('cataloginventory_stock_item')
+            ->willReturn(self::ITEM_TABLE);
+        $this->stock->method('getConnection')
+            ->willReturn($this->connectionMock);
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectMock);
+
+        $whereCalls = [];
+        $this->selectMock->method('from')->willReturnSelf();
+        $this->selectMock->method('where')
+            ->willReturnCallback(function ($condition, $value = null) use (&$whereCalls) {
+                $whereCalls[$condition] = $value;
+                return $this->selectMock;
+            });
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->with($this->identicalTo($this->selectMock))
+            ->willReturn(
+                [
+                    ['item_id' => '40', 'product_id' => '3'],
+                    ['item_id' => '10', 'product_id' => '1'],
+                ]
+            );
+        $this->connectionMock->method('quoteInto')
+            ->willReturnCallback(
+                static fn ($text, $value) => str_replace('?', (string)$value, $text)
+            );
+
+        $caseArguments = [];
+        $this->connectionMock->expects($this->once())
+            ->method('getCaseSql')
+            ->willReturnCallback(
+                function ($valueName, $casesResults, $defaultValue) use (&$caseArguments) {
+                    $caseArguments = [$valueName, $casesResults, $defaultValue];
+                    return new \Zend_Db_Expr('CASE');
+                }
+            );
+
+        $updateArguments = [];
+        $this->connectionMock->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(
+                function ($table, $bind, $where) use (&$updateArguments) {
+                    $updateArguments = [$table, $bind, $where];
+                    return 2;
+                }
+            );
+        $this->connectionMock->expects($this->once())->method('beginTransaction');
+        $this->connectionMock->expects($this->once())->method('commit');
+
+        $this->stock->correctItemsQty([3 => 5, 1 => 2], 1, '-');
+
+        $this->assertSame(['website_id = ?' => 1, 'product_id IN(?)' => [3, 1]], $whereCalls);
+        $this->assertSame('item_id', $caseArguments[0]);
+        $this->assertSame([10, 40], array_keys($caseArguments[1]));
+        $this->assertSame(['qty-2', 'qty-5'], array_values($caseArguments[1]));
+        $this->assertSame('qty', $caseArguments[2]);
+        $this->assertSame(self::ITEM_TABLE, $updateArguments[0]);
+        $this->assertSame(['item_id IN (?)' => [10, 40]], $updateArguments[2]);
+    }
+
+    /**
+     * No stock item row for the given products means nothing to update and nothing to lock.
+     *
+     * @return void
+     */
+    public function testCorrectItemsQtyWithoutMatchingStockItems(): void
+    {
+        $this->stock->method('getTable')
+            ->with('cataloginventory_stock_item')
+            ->willReturn(self::ITEM_TABLE);
+        $this->stock->method('getConnection')
+            ->willReturn($this->connectionMock);
+        $this->connectionMock->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectMock);
+        $this->selectMock->method('from')->willReturnSelf();
+        $this->selectMock->method('where')->willReturnSelf();
+        $this->connectionMock->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([]);
+        $this->connectionMock->expects($this->never())->method('update');
+        $this->connectionMock->expects($this->never())->method('beginTransaction');
+        $this->connectionMock->expects($this->never())->method('commit');
+
+        $this->stock->correctItemsQty([3 => 5], 1, '-');
     }
 }


### PR DESCRIPTION
### Description (*)

Under concurrent order placement on the legacy CatalogInventory path, InnoDB reports deadlocks (`1213`) on `cataloginventory_stock_item`, and the victim is the `SELECT ... FOR UPDATE` from `Stock::lockProductsStock()`.

`StockManagement::registerProductsSale()` locks the rows through one index and then updates them through another, inside a single transaction:

- `lockProductsStock()` resolves `item_id`s and runs `SELECT si.* ... WHERE item_id IN (...) FOR UPDATE`, a `range` on `PRIMARY`, so locks are taken in `item_id` order.
- After the per-item validation loop, `correctItemsQty()` runs `UPDATE ... SET qty = CASE product_id ... WHERE product_id IN (...) AND website_id = ?`, a `range` on `CATALOGINVENTORY_STOCK_ITEM_PRODUCT_ID_STOCK_ID`, so it requests locks again in `product_id` order, through secondary index records first. Its nested `beginTransaction()`/`commit()` releases nothing, because the adapter refcounts nesting.

`item_id` and `product_id` orderings are independent after imports and deletions, so two overlapping carts can request the same rows in opposite order.

The fix makes `correctItemsQty()` resolve `item_id`s with the same non-locking pre-select `lockProductsStock()` already uses, sort them, and update `WHERE item_id IN (...)` with `CASE item_id`. In `registerProductsSale()` the update then touches only rows the `FOR UPDATE` already holds on `PRIMARY`, so the transaction has exactly one lock acquisition order. `lockProductsStock()` additionally sorts its ids so that order is ascending for every transaction. `QtyCounterInterface`, the method signature and the `$items` contract are unchanged.

EXPLAIN on the same five rows (1200-row table):

| statement | before | after |
|---|---|---|
| `UPDATE ... WHERE product_id IN (...) AND website_id = 0` | range, `CATALOGINVENTORY_STOCK_ITEM_PRODUCT_ID_STOCK_ID` | |
| `UPDATE ... WHERE item_id IN (...)` | | range, `PRIMARY` |
| `SELECT ... WHERE item_id IN (...) FOR UPDATE` | range, `PRIMARY` | range, `PRIMARY` |

The deadlock itself needs the reporter's concurrency (100 JMeter users) and did not fire in a two-session interleave on a 1200-row table, so this PR is justified by the access paths, not by a reproduced deadlock. Please re-run the load scenario before closing the issue.

Cost: one extra indexed, non-locking `SELECT` per `correctItemsQty()` call, covered by `CATALOGINVENTORY_STOCK_ITEM_WEBSITE_ID_PRODUCT_ID`.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39417

### Manual testing scenarios (*)

1. Place an order for several simple products with legacy CatalogInventory (MSI disabled). Stock quantities decrease by the ordered qty.
2. Cancel the order. Quantities are restored (revert path uses the same method).
3. Enable the MySQL general log during checkout: the qty update is now `WHERE item_id IN (...)` and `EXPLAIN` shows `PRIMARY`.
4. Run the reporter's concurrent placeOrder scenario and compare the `1213` rate.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
