### PR TITLE
Use emulation-immune theme filesystem collection in Config Importer (#35843)

### DIFF
--- a/app/code/Magento/Theme/Model/Config/Importer.php
+++ b/app/code/Magento/Theme/Model/Config/Importer.php
@@ -10,7 +10,7 @@ use Magento\Framework\Exception\State\InvalidTransitionException;
 use Magento\Theme\Model\ResourceModel\Theme as ThemeResourceModel;
 use Magento\Theme\Model\ResourceModel\Theme\Data\Collection as ThemeDbCollection;
 use Magento\Theme\Model\ResourceModel\Theme\Data\CollectionFactory;
-use Magento\Theme\Model\Theme\Collection as ThemeFilesystemCollection;
+use Magento\Theme\Model\Theme\Data\Collection as ThemeFilesystemCollection;
 use Magento\Theme\Model\Theme\Data;
 use Magento\Theme\Model\Theme\Registration;
 
@@ -110,8 +110,7 @@ class Importer implements ImporterInterface
     }
 
     /**
-     * Returns array of warning messages which contain information about which changes (removing, registration)
-     * will be applied to themes.
+     * Returns array of warning messages about theme changes (removing, registration) to be applied.
      *
      * @param array $data The data that should be imported, used for creating warning messages
      * @return array

--- a/app/code/Magento/Theme/Model/Config/Importer.php
+++ b/app/code/Magento/Theme/Model/Config/Importer.php
@@ -10,7 +10,7 @@ use Magento\Framework\Exception\State\InvalidTransitionException;
 use Magento\Theme\Model\ResourceModel\Theme as ThemeResourceModel;
 use Magento\Theme\Model\ResourceModel\Theme\Data\Collection as ThemeDbCollection;
 use Magento\Theme\Model\ResourceModel\Theme\Data\CollectionFactory;
-use Magento\Theme\Model\Theme\Data\Collection as ThemeFilesystemCollection;
+use Magento\Theme\Model\Theme\Collection as ThemeFilesystemCollection;
 use Magento\Theme\Model\Theme\Data;
 use Magento\Theme\Model\Theme\Registration;
 

--- a/app/code/Magento/Theme/Test/Unit/Model/Config/ImporterTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/Config/ImporterTest.php
@@ -11,7 +11,7 @@ use Magento\Theme\Model\Config\Importer;
 use Magento\Theme\Model\ResourceModel\Theme as ThemeResourceModel;
 use Magento\Theme\Model\ResourceModel\Theme\Data\Collection as ThemeDbCollection;
 use Magento\Theme\Model\ResourceModel\Theme\Data\CollectionFactory;
-use Magento\Theme\Model\Theme\Collection as ThemeFilesystemCollection;
+use Magento\Theme\Model\Theme\Data\Collection as ThemeFilesystemCollection;
 use Magento\Theme\Model\Theme\Data;
 use Magento\Theme\Model\Theme\Registration;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/app/code/Magento/Theme/etc/di.xml
+++ b/app/code/Magento/Theme/etc/di.xml
@@ -61,6 +61,13 @@
         <plugin name="urlSignature" type="Magento\Theme\Model\Url\Plugin\Signature"/>
     </type>
     <type name="Magento\Theme\Model\Theme\Collection" shared="false" />
+    <type name="Magento\Theme\Model\Config\Importer">
+        <arguments>
+            <argument name="themeFilesystemCollection" xsi:type="object">
+                Magento\Theme\Model\Theme\Data\Collection
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\Theme\Model\View\Design">
         <arguments>
             <argument name="themes" xsi:type="array">

--- a/dev/tests/integration/testsuite/Magento/Theme/Model/Config/ImporterTest.php
+++ b/dev/tests/integration/testsuite/Magento/Theme/Model/Config/ImporterTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Theme\Model\Config;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\TestFramework\Helper\Bootstrap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @magentoDbIsolation enabled
+ */
+class ImporterTest extends TestCase
+{
+    /**
+     * @var State
+     */
+    private $appState;
+
+    protected function setUp(): void
+    {
+        $this->appState = Bootstrap::getObjectManager()->get(State::class);
+    }
+
+    public function testGetWarningMessagesDoesNotMislabelFrontendThemesAsAdminhtmlWhileAreaIsEmulated(): void
+    {
+        $messages = $this->appState->emulateAreaCode(
+            Area::AREA_ADMINHTML,
+            function () {
+                $importer = Bootstrap::getObjectManager()->create(Importer::class);
+                return $importer->getWarningMessages([]);
+            }
+        );
+
+        $joinedMessages = implode(PHP_EOL, $messages);
+
+        $this->assertStringNotContainsString('adminhtml/Magento/blank', $joinedMessages);
+        $this->assertStringNotContainsString('adminhtml/Magento/luma', $joinedMessages);
+    }
+
+    public function testGetWarningMessagesForCompleteThemesDoesNotMisreportFilesystemThemesWhileAreaIsEmulated(): void
+    {
+        $completeThemes = [
+            'adminhtml/Magento/backend' => ['area' => 'adminhtml'],
+            'frontend/Magento/blank' => ['area' => 'frontend'],
+            'frontend/Magento/luma' => ['area' => 'frontend'],
+        ];
+
+        $messages = $this->appState->emulateAreaCode(
+            Area::AREA_ADMINHTML,
+            function () use ($completeThemes) {
+                $importer = Bootstrap::getObjectManager()->create(Importer::class);
+                return $importer->getWarningMessages($completeThemes);
+            }
+        );
+
+        $joinedMessages = implode(PHP_EOL, $messages);
+
+        $this->assertStringNotContainsString('adminhtml/Magento/blank', $joinedMessages);
+        $this->assertStringNotContainsString('adminhtml/Magento/luma', $joinedMessages);
+
+        $removalMessages = implode(
+            PHP_EOL,
+            array_filter($messages, static fn (string $message): bool => str_contains($message, 'will be removed'))
+        );
+
+        $this->assertStringNotContainsString('frontend/Magento/blank', $removalMessages);
+        $this->assertStringNotContainsString('frontend/Magento/luma', $removalMessages);
+        $this->assertStringNotContainsString('adminhtml/Magento/backend', $removalMessages);
+    }
+}


### PR DESCRIPTION
### Description

`Magento\Theme\Model\Config\Importer` takes its filesystem theme list from `Magento\Theme\Model\Theme\Collection`. The item class of that collection is `ThemeInterface` (`Magento\Framework\View\Design\Theme\ThemeList::$_itemObjectClass`), which `app/etc/di.xml` resolves to `Magento\Theme\Model\Theme`, and that model returns the emulated area whenever one is active:

```php
if ($this->getData('area') && !$this->_appState->isAreaCodeEmulated()) {
    return $this->getData('area');
}
return $this->_appState->getAreaCode();
```

`Magento\Deploy\Console\Command\App\ConfigImportCommand` runs the whole import inside `EmulatedAdminhtmlAreaProcessor`, so `getFullPath()` reports `adminhtml/...` for every theme, frontend ones included. The DB side of the same comparison uses `Magento\Theme\Model\Theme\Data`, whose `getArea()` returns the stored column, so the two lists can never agree. Measured on a 2.4-develop instance inside `emulateAreaCode('adminhtml', ...)`:

| Collection | `getAllIds()` |
| --- | --- |
| `Magento\Theme\Model\Theme\Collection` | `adminhtml/Magento/blank`, `adminhtml/Magento/luma`, `adminhtml/Magento/backend` |
| `Magento\Theme\Model\Theme\Data\Collection` | `frontend/Magento/blank`, `frontend/Magento/luma`, `adminhtml/Magento/backend` |

Two effects follow. `getWarningMessages()` announces themes that do not exist, and because `$newThemes = array_diff($toBeRegistered, $themesInDb)` never consults `$data`, a complete `themes` section in `app/etc/config.php` cannot suppress it. More importantly, `import()` guards deletion with the same emulated list:

```php
$themesInFs = $this->themeFilesystemCollection->getAllIds();
foreach ($collection->getItems() as $theme) {
    $themeFullPath = $theme->getFullPath();
    if (!key_exists($themeFullPath, $data) && !in_array($themeFullPath, $themesInFs)) {
        $this->themeResourceModel->delete($theme);
    }
}
```

`$themeFullPath` is `frontend/Magento/luma` while `$themesInFs` holds `adminhtml/Magento/luma`, so the "still on the filesystem" guard never matches a frontend theme. That contradicts the class docblock, which states a theme present in the filesystem is registered rather than removed.

The fix injects `Magento\Theme\Model\Theme\Data\Collection`, which is what `Magento\Theme\Model\Theme\Registration` already uses for the same purpose. It extends `Magento\Theme\Model\Theme\Collection` and overrides only `$_itemObjectClass` with the emulation-immune `Theme\Data`, so the constructor stays type-compatible. `Theme::getArea()` is left alone, since other callers rely on the emulation behaviour.

Note for the Semantic Version Checker: the resolved type of the `$themeFilesystemCollection` constructor parameter narrows to a subclass. `Magento\Theme\Model\Config\Importer` is not annotated `@api`.

### Related Pull Requests

None.

### Fixed Issues

Fixes magento/magento2#35843

### Manual testing scenarios

1. On a clean installation, dump a complete themes section so config completeness cannot be the explanation:

```
bin/magento app:config:dump themes
```

The keys are `adminhtml/Magento/backend`, `frontend/Magento/blank`, `frontend/Magento/luma`.

2. Force the section to be re-evaluated by clearing its hash, which lives in the `flag` table rather than in `env.php`:

```
UPDATE flag SET flag_data = JSON_REMOVE(flag_data, '$.themes') WHERE flag_code = 'config_hash';
```

3. Run the upgrade interactively. The warnings reach the console only through the confirmation prompt in `ConfigImport\Processor::execute()`, so `--no-interaction` hides them:

```
printf 'yes\n' | bin/magento setup:upgrade
```

Before the fix:

```
Processing configurations data from configuration file...
The following themes will be registered: adminhtml/Magento/blank, adminhtml/Magento/luma
Do you want to continue [yes/no]?
```

After the fix the section imports without any warning.

4. For the deletion path, remove `frontend/Magento/luma` from the themes section, clear the hash again and re-run the upgrade. Before the fix the theme row is deleted even though `app/design/frontend/Magento/luma` is still on disk, and re-adding the entry re-creates it with a new `theme_id`, which breaks references such as `design/theme/theme_id` in core config. After the fix the row survives.

### Questions or comments

The reporter's original patch changed `Theme::getArea()` itself. This PR keeps that method as it is and corrects the collection the importer asks, which leaves area emulation working for every other caller.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests (if applicable)
- [x] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#41252: Use emulation-immune theme filesystem collection in Config Importer (#35843)