### PR TITLE
Reduce per-product work in listing swatch renderer (#39073)

### DIFF
--- a/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
+++ b/app/code/Magento/Swatches/Block/Product/Renderer/Configurable.php
@@ -36,27 +36,28 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     /**
      * Path to template file with Swatch renderer.
      */
-    const SWATCH_RENDERER_TEMPLATE = 'Magento_Swatches::product/view/renderer.phtml';
+    public const SWATCH_RENDERER_TEMPLATE = 'Magento_Swatches::product/view/renderer.phtml';
 
     /**
      * Path to default template file with standard Configurable renderer.
      */
-    const CONFIGURABLE_RENDERER_TEMPLATE = 'Magento_ConfigurableProduct::product/view/type/options/configurable.phtml';
+    public const CONFIGURABLE_RENDERER_TEMPLATE =
+        'Magento_ConfigurableProduct::product/view/type/options/configurable.phtml';
 
     /**
      * Action name for ajax request
      */
-    const MEDIA_CALLBACK_ACTION = 'swatches/ajax/media';
+    public const MEDIA_CALLBACK_ACTION = 'swatches/ajax/media';
 
     /**
      * Name of swatch image for json config
      */
-    const SWATCH_IMAGE_NAME = 'swatchImage';
+    public const SWATCH_IMAGE_NAME = 'swatchImage';
 
     /**
      * Name of swatch thumbnail for json config
      */
-    const SWATCH_THUMBNAIL_NAME = 'swatchThumb';
+    public const SWATCH_THUMBNAIL_NAME = 'swatchThumb';
 
     /**
      * Config path which contains number of swatches per product
@@ -79,9 +80,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     protected $swatchMediaHelper;
 
     /**
-     * Indicate if product has one or more Swatch attributes
-     *
      * @deprecated 100.1.0 unused
+     * @see \Magento\Swatches\Block\Product\Renderer\Configurable::isProductHasSwatchAttribute()
      *
      * @var boolean
      */
@@ -251,6 +251,7 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
      * Init isProductHasSwatchAttribute.
      *
      * @deprecated 100.2.0 Method isProductHasSwatchAttribute() is used instead of this.
+     * @see isProductHasSwatchAttribute()
      *
      * @codeCoverageIgnore
      * @return void
@@ -382,7 +383,7 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
      *
      * @param Product $childProduct
      * @param string $imageType
-     * @return string
+     * @return string|null
      */
     protected function getSwatchProductImage(Product $childProduct, $imageType)
     {
@@ -397,6 +398,8 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
         if (!empty($swatchImageId) && !empty($imageAttributes['type'])) {
             return $this->imageUrlBuilder->getUrl($childProduct->getData($imageAttributes['type']), $swatchImageId);
         }
+
+        return null;
     }
 
     /**
@@ -420,17 +423,21 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
      */
     protected function getConfigurableOptionsIds(array $attributeData)
     {
+        $attributeCodes = [];
+        /** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
+        foreach ($this->helper->getAllowAttributes($this->getProduct()) as $attribute) {
+            $productAttribute = $attribute->getProductAttribute();
+            if (isset($attributeData[$productAttribute->getId()])) {
+                $attributeCodes[] = $productAttribute->getAttributeCode();
+            }
+        }
+
         $ids = [];
         foreach ($this->getAllowProducts() as $product) {
-            /** @var \Magento\ConfigurableProduct\Model\Product\Type\Configurable\Attribute $attribute */
-            foreach ($this->helper->getAllowAttributes($this->getProduct()) as $attribute) {
-                $productAttribute = $attribute->getProductAttribute();
-                $productAttributeId = $productAttribute->getId();
-                if (isset($attributeData[$productAttributeId])) {
-                    $attributeValue = $product->getData($productAttribute->getAttributeCode());
-                    if ($attributeValue !== null) {
-                        $ids[$attributeValue] = 1;
-                    }
+            foreach ($attributeCodes as $attributeCode) {
+                $attributeValue = $product->getData($attributeCode);
+                if ($attributeValue !== null) {
+                    $ids[$attributeValue] = 1;
                 }
             }
         }
@@ -478,6 +485,7 @@ class Configurable extends \Magento\ConfigurableProduct\Block\Product\View\Type\
     /**
      * @inheritDoc
      * @deprecated 100.1.5 Now is used _toHtml() directly
+     * @see _toHtml()
      */
     protected function getHtmlOutput()
     {

--- a/app/code/Magento/Swatches/Helper/Data.php
+++ b/app/code/Magento/Swatches/Helper/Data.php
@@ -266,6 +266,7 @@ class Data
 
         $this->addFilterByAttributes($productCollection, $resultAttributesToFilter);
 
+        $productCollection->setPageSize(1);
         $variationProduct = $productCollection->getFirstItem();
         if ($variationProduct && $variationProduct->getId()) {
             return $this->productRepository->getById($variationProduct->getId());

--- a/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Block/Product/Renderer/Listing/ConfigurableTest.php
@@ -255,7 +255,7 @@ class ConfigurableTest extends TestCase
         $this->configurable->getJsonSwatchConfig();
     }
 
-    private function prepareGetJsonSwatchConfig()
+    private function prepareGetJsonSwatchConfig($allowAttributesInvocation = null)
     {
         $product1 = $this->createMock(\Magento\Catalog\Model\Product::class);
         $product1->expects($this->any())->method('isSaleable')->willReturn(true);
@@ -280,8 +280,39 @@ class ConfigurableTest extends TestCase
         $attribute1 = $this->createPartialMockWithReflection(Attribute::class, ['getProductAttribute']);
         $attribute1->method('getProductAttribute')->willReturn($productAttribute1);
 
-        $this->helper->expects($this->any())->method('getAllowAttributes')->with($this->product)
+        $this->helper->expects($allowAttributesInvocation ?? $this->any())->method('getAllowAttributes')
+            ->with($this->product)
             ->willReturn([$attribute1]);
+    }
+
+    /**
+     * @covers Magento\Swatches\Block\Product\Renderer\Configurable::getConfigurableOptionsIds
+     */
+    public function testGetJsonSwatchConfigResolvesAllowedAttributesOncePerProduct()
+    {
+        $products = [
+            1 => 'testA',
+            3 => 'testB'
+        ];
+        $this->prepareGetJsonSwatchConfig($this->once());
+        $this->configurable->setProduct($this->product);
+        $this->swatchHelper->expects($this->once())->method('getSwatchAttributesAsArray')
+            ->with($this->product)
+            ->willReturn(
+                [
+                    1 => [
+                        'options' => $products,
+                        'use_product_image_for_swatch' => true,
+                        'used_in_product_listing' => true,
+                        'attribute_code' => 'code',
+                    ],
+                ]
+            );
+        $this->swatchHelper->expects($this->once())->method('getSwatchesByOptionsId')
+            ->with([1, 3])
+            ->willReturn([3 => ['type' => null, 'value' => 'hello']]);
+        $this->jsonEncoder->expects($this->once())->method('encode');
+        $this->configurable->getJsonSwatchConfig();
     }
 
     public function testGetPricesJson()

--- a/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
+++ b/app/code/Magento/Swatches/Test/Unit/Helper/DataTest.php
@@ -334,6 +334,7 @@ class DataTest extends TestCase
 
         $this->prepareVariationCollection();
 
+        $this->productCollectionMock->expects($this->once())->method('setPageSize')->with(1);
         $this->productCollectionMock->method('getFirstItem')->willReturn($this->productMock);
         $this->productMock->method('getData')->with('id')->willReturn(95);
         $this->productModelFactoryMock->method('create')->willReturn($this->productMock);


### PR DESCRIPTION
### Description (*)

Two contained reductions of per-configurable work in the category listing swatch renderer. They do not remove the nine per-parent SQL statements the issue measures (each is intrinsically parent-scoped, and everything parent-independent is already memoized in EAV `Source\Table`, `Swatches\Helper\Data` and `SwatchAttributeCodes`), so this is a partial improvement on the axis the reporter is on, variations per configurable:

- `Renderer\Configurable::getConfigurableOptionsIds()` called `helper->getAllowAttributes($product)` inside the per-child loop, resolving the parent's configurable attributes once per variation. With 250 variations and 12 listed products that is 3000 resolutions per page. It is now resolved once per parent; the option id set is unchanged.
- `Helper\Data::loadVariationByFallback()` loaded the whole matching child collection and used `getFirstItem()`. It now sets `setPageSize(1)`. This path runs per parent from `Listing\Configurable::_getAdditionalConfig()` whenever a swatch attribute is in the layered navigation query.

Also fixes the pre-existing Static Tests warnings in the touched block (`public const`, `@see` on deprecated members, explicit `return null`).

### Fixed Issues (if relevant)

1. Partially addresses magento/magento2#39073

### Manual testing scenarios (*)

1. Category page with configurable products and swatches enabled: swatches, prices and images render as before.
2. Filter that category by a swatch attribute (layered navigation): the preselected variation image is unchanged.
3. Profile the page: `Swatches\Helper\Data::getAllowAttributes` call count drops from children x parents to parents.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
