### PR TITLE
Keep full page cache responses out of the browser cache when the Varnish cache type is used

### DIFF
--- a/app/code/Magento/PageCache/Model/App/Response/HttpPlugin.php
+++ b/app/code/Magento/PageCache/Model/App/Response/HttpPlugin.php
@@ -6,10 +6,13 @@
 
 namespace Magento\PageCache\Model\App\Response;
 
-use Magento\Framework\App\PageCache\NotCacheableInterface;
-use Magento\Framework\App\Response\Http as HttpResponse;
-use Magento\Framework\App\Request\Http as HttpRequest;
+use Laminas\Http\Header\CacheControl;
 use Magento\Framework\App\Http\Context;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\PageCache\NotCacheableInterface;
+use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\Stdlib\DateTime;
 
 /**
  * HTTP response plugin for frontend.
@@ -17,17 +20,25 @@ use Magento\Framework\App\Http\Context;
 class HttpPlugin
 {
     /**
+     * @var DateTime
+     */
+    private DateTime $dateTime;
+
+    /**
      * @param Context $context
      * @param HttpRequest $request
+     * @param DateTime|null $dateTime
      */
     public function __construct(
         private Context $context,
-        private HttpRequest $request
+        private HttpRequest $request,
+        ?DateTime $dateTime = null
     ) {
+        $this->dateTime = $dateTime ?? ObjectManager::getInstance()->get(DateTime::class);
     }
 
     /**
-     * Set proper value of X-Magento-Vary cookie.
+     * Set proper value of X-Magento-Vary cookie and keep public responses out of the browser cache.
      *
      * @param HttpResponse $subject
      * @return void
@@ -46,6 +57,41 @@ class HttpPlugin
         if (isset($varyCookie) && ($currentVary !== $varyCookie)) {
             $subject->setNoCacheHeaders();
         }
+        $this->preventBrowserCaching($subject);
         $subject->sendVary();
+    }
+
+    /**
+     * Keep a publicly cacheable response cacheable for the shared cache only.
+     *
+     * Cacheable pages are sent with "public, max-age=<ttl>, s-maxage=<ttl>" (see
+     * \Magento\PageCache\Model\Layout\LayoutPlugin). The built-in cache replaces that with no-cache headers
+     * before the response is sent (see \Magento\Framework\App\PageCache\Kernel::process) and the shipped
+     * Varnish VCL does the same in vcl_deliver, but nothing on the application side did it for the Varnish
+     * cache type. A browser that reaches the application without that VCL in front, or through a proxy that
+     * passes Cache-Control through, would otherwise keep personalised HTML for the whole TTL, for example the
+     * header rendered for a logged-in customer after the customer has logged out. Force max-age=0 for the
+     * browser and leave s-maxage untouched so Varnish and CDNs keep their TTL.
+     *
+     * @param HttpResponse $subject
+     * @return void
+     */
+    private function preventBrowserCaching(HttpResponse $subject): void
+    {
+        $cacheControl = $subject->getHeader('Cache-Control');
+        if (!$cacheControl instanceof CacheControl
+            || !$cacheControl->hasDirective('public')
+            || !$cacheControl->hasDirective('s-maxage')
+        ) {
+            return;
+        }
+
+        $cacheControl->addDirective('max-age', '0');
+        $subject->setHeader('Cache-Control', $cacheControl->getFieldValue(), true);
+        $subject->setHeader(
+            'Expires',
+            $this->dateTime->gmDate(HttpResponse::EXPIRATION_TIMESTAMP_FORMAT, $this->dateTime->strToTime('-1 year')),
+            true
+        );
     }
 }

--- a/app/code/Magento/PageCache/Test/Unit/Model/App/Response/HttpPluginTest.php
+++ b/app/code/Magento/PageCache/Test/Unit/Model/App/Response/HttpPluginTest.php
@@ -10,8 +10,10 @@ namespace Magento\PageCache\Test\Unit\Model\App\Response;
 use Magento\Framework\App\Http\Context;
 use Magento\Framework\App\Response\Http as HttpResponse;
 use Magento\Framework\App\Request\Http as HttpRequest;
+use Magento\Framework\Stdlib\DateTime;
 use Magento\MediaStorage\Model\File\Storage\Response as FileResponse;
 use Magento\PageCache\Model\App\Response\HttpPlugin;
+use Laminas\Http\Header\CacheControl;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -46,7 +48,8 @@ class HttpPluginTest extends TestCase
         $this->request = $this->createMock(HttpRequest::class);
         $this->httpPlugin = new HttpPlugin(
             $this->context,
-            $this->request
+            $this->request,
+            new DateTime()
         );
     }
 
@@ -103,5 +106,82 @@ class HttpPluginTest extends TestCase
         $responseMock->expects($this->never())->method('setNoCacheHeaders');
         $responseMock->expects($this->once())->method('sendVary');
         $this->httpPlugin->beforeSendResponse($responseMock);
+    }
+
+    /**
+     * A page that is public for the shared cache must not be reusable by the browser without revalidation:
+     * keep s-maxage for Varnish / CDNs, force max-age=0 for the browser (mirrors the built-in cache mode).
+     *
+     * @return void
+     */
+    public function testBeforeSendResponsePreventsBrowserCachingOfPublicResponses(): void
+    {
+        $this->context->expects($this->any())->method('getVaryString')->willReturn(null);
+        $this->request->expects($this->any())->method('get')->willReturn(null);
+        /** @var HttpResponse|MockObject $responseMock */
+        $responseMock = $this->createMock(HttpResponse::class);
+        $responseMock->expects($this->any())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn(CacheControl::fromString('Cache-Control: public, max-age=86400, s-maxage=86400'));
+        $headers = [];
+        $responseMock->expects($this->atLeastOnce())
+            ->method('setHeader')
+            ->willReturnCallback(
+                function (string $name, $value, bool $replace = false) use (&$headers, $responseMock) {
+                    $headers[strtolower($name)] = [$value, $replace];
+                    return $responseMock;
+                }
+            );
+        $responseMock->expects($this->never())->method('setNoCacheHeaders');
+        $responseMock->expects($this->once())->method('sendVary');
+
+        $this->httpPlugin->beforeSendResponse($responseMock);
+
+        $this->assertArrayHasKey('cache-control', $headers);
+        $cacheControl = CacheControl::fromString('Cache-Control: ' . $headers['cache-control'][0]);
+        $this->assertTrue($headers['cache-control'][1], 'Cache-Control must replace the existing header');
+        $this->assertTrue($cacheControl->hasDirective('public'));
+        $this->assertSame('0', (string)$cacheControl->getDirective('max-age'));
+        $this->assertSame('86400', (string)$cacheControl->getDirective('s-maxage'));
+        $this->assertArrayHasKey('expires', $headers);
+        $this->assertLessThan(time(), strtotime($headers['expires'][0]), 'Expires must be in the past');
+    }
+
+    /**
+     * Responses that are not public for the shared cache are left untouched.
+     *
+     * @param string|null $cacheControl
+     * @return void
+     */
+    #[DataProvider('nonPublicCacheControlDataProvider')]
+    public function testBeforeSendResponseLeavesNonPublicResponsesUntouched(?string $cacheControl): void
+    {
+        $this->context->expects($this->any())->method('getVaryString')->willReturn(null);
+        $this->request->expects($this->any())->method('get')->willReturn(null);
+        /** @var HttpResponse|MockObject $responseMock */
+        $responseMock = $this->createMock(HttpResponse::class);
+        $responseMock->expects($this->any())
+            ->method('getHeader')
+            ->with('Cache-Control')
+            ->willReturn($cacheControl === null ? false : CacheControl::fromString('Cache-Control: ' . $cacheControl));
+        $responseMock->expects($this->never())->method('setHeader');
+        $responseMock->expects($this->never())->method('setNoCacheHeaders');
+        $responseMock->expects($this->once())->method('sendVary');
+
+        $this->httpPlugin->beforeSendResponse($responseMock);
+    }
+
+    /**
+     * @return array
+     */
+    public static function nonPublicCacheControlDataProvider(): array
+    {
+        return [
+            'no_cache_control_header' => [null],
+            'no_store' => ['no-store, no-cache, must-revalidate, max-age=0'],
+            'private' => ['max-age=60, private'],
+            'public_without_shared_ttl' => ['public, max-age=60'],
+        ];
     }
 }


### PR DESCRIPTION
### Description (*)

With the full page cache type set to Varnish, cacheable pages are sent with `Cache-Control: public, max-age=<ttl>, s-maxage=<ttl>`. The built-in cache type rewrites that to `no-store` in PHP before the response is sent (`\Magento\Framework\App\PageCache\Kernel::process()`), and the shipped VCL does the same thing in `vcl_deliver`, but nothing on the application side did it for the Varnish type. Any browser that reaches Magento without that VCL in front (a plain nginx/PHP setup with the Varnish type selected, a custom VCL, a proxy or CDN that passes `Cache-Control` through) keeps personalised HTML for the whole TTL.

The visible symptom is magento/magento2#37358: after Sign Out, the 5 second redirect from `logoutSuccess` to the home page is a plain `location.assign`, the browser serves the copy of `/` it stored right after login (transferSize 0, deliveryType "cache" in Navigation Timing), and the header still shows the logged-in dropdown while customer-data.js shows the guest greeting.

This change makes `\Magento\PageCache\Model\App\Response\HttpPlugin::beforeSendResponse` (the plugin that already applies the X-Magento-Vary mismatch downgrade) force `max-age=0` and a past `Expires` on any response that leaves with `public` and `s-maxage`, and leaves `s-maxage` untouched. Browsers revalidate every navigation; Varnish and Fastly compute their TTL from `s-maxage`, so shared caching is unchanged. This mirrors what built-in mode already does and what the VCL does for correctly configured Varnish setups, so those setups see no behaviour change.

Considered and rejected: changing `\Magento\Framework\App\Response\Http::setPublicHeaders()` itself (a framework API change that also touches GraphQL and Swatches responses), or `cacheable="false"` on the `logoutSuccess` layout (does not address the cached home page).

History: the browser-facing rewrite in the shipped VCL (`vcl_deliver`, "Not letting browser to cache non-static files") was introduced in 2.2.2 for MAGETWO-83152 "Pages are cached in browser and not updated" (commits 6cda42ab2993, 5d1c79628c2e). That fixed the same symptom in the VCL template. The template is generated once and then maintained by the store owner, so stores whose VCL predates 2.2.2 or was customized without that block, and any setup where the browser does not go through Varnish, still receive `max-age=86400`. This change puts the guarantee in the application, where the built-in cache type already has it.

### Related Pull Requests

None.

### Fixed Issues (if relevant)

1. Fixes magento/magento2#37358

### Manual testing scenarios (*)

Preconditions: Luma, developer mode, Stores > Configuration > Advanced > System > Full Page Cache > Caching Application = Varnish Cache, no Varnish in front of the web server (or a proxy that passes `Cache-Control` through), a customer account.

1. Open the home page, click Sign In, log in. You are redirected to the home page and the header shows the welcome dropdown.
2. Open the dropdown, click Sign Out. The "You are signed out" page shows the guest links.
3. Wait for the 5 second redirect to the home page.

Before: the header shows the welcome dropdown (My Account / My Wish List / Sign Out) and no Sign In / Create an Account links; in devtools the document request for `/` is served from cache. A reload fixes it.
After: the header shows Sign In / Create an Account; the document request for `/` goes to the server.

Header check without a browser: `curl -sI <base-url>/` returns `Cache-Control: max-age=0, public, s-maxage=86400` and an `Expires` in the past (before: `max-age=86400, public, s-maxage=86400`).

With Varnish in front (VCL from `bin/magento varnish:vcl:generate`): pages still return `X-Magento-Cache-Debug: HIT` on the second request, ESI blocks render, and the browser-facing `Cache-Control` stays `no-store` as before.

### Questions or comments

The `Expires` header is set to the past for consistency with `max-age=0`; browsers prefer `max-age` when both are present (RFC 9111 section 5.2.2.1) and Varnish prefers `s-maxage`, so this only matters for HTTP/1.0 caches.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
