### PR TITLE
Add queue:config:status for message queue topology sync detection

### DIFF
--- a/app/code/Magento/MessageQueue/Console/QueueConfigStatusCommand.php
+++ b/app/code/Magento/MessageQueue/Console/QueueConfigStatusCommand.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MessageQueue\Console;
+
+use Magento\Framework\Console\Cli;
+use Magento\Framework\MessageQueue\Topology\Config\QueueConfigChangeDetectorInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Checks whether message-queue topology requires setup:upgrade synchronization.
+ */
+class QueueConfigStatusCommand extends Command
+{
+    public const COMMAND_QUEUE_CONFIG_STATUS = 'queue:config:status';
+
+    /**
+     * Exit code when setup:upgrade is required to synchronize queue config.
+     */
+    public const EXIT_CODE_UPGRADE_REQUIRED = 2;
+
+    /**
+     * @param QueueConfigChangeDetectorInterface $changeDetector
+     * @param string|null $name
+     */
+    public function __construct(
+        private readonly QueueConfigChangeDetectorInterface $changeDetector,
+        ?string $name = null
+    ) {
+        parent::__construct($name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $this->setName(self::COMMAND_QUEUE_CONFIG_STATUS);
+        $this->setDescription('Checks if queue topology configuration requires upgrade');
+        $this->setHelp(
+            <<<HELP
+This command compares queues declared in topology configuration with the
+persisted queue registry and reports when <info>setup:upgrade</info> is needed.
+Exit code <info>2</info> means upgrade is required (same convention as setup:db:status).
+HELP
+        );
+        parent::configure();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $missingQueues = $this->changeDetector->getMissingQueues();
+        if ($missingQueues !== []) {
+            $output->writeln(
+                '<info>Queue topology configuration has changed.</info>'
+            );
+            $output->writeln(
+                '<info>Run setup:upgrade to synchronize queue configuration.</info>'
+            );
+            $output->writeln(
+                '<comment>Missing queues: ' . implode(', ', $missingQueues) . '</comment>'
+            );
+            return self::EXIT_CODE_UPGRADE_REQUIRED;
+        }
+
+        $output->writeln('<info>Queue topology configuration is up to date.</info>');
+        return Cli::RETURN_SUCCESS;
+    }
+}

--- a/app/code/Magento/MessageQueue/Test/Unit/Console/QueueConfigStatusCommandTest.php
+++ b/app/code/Magento/MessageQueue/Test/Unit/Console/QueueConfigStatusCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MessageQueue\Test\Unit\Console;
+
+use Magento\Framework\Console\Cli;
+use Magento\Framework\MessageQueue\Topology\Config\QueueConfigChangeDetectorInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MessageQueue\Console\QueueConfigStatusCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class QueueConfigStatusCommandTest extends TestCase
+{
+    /**
+     * @var QueueConfigChangeDetectorInterface|MockObject
+     */
+    private $changeDetector;
+
+    /**
+     * @var QueueConfigStatusCommand
+     */
+    private $command;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->changeDetector = $this->createMock(QueueConfigChangeDetectorInterface::class);
+        $objectManager = new ObjectManager($this);
+        $this->command = $objectManager->getObject(
+            QueueConfigStatusCommand::class,
+            ['changeDetector' => $this->changeDetector]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteWhenUpToDate(): void
+    {
+        $this->changeDetector->method('getMissingQueues')->willReturn([]);
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(Cli::RETURN_SUCCESS, $exitCode);
+        $this->assertStringContainsString('up to date', $tester->getDisplay());
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteWhenUpgradeRequired(): void
+    {
+        $this->changeDetector->method('getMissingQueues')->willReturn(['repro.issue.38225']);
+        $tester = new CommandTester($this->command);
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(QueueConfigStatusCommand::EXIT_CODE_UPGRADE_REQUIRED, $exitCode);
+        $this->assertStringContainsString('setup:upgrade', $tester->getDisplay());
+        $this->assertStringContainsString('repro.issue.38225', $tester->getDisplay());
+    }
+}

--- a/app/code/Magento/MessageQueue/etc/di.xml
+++ b/app/code/Magento/MessageQueue/etc/di.xml
@@ -21,6 +21,7 @@
                 <item name="startConsumerCommand" xsi:type="object">Magento\MessageQueue\Console\StartConsumerCommand\Proxy</item>
                 <item name="consumerListCommand" xsi:type="object">Magento\MessageQueue\Console\ConsumerListCommand\Proxy</item>
                 <item name="restartConsumerCommand" xsi:type="object">Magento\MessageQueue\Console\RestartConsumerCommand\Proxy</item>
+                <item name="queueConfigStatusCommand" xsi:type="object">Magento\MessageQueue\Console\QueueConfigStatusCommand\Proxy</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/MysqlMq/Model/Queue/QueueConfigSynchronizer.php
+++ b/app/code/Magento/MysqlMq/Model/Queue/QueueConfigSynchronizer.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MysqlMq\Model\Queue;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as TopologyConfigInterface;
+
+/**
+ * Compares topology-configured queue names with the MySQL MQ queue table.
+ */
+class QueueConfigSynchronizer
+{
+    /**
+     * @param TopologyConfigInterface $topologyConfig
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(
+        private readonly TopologyConfigInterface $topologyConfig,
+        private readonly ResourceConnection $resourceConnection
+    ) {
+    }
+
+    /**
+     * Queue names declared by topology configuration.
+     *
+     * @return string[]
+     */
+    public function getConfiguredNames(): array
+    {
+        $queues = [];
+        foreach ($this->topologyConfig->getQueues() as $queue) {
+            $queues[] = $queue->getName();
+        }
+
+        return array_values(array_unique($queues));
+    }
+
+    /**
+     * Queue names currently stored in the database.
+     *
+     * @return string[]
+     */
+    public function getDatabaseNames(): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName('queue');
+        $select = $connection->select()->from($tableName, ['name']);
+
+        return $connection->fetchCol($select);
+    }
+
+    /**
+     * Configured queue names that are not yet present in the database.
+     *
+     * @return string[]
+     */
+    public function getMissingNames(): array
+    {
+        return array_values(
+            array_unique(
+                array_diff($this->getConfiguredNames(), $this->getDatabaseNames())
+            )
+        );
+    }
+}

--- a/app/code/Magento/MysqlMq/Model/QueueConfig/ChangeDetector.php
+++ b/app/code/Magento/MysqlMq/Model/QueueConfig/ChangeDetector.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MysqlMq\Model\QueueConfig;
+
+use Magento\Framework\MessageQueue\Topology\Config\QueueConfigChangeDetectorInterface;
+use Magento\MysqlMq\Model\Queue\QueueConfigSynchronizer;
+
+/**
+ * Detects missing MySQL MQ queues relative to topology configuration.
+ */
+class ChangeDetector implements QueueConfigChangeDetectorInterface
+{
+    /**
+     * @param QueueConfigSynchronizer $queueConfigSynchronizer
+     */
+    public function __construct(
+        private readonly QueueConfigSynchronizer $queueConfigSynchronizer
+    ) {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasChanges(): bool
+    {
+        return $this->getMissingQueues() !== [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMissingQueues(): array
+    {
+        return $this->queueConfigSynchronizer->getMissingNames();
+    }
+}

--- a/app/code/Magento/MysqlMq/Setup/Recurring.php
+++ b/app/code/Magento/MysqlMq/Setup/Recurring.php
@@ -3,13 +3,14 @@
  * Copyright 2018 Adobe
  * All Rights Reserved.
  */
+declare(strict_types=1);
 
 namespace Magento\MysqlMq\Setup;
 
 use Magento\Framework\Setup\InstallSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
-use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfig;
+use Magento\MysqlMq\Model\Queue\QueueConfigSynchronizer;
 
 /**
  * Class Recurring
@@ -17,16 +18,11 @@ use Magento\Framework\MessageQueue\Topology\ConfigInterface as MessageQueueConfi
 class Recurring implements InstallSchemaInterface
 {
     /**
-     * @var MessageQueueConfig
+     * @param QueueConfigSynchronizer $queueConfigSynchronizer
      */
-    private $messageQueueConfig;
-
-    /**
-     * @param MessageQueueConfig $messageQueueConfig
-     */
-    public function __construct(MessageQueueConfig $messageQueueConfig)
-    {
-        $this->messageQueueConfig = $messageQueueConfig;
+    public function __construct(
+        private readonly QueueConfigSynchronizer $queueConfigSynchronizer
+    ) {
     }
 
     /**
@@ -36,16 +32,10 @@ class Recurring implements InstallSchemaInterface
     {
         $setup->startSetup();
 
-        $queues = [];
-        foreach ($this->messageQueueConfig->getQueues() as $queue) {
-            $queues[] = $queue->getName();
-        }
-
-        $connection = $setup->getConnection();
-        $existingQueues = $connection->fetchCol($connection->select()->from($setup->getTable('queue'), 'name'));
-        $queues = array_unique(array_diff($queues, $existingQueues));
+        $queues = $this->queueConfigSynchronizer->getMissingNames();
         /** Populate 'queue' table */
         if (!empty($queues)) {
+            $connection = $setup->getConnection();
             $connection->insertArray($setup->getTable('queue'), ['name'], $queues);
         }
 

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/Queue/QueueConfigSynchronizerTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/Queue/QueueConfigSynchronizerTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MysqlMq\Test\Unit\Model\Queue;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\MessageQueue\Topology\Config\QueueConfigItemInterface;
+use Magento\Framework\MessageQueue\Topology\ConfigInterface as TopologyConfigInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MysqlMq\Model\Queue\QueueConfigSynchronizer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class QueueConfigSynchronizerTest extends TestCase
+{
+    /**
+     * @var QueueConfigSynchronizer
+     */
+    private $model;
+
+    /**
+     * @var TopologyConfigInterface|MockObject
+     */
+    private $topologyConfig;
+
+    /**
+     * @var ResourceConnection|MockObject
+     */
+    private $resourceConnection;
+
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $connection;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->topologyConfig = $this->createMock(TopologyConfigInterface::class);
+        $this->resourceConnection = $this->createMock(ResourceConnection::class);
+        $this->connection = $this->createMock(AdapterInterface::class);
+
+        $objectManager = new ObjectManager($this);
+        $this->model = $objectManager->getObject(
+            QueueConfigSynchronizer::class,
+            [
+                'topologyConfig' => $this->topologyConfig,
+                'resourceConnection' => $this->resourceConnection,
+            ]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetMissingNamesReturnsOnlyConfiguredQueuesAbsentFromDatabase(): void
+    {
+        $this->mockConfiguredQueues(['queue_a', 'queue_b', 'queue_c']);
+        $this->mockDatabaseQueues(['queue_a', 'legacy_removed_queue']);
+
+        $this->assertSame(['queue_b', 'queue_c'], $this->model->getMissingNames());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetMissingNamesWhenInSync(): void
+    {
+        $this->mockConfiguredQueues(['queue_a', 'queue_b']);
+        $this->mockDatabaseQueues(['queue_a', 'queue_b', 'legacy_removed_queue']);
+
+        $this->assertSame([], $this->model->getMissingNames());
+    }
+
+    /**
+     * @param string[] $names
+     * @return void
+     */
+    private function mockConfiguredQueues(array $names): void
+    {
+        $queues = [];
+        foreach ($names as $name) {
+            $queue = $this->createMock(QueueConfigItemInterface::class);
+            $queue->method('getName')->willReturn($name);
+            $queues[] = $queue;
+        }
+        $this->topologyConfig->method('getQueues')->willReturn($queues);
+    }
+
+    /**
+     * @param string[] $names
+     * @return void
+     */
+    private function mockDatabaseQueues(array $names): void
+    {
+        $tableName = 'queue';
+        $select = $this->createMock(Select::class);
+        $this->resourceConnection->method('getConnection')->willReturn($this->connection);
+        $this->resourceConnection->method('getTableName')->with('queue')->willReturn($tableName);
+        $this->connection->method('select')->willReturn($select);
+        $select->method('from')->with($tableName, ['name'])->willReturnSelf();
+        $this->connection->method('fetchCol')->with($select)->willReturn($names);
+    }
+}

--- a/app/code/Magento/MysqlMq/Test/Unit/Model/QueueConfig/ChangeDetectorTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Model/QueueConfig/ChangeDetectorTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\MysqlMq\Test\Unit\Model\QueueConfig;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MysqlMq\Model\Queue\QueueConfigSynchronizer;
+use Magento\MysqlMq\Model\QueueConfig\ChangeDetector;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ChangeDetectorTest extends TestCase
+{
+    /**
+     * @var ChangeDetector
+     */
+    private $model;
+
+    /**
+     * @var QueueConfigSynchronizer|MockObject
+     */
+    private $queueConfigSynchronizer;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp(): void
+    {
+        $this->queueConfigSynchronizer = $this->createMock(QueueConfigSynchronizer::class);
+        $objectManager = new ObjectManager($this);
+        $this->model = $objectManager->getObject(
+            ChangeDetector::class,
+            ['queueConfigSynchronizer' => $this->queueConfigSynchronizer]
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasChangesWhenQueuesAreMissing(): void
+    {
+        $this->queueConfigSynchronizer->method('getMissingNames')->willReturn(['queue_new']);
+        $this->assertTrue($this->model->hasChanges());
+        $this->assertSame(['queue_new'], $this->model->getMissingQueues());
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasNoChangesWhenInSync(): void
+    {
+        $this->queueConfigSynchronizer->method('getMissingNames')->willReturn([]);
+        $this->assertFalse($this->model->hasChanges());
+        $this->assertSame([], $this->model->getMissingQueues());
+    }
+}

--- a/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
+++ b/app/code/Magento/MysqlMq/Test/Unit/Setup/RecurringTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2018 Adobe
+ * Copyright 2026 Adobe
  * All Rights Reserved.
  */
 declare(strict_types=1);
@@ -8,12 +8,10 @@ declare(strict_types=1);
 namespace Magento\MysqlMq\Test\Unit\Setup;
 
 use Magento\Framework\DB\Adapter\AdapterInterface;
-use Magento\Framework\DB\Select;
-use Magento\Framework\MessageQueue\Topology\Config\QueueConfigItemInterface;
-use Magento\Framework\MessageQueue\Topology\ConfigInterface as TopologyConfigInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\MysqlMq\Model\Queue\QueueConfigSynchronizer;
 use Magento\MysqlMq\Setup\Recurring;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -21,70 +19,67 @@ use PHPUnit\Framework\TestCase;
 class RecurringTest extends TestCase
 {
     /**
-     * @var ObjectManager
-     */
-    private $objectManager;
-
-    /**
      * @var Recurring
      */
     private $model;
 
     /**
-     * @var \Magento\Framework\MessageQueue\ConfigInterface|MockObject
+     * @var QueueConfigSynchronizer|MockObject
      */
-    private $messageQueueConfig;
+    private $queueConfigSynchronizer;
 
     /**
-     * {@inheritdoc}
+     * @inheritdoc
      */
     protected function setUp(): void
     {
-        $this->objectManager = new ObjectManager($this);
-        $this->messageQueueConfig = $this->createMock(TopologyConfigInterface::class);
-        $this->model = $this->objectManager->getObject(
+        $objectManager = new ObjectManager($this);
+        $this->queueConfigSynchronizer = $this->createMock(QueueConfigSynchronizer::class);
+        $this->model = $objectManager->getObject(
             Recurring::class,
             [
-                'messageQueueConfig' => $this->messageQueueConfig,
+                'queueConfigSynchronizer' => $this->queueConfigSynchronizer,
             ]
         );
     }
 
     /**
-     * Test for install method
+     * Test for install method when missing queues exist.
      */
-    public function testInstall()
+    public function testInstall(): void
     {
-        for ($i = 1; $i <= 3; $i++) {
-            $queue = $this->createMock(QueueConfigItemInterface::class);
-            $queue->expects($this->once())
-                ->method('getName')
-                ->willReturn('queue_name_' . $i);
-            $queues[] = $queue;
-        }
-
-        $dbQueues = [
-            'queue_name_1',
-            'queue_name_2',
-        ];
-        $queuesToInsert = [
-            2 => 'queue_name_3'
-        ];
+        $queuesToInsert = ['queue_name_3'];
         $queueTableName = 'queue_table';
 
         $setup = $this->createMock(SchemaSetupInterface::class);
         $context = $this->createMock(ModuleContextInterface::class);
 
         $setup->expects($this->once())->method('startSetup')->willReturnSelf();
-        $this->messageQueueConfig->expects($this->once())->method('getQueues')->willReturn($queues);
+        $this->queueConfigSynchronizer->expects($this->once())
+            ->method('getMissingNames')
+            ->willReturn($queuesToInsert);
         $connection = $this->createMock(AdapterInterface::class);
         $setup->expects($this->once())->method('getConnection')->willReturn($connection);
-        $setup->expects($this->any())->method('getTable')->with('queue')->willReturn($queueTableName);
-        $select = $this->createMock(Select::class);
-        $connection->expects($this->once())->method('select')->willReturn($select);
-        $select->expects($this->once())->method('from')->with($queueTableName, 'name')->willReturnSelf();
-        $connection->expects($this->once())->method('fetchCol')->with($select)->willReturn($dbQueues);
+        $setup->expects($this->once())->method('getTable')->with('queue')->willReturn($queueTableName);
         $connection->expects($this->once())->method('insertArray')->with($queueTableName, ['name'], $queuesToInsert);
+        $setup->expects($this->once())->method('endSetup')->willReturnSelf();
+
+        $this->model->install($setup, $context);
+    }
+
+    /**
+     * Test for install method when no queues are missing.
+     */
+    public function testInstallWithNoMissingQueues(): void
+    {
+        $setup = $this->createMock(SchemaSetupInterface::class);
+        $context = $this->createMock(ModuleContextInterface::class);
+
+        $setup->expects($this->once())->method('startSetup')->willReturnSelf();
+        $this->queueConfigSynchronizer->expects($this->once())
+            ->method('getMissingNames')
+            ->willReturn([]);
+        $setup->expects($this->never())->method('getConnection');
         $setup->expects($this->once())->method('endSetup')->willReturnSelf();
 
         $this->model->install($setup, $context);

--- a/app/code/Magento/MysqlMq/etc/di.xml
+++ b/app/code/Magento/MysqlMq/etc/di.xml
@@ -57,4 +57,6 @@
             <argument name="instanceName" xsi:type="string">\Magento\MysqlMq\Model\Driver\Bulk\Exchange</argument>
         </arguments>
     </virtualType>
+    <preference for="Magento\Framework\MessageQueue\Topology\Config\QueueConfigChangeDetectorInterface"
+                type="Magento\MysqlMq\Model\QueueConfig\ChangeDetector"/>
 </config>

--- a/lib/internal/Magento/Framework/MessageQueue/Topology/Config/QueueConfigChangeDetectorInterface.php
+++ b/lib/internal/Magento/Framework/MessageQueue/Topology/Config/QueueConfigChangeDetectorInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ */
+declare(strict_types=1);
+
+namespace Magento\Framework\MessageQueue\Topology\Config;
+
+/**
+ * Detects whether message-queue topology config is out of sync with persisted queue registry.
+ *
+ * @api
+ */
+interface QueueConfigChangeDetectorInterface
+{
+    /**
+     * Check whether configured queues are missing from the persisted registry.
+     *
+     * @return bool
+     */
+    public function hasChanges(): bool;
+
+    /**
+     * Return queue names present in topology config but missing from the persisted registry.
+     *
+     * @return string[]
+     */
+    public function getMissingQueues(): array;
+}


### PR DESCRIPTION
## Summary
- Adds `queue:config:status` (exit code 2 when `setup:upgrade` is required) without changing `setup:db:status`, per maintainer feedback on #39698.
- Compares topology queues via `Topology\ConfigInterface::getQueues()` to the MySQL `queue` table using missing-only `array_diff` (legacy DB rows ignored).
- Refactors `Magento\MysqlMq\Setup\Recurring` to share the same synchronizer so status and upgrade stay aligned.

## Related
- Fixes #38225
- Supersedes closed #39698 (new approach: separate command; topology source; missing-only diff)
- Design aligned with community module https://github.com/furan917/Magento2-QueueConfigStatus and review comments from @kandy / @furan917 / @engcom-Hotel

## Manual testing scenarios
1. `bin/magento setup:upgrade` then `bin/magento queue:config:status` → exit 0
2. Add a new binding/destination in a module `queue_topology.xml`
3. `bin/magento cache:flush` then `bin/magento queue:config:status` → exit 2, lists missing queue
4. Confirm `bin/magento setup:db:status` still exit 0 (by design)
5. `bin/magento setup:upgrade` then `queue:config:status` → exit 0

## Test plan
- [x] Unit tests for QueueConfigSynchronizer, ChangeDetector, QueueConfigStatusCommand, Recurring
- [x] Manual local verification of exit codes 0 → 2 → 0
- [ ] Magento CI: Unit Tests, Static Tests

## Notes for deploy tooling
Call `queue:config:status` in addition to `setup:db:status` when deciding whether to run `setup:upgrade`.