### PR TITLE
Add server-side validation for CSP report_uri config (#41233)

### DIFF
--- a/app/code/Magento/Csp/Model/Config/Backend/ReportUri.php
+++ b/app/code/Magento/Csp/Model/Config/Backend/ReportUri.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Csp\Model\Config\Backend;
+
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Registry;
+use Magento\Framework\Validator\Url as UrlValidator;
+
+class ReportUri extends Value
+{
+    /**
+     * @var UrlValidator
+     */
+    private UrlValidator $urlValidator;
+
+    /**
+     * @param Context $context
+     * @param Registry $registry
+     * @param ScopeConfigInterface $config
+     * @param TypeListInterface $cacheTypeList
+     * @param UrlValidator $urlValidator
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        UrlValidator $urlValidator,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        $this->urlValidator = $urlValidator;
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeSave()
+    {
+        $value = (string)$this->getValue();
+
+        if ($value !== '' && !$this->urlValidator->isValid($value, ['http', 'https'])) {
+            $field = $this->getFieldConfig();
+            $label = $field && is_array($field) ? $field['label'] : 'Report URI';
+            throw new LocalizedException(__('Invalid %1. Specify a fully qualified URL.', $label));
+        }
+
+        return parent::beforeSave();
+    }
+}

--- a/app/code/Magento/Csp/Model/Mode/ConfigManager.php
+++ b/app/code/Magento/Csp/Model/Mode/ConfigManager.php
@@ -15,6 +15,7 @@ use Magento\Csp\Model\Mode\Data\ModeConfiguredFactory;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\State;
+use Magento\Framework\Validator\Url as UrlValidator;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 
@@ -49,18 +50,25 @@ class ConfigManager implements ModeConfigManagerInterface
     private $modeConfiguredFactory;
 
     /**
+     * @var UrlValidator
+     */
+    private UrlValidator $urlValidator;
+
+    /**
      * @param ScopeConfigInterface $config
      * @param Store $store
      * @param State $state
      * @param Http|null $request
      * @param ModeConfiguredFactory|null $modeConfiguredFactory
+     * @param UrlValidator|null $urlValidator
      */
     public function __construct(
         ScopeConfigInterface $config,
         Store $store,
         State $state,
         ?Http $request = null,
-        ?ModeConfiguredFactory $modeConfiguredFactory = null
+        ?ModeConfiguredFactory $modeConfiguredFactory = null,
+        ?UrlValidator $urlValidator = null
     ) {
         $this->config = $config;
         $this->storeModel = $store;
@@ -70,6 +78,8 @@ class ConfigManager implements ModeConfigManagerInterface
             ?? ObjectManager::getInstance()->get(Http::class);
         $this->modeConfiguredFactory = $modeConfiguredFactory
             ?? ObjectManager::getInstance()->get(ModeConfiguredFactory::class);
+        $this->urlValidator = $urlValidator
+            ?? ObjectManager::getInstance()->get(UrlValidator::class);
     }
 
     /**
@@ -125,6 +135,10 @@ class ConfigManager implements ModeConfigManagerInterface
                 ScopeInterface::SCOPE_STORE,
                 $this->storeModel->getStore()
             );
+        }
+
+        if (!empty($reportUri) && !$this->urlValidator->isValid((string)$reportUri, ['http', 'https'])) {
+            $reportUri = null;
         }
 
         return $this->modeConfiguredFactory->create([

--- a/app/code/Magento/Csp/Test/Unit/Model/Config/Backend/ReportUriTest.php
+++ b/app/code/Magento/Csp/Test/Unit/Model/Config/Backend/ReportUriTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Csp\Test\Unit\Model\Config\Backend;
+
+use Magento\Csp\Model\Config\Backend\ReportUri;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Registry;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Validator\Url as UrlValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ReportUriTest extends TestCase
+{
+    /**
+     * @var ReportUri
+     */
+    private ReportUri $model;
+
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+
+        $this->model = $objectManager->getObject(
+            ReportUri::class,
+            [
+                'context' => $objectManager->getObject(Context::class),
+                'registry' => $this->createMock(Registry::class),
+                'config' => $this->createMock(ScopeConfigInterface::class),
+                'cacheTypeList' => $this->createMock(TypeListInterface::class),
+                'urlValidator' => new UrlValidator(),
+            ]
+        );
+    }
+
+    #[DataProvider('validValueDataProvider')]
+    public function testBeforeSaveAllowsValidValue(string $value): void
+    {
+        $this->model->setValue($value);
+        $this->model->beforeSave();
+
+        $this->assertSame($value, $this->model->getValue());
+    }
+
+    public static function validValueDataProvider(): array
+    {
+        return [
+            'https url' => ['https://example.com/csp-report'],
+            'http url' => ['http://example.com/csp-report'],
+        ];
+    }
+
+    public function testBeforeSaveAllowsEmptyValue(): void
+    {
+        $this->model->setValue('');
+        $this->model->beforeSave();
+
+        $this->assertSame('', $this->model->getValue());
+    }
+
+    #[DataProvider('invalidValueDataProvider')]
+    public function testBeforeSaveThrowsOnInvalidValue(string $value): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $this->model->setValue($value);
+        $this->model->beforeSave();
+    }
+
+    public static function invalidValueDataProvider(): array
+    {
+        return [
+            'carriage return and line feed' => ["https://example.com/report\r\nX-Injected: 1"],
+            'not a url' => ['not-a-url'],
+            'javascript scheme' => ['javascript:alert(1)'],
+            'ftp scheme' => ['ftp://example.com/report'],
+        ];
+    }
+}

--- a/app/code/Magento/Csp/Test/Unit/Model/Mode/ConfigManagerTest.php
+++ b/app/code/Magento/Csp/Test/Unit/Model/Mode/ConfigManagerTest.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\App\State;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Validator\Url as UrlValidator;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\Store;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -62,6 +63,11 @@ class ConfigManagerTest extends TestCase
     private $modeConfiguredInterfaceMock;
 
     /**
+     * @var UrlValidator|MockObject
+     */
+    private $urlValidatorMock;
+
+    /**
      * Set Up
      */
     protected function setUp(): void
@@ -74,6 +80,7 @@ class ConfigManagerTest extends TestCase
         $this->requestMock = $this->createMock(Http::class);
         $this->modeConfiguredFactoryMock = $this->createPartialMock(ModeConfiguredFactory::class, ['create']);
         $this->modeConfiguredInterfaceMock = $this->createMock(ModeConfiguredInterface::class);
+        $this->urlValidatorMock = $this->createMock(UrlValidator::class);
 
         $this->model = $objectManager->getObject(
             ConfigManager::class,
@@ -82,7 +89,8 @@ class ConfigManagerTest extends TestCase
                 'storeModel' => $this->storeMock,
                 'state' => $this->stateMock,
                 'request' => $this->requestMock,
-                'modeConfiguredFactory' => $this->modeConfiguredFactoryMock
+                'modeConfiguredFactory' => $this->modeConfiguredFactoryMock,
+                'urlValidator' => $this->urlValidatorMock
             ]
         );
     }
@@ -120,6 +128,9 @@ class ConfigManagerTest extends TestCase
         $this->scopeConfigMock->expects($this->any())
             ->method('getValue')
             ->willReturn('testReportUri');
+        $this->urlValidatorMock->expects($this->any())
+            ->method('isValid')
+            ->willReturn(true);
         $this->modeConfiguredFactoryMock->expects($this->once())
             ->method('create')
             ->with(['reportOnly' => true, 'reportUri' => 'testReportUri'])
@@ -156,6 +167,11 @@ class ConfigManagerTest extends TestCase
                 };
             })
             ->willReturnOnConsecutiveCalls(true, 'testReportUri');
+
+        $this->urlValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with('testReportUri', ['http', 'https'])
+            ->willReturn(true);
 
         $this->modeConfiguredFactoryMock->expects($this->once())
             ->method('create')
@@ -195,9 +211,98 @@ class ConfigManagerTest extends TestCase
             })
             ->willReturnOnConsecutiveCalls(null, true, null, 'testPageReportUri');
 
+        $this->urlValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with('testPageReportUri', ['http', 'https'])
+            ->willReturn(true);
+
         $this->modeConfiguredFactoryMock->expects($this->once())
             ->method('create')
             ->with(['reportOnly' => true, 'reportUri' => 'testPageReportUri'])
+            ->willReturn($this->modeConfiguredInterfaceMock);
+
+        $result = $this->model->getConfigured();
+
+        $this->assertInstanceOf(ModeConfiguredInterface::class, $result);
+    }
+
+    /**
+     * Test a valid configured report URI is returned unchanged.
+     *
+     * @return void
+     */
+    public function testValidReportUriIsReturnedUnchanged(): void
+    {
+        $this->requestMock->expects($this->exactly(2))
+            ->method('getFullActionName')
+            ->willReturn('checkout_index_index');
+
+        $this->stateMock->expects($this->once())
+            ->method('getAreaCode')
+            ->willReturn(Area::AREA_FRONTEND);
+
+        $matcher = $this->exactly(2);
+        $this->scopeConfigMock->expects($matcher)
+            ->method('getValue')
+            ->willReturnCallback(function () use ($matcher) {
+                return match ($matcher->getInvocationCount()) {
+                    1 => ['csp/mode/checkout_index_index/report_only', ScopeInterface::SCOPE_STORE, null],
+                    2 => ['csp/mode/checkout_index_index/report_uri', ScopeInterface::SCOPE_STORE, null],
+                };
+            })
+            ->willReturnOnConsecutiveCalls(true, 'https://example.com/csp-report');
+
+        $this->urlValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with('https://example.com/csp-report', ['http', 'https'])
+            ->willReturn(true);
+
+        $this->modeConfiguredFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(['reportOnly' => true, 'reportUri' => 'https://example.com/csp-report'])
+            ->willReturn($this->modeConfiguredInterfaceMock);
+
+        $result = $this->model->getConfigured();
+
+        $this->assertInstanceOf(ModeConfiguredInterface::class, $result);
+    }
+
+    /**
+     * Test a report URI containing CR/LF is treated as absent instead of reaching the header layer.
+     *
+     * @return void
+     */
+    public function testInvalidReportUriIsTreatedAsAbsent(): void
+    {
+        $this->requestMock->expects($this->exactly(2))
+            ->method('getFullActionName')
+            ->willReturn('checkout_index_index');
+
+        $this->stateMock->expects($this->once())
+            ->method('getAreaCode')
+            ->willReturn(Area::AREA_FRONTEND);
+
+        $maliciousReportUri = "https://example.com/report\r\nX-Injected: 1";
+
+        $matcher = $this->exactly(2);
+        $this->scopeConfigMock->expects($matcher)
+            ->method('getValue')
+            ->willReturnCallback(function () use ($matcher) {
+                return match ($matcher->getInvocationCount()) {
+                    1 => ['csp/mode/checkout_index_index/report_only', ScopeInterface::SCOPE_STORE, null],
+                    2 => ['csp/mode/checkout_index_index/report_uri', ScopeInterface::SCOPE_STORE, null],
+                };
+            })
+            ->willReturnOnConsecutiveCalls(true, $maliciousReportUri);
+
+        $this->urlValidatorMock->expects($this->once())
+            ->method('isValid')
+            ->with($maliciousReportUri, ['http', 'https'])
+            ->willReturn(false);
+
+        $this->modeConfiguredFactoryMock->expects($this->once())
+            ->method('create')
+            ->with(['reportOnly' => true, 'reportUri' => null])
             ->willReturn($this->modeConfiguredInterfaceMock);
 
         $result = $this->model->getConfigured();

--- a/app/code/Magento/Csp/etc/adminhtml/system.xml
+++ b/app/code/Magento/Csp/etc/adminhtml/system.xml
@@ -19,6 +19,7 @@
                         <label>Report URI</label>
                         <comment>URI to report CSP violations on storefront. Used for all storefront pages that don't have own URI configured above.</comment>
                         <validate>validate-url</validate>
+                        <backend_model>Magento\Csp\Model\Config\Backend\ReportUri</backend_model>
                     </field>
                 </group>
                 <group id="admin" translate="label" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -27,6 +28,7 @@
                         <label>Report URI</label>
                         <comment>URI to report CSP violations in admin area. Used for all admin pages that don't have own URI configured above.</comment>
                         <validate>validate-url</validate>
+                        <backend_model>Magento\Csp\Model\Config\Backend\ReportUri</backend_model>
                     </field>
                 </group>
             </group>


### PR DESCRIPTION
### Description

The two CSP Report URI fields in `Csp/etc/adminhtml/system.xml` declared only `<validate>validate-url</validate>`. That rule runs in the browser, on the admin form. Nothing validated the value on the server.

A value containing CR or LF therefore reached `Csp\Model\Mode\ConfigManager::getConfigured()` untouched, was passed into `ModeConfigured`, and `Csp\Model\Policy\Renderer\SimplePolicyHeaderRenderer::render()` interpolated it into the header before calling `$response->setHeader()`. The header layer refuses a value containing CR or LF, which is correct, but it refuses by throwing. Nothing catches it, so every page returned HTTP 500 until the value was removed.

The fix has two parts, because a backend model alone does not close it:

1. `Csp\Model\Config\Backend\ReportUri` validates the value on save with `Framework\Validator\Url`, restricted to the `http` and `https` schemes. An empty value stays allowed — the field is optional. Both `report_uri` fields now declare it as their `backend_model`; the existing client-side `validate-url` rule is unchanged.
2. `ConfigManager` treats a report URI that is not a valid `http`/`https` URL as absent and passes `null` to the header layer. This covers the routes a backend model never sees: `app/etc/config.php`, a data patch, and the per-action paths `csp/mode/<area>_<fullActionName>/report_uri`, which are synthesised at runtime and have no admin field to attach a backend model to.

A valid report URI is unaffected and still renders.

### Fixed Issues

Fixes magento/magento2#41233

### Manual testing scenarios

1. Admin → Stores → Configuration → Security → Content Security Policy → Storefront Default → Report URI. Enter `not-a-url` and save. The save is rejected with a validation message instead of being accepted.
2. Bypass the form the way the report describes:
   ```sql
   UPDATE core_config_data
   SET value = CONCAT('https://example.com/csp', CHAR(13), CHAR(10), 'X-Injected: 1')
   WHERE path = 'csp/mode/storefront/report_uri';
   ```
   `bin/magento cache:flush`, then request any storefront page. Before this change: HTTP 500 on every page. After: the page renders, and the `Content-Security-Policy` header is emitted without a `report-uri` directive.
3. Set a valid `https://example.com/csp-report` and confirm the `report-uri` and `report-to` directives still appear.

### Questions or comments

`Semantic Version Checker` reports a constructor change on `ConfigManager`. The new `Framework\Validator\Url` parameter is optional and trailing, with an `ObjectManager` fallback, matching the existing `?Http $request = null` and `?ModeConfiguredFactory $modeConfiguredFactory = null` parameters on the same constructor.

The local `Static Tests` gate reports seven line-length warnings in `Csp/etc/adminhtml/system.xml`, on lines 8, 10, 16, 18, 20, 27 and 29. All seven are pre-existing and present on a clean `2.4-develop` checkout; this PR adds two `<backend_model>` lines and changes nothing else in that file. They are listed here rather than silently reformatted, since rewrapping the `<comment>` elements would change their translation msgids.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit tests
- [x] All automated tests passed successfully
