### PR TITLE
Fix GraphQL Content-Currency validation against the store named by the Store header (#41242)

### DIFF
--- a/app/code/Magento/DirectoryGraphQl/Controller/HttpRequestValidator/CurrencyValidator.php
+++ b/app/code/Magento/DirectoryGraphQl/Controller/HttpRequestValidator/CurrencyValidator.php
@@ -44,11 +44,11 @@ class CurrencyValidator implements HttpRequestValidatorInterface
         try {
             $headerValue = $request->getHeader('Content-Currency');
             if (!empty($headerValue)) {
-                $headerCurrency = strtoupper(ltrim(rtrim($headerValue)));
+                $headerCurrency = strtoupper(trim($headerValue));
                 $storeCode = $request->getHeader('Store');
                 /** @var \Magento\Store\Model\Store $currentStore */
                 $currentStore = !empty($storeCode)
-                    ? $this->storeManager->getStore(ltrim(rtrim($storeCode)))
+                    ? $this->storeManager->getStore(trim($storeCode))
                     : $this->storeManager->getStore();
                 if (!in_array($headerCurrency, $currentStore->getAvailableCurrencyCodes(true))) {
                     throw new GraphQlInputException(

--- a/app/code/Magento/DirectoryGraphQl/Controller/HttpRequestValidator/CurrencyValidator.php
+++ b/app/code/Magento/DirectoryGraphQl/Controller/HttpRequestValidator/CurrencyValidator.php
@@ -10,6 +10,7 @@ namespace Magento\DirectoryGraphQl\Controller\HttpRequestValidator;
 use Magento\Framework\App\HttpRequestInterface;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\GraphQl\Controller\HttpRequestValidatorInterface;
+use Magento\Store\Model\StoreIsInactiveException;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
@@ -44,15 +45,18 @@ class CurrencyValidator implements HttpRequestValidatorInterface
             $headerValue = $request->getHeader('Content-Currency');
             if (!empty($headerValue)) {
                 $headerCurrency = strtoupper(ltrim(rtrim($headerValue)));
+                $storeCode = $request->getHeader('Store');
                 /** @var \Magento\Store\Model\Store $currentStore */
-                $currentStore = $this->storeManager->getStore();
+                $currentStore = !empty($storeCode)
+                    ? $this->storeManager->getStore(ltrim(rtrim($storeCode)))
+                    : $this->storeManager->getStore();
                 if (!in_array($headerCurrency, $currentStore->getAvailableCurrencyCodes(true))) {
                     throw new GraphQlInputException(
                         __('Please correct the target currency')
                     );
                 }
             }
-        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        } catch (\Magento\Framework\Exception\NoSuchEntityException | StoreIsInactiveException $e) {
             $this->storeManager->setCurrentStore(null);
             throw new GraphQlInputException(
                 __("Requested store is not found")

--- a/app/code/Magento/DirectoryGraphQl/Test/Unit/Controller/HttpRequestValidator/CurrencyValidatorTest.php
+++ b/app/code/Magento/DirectoryGraphQl/Test/Unit/Controller/HttpRequestValidator/CurrencyValidatorTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\DirectoryGraphQl\Test\Unit\Controller\HttpRequestValidator;
+
+use Magento\DirectoryGraphQl\Controller\HttpRequestValidator\CurrencyValidator;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreIsInactiveException;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+
+class CurrencyValidatorTest extends TestCase
+{
+    /** @var StoreManagerInterface&MockObject */
+    private StoreManagerInterface $storeManager;
+
+    /** @var Http&Stub */
+    private Http $request;
+
+    /** @var CurrencyValidator */
+    private CurrencyValidator $model;
+
+    protected function setUp(): void
+    {
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->request = $this->createStub(Http::class);
+        $this->model = new CurrencyValidator($this->storeManager);
+    }
+
+    public function testStoreHeaderCurrencyAllowedOnRequestedStoreOnly(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'NOK'],
+                ['Store', 'website_a_store'],
+            ]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getAvailableCurrencyCodes')->with(true)->willReturn(['NOK', 'EUR']);
+
+        $this->storeManager->expects($this->once())
+            ->method('getStore')
+            ->with('website_a_store')
+            ->willReturn($store);
+
+        $this->model->validate($this->request);
+    }
+
+    public function testStoreHeaderCurrencyNotAllowedOnRequestedStore(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'NOK'],
+                ['Store', 'website_a_store'],
+            ]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getAvailableCurrencyCodes')->with(true)->willReturn(['EUR', 'USD']);
+
+        $this->storeManager->method('getStore')->with('website_a_store')->willReturn($store);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Please correct the target currency');
+
+        $this->model->validate($this->request);
+    }
+
+    public function testNoStoreHeaderCurrencyAllowedOnCurrentStore(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'USD'],
+                ['Store', null],
+            ]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getAvailableCurrencyCodes')->with(true)->willReturn(['USD', 'EUR']);
+
+        $this->storeManager->expects($this->once())
+            ->method('getStore')
+            ->with()
+            ->willReturn($store);
+
+        $this->model->validate($this->request);
+    }
+
+    public function testNoStoreHeaderCurrencyNotAllowed(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'NOK'],
+                ['Store', null],
+            ]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getAvailableCurrencyCodes')->with(true)->willReturn(['USD', 'EUR']);
+
+        $this->storeManager->method('getStore')->with()->willReturn($store);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Please correct the target currency');
+
+        $this->model->validate($this->request);
+    }
+
+    public function testStoreHeaderNamesNonExistentStore(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'NOK'],
+                ['Store', 'unknown_store'],
+            ]);
+
+        $this->storeManager->method('getStore')
+            ->with('unknown_store')
+            ->willThrowException(new NoSuchEntityException(__('Requested store is not found')));
+
+        $this->storeManager->expects($this->once())->method('setCurrentStore')->with(null);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Requested store is not found');
+
+        $this->model->validate($this->request);
+    }
+
+    public function testStoreHeaderNamesInactiveStore(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', 'NOK'],
+                ['Store', 'inactive_store'],
+            ]);
+
+        $this->storeManager->method('getStore')
+            ->with('inactive_store')
+            ->willThrowException(new StoreIsInactiveException(__('Store is inactive')));
+
+        $this->storeManager->expects($this->once())->method('setCurrentStore')->with(null);
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Requested store is not found');
+
+        $this->model->validate($this->request);
+    }
+
+    public function testEmptyCurrencyHeaderSkipsStoreLookup(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', ''],
+                ['Store', 'website_a_store'],
+            ]);
+
+        $this->storeManager->expects($this->never())->method('getStore');
+
+        $this->model->validate($this->request);
+    }
+
+    public function testCurrencyHeaderIsNormalizedBeforeCheck(): void
+    {
+        $this->request->method('getHeader')
+            ->willReturnMap([
+                ['Content-Currency', ' nok '],
+                ['Store', 'website_a_store'],
+            ]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getAvailableCurrencyCodes')->with(true)->willReturn(['NOK']);
+
+        $this->storeManager->method('getStore')->with('website_a_store')->willReturn($store);
+
+        $this->model->validate($this->request);
+    }
+}

--- a/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CurrencyHeaderValidationTest.php
+++ b/dev/tests/api-functional/testsuite/Magento/GraphQl/Directory/CurrencyHeaderValidationTest.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\GraphQl\Directory;
+
+use Magento\Catalog\Helper\Data;
+use Magento\Config\App\Config\Type\System;
+use Magento\Config\Model\ResourceModel\Config as ConfigResource;
+use Magento\Directory\Model\Currency;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Test\Fixture\Group as StoreGroupFixture;
+use Magento\Store\Test\Fixture\Store as StoreFixture;
+use Magento\Store\Test\Fixture\Website as WebsiteFixture;
+use Magento\TestFramework\Fixture\Config;
+use Magento\TestFramework\Fixture\DataFixture;
+use Magento\TestFramework\Fixture\DataFixtureStorage;
+use Magento\TestFramework\Fixture\DataFixtureStorageManager;
+use Magento\TestFramework\Helper\Bootstrap;
+use Magento\TestFramework\TestCase\GraphQlAbstract;
+
+#[
+    Config(Data::XML_PATH_PRICE_SCOPE, Data::PRICE_SCOPE_WEBSITE),
+    DataFixture(WebsiteFixture::class, as: 'website'),
+    DataFixture(StoreGroupFixture::class, ['website_id' => '$website.id$'], 'group'),
+    DataFixture(StoreFixture::class, ['store_group_id' => '$group.id$'], 'store'),
+]
+class CurrencyHeaderValidationTest extends GraphQlAbstract
+{
+    private const QUERY = <<<QUERY
+    {
+        storeConfig {
+            store_code
+            base_currency_code
+            default_display_currency_code
+        }
+    }
+    QUERY;
+
+    /**
+     * @var DataFixtureStorage
+     */
+    private $fixtures;
+
+    /**
+     * @var int
+     */
+    private $websiteId;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        $this->fixtures = DataFixtureStorageManager::getStorage();
+        $this->websiteId = (int) $this->fixtures->get('website')->getId();
+
+        $configResource = Bootstrap::getObjectManager()->get(ConfigResource::class);
+        $configResource->saveConfig(
+            Currency::XML_PATH_CURRENCY_ALLOW,
+            'NOK',
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        $configResource->saveConfig(
+            Currency::XML_PATH_CURRENCY_BASE,
+            'NOK',
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        $configResource->saveConfig(
+            Currency::XML_PATH_CURRENCY_DEFAULT,
+            'NOK',
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        Bootstrap::getObjectManager()->get(System::class)->clean();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function tearDown(): void
+    {
+        $configResource = Bootstrap::getObjectManager()->get(ConfigResource::class);
+        $configResource->deleteConfig(
+            Currency::XML_PATH_CURRENCY_ALLOW,
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        $configResource->deleteConfig(
+            Currency::XML_PATH_CURRENCY_BASE,
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        $configResource->deleteConfig(
+            Currency::XML_PATH_CURRENCY_DEFAULT,
+            ScopeInterface::SCOPE_WEBSITES,
+            $this->websiteId
+        );
+        Bootstrap::getObjectManager()->get(System::class)->clean();
+
+        parent::tearDown();
+    }
+
+    public function testCurrencyAllowedOnRequestedStoreIsAccepted(): void
+    {
+        $storeCode = $this->fixtures->get('store')->getCode();
+        $headers = ['Store' => $storeCode, 'Content-Currency' => 'NOK'];
+
+        $response = $this->graphQlQuery(self::QUERY, [], '', $headers);
+
+        $this->assertSame($storeCode, $response['storeConfig']['store_code']);
+        $this->assertSame('NOK', $response['storeConfig']['base_currency_code']);
+        $this->assertSame('NOK', $response['storeConfig']['default_display_currency_code']);
+    }
+
+    public function testCurrencyNotAllowedOnDefaultStoreIsRejectedWithoutStoreHeader(): void
+    {
+        $headers = ['Content-Currency' => 'NOK'];
+
+        $this->expectExceptionMessage('GraphQL response contains errors: Please correct the target currency');
+        $this->graphQlQuery(self::QUERY, [], '', $headers);
+    }
+
+    public function testCurrencyNotAllowedOnRequestedStoreIsRejected(): void
+    {
+        $storeCode = $this->fixtures->get('store')->getCode();
+        $headers = ['Store' => $storeCode, 'Content-Currency' => 'USD'];
+
+        $this->expectExceptionMessage('GraphQL response contains errors: Please correct the target currency');
+        $this->graphQlQuery(self::QUERY, [], '', $headers);
+    }
+}


### PR DESCRIPTION
### Description (*)

A GraphQL request that sends `Store: <store code>` together with `Content-Currency: <code>` is rejected with `Please correct the target currency` whenever that currency is allowed only on the requested website and not on the default one.

Root cause: `Magento\GraphQlCache\Controller\Plugin\GraphQl::beforeDispatch()` runs `validateRequest()` before `processHeaders()`. `Magento\DirectoryGraphQl\Controller\HttpRequestValidator\CurrencyValidator` therefore checks the header against `storeManager->getStore()`, which is still the default store, because the `Store` header is only applied by `StoreProcessor` inside `processHeaders()`. The validator throws, `processHeaders()` is skipped, and the second validation pass in `GraphQl::dispatch()` fails the same way. This ordering was introduced by AC-821 for #31336 (store validation must run before the store is switched) and tightened by AC-11729, so the plugin order is not changed here.

The fix makes `CurrencyValidator` resolve the store it validates against from the `Store` header itself, falling back to the current store when the header is absent. An unknown or inactive store code keeps producing `Requested store is not found`, matching `StoreValidator`, so the validator no longer depends on the order in which the two validators are registered.

Tests:
- New unit test `Magento\DirectoryGraphQl\Test\Unit\Controller\HttpRequestValidator\CurrencyValidatorTest` covering the header/no-header paths, rejected currencies, unknown and inactive store codes, empty header and normalisation.
- New API-functional test `Magento\GraphQl\Directory\CurrencyHeaderValidationTest` with a second website whose only allowed, base and default currency is `NOK` (absent from the default scope): `Store` + `Content-Currency: NOK` succeeds, `Content-Currency: NOK` without `Store` is rejected, `Store` + `Content-Currency: USD` is rejected.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#41242
2. Same defect as reported in magento/magento2#38732

### Manual testing scenarios (*)

1. Create a second website, store and store view (code `nok_sv`).
2. Set `catalog/price/scope` to Website. For the new website set `currency/options/allow`, `currency/options/base` and `currency/options/default` to `NOK`. Leave the default scope on `USD`.
3. `POST /graphql` with headers `Store: nok_sv`, `Content-Currency: NOK` and query `{ storeConfig { store_code base_currency_code } }`.
4. Before the fix: `Please correct the target currency`. After the fix: `store_code` is `nok_sv`, `base_currency_code` is `NOK`.
5. Repeat without the `Store` header: still rejected, because `NOK` is not allowed on the default store.

### Questions or comments

Local gates: unit, integration (no integration tests changed), PHPCS, PHPStan and the Static Tests reproduction were run on the changed files; the API-functional test relies on the upstream WebAPI build.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined templates](https://github.com/magento/devdocs/wiki/Magento-module-README.md) (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
