### PR TITLE
Bound admin product grid keyword search to the paged query (#36408)

### DIFF
--- a/app/code/Magento/CatalogSearch/Model/ResourceModel/Search/Collection.php
+++ b/app/code/Magento/CatalogSearch/Model/ResourceModel/Search/Collection.php
@@ -156,6 +156,22 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Product\Collection
     }
 
     /**
+     * Retrieve select of entity ids matching the backend search query (search by all stores)
+     *
+     * @param string $query
+     * @return \Magento\Framework\DB\Select
+     */
+    public function getBackendSearchEntityIdsSelect($query)
+    {
+        $this->_searchQuery = $query;
+
+        return $this->getConnection()->select()->distinct()->from(
+            ['search_result' => $this->_getSearchEntityIdsSql($query, false)],
+            [$this->getEntity()->getLinkField()]
+        );
+    }
+
+    /**
      * Retrieve collection of all attributes
      *
      * @return \Magento\Framework\Data\Collection\AbstractDb

--- a/app/code/Magento/CatalogSearch/Test/Unit/Ui/DataProvider/Product/AddFulltextFilterToCollectionTest.php
+++ b/app/code/Magento/CatalogSearch/Test/Unit/Ui/DataProvider/Product/AddFulltextFilterToCollectionTest.php
@@ -7,26 +7,31 @@ declare(strict_types=1);
 
 namespace Magento\CatalogSearch\Test\Unit\Ui\DataProvider\Product;
 
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\CatalogSearch\Model\ResourceModel\Search\Collection as SearchCollection;
 use Magento\CatalogSearch\Ui\DataProvider\Product\AddFulltextFilterToCollection;
-use Magento\Framework\Data\Collection;
-use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
+use Magento\Eav\Model\Entity\AbstractEntity;
+use Magento\Framework\DB\Select;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AddFulltextFilterToCollectionTest extends TestCase
 {
-    use MockCreationTrait;
-
     /**
      * @var SearchCollection|MockObject
      */
     private $searchCollection;
 
     /**
-     * @var Collection|MockObject
+     * @var ProductCollection|MockObject
      */
     private $collection;
+
+    /**
+     * @var Select|MockObject
+     */
+    private $select;
 
     /**
      * @var AddFulltextFilterToCollection
@@ -35,31 +40,64 @@ class AddFulltextFilterToCollectionTest extends TestCase
 
     protected function setUp(): void
     {
+        $entity = $this->createMock(AbstractEntity::class);
+        $entity->method('getLinkField')->willReturn('entity_id');
+
         $this->searchCollection = $this->createPartialMock(
             SearchCollection::class,
-            ['addBackendSearchFilter', 'load', 'getAllIds']
+            ['getEntity', 'getBackendSearchEntityIdsSelect']
         );
-        $this->searchCollection->method('load')->willReturnSelf();
+        $this->searchCollection->method('getEntity')->willReturn($entity);
 
-        $this->collection = $this->createPartialMockWithReflection(
-            Collection::class,
-            ['addIdFilter']
-        );
+        $this->select = $this->createMock(Select::class);
+        $this->collection = $this->createMock(ProductCollection::class);
+        $this->collection->method('getSelect')->willReturn($this->select);
 
         $this->model = new AddFulltextFilterToCollection($this->searchCollection);
     }
 
-    public function testAddFilter()
+    public function testAddFilterJoinsSearchResultSelect()
     {
+        $idsSelect = $this->createMock(Select::class);
         $this->searchCollection->expects($this->once())
-            ->method('addBackendSearchFilter')
-            ->with('test');
-        $this->searchCollection->expects($this->once())
-            ->method('getAllIds')
-            ->willReturn([]);
-        $this->collection->expects($this->once())
-            ->method('addIdFilter')
-            ->with(-1);
-        $this->model->addFilter($this->collection, 'test', ['fulltext' => 'test']);
+            ->method('getBackendSearchEntityIdsSelect')
+            ->with('test')
+            ->willReturn($idsSelect);
+
+        $this->select->expects($this->once())
+            ->method('joinInner')
+            ->with(
+                ['search_result' => $idsSelect],
+                'search_result.entity_id = e.entity_id',
+                []
+            );
+
+        $this->model->addFilter($this->collection, 'fulltext', ['fulltext' => 'test']);
+    }
+
+    /**
+     * @param array|null $condition
+     */
+    #[DataProvider('emptyConditionDataProvider')]
+    public function testAddFilterIsSkippedForEmptyCondition($condition)
+    {
+        $this->searchCollection->expects($this->never())
+            ->method('getBackendSearchEntityIdsSelect');
+        $this->select->expects($this->never())
+            ->method('joinInner');
+
+        $this->model->addFilter($this->collection, 'fulltext', $condition);
+    }
+
+    /**
+     * @return array
+     */
+    public static function emptyConditionDataProvider(): array
+    {
+        return [
+            'no condition' => [null],
+            'no fulltext key' => [['like' => 'test']],
+            'empty fulltext' => [['fulltext' => '']],
+        ];
     }
 }

--- a/app/code/Magento/CatalogSearch/Ui/DataProvider/Product/AddFulltextFilterToCollection.php
+++ b/app/code/Magento/CatalogSearch/Ui/DataProvider/Product/AddFulltextFilterToCollection.php
@@ -10,13 +10,11 @@ use Magento\Framework\Data\Collection;
 use Magento\Ui\DataProvider\AddFilterToCollectionInterface;
 
 /**
- * Class AddFulltextFilterToCollection
+ * Restricts a product collection to the entities matching an admin grid keyword
  */
 class AddFulltextFilterToCollection implements AddFilterToCollectionInterface
 {
     /**
-     * Search Collection
-     *
      * @var SearchCollection
      */
     private $searchCollection;
@@ -38,13 +36,12 @@ class AddFulltextFilterToCollection implements AddFilterToCollectionInterface
     {
         /** @var $collection \Magento\Catalog\Model\ResourceModel\Product\Collection */
         if (isset($condition['fulltext']) && (string)$condition['fulltext'] !== '') {
-            $this->searchCollection->addBackendSearchFilter($condition['fulltext']);
-            $productIds = $this->searchCollection->load()->getAllIds();
-            if (empty($productIds)) {
-                //add dummy id to prevent returning full unfiltered collection
-                $productIds = -1;
-            }
-            $collection->addIdFilter($productIds);
+            $linkField = $this->searchCollection->getEntity()->getLinkField();
+            $collection->getSelect()->joinInner(
+                ['search_result' => $this->searchCollection->getBackendSearchEntityIdsSelect($condition['fulltext'])],
+                "search_result.{$linkField} = e.{$linkField}",
+                []
+            );
         }
     }
 }

--- a/dev/tests/integration/testsuite/Magento/CatalogSearch/Ui/DataProvider/Product/AddFulltextFilterToCollectionTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogSearch/Ui/DataProvider/Product/AddFulltextFilterToCollectionTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogSearch\Ui\DataProvider\Product;
+
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
+use Magento\Catalog\Test\Fixture\Product as ProductFixture;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for the admin product grid keyword filter
+ */
+#[
+    DataFixture(
+        ProductFixture::class,
+        [
+            'sku' => 'gridsearch-alpha',
+            'name' => 'Alpha Grid Product',
+            'description' => 'Alpha description text',
+        ]
+    ),
+    DataFixture(
+        ProductFixture::class,
+        [
+            'sku' => 'gridsearch-beta',
+            'name' => 'Beta Grid Product',
+            'description' => 'Beta unicorndesc text',
+        ]
+    ),
+    DataFixture(
+        ProductFixture::class,
+        [
+            'sku' => 'unrelated-gamma',
+            'name' => 'Gamma Product',
+            'description' => 'Gamma description text',
+        ]
+    ),
+]
+class AddFulltextFilterToCollectionTest extends TestCase
+{
+    /**
+     * @var AddFulltextFilterToCollection
+     */
+    private $model;
+
+    /**
+     * @var ProductCollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $objectManager = Bootstrap::getObjectManager();
+        $this->model = $objectManager->create(AddFulltextFilterToCollection::class);
+        $this->collectionFactory = $objectManager->get(ProductCollectionFactory::class);
+    }
+
+    /**
+     * @param string $keyword
+     * @param array $expectedSkus
+     */
+    #[DataProvider('keywordDataProvider')]
+    public function testKeywordMatchesTheSameProductsAsBefore(string $keyword, array $expectedSkus): void
+    {
+        $collection = $this->createFilteredCollection($keyword);
+        $skus = $collection->getColumnValues('sku');
+        sort($skus);
+
+        $this->assertSame($expectedSkus, $skus);
+        $this->assertSame(count($expectedSkus), $collection->getSize());
+    }
+
+    /**
+     * @return array
+     */
+    public static function keywordDataProvider(): array
+    {
+        return [
+            'sku fragment' => ['gridsearch-alpha', ['gridsearch-alpha']],
+            'name fragment' => ['Beta Grid', ['gridsearch-beta']],
+            'description fragment' => ['unicorndesc', ['gridsearch-beta']],
+            'matches several products' => ['gridsearch-', ['gridsearch-alpha', 'gridsearch-beta']],
+            'no match' => ['zzz-nothing-matches-zzz', []],
+        ];
+    }
+
+    /**
+     * A keyword hit by several searchable attributes of one product must not duplicate the grid row
+     */
+    public function testProductIsReturnedOnceWhenSeveralAttributesMatch(): void
+    {
+        $collection = $this->createFilteredCollection('Alpha');
+
+        $this->assertSame(['gridsearch-alpha'], $collection->getColumnValues('sku'));
+        $this->assertSame(1, $collection->getSize());
+    }
+
+    /**
+     * The total count must stay correct while the collection itself is limited to one page
+     */
+    public function testPagingDoesNotAffectTheTotalCount(): void
+    {
+        $collection = $this->collectionFactory->create();
+        $this->model->addFilter($collection, 'fulltext', ['fulltext' => 'gridsearch-']);
+        $collection->setPageSize(1);
+        $collection->setCurPage(1);
+
+        $this->assertCount(1, $collection->getItems());
+        $this->assertSame(2, $collection->getSize());
+    }
+
+    /**
+     * @param string $keyword
+     * @return ProductCollection
+     */
+    private function createFilteredCollection(string $keyword): ProductCollection
+    {
+        $collection = $this->collectionFactory->create();
+        $this->model->addFilter($collection, 'fulltext', ['fulltext' => $keyword]);
+        $collection->load();
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
### Description (*)

The admin product grid keyword filter (`AddFulltextFilterToCollection`) ran the LIKE-based search collection with `load()`, instantiating a product model for every match, then `getAllIds()` ran the same unlimited query a second time, and the resulting id array was passed back to MySQL as a literal `IN (...)` list on the grid query. Paging applied only after all of that. At 50k products that is around 600 ms per keystroke (#36408); at millions of products it is a timeout and a memory blowup (#38867).

This attaches the id select to the grid collection as an `INNER JOIN` on a `SELECT DISTINCT` derived table instead, so one paged query runs and no ids are materialized in PHP. The derived table is materialized once (it contains `UNION ALL` and `DISTINCT`, so the optimizer cannot merge it or rewrite it into a correlated subquery). `Search\Collection::getBackendSearchEntityIdsSelect()` is a new public method that reuses `_getSearchEntityIdsSql()` unchanged, so the attributes searched, the `LIKE` pattern, the `store_id = 0` scope and the `IFNULL(t2.value, t1.value)` fallback are the same as `addBackendSearchFilter()`. The `DISTINCT` is what the `UNION ALL` requires so a product matching in sku and name is one grid row.

What this does not change: the `LIKE '%q%'` scan over the searchable EAV rows is still linear in catalog size. It removes the multiplier on top of it. A FULLTEXT index or routing the grid through the search engine would change the scaling law and is a separate decision.

Before, three statements plus model hydration:

```sql
SELECT e.* FROM catalog_product_entity AS e WHERE e.entity_id IN (<UNION>);            -- load()
SELECT e.entity_id FROM catalog_product_entity AS e WHERE e.entity_id IN (<UNION>);    -- getAllIds()
SELECT e.* FROM catalog_product_entity AS e WHERE e.entity_id IN (1,2,...,N) LIMIT 20; -- the grid
```

After, one:

```sql
SELECT e.* FROM catalog_product_entity AS e
INNER JOIN (SELECT DISTINCT search_result.entity_id FROM (<UNION>) AS search_result) AS search_result
  ON search_result.entity_id = e.entity_id
LIMIT 20;
```

SVC: `getBackendSearchEntityIdsSelect()` is an additive public method on an `@api` class (MINOR).

### Fixed Issues (if relevant)

1. Fixes magento/magento2#36408
2. Fixes magento/magento2#38867

### Manual testing scenarios (*)

1. Admin > Catalog > Products, type a keyword matching a sku, a name and a description into the grid search. The same products are returned as before, each once, and the record count matches.
2. Set the grid page size to 20 with more than 20 matches. The count stays at the full match total while paging.
3. Admin product form > Related Products > Add, search by keyword. Results are unchanged.
4. Enable the MySQL general log: the grid issues one paged query with the derived-table join and no `IN (id, id, ...)` list.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
