### PR TITLE
Reuse first locale deployment output in quick strategy (#10674)

### DIFF
--- a/app/code/Magento/Deploy/Service/DeployPackage.php
+++ b/app/code/Magento/Deploy/Service/DeployPackage.php
@@ -216,8 +216,30 @@ class DeployPackage
                 || $file->getTheme() !== $package->getTheme()
                 || $file->getLocale() !== $package->getLocale()
             )
-            && $file->getOrigPackage() === $parentPackage
+            && $this->checkIfInheritedFromSameSource($file, $parentPackage)
             && $this->deployStaticFile->readFile($file->getDeployedFileId(), $parentPackage->getPath());
+    }
+
+    /**
+     * Check if parent package holds the very same file, inherited from the same package and not overridden there
+     *
+     * @param PackageFile $file
+     * @param Package $parentPackage
+     * @return bool
+     */
+    private function checkIfInheritedFromSameSource(PackageFile $file, Package $parentPackage)
+    {
+        if ($file->getOrigPackage() === $parentPackage) {
+            return true;
+        }
+
+        $parentFile = $parentPackage->getFile($file->getFileId());
+
+        return $parentFile instanceof PackageFile
+            && $parentFile->getOrigPackage() === $file->getOrigPackage()
+            && $parentFile->getArea() === $file->getArea()
+            && $parentFile->getTheme() === $file->getTheme()
+            && $parentFile->getLocale() === $file->getLocale();
     }
 
     /**

--- a/app/code/Magento/Deploy/Strategy/QuickDeploy.php
+++ b/app/code/Magento/Deploy/Strategy/QuickDeploy.php
@@ -9,6 +9,8 @@ use Magento\Deploy\Console\DeployStaticOptions as Options;
 use Magento\Deploy\Package\Package;
 use Magento\Deploy\Package\PackagePool;
 use Magento\Deploy\Process\Queue;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Translate\Js\Config as JsTranslationConfig;
 use function array_key_exists;
 
 /**
@@ -32,17 +34,31 @@ class QuickDeploy implements StrategyInterface
     private $baseLocalePackages = [];
 
     /**
+     * @var Package[]
+     */
+    private $baseLocaleParents = [];
+
+    /**
+     * @var JsTranslationConfig
+     */
+    private $jsTranslationConfig;
+
+    /**
      * QuickDeploy constructor
      *
      * @param PackagePool $packagePool
      * @param Queue $queue
+     * @param JsTranslationConfig|null $jsTranslationConfig
      */
     public function __construct(
         PackagePool $packagePool,
-        Queue $queue
+        Queue $queue,
+        ?JsTranslationConfig $jsTranslationConfig = null
     ) {
         $this->packagePool = $packagePool;
         $this->queue = $queue;
+        $this->jsTranslationConfig = $jsTranslationConfig
+            ?: ObjectManager::getInstance()->get(JsTranslationConfig::class);
     }
 
     /**
@@ -75,7 +91,7 @@ class QuickDeploy implements StrategyInterface
             foreach ($levelPackages as $package) {
                 if ($parentCompilationRequested
                     || $this->canDeployTheme($package->getTheme(), $includeThemesMap, $excludeThemesMap)) {
-                    $this->queue->add($package);
+                    $this->queue->add($package, $this->getDeploymentDependencies($package));
                     $deployPackages[] = $package;
                 }
             }
@@ -98,30 +114,92 @@ class QuickDeploy implements StrategyInterface
         foreach ($levelPackages as $package) {
             $package->aggregate();
             if ($level > 1) {
-                $parentPackage = null;
-                $packageId = $package->getArea() . '/' . $package->getTheme();
-                // use base package if it is not the same as current
-                if (isset($this->baseLocalePackages[$packageId])
-                    && $package !== $this->baseLocalePackages[$packageId]
-                ) {
-                    $parentPackage = $this->baseLocalePackages[$packageId];
-                } else {
-                    $parentPackages = $package->getParentPackages();
-                    foreach (array_reverse($parentPackages) as $ancestorPackage) {
-                        if (!$ancestorPackage->isVirtual()) {
-                            $parentPackage = $ancestorPackage;
-                            break;
-                        }
-                        if ($parentPackage === null) {
-                            $parentPackage = $ancestorPackage;
-                        }
-                    }
-                }
+                $parentPackage = $this->resolveParentPackage($package);
                 if ($parentPackage) {
                     $package->setParent($parentPackage);
                 }
             }
         }
+    }
+
+    /**
+     * Retrieve package which deployed files can be reused for the given package
+     *
+     * @param Package $package
+     * @return Package|null
+     */
+    private function resolveParentPackage(Package $package): ?Package
+    {
+        $packageId = $package->getArea() . '/' . $package->getTheme();
+        $baseLocalePackage = $this->baseLocalePackages[$packageId] ?? null;
+        // use base package if it is not the same as current
+        if ($baseLocalePackage
+            && $package !== $baseLocalePackage
+            && $this->canReuseBaseLocalePackage($package, $baseLocalePackage)
+        ) {
+            $this->baseLocaleParents[$package->getPath()] = $baseLocalePackage;
+            return $baseLocalePackage;
+        }
+
+        $parentPackage = null;
+        foreach (array_reverse($package->getParentPackages()) as $ancestorPackage) {
+            if (!$ancestorPackage->isVirtual()) {
+                return $ancestorPackage;
+            }
+            if ($parentPackage === null) {
+                $parentPackage = $ancestorPackage;
+            }
+        }
+
+        return $parentPackage;
+    }
+
+    /**
+     * Check if deployed files of the base locale package can be reused for the given package
+     *
+     * @param Package $package
+     * @param Package $baseLocalePackage
+     * @return bool
+     */
+    private function canReuseBaseLocalePackage(Package $package, Package $baseLocalePackage): bool
+    {
+        // only the dictionary strategy keeps deployed JS files free of per-locale embedded translations
+        // @see \Magento\Translation\Model\Js\PreProcessor::process
+        if (!$this->jsTranslationConfig->dictionaryEnabled()) {
+            return false;
+        }
+
+        return !$this->hasLocaleSpecificFiles($package) && !$this->hasLocaleSpecificFiles($baseLocalePackage);
+    }
+
+    /**
+     * Check if package has own files, which are collected from "web/i18n/<locale>" directories
+     *
+     * @param Package $package
+     * @return bool
+     */
+    private function hasLocaleSpecificFiles(Package $package): bool
+    {
+        foreach ($package->getFiles() as $file) {
+            if ($file->getOrigPackage() === $package) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve packages which must be deployed before the given one
+     *
+     * @param Package $package
+     * @return Package[]
+     */
+    private function getDeploymentDependencies(Package $package): array
+    {
+        $baseLocalePackage = $this->baseLocaleParents[$package->getPath()] ?? null;
+
+        return $baseLocalePackage ? [$baseLocalePackage->getPath() => $baseLocalePackage] : [];
     }
 
     /**

--- a/app/code/Magento/Deploy/Test/Unit/Service/DeployPackageTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Service/DeployPackageTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Service;
+
+use Magento\Deploy\Console\DeployStaticOptions as Options;
+use Magento\Deploy\Package\Package;
+use Magento\Deploy\Package\PackageFile;
+use Magento\Deploy\Service\DeployPackage;
+use Magento\Deploy\Service\DeployStaticFile;
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Deploy package service unit tests
+ *
+ * @see DeployPackage
+ */
+class DeployPackageTest extends TestCase
+{
+    private const FILE_ID = 'Magento_Theme::css/styles-m.css';
+
+    /**
+     * @var DeployStaticFile|MockObject
+     */
+    private $deployStaticFile;
+
+    /**
+     * @var DeployPackage
+     */
+    private $service;
+
+    /**
+     * @var Package|MockObject
+     */
+    private $origPackage;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->deployStaticFile = $this->createMock(DeployStaticFile::class);
+        $this->origPackage = $this->createMock(Package::class);
+
+        $this->service = new DeployPackage(
+            $this->createMock(AppState::class),
+            $this->createMock(LocaleResolver::class),
+            $this->deployStaticFile,
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    /**
+     * File inherited by both packages from the same ancestor is copied from the parent package
+     *
+     * @return void
+     */
+    public function testFileIsCopiedFromPackageOfAnotherLocale(): void
+    {
+        $parentPackage = $this->createPackage('en_US');
+        $parentPackage->method('getFile')->with(self::FILE_ID)->willReturn($this->createInheritedFile());
+
+        $package = $this->createPackage('de_DE', $parentPackage);
+        $package->method('getFiles')->willReturn([$this->createInheritedFile()]);
+
+        $this->deployStaticFile->method('readFile')
+            ->with(self::FILE_ID, 'frontend/Magento/luma/en_US')
+            ->willReturn('content');
+        $this->deployStaticFile->expects($this->once())
+            ->method('copyFile')
+            ->with(self::FILE_ID, 'frontend/Magento/luma/en_US', 'frontend/Magento/luma/de_DE');
+        $this->deployStaticFile->expects($this->never())->method('deployFile');
+
+        $this->service->deployEmulated($package, $this->getOptions(), true);
+    }
+
+    /**
+     * File overridden in the parent package holds parent specific content and must not be reused
+     *
+     * @return void
+     */
+    public function testFileOverriddenInParentPackageIsDeployed(): void
+    {
+        $overriddenFile = $this->createInheritedFile('en_US');
+
+        $parentPackage = $this->createPackage('en_US');
+        $parentPackage->method('getFile')->with(self::FILE_ID)->willReturn($overriddenFile);
+
+        $package = $this->createPackage('de_DE', $parentPackage);
+        $package->method('getFiles')->willReturn([$this->createInheritedFile()]);
+
+        $this->deployStaticFile->expects($this->never())->method('copyFile');
+        $this->deployStaticFile->expects($this->once())
+            ->method('deployFile')
+            ->with(
+                'css/styles-m.css',
+                [
+                    'area' => 'frontend',
+                    'theme' => 'Magento/luma',
+                    'locale' => 'de_DE',
+                    'module' => 'Magento_Theme',
+                ]
+            );
+
+        $this->service->deployEmulated($package, $this->getOptions(), true);
+    }
+
+    /**
+     * File missing in the parent package must be deployed from source
+     *
+     * @return void
+     */
+    public function testFileMissingInParentPackageIsDeployed(): void
+    {
+        $parentPackage = $this->createPackage('en_US');
+        $parentPackage->method('getFile')->with(self::FILE_ID)->willReturn(false);
+
+        $package = $this->createPackage('de_DE', $parentPackage);
+        $package->method('getFiles')->willReturn([$this->createInheritedFile()]);
+
+        $this->deployStaticFile->expects($this->never())->method('copyFile');
+        $this->deployStaticFile->expects($this->once())->method('deployFile');
+
+        $this->service->deployEmulated($package, $this->getOptions(), true);
+    }
+
+    /**
+     * @return array
+     */
+    private function getOptions(): array
+    {
+        return [Options::NO_CSS => false];
+    }
+
+    /**
+     * @param string $locale
+     * @param Package|null $parentPackage
+     * @return Package|MockObject
+     */
+    private function createPackage(string $locale, ?Package $parentPackage = null)
+    {
+        $package = $this->createMock(Package::class);
+        $package->method('getArea')->willReturn('frontend');
+        $package->method('getTheme')->willReturn('Magento/luma');
+        $package->method('getLocale')->willReturn($locale);
+        $package->method('getPath')->willReturn('frontend/Magento/luma/' . $locale);
+        $package->method('getParent')->willReturn($parentPackage);
+        $package->method('getPostProcessors')->willReturn([]);
+
+        return $package;
+    }
+
+    /**
+     * @param string $locale
+     * @return PackageFile|MockObject
+     */
+    private function createInheritedFile(string $locale = 'default')
+    {
+        $file = $this->createMock(PackageFile::class);
+        $file->method('getFileId')->willReturn(self::FILE_ID);
+        $file->method('getDeployedFileId')->willReturn(self::FILE_ID);
+        $file->method('getFileName')->willReturn('css/styles-m.css');
+        $file->method('getModule')->willReturn('Magento_Theme');
+        $file->method('getArea')->willReturn('frontend');
+        $file->method('getTheme')->willReturn('Magento/luma');
+        $file->method('getLocale')->willReturn($locale);
+        $file->method('getOrigPackage')->willReturn($this->origPackage);
+
+        return $file;
+    }
+}

--- a/app/code/Magento/Deploy/Test/Unit/Strategy/QuickDeployTest.php
+++ b/app/code/Magento/Deploy/Test/Unit/Strategy/QuickDeployTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Deploy\Test\Unit\Strategy;
+
+use Magento\Deploy\Console\DeployStaticOptions as Options;
+use Magento\Deploy\Package\Package;
+use Magento\Deploy\Package\PackageFile;
+use Magento\Deploy\Package\PackagePool;
+use Magento\Deploy\Process\Queue;
+use Magento\Deploy\Strategy\QuickDeploy;
+use Magento\Framework\Translate\Js\Config as JsTranslationConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Quick deployment strategy unit tests
+ *
+ * @see QuickDeploy
+ */
+class QuickDeployTest extends TestCase
+{
+    /**
+     * @var PackagePool|MockObject
+     */
+    private $packagePool;
+
+    /**
+     * @var Queue|MockObject
+     */
+    private $queue;
+
+    /**
+     * @var JsTranslationConfig|MockObject
+     */
+    private $jsTranslationConfig;
+
+    /**
+     * @var array
+     */
+    private $options = [
+        Options::NO_PARENT => false,
+        Options::THEME => ['all'],
+        Options::EXCLUDE_THEME => ['none'],
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->packagePool = $this->createMock(PackagePool::class);
+        $this->queue = $this->createMock(Queue::class);
+        $this->jsTranslationConfig = $this->createMock(JsTranslationConfig::class);
+    }
+
+    /**
+     * Extra locale package must reuse deployed files of the first locale package of the same area and theme
+     *
+     * @return void
+     */
+    public function testExtraLocalePackageIsDeployedFromBaseLocalePackage(): void
+    {
+        $baseLocalePackage = $this->createPackage('en_US');
+        $extraLocalePackage = $this->createPackage('de_DE');
+
+        $this->jsTranslationConfig->method('dictionaryEnabled')->willReturn(true);
+        $baseLocalePackage->expects($this->never())->method('setParent');
+        $extraLocalePackage->expects($this->once())->method('setParent')->with($baseLocalePackage);
+
+        $addedPackages = [];
+        $this->queue->method('add')
+            ->willReturnCallback(
+                function (Package $package, array $dependencies) use (&$addedPackages) {
+                    $addedPackages[$package->getPath()] = $dependencies;
+                    return true;
+                }
+            );
+
+        $this->createStrategy([$baseLocalePackage, $extraLocalePackage])->deploy($this->options);
+
+        $this->assertSame(
+            [
+                'frontend/Magento/luma/en_US' => [],
+                'frontend/Magento/luma/de_DE' => ['frontend/Magento/luma/en_US' => $baseLocalePackage],
+            ],
+            $addedPackages
+        );
+    }
+
+    /**
+     * Package with own locale specific files must be compiled instead of reusing another locale
+     *
+     * @return void
+     */
+    public function testPackageWithLocaleSpecificFilesIsNotDeployedFromBaseLocalePackage(): void
+    {
+        $ancestorPackage = $this->createMock(Package::class);
+        $ancestorPackage->method('isVirtual')->willReturn(false);
+
+        $baseLocalePackage = $this->createPackage('en_US');
+        $extraLocalePackage = $this->createPackage('de_DE', true, [$ancestorPackage]);
+
+        $this->jsTranslationConfig->method('dictionaryEnabled')->willReturn(true);
+        $extraLocalePackage->expects($this->once())->method('setParent')->with($ancestorPackage);
+
+        $this->queue->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->anything(), []);
+
+        $this->createStrategy([$baseLocalePackage, $extraLocalePackage])->deploy($this->options);
+    }
+
+    /**
+     * Deployed JS files hold embedded translations unless dictionary strategy is used, so they can not be reused
+     *
+     * @return void
+     */
+    public function testExtraLocalePackageIsNotDeployedFromBaseLocalePackageWithoutJsDictionary(): void
+    {
+        $ancestorPackage = $this->createMock(Package::class);
+        $ancestorPackage->method('isVirtual')->willReturn(false);
+
+        $baseLocalePackage = $this->createPackage('en_US');
+        $extraLocalePackage = $this->createPackage('de_DE', false, [$ancestorPackage]);
+
+        $this->jsTranslationConfig->method('dictionaryEnabled')->willReturn(false);
+        $extraLocalePackage->expects($this->once())->method('setParent')->with($ancestorPackage);
+
+        $this->queue->expects($this->exactly(2))
+            ->method('add')
+            ->with($this->anything(), []);
+
+        $this->createStrategy([$baseLocalePackage, $extraLocalePackage])->deploy($this->options);
+    }
+
+    /**
+     * @param Package[] $packages
+     * @return QuickDeploy
+     */
+    private function createStrategy(array $packages): QuickDeploy
+    {
+        $indexedPackages = [];
+        foreach ($packages as $package) {
+            $indexedPackages[$package->getPath()] = $package;
+        }
+        $this->packagePool->method('getPackagesForDeployment')->willReturn($indexedPackages);
+
+        return new QuickDeploy($this->packagePool, $this->queue, $this->jsTranslationConfig);
+    }
+
+    /**
+     * @param string $locale
+     * @param bool $withLocaleSpecificFile
+     * @param Package[] $parentPackages
+     * @return Package|MockObject
+     */
+    private function createPackage(string $locale, bool $withLocaleSpecificFile = false, array $parentPackages = [])
+    {
+        $package = $this->createMock(Package::class);
+        $package->method('isVirtual')->willReturn(false);
+        $package->method('getArea')->willReturn('frontend');
+        $package->method('getTheme')->willReturn('Magento/luma');
+        $package->method('getLocale')->willReturn($locale);
+        $package->method('getPath')->willReturn('frontend/Magento/luma/' . $locale);
+        $package->method('getInheritanceLevel')->willReturn(1);
+        $package->method('getParentPackages')->willReturn($parentPackages);
+
+        $files = [];
+        if ($withLocaleSpecificFile) {
+            $file = $this->createMock(PackageFile::class);
+            $file->method('getOrigPackage')->willReturn($package);
+            $files[] = $file;
+        }
+        $package->method('getFiles')->willReturn($files);
+
+        return $package;
+    }
+}


### PR DESCRIPTION
### Description (*)

`setup:static-content:deploy -s quick` is documented to reuse the first locale's output for the following locales. It never did. From a clean `pub/static`, deploying `en_US de_DE` for Magento/luma, alternating strategies over three rounds: standard 15.95 / 16.02 / 16.62 s, quick 17.05 / 17.36 / 17.99 s. Quick is 8% slower at the median, produces the identical 6172 files, and under SPX runs `Less_Output_Mapped::add` 274.4K times and `Less_Visitor_processExtends::HasMatches` 5.4M times in both strategies, identical to the call.

Cause: two different notions of "parent". `QuickDeploy::preparePackages()` points each extra-locale package at the first-locale package via `setParent()`. `DeployPackage::checkIfCanCopy()` requires `$file->getOrigPackage() === $parentPackage`. But `origPackage` comes from `Package::collectParentPaths()`, which walks theme inheritance and the `default` locale, never a sibling locale. So the identity check is false for every file and `processFile()` falls through to `deployFile()`, the standard path.

Fix:

- `DeployPackage::checkIfCanCopy()` now accepts a parent that holds the same file inherited from the same origin package with unchanged area/theme/locale markers, so a file both locales inherited untouched from the same ancestor is copied from the first locale. A parent-side override (pre-processor stamping) still blocks the copy.
- `QuickDeploy` only reuses the base-locale package when neither package has locale-specific sources (`web/i18n/<locale>` files show up as files whose origin is the package itself) and when the JS translation strategy is `dictionary`, since `embedded` writes per-locale strings into deployed JS. Otherwise it falls back to the ancestor-theme parent exactly as before.
- The base-locale package is passed to `Queue::add()` as a dependency, so with `-j N` the extra locale cannot fork before its source is deployed. `QuickDeploy` previously queued packages with no dependencies at all.

`js-translation.json`, `requirejs-config.js` and JS bundles are deployed per package outside `DeployPackage` and are unaffected. Standard and compact strategies are unchanged: standard sets no parent; compact packages are not aggregated, so the new branch never matches there.

After the change, same environment and command, three alternating rounds, `Execution time` reported by the command (this run used the plain php-fpm container, so absolute times are lower than the SPX-container numbers above; compare within the table):

| round | standard | quick |
|---|---|---|
| 1 | 7.21 s | 5.82 s |
| 2 | 7.14 s | 5.76 s |
| 3 | 7.45 s | 5.77 s |
| median | 7.21 s | 5.77 s |

Quick is now 20% faster than standard with two locales instead of 8% slower, and both produce the same 6176 files under `pub/static/frontend`. The gain grows with the number of locales, since every locale after the first is copied.

SVC: `QuickDeploy::__construct()` gains an optional trailing `?JsTranslationConfig` parameter with an ObjectManager fallback (MINOR).

### Fixed Issues (if relevant)

1. Fixes magento/magento2#10674

### Manual testing scenarios (*)

1. `rm -rf var/view_preprocessed/* pub/static/*` then `bin/magento setup:static-content:deploy -f -s standard --theme Magento/luma --area frontend en_US de_DE`, note the time.
2. Same with `-s quick`. `de_DE` package lines finish in a fraction of the `en_US` time and the total drops below standard.
3. `diff -r pub/static/frontend/Magento/luma/en_US pub/static/frontend/Magento/luma/de_DE` differs only in `js-translation.json`, `requirejs-config.js` and bundles.
4. Repeat with `-j 4`; output identical.
5. `bin/magento config:set dev/js/translate_strategy embedded`, redeploy quick: timing returns to standard-like and `de_DE` JS contains translated strings.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
