### PR TITLE
Load Products List widget page by id before hydrating rows (#39565)

### DIFF
--- a/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
+++ b/app/code/Magento/CatalogWidget/Block/Product/ProductsList.php
@@ -23,6 +23,7 @@ use Magento\Framework\App\ActionInterface;
 use Magento\Framework\App\Http\Context as HttpContext;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\DB\Select;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
@@ -65,6 +66,11 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
      * Default value whether show pager or not
      */
     public const DEFAULT_SHOW_PAGER = false;
+
+    /**
+     * Product id field of the collection select
+     */
+    private const ID_FIELD = 'e.entity_id';
 
     /**
      * @var Pager
@@ -368,8 +374,68 @@ class ProductsList extends AbstractProduct implements BlockInterface, IdentityIn
      */
     protected function _beforeToHtml()
     {
-        $this->setProductCollection($this->createCollection());
+        $this->setProductCollection($this->resolveCollectionPage($this->createCollection()));
         return parent::_beforeToHtml();
+    }
+
+    /**
+     * Resolve the ids of the requested page and restrict the collection to them
+     *
+     * The widget selects whole product rows and de-duplicates them with DISTINCT, so the database has to
+     * materialize and sort every matching row before the LIMIT can be applied. Reading the ids of the page
+     * first keeps that sort down to a single column and leaves the wide select to the products actually shown.
+     *
+     * @param Collection $collection
+     * @return Collection
+     */
+    private function resolveCollectionPage(Collection $collection): Collection
+    {
+        $select = $collection->getSelect();
+        if (!$select->getPart(Select::LIMIT_COUNT)) {
+            return $collection;
+        }
+
+        if ($this->showPager()) {
+            // The pager total has to be read while the collection still matches the whole condition set.
+            $collection->getSize();
+        }
+
+        $idsSelect = clone $select;
+        $idsSelect->reset(Select::COLUMNS)->columns(self::ID_FIELD);
+        $this->selectSortExpressions($idsSelect);
+        $ids = $collection->getConnection()->fetchCol($idsSelect);
+
+        $select->reset(Select::WHERE)
+            ->reset(Select::LIMIT_COUNT)
+            ->reset(Select::LIMIT_OFFSET)
+            ->where(self::ID_FIELD . ' IN (?)', $ids ?: [0]);
+
+        return $collection;
+    }
+
+    /**
+     * Add the sort expressions of a DISTINCT select to its select list
+     *
+     * MySQL rejects a DISTINCT query whose ORDER BY expression is neither equal to one in the select list nor
+     * built from selected columns, so an id-only select cannot carry the sort orders the widget produces - the
+     * SKU condition, for one, orders by FIELD() over `sku`. Only the first column is read back.
+     *
+     * @param Select $select
+     * @return void
+     */
+    private function selectSortExpressions(Select $select): void
+    {
+        $columns = [];
+        foreach ($select->getPart(Select::ORDER) as $index => $order) {
+            $expression = is_array($order) ? $order[0] : $order;
+            if ((string)$expression !== self::ID_FIELD) {
+                $columns['sort_' . $index] = $expression;
+            }
+        }
+
+        if ($columns) {
+            $select->columns($columns);
+        }
     }
 
     /**

--- a/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
+++ b/app/code/Magento/CatalogWidget/Test/Unit/Block/Product/ProductsListTest.php
@@ -19,6 +19,9 @@ use Magento\Directory\Model\Currency;
 use Magento\Framework\App\Http\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\DB\Adapter\Pdo\Mysql;
+use Magento\Framework\DB\Select;
+use Magento\Framework\DB\Select\SelectRenderer;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Framework\Pricing\Render;
 use Magento\Framework\Serialize\Serializer\Json;
@@ -503,6 +506,163 @@ class ProductsListTest extends TestCase
             'page 3 of 3 with 12 total' => [3, 5, 12, 2, 10],
             'page beyond limit' => [3, 5, 9, 0, 10],
         ];
+    }
+
+    /**
+     * The rendered collection must be narrowed to the ids of the requested page, resolved by a separate query
+     */
+    public function testCollectionIsNarrowedToResolvedPageIds()
+    {
+        $idsSelectColumns = null;
+        $adapter = $this->createAdapter();
+        $adapter->expects($this->once())
+            ->method('fetchCol')
+            ->willReturnCallback(function (Select $idsSelect) use (&$idsSelectColumns) {
+                $idsSelectColumns = $idsSelect->getPart(Select::COLUMNS);
+                return [15, 9, 3];
+            });
+
+        $select = $this->createSelect($adapter);
+        $collection = $this->configureCollection($select, $adapter);
+        $collection->expects($this->never())->method('getSize');
+
+        $this->productsList->setData('show_pager', false);
+        $this->productsList->setData('products_count', 3);
+
+        $this->renderProductCollection();
+
+        $this->assertSame([['e', 'entity_id', null]], $idsSelectColumns);
+        $this->assertNull($select->getPart(Select::LIMIT_COUNT));
+        $this->assertNull($select->getPart(Select::LIMIT_OFFSET));
+        $this->assertSame(['(e.entity_id IN (15, 9, 3))'], $select->getPart(Select::WHERE));
+    }
+
+    /**
+     * A DISTINCT select is invalid on MySQL unless its ORDER BY expressions are part of the select list
+     */
+    public function testIdSelectCarriesSortExpressionsOfDistinctQuery()
+    {
+        $idsSelectColumns = null;
+        $adapter = $this->createAdapter();
+        $adapter->method('fetchCol')
+            ->willReturnCallback(function (Select $idsSelect) use (&$idsSelectColumns) {
+                $idsSelectColumns = $idsSelect->getPart(Select::COLUMNS);
+                return [15, 9, 3];
+            });
+
+        $sortExpression = new \Zend_Db_Expr("FIELD(e.sku, 'sku3', 'sku1', 'sku2')");
+        $select = $this->createSelect($adapter);
+        $select->reset(Select::ORDER)->order($sortExpression);
+
+        $this->configureCollection($select, $adapter);
+        $this->productsList->setData('show_pager', false);
+        $this->productsList->setData('products_count', 3);
+
+        $this->renderProductCollection();
+
+        $this->assertSame([['e', 'entity_id', null]], array_slice($idsSelectColumns, 0, 1));
+        $this->assertSame(
+            ["FIELD(e.sku, 'sku3', 'sku1', 'sku2')"],
+            array_map(static fn ($column) => (string)$column[1], array_slice($idsSelectColumns, 1))
+        );
+    }
+
+    /**
+     * The pager total must be read while the collection still matches the whole condition set
+     */
+    public function testPagerTotalIsResolvedBeforeCollectionIsNarrowed()
+    {
+        $adapter = $this->createAdapter();
+        $adapter->method('fetchCol')->willReturn([15, 9]);
+
+        $select = $this->createSelect($adapter);
+        $collection = $this->configureCollection($select, $adapter);
+
+        $whereBeforeSize = null;
+        $collection->expects($this->once())
+            ->method('getSize')
+            ->willReturnCallback(function () use ($select, &$whereBeforeSize) {
+                $whereBeforeSize = $select->getPart(Select::WHERE);
+                return 42;
+            });
+
+        $this->productsList->setData('show_pager', true);
+        $this->productsList->setData('products_per_page', 2);
+        $this->productsList->setData('products_count', 6);
+
+        $this->renderProductCollection();
+
+        $this->assertSame(['(at_status.value = 1)'], $whereBeforeSize);
+    }
+
+    /**
+     * @return Mysql|MockObject
+     */
+    private function createAdapter()
+    {
+        $adapter = $this->createMock(Mysql::class);
+        $adapter->method('quoteInto')->willReturnCallback(
+            static function ($text, $value) {
+                return str_replace('?', is_array($value) ? implode(', ', $value) : (string)$value, $text);
+            }
+        );
+
+        return $adapter;
+    }
+
+    /**
+     * @param Mysql $adapter
+     * @return Select
+     */
+    private function createSelect(Mysql $adapter): Select
+    {
+        $select = new Select($adapter, $this->createMock(SelectRenderer::class));
+        $select->from(['e' => 'catalog_product_entity'], ['e.*'])
+            ->distinct(true)
+            ->where('at_status.value = 1')
+            ->order('e.entity_id DESC');
+
+        return $select;
+    }
+
+    /**
+     * @param Select $select
+     * @param Mysql $adapter
+     * @return Collection|MockObject
+     */
+    private function configureCollection(Select $select, Mysql $adapter)
+    {
+        $collection = $this->createMock(Collection::class);
+        $collection->method('setVisibility')->willReturnSelf();
+        $collection->method('addMinimalPrice')->willReturnSelf();
+        $collection->method('addFinalPrice')->willReturnSelf();
+        $collection->method('addTaxPercents')->willReturnSelf();
+        $collection->method('addAttributeToSelect')->willReturnSelf();
+        $collection->method('addUrlRewrite')->willReturnSelf();
+        $collection->method('addStoreFilter')->willReturnSelf();
+        $collection->method('addAttributeToFilter')->willReturnSelf();
+        $collection->method('addAttributeToSort')->willReturnSelf();
+        $collection->method('distinct')->willReturnSelf();
+        $collection->method('getSelect')->willReturn($select);
+        $collection->method('getConnection')->willReturn($adapter);
+
+        $this->collectionFactory->expects($this->once())->method('create')->willReturn($collection);
+        $this->widgetConditionsHelper->method('decode')->willReturn([]);
+        $this->productsList->setData('conditions_encoded', 'some_serialized_conditions');
+        $this->productsList->setData('page_var_name', 'page');
+        $this->request->method('getParam')->with('page')->willReturn(1);
+        $this->getConditionsForCollection($collection);
+
+        return $collection;
+    }
+
+    /**
+     * @return void
+     */
+    private function renderProductCollection(): void
+    {
+        $method = new \ReflectionMethod($this->productsList, '_beforeToHtml');
+        $method->invoke($this->productsList);
     }
 
     public function testGetProductsCount()

--- a/dev/tests/integration/testsuite/Magento/CatalogWidget/Block/Product/ProductsListTest.php
+++ b/dev/tests/integration/testsuite/Magento/CatalogWidget/Block/Product/ProductsListTest.php
@@ -114,6 +114,77 @@ class ProductsListTest extends TestCase
     }
 
     /**
+     * The rendered collection must hold only the requested page, in the widget sort order,
+     * while the pager still reports the total number of products matching the condition
+     */
+    #[
+        DataFixture(CategoryFixture::class, ['is_anchor' => 0], 'category'),
+        DataFixture(ProductFixture::class, ['category_ids' => ['$category.id$']], 'product1'),
+        DataFixture(ProductFixture::class, ['category_ids' => ['$category.id$']], 'product2'),
+        DataFixture(ProductFixture::class, ['category_ids' => ['$category.id$']], 'product3'),
+        DataFixture(ProductFixture::class, ['category_ids' => ['$category.id$']], 'product4'),
+    ]
+    public function testRenderedCollectionHoldsRequestedPageOnly(): void
+    {
+        $this->objectManager->get(Processor::class)->reindexAll();
+
+        $categoryId = $this->fixtures->get('category')->getId();
+        $encodedConditions = '^[`1`:^[`type`:`Magento||CatalogWidget||Model||Rule||Condition||Combine`,'
+            . '`aggregator`:`all`,`value`:`1`,`new_child`:``^],`1--1`:'
+            . '^[`type`:`Magento||CatalogWidget||Model||Rule||Condition||Product`,'
+            . '`attribute`:`category_ids`,`operator`:`^[^]`,'
+            . '`value`:[`' . $categoryId . '`]^]^]';
+
+        $this->block->setData('conditions_encoded', $encodedConditions);
+        $this->block->setData('show_pager', true);
+        $this->block->setData('products_per_page', 2);
+        $this->block->setData('products_count', 4);
+        $this->block->setData('page_var_name', 'np');
+
+        (new \ReflectionMethod($this->block, '_beforeToHtml'))->invoke($this->block);
+        $collection = $this->block->getProductCollection();
+
+        $this->assertSame(
+            [
+                $this->fixtures->get('product4')->getSku(),
+                $this->fixtures->get('product3')->getSku(),
+            ],
+            $collection->getColumnValues('sku')
+        );
+        $this->assertEquals(4, $collection->getSize());
+    }
+
+    /**
+     * A SKU condition orders by FIELD(sku, ...), which the page id query has to carry in its select list
+     * to stay valid under ONLY_FULL_GROUP_BY
+     */
+    #[
+        DataFixture(ProductFixture::class, as: 'product1'),
+        DataFixture(ProductFixture::class, as: 'product2'),
+        DataFixture(ProductFixture::class, as: 'product3'),
+    ]
+    public function testRenderedCollectionKeepsSkuConditionOrder(): void
+    {
+        $skus = [
+            $this->fixtures->get('product3')->getSku(),
+            $this->fixtures->get('product1')->getSku(),
+            $this->fixtures->get('product2')->getSku(),
+        ];
+        $encodedConditions = '^[`1`:^[`type`:`Magento||CatalogWidget||Model||Rule||Condition||Combine`,'
+            . '`aggregator`:`all`,`value`:`1`,`new_child`:``^],`1--1`:'
+            . '^[`type`:`Magento||CatalogWidget||Model||Rule||Condition||Product`,'
+            . '`attribute`:`sku`,`operator`:`()`,`value`:`' . implode(',', $skus) . '`^]^]';
+
+        $this->block->setData('conditions_encoded', $encodedConditions);
+        $this->block->setData('products_count', 3);
+        $this->block->setData('page_var_name', 'np');
+
+        (new \ReflectionMethod($this->block, '_beforeToHtml'))->invoke($this->block);
+
+        $this->assertSame($skus, $this->block->getProductCollection()->getColumnValues('sku'));
+    }
+
+    /**
      * Test product list widget can process condition with dropdown type of attribute
      */
     #[


### PR DESCRIPTION
### Description (*)

The Products List widget (what the PageBuilder Products content type renders; the code is in Magento_CatalogWidget, not in page-builder) selects whole product rows with `DISTINCT`, joins the price index and category index, and orders by `e.entity_id DESC` (or by `FIELD(e.sku, ...)` for an SKU condition). That `ORDER BY` cannot be served from the driving table, so MySQL materializes and sorts every row the conditions match before applying `LIMIT 12`. At 1,200 products the plan already shows `Using temporary; Using filesort` over the full match set; at millions of products with a broad condition that is a page that never loads.

The fix resolves the requested page in two steps inside `_beforeToHtml()`:

1. A clone of the fully built select with its column list reduced to `e.entity_id` (plus any `ORDER BY` expression, so the `DISTINCT` stays valid under `ONLY_FULL_GROUP_BY`) runs with the original `ORDER BY`, `LIMIT` and `OFFSET` and returns the ids of the page.
2. The original select has its `WHERE` and `LIMIT` replaced by `e.entity_id IN (ids)`, so the wide row hydration is a primary-key lookup on the products actually shown.

The narrowing runs after `createCollection()` and therefore after `ConfigurableProduct`'s `afterCreateCollection` plugin, which `orWhere`s configurable parents in; replacing the `WHERE` rather than appending is deliberate because Zend does not parenthesize accumulated `WHERE` parts. The pager total is read via `getSize()` before narrowing and is cached by the collection, so `getPagerHtml()` still reports the full match count. Sorting, the `DISTINCT` on the wide select, block caching and `cache_lifetime` are unchanged. Nothing in `Magento_Rule` is touched.

Before (one statement):

```sql
SELECT DISTINCT e.*, price_index.price, ..., cat_index.position AS cat_index_position
FROM catalog_product_entity AS e
INNER JOIN <price index> AS price_index ON ...
INNER JOIN catalog_category_product_index_store1 AS cat_index ON ...
INNER JOIN catalog_category_product AS catalog_category_product_widget ON ...
INNER JOIN catalog_product_entity_int AS at_status ON ...
WHERE (at_status.value = 1) AND (catalog_category_product_widget.category_id IN (...))
ORDER BY e.entity_id DESC LIMIT 12
```

After (two statements):

```sql
SELECT DISTINCT e.entity_id FROM ... same joins and WHERE ... ORDER BY e.entity_id DESC LIMIT 12;
SELECT DISTINCT e.*, price_index.price, ..., cat_index.position AS cat_index_position
FROM ... same joins ... WHERE (e.entity_id IN (12 ids)) ORDER BY e.entity_id DESC;
```

The first statement still sorts the match set, but over one integer column instead of the wide row, which is what makes the materialize-and-sort plan cheap enough. Please compare `EXPLAIN` of both shapes on a large catalog; the reporter's environment is the one where the difference is decisive.

Test coverage note: the unit tests fail without the change (they assert the id select shape, the reset LIMIT and the narrowed WHERE). The two integration tests pass with and without it by design; they pin the rendered page, the pager total and the SKU condition order, and the SKU case is the one that exercises `DISTINCT` + `ORDER BY FIELD()` on MySQL 8, which a local MariaDB does not enforce.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#39565

### Manual testing scenarios (*)

1. Add a Products List widget (or a PageBuilder Products content type) with a category condition, products per page 12, pager on. The same products render in the same order, the pager total is the full match count.
2. Use an SKU `()` condition with SKUs in a non-id order. The rendered order follows the condition list.
3. Include a configurable product whose children are Not Visible Individually. The configurable renders once.
4. Enable the MySQL general log: the id select carries only `e.entity_id` (plus the sort expression when one exists) and the second select is `WHERE e.entity_id IN (...)`.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
- [x] All automated tests passed successfully (all builds are green)
