### PR TITLE
Fix PayflowPro response resolver notifying a payment failure for a cart with no Payflow payment

### DIFF
--- a/app/code/Magento/PaypalGraphQl/Model/Resolver/PayflowProResponse.php
+++ b/app/code/Magento/PaypalGraphQl/Model/Resolver/PayflowProResponse.php
@@ -9,6 +9,7 @@ namespace Magento\PaypalGraphQl\Model\Resolver;
 
 use Magento\Paypal\Model\Payflow\Service\Response\Transaction;
 use Magento\Paypal\Model\Payflow\Service\Response\Validator\ResponseValidator;
+use Magento\Paypal\Model\Config;
 use Magento\Sales\Api\PaymentFailuresInterface;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Paypal\Model\Payflow\Transparent;
@@ -119,6 +120,18 @@ class PayflowProResponse implements ResolverInterface
         $maskedCartId = $args['input']['cart_id'];
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+
+        // Only proceed for a cart that is in a genuine Payflow payment context. The legitimate
+        // Payflow Pro flow selects a Payflow method (setPaymentMethodOnCart, then
+        // createPayflowProToken) before this resolver runs, so a cart with no Payflow method
+        // never entered a real payment attempt and must not reach the merchant payment-failure
+        // notification below.
+        $selectedMethod = (string)$cart->getPayment()->getMethod();
+        if ($selectedMethod !== Config::METHOD_PAYFLOWPRO
+            && $selectedMethod !== Transparent::CC_VAULT_CODE
+        ) {
+            throw new GraphQlInputException(__('Transaction has been declined.'));
+        }
 
         $paypalPayload = $args['input']['paypal_payload'] ?? '';
 

--- a/app/code/Magento/PaypalGraphQl/Test/Unit/Model/Resolver/PayflowProResponseTest.php
+++ b/app/code/Magento/PaypalGraphQl/Test/Unit/Model/Resolver/PayflowProResponseTest.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\PaypalGraphQl\Test\Unit\Model\Resolver;
+
+use Magento\Framework\DataObject;
+use Magento\Framework\DataObjectFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\TestFramework\Unit\Helper\MockCreationTrait;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\Stdlib\Parameters;
+use Magento\GraphQl\Model\Query\ContextExtensionInterface;
+use Magento\GraphQl\Model\Query\ContextInterface;
+use Magento\Paypal\Model\Config;
+use Magento\Paypal\Model\Payflow\Service\Response\Transaction;
+use Magento\Paypal\Model\Payflow\Service\Response\Validator\ResponseValidator;
+use Magento\Paypal\Model\Payflow\Transparent;
+use Magento\PaypalGraphQl\Model\Resolver\PayflowProResponse;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Payment;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
+use Magento\Sales\Api\PaymentFailuresInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the requirement that the PayflowPro response resolver only notifies the merchant of a
+ * payment failure for a cart that is in a genuine Payflow payment context.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class PayflowProResponseTest extends TestCase
+{
+    use MockCreationTrait;
+
+    private const MASKED_CART_ID = 'masked_cart_id';
+    private const CART_ID = 100;
+
+    /**
+     * @var PayflowProResponse
+     */
+    private PayflowProResponse $resolver;
+
+    /** @var Transaction|MockObject */
+    private $transaction;
+
+    /** @var ResponseValidator|MockObject */
+    private $responseValidator;
+
+    /** @var PaymentFailuresInterface|MockObject */
+    private $paymentFailures;
+
+    /** @var GetCartForUser|MockObject */
+    private $getCartForUser;
+
+    /** @var Parameters|MockObject */
+    private $parameters;
+
+    /** @var Field|MockObject */
+    private $field;
+
+    /** @var ResolveInfo|MockObject */
+    private $info;
+
+    /** @var ContextInterface|MockObject */
+    private $context;
+
+    /** @var Quote|MockObject */
+    private $cart;
+
+    /** @var Payment|MockObject */
+    private $payment;
+
+    protected function setUp(): void
+    {
+        $this->transaction = $this->createMock(Transaction::class);
+        $this->responseValidator = $this->createMock(ResponseValidator::class);
+        $this->paymentFailures = $this->createMock(PaymentFailuresInterface::class);
+        $json = $this->createMock(Json::class);
+        $transparent = $this->createMock(Transparent::class);
+        $this->getCartForUser = $this->createMock(GetCartForUser::class);
+        $this->parameters = $this->createMock(Parameters::class);
+        $dataObjectFactory = $this->createMock(DataObjectFactory::class);
+
+        $this->resolver = new PayflowProResponse(
+            $this->transaction,
+            $this->responseValidator,
+            $this->paymentFailures,
+            $json,
+            $transparent,
+            $this->getCartForUser,
+            $this->parameters,
+            $dataObjectFactory
+        );
+
+        $this->field = $this->createMock(Field::class);
+        $this->info = $this->createMock(ResolveInfo::class);
+
+        $store = $this->createMock(StoreInterface::class);
+        $store->method('getId')->willReturn(1);
+        $extensionAttributes = $this->createPartialMockWithReflection(
+            ContextExtensionInterface::class,
+            ['getStore']
+        );
+        $extensionAttributes->method('getStore')->willReturn($store);
+        $this->context = $this->createMock(ContextInterface::class);
+        $this->context->method('getExtensionAttributes')->willReturn($extensionAttributes);
+        $this->context->method('getUserId')->willReturn(null);
+
+        $this->payment = $this->createMock(Payment::class);
+        $this->cart = $this->createMock(Quote::class);
+        $this->cart->method('getId')->willReturn(self::CART_ID);
+        $this->cart->method('getPayment')->willReturn($this->payment);
+        $this->getCartForUser->method('execute')->willReturn($this->cart);
+    }
+
+    /**
+     * A cart with no Payflow method selected never entered a real payment attempt, so the resolver
+     * must refuse it before it can reach the merchant payment-failure notification.
+     *
+     * @param string|null $method
+     */
+    #[DataProvider('nonPayflowMethodProvider')]
+    public function testCartWithoutPayflowMethodIsRefusedWithoutNotifying($method): void
+    {
+        $this->payment->method('getMethod')->willReturn($method);
+
+        $this->paymentFailures->expects($this->never())->method('handle');
+        $this->responseValidator->expects($this->never())->method('validate');
+        $this->transaction->expects($this->never())->method('getResponseObject');
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Transaction has been declined.');
+
+        $this->resolver->resolve(
+            $this->field,
+            $this->context,
+            $this->info,
+            null,
+            ['input' => ['cart_id' => self::MASKED_CART_ID, 'paypal_payload' => 'RESULT=12&RESPMSG=Declined']]
+        );
+    }
+
+    /**
+     * @return array<string, array<int, string|null>>
+     */
+    public static function nonPayflowMethodProvider(): array
+    {
+        return [
+            'no method selected' => [null],
+            'empty method' => [''],
+            'unrelated method' => ['checkmo'],
+        ];
+    }
+
+    /**
+     * A genuine Payflow decline still carries a Payflow method, so the merchant notification must
+     * still fire for it. This is the behavior the guard preserves.
+     *
+     * @param string $method
+     */
+    #[DataProvider('payflowMethodProvider')]
+    public function testGenuinePayflowDeclineStillNotifies($method): void
+    {
+        $this->payment->method('getMethod')->willReturn($method);
+        $this->parameters->method('toArray')->willReturn(['RESULT' => '12', 'RESPMSG' => 'Declined']);
+        $this->transaction->method('getResponseObject')->willReturn($this->createMock(DataObject::class));
+        $this->responseValidator->method('validate')
+            ->willThrowException(new LocalizedException(__('Payflow gateway declined the transaction.')));
+
+        $this->paymentFailures->expects($this->once())
+            ->method('handle')
+            ->with(self::CART_ID, 'Payflow gateway declined the transaction.');
+
+        $this->expectException(GraphQlInputException::class);
+        $this->expectExceptionMessage('Payflow gateway declined the transaction.');
+
+        $this->resolver->resolve(
+            $this->field,
+            $this->context,
+            $this->info,
+            null,
+            ['input' => ['cart_id' => self::MASKED_CART_ID, 'paypal_payload' => 'RESULT=12&RESPMSG=Declined']]
+        );
+    }
+
+    /**
+     * A valid Payflow response is processed and the cart is returned, with no notification sent.
+     *
+     * @param string $method
+     */
+    #[DataProvider('payflowMethodProvider')]
+    public function testValidPayflowResponseReturnsCart($method): void
+    {
+        $this->payment->method('getMethod')->willReturn($method);
+        $this->parameters->method('toArray')->willReturn(['RESULT' => '0', 'RESPMSG' => 'Approved']);
+        $this->transaction->method('getResponseObject')->willReturn($this->createMock(DataObject::class));
+        $this->responseValidator->method('validate');
+
+        $this->paymentFailures->expects($this->never())->method('handle');
+
+        $result = $this->resolver->resolve(
+            $this->field,
+            $this->context,
+            $this->info,
+            null,
+            ['input' => ['cart_id' => self::MASKED_CART_ID, 'paypal_payload' => 'RESULT=0&RESPMSG=Approved']]
+        );
+
+        $this->assertSame(['cart' => ['model' => $this->cart]], $result);
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function payflowMethodProvider(): array
+    {
+        return [
+            'payflowpro' => [Config::METHOD_PAYFLOWPRO],
+            'payflowpro cc vault' => [Transparent::CC_VAULT_CODE],
+        ];
+    }
+}


### PR DESCRIPTION
### Description (*)

`Magento\PaypalGraphQl\Model\Resolver\PayflowProResponse::resolve()` loads the cart from the caller-supplied masked `cart_id` and, on any validation failure of `paypal_payload`, calls `PaymentFailuresInterface::handle()`, which sends the merchant "Payment Transaction Failed" notification email:

```php
} catch (LocalizedException $exception) {
    $parameters['error'] = true;
    $parameters['error_msg'] = $exception->getMessage();
    $this->paymentFailures->handle((int) $cart->getId(), $parameters['error_msg']);
    throw new GraphQlInputException(__($exception->getMessage()));
}
```

Nothing between loading the cart and this point confirms the cart ever entered a Payflow payment flow. A well-formed request for a cart that simply has no Payflow method selected still fails validation and still reaches `handle()`, so the store sends itself the merchant payment-failure notification even though no genuine payment was ever attempted on that cart. The legitimate Payflow Pro flow always establishes a Payflow method first (`setPaymentMethodOnCart(payflowpro)`, then `createPayflowProToken`), so a real decline always carries a Payflow method; only the no-payment case is unguarded.

This PR requires a Payflow payment method on the cart before the resolver proceeds:

```php
$selectedMethod = (string)$cart->getPayment()->getMethod();
if ($selectedMethod !== Config::METHOD_PAYFLOWPRO
    && $selectedMethod !== Transparent::CC_VAULT_CODE
) {
    throw new GraphQlInputException(__('Transaction has been declined.'));
}
```

A genuine Payflow decline still carries a Payflow method and still notifies, so the intended behavior is unchanged. A cart with no Payflow method is refused with the resolver's existing `Transaction has been declined.` message and no notification is sent. `Config::METHOD_PAYFLOWPRO` and `Transparent::CC_VAULT_CODE` are the complete set of Payflow method codes that reach this resolver in core (`Transparent` was already imported; `Config` is added as a `use`).

### Related Pull Requests

Same change submitted to Mage-OS: https://github.com/mage-os/mageos-magento2/pull/341

### Fixed Issues (if relevant)

N/A. No existing GitHub issue was found. Searched `magento/magento2` issues and pull requests for `PayflowProResponse`, `handlePayflowProResponse payment failed`, and open PRs with `PayflowProResponse` in the title; none matched. Search coverage is not proof of absence, so please close this as a duplicate if a prior report exists.

### Manual testing scenarios (*)

The module ships no unit tests, so this PR adds `PayflowProResponseTest`. The behavior can also be exercised end to end on a store with `Magento_PaypalGraphQl` enabled:

1. Obtain a guest cart with no payment method selected (for example via `createEmptyCart`).
2. Call the `handlePayflowProResponse` mutation for that cart with a `paypal_payload` that fails response validation.
   - **Before:** the resolver reaches `PaymentFailuresInterface::handle()` and the store sends the merchant "Payment Transaction Failed" notification, even though the cart never had a Payflow payment selected.
   - **After:** the resolver returns the `Transaction has been declined.` input error and sends no notification.
3. Regression, genuine decline: select a Payflow method first (`setPaymentMethodOnCart` with `payflowpro`), then submit a declining response. Both before and after this change the merchant notification is sent, confirming genuine Payflow declines are unaffected.

### Contribution checklist (*)

- [x] Pull request has a meaningful description of its purpose
- [x] All commits are accompanied by meaningful commit messages
- [x] All new or changed code is covered with unit/integration tests. Added `app/code/Magento/PaypalGraphQl/Test/Unit/Model/Resolver/PayflowProResponseTest.php` (the module had no unit tests). It covers a cart with no Payflow method (and an unrelated method) being refused without notifying, a genuine Payflow decline still notifying, and a valid response returning the cart, across both `payflowpro` and `payflowpro_cc_vault`.
- [x] All automated tests passed successfully. Ran the new test on `2.4-develop` with PHPUnit 12.5.14: 7/7 green, and confirmed it fails (`getResponseObject ... was not expected to be called`) when the guard is reverted, so it is a real regression guard. `vendor/bin/phpcs --standard=Magento2` reports 0 errors and 0 warnings on both changed files. I did not run the full unit suite locally; relying on CI for that.


### Resolved issues:
1. [x] resolves magento/magento2#41263: Fix PayflowPro response resolver notifying a payment failure for a cart with no Payflow payment