### PR TITLE
Reduce per-item cart price rule validation overhead (#37721)

### DIFF
--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -136,7 +136,7 @@ class Utility
          * only, so that excluded items do not count toward the condition threshold.
          */
         $savedTotals = null;
-        if ($this->ruleHasItemRestrictions($rule) && $this->hasEligibleLineItemsForRule($rule, $address)) {
+        if ($this->ruleHasItemRestrictions($rule) && $this->ruleHasAddressConditions($rule)) {
             $savedTotals = $this->setEligibleItemsTotalsOnAddress($rule, $address);
         }
         try {
@@ -178,21 +178,20 @@ class Utility
     }
 
     /**
-     * Whether at least one cart line item matches the rule's actions (eligible for the discount on items)
+     * Check if the rule has address-level conditions to evaluate
      *
      * @param Rule $rule
-     * @param Address $address
      * @return bool
      */
-    private function hasEligibleLineItemsForRule(Rule $rule, Address $address): bool
+    private function ruleHasAddressConditions(Rule $rule): bool
     {
-        foreach ($address->getAllItems() as $item) {
-            if ($this->isItemEligibleForRuleTotals($item, $rule)) {
-                return true;
-            }
+        $conditions = $rule->getConditions();
+        if (!$conditions instanceof \Magento\Rule\Model\Condition\Combine) {
+            return false;
         }
+        $nestedConditions = $conditions->getConditions();
 
-        return false;
+        return is_array($nestedConditions) && $nestedConditions !== [];
     }
 
     /**
@@ -200,20 +199,26 @@ class Utility
      *
      * @param Rule $rule
      * @param Address $address
-     * @return array Saved address totals to restore after validation
+     * @return array|null Saved address totals to restore after validation, null when no item is eligible
      */
-    private function setEligibleItemsTotalsOnAddress(Rule $rule, Address $address): array
+    private function setEligibleItemsTotalsOnAddress(Rule $rule, Address $address): ?array
     {
         $baseSubtotal = $baseSubtotalInclTax = $totalQty = $weight = 0;
+        $hasEligibleItem = false;
 
         foreach ($address->getAllItems() as $item) {
             if (!$this->isItemEligibleForRuleTotals($item, $rule)) {
                 continue;
             }
+            $hasEligibleItem = true;
             $baseSubtotal += (float) $item->getBaseRowTotal();
             $baseSubtotalInclTax += (float) $item->getBaseRowTotalInclTax();
             $totalQty += (float) $item->getQty();
             $weight += (float) $item->getRowWeight();
+        }
+
+        if (!$hasEligibleItem) {
+            return null;
         }
 
         $saved = [

--- a/app/code/Magento/SalesRule/Model/Utility.php
+++ b/app/code/Magento/SalesRule/Model/Utility.php
@@ -169,12 +169,8 @@ class Utility
         } catch (\Throwable $e) {
             return false;
         }
-        if (!$actions instanceof \Magento\Rule\Model\Condition\Combine) {
-            return false;
-        }
-        $conditions = $actions->getConditions();
 
-        return !empty($conditions) && is_array($conditions);
+        return $this->combineHasConditions($actions);
     }
 
     /**
@@ -185,13 +181,23 @@ class Utility
      */
     private function ruleHasAddressConditions(Rule $rule): bool
     {
-        $conditions = $rule->getConditions();
-        if (!$conditions instanceof \Magento\Rule\Model\Condition\Combine) {
+        return $this->combineHasConditions($rule->getConditions());
+    }
+
+    /**
+     * Whether a condition combine instance carries at least one child condition
+     *
+     * @param mixed $combine
+     * @return bool
+     */
+    private function combineHasConditions($combine): bool
+    {
+        if (!$combine instanceof \Magento\Rule\Model\Condition\Combine) {
             return false;
         }
-        $nestedConditions = $conditions->getConditions();
+        $conditions = $combine->getConditions();
 
-        return is_array($nestedConditions) && $nestedConditions !== [];
+        return is_array($conditions) && $conditions !== [];
     }
 
     /**

--- a/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
+++ b/app/code/Magento/SalesRule/Test/Unit/Model/UtilityTest.php
@@ -594,12 +594,13 @@ class UtilityTest extends TestCase
         $actionsCombine->method('getConditions')->willReturn([1]);
 
         $rule = $this->createPartialMock(Rule::class, [
-            'getActions', 'validate', 'hasIsValidForAddress', 'getIsValidForAddress',
+            'getActions', 'getConditions', 'validate', 'hasIsValidForAddress', 'getIsValidForAddress',
             'setIsValidForAddress', 'afterLoad'
         ]);
         $rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
         $rule->method('hasIsValidForAddress')->willReturn(false);
         $rule->method('getActions')->willReturn($actionsCombine);
+        $rule->method('getConditions')->willReturn($this->addressConditionsCombineStub());
         $rule->method('validate')->willReturn(false);
         $rule->method('afterLoad');
 
@@ -642,6 +643,108 @@ class UtilityTest extends TestCase
         $this->validateCoupon->method('execute')->willReturn(true);
 
         $this->assertTrue($this->utility->canProcessRule($rule, $this->address));
+    }
+
+    /**
+     * A rule without address-level conditions cannot be affected by eligible-item totals,
+     * so the cart is not walked at all.
+     *
+     * @return void
+     */
+    public function testCanProcessRuleSkipsEligibleItemTotalsWhenRuleHasNoAddressConditions(): void
+    {
+        $actionsCombine = $this->createMock(RuleCombine::class);
+        $actionsCombine->method('getConditions')->willReturn([$this->createStub(AbstractCondition::class)]);
+
+        $emptyConditions = $this->createMock(RuleCombine::class);
+        $emptyConditions->method('getConditions')->willReturn([]);
+
+        $rule = $this->createPartialMock(Rule::class, [
+            'getActions',
+            'getConditions',
+            'validate',
+            'hasIsValidForAddress',
+            'getIsValidForAddress',
+            'setIsValidForAddress',
+            'afterLoad',
+        ]);
+        $rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
+        $rule->method('hasIsValidForAddress')->willReturn(false);
+        $rule->method('getActions')->willReturn($actionsCombine);
+        $rule->method('getConditions')->willReturn($emptyConditions);
+        $rule->method('validate')->willReturn(true);
+        $rule->method('afterLoad');
+
+        $address = $this->createPartialMockWithReflection(Address::class, [
+            'isObjectNew',
+            'getQuote',
+            'getAllItems',
+            'setBaseSubtotal',
+        ]);
+        $address->method('isObjectNew')->willReturn(false);
+        $address->method('getQuote')->willReturn($this->quote);
+        $address->expects($this->never())->method('getAllItems');
+        $address->expects($this->never())->method('setBaseSubtotal');
+
+        $this->validateCoupon->method('execute')->willReturn(true);
+
+        $this->assertTrue($this->utility->canProcessRule($rule, $address));
+    }
+
+    /**
+     * When no cart item matches the rule actions, address totals stay untouched.
+     *
+     * @return void
+     */
+    public function testCanProcessRuleKeepsAddressTotalsWhenNoItemIsEligible(): void
+    {
+        $actionsCombine = $this->createMock(RuleCombine::class);
+        $actionsCombine->method('getConditions')->willReturn([$this->createStub(AbstractCondition::class)]);
+        $actionsCombine->method('validate')->willReturn(false);
+
+        $rule = $this->createPartialMock(Rule::class, [
+            'getActions',
+            'getConditions',
+            'validate',
+            'hasIsValidForAddress',
+            'getIsValidForAddress',
+            'setIsValidForAddress',
+            'afterLoad',
+        ]);
+        $rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
+        $rule->method('hasIsValidForAddress')->willReturn(false);
+        $rule->method('getActions')->willReturn($actionsCombine);
+        $rule->method('getConditions')->willReturn($this->addressConditionsCombineStub());
+        $rule->method('validate')->willReturn(true);
+        $rule->method('afterLoad');
+
+        $lineItem = $this->eligibleTotalsItemStub([
+            'getParentItem' => null,
+            'getHasChildren' => false,
+            'getChildren' => [],
+            'isChildrenCalculated' => false,
+            'getNoDiscount' => false,
+        ]);
+
+        $addressState = $this->defaultEligibleTotalsAddressState();
+        $address = $this->createAddressMockWithTrackedTotals($addressState, [$lineItem]);
+        $address->expects($this->never())->method('setBaseSubtotal');
+
+        $this->validateCoupon->method('execute')->willReturn(true);
+
+        $this->assertTrue($this->utility->canProcessRule($rule, $address));
+        $this->assertSame($this->defaultEligibleTotalsAddressState(), $addressState);
+    }
+
+    /**
+     * @return RuleCombine&MockObject
+     */
+    private function addressConditionsCombineStub(): MockObject
+    {
+        $conditions = $this->createMock(RuleCombine::class);
+        $conditions->method('getConditions')->willReturn([$this->createStub(AbstractCondition::class)]);
+
+        return $conditions;
     }
 
     /**
@@ -799,6 +902,7 @@ class UtilityTest extends TestCase
 
         $rule = $this->createPartialMock(Rule::class, [
             'getActions',
+            'getConditions',
             'validate',
             'hasIsValidForAddress',
             'getIsValidForAddress',
@@ -808,6 +912,7 @@ class UtilityTest extends TestCase
         $rule->setCouponType(Rule::COUPON_TYPE_NO_COUPON);
         $rule->method('hasIsValidForAddress')->willReturn(false);
         $rule->method('getActions')->willReturn($actionsCombine);
+        $rule->method('getConditions')->willReturn($this->addressConditionsCombineStub());
         $rule->method('validate')->willReturn($validationResult);
         $rule->method('afterLoad');
         $rule->expects($this->once())

--- a/dev/tests/integration/testsuite/Magento/SalesRule/Model/Quote/DiscountTest.php
+++ b/dev/tests/integration/testsuite/Magento/SalesRule/Model/Quote/DiscountTest.php
@@ -1247,4 +1247,43 @@ class DiscountTest extends TestCase
         $this->assertEquals(465.0, $discounts['operator']);
         $this->assertEquals(0.0, $discounts['cover']);
     }
+
+    #[
+        AppIsolation(true),
+        DataFixture(ProductFixture::class, ['sku' => 'simple-eligible', 'price' => 100], as: 'p1'),
+        DataFixture(ProductFixture::class, ['sku' => 'simple-excluded', 'price' => 100], as: 'p2'),
+        DataFixture(
+            RuleFixture::class,
+            [
+                'simple_action' => Rule::BY_PERCENT_ACTION,
+                'discount_amount' => 10,
+                'conditions' => [
+                    ['attribute' => 'base_subtotal', 'operator' => '<', 'value' => 150],
+                ],
+                'actions' => [
+                    ['attribute' => 'sku', 'operator' => '!=', 'value' => 'simple-excluded'],
+                ],
+            ],
+            'rule'
+        ),
+        DataFixture(GuestCartFixture::class, as: 'cart'),
+        DataFixture(AddProductToCartFixture::class, ['cart_id' => '$cart.id$', 'product_id' => '$p1.id$', 'qty' => 1]),
+        DataFixture(AddProductToCartFixture::class, ['cart_id' => '$cart.id$', 'product_id' => '$p2.id$', 'qty' => 1]),
+    ]
+    public function testSubtotalConditionIsEvaluatedAgainstItemsMatchingTheRuleActions(): void
+    {
+        $quote = $this->quoteRepository->get($this->fixtures->get('cart')->getId());
+        $quote->collectTotals();
+
+        $this->assertEquals(200, $quote->getSubtotal());
+        $this->assertEquals(190, $quote->getSubtotalWithDiscount());
+
+        $discounts = [];
+        foreach ($quote->getAllItems() as $item) {
+            $discounts[$item->getSku()] = (float)$item->getDiscountAmount();
+        }
+
+        $this->assertEquals(10.0, $discounts['simple-eligible']);
+        $this->assertEquals(0.0, $discounts['simple-excluded']);
+    }
 }


### PR DESCRIPTION
### Description (*)

The issue reports slow cart totals with many sales rules. The query it quotes (`main_table.rule_id IN (?)`) no longer exists: it was added in 43d521d1d81 and removed four days later by fa7fb549db6 (2019). On 2.4-develop the rule collection for a 10-item cart with 20 applicable rules costs 4 queries and 6.5 ms. The cost that remains is in PHP, in the per-item x per-rule validation path, and it is what the 2023 confirmation video shows.

`Utility::canProcessRule()` is called once per (item, rule) pair from `RulesApplier::applyRules()`. Since AC-16417 it walks the whole cart twice per call for rules with item-level actions: `hasEligibleLineItemsForRule()` runs `getActions()->validate($item)` over every item to find one eligible item, then `setEligibleItemsTotalsOnAddress()` runs the same validation over every item again to sum them.

This PR:

- merges the two passes into one, with `setEligibleItemsTotalsOnAddress()` returning `null` when no item is eligible (the same branch the old `false` took);
- skips the totals substitution entirely when the rule has no cart conditions. `Combine::_isValid()` returns `true` for an empty condition set, so substituting address totals cannot change the outcome for a rule like "10% off everything except SKU X".

Discount results are unchanged. The existing integration tests `testFixedAmountWholeCartDiscountOnConfigurableProduct` and `testFixedAmountWholeCartDiscountOnBundleProduct` cover the actions-without-conditions shape, and a new integration test covers the branch that is kept: a `base_subtotal < 150` rule with an SKU exclusion must still see the eligible-item subtotal, not the cart subtotal.

Left for a follow-up, because it changes semantics: `Rule::_getAddressId()` returns `null` for an unsaved quote address, which disables the validation memo on the first `collectTotals()` after add-to-cart.

Test coverage note: the two new unit tests fail without the change (the cart is walked, `setBaseSubtotal()` is called). The new integration test passes with and without it by design; it pins the discount outcome of the branch this PR keeps. Local gates: unit, integration, PHPCS, PHPStan and static pass; the five `QuoteConfigProductAttributesTest` errors in the SalesRule unit suite are order-dependent and identical on a clean `2.4-develop` checkout.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#37721

### Manual testing scenarios (*)

1. Create 20 active cart price rules, half with an action condition (SKU is not X) and no cart condition, half with a subtotal condition.
2. Add 10 items to the cart. Discounts applied are identical before and after.
3. Profile `TotalsCollector::collect` (SPX or Xdebug): `Magento\Rule\Model\Condition\Combine::validate` call count drops by items x rules for every conditionless rule and by half for the rest.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
