### PR TITLE
Correct EditorConfig rules for generated whitelist and patch files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,15 +8,15 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,diff,patch}]
 trim_trailing_whitespace = false
 
 [*.{yml,yaml,json}]
 indent_size = 2
 
-[{composer,auth}.json]
+[{composer,auth,patches}.json]
 indent_size = 4
 
 [db_schema_whitelist.json]
 indent_size = 4
-trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
### Description

This pull request updates `.editorconfig` rules for file types used in Magento development:

- Preserves trailing whitespace in Markdown, `.patch`, and `.diff` files.
- Uses four-space indentation for `composer.json`, `auth.json`, and `patches.json`.
- Replaces the incorrect trailing-whitespace override for `db_schema_whitelist.json` with a final-newline rule.

[Adobe Commerce documentation](https://experienceleague.adobe.com/en/docs/commerce-operations/upgrade-guide/patches/overview) describes both `.patch` and `.diff` files and warns that automatic trailing-whitespace removal can break them. In the [unified diff format](https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html), an unchanged line starts with a space. If the unchanged source line is empty, the patch line contains only this one space. Trimming it removes the required context marker. Patch files can also represent source files with intentional trailing spaces, so their line content should remain as generated.

Adobe [documents `cweagans/composer-patches`](https://experienceleague.adobe.com/en/docs/commerce-operations/upgrade-guide/patches/apply) as an option for applying custom patches with Composer. Composer patch-file conventions include:

- [`cweagans/composer-patches` 1.7.3](https://github.com/cweagans/composer-patches/blob/1.7.3/README.md#using-an-external-patch-file): uses `composer.patches.json` as an example filename.
- [`cweagans/composer-patches` 2.0.0](https://github.com/cweagans/composer-patches/blob/2.0.0/docs/usage/configuration.md#patches-file): uses `patches.json` as the default filename.
- [`vaimo/composer-patches`](https://github.com/vaimo/composer-patches/blob/master/docs/USAGE_BASIC.md#declaration-patchesjson): documents `patches.json` and supports custom or multiple filenames.

Since current Composer patch tools use or document `patches.json`, this pull request proposes it as the standard external patch definitions filename for Magento projects. The explicit EditorConfig rule provides four-space indentation for this file without changing indentation for all JSON files.

The existing `trim_trailing_whitespace = false` setting for `db_schema_whitelist.json` was introduced by [PR #31166](https://github.com/magento/magento2/pull/31166) to prevent editors from adding a final newline. However, this property controls spaces before line endings and does not override the inherited `insert_final_newline = true` setting. Magento [generates this file with the CLI](https://developer.adobe.com/commerce/php/development/components/declarative-schema/migration-scripts/#create-a-schema-whitelist), and [`JsonPersistor`](https://github.com/magento/magento2/blob/2.4-develop/lib/internal/Magento/Framework/Setup/JsonPersistor.php#L22) writes the formatted JSON without appending a newline. Using `insert_final_newline = false` corrects the earlier configuration and keeps the generated output unchanged when the file is saved in an editor.

### Related Pull Requests

- [magento/magento2#31166](https://github.com/magento/magento2/pull/31166) introduced the `db_schema_whitelist.json` rule corrected by this pull request.

### Fixed Issues (if relevant)

N/A

### Manual testing scenarios

1. Open a `.patch` or `.diff` file containing an empty unchanged line, save it, and verify that its single space context marker remains.
2. Open `patches.json` and verify that the editor uses four-space indentation.
3. Open `db_schema_whitelist.json` and verify that the editor does not add a final newline.

### Questions or comments

Do maintainers agree with using `patches.json` as the standard external patch definitions filename for Magento projects?

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41241: Correct EditorConfig rules for generated whitelist and patch files