### PR TITLE
Invalidate cached cmsPage GraphQL response when a widget-embedded product changes

### DIFF
--- a/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Page.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/DataProvider/Page.php
@@ -10,9 +10,12 @@ namespace Magento\CmsGraphQl\Model\Resolver\DataProvider;
 use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Api\GetPageByIdentifierInterface;
 use Magento\Cms\Api\PageRepositoryInterface;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\View\LayoutInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 
 /**
@@ -20,6 +23,11 @@ use Magento\Widget\Model\Template\FilterEmulate;
  */
 class Page
 {
+    /**
+     * Resolved-data key carrying cache tags of entities rendered by widgets inside the page content.
+     */
+    public const WIDGET_IDENTITIES = 'widget_identities';
+
     /**
      * @var GetPageByIdentifierInterface
      */
@@ -36,19 +44,27 @@ class Page
     private FilterEmulate $widgetFilter;
 
     /**
+     * @var LayoutInterface
+     */
+    private LayoutInterface $layout;
+
+    /**
      * @param PageRepositoryInterface $pageRepository
      * @param FilterEmulate $widgetFilter
      * @param GetPageByIdentifierInterface $getPageByIdentifier
+     * @param LayoutInterface|null $layout
      */
     public function __construct(
         PageRepositoryInterface $pageRepository,
         FilterEmulate $widgetFilter,
-        GetPageByIdentifierInterface $getPageByIdentifier
+        GetPageByIdentifierInterface $getPageByIdentifier,
+        ?LayoutInterface $layout = null
     ) {
 
         $this->pageRepository = $pageRepository;
         $this->widgetFilter = $widgetFilter;
         $this->pageByIdentifier = $getPageByIdentifier;
+        $this->layout = $layout ?? ObjectManager::getInstance()->get(LayoutInterface::class);
     }
 
     /**
@@ -105,11 +121,34 @@ class Page
             PageInterface::META_DESCRIPTION => $page->getMetaDescription(),
             PageInterface::META_KEYWORDS => $page->getMetaKeywords(),
             PageInterface::PAGE_ID => $page->getId(),
-            PageInterface::IDENTIFIER => $page->getIdentifier()
+            PageInterface::IDENTIFIER => $page->getIdentifier(),
+            self::WIDGET_IDENTITIES => []
         ];
         if (empty($fields) || in_array(PageInterface::CONTENT, $fields)) {
+            $blocksBefore = $this->layout->getAllBlocks();
             $pageData[PageInterface::CONTENT] = $this->widgetFilter->filter($page->getContent());
+            $pageData[self::WIDGET_IDENTITIES] = $this->collectWidgetIdentities($blocksBefore);
         }
         return $pageData;
+    }
+
+    /**
+     * Collect cache tags of the widget blocks rendered while filtering the page content.
+     *
+     * Mirrors how FPC tags a page (see PageCache\Model\Layout\LayoutPlugin), so disabling/saving a product
+     * shown by an embedded widget invalidates the cached GraphQL response as well.
+     *
+     * @param array $blocksBefore Blocks already in the shared layout before the content was rendered
+     * @return string[]
+     */
+    private function collectWidgetIdentities(array $blocksBefore): array
+    {
+        $identities = [];
+        foreach (array_diff_key($this->layout->getAllBlocks(), $blocksBefore) as $block) {
+            if ($block instanceof IdentityInterface) {
+                $identities[] = $block->getIdentities();
+            }
+        }
+        return $identities ? array_values(array_unique(array_merge([], ...$identities))) : [];
     }
 }

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Page/Identity.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Page/Identity.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Magento\CmsGraphQl\Model\Resolver\Page;
 
 use Magento\Cms\Api\Data\PageInterface;
+use Magento\CmsGraphQl\Model\Resolver\DataProvider\Page as PageDataProvider;
 use Magento\Framework\GraphQl\Query\Resolver\IdentityInterface;
 
 /**
@@ -26,7 +27,12 @@ class Identity implements IdentityInterface
      */
     public function getIdentities(array $resolvedData): array
     {
-        return empty($resolvedData[PageInterface::PAGE_ID]) ?
-            [] : [$this->cacheTag, sprintf('%s_%s', $this->cacheTag, $resolvedData[PageInterface::PAGE_ID])];
+        if (empty($resolvedData[PageInterface::PAGE_ID])) {
+            return [];
+        }
+        return array_merge(
+            [$this->cacheTag, sprintf('%s_%s', $this->cacheTag, $resolvedData[PageInterface::PAGE_ID])],
+            $resolvedData[PageDataProvider::WIDGET_IDENTITIES] ?? []
+        );
     }
 }

--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Page/ResolverCacheIdentity.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Page/ResolverCacheIdentity.php
@@ -9,6 +9,7 @@ namespace Magento\CmsGraphQl\Model\Resolver\Page;
 
 use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Model\Page;
+use Magento\CmsGraphQl\Model\Resolver\DataProvider\Page as PageDataProvider;
 use Magento\GraphQlResolverCache\Model\Resolver\Result\Cache\IdentityInterface;
 
 /**
@@ -26,7 +27,12 @@ class ResolverCacheIdentity implements IdentityInterface
      */
     public function getIdentities($resolvedData, ?array $parentResolvedData = null): array
     {
-        return empty($resolvedData[PageInterface::PAGE_ID]) ?
-            [] : [sprintf('%s_%s', $this->cacheTag, $resolvedData[PageInterface::PAGE_ID])];
+        if (empty($resolvedData[PageInterface::PAGE_ID])) {
+            return [];
+        }
+        return array_merge(
+            [sprintf('%s_%s', $this->cacheTag, $resolvedData[PageInterface::PAGE_ID])],
+            $resolvedData[PageDataProvider::WIDGET_IDENTITIES] ?? []
+        );
     }
 }

--- a/app/code/Magento/CmsGraphQl/Test/Unit/Model/Resolver/DataProvider/PageTest.php
+++ b/app/code/Magento/CmsGraphQl/Test/Unit/Model/Resolver/DataProvider/PageTest.php
@@ -11,8 +11,10 @@ use Magento\Cms\Api\Data\PageInterface;
 use Magento\Cms\Api\GetPageByIdentifierInterface;
 use Magento\Cms\Api\PageRepositoryInterface;
 use Magento\CmsGraphQl\Model\Resolver\DataProvider\Page;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\View\LayoutInterface;
 use Magento\Widget\Model\Template\FilterEmulate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +37,11 @@ class PageTest extends TestCase
     private FilterEmulate $widgetFilterMock;
 
     /**
+     * @var LayoutInterface|MockObject
+     */
+    private LayoutInterface $layoutMock;
+
+    /**
      * @var Page
      */
     private Page $page;
@@ -44,11 +51,14 @@ class PageTest extends TestCase
         $this->pageRepositoryMock = $this->createMock(PageRepositoryInterface::class);
         $this->widgetFilterMock = $this->createMock(FilterEmulate::class);
         $this->pageByIdentifierMock = $this->createMock(GetPageByIdentifierInterface::class);
+        $this->layoutMock = $this->createMock(LayoutInterface::class);
+        $this->layoutMock->method('getAllBlocks')->willReturn([]);
 
         $this->page = new Page(
             $this->pageRepositoryMock,
             $this->widgetFilterMock,
-            $this->pageByIdentifierMock
+            $this->pageByIdentifierMock,
+            $this->layoutMock
         );
     }
 
@@ -312,6 +322,7 @@ class PageTest extends TestCase
             PageInterface::META_KEYWORDS => 'Meta Keywords',
             PageInterface::PAGE_ID => 1,
             PageInterface::IDENTIFIER => 'page-identifier',
+            Page::WIDGET_IDENTITIES => [],
         ];
 
         if ($content !== null) {
@@ -319,5 +330,34 @@ class PageTest extends TestCase
         }
 
         return $data;
+    }
+
+    /**
+     * Content rendered by a widget contributes that widget's cache tags to the resolved data,
+     * so the cached CMS page is invalidated when the embedded entity changes.
+     *
+     * @return void
+     */
+    public function testWidgetIdentitiesAreCollectedFromRenderedContent(): void
+    {
+        $this->pageRepositoryMock->method('getById')->with(1)->willReturn($this->getActivePageMock());
+        $this->widgetFilterMock->method('filter')->with('page content')->willReturn('filtered page content');
+
+        $widgetBlock = $this->createMock(IdentityInterface::class);
+        $widgetBlock->method('getIdentities')->willReturn(['cat_p_42', 'cat_p']);
+
+        // No blocks before rendering; the widget block appears afterwards.
+        $layoutMock = $this->createMock(LayoutInterface::class);
+        $layoutMock->method('getAllBlocks')->willReturnOnConsecutiveCalls([], ['products_widget' => $widgetBlock]);
+        $page = new Page(
+            $this->pageRepositoryMock,
+            $this->widgetFilterMock,
+            $this->pageByIdentifierMock,
+            $layoutMock
+        );
+
+        $result = $page->getDataByPageId(1);
+
+        self::assertSame(['cat_p_42', 'cat_p'], $result[Page::WIDGET_IDENTITIES]);
     }
 }


### PR DESCRIPTION
### Description

A CMS page whose PageBuilder content contains a Catalog "Products" widget is served by the `cmsPage` GraphQL query. `Magento\CmsGraphQl\Model\Resolver\DataProvider\Page` renders the widget content into HTML via `widgetFilter->filter()`, but the cache identities for the resolved page (`Page\ResolverCacheIdentity` for the GraphQL resolver cache and `Page\Identity` for FPC) only emitted `cms_p_<pageId>`. They carried no tags for the products embedded in the rendered widgets.

As a result, disabling (or saving) a product shown by an embedded widget cleaned that product's `catalog_product_<id>` tag, but the cached `cmsPage` response was tagged only with the CMS page id, so it was never invalidated — the disabled product kept appearing in the GraphQL response. The Luma storefront reflects the change correctly because FPC aggregates every rendered block's `getIdentities()` for the page (see `Magento\PageCache\Model\Layout\LayoutPlugin::afterGetOutput`); the GraphQL path renders through `widgetFilter->filter()` and discarded those block identities.

This change collects the cache tags of the widget blocks created while filtering the page content (diffing the shared layout's blocks around the `filter()` call and reading `getIdentities()` from any new block implementing `Magento\Framework\DataObject\IdentityInterface`), and carries them on the resolved data under a new internal key. Both identity classes then merge those tags into the identities they emit. So disabling/saving a product rendered by an embedded widget now invalidates the cached page, on both the resolver cache and FPC.

Notes:
- The tags are stored in the resolved data (not recomputed from the layout in the identity classes) because on a resolver-cache hit no widget renders, yet the FPC identity still runs against the cached payload — the tags must be persisted inside it to survive that path.
- The widget block's tags are used verbatim, including the `catalog_product` fallback an empty product list returns, matching how FPC tags the same page.
- The identical gap exists for `cmsBlocks` (`DataProvider\Block` + its identity classes); that is separate, non-shared code and is left for a follow-up to keep this change focused on the reported `cmsPage` scenario.

### Related Issue

Fixes #39760

### Manual testing scenarios

1. Create a CMS page and add a PageBuilder "Products" widget (no condition) that includes at least one product.
2. Run the `cmsPage` GraphQL query (GET) requesting `content` — the product appears in the rendered content.
3. Disable one of those products.
4. Run the same `cmsPage` query again.
   - Before this change: the disabled product still appears (stale cached response).
   - After this change: the response is regenerated and the disabled product is gone.

### Questions or comments

None.

### Contribution checklist

- [x] Pull request has a meaningful description of its purpose
- [x] All existing and new tests pass
- [x] Static tests pass
- [x] Ensured backward compatibility