### PR TITLE
Guard null order item ids when setting downloadable link status (#41230)

### DIFF
--- a/app/code/Magento/Downloadable/Observer/SetLinkStatusObserver.php
+++ b/app/code/Magento/Downloadable/Observer/SetLinkStatusObserver.php
@@ -115,12 +115,13 @@ class SetLinkStatusObserver implements ObserverInterface
                         $availableStatuses[] = \Magento\Sales\Model\Order\Item::STATUS_BACKORDERED;
                     }
 
-                    if (in_array($item->getStatusId(), $availableStatuses)) {
-                        $downloadableItemsStatuses[$item->getId()] = $linkStatuses['avail'];
+                    $itemId = $item->getId();
+                    if ($itemId !== null && in_array($item->getStatusId(), $availableStatuses)) {
+                        $downloadableItemsStatuses[$itemId] = $linkStatuses['avail'];
                     }
 
-                    if ($item->getQtyOrdered() - $item->getQtyRefunded() == 0) {
-                        $expiredOrderItemIds[] = $item->getId();
+                    if ($itemId !== null && $item->getQtyOrdered() - $item->getQtyRefunded() == 0) {
+                        $expiredOrderItemIds[] = $itemId;
                     }
                 }
             }
@@ -130,7 +131,10 @@ class SetLinkStatusObserver implements ObserverInterface
                 if ($item->getProductType() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
                     || $item->getRealProductType() == \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE
                 ) {
-                    $downloadableItemsStatuses[$item->getId()] = $status;
+                    $itemId = $item->getId();
+                    if ($itemId !== null) {
+                        $downloadableItemsStatuses[$itemId] = $status;
+                    }
                 }
             }
         }

--- a/app/code/Magento/Downloadable/Test/Unit/Observer/SetLinkStatusObserverTest.php
+++ b/app/code/Magento/Downloadable/Test/Unit/Observer/SetLinkStatusObserverTest.php
@@ -361,6 +361,191 @@ class SetLinkStatusObserverTest extends TestCase
         $this->assertInstanceOf(SetLinkStatusObserver::class, $result);
     }
 
+    /**
+     * @return array
+     */
+    public static function pendingOrderStatesDataProvider()
+    {
+        return [
+            'holded' => [Order::STATE_HOLDED],
+            'pending_payment' => [Order::STATE_PENDING_PAYMENT],
+            'payment_review' => [Order::STATE_PAYMENT_REVIEW],
+        ];
+    }
+
+    /**
+     * An order's downloadable items have no order item id yet when this observer
+     * runs on the order's own save, before sales_order_item_save_after creates them.
+     *
+     * @param string $orderState
+     */
+    #[DataProvider('pendingOrderStatesDataProvider')]
+    public function testSetLinkStatusPendingSkipsCollectionQueryForNullItemIds($orderState)
+    {
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->atLeastOnce())
+            ->method('getState')
+            ->willReturn($orderState);
+
+        $this->orderMock->expects($this->once())
+            ->method('getAllItems')
+            ->willReturn(
+                [
+                    $this->createOrderItem(null),
+                    $this->createOrderItem(null, Item::STATUS_PENDING, null),
+                ]
+            );
+
+        $this->itemsFactory->expects($this->never())
+            ->method('create');
+
+        $result = $this->setLinkStatusObserver->execute($this->observerMock);
+        $this->assertInstanceOf(SetLinkStatusObserver::class, $result);
+    }
+
+    /**
+     * @param string $orderState
+     */
+    #[DataProvider('pendingOrderStatesDataProvider')]
+    public function testSetLinkStatusPendingQueriesCollectionForRealItemIdsOnly($orderState)
+    {
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->atLeastOnce())
+            ->method('getState')
+            ->willReturn($orderState);
+
+        $this->orderMock->expects($this->once())
+            ->method('getAllItems')
+            ->willReturn(
+                [
+                    $this->createOrderItem(null),
+                    $this->createOrderItem(2),
+                ]
+            );
+
+        $this->itemsFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->createLinkItemCollection([2], []));
+
+        $result = $this->setLinkStatusObserver->execute($this->observerMock);
+        $this->assertInstanceOf(SetLinkStatusObserver::class, $result);
+    }
+
+    public function testSetLinkStatusAvailableSkipsCollectionQueryForNullItemIds()
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->willReturn(Item::STATUS_PENDING);
+
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->atLeastOnce())
+            ->method('getState')
+            ->willReturn(Order::STATE_PROCESSING);
+
+        $this->orderMock->expects($this->once())
+            ->method('getAllItems')
+            ->willReturn(
+                [
+                    $this->createOrderItem(null, Item::STATUS_PENDING),
+                    $this->createOrderItem(null, Item::STATUS_INVOICED),
+                ]
+            );
+
+        $this->itemsFactory->expects($this->never())
+            ->method('create');
+
+        $result = $this->setLinkStatusObserver->execute($this->observerMock);
+        $this->assertInstanceOf(SetLinkStatusObserver::class, $result);
+    }
+
+    public function testSetLinkStatusAvailableQueriesCollectionForRealItemIdsOnly()
+    {
+        $this->scopeConfig->expects($this->once())
+            ->method('getValue')
+            ->willReturn(Item::STATUS_PENDING);
+
+        $this->observerMock->expects($this->once())
+            ->method('getEvent')
+            ->willReturn($this->eventMock);
+
+        $this->eventMock->expects($this->once())
+            ->method('getOrder')
+            ->willReturn($this->orderMock);
+
+        $this->orderMock->expects($this->once())
+            ->method('getId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->once())
+            ->method('getStoreId')
+            ->willReturn(1);
+
+        $this->orderMock->expects($this->atLeastOnce())
+            ->method('getState')
+            ->willReturn(Order::STATE_PROCESSING);
+
+        $this->orderMock->expects($this->once())
+            ->method('getAllItems')
+            ->willReturn(
+                [
+                    $this->createOrderItem(null, Item::STATUS_INVOICED),
+                    $this->createOrderItem(2, Item::STATUS_INVOICED),
+                ]
+            );
+
+        $this->itemsFactory->expects($this->once())
+            ->method('create')
+            ->willReturn($this->createLinkItemCollection([2], []));
+
+        $result = $this->setLinkStatusObserver->execute($this->observerMock);
+        $this->assertInstanceOf(SetLinkStatusObserver::class, $result);
+    }
+
     public function testSetLinkStatusEmptyOrder()
     {
         $this->observerMock->expects($this->once())

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
@@ -5,17 +5,6 @@
  */
 namespace Magento\Downloadable\Model\Observer;
 
-use Magento\Catalog\Api\ProductRepositoryInterface;
-use Magento\Downloadable\Model\Link\Purchased\Item;
-use Magento\Downloadable\Model\Product\Type;
-use Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\CollectionFactory;
-use Magento\Sales\Api\OrderRepositoryInterface;
-use Magento\Sales\Model\Order;
-use Magento\Sales\Model\Order\Address;
-use Magento\Sales\Model\Order\Item as OrderItem;
-use Magento\Sales\Model\Order\Payment;
-use PHPUnit\Framework\Attributes\DataProvider;
-
 /**
  * Integration test for case, when customer is able to download
  * downloadable product, after order was canceled.
@@ -23,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class SetLinkStatusObserverTest extends \PHPUnit\Framework\TestCase
 {
     /**
+     * Object manager
      * @var \Magento\Framework\ObjectManagerInterface
      */
     private $objectManager;
@@ -75,105 +65,5 @@ class SetLinkStatusObserverTest extends \PHPUnit\Framework\TestCase
                 $linkItem->getStatus()
             );
         }
-    }
-
-    /**
-     * Order items have no id yet when sales_order_save_after fires on a first order save,
-     * so a branch that keys $downloadableItemsStatuses by $item->getId() writes an unusable key.
-     * Holded's intended status equals the row's creation default, so only Pending Payment and
-     * Payment Review are distinguishing.
-     *
-     * @magentoDataFixture Magento/Downloadable/_files/product_downloadable.php
-     * @magentoDbIsolation enabled
-     */
-    #[DataProvider('firstSaveOrderStateDataProvider')]
-    public function testLinkStatusOnFirstSaveOfOrderInNonProcessingState(string $state, string $expectedLinkStatus)
-    {
-        $order = $this->saveNewOrderWithDownloadableItemInState($state);
-        $orderItem = current($order->getAllItems());
-
-        /** @var CollectionFactory $collectionFactory */
-        $collectionFactory = $this->objectManager->get(CollectionFactory::class);
-        $linkCollection = $collectionFactory->create();
-        $linkCollection->addFieldToFilter('order_item_id', $orderItem->getId());
-
-        $this->assertGreaterThan(0, $linkCollection->count());
-
-        /** @var Item $linkItem */
-        foreach ($linkCollection->getItems() as $linkItem) {
-            $this->assertEquals($expectedLinkStatus, $linkItem->getStatus());
-        }
-    }
-
-    /**
-     * @return array
-     */
-    public static function firstSaveOrderStateDataProvider(): array
-    {
-        return [
-            'pending payment' => [Order::STATE_PENDING_PAYMENT, Item::LINK_STATUS_PENDING_PAYMENT],
-            'payment review' => [Order::STATE_PAYMENT_REVIEW, Item::LINK_STATUS_PAYMENT_REVIEW],
-            'holded' => [Order::STATE_HOLDED, Item::LINK_STATUS_PENDING],
-        ];
-    }
-
-    /**
-     * @param string $state
-     * @return Order
-     */
-    private function saveNewOrderWithDownloadableItemInState(string $state): Order
-    {
-        $billingAddress = $this->objectManager->create(
-            Address::class,
-            [
-                'data' => [
-                    'firstname' => 'guest',
-                    'lastname' => 'guest',
-                    'email' => 'customer@example.com',
-                    'street' => 'street',
-                    'city' => 'Los Angeles',
-                    'region' => 'CA',
-                    'postcode' => '1',
-                    'country_id' => 'US',
-                    'telephone' => '1',
-                ],
-            ]
-        );
-        $billingAddress->setAddressType('billing');
-
-        $payment = $this->objectManager->create(Payment::class);
-        $payment->setMethod('checkmo');
-
-        /** @var ProductRepositoryInterface $productRepository */
-        $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
-        $product = $productRepository->get('downloadable-product');
-        $link = $product->getExtensionAttributes()->getDownloadableProductLinks()[0];
-
-        /** @var OrderItem $orderItem */
-        $orderItem = $this->objectManager->create(OrderItem::class);
-        $orderItem->setProductId($product->getId())
-            ->setProductType(Type::TYPE_DOWNLOADABLE)
-            ->setProductOptions(['links' => [$link->getId()]])
-            ->setBasePrice(100)
-            ->setQtyOrdered(1);
-
-        /** @var Order $order */
-        $order = $this->objectManager->create(Order::class);
-        $order->setCustomerEmail('mail@to.co')
-            ->addItem($orderItem)
-            ->setIncrementId('100000041230')
-            ->setCustomerIsGuest(true)
-            ->setStoreId(1)
-            ->setEmailSent(1)
-            ->setState($state)
-            ->setStatus($state)
-            ->setBillingAddress($billingAddress)
-            ->setPayment($payment);
-
-        /** @var OrderRepositoryInterface $orderRepository */
-        $orderRepository = $this->objectManager->get(OrderRepositoryInterface::class);
-        $orderRepository->save($order);
-
-        return $order;
     }
 }

--- a/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
+++ b/dev/tests/integration/testsuite/Magento/Downloadable/Model/Observer/SetLinkStatusObserverTest.php
@@ -5,6 +5,17 @@
  */
 namespace Magento\Downloadable\Model\Observer;
 
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Downloadable\Model\Link\Purchased\Item;
+use Magento\Downloadable\Model\Product\Type;
+use Magento\Downloadable\Model\ResourceModel\Link\Purchased\Item\CollectionFactory;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Address;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\Attributes\DataProvider;
+
 /**
  * Integration test for case, when customer is able to download
  * downloadable product, after order was canceled.
@@ -12,7 +23,6 @@ namespace Magento\Downloadable\Model\Observer;
 class SetLinkStatusObserverTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * Object manager
      * @var \Magento\Framework\ObjectManagerInterface
      */
     private $objectManager;
@@ -65,5 +75,105 @@ class SetLinkStatusObserverTest extends \PHPUnit\Framework\TestCase
                 $linkItem->getStatus()
             );
         }
+    }
+
+    /**
+     * Order items have no id yet when sales_order_save_after fires on a first order save,
+     * so a branch that keys $downloadableItemsStatuses by $item->getId() writes an unusable key.
+     * Holded's intended status equals the row's creation default, so only Pending Payment and
+     * Payment Review are distinguishing.
+     *
+     * @magentoDataFixture Magento/Downloadable/_files/product_downloadable.php
+     * @magentoDbIsolation enabled
+     */
+    #[DataProvider('firstSaveOrderStateDataProvider')]
+    public function testLinkStatusOnFirstSaveOfOrderInNonProcessingState(string $state, string $expectedLinkStatus)
+    {
+        $order = $this->saveNewOrderWithDownloadableItemInState($state);
+        $orderItem = current($order->getAllItems());
+
+        /** @var CollectionFactory $collectionFactory */
+        $collectionFactory = $this->objectManager->get(CollectionFactory::class);
+        $linkCollection = $collectionFactory->create();
+        $linkCollection->addFieldToFilter('order_item_id', $orderItem->getId());
+
+        $this->assertGreaterThan(0, $linkCollection->count());
+
+        /** @var Item $linkItem */
+        foreach ($linkCollection->getItems() as $linkItem) {
+            $this->assertEquals($expectedLinkStatus, $linkItem->getStatus());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function firstSaveOrderStateDataProvider(): array
+    {
+        return [
+            'pending payment' => [Order::STATE_PENDING_PAYMENT, Item::LINK_STATUS_PENDING_PAYMENT],
+            'payment review' => [Order::STATE_PAYMENT_REVIEW, Item::LINK_STATUS_PAYMENT_REVIEW],
+            'holded' => [Order::STATE_HOLDED, Item::LINK_STATUS_PENDING],
+        ];
+    }
+
+    /**
+     * @param string $state
+     * @return Order
+     */
+    private function saveNewOrderWithDownloadableItemInState(string $state): Order
+    {
+        $billingAddress = $this->objectManager->create(
+            Address::class,
+            [
+                'data' => [
+                    'firstname' => 'guest',
+                    'lastname' => 'guest',
+                    'email' => 'customer@example.com',
+                    'street' => 'street',
+                    'city' => 'Los Angeles',
+                    'region' => 'CA',
+                    'postcode' => '1',
+                    'country_id' => 'US',
+                    'telephone' => '1',
+                ],
+            ]
+        );
+        $billingAddress->setAddressType('billing');
+
+        $payment = $this->objectManager->create(Payment::class);
+        $payment->setMethod('checkmo');
+
+        /** @var ProductRepositoryInterface $productRepository */
+        $productRepository = $this->objectManager->get(ProductRepositoryInterface::class);
+        $product = $productRepository->get('downloadable-product');
+        $link = $product->getExtensionAttributes()->getDownloadableProductLinks()[0];
+
+        /** @var OrderItem $orderItem */
+        $orderItem = $this->objectManager->create(OrderItem::class);
+        $orderItem->setProductId($product->getId())
+            ->setProductType(Type::TYPE_DOWNLOADABLE)
+            ->setProductOptions(['links' => [$link->getId()]])
+            ->setBasePrice(100)
+            ->setQtyOrdered(1);
+
+        /** @var Order $order */
+        $order = $this->objectManager->create(Order::class);
+        $order->setCustomerEmail('mail@to.co')
+            ->addItem($orderItem)
+            ->setIncrementId('100000041230')
+            ->setCustomerIsGuest(true)
+            ->setStoreId(1)
+            ->setEmailSent(1)
+            ->setState($state)
+            ->setStatus($state)
+            ->setBillingAddress($billingAddress)
+            ->setPayment($payment);
+
+        /** @var OrderRepositoryInterface $orderRepository */
+        $orderRepository = $this->objectManager->get(OrderRepositoryInterface::class);
+        $orderRepository->save($order);
+
+        return $order;
     }
 }


### PR DESCRIPTION
### Description

`Magento\Downloadable\Observer\SetLinkStatusObserver` runs on `sales_order_save_after` and keys `$downloadableItemsStatuses` by `$item->getId()`. That event is dispatched from `Magento\Framework\Model\ResourceModel\Db\VersionControl\AbstractDb::processAfterSaves()` before `entityRelationComposite->processRelations()`, and order item ids are assigned only in `Magento\Sales\Model\ResourceModel\Order\Relation::processRelation()` — so on an order's first save every item still has a null id.

The canceled/closed/complete branch already guards this: commit `c7d24c7bc23` ("AC-16521: Unable to place an order with Downloadable products and online payment in capture mode") introduced `$itemId = $item->getId(); if ($itemId !== null)` there. Three sites were left unguarded: the offset write at line 119 and the `$expiredOrderItemIds[] = $item->getId()` append at line 123 in the `else` branch, and the offset write at line 133 in the `if (!$downloadableItemsStatuses && $status)` fallback, which is reached whenever an order's state at its first save is `pending_payment`, `holded` or `payment_review`.

Two consequences:

- On PHP 8.5, using null as an array offset is deprecated (`Using null as an array offset is deprecated, use an empty string instead`). On installations where deprecations are promoted to exceptions, this propagates through `OrderRepository::save()` and aborts placement of any order containing a downloadable item that takes one of those paths.
- On earlier versions the write is silent but useless: the null key collapses to an empty string, so the purchased-items collection is filtered by `order_item_id IN ('')` and the expired-items collection by `IN (null)`. Neither can match a row.

This change applies the existing AC-16521 guard shape to the three remaining sites. No branch logic, status resolution or ordering is changed.

Worth stating plainly, because the issue description implies more: the guard does not change which status a link row ends up with. `SaveDownloadableOrderItemObserver`, which creates the `downloadable_link_purchased_item` rows, is wired to `sales_order_item_save_after` and therefore runs after this observer, setting `pending` or `available`; the payment-state statuses are applied on a later save of the order, once item ids exist. What this PR fixes is the null offset itself — the PHP 8.5 fatal, and the two queries that can never match.

### Fixed Issues

Fixes magento/magento2#41230

### Manual testing scenarios

1. On PHP 8.5 with deprecations promoted to exceptions, place an order containing a downloadable product with a payment flow that leaves the order in Pending Payment at placement (Holded or Payment Review at first save behave the same).
2. Before: placement fails, and `var/log/exception.log` shows `Using null as an array offset is deprecated, use an empty string instead` from `SetLinkStatusObserver::execute()`. After: the order is placed.
3. On PHP 8.3/8.4, enable query logging and place the same order. Before: a purchased-items query filtered by `order_item_id IN ('')`. After: no such query is issued.

### Questions or comments

The first commit added an integration test asserting the link row's final status. That expectation was wrong — those statuses are not reachable at this event, for the reason described above — so the second commit reverts it and replaces it with unit coverage of what the guard actually guarantees. The integration test file is byte-identical to `2.4-develop` again and does not appear in this PR's diff.

Unit tests added to the existing `Magento\Downloadable\Test\Unit\Observer\SetLinkStatusObserverTest`, reusing its `createOrderItem()`/`createLinkItemCollection()` helpers: for the fallback path (`holded`, `pending_payment`, `payment_review` via a data provider) and for the `else` path, items with null ids must not cause the purchased-items collection to be created at all, and a mix of null and real ids must reach the collection filtered by the real ids only.

Verified red against the unguarded observer and green with the guard:

```
# upstream/2.4-develop observer, new tests present
Tests: 15, Assertions: 60, Failures: 8

# with the guard
Tests: 15, Assertions: 98  (OK)
```

The failure diff on the unguarded run shows the collapse directly: `- 0 => 2` / `+ 0 => ''` / `+ 1 => 2`.

Gates run locally against `upstream/2.4-develop`: module unit suite 205 tests green, PHPCS 0 errors 0 warnings on both touched files, PHPStan no errors, static/LiveCodeTest green (2 skips reproduce on a clean checkout). The Semantic Version Checker helper flags only the new public test methods in the unit test class.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)
