### PR TITLE
Speed up setup:di:compile by removing repeated di.xml parsing

### DIFF
--- a/lib/internal/Magento/Framework/ObjectManager/Config/Reader/Dom.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Config/Reader/Dom.php
@@ -5,7 +5,8 @@
  */
 namespace Magento\Framework\ObjectManager\Config\Reader;
 
-class Dom extends \Magento\Framework\Config\Reader\Filesystem
+class Dom extends \Magento\Framework\Config\Reader\Filesystem implements
+    \Magento\Framework\ObjectManager\ResetAfterRequestInterface
 {
     /**
      * Name of an attribute that stands for data type of node values
@@ -53,6 +54,49 @@ class Dom extends \Magento\Framework\Config\Reader\Filesystem
             $domDocumentClass,
             $defaultScope
         );
+    }
+
+    /**
+     * Parsed configuration per scope, memoized for the lifetime of this reader.
+     *
+     * Reading a scope re-parses and DOM-merges every di.xml that contributes to it (~250 files
+     * and ~12k nodes for 'global'), and several consumers ask the same reader for the same scope
+     * during one setup:di:compile. The cache is per instance on purpose: a result depends on this
+     * reader's file resolver, merge rules, schema and validation state, so two differently
+     * configured readers must never see each other's results.
+     *
+     * @var array
+     */
+    private $scopeCache = [];
+
+    /**
+     * Read configuration for the given scope, parsing each scope at most once per reader.
+     *
+     * @param string|null $scope
+     * @return array
+     */
+    public function read($scope = null)
+    {
+        // Normalise exactly as the parent does, so read() and read($defaultScope) share an entry.
+        $scope = $scope ?: $this->_defaultScope;
+        if (!array_key_exists($scope, $this->scopeCache)) {
+            $this->scopeCache[$scope] = parent::read($scope);
+        }
+
+        return $this->scopeCache[$scope];
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * The parsed scopes are held for the lifetime of this reader, which is shared and long-lived:
+     * app/etc/di.xml wires it into the configuration loader, the interception config and the
+     * plugin list. That is fine for a command, but a long-running process should not carry a
+     * request's parsed configuration into the next one.
+     */
+    public function _resetState(): void
+    {
+        $this->scopeCache = [];
     }
 
     /**

--- a/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/Reader/DomTest.php
+++ b/lib/internal/Magento/Framework/ObjectManager/Test/Unit/Config/Reader/DomTest.php
@@ -71,4 +71,83 @@ class DomTest extends TestCase
         $this->converterMock->expects($this->once())->method('convert')->with('reader dom result');
         $this->model->read();
     }
+
+    /**
+     * Repeated reads of one scope must parse the configuration only once.
+     */
+    public function testReadParsesEachScopeOnce()
+    {
+        $this->fileResolverMock->expects($this->once())->method('get')->willReturn(['first content item']);
+        $this->converterMock->expects($this->once())->method('convert')->willReturn(['converted']);
+
+        $first = $this->model->read('global');
+        $second = $this->model->read('global');
+
+        $this->assertSame(['converted'], $first);
+        $this->assertSame($first, $second);
+    }
+
+    /**
+     * read() and read($defaultScope) address the same scope and must share one parse.
+     */
+    public function testReadNormalizesTheDefaultScope()
+    {
+        $model = new Dom(
+            $this->fileResolverMock,
+            $this->converterMock,
+            $this->schemaLocatorMock,
+            $this->validationStateMock,
+            'filename.xml',
+            [],
+            '\ConfigDomMock',
+            'frontend'
+        );
+        $this->fileResolverMock->expects($this->once())
+            ->method('get')
+            ->with('filename.xml', 'frontend')
+            ->willReturn(['first content item']);
+        $this->converterMock->expects($this->once())->method('convert')->willReturn(['converted']);
+
+        $this->assertSame(['converted'], $model->read());
+        $this->assertSame(['converted'], $model->read('frontend'));
+    }
+
+    /**
+     * Two readers may be configured differently, so one must never serve the other's result.
+     */
+    public function testReadIsNotSharedBetweenInstances()
+    {
+        $otherResolver = $this->createMock(FileResolverInterface::class);
+        $otherConverter = $this->createMock(\Magento\Framework\ObjectManager\Config\Mapper\Dom::class);
+        $other = new Dom(
+            $otherResolver,
+            $otherConverter,
+            $this->schemaLocatorMock,
+            $this->validationStateMock,
+            'filename.xml',
+            [],
+            '\ConfigDomMock'
+        );
+
+        $this->fileResolverMock->expects($this->once())->method('get')->willReturn(['first content item']);
+        $this->converterMock->expects($this->once())->method('convert')->willReturn(['from first reader']);
+        $otherResolver->expects($this->once())->method('get')->willReturn(['first content item']);
+        $otherConverter->expects($this->once())->method('convert')->willReturn(['from second reader']);
+
+        $this->assertSame(['from first reader'], $this->model->read('global'));
+        $this->assertSame(['from second reader'], $other->read('global'));
+    }
+
+    /**
+     * A long-running process must not carry one request's parsed configuration into the next.
+     */
+    public function testResetStateDropsTheMemoizedScopes()
+    {
+        $this->fileResolverMock->expects($this->exactly(2))->method('get')->willReturn(['first content item']);
+        $this->converterMock->expects($this->exactly(2))->method('convert')->willReturn(['converted']);
+
+        $this->assertSame(['converted'], $this->model->read('global'));
+        $this->model->_resetState();
+        $this->assertSame(['converted'], $this->model->read('global'), 'the scope should be parsed again');
+    }
 }


### PR DESCRIPTION
### Description (*)

Reading a di.xml scope re-parses and DOM-merges every file that contributes to it — 254 files and about 12k nodes for `global` on a stock install, roughly 0.6s. During one `setup:di:compile` that read happens **five times for `global` alone**, from four independent call sites that never share a result: the object manager bootstrap, the interception configuration builder, the interception cache, and the area configuration reader.

`ObjectManager\Config\Reader\Dom` now memoizes its parsed result per scope, normalising the scope exactly as `Config\Reader\Filesystem::read()` does so `read()` and `read($defaultScope)` share an entry.

**The cache is per instance on purpose.** A result depends on the reader's file resolver, merge rules, schema and validation state, so two differently configured readers must never see each other's results, and a cached unvalidated read must never satisfy a reader that asked for validation.

`app/etc/di.xml` wires this reader into the configuration loader, the interception config and the plugin list, all of which outlive a single scope read — so the parsed scopes would otherwise be held for the lifetime of the process. The reader implements `ResetAfterRequestInterface` to drop them, for application server mode and other long-running processes.

#### Measurements

Clean install, 337 modules, cold `generated/`, best of three, idle machine:

| | |
| --- | ---: |
| before | 13.63s |
| after | **8.89s** |

Generated output is byte-identical — every metadata file and every interceptor, verified by checksum.

### Related Pull Requests

The parallel-compilation half of the original change has been split into a follow-up so this one can be reviewed on its own. It is on `qoliber/di-compile-parallel` and adds worker processes for area configuration and interceptor generation (8.89s → 6.95s), which raises questions this PR does not — inherited connections across `fork()`, worker budgets under cgroup quotas, and failure reporting from a child. Those belong in their own review.

### Fixed Issues (if relevant)

None linked; found by profiling.

### Manual testing scenarios (*)

1. `rm -rf generated/code generated/metadata && time bin/magento setup:di:compile`
   `find generated -name '*.php' | sort | xargs md5sum > /tmp/before.txt`
2. Apply this branch, repeat, writing `/tmp/after.txt`.
3. `diff /tmp/before.txt /tmp/after.txt` — expect no differences, and a faster compile.
4. `bin/magento cache:flush`, then load a storefront page and the admin to confirm the compiled config is sound.

### Questions or comments

- The memoization is what makes the compile faster, and retaining the parsed scopes is inseparable from it; `_resetState()` caps that for long-running processes rather than removing the trade.
- While profiling this I noticed `DiCompileCommand::configureObjectManager()` injects `excludePatterns` — containing the absolute install path — into `ClassesScanner`, and that argument is serialized into all seven compiled area configs. It makes the compiled output non-reproducible across build paths. Out of scope here, but happy to raise it separately.

Thanks to the Mage-OS reviewers on mage-os/mageos-magento2#338, whose review of the original combined branch prompted this split.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any README.md predefined sections require an update
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41265: Speed up setup:di:compile by removing repeated di.xml parsing