### PR TITLE
Resolve legacy cache backend class names to their Symfony adapters (#41213)

### DIFF
--- a/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
+++ b/lib/internal/Magento/Framework/Cache/Frontend/Adapter/SymfonyAdapterProvider.php
@@ -81,19 +81,24 @@ class SymfonyAdapterProvider implements ResetAfterRequestInterface
     private array $adapterTypeMap = [
         // Redis backends
         'redis' => 'redis',
+        'magento\framework\cache\backend\redis' => 'redis',
+        'cm_cache_backend_redis' => 'redis',
 
         // Valkey backends
         'valkey' => 'redis',
+        'magento\framework\cache\backend\valkey' => 'redis',
 
         // Memcached backends
         'memcached' => 'memcached',
         'libmemcached' => 'memcached',
+        'magento\framework\cache\backend\memcached' => 'memcached',
 
         // File backends
         'file' => 'filesystem',
 
         // Database backend
         'database' => 'database',
+        'magento\framework\cache\backend\database' => 'database',
 
         // APCu backends
         'apc' => 'apcu',

--- a/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
+++ b/lib/internal/Magento/Framework/Cache/Test/Unit/Frontend/Adapter/SymfonyAdapterProviderTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\Cache\Test\Unit\Frontend\Adapter;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Cache\Frontend\Adapter\SymfonyAdapterProvider;
+use Magento\Framework\Cache\Frontend\Adapter\SymfonyAdapters\FilesystemTagAdapter;
+use Magento\Framework\Cache\Frontend\Adapter\SymfonyAdapters\RedisTagAdapter;
+use Magento\Framework\DB\Adapter\AdapterInterface as DbAdapterInterface;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\Framework\Serialize\Serializer\Serialize;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Exception\CacheException;
+
+/**
+ * Test for legacy class-name backend resolution in the Symfony cache adapter factory
+ */
+class SymfonyAdapterProviderTest extends TestCase
+{
+    /**
+     * @var Filesystem&MockObject
+     */
+    private $filesystem;
+
+    /**
+     * @var ResourceConnection&MockObject
+     */
+    private $resource;
+
+    /**
+     * @var Serialize&MockObject
+     */
+    private $serializer;
+
+    /**
+     * @var SymfonyAdapterProvider
+     */
+    private $provider;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = $this->createMock(Filesystem::class);
+        $cacheDirectory = $this->createMock(ReadInterface::class);
+        $cacheDirectory->method('getAbsolutePath')->willReturn(sys_get_temp_dir() . '/symfony-adapter-provider-test');
+        $this->filesystem->method('getDirectoryRead')->with(DirectoryList::CACHE)->willReturn($cacheDirectory);
+
+        $this->resource = $this->createMock(ResourceConnection::class);
+        $this->serializer = $this->createMock(Serialize::class);
+
+        $this->provider = new SymfonyAdapterProvider($this->filesystem, $this->resource, $this->serializer);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function redisAliasProvider(): array
+    {
+        return [
+            'redis short alias' => ['redis'],
+            'redis class name' => ['Magento\Framework\Cache\Backend\Redis'],
+            'valkey short alias' => ['valkey'],
+            'valkey class name' => ['Magento\Framework\Cache\Backend\Valkey'],
+            'legacy Cm_Cache_Backend_Redis class name' => ['Cm_Cache_Backend_Redis'],
+        ];
+    }
+
+    /**
+     * A legacy class-name backend must resolve to the same tag adapter as its short alias.
+     */
+    #[DataProvider('redisAliasProvider')]
+    public function testRedisBackendAliasesProduceRedisTagAdapter(string $backendType): void
+    {
+        $cachePool = new RedisAdapter(new \Redis());
+
+        $tagAdapter = $this->provider->createTagAdapter($backendType, $cachePool);
+
+        $this->assertInstanceOf(RedisTagAdapter::class, $tagAdapter);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function memcachedAliasProvider(): array
+    {
+        return [
+            'memcached short alias' => ['memcached'],
+            'memcached class name' => ['Magento\Framework\Cache\Backend\Memcached'],
+        ];
+    }
+
+    /**
+     * Memcached adapter creation requires the ext-memcached extension, which is not present in the
+     * unit test environment; both the short alias and the class name must fail identically, so
+     * parity is asserted on the exception Symfony raises before any socket is touched.
+     */
+    #[DataProvider('memcachedAliasProvider')]
+    public function testMemcachedBackendAliasesFailIdentically(string $backendType): void
+    {
+        $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('Memcached > 3.1.5 is required.');
+
+        $this->provider->createAdapter($backendType, []);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function databaseAliasProvider(): array
+    {
+        return [
+            'database short alias' => ['database'],
+            'database class name' => ['Magento\Framework\Cache\Backend\Database'],
+        ];
+    }
+
+    /**
+     * A resolved (non-filesystem) backend is wrapped in TagAwareAdapter; an unmapped backend falls
+     * back to a bare FilesystemAdapter.
+     */
+    #[DataProvider('databaseAliasProvider')]
+    public function testDatabaseBackendAliasesProduceTagAwareAdapter(string $backendType): void
+    {
+        $dbAdapter = $this->createMock(DbAdapterInterface::class);
+        $this->resource->method('getConnection')->willReturn($dbAdapter);
+        $this->resource->method('getTableName')->willReturnMap([
+            ['cache', 'cache'],
+            ['cache_tag', 'cache_tag'],
+        ]);
+
+        $adapter = $this->provider->createAdapter($backendType, []);
+
+        $this->assertInstanceOf(TagAwareAdapter::class, $adapter);
+    }
+
+    /**
+     * An unknown backend type resolves to a bare FilesystemAdapter.
+     */
+    public function testUnknownBackendTypeStillResolvesToFilesystemAdapter(): void
+    {
+        $adapter = $this->provider->createAdapter('Some\Unmapped\Backend\ClassName', []);
+
+        $this->assertInstanceOf(FilesystemAdapter::class, $adapter);
+    }
+
+    /**
+     * The tag adapter side of an unknown backend type must also keep resolving to the filesystem
+     * tag adapter, not the Redis one.
+     */
+    public function testUnknownBackendTypeStillResolvesToFilesystemTagAdapter(): void
+    {
+        $cachePool = $this->createMock(CacheItemPoolInterface::class);
+
+        $tagAdapter = $this->provider->createTagAdapter('Some\Unmapped\Backend\ClassName', $cachePool);
+
+        $this->assertInstanceOf(FilesystemTagAdapter::class, $tagAdapter);
+    }
+}


### PR DESCRIPTION
### Description

2.4.9 routes cache creation through Symfony Cache. `Magento\Framework\App\Cache\Frontend\Factory::createSymfonyCache()` passes the raw configured `cache/frontend/*/backend` string to `SymfonyAdapterProvider::createAdapter()`, and that provider resolves the value against `$adapterTypeMap`, which contained short aliases only (`redis`, `valkey`, `memcached`, `libmemcached`, `file`, `database`, `apc`, `apcu`, `two_levels`, `twolevel`). Both `createAdapter()` and `createTagAdapter()` end with `$resolvedType = $this->adapterTypeMap[$backendTypeLower] ?? 'filesystem';`, so a backend configured with a class name — `Magento\Framework\Cache\Backend\Redis`, `...\Valkey`, `...\Database`, `...\Memcached`, or the legacy `Cm_Cache_Backend_Redis` — never matched and resolved to a `FilesystemAdapter`.

Class names remain a supported configuration surface: `Factory::_getBackendOptions()` accepts any `class_exists()` backend in its `default:` case, `Factory::isSymfonyL2Cache()` already normalises a lowercased FQCN alongside its short aliases, and the class-name form is what the Redis page cache documentation shows. The result on an upgraded store is a cache that reports healthy from `cache:status` and the admin while every entry goes to `var/cache` and Redis stays empty.

This change adds the lowercased class names to the existing map, next to the aliases they correspond to. Both call sites read the same map, so no new resolution logic is introduced.

Not included, deliberately: turning the `?? 'filesystem'` default into an exception, and logging when the fallback is taken. Both are worth doing, but they are a behaviour decision rather than a bug fix — throwing would break installations running a custom backend class, and constructing a logger at cache bootstrap is circular with the cache itself. Happy to follow up in a separate PR if maintainers want the fallback to fail loudly or warn.

`Eaccelerator`, `MongoDb`, `RemoteSynchronizedCache`, `SymfonyL2Cache` and `AbstractBackend` are intentionally left unmapped: they have no equivalent adapter in this map, and `SymfonyL2Cache` is already handled by `Factory::isSymfonyL2Cache()`.

Note for whoever sequences this: #41159 also touches `SymfonyAdapterProvider.php` (it adds `resolveAdapterType()`/`isFilesystemBackend()` helpers around the same fallback for the unrelated `cache_dir` fix in #41157). The two changes are compatible but will conflict textually.

### Fixed Issues

Fixes magento/magento2#41213

### Manual testing scenarios

1. Install 2.4-develop with Redis reachable over TCP.
2. Configure `app/etc/env.php` with the class-name form:
   ```php
   'cache' => ['frontend' => ['default' => [
       'id_prefix' => 'magento2_',
       'backend' => 'Magento\\Framework\\Cache\\Backend\\Redis',
       'backend_options' => ['server' => '127.0.0.1', 'port' => '6379', 'database' => '1'],
   ]]],
   ```
3. Run `bin/magento cache:flush`, browse a storefront page.
4. Before: `redis-cli -n 1 dbsize` stays `0` and `var/cache` grows. After: cache entries appear in Redis db 1 and `var/cache` stays empty, matching the behaviour of `'backend' => 'redis'` with identical `backend_options`.

### Questions or comments

Gates run locally against `upstream/2.4-develop`: unit (11 tests, 15 assertions — the new `SymfonyAdapterProviderTest`), PHPCS (0 errors, 0 warnings on both files), PHPStan (no errors), static/LiveCodeTest (green; 2 skips reproduce on a clean checkout). The unit tests avoid live services — Redis via an unconnected `\Redis` instance, Memcached via the `extension_loaded()` failure Symfony raises before touching a socket, Database via a mocked `ResourceConnection` — and two of them pin the unchanged filesystem default for an unmapped backend type.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
